### PR TITLE
Fix transcript signature cleanup after instrumentation locking

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
@@ -258,11 +258,11 @@ struct AgentConversationReplaySerialization: Equatable {
 
         static func removeRefreshInputSignatures(for tabIDs: Set<UUID>) {
             guard !tabIDs.isEmpty else { return }
-            refreshSignatureLock.lock()
-            for tabID in tabIDs {
-                lastRefreshInputSignatureByTabID.removeValue(forKey: tabID)
+            state.withLock {
+                for tabID in tabIDs {
+                    $0.lastRefreshInputSignatureByTabID.removeValue(forKey: tabID)
+                }
             }
-            refreshSignatureLock.unlock()
         }
 
         static func durationMS(since start: TimeInterval) -> Double {

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -258,9 +258,10 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
 
         AgentTranscriptDebugInstrumentation.reset()
         defer { AgentTranscriptDebugInstrumentation.reset() }
-        AgentTranscriptDebugInstrumentation.isEnabled = true
         var attempts: [AgentTranscriptRefreshAttemptMetrics] = []
-        AgentTranscriptDebugInstrumentation.refreshAttemptHandler = { attempts.append($0) }
+        AgentTranscriptDebugInstrumentation.configure(.init(
+            refreshAttemptHandler: { attempts.append($0) }
+        ))
 
         emitTranscriptRefreshAttempt(tabID: removedTabID, inputSignature: "removed-signature")
         emitTranscriptRefreshAttempt(tabID: retainedTabID, inputSignature: "retained-signature")


### PR DESCRIPTION
## Summary
- route transcript refresh-signature cleanup through the synchronized instrumentation state introduced by #736
- update the background compose-tab regression test to use the current `configure(_:)` instrumentation API
- restore current-main compilation after the additive #739 patch landed against the superseded instrumentation API

## Root cause
PR #736 moved refresh signatures into `LockedState` and replaced direct debug setters with `configure(_:)`. PR #739 was validated on a pre-#736 base, then squash-applied cleanly without a textual conflict, leaving references to the removed globals and setters.

## Validation
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-test FILTER=BackgroundComposeTabAdmissionTests`
- `make dev-test FILTER=AgentTranscriptDebugInstrumentationTests` (2 tests, 0 failures)
- `make dev-lint`
- contribution commit and push preflights

The path-selected `pr-ready` lane passed guardrails, secret scans, and lint. Its full root suite reached 4,112 tests and reported four failures in codemap/workspace suites; current main could not compile before this patch, so no pre-fix full-suite baseline exists and causality is not claimed:
- `CodemapAutomaticSelectionGraphNativeTests.testPendingViewModelSelectionRetriesWhenMarkerBecomesReadyWithoutRootStatusChange`
- `CodemapBindingEnginePipelineTests.testPipelineManifestsRemainDistinct`
- `WorkspaceCodemapLiveOverlayTests.testManifestAdoptionClearsOnlyItsPipelineShadows`
- `WorkspacePendingSeededRootTests.testEligibleReceiptStaysHiddenUntilAtomicCommitThenServesProjectedSearchAndRead`

## Review
Fable 5 High reviewed the root cause and minimal locking/API migration before implementation.