### PR TITLE
Fix workspace authority conflict recovery

### DIFF
--- a/Sources/RepoPrompt/App/WindowContentView.swift
+++ b/Sources/RepoPrompt/App/WindowContentView.swift
@@ -22,6 +22,9 @@ struct WindowContentView: View {
 
     var body: some View {
         ContentView(windowState: windowState)
+            .safeAreaInset(edge: .top) {
+                WorkspaceAuthorityRecoveryBanner(workspaceManager: windowState.workspaceManager)
+            }
             .safeAreaInset(edge: .top) { GlobalSettingsPersistenceBlockBanner(allowsSessionDismissal: true) }
             .environmentObject(windowState) // If your subviews need it
             .environmentObject(sparkleManager)

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsWorkspace.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsWorkspace.swift
@@ -264,7 +264,7 @@ import MCP
             guard let workspace = window.workspaceManager.activeWorkspace else { return nil }
             let url = window.workspaceManager.workspaceFileURL(for: workspace)
             guard FileManager.default.fileExists(atPath: url.path),
-                  let diskWorkspace = try? WorkspaceManagerViewModel.loadWorkspaceFromFile(at: url)
+                  let diskWorkspace = try? WorkspaceManagerViewModel.loadWorkspaceFromFile(at: url, scheduleNormalizationWriteback: false)
             else {
                 return nil
             }

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -231,24 +231,103 @@ struct WorkspaceMenuQuery {
 }
 
 struct DomainWorkspaceAuthorityIssue: Equatable, Identifiable {
+    enum Kind: String, Equatable {
+        case externalConflict
+        case degradedReadOnly
+        case removed
+        case commandFailure
+        case projectionFailure
+    }
+
     let id: UUID
     let workspaceID: UUID?
     let operation: String
-    let message: String
-    let canResolveExternalConflict: Bool
+    let kind: Kind
+    let reason: String?
+    let diagnostic: String?
 
     init(
         id: UUID = UUID(),
         workspaceID: UUID?,
         operation: String,
-        message: String,
-        canResolveExternalConflict: Bool
+        kind: Kind,
+        reason: String? = nil,
+        diagnostic: String? = nil
     ) {
         self.id = id
         self.workspaceID = workspaceID
         self.operation = operation
-        self.message = message
-        self.canResolveExternalConflict = canResolveExternalConflict
+        self.kind = kind
+        self.reason = reason
+        self.diagnostic = diagnostic
+    }
+
+    var canResolveExternalConflict: Bool {
+        kind == .externalConflict
+    }
+
+    var stableCode: String {
+        switch kind {
+        case .externalConflict: "workspace_external_conflict"
+        case .degradedReadOnly: "workspace_read_only_degraded"
+        case .removed: "workspace_unavailable"
+        case .commandFailure: "workspace_authority_command_failed"
+        case .projectionFailure: "workspace_authority_projection_failed"
+        }
+    }
+
+    var message: String {
+        switch kind {
+        case .externalConflict:
+            "RepoPrompt retained both local working state and externally saved workspace state. Choose which state to keep."
+        case .degradedReadOnly:
+            "This workspace is read-only until its persistence problem is resolved."
+        case .removed:
+            "This workspace is no longer available."
+        case .commandFailure, .projectionFailure:
+            diagnostic ?? reason ?? "The workspace authority operation failed."
+        }
+    }
+
+    var recoveryInstruction: String {
+        switch kind {
+        case .externalConflict:
+            "Resolve the workspace with Keep Local or Use External, then retry."
+        case .degradedReadOnly:
+            "Retry the workspace authority refresh after correcting the persistence problem."
+        case .removed:
+            "Select or open another workspace, then retry."
+        case .commandFailure, .projectionFailure:
+            "Retry after the workspace authority error is resolved."
+        }
+    }
+
+    var agentAdmissionMessage: String {
+        let preciseReason = reason ?? diagnostic ?? kind.rawValue
+        return "[\(stableCode)] agent_run.start blocked: \(preciseReason). \(recoveryInstruction)"
+    }
+}
+
+struct DomainWorkspaceAuthorityOperationError: LocalizedError {
+    let outcome: DomainCommandOutcome
+
+    var errorDescription: String? {
+        let code = outcome.errorCode?.rawValue ?? "workspace_authority_command_failed"
+        let diagnostic = outcome.diagnostic ?? outcome.disposition.rawValue
+        let recovery = if case .externalConflict = outcome.workspace?.health {
+            " Resolve the workspace with Keep Local or Use External, then retry."
+        } else {
+            ""
+        }
+        return "[\(code)] \(diagnostic).\(recovery)"
+    }
+}
+
+private enum WorkspaceDirectWriteError: LocalizedError {
+    case domainAuthorityRequired
+
+    var errorDescription: String? {
+        "Runtime-owned workspaces must be written through the domain workspace authority."
     }
 }
 
@@ -289,6 +368,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             guard oldValue != activeWorkspaceID else { return }
             workspaceSearchReadinessFence.publish(nil)
             refreshSelectionMirrorContextRevision()
+            synchronizeDomainAuthorityIssueForActiveWorkspace(operation: "workspace_selection")
         }
     }
 
@@ -313,6 +393,7 @@ class WorkspaceManagerViewModel: ObservableObject {
     private var domainWorkspaceFileURLsByID: [UUID: URL] = [:]
     private var domainWorkspaceRevisionsByID: [UUID: DomainRevisionState] = [:]
     private var domainWorkspaceDigestsByID: [UUID: String] = [:]
+    private var domainWorkspaceHealthByID: [UUID: DomainAuthorityHealth] = [:]
     private var workspaceRenameIntentByID: [UUID: UUID] = [:]
     private var workspaceHiddenIntentByID: [UUID: UUID] = [:]
     private var domainWorkspaceCatalogRevision: UInt64 = 0
@@ -2108,6 +2189,9 @@ class WorkspaceManagerViewModel: ObservableObject {
                         digestsByWorkspaceID: Dictionary(uniqueKeysWithValues: snapshot.workspaces.map {
                             ($0.document.workspaceID, $0.document.contentDigest)
                         }),
+                        healthByWorkspaceID: Dictionary(uniqueKeysWithValues: snapshot.workspaces.map {
+                            ($0.document.workspaceID, $0.health)
+                        }),
                         catalogRevision: snapshot.catalogRevision,
                         preferredActiveWorkspaceID: activeWorkspaceID,
                         publicationSequence: snapshot.publicationSequence
@@ -2147,7 +2231,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
                 if FileManager.default.fileExists(atPath: wURL.path) {
                     do {
-                        try loadedMutable.append(Self.loadWorkspaceFromFile(at: wURL))
+                        try loadedMutable.append(Self.loadWorkspaceFromFile(at: wURL, scheduleNormalizationWriteback: true))
                     } catch {
                         print("Error loading workspace from new scheme: \(error)")
                     }
@@ -2196,7 +2280,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
 
         do {
-            let diskWorkspace = try await Self.loadWorkspaceFromFileAsync(at: fileURL)
+            let diskWorkspace = try await Self.loadWorkspaceFromFileAsync(at: fileURL, scheduleNormalizationWriteback: false)
             guard let latestIndex = workspaceIndex(for: workspaceID) else { return }
             guard !hasLocalRepoPathEdit(for: workspaces[latestIndex]) else { return }
             let previousRepoPaths = workspaces[latestIndex].repoPaths
@@ -2243,7 +2327,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
                 if FileManager.default.fileExists(atPath: wURL.path) {
                     do {
-                        let ws = try Self.loadWorkspaceFromFile(at: wURL)
+                        let ws = try Self.loadWorkspaceFromFile(at: wURL, scheduleNormalizationWriteback: false)
                         print("[WorkspaceSnapshot] Loaded \(ws.name): \(ws.repoPaths.count) repoPaths")
                         loaded.append(ws)
                     } catch {
@@ -2290,7 +2374,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 }
 
                 do {
-                    let ws = try Self.loadWorkspaceFromFile(at: wURL)
+                    let ws = try Self.loadWorkspaceFromFile(at: wURL, scheduleNormalizationWriteback: false)
                     updatesMutable.append((entry.id, ws.presets, ws.activePresetID))
                 } catch {
                     print("Error reloading presets for workspace \(entry.name): \(error)")
@@ -3384,7 +3468,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             let diskURL = workspaceFileURL(for: newWorkspace)
             if FileManager.default.fileExists(atPath: diskURL.path) {
                 do {
-                    let upgraded = try await Self.loadWorkspaceFromFileAsync(at: diskURL)
+                    let upgraded = try await Self.loadWorkspaceFromFileAsync(at: diskURL, scheduleNormalizationWriteback: false)
                     workspaces[wsIndex] = upgraded
                     recordRepoPathBaseline(for: upgraded)
                 } catch {
@@ -3401,7 +3485,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             }
 
             do {
-                let upgraded = try await Self.loadWorkspaceFromFileAsync(at: diskURL)
+                let upgraded = try await Self.loadWorkspaceFromFileAsync(at: diskURL, scheduleNormalizationWriteback: false)
                 workspaces.append(upgraded)
                 recordRepoPathBaseline(for: upgraded)
                 activeWorkspaceID = upgraded.id
@@ -4023,30 +4107,37 @@ class WorkspaceManagerViewModel: ObservableObject {
             workspaceID: workspaceID,
             revisions: outcome.workspace?.revisions ?? outcome.after,
             digest: outcome.workspace?.document.contentDigest ?? outcome.resultingDigest,
+            health: outcome.workspace?.health,
             catalogRevision: outcome.catalogRevision
         )
-        if domainWorkspaceAuthorityIssue?.workspaceID == workspaceID,
-           outcome.disposition == .applied
+        if Self.isSuccessfulDomainOutcome(outcome),
+           domainWorkspaceAuthorityIssue?.workspaceID == workspaceID,
+           domainWorkspaceAuthorityIssue?.kind == .commandFailure
         {
-            domainWorkspaceAuthorityIssue = nil
+            publishDomainAuthorityIssueIfChanged(nil)
         }
+        synchronizeDomainAuthorityIssueForActiveWorkspace(operation: "authority_outcome")
     }
 
     func applyDomainAuthorityBaseline(
         workspaceID: UUID,
         revisions: DomainRevisionState,
         digest: String,
+        health: DomainAuthorityHealth,
         catalogRevision: UInt64
     ) {
         domainWorkspaceRevisionsByID[workspaceID] = revisions
         domainWorkspaceDigestsByID[workspaceID] = digest
+        domainWorkspaceHealthByID[workspaceID] = health
         domainWorkspaceCatalogRevision = max(domainWorkspaceCatalogRevision, catalogRevision)
+        synchronizeDomainAuthorityIssueForActiveWorkspace(operation: "authority_projection")
     }
 
     private func applyDomainAuthorityBaseline(
         workspaceID: UUID,
         revisions: DomainRevisionState?,
         digest: String?,
+        health: DomainAuthorityHealth?,
         catalogRevision: UInt64
     ) {
         if let revisions {
@@ -4055,29 +4146,97 @@ class WorkspaceManagerViewModel: ObservableObject {
         if let digest {
             domainWorkspaceDigestsByID[workspaceID] = digest
         }
+        if let health {
+            domainWorkspaceHealthByID[workspaceID] = health
+        }
         domainWorkspaceCatalogRevision = max(domainWorkspaceCatalogRevision, catalogRevision)
     }
 
-    func reportDomainAuthorityIssue(_ outcome: DomainCommandOutcome, operation: String) {
-        let hasExternalConflict: Bool = if case .externalConflict = outcome.workspace?.health {
-            true
-        } else {
-            outcome.diagnostic?.contains("external") == true
+    private func authorityIssue(
+        workspaceID: UUID?,
+        operation: String,
+        health: DomainAuthorityHealth,
+        diagnostic: String? = nil
+    ) -> DomainWorkspaceAuthorityIssue? {
+        switch health {
+        case .writable:
+            nil
+        case let .externalConflict(reason):
+            DomainWorkspaceAuthorityIssue(
+                workspaceID: workspaceID,
+                operation: operation,
+                kind: .externalConflict,
+                reason: reason,
+                diagnostic: diagnostic
+            )
+        case let .degradedReadOnly(reason):
+            DomainWorkspaceAuthorityIssue(
+                workspaceID: workspaceID,
+                operation: operation,
+                kind: .degradedReadOnly,
+                reason: reason,
+                diagnostic: diagnostic
+            )
+        case .removed:
+            DomainWorkspaceAuthorityIssue(
+                workspaceID: workspaceID,
+                operation: operation,
+                kind: .removed,
+                reason: health.reason,
+                diagnostic: diagnostic
+            )
         }
-        let nextIssue = DomainWorkspaceAuthorityIssue(
-            workspaceID: outcome.workspace?.document.workspaceID,
+    }
+
+    private func publishDomainAuthorityIssueIfChanged(_ issue: DomainWorkspaceAuthorityIssue?) {
+        guard domainWorkspaceAuthorityIssue?.workspaceID != issue?.workspaceID
+            || domainWorkspaceAuthorityIssue?.operation != issue?.operation
+            || domainWorkspaceAuthorityIssue?.kind != issue?.kind
+            || domainWorkspaceAuthorityIssue?.reason != issue?.reason
+            || domainWorkspaceAuthorityIssue?.diagnostic != issue?.diagnostic
+        else { return }
+        domainWorkspaceAuthorityIssue = issue
+    }
+
+    private func synchronizeDomainAuthorityIssueForActiveWorkspace(operation: String) {
+        guard let activeWorkspaceID,
+              let health = domainWorkspaceHealthByID[activeWorkspaceID]
+        else { return }
+        if let issue = authorityIssue(
+            workspaceID: activeWorkspaceID,
             operation: operation,
-            message: outcome.diagnostic ?? outcome.disposition.rawValue,
-            canResolveExternalConflict: hasExternalConflict
-        )
-        if domainWorkspaceAuthorityIssue?.workspaceID != nextIssue.workspaceID
-            || domainWorkspaceAuthorityIssue?.operation != nextIssue.operation
-            || domainWorkspaceAuthorityIssue?.message != nextIssue.message
-            || domainWorkspaceAuthorityIssue?.canResolveExternalConflict != nextIssue.canResolveExternalConflict
+            health: health
+        ) {
+            publishDomainAuthorityIssueIfChanged(issue)
+        } else if let current = domainWorkspaceAuthorityIssue,
+                  current.kind == .externalConflict
+                  || current.kind == .degradedReadOnly
+                  || current.kind == .removed
         {
-            domainWorkspaceAuthorityIssue = nextIssue
+            publishDomainAuthorityIssueIfChanged(nil)
         }
-        if let workspaceID = outcome.workspace?.document.workspaceID,
+    }
+
+    func reportDomainAuthorityIssue(_ outcome: DomainCommandOutcome, operation: String) {
+        let workspaceID = outcome.workspace?.document.workspaceID
+        if let workspace = outcome.workspace,
+           let healthIssue = authorityIssue(
+               workspaceID: workspaceID,
+               operation: operation,
+               health: workspace.health,
+               diagnostic: outcome.diagnostic
+           )
+        {
+            publishDomainAuthorityIssueIfChanged(healthIssue)
+        } else {
+            publishDomainAuthorityIssueIfChanged(DomainWorkspaceAuthorityIssue(
+                workspaceID: workspaceID,
+                operation: operation,
+                kind: .commandFailure,
+                diagnostic: outcome.diagnostic ?? outcome.disposition.rawValue
+            ))
+        }
+        if let workspaceID,
            let workspace = workspace(withID: workspaceID)
         {
             WorkspaceSaveTracer.event(
@@ -4087,18 +4246,21 @@ class WorkspaceManagerViewModel: ObservableObject {
                 extra: [
                     "operation": operation,
                     "disposition": outcome.disposition.rawValue,
-                    "errorCode": outcome.errorCode?.rawValue ?? "none"
+                    "errorCode": outcome.errorCode?.rawValue ?? "none",
+                    "authorityHealth": String(describing: outcome.workspace?.health ?? .removed),
+                    "authorityReason": outcome.workspace?.health.reason ?? "none"
                 ]
             )
         }
     }
 
     func reportDomainProjectionFailure(_ error: Error) {
-        reportDomainAuthorityFailure(
-            error,
+        publishDomainAuthorityIssueIfChanged(DomainWorkspaceAuthorityIssue(
             workspaceID: nil,
-            operation: "projection"
-        )
+            operation: "projection",
+            kind: .projectionFailure,
+            diagnostic: error.localizedDescription
+        ))
     }
 
     func reportDomainAuthorityFailure(
@@ -4106,13 +4268,34 @@ class WorkspaceManagerViewModel: ObservableObject {
         workspaceID: UUID?,
         operation: String
     ) {
-        domainWorkspaceAuthorityIssue = DomainWorkspaceAuthorityIssue(
+        publishDomainAuthorityIssueIfChanged(DomainWorkspaceAuthorityIssue(
             workspaceID: workspaceID,
             operation: operation,
-            message: error.localizedDescription,
-            canResolveExternalConflict: false
-        )
+            kind: .commandFailure,
+            diagnostic: error.localizedDescription
+        ))
         Self.logger.error("Domain workspace authority \(operation, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+    }
+
+    private func protectedAgentIdentities(for workspaceID: UUID) -> [DomainProtectedAgentIdentity] {
+        guard let workspace = workspace(withID: workspaceID) else { return [] }
+        let composed = workspace.composeTabs.map {
+            DomainProtectedAgentIdentity(
+                tabID: $0.id,
+                location: .composed,
+                activeAgentSessionID: $0.activeAgentSessionID,
+                isPinned: $0.isPinned
+            )
+        }
+        let stashed = workspace.stashedTabs.map {
+            DomainProtectedAgentIdentity(
+                tabID: $0.tab.id,
+                location: .stashed,
+                activeAgentSessionID: $0.tab.activeAgentSessionID,
+                isPinned: $0.tab.isPinned
+            )
+        }
+        return (composed + stashed).filter(\.requiresProtection)
     }
 
     @discardableResult
@@ -4124,6 +4307,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         let outcome = await domainWorkspaceAuthorityClient.resolveConflict(
             workspaceID: workspaceID,
             acceptExternal: acceptExternal,
+            protectedAgentIdentities: protectedAgentIdentities(for: workspaceID),
             expectedWorkspaceRevision: domainWorkspaceRevisionsByID[
                 workspaceID
             ]?.workingRevision
@@ -4133,24 +4317,46 @@ class WorkspaceManagerViewModel: ObservableObject {
             reportDomainAuthorityIssue(outcome, operation: "resolve_external_conflict")
             return false
         }
-        domainWorkspaceAuthorityIssue = nil
+        synchronizeDomainAuthorityIssueForActiveWorkspace(operation: "resolve_external_conflict")
         return true
     }
 
     func refreshDomainWorkspaceAuthority() async {
         guard let domainWorkspaceAuthorityClient else { return }
         let snapshot = await domainWorkspaceAuthorityClient.reloadExternalChanges()
-        if let conflict = snapshot.workspaces.first(where: {
-            if case .externalConflict = $0.health { return true }
-            return false
-        }) {
-            domainWorkspaceAuthorityIssue = DomainWorkspaceAuthorityIssue(
-                workspaceID: conflict.document.workspaceID,
-                operation: "external_refresh",
-                message: "The saved workspace changed while local working state is dirty.",
-                canResolveExternalConflict: true
+        for workspace in snapshot.workspaces {
+            applyDomainAuthorityBaseline(
+                workspaceID: workspace.document.workspaceID,
+                revisions: workspace.revisions,
+                digest: workspace.document.contentDigest,
+                health: workspace.health,
+                catalogRevision: snapshot.catalogRevision
             )
         }
+        synchronizeDomainAuthorityIssueForActiveWorkspace(operation: "external_refresh")
+    }
+
+    func domainAuthorityAdmissionIssue(for workspaceID: UUID) async -> DomainWorkspaceAuthorityIssue? {
+        guard let domainWorkspaceAuthorityClient else { return nil }
+        guard let snapshot = await domainWorkspaceAuthorityClient.store.workspaceSnapshot(workspaceID) else {
+            return authorityIssue(
+                workspaceID: workspaceID,
+                operation: "agent_admission",
+                health: .removed
+            )
+        }
+        applyDomainAuthorityBaseline(
+            workspaceID: workspaceID,
+            revisions: snapshot.revisions,
+            digest: snapshot.document.contentDigest,
+            health: snapshot.health,
+            catalogRevision: domainWorkspaceCatalogRevision
+        )
+        return authorityIssue(
+            workspaceID: workspaceID,
+            operation: "agent_admission",
+            health: snapshot.health
+        )
     }
 
     private static func isSuccessfulDomainOutcome(_ outcome: DomainCommandOutcome) -> Bool {
@@ -4164,6 +4370,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         fileURLsByWorkspaceID: [UUID: URL],
         revisionsByWorkspaceID: [UUID: DomainRevisionState],
         digestsByWorkspaceID: [UUID: String],
+        healthByWorkspaceID: [UUID: DomainAuthorityHealth],
         catalogRevision: UInt64,
         preferredActiveWorkspaceID: UUID?,
         publicationSequence: UInt64
@@ -4182,6 +4389,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             domainWorkspaceFileURLsByID = fileURLsByWorkspaceID
             domainWorkspaceRevisionsByID = revisionsByWorkspaceID
             domainWorkspaceDigestsByID = digestsByWorkspaceID
+            domainWorkspaceHealthByID = healthByWorkspaceID
             domainWorkspaceCatalogRevision = catalogRevision
         } else {
             let trackedWorkspaceIDs = Set(confirmedDomainReadRegistrationsByWorkspaceID.keys)
@@ -4199,6 +4407,27 @@ class WorkspaceManagerViewModel: ObservableObject {
         } else if !projectedWorkspaces.contains(where: { $0.id == activeWorkspaceID }) {
             activeWorkspaceID = projectedWorkspaces.first?.id
         }
+        synchronizeDomainAuthorityIssueForActiveWorkspace(operation: "authority_projection")
+    }
+
+    func applyDomainAuthorityMetadataProjection(
+        revisionsByWorkspaceID: [UUID: DomainRevisionState],
+        digestsByWorkspaceID: [UUID: String],
+        healthByWorkspaceID: [UUID: DomainAuthorityHealth],
+        catalogRevision: UInt64,
+        publicationSequence: UInt64
+    ) {
+        guard publicationSequence >= lastDomainProjectionSequence else { return }
+        lastDomainProjectionSequence = publicationSequence
+        invalidateConfirmedDomainReadRegistrations(
+            previousDigestsByWorkspaceID: domainWorkspaceDigestsByID,
+            projectedDigestsByWorkspaceID: digestsByWorkspaceID
+        )
+        domainWorkspaceRevisionsByID = revisionsByWorkspaceID
+        domainWorkspaceDigestsByID = digestsByWorkspaceID
+        domainWorkspaceHealthByID = healthByWorkspaceID
+        domainWorkspaceCatalogRevision = catalogRevision
+        synchronizeDomainAuthorityIssueForActiveWorkspace(operation: "authority_health_projection")
     }
 
     func collectComposeTabSnapshot(name: String, base: ComposeTabState? = nil) -> ComposeTabState {
@@ -8030,6 +8259,9 @@ class WorkspaceManagerViewModel: ObservableObject {
                 return result.savedStateVersion
             } catch is CancellationError {
                 return nil
+            } catch let error as DomainWorkspaceAuthorityOperationError {
+                reportDomainAuthorityIssue(error.outcome, operation: "save_workspace")
+                return nil
             } catch {
                 reportDomainAuthorityFailure(
                     error,
@@ -8074,7 +8306,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 }
 
                 let diskWorkspace: WorkspaceModel? = if fm.fileExists(atPath: fileURL.path) {
-                    try? Self.loadWorkspaceFromFile(at: fileURL)
+                    try? Self.loadWorkspaceFromFile(at: fileURL, scheduleNormalizationWriteback: false)
                 } else {
                     nil
                 }
@@ -8201,7 +8433,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
         let mergeResult = await Task.detached(priority: .utility) {
             let diskWorkspace: WorkspaceModel? = if FileManager.default.fileExists(atPath: targetURL.path) {
-                try? Self.loadWorkspaceFromFile(at: targetURL)
+                try? Self.loadWorkspaceFromFile(at: targetURL, scheduleNormalizationWriteback: false)
             } else {
                 nil
             }
@@ -8269,11 +8501,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
         applyDomainAuthorityOutcome(outcome, workspaceID: workspaceToSave.id)
         guard Self.isSuccessfulDomainOutcome(outcome) else {
-            throw NSError(
-                domain: "RepoPrompt.DomainWorkspaceAuthority",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: outcome.diagnostic ?? outcome.disposition.rawValue]
-            )
+            throw DomainWorkspaceAuthorityOperationError(outcome: outcome)
         }
 
         if let index = workspaceIndex(for: workspaceToSave.id) {
@@ -8333,7 +8561,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         if preserveDiskRepoPathsIfUnchangedSinceBaseline,
            FileManager.default.fileExists(atPath: targetURL.path)
         {
-            let diskWorkspace = try? Self.loadWorkspaceFromFile(at: targetURL)
+            let diskWorkspace = try? Self.loadWorkspaceFromFile(at: targetURL, scheduleNormalizationWriteback: false)
             let mergeResult = Self.workspaceForSavePreservingDiskRepoPaths(
                 current: workspace,
                 diskWorkspace: diskWorkspace,
@@ -8373,13 +8601,25 @@ class WorkspaceManagerViewModel: ObservableObject {
         return finalURL
     }
 
-    nonisolated func saveWorkspaceToFileAsync(_ workspace: WorkspaceModel, baseRoot: URL, metadata: WorkspaceSavePayloadMetadata? = nil) async throws -> URL {
-        // Encode JSON
-        let encoded = try JSONEncoder().encode(workspace)
+    func saveWorkspaceToFileAsync(
+        _ workspace: WorkspaceModel,
+        baseRoot: URL,
+        metadata: WorkspaceSavePayloadMetadata? = nil
+    ) async throws -> URL {
+        let finalURL = workspaceFileURL(for: workspace, baseRoot: baseRoot)
+        guard domainWorkspaceAuthorityClient == nil else {
+            WorkspaceSaveTracer.event(
+                "workspaceSave.direct.denied",
+                metadata: metadata ?? workspaceSaveMetadata(for: workspace, source: .directUnknown),
+                url: finalURL,
+                extra: ["reason": "domain_authority_required"]
+            )
+            throw WorkspaceDirectWriteError.domainAuthorityRequired
+        }
 
-        // Prepare file path
-        let folder = try ensureWorkspaceDirectoryExists(for: workspace, baseRoot: baseRoot)
-        let finalURL = folder.appendingPathComponent("workspace.json")
+        // Encode JSON only after the authority check so a denied writer has no side effects.
+        let encoded = try JSONEncoder().encode(workspace)
+        _ = try ensureWorkspaceDirectoryExists(for: workspace, baseRoot: baseRoot)
 
         // Enqueue write to shared disk writer for serialization
         WorkspaceFileDecodeCache.shared.invalidate(url: finalURL)
@@ -8431,7 +8671,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     nonisolated static func loadWorkspaceFromFileResult(
         at fileURL: URL,
-        scheduleNormalizationWriteback: Bool = true
+        scheduleNormalizationWriteback: Bool
     ) throws -> WorkspaceFileLoadResult {
         let cachedResult = try WorkspaceFileDecodeCache.shared.loadWorkspace(at: fileURL)
         let normalizationSaveTask: Task<Void, Never>?
@@ -8477,13 +8717,25 @@ class WorkspaceManagerViewModel: ObservableObject {
         )
     }
 
-    nonisolated static func loadWorkspaceFromFile(at fileURL: URL) throws -> WorkspaceModel {
-        try loadWorkspaceFromFileResult(at: fileURL).workspace
+    nonisolated static func loadWorkspaceFromFile(
+        at fileURL: URL,
+        scheduleNormalizationWriteback: Bool
+    ) throws -> WorkspaceModel {
+        try loadWorkspaceFromFileResult(
+            at: fileURL,
+            scheduleNormalizationWriteback: scheduleNormalizationWriteback
+        ).workspace
     }
 
-    nonisolated static func loadWorkspaceFromFileAsync(at fileURL: URL) async throws -> WorkspaceModel {
+    nonisolated static func loadWorkspaceFromFileAsync(
+        at fileURL: URL,
+        scheduleNormalizationWriteback: Bool
+    ) async throws -> WorkspaceModel {
         try await Task.detached(priority: .utility) {
-            try Self.loadWorkspaceFromFile(at: fileURL)
+            try Self.loadWorkspaceFromFile(
+                at: fileURL,
+                scheduleNormalizationWriteback: scheduleNormalizationWriteback
+            )
         }.value
     }
 

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -4417,6 +4417,9 @@ class WorkspaceManagerViewModel: ObservableObject {
         } else if !projectedWorkspaces.contains(where: { $0.id == activeWorkspaceID }) {
             activeWorkspaceID = projectedWorkspaces.first?.id
         }
+        if domainWorkspaceAuthorityIssue?.kind == .projectionFailure {
+            publishDomainAuthorityIssueIfChanged(nil)
+        }
         synchronizeDomainAuthorityIssueForActiveWorkspace(operation: "authority_projection")
     }
 

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -642,6 +642,16 @@ class WorkspaceManagerViewModel: ObservableObject {
             lastSyncedRepoPathsByWorkspaceID[workspaceID]
         }
 
+        func debugDomainAuthorityBaseline(
+            for workspaceID: UUID
+        ) -> (revisions: DomainRevisionState?, digest: String?, health: DomainAuthorityHealth?) {
+            (
+                domainWorkspaceRevisionsByID[workspaceID],
+                domainWorkspaceDigestsByID[workspaceID],
+                domainWorkspaceHealthByID[workspaceID]
+            )
+        }
+
         func debugPublishWorkingDocumentToDomainAuthority(_ workspace: WorkspaceModel) async {
             publishWorkingDocumentToDomainAuthority(workspace)
             await debugAwaitWorkingDocumentCommitToDomainAuthority(workspaceID: workspace.id)
@@ -4338,7 +4348,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     func domainAuthorityAdmissionIssue(for workspaceID: UUID) async -> DomainWorkspaceAuthorityIssue? {
         guard let domainWorkspaceAuthorityClient else { return nil }
-        guard let snapshot = await domainWorkspaceAuthorityClient.store.workspaceSnapshot(workspaceID) else {
+        guard let snapshot = await domainWorkspaceAuthorityClient.canonicalWorkspaceSnapshot(workspaceID) else {
             return authorityIssue(
                 workspaceID: workspaceID,
                 operation: "agent_admission",

--- a/Sources/RepoPrompt/Features/Workspaces/Views/WorkspaceAuthorityRecoveryBanner.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/Views/WorkspaceAuthorityRecoveryBanner.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Window-level recovery for workspace authority failures. The manager remains the sole UI
+/// projection of domain health; this view never inspects or mutates workspace files directly.
+struct WorkspaceAuthorityRecoveryBanner: View {
+    @ObservedObject var workspaceManager: WorkspaceManagerViewModel
+
+    @State private var isResolving = false
+    @State private var confirmUseExternal = false
+    @State private var actionError: String?
+
+    var body: some View {
+        if let issue = visibleIssue {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(title(for: issue))
+                            .font(.callout.weight(.semibold))
+                        Text(issue.message)
+                            .font(.callout)
+                            .fixedSize(horizontal: false, vertical: true)
+                        if let reason = issue.reason {
+                            Text("Reason: \(reason)")
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                        if let diagnostic = issue.diagnostic,
+                           diagnostic != issue.reason
+                        {
+                            Text(diagnostic)
+                                .font(.caption)
+                                .foregroundStyle(.red)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                    Spacer(minLength: 0)
+                }
+
+                if let actionError {
+                    Text(actionError)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack {
+                    if issue.canResolveExternalConflict,
+                       let workspaceID = issue.workspaceID
+                    {
+                        Button("Keep Local") {
+                            resolve(workspaceID: workspaceID, acceptExternal: false)
+                        }
+                        .disabled(isResolving)
+                        .hoverTooltip("Keep RepoPrompt's local working state; the next save replaces the external file")
+
+                        Button("Use External…") {
+                            confirmUseExternal = true
+                        }
+                        .buttonStyle(.borderless)
+                        .disabled(isResolving)
+                        .confirmationDialog(
+                            "Use externally saved workspace state?",
+                            isPresented: $confirmUseExternal,
+                            titleVisibility: .visible
+                        ) {
+                            Button("Use External", role: .destructive) {
+                                resolve(workspaceID: workspaceID, acceptExternal: true)
+                            }
+                            Button("Cancel", role: .cancel) {}
+                        } message: {
+                            Text("Local dirty workspace changes will be discarded. RepoPrompt will refuse this action if it would remove or rebind a live or pinned Agent tab.")
+                        }
+                    } else if issue.kind == .degradedReadOnly || issue.kind == .commandFailure {
+                        Button("Retry") {
+                            refresh()
+                        }
+                        .disabled(isResolving)
+                    }
+                    if isResolving {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                Color(nsColor: .windowBackgroundColor),
+                in: RoundedRectangle(cornerRadius: 8)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.orange.opacity(0.8), lineWidth: 1)
+            }
+            .overlay(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(.orange)
+                    .frame(width: 4)
+                    .padding(.vertical, 6)
+            }
+            .padding(.horizontal)
+            .padding(.top, 6)
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    private var visibleIssue: DomainWorkspaceAuthorityIssue? {
+        guard let issue = workspaceManager.domainWorkspaceAuthorityIssue else { return nil }
+        guard issue.workspaceID == nil || issue.workspaceID == workspaceManager.activeWorkspaceID else {
+            return nil
+        }
+        return issue
+    }
+
+    private func title(for issue: DomainWorkspaceAuthorityIssue) -> String {
+        switch issue.kind {
+        case .externalConflict: "Workspace changes need a decision"
+        case .degradedReadOnly: "Workspace is read-only"
+        case .removed: "Workspace is unavailable"
+        case .commandFailure: "Workspace change failed"
+        case .projectionFailure: "Workspace state could not be displayed"
+        }
+    }
+
+    private func resolve(workspaceID: UUID, acceptExternal: Bool) {
+        isResolving = true
+        actionError = nil
+        Task { @MainActor in
+            let resolved = await workspaceManager.resolveDomainWorkspaceConflict(
+                workspaceID: workspaceID,
+                acceptExternal: acceptExternal
+            )
+            if !resolved {
+                actionError = workspaceManager.domainWorkspaceAuthorityIssue?.diagnostic
+                    ?? "The workspace conflict could not be resolved. No state was changed."
+            }
+            isResolving = false
+        }
+    }
+
+    private func refresh() {
+        isResolving = true
+        actionError = nil
+        Task { @MainActor in
+            await workspaceManager.refreshDomainWorkspaceAuthority()
+            isResolving = false
+        }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
@@ -183,6 +183,12 @@ private let agentRunExpiredHandleRecoveryNote = [
 struct AgentRunMCPToolService {
     typealias RequestMetadata = MCPServerViewModel.RequestMetadata
     typealias HeartbeatOperation = @Sendable () async throws -> Value
+
+    static func requireWritableWorkspaceAuthority(_ issue: DomainWorkspaceAuthorityIssue?) throws {
+        guard let issue else { return }
+        throw MCPError.invalidParams(issue.agentAdmissionMessage)
+    }
+
     typealias StartRun = @MainActor (
         _ target: AgentModeViewModel.MCPSessionTarget,
         _ message: String,
@@ -331,6 +337,9 @@ struct AgentRunMCPToolService {
         guard workspace.isSystemWorkspace == false else {
             throw MCPError.invalidParams("Cannot start an agent run from the default system workspace. Open or select a project workspace and try again.")
         }
+        try await Self.requireWritableWorkspaceAuthority(
+            targetWindow.workspaceManager.domainAuthorityAdmissionIssue(for: workspace.id)
+        )
 
         let agentModeVM = targetWindow.agentModeViewModel
         let parentSourceTabID = await resolveSpawnParentSourceTabID(metadata)
@@ -632,6 +641,9 @@ struct AgentRunMCPToolService {
         #endif
         let outcome: AgentExternalMCPRunStarter.StartOutcome
         do {
+            try await Self.requireWritableWorkspaceAuthority(
+                targetWindow.workspaceManager.domainAuthorityAdmissionIssue(for: workspace.id)
+            )
             WorktreeStartupInstrumentation.record(.providerStart, context: worktreeStartupContext)
             #if DEBUG
                 if worktreeStartupBenchmarkToken != nil {

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppShared/DomainWorkspacePresentationBridge.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppShared/DomainWorkspacePresentationBridge.swift
@@ -21,6 +21,10 @@ struct DomainWorkspaceAuthorityClient {
         await store.snapshot()
     }
 
+    func canonicalWorkspaceSnapshot(_ workspaceID: UUID) async -> DomainWorkspaceSnapshot? {
+        await store.canonicalWorkspaceSnapshot(workspaceID)
+    }
+
     /// Awaited read-registration seam for current app state. Unlike create/replace/save, this is
     /// transient and therefore also supports ephemeral and focused-test workspaces.
     func registerForRead(

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppShared/DomainWorkspacePresentationBridge.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppShared/DomainWorkspacePresentationBridge.swift
@@ -116,6 +116,7 @@ struct DomainWorkspaceAuthorityClient {
     func resolveConflict(
         workspaceID: UUID,
         acceptExternal: Bool,
+        protectedAgentIdentities: [DomainProtectedAgentIdentity],
         expectedWorkspaceRevision: UInt64?,
         operationID: UUID = UUID()
     ) async -> DomainCommandOutcome {
@@ -125,7 +126,8 @@ struct DomainWorkspaceAuthorityClient {
             origin: .appPresentation(windowID: windowID),
             command: .resolveExternalConflict(
                 workspaceID: workspaceID,
-                acceptExternal: acceptExternal
+                acceptExternal: acceptExternal,
+                protectedAgentIdentities: protectedAgentIdentities
             )
         ))
     }
@@ -170,6 +172,7 @@ final class DomainWorkspacePresentationBridge {
     private var subscriptionTask: Task<Void, Never>?
     private var lastPublicationSequence: UInt64 = 0
     private var projectedDigests: [UUID: String] = [:]
+    private var projectedHealth: [UUID: DomainAuthorityHealth] = [:]
     private var projectedModels: [UUID: WorkspaceModel] = [:]
 
     init(workspaceManager: WorkspaceManagerViewModel, client: DomainWorkspaceAuthorityClient) {
@@ -185,6 +188,7 @@ final class DomainWorkspacePresentationBridge {
         subscriptionTask?.cancel()
         subscriptionTask = nil
         projectedDigests.removeAll(keepingCapacity: false)
+        projectedHealth.removeAll(keepingCapacity: false)
         projectedModels.removeAll(keepingCapacity: false)
     }
 
@@ -258,7 +262,7 @@ final class DomainWorkspacePresentationBridge {
         let snapshot = await client.snapshot()
         project(
             snapshot,
-            force: gap || event.kind == .externalReloaded || event.kind == .degraded
+            force: gap || event.kind == .externalReloaded
         )
     }
 
@@ -282,10 +286,12 @@ final class DomainWorkspacePresentationBridge {
         else { return false }
         projectedModels[workspaceID] = model
         projectedDigests[workspaceID] = workspace.document.contentDigest
+        projectedHealth[workspaceID] = workspace.health
         workspaceManager?.applyDomainAuthorityBaseline(
             workspaceID: workspaceID,
             revisions: workspace.revisions,
             digest: workspace.document.contentDigest,
+            health: workspace.health,
             catalogRevision: event.catalogRevision
         )
         lastPublicationSequence = event.sequence
@@ -299,22 +305,32 @@ final class DomainWorkspacePresentationBridge {
         let nextDigests = Dictionary(uniqueKeysWithValues: snapshot.workspaces.map {
             ($0.document.workspaceID, $0.document.contentDigest)
         })
+        let nextHealth = Dictionary(uniqueKeysWithValues: snapshot.workspaces.map {
+            ($0.document.workspaceID, $0.health)
+        })
+        let revisions = Dictionary(uniqueKeysWithValues: snapshot.workspaces.map {
+            ($0.document.workspaceID, $0.revisions)
+        })
         let changedIDs = Set(snapshot.workspaces.compactMap { workspace -> UUID? in
             projectedDigests[workspace.document.workspaceID] == workspace.document.contentDigest
                 ? nil
                 : workspace.document.workspaceID
         })
         let removedIDs = Set(projectedModels.keys).subtracting(nextDigests.keys)
-        guard force || !changedIDs.isEmpty || !removedIDs.isEmpty else {
-            for workspace in snapshot.workspaces {
-                workspaceManager?.applyDomainAuthorityBaseline(
-                    workspaceID: workspace.document.workspaceID,
-                    revisions: workspace.revisions,
-                    digest: workspace.document.contentDigest,
-                    catalogRevision: snapshot.catalogRevision
-                )
-            }
+        let requiresModelProjection = !changedIDs.isEmpty
+            || !removedIDs.isEmpty
+            || (force && projectedModels.isEmpty && !snapshot.workspaces.isEmpty)
+        guard requiresModelProjection else {
+            projectedDigests = nextDigests
+            projectedHealth = nextHealth
             lastPublicationSequence = snapshot.publicationSequence
+            workspaceManager?.applyDomainAuthorityMetadataProjection(
+                revisionsByWorkspaceID: revisions,
+                digestsByWorkspaceID: nextDigests,
+                healthByWorkspaceID: nextHealth,
+                catalogRevision: snapshot.catalogRevision,
+                publicationSequence: snapshot.publicationSequence
+            )
             return
         }
 
@@ -343,16 +359,16 @@ final class DomainWorkspacePresentationBridge {
         }
         projectedModels = nextModels
         projectedDigests = nextDigests
+        projectedHealth = nextHealth
         lastPublicationSequence = snapshot.publicationSequence
         workspaceManager?.applyDomainWorkspaceProjection(
             decoded,
             fileURLsByWorkspaceID: Dictionary(uniqueKeysWithValues: snapshot.workspaces.map {
                 ($0.document.workspaceID, $0.document.fileURL)
             }),
-            revisionsByWorkspaceID: Dictionary(uniqueKeysWithValues: snapshot.workspaces.map {
-                ($0.document.workspaceID, $0.revisions)
-            }),
+            revisionsByWorkspaceID: revisions,
             digestsByWorkspaceID: nextDigests,
+            healthByWorkspaceID: nextHealth,
             catalogRevision: snapshot.catalogRevision,
             preferredActiveWorkspaceID: workspaceManager?.activeWorkspaceID,
             publicationSequence: snapshot.publicationSequence

--- a/Sources/RepoPromptDomainRuntime/DomainWorkspaceCommand.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainWorkspaceCommand.swift
@@ -23,7 +23,11 @@ package enum DomainWorkspaceCommand: Codable, Equatable, Sendable {
     case replaceWorkingDocument(DomainWorkspaceDocument)
     case saveWorkspaceDocument(workspaceID: UUID)
     case deleteWorkspace(workspaceID: UUID)
-    case resolveExternalConflict(workspaceID: UUID, acceptExternal: Bool)
+    case resolveExternalConflict(
+        workspaceID: UUID,
+        acceptExternal: Bool,
+        protectedAgentIdentities: [DomainProtectedAgentIdentity]
+    )
 }
 
 package struct DomainWorkspaceCommandEnvelope: Codable, Equatable, Sendable {
@@ -67,8 +71,23 @@ package struct DomainWorkspaceCommandEnvelope: Codable, Equatable, Sendable {
             components += ["save", workspaceID.uuidString]
         case let .deleteWorkspace(workspaceID):
             components += ["delete", workspaceID.uuidString]
-        case let .resolveExternalConflict(workspaceID, acceptExternal):
+        case let .resolveExternalConflict(workspaceID, acceptExternal, protectedAgentIdentities):
             components += ["resolve", workspaceID.uuidString, acceptExternal ? "external" : "local"]
+            components += protectedAgentIdentities
+                .sorted {
+                    if $0.location.rawValue != $1.location.rawValue {
+                        return $0.location.rawValue < $1.location.rawValue
+                    }
+                    return $0.tabID.uuidString < $1.tabID.uuidString
+                }
+                .flatMap {
+                    [
+                        $0.location.rawValue,
+                        $0.tabID.uuidString,
+                        $0.activeAgentSessionID?.uuidString ?? "nil",
+                        $0.isPinned ? "pinned" : "unpinned"
+                    ]
+                }
         }
         let canonical = components.map { "\($0.utf8.count):\($0)" }.joined(separator: "|")
         return DomainContentDigest.sha256(Data(canonical.utf8))
@@ -88,6 +107,9 @@ package enum DomainCommandDisposition: String, Codable, Sendable {
 package enum DomainCommandErrorCode: String, Codable, Sendable {
     case stateConflict = "state_conflict"
     case runtimeReadOnlyDegraded = "runtime_read_only_degraded"
+    case workspaceExternalConflict = "workspace_external_conflict"
+    case workspaceReadOnlyDegraded = "workspace_read_only_degraded"
+    case protectedAgentIdentityConflict = "protected_agent_identity_conflict"
     case operationIDCollision = "operation_id_collision"
     case workspaceUnavailable = "workspace_unavailable"
     case invalidDocument = "invalid_document"

--- a/Sources/RepoPromptDomainRuntime/DomainWorkspaceContextAuthority.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainWorkspaceContextAuthority.swift
@@ -352,10 +352,11 @@ actor DomainWorkspaceContextAuthority {
             await replaceWorkingDocument(document, envelope: envelope, fingerprint: fingerprint)
         case let .saveWorkspaceDocument(workspaceID):
             await saveWorkspace(workspaceID, envelope: envelope, fingerprint: fingerprint)
-        case let .resolveExternalConflict(workspaceID, acceptExternal):
+        case let .resolveExternalConflict(workspaceID, acceptExternal, protectedAgentIdentities):
             await resolveExternalConflict(
                 workspaceID,
                 acceptExternal: acceptExternal,
+                protectedAgentIdentities: protectedAgentIdentities,
                 envelope: envelope,
                 fingerprint: fingerprint
             )
@@ -997,12 +998,7 @@ actor DomainWorkspaceContextAuthority {
             )
         }
         guard record.health.acceptsMutations else {
-            return recordTransientOutcome(
-                envelope: envelope,
-                disposition: .readOnly,
-                errorCode: .runtimeReadOnlyDegraded,
-                diagnostic: "workspace_not_writable"
-            )
+            return healthRejectionOutcome(envelope, record: record)
         }
         if let expected = envelope.expectedWorkspaceRevision,
            expected != record.revisions.workingRevision
@@ -1091,12 +1087,7 @@ actor DomainWorkspaceContextAuthority {
         }
         if var record = records[document.workspaceID] {
             guard record.health.acceptsMutations else {
-                return recordTransientOutcome(
-                    envelope: envelope,
-                    disposition: .readOnly,
-                    errorCode: .runtimeReadOnlyDegraded,
-                    diagnostic: "workspace_not_writable"
-                )
+                return healthRejectionOutcome(envelope, record: record)
             }
             if let expected = envelope.expectedWorkspaceRevision,
                expected != record.revisions.workingRevision
@@ -1234,12 +1225,7 @@ actor DomainWorkspaceContextAuthority {
             )
         }
         guard record.health.acceptsMutations else {
-            return recordTransientOutcome(
-                envelope: envelope,
-                disposition: .readOnly,
-                errorCode: .runtimeReadOnlyDegraded,
-                diagnostic: "workspace_not_writable"
-            )
+            return healthRejectionOutcome(envelope, record: record)
         }
         if let expected = envelope.expectedWorkspaceRevision,
            expected != record.revisions.workingRevision
@@ -1339,11 +1325,7 @@ actor DomainWorkspaceContextAuthority {
                         diagnostic: eventDiagnostic
                     )
                 }
-                return conflictOutcome(
-                    envelope,
-                    record: current,
-                    diagnostic: "external_document_conflict"
-                )
+                return healthRejectionOutcome(envelope, record: current)
             }
             return persistenceFailureOutcome(envelope, record: record, error: error)
         } catch {
@@ -1374,6 +1356,7 @@ actor DomainWorkspaceContextAuthority {
     private func resolveExternalConflict(
         _ workspaceID: UUID,
         acceptExternal: Bool,
+        protectedAgentIdentities: [DomainProtectedAgentIdentity],
         envelope: DomainWorkspaceCommandEnvelope,
         fingerprint: String
     ) async -> DomainCommandOutcome {
@@ -1393,6 +1376,20 @@ actor DomainWorkspaceContextAuthority {
            expected != before.workingRevision
         {
             return conflictOutcome(envelope, record: record, diagnostic: "workspace_revision_mismatch")
+        }
+        if acceptExternal,
+           let diagnostic = Self.protectedAgentIdentityConflict(
+               local: record.document,
+               external: external,
+               callerClaims: protectedAgentIdentities
+           )
+        {
+            return recordTransientOutcome(
+                envelope: envelope,
+                disposition: .conflict,
+                errorCode: .protectedAgentIdentityConflict,
+                diagnostic: diagnostic
+            )
         }
         let now = Date()
         let after = acceptExternal
@@ -1613,6 +1610,103 @@ actor DomainWorkspaceContextAuthority {
         unavailableWorkspaces.removeValue(forKey: workspaceID)
     }
 
+    private func healthRejectionOutcome(
+        _ envelope: DomainWorkspaceCommandEnvelope,
+        record: WorkspaceRecord
+    ) -> DomainCommandOutcome {
+        let disposition: DomainCommandDisposition
+        let errorCode: DomainCommandErrorCode
+        let diagnostic: String
+        switch record.health {
+        case .writable:
+            return recordTransientOutcome(
+                envelope: envelope,
+                disposition: .failed,
+                errorCode: .persistenceFailure,
+                diagnostic: "unexpected_writable_health_rejection"
+            )
+        case let .externalConflict(reason):
+            disposition = .conflict
+            errorCode = .workspaceExternalConflict
+            diagnostic = reason
+        case let .degradedReadOnly(reason):
+            disposition = .readOnly
+            errorCode = .workspaceReadOnlyDegraded
+            diagnostic = reason
+        case .removed:
+            disposition = .invalid
+            errorCode = .workspaceUnavailable
+            diagnostic = "workspace_removed"
+        }
+        return recordTransientOutcome(
+            envelope: envelope,
+            disposition: disposition,
+            errorCode: errorCode,
+            diagnostic: diagnostic
+        )
+    }
+
+    private static func protectedAgentIdentityConflict(
+        local: DomainWorkspaceDocument,
+        external: DomainWorkspaceDocument,
+        callerClaims: [DomainProtectedAgentIdentity]
+    ) -> String? {
+        var protectedByTabID = Dictionary(
+            uniqueKeysWithValues: local.metadata.agentIdentityClaims
+                .filter(\.requiresProtection)
+                .map { ($0.tabID, $0) }
+        )
+        for callerClaim in callerClaims where callerClaim.requiresProtection {
+            if let existing = protectedByTabID[callerClaim.tabID] {
+                guard existing.location == callerClaim.location else {
+                    return "protected_agent_identity_precondition_mismatch"
+                }
+                if let existingSessionID = existing.activeAgentSessionID,
+                   let callerSessionID = callerClaim.activeAgentSessionID,
+                   existingSessionID != callerSessionID
+                {
+                    return "protected_agent_identity_precondition_mismatch"
+                }
+                protectedByTabID[callerClaim.tabID] = DomainProtectedAgentIdentity(
+                    tabID: callerClaim.tabID,
+                    location: existing.location,
+                    activeAgentSessionID: callerClaim.activeAgentSessionID ?? existing.activeAgentSessionID,
+                    isPinned: existing.isPinned || callerClaim.isPinned
+                )
+            } else {
+                protectedByTabID[callerClaim.tabID] = callerClaim
+            }
+        }
+
+        let externalByTabID = Dictionary(
+            uniqueKeysWithValues: external.metadata.agentIdentityClaims.map { ($0.tabID, $0) }
+        )
+        let sessionCounts = Dictionary(
+            grouping: external.metadata.agentIdentityClaims.compactMap(\.activeAgentSessionID),
+            by: { $0 }
+        ).mapValues(\.count)
+        for claim in protectedByTabID.values {
+            guard let candidate = externalByTabID[claim.tabID] else {
+                return "protected_agent_identity_missing"
+            }
+            guard candidate.location == claim.location else {
+                return "protected_agent_identity_location_changed"
+            }
+            guard candidate.activeAgentSessionID == claim.activeAgentSessionID else {
+                return "protected_agent_identity_rebound"
+            }
+            guard !claim.isPinned || candidate.isPinned else {
+                return "protected_agent_identity_unpinned"
+            }
+            if let sessionID = claim.activeAgentSessionID,
+               sessionCounts[sessionID] != 1
+            {
+                return "protected_agent_identity_duplicated"
+            }
+        }
+        return nil
+    }
+
     private func conflictOutcome(
         _ envelope: DomainWorkspaceCommandEnvelope,
         record: WorkspaceRecord,
@@ -1813,7 +1907,7 @@ private extension DomainWorkspaceCommandEnvelope {
         case let .replaceWorkingDocument(document): document.workspaceID
         case let .saveWorkspaceDocument(workspaceID): workspaceID
         case let .deleteWorkspace(workspaceID): workspaceID
-        case let .resolveExternalConflict(workspaceID, _): workspaceID
+            case let .resolveExternalConflict(workspaceID, _, _): workspaceID
         }
     }
 }

--- a/Sources/RepoPromptDomainRuntime/DomainWorkspaceContextAuthority.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainWorkspaceContextAuthority.swift
@@ -42,6 +42,12 @@ package struct DomainWorkspaceStore {
     package func workspaceSnapshot(_ workspaceID: UUID) async -> DomainWorkspaceSnapshot? {
         await authority.workspaceSnapshot(workspaceID)
     }
+
+    /// Returns only persisted command-authority state. Read registrations are routing overlays and
+    /// must not influence mutation admission, recovery CAS baselines, or authority health.
+    package func canonicalWorkspaceSnapshot(_ workspaceID: UUID) async -> DomainWorkspaceSnapshot? {
+        await authority.canonicalWorkspaceSnapshot(workspaceID)
+    }
 }
 
 package struct DomainContextStore {
@@ -222,9 +228,9 @@ actor DomainWorkspaceContextAuthority {
         readRegistrations[workspaceID] ?? records[workspaceID].map(makeSnapshot)
     }
 
-    /// Command outcomes must report canonical record state; the read overlay is routing-only and
-    /// must never leak into dedup replay or transient-outcome revision lines.
-    private func canonicalWorkspaceSnapshot(_ workspaceID: UUID) -> DomainWorkspaceSnapshot? {
+    /// Command outcomes and mutation admission must report canonical record state; the read
+    /// overlay is routing-only and must never leak into recovery health or revision baselines.
+    func canonicalWorkspaceSnapshot(_ workspaceID: UUID) -> DomainWorkspaceSnapshot? {
         records[workspaceID].map(makeSnapshot)
     }
 

--- a/Sources/RepoPromptDomainRuntime/DomainWorkspaceModels.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainWorkspaceModels.swift
@@ -48,6 +48,45 @@ package enum DomainAuthorityHealth: Codable, Equatable {
         if case .writable = self { return true }
         return false
     }
+
+    package var reason: String? {
+        switch self {
+        case .writable:
+            nil
+        case let .externalConflict(reason), let .degradedReadOnly(reason):
+            reason
+        case .removed:
+            "workspace_removed"
+        }
+    }
+}
+
+package enum DomainWorkspaceTabLocation: String, Codable, Equatable, Hashable, Sendable {
+    case composed
+    case stashed
+}
+
+package struct DomainProtectedAgentIdentity: Codable, Equatable, Hashable, Sendable {
+    package let tabID: UUID
+    package let location: DomainWorkspaceTabLocation
+    package let activeAgentSessionID: UUID?
+    package let isPinned: Bool
+
+    package init(
+        tabID: UUID,
+        location: DomainWorkspaceTabLocation,
+        activeAgentSessionID: UUID?,
+        isPinned: Bool
+    ) {
+        self.tabID = tabID
+        self.location = location
+        self.activeAgentSessionID = activeAgentSessionID
+        self.isPinned = isPinned
+    }
+
+    package var requiresProtection: Bool {
+        activeAgentSessionID != nil || isPinned
+    }
 }
 
 package struct DomainContextMetadata: Codable, Equatable {
@@ -86,6 +125,7 @@ package struct DomainWorkspaceMetadata: Codable, Equatable {
     package let isEphemeral: Bool
     package let activeContextID: UUID?
     package let contexts: [DomainContextMetadata]
+    package let agentIdentityClaims: [DomainProtectedAgentIdentity]
 
     package init(
         workspaceID: UUID,
@@ -97,7 +137,8 @@ package struct DomainWorkspaceMetadata: Codable, Equatable {
         isHiddenInMenus: Bool,
         isEphemeral: Bool,
         activeContextID: UUID?,
-        contexts: [DomainContextMetadata]
+        contexts: [DomainContextMetadata],
+        agentIdentityClaims: [DomainProtectedAgentIdentity] = []
     ) {
         self.workspaceID = workspaceID
         self.schemaVersion = schemaVersion
@@ -109,6 +150,7 @@ package struct DomainWorkspaceMetadata: Codable, Equatable {
         self.isEphemeral = isEphemeral
         self.activeContextID = activeContextID
         self.contexts = contexts
+        self.agentIdentityClaims = agentIdentityClaims
     }
 }
 
@@ -236,6 +278,7 @@ private enum DomainWorkspaceDocumentDecoder {
             throw DomainWorkspaceDocumentError.futureSchema(schemaVersion)
         }
         var contextIDs = Set<UUID>()
+        var agentIdentityClaims: [DomainProtectedAgentIdentity] = []
         let contexts = try ((object["composeTabs"] as? [Any]) ?? []).map { raw -> DomainContextMetadata in
             guard let context = raw as? [String: Any],
                   let contextIDString = context["id"] as? String,
@@ -246,6 +289,12 @@ private enum DomainWorkspaceDocumentDecoder {
             guard contextIDs.insert(contextID).inserted else {
                 throw DomainWorkspaceDocumentError.invalidContext(contextID)
             }
+            agentIdentityClaims.append(DomainProtectedAgentIdentity(
+                tabID: contextID,
+                location: .composed,
+                activeAgentSessionID: (context["activeAgentSessionID"] as? String).flatMap(UUID.init(uuidString:)),
+                isPinned: context["isPinned"] as? Bool ?? false
+            ))
             let bytes = try JSONSerialization.data(withJSONObject: context, options: [.sortedKeys])
             return DomainContextMetadata(
                 identity: DomainContextIdentity(workspaceID: workspaceID, contextID: contextID),
@@ -255,6 +304,24 @@ private enum DomainWorkspaceDocumentDecoder {
                 documentBytes: bytes,
                 contentDigest: DomainContentDigest.sha256(bytes)
             )
+        }
+        for raw in (object["stashedTabs"] as? [Any]) ?? [] {
+            guard let stashed = raw as? [String: Any],
+                  let tab = stashed["tab"] as? [String: Any],
+                  let tabIDString = tab["id"] as? String,
+                  let tabID = UUID(uuidString: tabIDString)
+            else {
+                throw DomainWorkspaceDocumentError.invalidContext(nil)
+            }
+            guard contextIDs.insert(tabID).inserted else {
+                throw DomainWorkspaceDocumentError.invalidContext(tabID)
+            }
+            agentIdentityClaims.append(DomainProtectedAgentIdentity(
+                tabID: tabID,
+                location: .stashed,
+                activeAgentSessionID: (tab["activeAgentSessionID"] as? String).flatMap(UUID.init(uuidString:)),
+                isPinned: tab["isPinned"] as? Bool ?? false
+            ))
         }
         let customStoragePath: URL? = if let raw = object["customStoragePath"] as? String {
             URL(string: raw) ?? URL(fileURLWithPath: raw)
@@ -271,7 +338,8 @@ private enum DomainWorkspaceDocumentDecoder {
             isHiddenInMenus: object["isHiddenInMenus"] as? Bool ?? false,
             isEphemeral: object["ephemeralFlag"] as? Bool ?? false,
             activeContextID: (object["activeComposeTabID"] as? String).flatMap(UUID.init(uuidString:)),
-            contexts: contexts
+            contexts: contexts,
+            agentIdentityClaims: agentIdentityClaims
         )
     }
 }

--- a/Sources/RepoPromptDomainRuntime/DomainWorkspaceModels.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainWorkspaceModels.swift
@@ -305,17 +305,16 @@ private enum DomainWorkspaceDocumentDecoder {
                 contentDigest: DomainContentDigest.sha256(bytes)
             )
         }
+        // WorkspaceModel treats stashed tabs as recoverable compatibility data: malformed arrays
+        // decode as empty and composed/stashed ID collisions are removed during normalization.
+        // Mirror that behavior for identity claims instead of making the whole workspace unreadable.
         for raw in (object["stashedTabs"] as? [Any]) ?? [] {
             guard let stashed = raw as? [String: Any],
                   let tab = stashed["tab"] as? [String: Any],
                   let tabIDString = tab["id"] as? String,
-                  let tabID = UUID(uuidString: tabIDString)
-            else {
-                throw DomainWorkspaceDocumentError.invalidContext(nil)
-            }
-            guard contextIDs.insert(tabID).inserted else {
-                throw DomainWorkspaceDocumentError.invalidContext(tabID)
-            }
+                  let tabID = UUID(uuidString: tabIDString),
+                  contextIDs.insert(tabID).inserted
+            else { continue }
             agentIdentityClaims.append(DomainProtectedAgentIdentity(
                 tabID: tabID,
                 location: .stashed,

--- a/Tests/RepoPromptDomainRuntimeTests/DomainWorkspaceContextAuthorityTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainWorkspaceContextAuthorityTests.swift
@@ -625,31 +625,56 @@ final class DomainWorkspaceContextAuthorityTests: XCTestCase {
         try conflictingExternal.documentBytes.write(to: fixture.workspaceFile, options: .atomic)
         await runtime.workspaceStore.reloadExternalChanges()
         snapshot = await runtime.workspaceStore.snapshot().workspaces.first
-        if case .externalConflict = snapshot?.health {
-            // Expected.
-        } else {
-            XCTFail("Dirty workspace did not enter external-conflict state")
-        }
+        XCTAssertEqual(
+            snapshot?.health,
+            .externalConflict(reason: "saved_document_changed_while_working_state_dirty")
+        )
         XCTAssertEqual(snapshot?.document.documentBytes, working.documentBytes)
 
-        let rebase = await runtime.workspaceStore.execute(.init(
+        let rejectedMutation = await runtime.workspaceStore.execute(.init(
             operationID: UUID(),
             expectedWorkspaceRevision: snapshot?.revisions.workingRevision,
             origin: .standalone,
-            command: .resolveExternalConflict(workspaceID: fixture.workspaceID, acceptExternal: false)
+            command: .replaceWorkingDocument(try fixture.document(prompt: "blocked mutation"))
         ))
-        XCTAssertEqual(rebase.disposition, .applied)
-        XCTAssertEqual(rebase.workspace?.health, .writable)
-        XCTAssertNotNil(rebase.after?.dirtyRevision)
+        XCTAssertEqual(rejectedMutation.disposition, .conflict)
+        XCTAssertEqual(rejectedMutation.errorCode, .workspaceExternalConflict)
+        XCTAssertEqual(rejectedMutation.diagnostic, "saved_document_changed_while_working_state_dirty")
         _ = await runtime.shutdown()
 
         let restarted = fixture.runtime(generation: 2)
         try await restarted.start()
-        let recovered = await restarted.workspaceStore.snapshot().workspaces.first
+        await restarted.workspaceStore.reloadExternalChanges()
+        let restartedConflict = await restarted.workspaceStore.snapshot().workspaces.first
+        XCTAssertEqual(restartedConflict?.document.documentBytes, working.documentBytes)
+        XCTAssertEqual(
+            restartedConflict?.health,
+            .externalConflict(reason: "saved_document_changed_while_working_state_dirty")
+        )
+        XCTAssertNotNil(restartedConflict?.revisions.dirtyRevision)
+
+        let rebase = await restarted.workspaceStore.execute(.init(
+            operationID: UUID(),
+            expectedWorkspaceRevision: restartedConflict?.revisions.workingRevision,
+            origin: .standalone,
+            command: .resolveExternalConflict(
+                workspaceID: fixture.workspaceID,
+                acceptExternal: false,
+                protectedAgentIdentities: []
+            )
+        ))
+        XCTAssertEqual(rebase.disposition, .applied)
+        XCTAssertEqual(rebase.workspace?.health, .writable)
+        XCTAssertNotNil(rebase.after?.dirtyRevision)
+        _ = await restarted.shutdown()
+
+        let recoveredRuntime = fixture.runtime(generation: 3)
+        try await recoveredRuntime.start()
+        let recovered = await recoveredRuntime.workspaceStore.snapshot().workspaces.first
         XCTAssertEqual(recovered?.document.documentBytes, working.documentBytes)
         XCTAssertEqual(recovered?.health, .writable)
         XCTAssertNotNil(recovered?.revisions.dirtyRevision)
-        let save = await restarted.workspaceStore.execute(.init(
+        let save = await recoveredRuntime.workspaceStore.execute(.init(
             operationID: UUID(),
             expectedWorkspaceRevision: recovered?.revisions.workingRevision,
             origin: .standalone,
@@ -657,6 +682,137 @@ final class DomainWorkspaceContextAuthorityTests: XCTestCase {
         ))
         XCTAssertEqual(save.disposition, .applied)
         XCTAssertEqual(try Data(contentsOf: fixture.workspaceFile), working.documentBytes)
+    }
+
+    func testAcceptExternalRejectsAgentIdentityLossWithoutChangingConflictState() async throws {
+        let fixture = try Fixture.make()
+        defer { fixture.remove() }
+        let runtime = fixture.runtime()
+        try await runtime.start()
+
+        let initialCatalog = await runtime.workspaceStore.snapshot()
+        let initial = try XCTUnwrap(initialCatalog.workspaces.first)
+        let sessionID = UUID()
+        let local = try fixture.agentDocument(
+            prompt: "local live agent",
+            activeAgentSessionID: sessionID,
+            isPinned: true,
+            location: .composed
+        )
+        let working = await runtime.workspaceStore.execute(.init(
+            operationID: UUID(),
+            expectedWorkspaceRevision: initial.revisions.workingRevision,
+            origin: .standalone,
+            command: .replaceWorkingDocument(local)
+        ))
+        XCTAssertEqual(working.disposition, .applied)
+
+        let external = try fixture.agentDocument(
+            prompt: "external moved agent",
+            activeAgentSessionID: sessionID,
+            isPinned: true,
+            location: .stashed
+        )
+        try external.documentBytes.write(to: fixture.workspaceFile, options: .atomic)
+        await runtime.workspaceStore.reloadExternalChanges()
+        let conflictCatalog = await runtime.workspaceStore.snapshot()
+        let conflicted = try XCTUnwrap(conflictCatalog.workspaces.first)
+        XCTAssertEqual(
+            conflicted.health,
+            .externalConflict(reason: "saved_document_changed_while_working_state_dirty")
+        )
+
+        let rejected = await runtime.workspaceStore.execute(.init(
+            operationID: UUID(),
+            expectedWorkspaceRevision: conflicted.revisions.workingRevision,
+            origin: .standalone,
+            command: .resolveExternalConflict(
+                workspaceID: fixture.workspaceID,
+                acceptExternal: true,
+                protectedAgentIdentities: []
+            )
+        ))
+        XCTAssertEqual(rejected.disposition, .conflict)
+        XCTAssertEqual(rejected.errorCode, .protectedAgentIdentityConflict)
+        XCTAssertEqual(rejected.diagnostic, "protected_agent_identity_location_changed")
+        let unchangedCatalog = await runtime.workspaceStore.snapshot()
+        let unchanged = try XCTUnwrap(unchangedCatalog.workspaces.first)
+        XCTAssertEqual(unchanged.document.documentBytes, local.documentBytes)
+        XCTAssertEqual(unchanged.health, conflicted.health)
+        XCTAssertEqual(try Data(contentsOf: fixture.workspaceFile), external.documentBytes)
+
+        let keepLocal = await runtime.workspaceStore.execute(.init(
+            operationID: UUID(),
+            expectedWorkspaceRevision: unchanged.revisions.workingRevision,
+            origin: .standalone,
+            command: .resolveExternalConflict(
+                workspaceID: fixture.workspaceID,
+                acceptExternal: false,
+                protectedAgentIdentities: []
+            )
+        ))
+        XCTAssertEqual(keepLocal.disposition, .applied)
+        XCTAssertEqual(keepLocal.workspace?.document.metadata.agentIdentityClaims, local.metadata.agentIdentityClaims)
+    }
+
+    func testAcceptExternalPreservesCompatibleAgentIdentityAcrossRestart() async throws {
+        let fixture = try Fixture.make()
+        defer { fixture.remove() }
+        let runtime = fixture.runtime()
+        try await runtime.start()
+
+        let initialCatalog = await runtime.workspaceStore.snapshot()
+        let initial = try XCTUnwrap(initialCatalog.workspaces.first)
+        let sessionID = UUID()
+        let local = try fixture.agentDocument(
+            prompt: "local live agent",
+            activeAgentSessionID: sessionID,
+            isPinned: true,
+            location: .composed
+        )
+        let working = await runtime.workspaceStore.execute(.init(
+            operationID: UUID(),
+            expectedWorkspaceRevision: initial.revisions.workingRevision,
+            origin: .standalone,
+            command: .replaceWorkingDocument(local)
+        ))
+        XCTAssertEqual(working.disposition, .applied)
+
+        let external = try fixture.agentDocument(
+            prompt: "compatible external state",
+            activeAgentSessionID: sessionID,
+            isPinned: true,
+            location: .composed
+        )
+        try external.documentBytes.write(to: fixture.workspaceFile, options: .atomic)
+        await runtime.workspaceStore.reloadExternalChanges()
+        let conflictCatalog = await runtime.workspaceStore.snapshot()
+        let conflicted = try XCTUnwrap(conflictCatalog.workspaces.first)
+        let accepted = await runtime.workspaceStore.execute(.init(
+            operationID: UUID(),
+            expectedWorkspaceRevision: conflicted.revisions.workingRevision,
+            origin: .standalone,
+            command: .resolveExternalConflict(
+                workspaceID: fixture.workspaceID,
+                acceptExternal: true,
+                protectedAgentIdentities: []
+            )
+        ))
+        XCTAssertEqual(accepted.disposition, .applied)
+        XCTAssertEqual(accepted.workspace?.health, .writable)
+        XCTAssertNil(accepted.after?.dirtyRevision)
+        XCTAssertEqual(accepted.workspace?.document.documentBytes, external.documentBytes)
+        XCTAssertEqual(accepted.workspace?.document.metadata.agentIdentityClaims, external.metadata.agentIdentityClaims)
+        _ = await runtime.shutdown()
+
+        let restarted = fixture.runtime(generation: 2)
+        try await restarted.start()
+        let recoveredCatalog = await restarted.workspaceStore.snapshot()
+        let recovered = try XCTUnwrap(recoveredCatalog.workspaces.first)
+        XCTAssertEqual(recovered.health, .writable)
+        XCTAssertNil(recovered.revisions.dirtyRevision)
+        XCTAssertEqual(recovered.document.documentBytes, external.documentBytes)
+        XCTAssertEqual(recovered.document.metadata.agentIdentityClaims, external.metadata.agentIdentityClaims)
     }
 
     func testSaveTimeExternalConflictCapturesResolvableDocument() async throws {
@@ -696,7 +852,11 @@ final class DomainWorkspaceContextAuthorityTests: XCTestCase {
             operationID: UUID(),
             expectedWorkspaceRevision: conflictSnapshot.revisions.workingRevision,
             origin: .standalone,
-            command: .resolveExternalConflict(workspaceID: fixture.workspaceID, acceptExternal: false)
+            command: .resolveExternalConflict(
+                workspaceID: fixture.workspaceID,
+                acceptExternal: false,
+                protectedAgentIdentities: []
+            )
         ))
         XCTAssertEqual(resolved.disposition, .applied)
         XCTAssertEqual(resolved.workspace?.health, .writable)
@@ -903,7 +1063,8 @@ final class DomainWorkspaceContextAuthorityTests: XCTestCase {
             command: .replaceWorkingDocument(fixture.document(prompt: "must not apply"))
         ))
         XCTAssertEqual(rejected.disposition, .readOnly)
-        XCTAssertEqual(rejected.errorCode, .runtimeReadOnlyDegraded)
+        XCTAssertEqual(rejected.errorCode, .workspaceReadOnlyDegraded)
+        XCTAssertEqual(rejected.diagnostic, workspace?.health.reason)
     }
 
     func testTwoWindowCaptureRevisionConflictPreventsLostUpdate() async throws {
@@ -1657,6 +1818,43 @@ private struct Fixture {
         ]
         let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
         return try DomainWorkspaceDocument.decode(documentBytes: data, fileURL: fileURL)
+    }
+
+    func agentDocument(
+        prompt: String,
+        activeAgentSessionID: UUID,
+        isPinned: Bool,
+        location: DomainWorkspaceTabLocation
+    ) throws -> DomainWorkspaceDocument {
+        let tab: [String: Any] = [
+            "id": contextID.uuidString,
+            "name": "Context",
+            "prompt": prompt,
+            "activeAgentSessionID": activeAgentSessionID.uuidString,
+            "isPinned": isPinned
+        ]
+        var object: [String: Any] = [
+            "id": workspaceID.uuidString,
+            "schemaVersion": 1,
+            "name": workspaceName,
+            "repoPaths": ["/tmp/repo"],
+            "isSystemWorkspace": false,
+            "isHiddenInMenus": false,
+            "composeTabs": []
+        ]
+        switch location {
+        case .composed:
+            object["activeComposeTabID"] = contextID.uuidString
+            object["composeTabs"] = [tab]
+        case .stashed:
+            object["stashedTabs"] = [[
+                "id": UUID().uuidString,
+                "tab": tab,
+                "stashedAt": "2026-08-06T00:00:00Z"
+            ]]
+        }
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return try DomainWorkspaceDocument.decode(documentBytes: data, fileURL: workspaceFile)
     }
 
     func remove() {

--- a/Tests/RepoPromptDomainRuntimeTests/DomainWorkspaceContextAuthorityTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainWorkspaceContextAuthorityTests.swift
@@ -86,6 +86,12 @@ final class DomainWorkspaceContextAuthorityTests: XCTestCase {
             canonicalDocument.contentDigest,
             "Fixture must produce a divergent overlay digest for the assertion to be meaningful."
         )
+        let canonicalWhileOverlayActive = await runtime.workspaceStore.canonicalWorkspaceSnapshot(
+            fixture.workspaceID
+        )
+        XCTAssertEqual(canonicalWhileOverlayActive?.document.contentDigest, canonicalDocument.contentDigest)
+        XCTAssertEqual(canonicalWhileOverlayActive?.revisions, created.workspace?.revisions)
+        XCTAssertEqual(canonicalWhileOverlayActive?.health, .writable)
 
         // Transient outcome path: a catalog-revision conflict is recorded while the overlay shadows
         // read routing. The outcome must still report canonical record state.
@@ -813,6 +819,38 @@ final class DomainWorkspaceContextAuthorityTests: XCTestCase {
         XCTAssertNil(recovered.revisions.dirtyRevision)
         XCTAssertEqual(recovered.document.documentBytes, external.documentBytes)
         XCTAssertEqual(recovered.document.metadata.agentIdentityClaims, external.metadata.agentIdentityClaims)
+    }
+
+    func testDomainDecodeIgnoresMalformedAndComposedDuplicateStashedIdentityClaims() throws {
+        let fixture = try Fixture.make()
+        defer { fixture.remove() }
+        let sessionID = UUID()
+        let composed = try fixture.agentDocument(
+            prompt: "composed agent",
+            activeAgentSessionID: sessionID,
+            isPinned: true,
+            location: .composed
+        )
+        var object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: composed.documentBytes) as? [String: Any]
+        )
+        let composedTab = try XCTUnwrap((object["composeTabs"] as? [[String: Any]])?.first)
+        object["stashedTabs"] = [
+            ["malformed": true],
+            [
+                "id": UUID().uuidString,
+                "tab": composedTab,
+                "stashedAt": 0
+            ]
+        ]
+        let bytes = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+
+        let decoded = try DomainWorkspaceDocument.decode(
+            documentBytes: bytes,
+            fileURL: fixture.workspaceFile
+        )
+
+        XCTAssertEqual(decoded.metadata.agentIdentityClaims, composed.metadata.agentIdentityClaims)
     }
 
     func testSaveTimeExternalConflictCapturesResolvableDocument() async throws {

--- a/Tests/RepoPromptTests/MCP/AgentRunWorkspaceAuthorityAdmissionTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorkspaceAuthorityAdmissionTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import MCP
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class AgentRunWorkspaceAuthorityAdmissionTests: XCTestCase {
+    func testExternalConflictBlocksAdmissionWithPreciseRecoveryMessage() throws {
+        let reason = "saved_document_changed_while_working_state_dirty"
+        let issue = DomainWorkspaceAuthorityIssue(
+            workspaceID: UUID(),
+            operation: "externalReload",
+            kind: .externalConflict,
+            reason: reason
+        )
+
+        XCTAssertThrowsError(try AgentRunMCPToolService.requireWritableWorkspaceAuthority(issue)) { error in
+            XCTAssertEqual(
+                String(describing: error),
+                "[-32602] Invalid params: [workspace_external_conflict] agent_run.start blocked: \(reason). Resolve the workspace with Keep Local or Use External, then retry."
+            )
+        }
+    }
+
+    func testWritableWorkspaceAllowsAdmission() throws {
+        XCTAssertNoThrow(try AgentRunMCPToolService.requireWritableWorkspaceAuthority(nil))
+    }
+}

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -324,6 +324,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             fileURLsByWorkspaceID: [:],
             revisionsByWorkspaceID: [:],
             digestsByWorkspaceID: [:],
+            healthByWorkspaceID: [:],
             catalogRevision: 1,
             preferredActiveWorkspaceID: currentWorkspace.id,
             publicationSequence: 1

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSavePreparationTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSavePreparationTests.swift
@@ -721,6 +721,43 @@ import XCTest
             XCTAssertTrue(issue.agentAdmissionMessage.contains("Keep Local"))
             XCTAssertTrue(issue.agentAdmissionMessage.contains("Use External"))
             XCTAssertTrue(issue.canResolveExternalConflict)
+
+            let canonicalBaseline = manager.debugDomainAuthorityBaseline(for: workspaceID)
+            XCTAssertEqual(canonicalBaseline.revisions, conflictedSnapshot.revisions)
+            XCTAssertEqual(canonicalBaseline.digest, conflictedSnapshot.document.contentDigest)
+            XCTAssertEqual(canonicalBaseline.health, conflictedSnapshot.health)
+
+            var readOverlay = localDirty
+            readOverlay.currentPromptText = "transient read-routing overlay"
+            let readOverlayDocument = try DomainWorkspaceDocument.decode(
+                documentBytes: JSONEncoder().encode(readOverlay),
+                fileURL: savedDocument.document.fileURL
+            )
+            let registeredOverlay = await runtime.workspaceStore.registerReadDocument(readOverlayDocument)
+            XCTAssertEqual(registeredOverlay.health, .writable)
+            XCTAssertNotEqual(registeredOverlay.revisions, conflictedSnapshot.revisions)
+            XCTAssertNotEqual(registeredOverlay.document.contentDigest, conflictedSnapshot.document.contentDigest)
+            let routedOverlay = await runtime.contextStore.workspaceSnapshot(workspaceID)
+            XCTAssertEqual(routedOverlay?.document.contentDigest, readOverlayDocument.contentDigest)
+
+            let admissionResult = await manager.domainAuthorityAdmissionIssue(for: workspaceID)
+            let admissionIssue = try XCTUnwrap(admissionResult)
+            XCTAssertEqual(admissionIssue.kind, .externalConflict)
+            XCTAssertEqual(admissionIssue.reason, "saved_document_changed_while_working_state_dirty")
+            XCTAssertEqual(admissionIssue.stableCode, "workspace_external_conflict")
+            let retainedIssue = try XCTUnwrap(manager.domainWorkspaceAuthorityIssue)
+            XCTAssertEqual(retainedIssue.kind, .externalConflict)
+            XCTAssertEqual(retainedIssue.reason, "saved_document_changed_while_working_state_dirty")
+
+            let baselineAfterAdmission = manager.debugDomainAuthorityBaseline(for: workspaceID)
+            XCTAssertEqual(baselineAfterAdmission.revisions, conflictedSnapshot.revisions)
+            XCTAssertEqual(baselineAfterAdmission.digest, conflictedSnapshot.document.contentDigest)
+            XCTAssertEqual(baselineAfterAdmission.health, conflictedSnapshot.health)
+            let canonicalAfterAdmission = await runtime.workspaceStore.canonicalWorkspaceSnapshot(workspaceID)
+            XCTAssertEqual(canonicalAfterAdmission?.revisions, conflictedSnapshot.revisions)
+            XCTAssertEqual(canonicalAfterAdmission?.document.contentDigest, conflictedSnapshot.document.contentDigest)
+            XCTAssertEqual(canonicalAfterAdmission?.health, conflictedSnapshot.health)
+
             let conflictResolved = await manager.resolveDomainWorkspaceConflict(
                 workspaceID: workspaceID,
                 acceptExternal: true

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSavePreparationTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSavePreparationTests.swift
@@ -187,6 +187,12 @@ import XCTest
             // End-to-end: a domain projection publication re-validates the cache through the same
             // seam. Without an authority client this composition conservatively clears it.
             try confirmRegistration()
+            manager.reportDomainProjectionFailure(NSError(
+                domain: "WorkspaceSavePreparationTests",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "transient projection failure"]
+            ))
+            XCTAssertEqual(manager.domainWorkspaceAuthorityIssue?.kind, .projectionFailure)
             manager.applyDomainWorkspaceProjection(
                 [workspace],
                 fileURLsByWorkspaceID: [workspace.id: fileURL],
@@ -200,6 +206,10 @@ import XCTest
             XCTAssertNotNil(
                 manager.domainReadRegistrationToken(for: workspace, fileURL: fileURL),
                 "A projected catalog publication must invalidate confirmed read registrations."
+            )
+            XCTAssertNil(
+                manager.domainWorkspaceAuthorityIssue,
+                "A successful full-model projection must clear its stale projection failure."
             )
         }
 
@@ -757,6 +767,17 @@ import XCTest
             XCTAssertEqual(canonicalAfterAdmission?.revisions, conflictedSnapshot.revisions)
             XCTAssertEqual(canonicalAfterAdmission?.document.contentDigest, conflictedSnapshot.document.contentDigest)
             XCTAssertEqual(canonicalAfterAdmission?.health, conflictedSnapshot.health)
+
+            manager.reportDomainAuthorityFailure(
+                NSError(
+                    domain: "WorkspaceSavePreparationTests",
+                    code: 4,
+                    userInfo: [NSLocalizedDescriptionKey: "transient command failure"]
+                ),
+                workspaceID: workspaceID,
+                operation: "test_command_failure"
+            )
+            XCTAssertEqual(manager.domainWorkspaceAuthorityIssue?.kind, .commandFailure)
 
             let conflictResolved = await manager.resolveDomainWorkspaceConflict(
                 workspaceID: workspaceID,

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSavePreparationTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSavePreparationTests.swift
@@ -78,7 +78,7 @@ import XCTest
             await saveTask.value
             manager.setWorkspaceSavePreparationDidFinishHandlerForTesting(nil)
 
-            let savedA = try WorkspaceManagerViewModel.loadWorkspaceFromFile(at: arrival.fileURL)
+            let savedA = try WorkspaceManagerViewModel.loadWorkspaceFromFile(at: arrival.fileURL, scheduleNormalizationWriteback: false)
             XCTAssertEqual(savedA.id, workspaceA.id)
             XCTAssertFalse(FileManager.default.fileExists(atPath: manager.workspaceFileURL(for: workspaceB).path))
         }
@@ -192,6 +192,7 @@ import XCTest
                 fileURLsByWorkspaceID: [workspace.id: fileURL],
                 revisionsByWorkspaceID: [:],
                 digestsByWorkspaceID: [workspace.id: "digest-c"],
+                healthByWorkspaceID: [workspace.id: .writable],
                 catalogRevision: 1,
                 preferredActiveWorkspaceID: workspace.id,
                 publicationSequence: 1
@@ -318,7 +319,8 @@ import XCTest
             let diagnostics = manager.workspaceSaveDiagnosticsForTesting(workspaceID: workspace.id)
             XCTAssertEqual(diagnostics.attemptCount, 2)
             let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(
-                at: manager.workspaceFileURL(for: workspace)
+                at: manager.workspaceFileURL(for: workspace),
+                scheduleNormalizationWriteback: false
             )
             XCTAssertEqual(saved.currentPromptText, "newer state")
             XCTAssertEqual(
@@ -635,6 +637,15 @@ import XCTest
             XCTAssertEqual(decoded.currentPromptText, "newer runtime state")
             XCTAssertEqual(decoded.repoPaths, ["/tmp/runtime-baseline"])
 
+            let deniedDirectWriteRoot = root.appendingPathComponent("DeniedDirectWrite", isDirectory: true)
+            do {
+                _ = try await manager.saveWorkspaceToFileAsync(decoded, baseRoot: deniedDirectWriteRoot)
+                XCTFail("A domain-owned workspace must reject the legacy direct writer")
+            } catch {
+                XCTAssertTrue(error.localizedDescription.contains("domain workspace authority"))
+            }
+            XCTAssertFalse(FileManager.default.fileExists(atPath: deniedDirectWriteRoot.path))
+
             let staleID = UUID()
             let staleIndex: [[String: Any]] = [[
                 "id": staleID.uuidString,
@@ -673,11 +684,17 @@ import XCTest
             XCTAssertEqual(dirtySnapshot.revisions.dirtyRevision, dirtySnapshot.revisions.workingRevision)
             var external = decoded
             external.currentPromptText = "external accepted state"
+            let projectedPromptBeforeConflict = manager.workspaces.first(where: { $0.id == workspaceID })?.currentPromptText
             try JSONEncoder().encode(external).write(
                 to: savedDocument.document.fileURL,
                 options: .atomic
             )
-            await manager.refreshDomainWorkspaceAuthority()
+            await runtime.workspaceStore.reloadExternalChanges()
+            let conflictCatalog = await runtime.workspaceStore.snapshot()
+            let conflictProjectionCompleted = await presentationBridge.waitUntilProjected(
+                through: conflictCatalog.publicationSequence
+            )
+            XCTAssertTrue(conflictProjectionCompleted)
             let conflictedSnapshot = try await waitForDomainWorkspace(
                 runtime,
                 workspaceID: workspaceID,
@@ -686,11 +703,23 @@ import XCTest
                 if case .externalConflict = snapshot.health { return true }
                 return false
             }
-            guard case .externalConflict = conflictedSnapshot.health else {
-                return XCTFail("Expected an authoritative external conflict")
-            }
+            XCTAssertEqual(
+                conflictedSnapshot.health,
+                .externalConflict(reason: "saved_document_changed_while_working_state_dirty")
+            )
+            XCTAssertEqual(
+                manager.workspaces.first(where: { $0.id == workspaceID })?.currentPromptText,
+                projectedPromptBeforeConflict,
+                "A health-only projection must not replace the dirty live workspace model."
+            )
             let issue = try XCTUnwrap(manager.domainWorkspaceAuthorityIssue)
             XCTAssertEqual(issue.workspaceID, workspaceID)
+            XCTAssertEqual(issue.kind, .externalConflict)
+            XCTAssertEqual(issue.reason, "saved_document_changed_while_working_state_dirty")
+            XCTAssertEqual(issue.stableCode, "workspace_external_conflict")
+            XCTAssertTrue(issue.agentAdmissionMessage.contains("saved_document_changed_while_working_state_dirty"))
+            XCTAssertTrue(issue.agentAdmissionMessage.contains("Keep Local"))
+            XCTAssertTrue(issue.agentAdmissionMessage.contains("Use External"))
             XCTAssertTrue(issue.canResolveExternalConflict)
             let conflictResolved = await manager.resolveDomainWorkspaceConflict(
                 workspaceID: workspaceID,

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
@@ -728,7 +728,7 @@ final class WorkspaceSwitchRecoveryTests: XCTestCase {
         try await Task.sleep(nanoseconds: 250_000_000)
         await manager.pollAndSaveStateAsync()
         let workspaceURL = manager.workspaceFileURL(for: fixture.workspace)
-        let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(at: workspaceURL)
+        let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(at: workspaceURL, scheduleNormalizationWriteback: false)
         let savedTab = try XCTUnwrap(saved.composeTabs.first(where: { $0.id == fixture.tabID }))
         XCTAssertFalse(savedTab.selection.selectedPaths.isEmpty)
         XCTAssertEqual(savedTab.selection, fixture.selection)
@@ -755,7 +755,7 @@ final class WorkspaceSwitchRecoveryTests: XCTestCase {
             try await Task.sleep(nanoseconds: 250_000_000)
             await manager.pollAndSaveStateAsync()
             let workspaceURL = manager.workspaceFileURL(for: fixture.workspace)
-            let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(at: workspaceURL)
+            let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(at: workspaceURL, scheduleNormalizationWriteback: false)
             let savedTab = try XCTUnwrap(saved.composeTabs.first(where: { $0.id == fixture.tabID }))
             XCTAssertFalse(savedTab.selection.selectedPaths.isEmpty)
             XCTAssertEqual(savedTab.selection, fixture.selection)
@@ -852,7 +852,8 @@ final class WorkspaceSwitchRecoveryTests: XCTestCase {
         manager.markWorkspaceDirty()
         await manager.pollAndSaveStateAsync()
         let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(
-            at: manager.workspaceFileURL(for: workspace)
+            at: manager.workspaceFileURL(for: workspace),
+            scheduleNormalizationWriteback: false
         )
         XCTAssertEqual(
             try Set(XCTUnwrap(saved.composeTabs.first(where: { $0.id == tabID })).selection.selectedPaths),


### PR DESCRIPTION
## Summary

- preserve structured workspace authority health through manager, UI, and MCP error paths
- add explicit Keep Local and Use External recovery for restart-persistent external conflicts
- protect live and pinned Agent identities during recovery
- block non-authoritative runtime workspace writes and make normalization writeback explicit
- use canonical authority state for Agent admission instead of writable read-routing overlays
- tolerate malformed or duplicate stashed identity claims consistently with existing workspace normalization

Closes #743.

## Root cause

A dirty journal plus a divergent `workspace.json` correctly enters fail-closed external-conflict health. The precise health reason was then collapsed into `workspace_not_writable`, health-only changes could be hidden by document-oriented projection, and no safe recovery UI was reachable. A read-registration overlay could additionally report synthetic writable health during Agent admission and overwrite canonical recovery baselines.

The historical second writer remains unattributed; this change does not claim PR #742 caused it.

## Validation

- `DomainWorkspaceContextAuthorityTests`: 29 passed
- `WorkspaceSavePreparationTests`: 14 passed
- `AgentRunWorkspaceAuthorityAdmissionTests`: 2 passed
- SwiftFormat: clean
- strict Swift lint: passed
- `swift build --product RepoPrompt`: passed
- contribution commit and push preflights: passed
- independent Fable 5 High review completed; its must-fix canonical-overlay finding was resolved with regression coverage

### PR-ready full-suite note

The path-selected PR-ready lane passed guardrails and lint, but its 43-minute full root suite reported failures in four unrelated Codemap, durable-artifact, and headless-transport tests. Each reported failure passed when rerun individually through conductor:

- `CodemapBindingEngineManifestWriteTests/testDeferredCapRetainsOldestPrefixShedsNewestSuffixAndKeepsPipelineDirty`
- `CodeMapRootManifestStoreTests/testLogicalAccessEvictionKeepsHotOldManifestOverColdNewManifest`
- `DirectHeadlessStdioTransportTests/testParentProcessChangeAndReadFailureHaveExplicitProvenance`
- `DurableArtifactIdentityLeaseGCTests/testCatalogMarksProtectObjectsAndMarkLossOnlyProducesCacheMiss`

No visible-app smoke was run.
