### PR TITLE
Harden legacy defaults collection during startup

### DIFF
--- a/Sources/RepoPrompt/App/AppDomainRuntimeComposition.swift
+++ b/Sources/RepoPrompt/App/AppDomainRuntimeComposition.swift
@@ -29,7 +29,30 @@ private enum AppDomainRuntimeMetrics {
 final class AppDomainRuntimeComposition: Sendable {
     static let shared = AppDomainRuntimeComposition()
 
+    private static let legacyRuntimeDefaultKeys = [
+        "workspace.approvalSettings",
+        "agentModeAutoEditEnabled"
+    ]
+
     let runtime: MCPDomainRuntime
+
+    static func collectLegacyRuntimeDefaults(from defaults: UserDefaults) -> [String: Data] {
+        var collected: [String: Data] = [:]
+        for key in legacyRuntimeDefaultKeys {
+            guard let value = defaults.object(forKey: key) else { continue }
+            if let data = value as? Data {
+                collected[key] = data
+            } else if JSONSerialization.isValidJSONObject(["v": value]),
+                      let data = try? JSONSerialization.data(
+                          withJSONObject: value,
+                          options: .fragmentsAllowed
+                      )
+            {
+                collected[key] = data
+            }
+        }
+        return collected
+    }
 
     private init() {
         let applicationSupport = FileManager.default.urls(
@@ -37,22 +60,13 @@ final class AppDomainRuntimeComposition: Sendable {
             in: .userDomainMask
         ).first ?? FileManager.default.temporaryDirectory
         let root = applicationSupport.appendingPathComponent("RepoPrompt CE", isDirectory: true)
-        var legacyRuntimeDefaults: [String: Data] = [:]
         let defaults = UserDefaults.standard
         let customStoragePath = defaults.string(forKey: "GlobalCustomStorageURL")
+        var legacyRuntimeDefaults = Self.collectLegacyRuntimeDefaults(from: defaults)
         if let customStoragePath,
            let bytes = try? JSONEncoder().encode(customStoragePath)
         {
             legacyRuntimeDefaults["GlobalCustomStorageURL"] = bytes
-        }
-        for key in ["workspace.approvalSettings", "agentModeAutoEditEnabled"] {
-            if let data = defaults.data(forKey: key) {
-                legacyRuntimeDefaults[key] = data
-            } else if defaults.object(forKey: key) != nil,
-                      let data = try? JSONSerialization.data(withJSONObject: defaults.object(forKey: key) as Any)
-            {
-                legacyRuntimeDefaults[key] = data
-            }
         }
         let workspaceStorageDirectory = customStoragePath.map {
             URL(fileURLWithPath: $0, isDirectory: true)

--- a/Tests/RepoPromptTests/App/AppDomainRuntimeCompositionTests.swift
+++ b/Tests/RepoPromptTests/App/AppDomainRuntimeCompositionTests.swift
@@ -1,0 +1,57 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class AppDomainRuntimeCompositionTests: XCTestCase {
+    func testCollectLegacyRuntimeDefaultsSerializesBooleanScalarFragments() throws {
+        for value in [true, false] {
+            let (defaults, suiteName) = try makeIsolatedDefaults()
+            defer { defaults.removePersistentDomain(forName: suiteName) }
+            defaults.set(value, forKey: "agentModeAutoEditEnabled")
+
+            let collected = AppDomainRuntimeComposition.collectLegacyRuntimeDefaults(from: defaults)
+            let data = try XCTUnwrap(collected["agentModeAutoEditEnabled"])
+
+            XCTAssertEqual(try JSONDecoder().decode(Bool.self, from: data), value)
+            XCTAssertEqual(String(decoding: data, as: UTF8.self), value ? "true" : "false")
+        }
+    }
+
+    func testCollectLegacyRuntimeDefaultsPreservesRawDataAlongsideBoolean() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let approvalBytes = Data([0x00, 0xFF, 0x7B, 0x01])
+        defaults.set(approvalBytes, forKey: "workspace.approvalSettings")
+        defaults.set(false, forKey: "agentModeAutoEditEnabled")
+
+        let collected = AppDomainRuntimeComposition.collectLegacyRuntimeDefaults(from: defaults)
+
+        XCTAssertEqual(collected["workspace.approvalSettings"], approvalBytes)
+        let booleanData = try XCTUnwrap(collected["agentModeAutoEditEnabled"])
+        XCTAssertFalse(try JSONDecoder().decode(Bool.self, from: booleanData))
+    }
+
+    func testCollectLegacyRuntimeDefaultsSkipsInvalidValueWithoutMutationAndIsRepeatable() throws {
+        let (defaults, suiteName) = try makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let invalidDate = Date(timeIntervalSince1970: 1_725_000_000)
+        defaults.set(invalidDate, forKey: "workspace.approvalSettings")
+        defaults.set(true, forKey: "agentModeAutoEditEnabled")
+
+        let first = AppDomainRuntimeComposition.collectLegacyRuntimeDefaults(from: defaults)
+        let second = AppDomainRuntimeComposition.collectLegacyRuntimeDefaults(from: defaults)
+
+        XCTAssertEqual(first, second)
+        XCTAssertNil(first["workspace.approvalSettings"])
+        let booleanData = try XCTUnwrap(first["agentModeAutoEditEnabled"])
+        XCTAssertTrue(try JSONDecoder().decode(Bool.self, from: booleanData))
+        XCTAssertEqual(defaults.object(forKey: "workspace.approvalSettings") as? Date, invalidDate)
+        XCTAssertEqual(defaults.object(forKey: "agentModeAutoEditEnabled") as? Bool, true)
+    }
+
+    private func makeIsolatedDefaults() throws -> (defaults: UserDefaults, suiteName: String) {
+        let suiteName = "AppDomainRuntimeCompositionTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+}


### PR DESCRIPTION
## Summary

- harden legacy `UserDefaults` collection during app-domain startup
- preserve stored `Data` byte-for-byte and serialize valid scalar fragments safely
- skip only invalid rollback entries without mutating source defaults
- add focused upgrade regression coverage for both Boolean values, mixed raw data, invalid sibling values, repeatability, and non-mutation

## Root cause

Pre-v1.2 releases stored `agentModeAutoEditEnabled` as a Boolean. v1.2.0 collected that value during startup with `JSONSerialization.data(withJSONObject:)` but without `.fragmentsAllowed`, causing an uncaught `NSInvalidArgumentException` before initialization completed.

This implements the hardened scope from the issue investigation handoff rather than deleting caches or the defaults domain.

## Validation

- `make dev-test FILTER=AppDomainRuntimeCompositionTests` — 3 passed, 0 failures
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `make dev-lint` — passed
- commit and push contribution preflights — passed
- Oracle review — no actionable findings
- full PR-ready root suite — reached the local 3,600-second conductor limit while tests were still progressing; no test failure was reported before timeout, so hosted CI remains the full-suite authority

Closes #715.

Supersedes #718.
