### PR TITLE
Migrate RepoPromptShared to Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -188,7 +188,9 @@ let package = Package(
         .target(
             name: "RepoPromptShared",
             path: "Sources/RepoPromptShared",
-            swiftSettings: [.define("DEBUG", .when(configuration: .debug))]
+            swiftSettings: swift6LanguageMode + [
+                .define("DEBUG", .when(configuration: .debug))
+            ]
         ),
         .target(name: "CSwiftPCRE2", path: "Sources/CSwiftPCRE2", exclude: ["deps/sljit/sljit_src/sljitNativeARM_64.c", "deps/sljit/sljit_src/sljitSerialize.c", "deps/sljit/sljit_src/sljitUtils.c", "deps/sljit/sljit_src/sljitNativeX86_common.c", "deps/sljit/sljit_src/sljitNativeX86_64.c", "deps/sljit/sljit_src/sljitNativeX86_32.c", "deps/sljit/sljit_src/allocator_src/sljitWXExecAllocatorPosix.c", "deps/sljit/sljit_src/allocator_src/sljitProtExecAllocatorPosix.c", "deps/sljit/sljit_src/allocator_src/sljitExecAllocatorPosix.c", "deps/sljit/sljit_src/allocator_src/sljitExecAllocatorCore.c", "deps/sljit/sljit_src/allocator_src/sljitExecAllocatorApple.c"], publicHeadersPath: "include", cSettings: [.headerSearchPath("include"), .headerSearchPath("src"), .define("PCRE2_CODE_UNIT_WIDTH", to: "8"), .define("HAVE_CONFIG_H")]),
         .target(name: "RepoPromptC", path: "Sources/RepoPromptC", publicHeadersPath: "include", cSettings: [.headerSearchPath("include")]),

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
@@ -258,11 +258,11 @@ struct AgentConversationReplaySerialization: Equatable {
 
         static func removeRefreshInputSignatures(for tabIDs: Set<UUID>) {
             guard !tabIDs.isEmpty else { return }
-            refreshSignatureLock.lock()
-            for tabID in tabIDs {
-                lastRefreshInputSignatureByTabID.removeValue(forKey: tabID)
+            state.withLock { state in
+                for tabID in tabIDs {
+                    state.lastRefreshInputSignatureByTabID.removeValue(forKey: tabID)
+                }
             }
-            refreshSignatureLock.unlock()
         }
 
         static func durationMS(since start: TimeInterval) -> Double {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceCodemapBindingEngineModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceCodemapBindingEngineModels.swift
@@ -546,6 +546,8 @@ struct WorkspaceCodemapBindingEngineHooks {
     ) async -> Void
     let afterManifestStoreWriteBeforeCompletion: @Sendable (WorkspaceCodemapRootEpoch) async -> Void
     #if DEBUG
+        /// Deterministic async race seam immediately before manifest persistence.
+        let beforeManifestStoreWrite: @Sendable (WorkspaceCodemapRootEpoch) async -> Void
         /// Deterministic race seam, structurally absent from non-DEBUG products.
         let afterPublishedArtifactLookupBeforeCurrentnessValidation: @Sendable (
             WorkspaceCodemapRootEpoch
@@ -565,6 +567,7 @@ struct WorkspaceCodemapBindingEngineHooks {
             afterManifestRevisionQueuedBeforeWaiterInstall
         self.afterManifestStoreWriteBeforeCompletion = afterManifestStoreWriteBeforeCompletion
         #if DEBUG
+            beforeManifestStoreWrite = { _ in }
             afterPublishedArtifactLookupBeforeCurrentnessValidation = { _ in }
         #endif
     }
@@ -587,6 +590,32 @@ struct WorkspaceCodemapBindingEngineHooks {
             self.afterManifestRevisionQueuedBeforeWaiterInstall =
                 afterManifestRevisionQueuedBeforeWaiterInstall
             self.afterManifestStoreWriteBeforeCompletion = afterManifestStoreWriteBeforeCompletion
+            beforeManifestStoreWrite = { _ in }
+            self.afterPublishedArtifactLookupBeforeCurrentnessValidation =
+                afterPublishedArtifactLookupBeforeCurrentnessValidation
+        }
+
+        init(
+            debugBeforeManifestStoreWrite: @escaping @Sendable (
+                WorkspaceCodemapRootEpoch
+            ) async -> Void,
+            event: @escaping @Sendable (WorkspaceCodemapBindingEngineHookEvent) -> Void = { _ in },
+            afterManifestRevisionQueuedBeforeWaiterInstall: @escaping @Sendable (
+                WorkspaceCodemapRootEpoch,
+                UInt64
+            ) async -> Void = { _, _ in },
+            afterManifestStoreWriteBeforeCompletion: @escaping @Sendable (
+                WorkspaceCodemapRootEpoch
+            ) async -> Void = { _ in },
+            afterPublishedArtifactLookupBeforeCurrentnessValidation: @escaping @Sendable (
+                WorkspaceCodemapRootEpoch
+            ) async -> Void = { _ in }
+        ) {
+            self.event = event
+            self.afterManifestRevisionQueuedBeforeWaiterInstall =
+                afterManifestRevisionQueuedBeforeWaiterInstall
+            self.afterManifestStoreWriteBeforeCompletion = afterManifestStoreWriteBeforeCompletion
+            beforeManifestStoreWrite = debugBeforeManifestStoreWrite
             self.afterPublishedArtifactLookupBeforeCurrentnessValidation =
                 afterPublishedArtifactLookupBeforeCurrentnessValidation
         }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionMutationService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionMutationService.swift
@@ -92,6 +92,24 @@ struct WorkspaceCodemapAutomaticSelectionWaiter {
     }
 }
 
+struct WorkspaceCodemapAutomaticSelectionClock {
+    let now: @Sendable () -> ContinuousClock.Instant
+
+    static let production = Self { ContinuousClock.now }
+}
+
+struct WorkspaceCodemapAutomaticSelectionDemandChangeWaiter {
+    let wait: @Sendable (
+        WorkspaceFileContextStore,
+        WorkspaceCodemapArtifactDemandTicket,
+        ContinuousClock.Instant
+    ) async -> WorkspaceCodemapArtifactDemandResult
+
+    static let production = Self { store, ticket, deadline in
+        await store.waitForCodemapArtifactDemandChange(ticket, deadline: deadline)
+    }
+}
+
 private actor WorkspaceCodemapAutomaticSelectionDemandOwnership {
     private var retainedTargetTickets = Set<WorkspaceCodemapArtifactDemandTicket>()
 
@@ -101,6 +119,25 @@ private actor WorkspaceCodemapAutomaticSelectionDemandOwnership {
             retainedTargetTickets.insert(ticket)
         case .notAcquired:
             break
+        }
+    }
+
+    func owns(_ ticket: WorkspaceCodemapArtifactDemandTicket) -> Bool {
+        retainedTargetTickets.contains(ticket)
+    }
+
+    func replaceConsumed(
+        _ oldTicket: WorkspaceCodemapArtifactDemandTicket,
+        with result: WorkspaceCodemapArtifactDemandResult
+    ) {
+        retainedTargetTickets.remove(oldTicket)
+        let replacement: WorkspaceCodemapArtifactDemandTicket? = switch result {
+        case let .pending(ticket): ticket
+        case let .ready(ready): ready.ticket
+        case .unavailable: nil
+        }
+        if let replacement {
+            retainedTargetTickets.insert(replacement)
         }
     }
 
@@ -116,6 +153,8 @@ struct WorkspaceSelectionMutationService {
     let codemapsGloballyDisabledMessage: String
     let automaticSelectionPolicy: WorkspaceCodemapAutomaticSelectionRequestPolicy
     let automaticSelectionWaiter: WorkspaceCodemapAutomaticSelectionWaiter
+    let automaticSelectionClock: WorkspaceCodemapAutomaticSelectionClock
+    let automaticSelectionDemandChangeWaiter: WorkspaceCodemapAutomaticSelectionDemandChangeWaiter
     let removePathsDidCaptureExistingHook: @Sendable (StoredSelection) async -> Void
 
     init(
@@ -124,6 +163,8 @@ struct WorkspaceSelectionMutationService {
         codemapsGloballyDisabledMessage: String = "Code maps are disabled for this tool.",
         automaticSelectionPolicy: WorkspaceCodemapAutomaticSelectionRequestPolicy = .default,
         automaticSelectionWaiter: WorkspaceCodemapAutomaticSelectionWaiter = .production,
+        automaticSelectionClock: WorkspaceCodemapAutomaticSelectionClock = .production,
+        automaticSelectionDemandChangeWaiter: WorkspaceCodemapAutomaticSelectionDemandChangeWaiter = .production,
         removePathsDidCaptureExistingHook: @escaping @Sendable (StoredSelection) async -> Void = { _ in }
     ) {
         self.store = store
@@ -131,6 +172,8 @@ struct WorkspaceSelectionMutationService {
         self.codemapsGloballyDisabledMessage = codemapsGloballyDisabledMessage
         self.automaticSelectionPolicy = automaticSelectionPolicy
         self.automaticSelectionWaiter = automaticSelectionWaiter
+        self.automaticSelectionClock = automaticSelectionClock
+        self.automaticSelectionDemandChangeWaiter = automaticSelectionDemandChangeWaiter
         self.removePathsDidCaptureExistingHook = removePathsDidCaptureExistingHook
     }
 
@@ -881,12 +924,18 @@ struct WorkspaceSelectionMutationService {
                 resultsByTarget[target] = owned.result
             }
 
-            let clock = ContinuousClock()
-            let deadline = clock.now.advanced(by: automaticSelectionPolicy.maximumTotalWait)
+            let deadline = automaticSelectionClock.now().advanced(
+                by: automaticSelectionPolicy.maximumTotalWait
+            )
             for round in 0 ..< automaticSelectionPolicy.maximumReadinessRounds {
                 try Task.checkCancellation()
                 var waiting = false
+                var hasBusy = false
                 var retryAfter: [Int] = []
+                var pendingTickets: [(
+                    target: WorkspaceCodemapAutomaticSelectionTarget,
+                    ticket: WorkspaceCodemapArtifactDemandTicket
+                )] = []
                 for (target, current) in resultsByTarget {
                     let refreshed: WorkspaceCodemapArtifactDemandResult = switch current {
                     case let .pending(ticket):
@@ -896,10 +945,12 @@ struct WorkspaceSelectionMutationService {
                     }
                     resultsByTarget[target] = refreshed
                     switch refreshed {
-                    case .pending:
+                    case let .pending(ticket):
                         waiting = true
+                        pendingTickets.append((target, ticket))
                     case let .unavailable(.busy(milliseconds)):
                         waiting = true
+                        hasBusy = true
                         if let milliseconds { retryAfter.append(milliseconds) }
                     case .ready, .unavailable:
                         break
@@ -907,22 +958,64 @@ struct WorkspaceSelectionMutationService {
                 }
                 guard waiting,
                       round + 1 < automaticSelectionPolicy.maximumReadinessRounds,
-                      clock.now < deadline
+                      automaticSelectionClock.now() < deadline
                 else { break }
+
+                if !pendingTickets.isEmpty, !hasBusy {
+                    let firstCompletion: (
+                        target: WorkspaceCodemapAutomaticSelectionTarget,
+                        result: WorkspaceCodemapArtifactDemandResult
+                    )? = try await withThrowingTaskGroup(
+                        of: (
+                            target: WorkspaceCodemapAutomaticSelectionTarget,
+                            result: WorkspaceCodemapArtifactDemandResult
+                        ).self
+                    ) { group in
+                        for pending in pendingTickets {
+                            group.addTask {
+                                try Task.checkCancellation()
+                                let result = await automaticSelectionDemandChangeWaiter.wait(
+                                    store,
+                                    pending.ticket,
+                                    deadline
+                                )
+                                try Task.checkCancellation()
+                                return (pending.target, result)
+                            }
+                        }
+                        guard let first = try await group.next() else { return nil }
+                        group.cancelAll()
+                        return first
+                    }
+                    if let firstCompletion {
+                        resultsByTarget[firstCompletion.target] = firstCompletion.result
+                    }
+                    continue
+                }
+
                 try await waitForAutomaticSelectionReadiness(
                     round: round,
                     suggestedMilliseconds: retryAfter,
-                    clock: clock,
                     deadline: deadline
                 )
                 for (target, current) in resultsByTarget {
                     guard case .unavailable(.busy) = current,
                           let rootReceipt = rootReceiptByEpoch[target.rootEpoch]
                     else { continue }
-                    if let priorTicket = ticketsByTarget.removeValue(forKey: target) {
-                        _ = await store.cancelCodemapArtifactDemand(priorTicket)
-                    }
-                    if let owned = await store.requestAutomaticCodemapTargetWithOwnership(
+                    if let priorTicket = ticketsByTarget[target],
+                       await ownership.owns(priorTicket)
+                    {
+                        let retried = await store.retryBusyCodemapArtifactDemand(
+                            priorTicket,
+                            priority: .background
+                        )
+                        let oldStatus = await store.codemapArtifactDemandStatus(priorTicket)
+                        if case .unavailable(.staleCurrentness) = oldStatus {
+                            await ownership.replaceConsumed(priorTicket, with: retried)
+                            ticketsByTarget[target] = automaticSelectionTicket(from: retried)
+                        }
+                        resultsByTarget[target] = retried
+                    } else if let owned = await store.requestAutomaticCodemapTargetWithOwnership(
                         target: target,
                         rootReceipt: rootReceipt,
                         rootScope: rootScope,
@@ -1045,10 +1138,19 @@ struct WorkspaceSelectionMutationService {
         }
     }
 
+    private func automaticSelectionTicket(
+        from result: WorkspaceCodemapArtifactDemandResult
+    ) -> WorkspaceCodemapArtifactDemandTicket? {
+        switch result {
+        case let .pending(ticket): ticket
+        case let .ready(ready): ready.ticket
+        case .unavailable: nil
+        }
+    }
+
     private func waitForAutomaticSelectionReadiness(
         round: Int,
         suggestedMilliseconds: [Int],
-        clock: ContinuousClock,
         deadline: ContinuousClock.Instant
     ) async throws {
         let shift = min(round, 20)
@@ -1057,7 +1159,7 @@ struct WorkspaceSelectionMutationService {
         let suggested = suggestedMilliseconds.max() ?? 0
         let milliseconds = max(bounded, suggested)
         let proposed = Duration.milliseconds(milliseconds)
-        let remaining = clock.now.duration(to: deadline)
+        let remaining = automaticSelectionClock.now().duration(to: deadline)
         guard remaining > .zero else { return }
         try await automaticSelectionWaiter.sleep(min(proposed, remaining))
     }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapBindingEngine.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapBindingEngine.swift
@@ -8094,6 +8094,9 @@ actor WorkspaceCodemapBindingEngine {
                     continue
                 }
                 #if DEBUG
+                    await hooks.beforeManifestStoreWrite(scope.rootEpoch)
+                #endif
+                #if DEBUG
                     let debugContext = DebugManifestStoreAttemptContext(
                         rootEpoch: scope.rootEpoch,
                         proof: batch.proof,

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
@@ -164,22 +164,47 @@ struct WorkspaceCodemapSourceAuthorityRequest: Hashable {
     let currentIngressGeneration: UInt64
 }
 
+enum WorkspaceCodemapSourceAuthorityRejection: Equatable {
+    enum CapturePhase: Equatable {
+        case preRepository
+        case postRepository
+    }
+
+    case requestUnavailable
+    case candidateRequestRejected(index: Int)
+    case candidateFingerprintUnavailable(index: Int)
+    case candidateAttributesChanged(index: Int)
+    case candidatePathChanged(index: Int)
+    case registrationAuthorityChanged
+    case repositoryAuthorityChangedDuringIssuance
+    case capabilityChanged
+    case tokenIssuanceRejected(index: Int)
+    case cancelled
+    case captureFailed(
+        phase: CapturePhase,
+        reason: WorkspaceCodemapGitTransientUnavailableReason
+    )
+}
+
 struct WorkspaceCodemapGitCapabilityServiceHooks {
     var beforeResolution: @Sendable () async -> Void
     var afterFirstAuthorityCapture: @Sendable () async -> Void
     var afterSourcePathFingerprintCapture: @Sendable () async -> Void
     var afterAuthorityEvidenceOpen: @Sendable (URL) -> Void
+    var sourceAuthorityRejected: @Sendable (WorkspaceCodemapSourceAuthorityRejection) -> Void
 
     init(
         beforeResolution: @escaping @Sendable () async -> Void = {},
         afterFirstAuthorityCapture: @escaping @Sendable () async -> Void = {},
         afterSourcePathFingerprintCapture: @escaping @Sendable () async -> Void = {},
-        afterAuthorityEvidenceOpen: @escaping @Sendable (URL) -> Void = { _ in }
+        afterAuthorityEvidenceOpen: @escaping @Sendable (URL) -> Void = { _ in },
+        sourceAuthorityRejected: @escaping @Sendable (WorkspaceCodemapSourceAuthorityRejection) -> Void = { _ in }
     ) {
         self.beforeResolution = beforeResolution
         self.afterFirstAuthorityCapture = afterFirstAuthorityCapture
         self.afterSourcePathFingerprintCapture = afterSourcePathFingerprintCapture
         self.afterAuthorityEvidenceOpen = afterAuthorityEvidenceOpen
+        self.sourceAuthorityRejected = sourceAuthorityRejected
     }
 
     static let none = WorkspaceCodemapGitCapabilityServiceHooks()
@@ -720,7 +745,10 @@ actor WorkspaceCodemapGitCapabilityService {
               capability.rootEpoch == observedRootEpoch,
               capability.repositoryAuthority == observedRepositoryAuthority,
               let stableAuthority = record.stableAuthority
-        else { return unavailable }
+        else {
+            hooks.sourceAuthorityRejected(Task.isCancelled ? .cancelled : .requestUnavailable)
+            return unavailable
+        }
 
         let loadedRoot = URL(fileURLWithPath: record.binding.standardizedLoadedRootPath)
         var candidatePaths = [String?](repeating: nil, count: candidates.count)
@@ -729,6 +757,7 @@ actor WorkspaceCodemapGitCapabilityService {
             count: candidates.count
         )
         var preAttributeGenerations = [String?](repeating: nil, count: candidates.count)
+        var capturePhase = WorkspaceCodemapSourceAuthorityRejection.CapturePhase.preRepository
 
         do {
             for index in candidates.indices {
@@ -741,17 +770,24 @@ actor WorkspaceCodemapGitCapabilityService {
                           path,
                           insideLoadedRootPrefix: capability.repositoryRelativeLoadedRootPrefix
                       )
-                else { continue }
+                else {
+                    hooks.sourceAuthorityRejected(.candidateRequestRejected(index: index))
+                    continue
+                }
                 do {
                     let fingerprint = try pathFingerprintClient.fingerprint(
                         capability.repositoryLayout.workTreeRoot,
                         path
                     )
-                    guard fingerprint.isRegularFile else { continue }
+                    guard fingerprint.isRegularFile else {
+                        hooks.sourceAuthorityRejected(.candidateFingerprintUnavailable(index: index))
+                        continue
+                    }
                     candidatePaths[index] = path
                     prePathFingerprints[index] = fingerprint
                     await hooks.afterSourcePathFingerprintCapture()
                 } catch {
+                    hooks.sourceAuthorityRejected(.candidateFingerprintUnavailable(index: index))
                     continue
                 }
                 try Task.checkCancellation()
@@ -763,6 +799,7 @@ actor WorkspaceCodemapGitCapabilityService {
                 prefix: capability.repositoryRelativeLoadedRootPrefix
             )
             guard preRepository.stableAuthority.matchesSourceAuthorityStability(of: stableAuthority) else {
+                hooks.sourceAuthorityRejected(.registrationAuthorityChanged)
                 return unavailable
             }
             await hooks.afterFirstAuthorityCapture()
@@ -779,6 +816,7 @@ actor WorkspaceCodemapGitCapabilityService {
                         includeBoundedContents: true
                     )
                 } catch {
+                    hooks.sourceAuthorityRejected(.candidateAttributesChanged(index: index))
                     candidatePaths[index] = nil
                     prePathFingerprints[index] = nil
                 }
@@ -800,8 +838,11 @@ actor WorkspaceCodemapGitCapabilityService {
                     )
                     if postAttributes == preAttributes {
                         postAttributeGenerations[index] = postAttributes
+                    } else {
+                        hooks.sourceAuthorityRejected(.candidateAttributesChanged(index: index))
                     }
                 } catch {
+                    hooks.sourceAuthorityRejected(.candidateAttributesChanged(index: index))
                     postAttributeGenerations[index] = nil
                 }
                 try Task.checkCancellation()
@@ -825,14 +866,19 @@ actor WorkspaceCodemapGitCapabilityService {
                     #endif
                     guard postPathFingerprint == prePathFingerprint,
                           postPathFingerprint.isRegularFile
-                    else { continue }
+                    else {
+                        hooks.sourceAuthorityRejected(.candidatePathChanged(index: index))
+                        continue
+                    }
                     postPathFingerprints[index] = postPathFingerprint
                 } catch {
+                    hooks.sourceAuthorityRejected(.candidateFingerprintUnavailable(index: index))
                     continue
                 }
                 try Task.checkCancellation()
             }
 
+            capturePhase = .postRepository
             let postRepository = try await captureAuthority(
                 loadedRoot: loadedRoot,
                 expectedLayout: capability.repositoryLayout,
@@ -840,11 +886,20 @@ actor WorkspaceCodemapGitCapabilityService {
             )
             // Earlier root-wide churn does not invalidate the current request, but this request
             // must observe one unchanged root authority across its two captures.
-            guard preRepository == postRepository,
-                  postRepository.stableAuthority.matchesSourceAuthorityStability(of: stableAuthority),
-                  case let .eligible(currentCapability) = records[capability.rootEpoch]?.state,
+            guard preRepository == postRepository else {
+                hooks.sourceAuthorityRejected(.repositoryAuthorityChangedDuringIssuance)
+                return unavailable
+            }
+            guard postRepository.stableAuthority.matchesSourceAuthorityStability(of: stableAuthority) else {
+                hooks.sourceAuthorityRejected(.registrationAuthorityChanged)
+                return unavailable
+            }
+            guard case let .eligible(currentCapability) = records[capability.rootEpoch]?.state,
                   currentCapability == capability
-            else { return unavailable }
+            else {
+                hooks.sourceAuthorityRejected(.capabilityChanged)
+                return unavailable
+            }
             try Task.checkCancellation()
 
             var authorities = unavailable
@@ -868,14 +923,28 @@ actor WorkspaceCodemapGitCapabilityService {
                     observedIngressGeneration: candidate.observedIngressGeneration,
                     currentIngressGeneration: candidate.currentIngressGeneration
                 )
+                if authorities[index] == nil {
+                    hooks.sourceAuthorityRejected(.tokenIssuanceRejected(index: index))
+                }
                 try Task.checkCancellation()
             }
             guard !Task.isCancelled,
                   case let .eligible(finalCapability) = records[capability.rootEpoch]?.state,
                   finalCapability == capability
-            else { return unavailable }
+            else {
+                hooks.sourceAuthorityRejected(Task.isCancelled ? .cancelled : .capabilityChanged)
+                return unavailable
+            }
             return authorities
         } catch {
+            hooks.sourceAuthorityRejected(
+                error is CancellationError
+                    ? .cancelled
+                    : .captureFailed(
+                        phase: capturePhase,
+                        reason: Self.transientReason(for: error)
+                    )
+            )
             return unavailable
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -545,6 +545,36 @@ actor WorkspaceFileContextStore {
             }
         }
 
+        func wait() async {
+            let waiterID = UUID()
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    guard !Task.isCancelled else {
+                        continuation.resume()
+                        return
+                    }
+
+                    lock.lock()
+                    guard !didComplete else {
+                        lock.unlock()
+                        continuation.resume()
+                        return
+                    }
+                    waitersByID[waiterID] = Waiter(
+                        continuation: continuation,
+                        deadlineTask: nil
+                    )
+                    lock.unlock()
+
+                    if Task.isCancelled {
+                        resume(waiterID)
+                    }
+                }
+            } onCancel: {
+                self.resume(waiterID)
+            }
+        }
+
         func resolve() {
             lock.lock()
             guard !didComplete else {
@@ -13096,6 +13126,7 @@ actor WorkspaceFileContextStore {
         codemapSessionsByRootEpoch[ticket.rootEpoch] = session
         bundle?.close()
         if let engine = session.engine {
+            await codemapCancellationCleanupHook(ticket)
             _ = await engine.cancel(owner: record.owner)
         }
         guard !Task.isCancelled else { return .unavailable(.cancelled) }
@@ -14171,6 +14202,25 @@ actor WorkspaceFileContextStore {
                 codemapTicketsShareDemand(record.ticket, ticket)
             else { return 0 }
             return record.completion.waiterCount
+        }
+
+        func waitForCodemapArtifactDemandCompletionForTesting(
+            _ ticket: WorkspaceCodemapArtifactDemandTicket
+        ) async -> WorkspaceCodemapArtifactDemandResult {
+            guard codemapDemandIsCurrent(ticket),
+                  let record = codemapSessionsByRootEpoch[ticket.rootEpoch]?
+                  .demandsByFileID[ticket.fileID],
+                  codemapTicketsShareDemand(record.ticket, ticket),
+                  record.retainIDs.contains(ticket.retainID)
+            else {
+                return .unavailable(.staleCurrentness)
+            }
+            let current = codemapDemandResult(record.result, for: ticket)
+            guard case .pending = current, record.task != nil else {
+                return current
+            }
+            await record.completion.wait()
+            return codemapArtifactDemandStatus(ticket)
         }
 
         func codemapArtifactDemandRetainCountForTesting(

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -5,6 +5,16 @@ import XCTest
 
 @MainActor
 final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
+    private var retainedHosts: [AgentModeViewModel] = []
+
+    override func tearDown() async throws {
+        for host in retainedHosts {
+            await host.prepareForWindowClose()
+        }
+        retainedHosts.removeAll()
+        try await super.tearDown()
+    }
+
     func testThreadSnapshotParsesAuthoritativeActiveCommandItem() throws {
         let itemID = UUID().uuidString
         let snapshot = CodexNativeSessionController.test_parseThreadSnapshot(
@@ -2941,6 +2951,7 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
             testCodexStallWatchdogRecoveryThreshold: watchdogRecoveryThreshold
         )
         viewModel.test_initializeRunService()
+        retainedHosts.append(viewModel)
         return viewModel
     }
 

--- a/Tests/RepoPromptTests/CodeMap/CodeMapArtifactBuildCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/CodeMap/CodeMapArtifactBuildCoordinatorTests.swift
@@ -54,6 +54,7 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
         let queuedInput = try makeInput("bounds-queued", root: fixture.root)
         let busyInput = try makeInput("bounds-busy", root: fixture.root)
         let gate = CoordinatorTestGate()
+        let hookEvents = CoordinatorHookCondition()
         let coordinator = makeCoordinator(
             fixture: fixture,
             policy: CodeMapArtifactBuildCoordinatorPolicy(
@@ -66,7 +67,8 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
                 maximumConsecutiveDemandAdmissions: 2,
                 agePromotionNanoseconds: 1_000_000_000,
                 retryAfterMilliseconds: 17
-            )
+            ),
+            hooks: CodeMapArtifactBuildCoordinatorHooks { hookEvents.record($0) }
         ) { _, _, _ in
             await gate.enter()
             return .readyNoSymbols
@@ -75,7 +77,12 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
         let first = Task { try await coordinator.resolve(request(firstInput)) }
         await gate.waitUntilEntered()
         let queued = Task { try await coordinator.resolve(request(queuedInput)) }
-        try await waitUntil { await coordinator.accounting().queuedBuildCount == 1 }
+        try await hookEvents.waitUntil(
+            kind: .buildEnqueued,
+            artifactStorageDigest: queuedInput.artifactKey.storageDigestHex
+        )
+        let queuedAccounting = await coordinator.accounting()
+        XCTAssertEqual(queuedAccounting.queuedBuildCount, 1)
 
         do {
             _ = try await coordinator.resolve(request(busyInput))
@@ -232,7 +239,11 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
         )
         XCTAssertEqual(input.artifactKey, finalWaiterInput.artifactKey)
         let gate = CoordinatorTestGate()
-        let coordinator = makeCoordinator(fixture: fixture) { _, _, _ in
+        let hookEvents = CoordinatorHookCondition()
+        let coordinator = makeCoordinator(
+            fixture: fixture,
+            hooks: CodeMapArtifactBuildCoordinatorHooks { hookEvents.record($0) }
+        ) { _, _, _ in
             await gate.enter()
             return .readyNoSymbols
         }
@@ -246,7 +257,12 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
         finalWaiter.cancel()
         await assertCancellation(finalWaiter)
         await gate.release()
-        try await waitUntil { await coordinator.accounting().activeFlightCount == 0 }
+        try await hookEvents.waitUntil(
+            kind: .flightCompleted,
+            artifactStorageDigest: input.artifactKey.storageDigestHex
+        )
+        let completedAccounting = await coordinator.accounting()
+        XCTAssertEqual(completedAccounting.activeFlightCount, 0)
 
         switch try await fixture.artifactStore.lookup(key: input.artifactKey) {
         case .miss: XCTFail("admitted non-preemptive build did not persist")
@@ -271,6 +287,7 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
         defer { fixture.remove() }
         let casInput = try makeInput("cancel-during-cas", root: fixture.root)
         let insertGate = CoordinatorTestGate()
+        let casHookEvents = CoordinatorHookCondition()
         let storeClient = CodeMapArtifactStoreClient(
             lookup: { try await fixture.artifactStore.lookup(key: $0) },
             insert: { key, outcome in
@@ -283,14 +300,20 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
         let casCoordinator = CodeMapArtifactBuildCoordinator(
             artifactStore: storeClient,
             locatorStore: GitBlobCodeMapLocatorStoreClient(store: fixture.locatorStore),
-            builder: CodeMapArtifactBuilderClient(build: { _, _, _ in .readyNoSymbols })
+            builder: CodeMapArtifactBuilderClient(build: { _, _, _ in .readyNoSymbols }),
+            hooks: CodeMapArtifactBuildCoordinatorHooks { casHookEvents.record($0) }
         )
         let casTask = Task { try await casCoordinator.resolve(request(casInput)) }
         await insertGate.waitUntilEntered()
         casTask.cancel()
         await assertCancellation(casTask)
         await insertGate.release()
-        try await waitUntil { await casCoordinator.accounting().activeFlightCount == 0 }
+        try await casHookEvents.waitUntil(
+            kind: .flightCompleted,
+            artifactStorageDigest: casInput.artifactKey.storageDigestHex
+        )
+        let completedCASAccounting = await casCoordinator.accounting()
+        XCTAssertEqual(completedCASAccounting.activeFlightCount, 0)
         _ = try await requireHit(fixture.artifactStore, key: casInput.artifactKey)
 
         let locatedInput = try await makeInput("cancel-during-locator", root: fixture.root, withLocator: true)
@@ -299,6 +322,7 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
             deterministicOutcome: .readyNoSymbols
         )
         let locatorGate = CoordinatorTestGate()
+        let locatorHookEvents = CoordinatorHookCondition()
         let locatorClient = GitBlobCodeMapLocatorStoreClient(
             read: { try await fixture.locatorStore.read(identity: $0) },
             write: { association in
@@ -309,14 +333,20 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
         let locatorCoordinator = CodeMapArtifactBuildCoordinator(
             artifactStore: CodeMapArtifactStoreClient(store: fixture.artifactStore),
             locatorStore: locatorClient,
-            builder: CodeMapArtifactBuilderClient(build: { _, _, _ in .readyNoSymbols })
+            builder: CodeMapArtifactBuilderClient(build: { _, _, _ in .readyNoSymbols }),
+            hooks: CodeMapArtifactBuildCoordinatorHooks { locatorHookEvents.record($0) }
         )
         let locatorTask = Task { try await locatorCoordinator.resolve(request(locatedInput)) }
         await locatorGate.waitUntilEntered()
         locatorTask.cancel()
         await assertCancellation(locatorTask)
         await locatorGate.release()
-        try await waitUntil { await locatorCoordinator.accounting().activeFlightCount == 0 }
+        try await locatorHookEvents.waitUntil(
+            kind: .flightCompleted,
+            artifactStorageDigest: locatedInput.artifactKey.storageDigestHex
+        )
+        let completedLocatorAccounting = await locatorCoordinator.accounting()
+        XCTAssertEqual(completedLocatorAccounting.activeFlightCount, 0)
         let publishedLocator = try await fixture.locatorStore.read(
             identity: XCTUnwrap(locatedInput.locatorIdentity)
         )
@@ -2056,6 +2086,7 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
         fixture: CoordinatorFixture,
         policy: CodeMapArtifactBuildCoordinatorPolicy = .default,
         clock: CodeMapArtifactBuildCoordinatorClock = .continuous,
+        hooks: CodeMapArtifactBuildCoordinatorHooks = .none,
         build: @escaping @Sendable (
             CodeMapArtifactBuildInput,
             UUID,
@@ -2067,7 +2098,8 @@ final class CodeMapArtifactBuildCoordinatorTests: XCTestCase {
             locatorStore: GitBlobCodeMapLocatorStoreClient(store: fixture.locatorStore),
             builder: CodeMapArtifactBuilderClient(build: build),
             policy: policy,
-            clock: clock
+            clock: clock,
+            hooks: hooks
         )
     }
 
@@ -2514,6 +2546,29 @@ private actor CoordinatorHookRecorder {
 
     func append(_ event: CodeMapArtifactBuildCoordinatorHookEvent) {
         events.append(event)
+    }
+}
+
+private final class CoordinatorHookCondition: @unchecked Sendable {
+    private let events = AsyncTestCondition<[CodeMapArtifactBuildCoordinatorHookEvent]>([])
+
+    func record(_ event: CodeMapArtifactBuildCoordinatorHookEvent) {
+        events.update { $0.append(event) }
+    }
+
+    func waitUntil(
+        kind: CodeMapArtifactBuildCoordinatorHookKind,
+        artifactStorageDigest: String,
+        timeout: TimeInterval = TestFenceDefaults.enterWait
+    ) async throws {
+        try await events.waitUntil(
+            "coordinator hook \(kind.rawValue) for \(artifactStorageDigest)",
+            timeout: timeout
+        ) { events in
+            events.contains {
+                $0.kind == kind && $0.artifactStorageDigest == artifactStorageDigest
+            }
+        }
     }
 }
 

--- a/Tests/RepoPromptTests/Helpers/CodemapBindingEngineTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/CodemapBindingEngineTestSupport.swift
@@ -854,29 +854,6 @@ actor EngineSecondCatalogResolutionMutation {
     }
 }
 
-/// Sync writer-hook fence — named thin wrapper over `TestBlockingFence`.
-final class EngineBlockingGate: @unchecked Sendable {
-    static let defaultEnterWaitTimeout = TestFenceDefaults.releaseWait
-
-    private let fence = TestBlockingFence(name: "engine blocking gate")
-
-    func enterAndWait(timeout: TimeInterval = defaultEnterWaitTimeout) {
-        fence.enterAndWait(timeout: timeout)
-    }
-
-    @discardableResult
-    func waitUntilEntered(
-        timeout: TimeInterval = TestFenceDefaults.enterWait,
-        failOnTimeout: Bool = true
-    ) -> Bool {
-        fence.waitUntilEntered(timeout: timeout, failOnTimeout: failOnTimeout)
-    }
-
-    func release() {
-        fence.release()
-    }
-}
-
 /// Async engine fence — named thin wrapper over `TestReleaseFence`.
 final class EngineAsyncGate: @unchecked Sendable {
     private let fence = TestReleaseFence(name: "engine async gate")
@@ -1148,6 +1125,24 @@ actor EngineFirstResolutionGate {
         }
     }
 
+    func waitUntilResolutionCount(
+        _ expectedCount: Int,
+        timeout: Duration = TestFenceDefaults.enterWaitDuration
+    ) async -> Bool {
+        do {
+            return try await state.waitUntilResolutionCount(
+                expectedCount,
+                timeout: CodemapBindingEngineTestCase.timeInterval(timeout)
+            )
+        } catch {
+            if state.resolutionCount >= expectedCount {
+                return true
+            }
+            XCTFail(error.localizedDescription)
+            return false
+        }
+    }
+
     func releaseFirstResolution() {
         state.releaseFirstResolution()
     }
@@ -1160,6 +1155,7 @@ private final class EngineFirstResolutionGateState: @unchecked Sendable {
     }
 
     private let lock = NSLock()
+    private let resolutionCountCondition = AsyncTestCondition<Int>(0)
     private var storedResolutionCount = 0
     private var storedFirstResolutionEntered = false
     private var firstResolutionReleased = false
@@ -1169,7 +1165,7 @@ private final class EngineFirstResolutionGateState: @unchecked Sendable {
     private var firstResolutionWaiters: [ResolutionWaiter] = []
 
     var resolutionCount: Int {
-        lock.withLock { storedResolutionCount }
+        resolutionCountCondition.snapshot()
     }
 
     var firstResolutionEntered: Bool {
@@ -1177,14 +1173,19 @@ private final class EngineFirstResolutionGateState: @unchecked Sendable {
     }
 
     func enter() async {
-        let entry = lock.withLock { () -> (readyWaiters: [ResolutionWaiter], shouldBlock: Bool) in
+        let entry = lock.withLock { () -> (
+            count: Int,
+            readyWaiters: [ResolutionWaiter],
+            shouldBlock: Bool
+        ) in
             storedResolutionCount += 1
-            guard storedResolutionCount == 1 else { return ([], false) }
+            guard storedResolutionCount == 1 else { return (storedResolutionCount, [], false) }
             storedFirstResolutionEntered = true
             let waiters = firstResolutionWaiters
             firstResolutionWaiters.removeAll()
-            return (waiters, true)
+            return (storedResolutionCount, waiters, true)
         }
+        resolutionCountCondition.update { $0 = entry.count }
         for waiter in entry.readyWaiters {
             waiter.continuation.resume()
         }
@@ -1244,6 +1245,14 @@ private final class EngineFirstResolutionGateState: @unchecked Sendable {
             throw error
         }
         return firstResolutionEntered
+    }
+
+    func waitUntilResolutionCount(_ expectedCount: Int, timeout: TimeInterval) async throws -> Bool {
+        try await resolutionCountCondition.waitUntil(
+            "engine resolution count \(expectedCount)",
+            timeout: timeout
+        ) { $0 >= expectedCount }
+        return resolutionCount >= expectedCount
     }
 
     func releaseFirstResolution() {

--- a/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
@@ -831,14 +831,23 @@ final class CodemapLockedCounter: @unchecked Sendable {
 }
 
 final class CodemapLockedValues<Value: Sendable>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var storage: [Value] = []
+    private let condition = AsyncTestCondition<[Value]>([])
 
     var values: [Value] {
-        lock.withLock { storage }
+        condition.snapshot()
     }
 
     func append(_ value: Value) {
-        lock.withLock { storage.append(value) }
+        condition.update { $0.append(value) }
+    }
+
+    func waitUntilCount(
+        _ expectedCount: Int,
+        timeout: TimeInterval = TestFenceDefaults.enterWait
+    ) async throws {
+        try await condition.waitUntil(
+            "codemap recorded value count \(expectedCount)",
+            timeout: timeout
+        ) { $0.count >= expectedCount }
     }
 }

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -258,9 +258,10 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
 
         AgentTranscriptDebugInstrumentation.reset()
         defer { AgentTranscriptDebugInstrumentation.reset() }
-        AgentTranscriptDebugInstrumentation.isEnabled = true
         var attempts: [AgentTranscriptRefreshAttemptMetrics] = []
-        AgentTranscriptDebugInstrumentation.refreshAttemptHandler = { attempts.append($0) }
+        AgentTranscriptDebugInstrumentation.configure(.init(
+            refreshAttemptHandler: { attempts.append($0) }
+        ))
 
         emitTranscriptRefreshAttempt(tabID: removedTabID, inputSignature: "removed-signature")
         emitTranscriptRefreshAttempt(tabID: retainedTabID, inputSignature: "retained-signature")

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
@@ -618,11 +618,11 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
             ]
         )
         let fixture = try CodemapStoreFixture(name: #function, syntheticGraphArtifacts: true)
-        let demandPublication = TestReleaseFence(name: "automatic target publication")
+        let readinessWait = TestReleaseFence(name: "automatic target readiness wait")
         let demandGateEnabled = CodemapLockedCounter()
         let cleaned = CodemapLockedValues<WorkspaceCodemapArtifactDemandTicket>()
         addTeardownBlock {
-            demandPublication.release()
+            readinessWait.release()
             await fixture.shutdown()
             repository.cleanup()
         }
@@ -630,7 +630,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
             cancellationCleanupHook: { cleaned.append($0) },
             demandResultHook: { _, result in
                 if demandGateEnabled.value > 0 {
-                    await demandPublication.enterAndWaitIgnoringCancellationUntilRelease()
+                    return .busy(retryAfterMilliseconds: 0)
                 }
                 return result
             }
@@ -655,15 +655,18 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
                 initialBackoffMilliseconds: 1,
                 maximumBackoffMilliseconds: 1,
                 maximumTotalWait: .seconds(5)
-            )
+            ),
+            automaticSelectionWaiter: .init(sleep: { _ in
+                await readinessWait.enterAndWaitIgnoringCancellationUntilRelease()
+            })
         )
         let resolution = Task {
             try await service.resolveAutomaticCodemapSelection(sourceFileIDs: [source.id])
         }
-        let entered = await demandPublication.waitUntilEntered(timeout: TestFenceDefaults.enterWait)
+        let entered = await readinessWait.waitUntilEntered(timeout: TestFenceDefaults.enterWait)
         XCTAssertTrue(entered)
         resolution.cancel()
-        demandPublication.release()
+        readinessWait.release()
         do {
             _ = try await resolution.value
             XCTFail("Expected automatic target demand cancellation.")

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 @testable import RepoPromptApp
 import XCTest
@@ -580,6 +581,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
             expectedTargetFileIDs: [target.id]
         )
         let ticketOffset = fixture.demandedTickets.values.count
+        let fixedRetryTime = ContinuousClock.now
         let service = WorkspaceSelectionMutationService(
             store: store,
             automaticSelectionPolicy: .init(
@@ -588,12 +590,18 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
                 maximumBackoffMilliseconds: 25,
                 maximumTotalWait: .seconds(10)
             ),
-            automaticSelectionWaiter: .init(sleep: { _ in
-                try await Task.sleep(for: .milliseconds(25))
+            automaticSelectionWaiter: .init(sleep: { _ in await Task.yield() }),
+            automaticSelectionClock: .init(now: { fixedRetryTime }),
+            automaticSelectionDemandChangeWaiter: .init(wait: { store, ticket, _ in
+                await store.waitForCodemapArtifactDemandCompletionForTesting(ticket)
             })
         )
         let result = try await service.resolveAutomaticCodemapSelection(sourceFileIDs: [source.id])
-        XCTAssertEqual(result.targets.map(\.fileID), [target.id])
+        XCTAssertEqual(
+            result.targets.map(\.fileID),
+            [target.id],
+            "Busy retry must preserve a valid target; issues=\(result.issues)"
+        )
         let demanded = Array(fixture.demandedTickets.values.dropFirst(ticketOffset))
         XCTAssertEqual(demanded.map(\.fileID), [target.id, target.id])
         XCTAssertEqual(demandAttempts.value, 2)
@@ -611,12 +619,10 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         )
         let fixture = try CodemapStoreFixture(name: #function, syntheticGraphArtifacts: true)
         let demandPublication = TestReleaseFence(name: "automatic target publication")
-        let readinessWait = TestReleaseFence(name: "automatic target readiness wait")
         let demandGateEnabled = CodemapLockedCounter()
         let cleaned = CodemapLockedValues<WorkspaceCodemapArtifactDemandTicket>()
         addTeardownBlock {
             demandPublication.release()
-            readinessWait.release()
             await fixture.shutdown()
             repository.cleanup()
         }
@@ -649,29 +655,26 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
                 initialBackoffMilliseconds: 1,
                 maximumBackoffMilliseconds: 1,
                 maximumTotalWait: .seconds(5)
-            ),
-            automaticSelectionWaiter: .init(sleep: { _ in
-                await readinessWait.enterAndWaitIgnoringCancellationUntilRelease()
-            })
+            )
         )
         let resolution = Task {
             try await service.resolveAutomaticCodemapSelection(sourceFileIDs: [source.id])
         }
-        let entered = await readinessWait.waitUntilEntered(timeout: TestFenceDefaults.enterWait)
+        let entered = await demandPublication.waitUntilEntered(timeout: TestFenceDefaults.enterWait)
         XCTAssertTrue(entered)
         resolution.cancel()
-        readinessWait.release()
+        demandPublication.release()
         do {
             _ = try await resolution.value
             XCTFail("Expected automatic target demand cancellation.")
         } catch is CancellationError {
             // Expected.
         }
-        demandPublication.release()
         XCTAssertEqual(
             Array(fixture.demandedTickets.values.dropFirst(ticketOffset)).map(\.fileID),
             [target.id]
         )
+        try await cleaned.waitUntilCount(cleanupOffset + 1)
         XCTAssertEqual(
             Array(cleaned.values.dropFirst(cleanupOffset)).map(\.fileID),
             [target.id]
@@ -689,14 +692,12 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         )
         let fixture = try CodemapStoreFixture(name: #function, syntheticGraphArtifacts: true)
         let publication = TestReleaseFence(name: "automatic target publication")
-        let cleaned = CodemapLockedValues<WorkspaceCodemapArtifactDemandTicket>()
         addTeardownBlock {
             publication.release()
             await fixture.shutdown()
             repository.cleanup()
         }
         let store = fixture.makeStore(
-            cancellationCleanupHook: { cleaned.append($0) },
             demandResultHook: { _, result in
                 await publication.enterAndWait()
                 return result
@@ -727,6 +728,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         }
         let publicationEntered = await publication.waitUntilEntered(timeout: TestFenceDefaults.enterWait)
         XCTAssertTrue(publicationEntered)
+        let demandTicket = try XCTUnwrap(fixture.demandedTickets.values.last)
         try "struct Target { let changed: Bool }\n".write(
             to: rootURL.appendingPathComponent("Sources/Target.swift"),
             atomically: true,
@@ -741,7 +743,11 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         XCTAssertEqual(result.targets, [])
         XCTAssertFalse(result.issues.isEmpty)
         XCTAssertTrue([.pending, .unavailable].contains(result.roots[0].status))
-        XCTAssertEqual(cleaned.values.map(\.fileID), [target.id])
+        let cleanup = await store.codemapArtifactDemandCleanupSnapshotForTesting(demandTicket)
+        XCTAssertFalse(cleanup.demandRecordPresent)
+        XCTAssertFalse(cleanup.bundlePresent)
+        XCTAssertEqual(cleanup.ownerCount, 0)
+        XCTAssertFalse(cleanup.liveOverlayPresent)
     }
 
     func testDefaultCandidateDemandCapRejects1025Targets() {
@@ -1029,22 +1035,24 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         _ = try manager.attachRootShell(for: root, workspaceID: UUID())
         let sourceViewModelValue = await manager.materializeFileForUserInput(source.standardizedFullPath)
         let sourceViewModel = try XCTUnwrap(sourceViewModelValue)
-        manager.selectFileForTesting(sourceViewModel)
-        let clock = ContinuousClock()
-        let retryDeadline = clock.now.advanced(by: .seconds(3))
-        while fixture.demandedTickets.values.count < 2, clock.now < retryDeadline {
-            try await Task.sleep(for: .milliseconds(5))
+        let committedSelection = AsyncTestCondition(manager.autoCodemapFiles.map(\.id))
+        let selectionCancellable = manager.$autoCodemapFiles.sink { files in
+            committedSelection.update { $0 = files.map(\.id) }
         }
+        defer { selectionCancellable.cancel() }
+        manager.selectFileForTesting(sourceViewModel)
+        try await fixture.demandedTickets.waitUntilCount(2)
 
         XCTAssertTrue(manager.autoCodemapFiles.isEmpty)
         let unchangedRootStatus = manager.codemapRootStatus(rootID: root.id)
         XCTAssertEqual(fixture.demandedTickets.values.map(\.fileID), [target.id, target.id])
 
         readyPublication.release()
-        let deadline = clock.now.advanced(by: .seconds(5))
-        while manager.autoCodemapFiles.map(\.id) != [target.id], clock.now < deadline {
-            try await Task.sleep(for: .milliseconds(25))
-        }
+        try await committedSelection.waitUntil(
+            "automatic codemap target selection commit",
+            timeout: TestFenceDefaults.releaseWait
+        ) { $0 == [target.id] }
+        await manager.waitForAutoCodemapSyncForTesting()
 
         XCTAssertEqual(manager.autoCodemapFiles.map(\.id), [target.id])
         XCTAssertFalse(manager.automaticCodemapReadinessRetryPendingForTesting)

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineInvalidationTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineInvalidationTests.swift
@@ -137,17 +137,26 @@ final class CodemapBindingEngineInvalidationTests: CodemapBindingEngineTestCase 
                 "Sources/Survivor.swift": SwiftFixtureSource.emptyStruct("Survivor")
             ]
         )
+        let sourceAuthorityRejections = CodemapLockedValues<WorkspaceCodemapSourceAuthorityRejection>()
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: CodeMapArtifactRuntime(
                 rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts")
+            ),
+            capabilityHooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                sourceAuthorityRejected: { sourceAuthorityRejections.append($0) }
             )
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
-        guard case .ready = await fixture.engine.demand(fixture.demand(path: "Sources/Fenced.swift")),
-              case .ready = await fixture.engine.demand(fixture.demand(path: "Sources/Survivor.swift"))
+        let fencedResult = await fixture.engine.demand(fixture.demand(path: "Sources/Fenced.swift"))
+        let survivorResult = await fixture.engine.demand(fixture.demand(path: "Sources/Survivor.swift"))
+        guard case .ready = fencedResult,
+              case .ready = survivorResult
         else {
-            return XCTFail("Expected initial ready results.")
+            return XCTFail(
+                "Expected initial ready results; fenced=\(fencedResult), survivor=\(survivorResult), " +
+                    "sourceAuthorityRejections=\(sourceAuthorityRejections.values)."
+            )
         }
         let graph = await fixture.engine.selectionGraph(rootEpoch: fixture.rootEpoch)
         let graphReady = await waitForEngineCondition {

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineManifestWriteTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineManifestWriteTests.swift
@@ -253,11 +253,22 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
         await settlementRegistry.awaitDrained(windowID: settlementWindowID)
 
         await fixture.engine.unloadRoot(rootEpoch: fixture.rootEpoch)
-        let reloaded = try await makeEngineFixture(root: root, runtime: runtime)
+        let reloadedEvents = EngineHookEvents()
+        let reloaded = try await makeEngineFixture(
+            root: root,
+            runtime: runtime,
+            hooks: WorkspaceCodemapBindingEngineHooks { reloadedEvents.record($0) }
+        )
         _ = await reloaded.engine.registerRoot(reloaded.registration)
         for path in ["Sources/One.swift", "Sources/Two.swift", "Sources/Three.swift"] {
-            guard await isReady(reloaded.engine.demand(reloaded.demand(path: path))) else {
-                return XCTFail("Expected batched manifest record for \(path).")
+            let result = await reloaded.engine.demand(reloaded.demand(path: path))
+            guard isReady(result) else {
+                return await XCTFail(bindingDemandFailureMessage(
+                    "Expected batched manifest record for \(path).",
+                    result: result,
+                    accounting: reloaded.engine.accounting(),
+                    events: reloadedEvents.snapshot()
+                ))
             }
         }
     }

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineManifestWriteTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineManifestWriteTests.swift
@@ -10,7 +10,7 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
             named: "repository",
             files: ["Sources/Shutdown.swift": SwiftFixtureSource.emptyStruct("Shutdown")]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = TestBlockingFence(name: "non-cancellable manifest store write")
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: CodeMapArtifactRuntime(
@@ -24,8 +24,7 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
         let demand = Task {
             await fixture.engine.demand(fixture.demand(path: "Sources/Shutdown.swift"))
         }
-        let writeEntered = await writeGate.waitUntilEntered()
-        XCTAssertTrue(writeEntered)
+        XCTAssertTrue(writeGate.waitUntilEntered())
         let shutdownFinished = EngineCompletionFlag()
         let shutdown = Task {
             await fixture.engine.shutdown()
@@ -54,18 +53,15 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 "Sources/Two.swift": SwiftFixtureSource.emptyStruct("Two")
             ]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
-            rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() }
-            )
+            rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts")
         )
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: runtime,
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: "Sources/One.swift")) }
@@ -135,25 +131,23 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 "Sources/Three.swift": SwiftFixtureSource.emptyStruct("Three")
             ]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let hookEvents = EngineHookEvents()
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: CodeMapArtifactRuntime(
-                rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-                manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                    afterWriteShardAdmission: { writeGate.enterAndWait() }
-                )
+                rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts")
             ),
             policy: WorkspaceCodemapBindingEnginePolicy(
                 maximumQueuedGraphIndexManifestMutationByteCountPerRoot: 1,
                 maximumQueuedGraphIndexManifestMutationByteCount: 1
             ),
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: "Sources/One.swift")) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         let second = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Two.swift")) }
         let third = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Three.swift")) }
         XCTAssertTrue(hookEvents.wait(kind: .manifestRevisionQueued, numericValue: 3, timeout: 20))
@@ -221,22 +215,20 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 "Sources/Three.swift": SwiftFixtureSource.emptyStruct("Three")
             ]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
-            rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() }
-            )
+            rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts")
         )
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: runtime,
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: "Sources/One.swift")) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         let second = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Two.swift")) }
         let third = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Three.swift")) }
         XCTAssertTrue(hookEvents.wait(kind: .manifestRevisionQueued, numericValue: 3, timeout: 20))
@@ -277,22 +269,20 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
             named: "repository",
             files: [path: SwiftFixtureSource.emptyStruct("Original")]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
-            rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() }
-            )
+            rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts")
         )
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: runtime,
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let original = Task { await fixture.engine.demand(fixture.demand(path: path)) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         let invalidation = Task {
             await fixture.engine.invalidateModified(
                 rootEpoch: fixture.rootEpoch,
@@ -346,24 +336,22 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 "Sources/Three.swift": SwiftFixtureSource.emptyStruct("Three")
             ]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let fault = EngineManifestFaultOnPublication(2)
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
             rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() },
-                faultAction: fault.action
-            )
+            manifestStoreHooks: CodeMapRootManifestStoreHooks(faultAction: fault.action)
         )
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: runtime,
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: "Sources/One.swift")) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         let second = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Two.swift")) }
         let third = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Three.swift")) }
         XCTAssertTrue(hookEvents.wait(kind: .manifestRevisionQueued, numericValue: 3, timeout: 20))
@@ -464,15 +452,12 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 ($0.element, SwiftFixtureSource.emptyStruct("Item\($0.offset + 1)"))
             })
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let fault = EngineManifestFaultOnPublication(1)
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
             rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() },
-                faultAction: fault.action
-            )
+            manifestStoreHooks: CodeMapRootManifestStoreHooks(faultAction: fault.action)
         )
         let fixture = try await makeEngineFixture(
             root: root,
@@ -480,11 +465,12 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
             policy: WorkspaceCodemapBindingEnginePolicy(
                 maximumManifestWriterDeferredItemCount: 3
             ),
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: paths[0])) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         var successors: [Task<WorkspaceCodemapBindingDemandResult, Never>] = []
         for (offset, path) in paths.dropFirst().enumerated() {
             successors.append(Task {
@@ -562,15 +548,12 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
             named: "repository",
             files: [path: SwiftFixtureSource.emptyStruct("Feature")]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let fault = EngineManifestFaultOnPublication(1)
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
             rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() },
-                faultAction: fault.action
-            )
+            manifestStoreHooks: CodeMapRootManifestStoreHooks(faultAction: fault.action)
         )
         let fixture = try await makeEngineFixture(
             root: root,
@@ -578,11 +561,12 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
             policy: WorkspaceCodemapBindingEnginePolicy(
                 maximumManifestWriterDeferredItemCount: 2
             ),
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let original = Task { await fixture.engine.demand(fixture.demand(path: path)) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
 
         let firstInvalidation = Task {
             await fixture.engine.invalidateModified(
@@ -654,14 +638,11 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 paths[2]: SwiftFixtureSource.emptyStruct("Three")
             ]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let fault = EngineManifestFaultOnPublications([1, 2, 3])
         let runtime = try CodeMapArtifactRuntime(
             rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() },
-                faultAction: fault.action
-            )
+            manifestStoreHooks: CodeMapRootManifestStoreHooks(faultAction: fault.action)
         )
         let hookEvents = EngineHookEvents()
         let fixture = try await makeEngineFixture(
@@ -670,11 +651,12 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
             policy: WorkspaceCodemapBindingEnginePolicy(
                 maximumManifestWriterDeferredItemCount: 2
             ),
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: paths[0])) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         let second = Task { await fixture.engine.demand(fixture.demand(path: paths[1])) }
         XCTAssertTrue(hookEvents.wait(kind: .manifestRevisionQueued, numericValue: 2, timeout: 20))
         let third = Task { await fixture.engine.demand(fixture.demand(path: paths[2])) }
@@ -962,24 +944,22 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 "Sources/Three.swift": SwiftFixtureSource.emptyStruct("Three")
             ]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let fault = EngineManifestFaultOnPublication(2)
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
             rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() },
-                faultAction: fault.action
-            )
+            manifestStoreHooks: CodeMapRootManifestStoreHooks(faultAction: fault.action)
         )
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: runtime,
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: "Sources/One.swift")) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         let second = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Two.swift")) }
         let third = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Three.swift")) }
         let queued = await waitForEngineCondition {
@@ -1022,24 +1002,22 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 "Sources/Three.swift": SwiftFixtureSource.emptyStruct("Three")
             ]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let fault = EngineManifestFaultOnPublications([2, 3])
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
             rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() },
-                faultAction: fault.action
-            )
+            manifestStoreHooks: CodeMapRootManifestStoreHooks(faultAction: fault.action)
         )
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: runtime,
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: "Sources/One.swift")) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         let second = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Two.swift")) }
         let third = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Three.swift")) }
         let queued = await waitForEngineCondition {
@@ -1118,24 +1096,22 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
                 "Sources/Three.swift": SwiftFixtureSource.emptyStruct("Three")
             ]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let fault = EngineManifestFaultOnPublications(Array(2 ..< 100))
         let hookEvents = EngineHookEvents()
         let runtime = try CodeMapArtifactRuntime(
             rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() },
-                faultAction: fault.action
-            )
+            manifestStoreHooks: CodeMapRootManifestStoreHooks(faultAction: fault.action)
         )
         let fixture = try await makeEngineFixture(
             root: root,
             runtime: runtime,
-            hooks: WorkspaceCodemapBindingEngineHooks { hookEvents.record($0) }
+            hooks: manifestWriteGateHooks(writeGate) { hookEvents.record($0) }
         )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let first = Task { await fixture.engine.demand(fixture.demand(path: "Sources/One.swift")) }
-        XCTAssertTrue(writeGate.waitUntilEntered())
+        let writeEntered = await writeGate.waitUntilEntered()
+        XCTAssertTrue(writeEntered)
         let second = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Two.swift")) }
         let third = Task { await fixture.engine.demand(fixture.demand(path: "Sources/Three.swift")) }
         XCTAssertTrue(hookEvents.wait(kind: .manifestRevisionQueued, numericValue: 3, timeout: 20))
@@ -1371,14 +1347,15 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
             named: "repository",
             files: ["Sources/Feature.swift": SwiftFixtureSource.emptyStruct("Feature")]
         )
-        let writeGate = EngineBlockingGate()
+        let writeGate = EngineAsyncGate()
         let runtime = try CodeMapArtifactRuntime(
-            rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts"),
-            manifestStoreHooks: CodeMapRootManifestStoreHooks(
-                afterWriteShardAdmission: { writeGate.enterAndWait() }
-            )
+            rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts")
         )
-        let fixture = try await makeEngineFixture(root: root, runtime: runtime)
+        let fixture = try await makeEngineFixture(
+            root: root,
+            runtime: runtime,
+            hooks: manifestWriteGateHooks(writeGate)
+        )
         _ = await fixture.engine.registerRoot(fixture.registration)
         let demand = Task {
             await fixture.engine.demand(fixture.demand(path: "Sources/Feature.swift"))
@@ -1487,6 +1464,16 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
         XCTAssertEqual(drained.ownerAdmissionHistoryCount, 0)
         XCTAssertEqual(drained.counters.cancellations, 2)
     }
+}
+
+private func manifestWriteGateHooks(
+    _ gate: EngineAsyncGate,
+    event: @escaping @Sendable (WorkspaceCodemapBindingEngineHookEvent) -> Void = { _ in }
+) -> WorkspaceCodemapBindingEngineHooks {
+    WorkspaceCodemapBindingEngineHooks(
+        debugBeforeManifestStoreWrite: { _ in await gate.enterAndWait() },
+        event: event
+    )
 }
 
 private enum ManifestRetryWaiterTestError: Error {

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineWarmManifestTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineWarmManifestTests.swift
@@ -535,7 +535,14 @@ final class CodemapBindingEngineWarmManifestTests: CodemapBindingEngineTestCase 
                 let runtime = try CodeMapArtifactRuntime(
                     rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts")
                 )
-                let fixture = try await makeEngineFixture(root: root, runtime: runtime)
+                let sourceAuthorityRejections = CodemapLockedValues<WorkspaceCodemapSourceAuthorityRejection>()
+                let fixture = try await makeEngineFixture(
+                    root: root,
+                    runtime: runtime,
+                    capabilityHooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                        sourceAuthorityRejected: { sourceAuthorityRejections.append($0) }
+                    )
+                )
                 guard case .registered = await fixture.engine.registerRoot(fixture.registration) else {
                     return XCTFail("Expected registration for \(state.rawValue) / \(churn.rawValue).")
                 }
@@ -586,7 +593,8 @@ final class CodemapBindingEngineWarmManifestTests: CodemapBindingEngineTestCase 
                 )
                 XCTAssertNotNil(
                     directSourceAuthority,
-                    "Expected source authority after \(state.rawValue) / \(churn.rawValue)."
+                    "Expected source authority after \(state.rawValue) / \(churn.rawValue); " +
+                        "rejections=\(sourceAuthorityRejections.values)."
                 )
                 let result = await fixture.engine.demand(fixture.demand(path: targetPath))
                 guard isReady(result) else {
@@ -644,12 +652,11 @@ final class CodemapBindingEngineWarmManifestTests: CodemapBindingEngineTestCase 
                 priority: .background
             ))
         }
-        guard let replacementResult = await demandResult(
-            replacement,
-            before: .seconds(5)
-        ), await adoptionGate.resolutionCount >= 2,
-        isReady(replacementResult)
-        else {
+        guard await adoptionGate.waitUntilResolutionCount(2) else {
+            return XCTFail("Expected replacement adoption to enter after invalidation.")
+        }
+        let replacementResult = await replacement.value
+        guard isReady(replacementResult) else {
             return XCTFail("Expected warm manifest adoption to retry after invalidation.")
         }
         await adoptionGate.releaseFirstResolution()
@@ -838,10 +845,11 @@ final class CodemapBindingEngineWarmManifestTests: CodemapBindingEngineTestCase 
         guard case .cancelled = await blocked.value else {
             return XCTFail("Expected logical cancellation before blocked I/O drained.")
         }
-        guard let replacementResult = await demandResult(replacement, before: .seconds(5)),
-              isReady(replacementResult),
-              await gate.resolutionCount >= 2
-        else {
+        guard await gate.waitUntilResolutionCount(2) else {
+            return XCTFail("Expected replacement read admission while stale I/O remained blocked.")
+        }
+        let replacementResult = await replacement.value
+        guard isReady(replacementResult) else {
             return XCTFail("Expected immediate replacement admission while stale I/O remained blocked.")
         }
         let recovered = await fixture.engine.accounting()

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineWarmManifestTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineWarmManifestTests.swift
@@ -193,10 +193,21 @@ final class CodemapBindingEngineWarmManifestTests: CodemapBindingEngineTestCase 
         )
         let artifactRoot = try makeSecureDirectory(in: repository.sandbox, named: "artifacts")
         let runtime = try CodeMapArtifactRuntime(rootURL: artifactRoot)
-        let seed = try await makeEngineFixture(root: root, runtime: runtime)
+        let seedEvents = EngineHookEvents()
+        let seed = try await makeEngineFixture(
+            root: root,
+            runtime: runtime,
+            hooks: WorkspaceCodemapBindingEngineHooks { seedEvents.record($0) }
+        )
         _ = await seed.engine.registerRoot(seed.registration)
-        guard case .ready = await seed.engine.demand(seed.demand(path: "Sources/Warm.swift")) else {
-            return XCTFail("Expected warm artifact seed.")
+        let seedResult = await seed.engine.demand(seed.demand(path: "Sources/Warm.swift"))
+        guard case .ready = seedResult else {
+            return await XCTFail(bindingDemandFailureMessage(
+                "Expected warm artifact seed.",
+                result: seedResult,
+                accounting: seed.engine.accounting(),
+                events: seedEvents.snapshot()
+            ))
         }
         await seed.engine.unloadRoot(rootEpoch: seed.rootEpoch)
 

--- a/docs/migrations/swift-6-2-concurrency/migration-ledger.md
+++ b/docs/migrations/swift-6-2-concurrency/migration-ledger.md
@@ -1,11 +1,11 @@
 # Swift 6.2 Concurrency Migration Ledger
 
-Updated: 2026-07-26
+Updated: 2026-08-08
 
 ## Toolchain and policy
 
-- Active compiler: Apple Swift 6.2.4 (`swift-driver` 1.127.15), arm64-apple-macosx26.0.
-- Root package tools version: 6.2; the package default remains Swift 5. Target-local Swift 6 boundaries are listed below; the headless domain runtime is first evidenced with Swift 5 complete checking before its separate M1 language-mode promotion.
+- Active compiler: Apple Swift 6.3.3 (`swift-driver` 1.148.6), arm64-apple-macosx26.0.
+- Root package tools version: 6.2; the package default remains Swift 5. Target-local Swift 6 boundaries are listed below; each newly promoted boundary is first evidenced with Swift 5 complete checking before its separate language-mode promotion.
 - Migration policy: target-scoped complete strict-concurrency checking first, followed by independently evidenced target-local `.swiftLanguageMode(.v6)`. No default MainActor or Swift 6.2 execution/isolation feature is adopted by this tranche.
 
 ## Completed boundaries
@@ -21,6 +21,7 @@ Updated: 2026-07-26
 | `RepoPromptRegexCore` | extraction `6feead2fcfbbd53bc9d4b9d0255401ec51bfd374`; Item 6 this change | Swift 6 | Production and owner-test targets compile with `-swift-version 6`; eight owner tests and Swift 5 app-consumer linkage pass. |
 | `RepoPromptCodeMapCore` / owner tests | extraction `22bfff1c5904d5f02c0a881055142c94f4783a84`; Item 6 this change | Swift 6 | Production and owner-test targets compile with `-swift-version 6`; 16 owner tests, mixed-mode app tests, and both Swift 5 product builds pass. |
 | `RepoPromptDomainRuntime` / owner tests (M1 foundation + M2 workspace/context authority) | Swift 5 foundation `76f3dcae131b2880a37a4c0ef6d1e80b2e784129`; Swift 6 promotion `5ccbc063`; M2 this branch | Swift 6 | Production and owner-test targets compile with target-local Swift 6 language mode and complete strict-concurrency checking; M2 adds actor-owned persistence, snapshots, routing, and launch-token values without isolation escape hatches. |
+| `RepoPromptShared` | this PR; initial baseline `cc9ff8f5901c2d511eef2e52d45cb21df780bace`, refreshed task base `c42e153b4f5c6d469c59d694ceb22a069800914e` | Swift 6 | The shared app/MCP protocol target passed Swift 5 complete checking before target-local Swift 6 promotion. Both mixed-mode products and the implicated CodeMap/lifecycle tests pass under Swift 6; final phase validation is recorded below. |
 
 ## Item 3 ownership record
 
@@ -45,7 +46,7 @@ Test ownership:
 
 ## Strict-concurrency diagnostics and escape-hatch inventory
 
-- `RepoPromptRegexCore`, `RepoPromptCodeMapCore`, `RepoPromptRegexCoreTests`, and `RepoPromptCodeMapCoreTests` now use target-local Swift 6 language mode. Verbose SwiftPM compiler invocations contain `-swift-version 6` for exactly those four modules; `RepoPromptApp`, `RepoPromptTests`, and `RepoPromptMCP` remain `-swift-version 5` consumers. No invocation adds default MainActor, `NonisolatedNonsendingByDefault`, `InferIsolatedConformances`, or another execution/isolation feature.
+- `RepoPromptRegexCore`, `RepoPromptCodeMapCore`, `RepoPromptDomainRuntime`, their owner-test targets, and `RepoPromptShared` now use target-local Swift 6 language mode. `RepoPromptApp`, `RepoPromptTests`, `RepoPromptMCP`, and the package default remain Swift 5 consumers. No invocation adds default MainActor, `NonisolatedNonsendingByDefault`, `InferIsolatedConformances`, or another execution/isolation feature.
 - Parser and cursor objects remain invocation-local and never cross a Sendable boundary. Public cross-target graphs remain package-visible immutable Sendable values.
 
 | Escape hatch | Scope | Preserved invariant | Audit / removal condition |
@@ -53,7 +54,7 @@ Test ownership:
 | `nonisolated(unsafe)` on standard-library `Regex` constants | 25 existing annotations in `LanguageTypeExtractor` | Every value is immutable and initialized once; matching is nonmutating; no mutable shared cache or escaping match state is hidden by the annotation. The annotation exists because the standard-library `Regex` output metadata used here does not expose Sendable conformance. | Re-audit when the deployed Swift standard library makes these concrete/type-erased `Regex` values Sendable; remove only when the active minimum toolchain compiles the declarations without the escape hatch. |
 | `PCRE2Regex: @unchecked Sendable` | One existing class in `RepoPromptRegexCore` | Compilation, including JIT, completes before publication and the compiled `pcre2_code` is immutable afterward. Ordinary matches allocate independent match data/context; `MatchSession` owns mutable state, is deliberately non-Sendable, and is confined to one sequential consumer. A live call retains the regex, preventing deinitialization from racing the call. The current implementation therefore needs no lock around immutable compiled code. | Re-audit on a PCRE2 upgrade or any change that shares mutable match/session state, mutates compiled code after publication, or changes lifetime ownership. |
 
-No new escape hatch or source annotation was added for Item 6. M1 likewise adds no `nonisolated(unsafe)`, `@unchecked Sendable`, `@preconcurrency`, or default-actor-isolation escape hatch to `RepoPromptDomainRuntime`. The four target logs and raw verbose invocation evidence contain zero diagnostics attributed to their source or owner-test paths.
+No new escape hatch or source annotation was added for Item 6, M1/M2, or the `RepoPromptShared` promotion. The promoted target logs and raw verbose invocation evidence contain zero diagnostics attributed to their source or owner-test paths.
 
 ## Item 3 evidence
 
@@ -77,6 +78,16 @@ No new escape hatch or source annotation was added for Item 6. M1 likewise adds 
 - Swift 5 consumer products: RepoPrompt ticket `6c091ce4…`; repoprompt-mcp ticket `afed7b28…`; both built successfully.
 - Phase boundary: full root ticket `a5f3c831…` passed in 9m28s; full provider ticket `11ad3aad…` passed; lint ticket `ce6cd2f4…`, 23 generator contract tests, and source/license guardrails passed.
 - Package default remains `swiftLanguageModes: [.v5]`; `Package.resolved` and all source files are unchanged.
+
+## RepoPromptShared Swift 6 language-mode evidence
+
+- Clean baseline at `cc9ff8f5901c2d511eef2e52d45cb21df780bace`: `RepoPrompt` ticket `101708d1-f662-44ef-9379-ee521d3504b2` and `repoprompt-mcp` ticket `caa17164-ef7b-467f-8213-fba21efaf04e` built successfully before any manifest change.
+- Swift 5 complete strict-concurrency stage: both products passed (`b2aa4b5e-9f09-424a-9434-270dcfb05d9d` / `0d58dbb0-8dbc-414a-b35d-c2166f5c5525`), along with six tracer tests (`c700c5d2-1c74-4f48-9989-2ebc17f779e6`), 18 JSON-RPC ledger tests (`2daba278-6020-425b-96fa-24d079e32106`), and seven MCP message tests (`272cc344-8c8a-452f-82e9-3a94f0af3f37`). No `RepoPromptShared` compiler diagnostic or source repair was required.
+- Target-local Swift 6 stage: the SwiftPM build plan records `-swift-version 6` for `RepoPromptShared`. Both products passed before the broader investigation (`97afbe82-f83f-46ff-8c2b-cb444d3ff744` / `7cbb0a90-f3b1-40e3-bcec-a006ae5325a7`), as did the same six tracer (`61038d4b-3b1f-47fa-8487-d30692ed6e0b`), 18 JSON-RPC ledger (`80b22dff-73e3-463c-81de-16f427c38da2`), and seven MCP message (`e00bbca4-9fb6-4e7c-90ae-631a48f29d70`) tests.
+- The first full-suite run exposed seven load/order-sensitive CodeMap failures and later stopped making progress while multiple Codex watchdog tasks remained alive from the liveness suite. No assertion, retry count, or timeout was weakened. Coordinator tests now wait on lifecycle hook delivery, binding-engine tests wait on explicit resolution-count signals, automatic-selection coverage waits on the real sync task, and the liveness suite performs the production window-close teardown used by neighboring suites. Source-authority rejection remains fail-closed and now reports a redacted typed rejection boundary for future diagnosis.
+- The implicated suites passed together under Swift 6 in ticket `b2b1c0e1-ffb6-496b-8f5f-9a9117201037`: 162 tests covering coordinator cancellation/publication, automatic selection, binding invalidation, warm-manifest adoption, Codex liveness teardown, and the memory-sampler boundary. Post-repair product builds passed for `RepoPrompt` (`9669f37c-b1fc-4fb5-bea5-8dc952e659e8`) and `repoprompt-mcp` (`9c66d0f3-c973-4553-bccf-e55ef9af32b8`). Final full-suite/style/guardrail evidence is pending.
+- The refreshed current-main investigation reproduced a genuine automatic-selection scheduling failure rather than extending its wait budget: pending target demands now use completion-driven waiting, and owned busy demands use atomic replacement with exact retained-ticket cleanup. The deterministic busy, cancellation, manifest-shutdown, and source-authority cases passed under tickets `7038f675-3b71-4efc-86b3-57c14f9fc875`, `ab25dd8f-d932-4824-b1a8-7beee4c3a911`, and `9f66bb42-656f-4560-af64-c48a5cd0857f`; refreshed Swift 6 `RepoPrompt` build ticket `7367af22-ea86-4a37-b798-ae9de7c9f01d` passed. Production deadlines and fail-closed behavior remain unchanged.
+- The package default, `RepoPromptApp`, `RepoPromptTests`, and `RepoPromptMCP` remain Swift 5. No default-actor-isolation feature or unchecked concurrency escape hatch was added, and no app lifecycle action was run.
 
 ## M1 headless domain-runtime foundation evidence
 


### PR DESCRIPTION
## Summary

- migrate `RepoPromptShared` to Swift 6 language mode after completing its Swift 5 remediation stage in the same change
- preserve explicit isolation policy: no default actor isolation and no new unsafe concurrency escape hatches
- make CodeMap automatic-selection demand retries, cancellation cleanup, and completion waiting ownership-driven and deterministic
- replace blocking manifest-writer test hooks with async pre-write seams while retaining the one intentionally non-cancellable shutdown fence
- add typed, fail-closed source-authority rejection diagnostics and update the Swift 6 migration ledger
- integrate the latest `origin/main` (`db8de7db`) and repair the transcript-signature cleanup call sites/tests that otherwise prevented current main from compiling

## Migration approach

This combines the two requested stages in one PR:

1. remediate `RepoPromptShared` and its affected CodeMap concurrency/test boundaries while still in Swift 5 mode
2. enable the existing Swift 6 language-mode setting for the target and validate the switched target

Production retry/deadline budgets are unchanged. The test-only completion seams remove polling and wall-clock races rather than weakening assertions or increasing timeouts.

## Validation

- `make dev-lint` — passed (`0dfc9890-0796-4cf2-a2ac-1f16e0816679`)
- Swift 6 `RepoPrompt` product build — passed (`7367af22-ea86-4a37-b798-ae9de7c9f01d`)
- automatic-selection root-cause trio — passed (`9f66bb42-656f-4560-af64-c48a5cd0857f`)
- cancellation cleanup regression — passed (`ab25dd8f-d932-4824-b1a8-7beee4c3a911`)
- warm-manifest suite — 19/19 passed (`d9a4ca08-3e2b-4ccc-b9e0-af5890086a71`)
- post-format focused regressions — 3/3 passed (`979fd97c-54a3-4610-a027-4e18f83520c4`)
- mandatory contribution `commit` and `push` preflights — passed

Additional dual-heavy-slot stress exposed wall-clock sensitivity in one warm-adoption test while another checkout was compiling/testing concurrently; the repository-default coordinated lane and focused regression pass. No timeout was increased and failure diagnostics were strengthened.

No app was launched.
