### PR TITLE
Fence tool-card presentation derivation from render recomputation

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/AgentControlToolCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/AgentControlToolCards.swift
@@ -260,7 +260,7 @@ struct AgentRunResultCard: View {
         guard let raw = item.toolResultJSON?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
             return false
         }
-        if let object = ToolRawJSON.object(from: item.toolResultJSON),
+        if let object = ToolJSON.rawObject(from: item.toolResultJSON),
            ToolRawJSON.bool(object, key: "summary_only") == true
         {
             return false
@@ -375,7 +375,7 @@ struct AgentExploreResultCard: View {
         guard let raw = item.toolResultJSON?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
             return false
         }
-        if let object = ToolRawJSON.object(from: item.toolResultJSON),
+        if let object = ToolJSON.rawObject(from: item.toolResultJSON),
            ToolRawJSON.bool(object, key: "summary_only") == true
         {
             return false
@@ -478,7 +478,7 @@ struct AgentManageResultCard: View {
         guard let raw = item.toolResultJSON?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
             return false
         }
-        if let object = ToolRawJSON.object(from: item.toolResultJSON),
+        if let object = ToolJSON.rawObject(from: item.toolResultJSON),
            ToolRawJSON.bool(object, key: "summary_only") == true
         {
             return false

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardProjectionCache.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardProjectionCache.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Bounded memoization fence for deterministic tool-card presentation
+/// projections derived from immutable transcript JSON payloads.
+///
+/// SwiftUI re-evaluates tool-card `body` frequently while a transcript
+/// streams. Decoding completed tool-result JSON and classifying it into
+/// presentation values (DTOs, structured objects, card status) is
+/// deterministic for a given payload, so this cache performs each derivation
+/// once per unique input revision and reuses the immutable value across body
+/// recomputations.
+///
+/// This cache is not an authority. Canonical transcript items remain the only
+/// source of truth; entries are keyed purely by input content, so a changed
+/// payload (for example a new streaming revision) naturally misses and is
+/// derived fresh. Storage is bounded: when the entry count reaches
+/// `maxEntryCount` the map is dropped wholesale and rebuilt on demand — the
+/// same policy used by `BashToolResultParser.Cache` and
+/// `AgentToolResultProcessingContext`.
+final class ToolCardProjectionCache: @unchecked Sendable {
+    static let shared = ToolCardProjectionCache()
+
+    static let maxEntryCount = 512
+
+    private struct Key: Hashable {
+        let kind: ObjectIdentifier
+        let variant: String
+        let primary: String
+        let secondary: String?
+    }
+
+    private enum Entry {
+        case value(Any)
+        case missing
+    }
+
+    #if DEBUG
+        struct Metrics: Equatable {
+            var hitCount = 0
+            var missCount = 0
+            var evictionCount = 0
+        }
+
+        private var metrics = Metrics()
+    #endif
+
+    private let lock = NSLock()
+    private var storage: [Key: Entry] = [:]
+
+    /// Returns the memoized projection for `(Value.self, variant, primary,
+    /// secondary)`, computing it once per unique input. `compute` must be a
+    /// pure function of the key inputs. A `nil` computed value is memoized as
+    /// missing so failed derivations are not retried on every body evaluation.
+    ///
+    /// Inputs with a `nil` or empty `primary` are not cached; `compute` runs
+    /// directly (it is expected to be trivial for empty payloads).
+    func projection<Value>(
+        _ valueType: Value.Type,
+        variant: String,
+        primary: String?,
+        secondary: String? = nil,
+        compute: () -> Value?
+    ) -> Value? {
+        guard let primary, !primary.isEmpty else {
+            return compute()
+        }
+        let key = Key(
+            kind: ObjectIdentifier(valueType),
+            variant: variant,
+            primary: primary,
+            secondary: secondary
+        )
+        lock.lock()
+        if let cached = storage[key] {
+            #if DEBUG
+                metrics.hitCount += 1
+            #endif
+            lock.unlock()
+            switch cached {
+            case let .value(value):
+                return value as? Value
+            case .missing:
+                return nil
+            }
+        }
+        #if DEBUG
+            metrics.missCount += 1
+        #endif
+        lock.unlock()
+
+        let value = compute()
+
+        lock.lock()
+        if storage.count >= Self.maxEntryCount {
+            #if DEBUG
+                metrics.evictionCount += 1
+            #endif
+            storage.removeAll(keepingCapacity: true)
+        }
+        storage[key] = value.map(Entry.value) ?? .missing
+        lock.unlock()
+        return value
+    }
+
+    #if DEBUG
+        func metricsSnapshot() -> Metrics {
+            lock.lock()
+            defer { lock.unlock() }
+            return metrics
+        }
+
+        var entryCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage.count
+        }
+    #endif
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolJSON.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolJSON.swift
@@ -37,25 +37,40 @@ enum ToolJSON {
         return raw.data(using: .utf8)
     }
 
-    /// Decode args DTOs (uses convertFromSnakeCase for DTOs without explicit CodingKeys)
-    static func decodeArgs<T: Decodable>(_ type: T.Type, from json: String?) -> T? {
-        guard let data = data(from: json) else { return nil }
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try? decoder.decode(type, from: data)
+    /// Decode args DTOs (uses convertFromSnakeCase for DTOs without explicit CodingKeys).
+    /// Memoized per unique payload via `ToolCardProjectionCache` so repeated
+    /// SwiftUI body evaluations reuse the derived DTO.
+    static func decodeArgs<T: Decodable>(
+        _ type: T.Type,
+        from json: String?,
+        cache: ToolCardProjectionCache = .shared
+    ) -> T? {
+        cache.projection(T.self, variant: "args", primary: json) {
+            guard let data = data(from: json) else { return nil }
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try? decoder.decode(type, from: data)
+        }
     }
 
-    /// Decode result DTOs (no key conversion - result DTOs have explicit CodingKeys)
-    static func decodeResult<T: Decodable>(_ type: T.Type, from json: String?) -> T? {
-        guard let directData = data(from: json) else { return nil }
-        let decoder = JSONDecoder()
-        if let nestedJSON = preferredStructuredResultJSON(from: json, requireEnvelope: true),
-           let nestedData = data(from: nestedJSON),
-           let nested = try? decoder.decode(type, from: nestedData)
-        {
-            return nested
+    /// Decode result DTOs (no key conversion - result DTOs have explicit CodingKeys).
+    /// Memoized per unique payload via `ToolCardProjectionCache`.
+    static func decodeResult<T: Decodable>(
+        _ type: T.Type,
+        from json: String?,
+        cache: ToolCardProjectionCache = .shared
+    ) -> T? {
+        cache.projection(T.self, variant: "result", primary: json) {
+            guard let directData = data(from: json) else { return nil }
+            let decoder = JSONDecoder()
+            if let nestedJSON = preferredStructuredResultJSON(from: json, requireEnvelope: true, cache: cache),
+               let nestedData = data(from: nestedJSON),
+               let nested = try? decoder.decode(type, from: nestedData)
+            {
+                return nested
+            }
+            return try? decoder.decode(type, from: directData)
         }
-        return try? decoder.decode(type, from: directData)
     }
 
     /// Legacy decode - prefer decodeArgs or decodeResult
@@ -63,31 +78,54 @@ enum ToolJSON {
         decodeResult(type, from: json)
     }
 
-    static func preferredStructuredResultJSON(from json: String?, requireEnvelope: Bool = false) -> String? {
-        guard let data = data(from: json),
-              let root = try? JSONSerialization.jsonObject(with: data)
-        else {
-            return requireEnvelope ? nil : json?.trimmingCharacters(in: .whitespacesAndNewlines)
+    /// Memoized `ToolRawJSON.object(from:)` for presentation-layer reads.
+    /// Tool cards should use this instead of calling `ToolRawJSON.object`
+    /// directly inside `body` evaluation.
+    static func rawObject(
+        from json: String?,
+        cache: ToolCardProjectionCache = .shared
+    ) -> [String: Any]? {
+        cache.projection([String: Any].self, variant: "rawObject", primary: json) {
+            ToolRawJSON.object(from: json)
         }
-        guard let preferred = preferredStructuredValue(in: root) else {
-            return requireEnvelope ? nil : json?.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        return canonicalJSONString(from: preferred)
     }
 
-    static func structuredResultObject(from json: String?) -> [String: Any]? {
-        if let preferred = preferredStructuredResultJSON(from: json),
-           let data = preferred.data(using: .utf8),
-           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        {
+    static func preferredStructuredResultJSON(
+        from json: String?,
+        requireEnvelope: Bool = false,
+        cache: ToolCardProjectionCache = .shared
+    ) -> String? {
+        cache.projection(String.self, variant: "preferredJSON|env:\(requireEnvelope)", primary: json) {
+            guard let data = data(from: json),
+                  let root = try? JSONSerialization.jsonObject(with: data)
+            else {
+                return requireEnvelope ? nil : json?.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            guard let preferred = preferredStructuredValue(in: root) else {
+                return requireEnvelope ? nil : json?.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return canonicalJSONString(from: preferred)
+        }
+    }
+
+    static func structuredResultObject(
+        from json: String?,
+        cache: ToolCardProjectionCache = .shared
+    ) -> [String: Any]? {
+        cache.projection([String: Any].self, variant: "structuredResultObject", primary: json) {
+            if let preferred = preferredStructuredResultJSON(from: json, cache: cache),
+               let data = preferred.data(using: .utf8),
+               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            {
+                return object
+            }
+            guard let data = data(from: json),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else {
+                return nil
+            }
             return object
         }
-        guard let data = data(from: json),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return nil
-        }
-        return object
     }
 
     static func prettyPrinted(_ json: String) -> String {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultAppSettingsCard.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultAppSettingsCard.swift
@@ -9,7 +9,7 @@ struct AppSettingsCardPresentation: Equatable {
 
 enum AppSettingsCardPresentationBuilder {
     static func callSubtitle(argsJSON: String?) -> String? {
-        guard let args = ToolRawJSON.object(from: argsJSON) else { return nil }
+        guard let args = ToolJSON.rawObject(from: argsJSON) else { return nil }
         let op = normalizedOp(string(args, key: "op")) ?? "app_settings"
         switch op {
         case "list":
@@ -24,7 +24,7 @@ enum AppSettingsCardPresentationBuilder {
     }
 
     static func build(argsJSON: String?, resultJSON: String?, toolIsError: Bool?) -> AppSettingsCardPresentation {
-        let args = ToolRawJSON.object(from: argsJSON)
+        let args = ToolJSON.rawObject(from: argsJSON)
         let preferredResultJSON = ToolJSON.preferredStructuredResultJSON(from: resultJSON)
         let result = resultObject(from: resultJSON, preferredResultJSON: preferredResultJSON)
         let op = normalizedOp(string(result, key: "op"))
@@ -53,10 +53,10 @@ enum AppSettingsCardPresentationBuilder {
     }
 
     private static func resultObject(from raw: String?, preferredResultJSON: String?) -> [String: Any]? {
-        if let object = ToolRawJSON.object(from: preferredResultJSON) {
+        if let object = ToolJSON.rawObject(from: preferredResultJSON) {
             return object
         }
-        return ToolRawJSON.object(from: raw)
+        return ToolJSON.rawObject(from: raw)
     }
 
     private static func listCallSubtitle(args: [String: Any]) -> String {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultCardShared.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultCardShared.swift
@@ -5,7 +5,7 @@ func toolResultHasPayload(_ item: AgentChatItem) -> Bool {
         return false
     }
     guard !raw.isEmpty else { return false }
-    if let object = ToolRawJSON.object(from: item.toolResultJSON),
+    if let object = ToolJSON.rawObject(from: item.toolResultJSON),
        ToolRawJSON.bool(object, key: "summary_only") == true
     {
         return false
@@ -14,7 +14,7 @@ func toolResultHasPayload(_ item: AgentChatItem) -> Bool {
 }
 
 func toolResultIsSummaryOnly(_ item: AgentChatItem) -> Bool {
-    guard let object = ToolRawJSON.object(from: item.toolResultJSON) else {
+    guard let object = ToolJSON.rawObject(from: item.toolResultJSON) else {
         return false
     }
     return ToolRawJSON.bool(object, key: "summary_only") == true
@@ -39,7 +39,7 @@ struct StoredToolCardPresentation: Equatable {
     }
 
     static func fromSummaryOnly(raw: String?) -> StoredToolCardPresentation? {
-        guard let object = ToolRawJSON.object(from: raw),
+        guard let object = ToolJSON.rawObject(from: raw),
               ToolRawJSON.bool(object, key: "summary_only") == true
         else {
             return nil
@@ -126,7 +126,7 @@ extension ToolCardStatus {
 }
 
 func storageStatusSubtitle(for item: AgentChatItem) -> String? {
-    guard let object = ToolRawJSON.object(from: item.toolResultJSON),
+    guard let object = ToolJSON.rawObject(from: item.toolResultJSON),
           ToolRawJSON.bool(object, key: "summary_only") == true
     else {
         return nil

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultMarkdownContent.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultMarkdownContent.swift
@@ -102,7 +102,7 @@ private enum ToolResultMarkdownRenderer {
     }
 
     private static func mcpTransportMarkdown(from payload: String) -> String? {
-        guard let object = ToolRawJSON.object(from: payload) else { return nil }
+        guard let object = ToolJSON.rawObject(from: payload) else { return nil }
         let envelope = (object["Ok"] as? [String: Any])
             ?? (object["ok"] as? [String: Any])
             ?? (object["Err"] as? [String: Any])

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultReadSearchCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultReadSearchCards.swift
@@ -195,14 +195,14 @@ struct NativeToolResultCard: View {
 enum NativeToolCardPresentationBuilder {
     static func build(item: AgentChatItem, normalizedToolName: String?) -> AgentToolCardRenderSummary? {
         let normalizedToolName = normalizedToolName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if let summaryObject = ToolRawJSON.object(from: item.toolResultJSON),
+        if let summaryObject = ToolJSON.rawObject(from: item.toolResultJSON),
            let renderSummary = AgentToolCardRenderSummary(summaryOnlyObject: summaryObject)
         {
             guard canTrustStoredSummary(renderSummary, normalizedToolName: normalizedToolName) else { return nil }
             return renderSummary
         }
-        let rawObject = ToolRawJSON.object(from: item.toolResultJSON)
-        let argsObject = ToolRawJSON.object(from: item.toolArgsJSON)
+        let rawObject = ToolJSON.rawObject(from: item.toolResultJSON)
+        let argsObject = ToolJSON.rawObject(from: item.toolArgsJSON)
         let statusWord = statusWord(for: item)
         return AgentToolCardRenderSummaryBuilder.build(
             normalizedToolName: normalizedToolName,
@@ -234,7 +234,7 @@ enum NativeToolCardPresentationBuilder {
     private static func statusWord(for item: AgentChatItem) -> String {
         if item.toolIsError == true { return "failed" }
         if item.toolIsError == false { return "success" }
-        guard let object = ToolRawJSON.object(from: item.toolResultJSON) else { return "unknown" }
+        guard let object = ToolJSON.rawObject(from: item.toolResultJSON) else { return "unknown" }
         for key in ["status", "state", "outcome", "result"] {
             if let value = ToolRawJSON.string(object, key: key)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
                 return value

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultStatusResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultStatusResolver.swift
@@ -1,8 +1,30 @@
 import Foundation
 
 enum ToolResultStatusResolver {
-    static func resolve(toolIsError: Bool?, raw: String?, fallback: ToolCardStatus) -> ToolCardStatus {
-        guard let object = ToolRawJSON.object(from: raw) else {
+    /// Resolves the presentation status for a tool result payload.
+    /// Classification is deterministic for a given `(toolIsError, raw,
+    /// fallback)` input, so the derived status is memoized via
+    /// `ToolCardProjectionCache` and reused across SwiftUI body evaluations.
+    static func resolve(
+        toolIsError: Bool?,
+        raw: String?,
+        fallback: ToolCardStatus,
+        cache: ToolCardProjectionCache = .shared
+    ) -> ToolCardStatus {
+        let variant = "status|e:\(toolIsError.map { $0 ? "1" : "0" } ?? "-")|f:\(fallback.projectionCacheDiscriminator)"
+        let resolved = cache.projection(ToolCardStatus.self, variant: variant, primary: raw) {
+            resolveUncached(toolIsError: toolIsError, raw: raw, fallback: fallback, cache: cache)
+        }
+        return resolved ?? fallback
+    }
+
+    private static func resolveUncached(
+        toolIsError: Bool?,
+        raw: String?,
+        fallback: ToolCardStatus,
+        cache: ToolCardProjectionCache
+    ) -> ToolCardStatus {
+        guard let object = ToolJSON.rawObject(from: raw, cache: cache) else {
             if toolIsError == true { return .failure }
             if toolIsError == false { return .success }
             return fallback
@@ -148,5 +170,18 @@ enum ToolResultStatusResolver {
         let normalized = AgentTranscriptToolStatusSemantics.normalizedStatusWord(value)
         let transcriptStatus = AgentTranscriptToolStatusSemantics.transcriptStatus(fromNormalizedStatusWord: normalized)
         return ToolCardStatus.fromTranscriptStatus(transcriptStatus)
+    }
+}
+
+private extension ToolCardStatus {
+    /// Stable cache-key discriminator for `ToolCardProjectionCache` variants.
+    var projectionCacheDiscriminator: String {
+        switch self {
+        case .running: "running"
+        case .success: "success"
+        case .warning: "warning"
+        case .failure: "failure"
+        case .neutral: "neutral"
+        }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultUnknownCard.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultUnknownCard.swift
@@ -14,7 +14,7 @@ struct UnknownToolResultCard: View {
         if let subtitle = StoredToolCardPresentation.fromSummaryOnly(raw: item.toolResultJSON)?.inlineSubtitle {
             return subtitle
         }
-        guard let obj = ToolRawJSON.object(from: item.toolResultJSON) else { return nil }
+        guard let obj = ToolJSON.rawObject(from: item.toolResultJSON) else { return nil }
         if let status = ToolRawJSON.string(obj, key: "status"), !status.isEmpty {
             return status
         }

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/ToolCardProjectionFenceTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/ToolCardProjectionFenceTests.swift
@@ -1,0 +1,233 @@
+@testable import RepoPromptApp
+import XCTest
+
+/// Regression tests for the tool-card presentation projection fence.
+///
+/// Tool-card presentation derivations (DTO decoding, structured-object
+/// parsing, status classification) are deterministic functions of immutable
+/// transcript JSON. These tests demonstrate that repeated evaluation — the
+/// shape of repeated SwiftUI `body` recomputation — performs each derivation
+/// once per unique input revision via `ToolCardProjectionCache`, stays
+/// deterministic, and remains memory-bounded.
+final class ToolCardProjectionFenceTests: XCTestCase {
+    private struct ProbeArgs: Decodable, Equatable {
+        let path: String?
+        let maxDepth: Int?
+    }
+
+    private struct ProbeResult: Decodable, Equatable {
+        let status: String
+
+        private enum CodingKeys: String, CodingKey {
+            case status
+        }
+    }
+
+    // MARK: - Cache core semantics
+
+    func testProjectionComputesOncePerUniqueInput() {
+        let cache = ToolCardProjectionCache()
+        var computeCount = 0
+
+        for _ in 0 ..< 5 {
+            let value = cache.projection(String.self, variant: "probe", primary: "{\"a\":1}") {
+                computeCount += 1
+                return "derived"
+            }
+            XCTAssertEqual(value, "derived")
+        }
+
+        XCTAssertEqual(computeCount, 1)
+        let metrics = cache.metricsSnapshot()
+        XCTAssertEqual(metrics.missCount, 1)
+        XCTAssertEqual(metrics.hitCount, 4)
+    }
+
+    func testProjectionMemoizesFailedDerivationsWithoutRetry() {
+        let cache = ToolCardProjectionCache()
+        var computeCount = 0
+
+        for _ in 0 ..< 3 {
+            let value = cache.projection(String.self, variant: "probe", primary: "not json") { () -> String? in
+                computeCount += 1
+                return nil
+            }
+            XCTAssertNil(value)
+        }
+
+        XCTAssertEqual(computeCount, 1)
+    }
+
+    func testProjectionDoesNotCacheEmptyPayloads() {
+        let cache = ToolCardProjectionCache()
+        var computeCount = 0
+
+        for _ in 0 ..< 2 {
+            _ = cache.projection(String.self, variant: "probe", primary: nil) {
+                computeCount += 1
+                return "x"
+            }
+            _ = cache.projection(String.self, variant: "probe", primary: "") {
+                computeCount += 1
+                return "x"
+            }
+        }
+
+        XCTAssertEqual(computeCount, 4)
+        XCTAssertEqual(cache.entryCount, 0)
+    }
+
+    func testProjectionIsolatesKindVariantAndSecondaryKeys() {
+        let cache = ToolCardProjectionCache()
+        let raw = "{\"a\":1}"
+
+        let stringValue = cache.projection(String.self, variant: "v1", primary: raw) { "s" }
+        let intValue = cache.projection(Int.self, variant: "v1", primary: raw) { 7 }
+        let otherVariant = cache.projection(String.self, variant: "v2", primary: raw) { "t" }
+        let withSecondary = cache.projection(String.self, variant: "v1", primary: raw, secondary: "args") { "u" }
+
+        XCTAssertEqual(stringValue, "s")
+        XCTAssertEqual(intValue, 7)
+        XCTAssertEqual(otherVariant, "t")
+        XCTAssertEqual(withSecondary, "u")
+        XCTAssertEqual(cache.metricsSnapshot().missCount, 4)
+        XCTAssertEqual(cache.entryCount, 4)
+
+        // Repeats hit their own entries without recomputation.
+        XCTAssertEqual(cache.projection(String.self, variant: "v1", primary: raw) { "unused" }, "s")
+        XCTAssertEqual(cache.projection(Int.self, variant: "v1", primary: raw) { -1 }, 7)
+        XCTAssertEqual(cache.metricsSnapshot().missCount, 4)
+    }
+
+    func testProjectionStorageStaysBoundedAndRecoversAfterEviction() {
+        let cache = ToolCardProjectionCache()
+
+        for index in 0 ..< (ToolCardProjectionCache.maxEntryCount + 8) {
+            _ = cache.projection(Int.self, variant: "probe", primary: "payload-\(index)") { index }
+        }
+
+        let metrics = cache.metricsSnapshot()
+        XCTAssertGreaterThanOrEqual(metrics.evictionCount, 1)
+        XCTAssertLessThanOrEqual(cache.entryCount, ToolCardProjectionCache.maxEntryCount)
+
+        // Evicted entries recompute correctly on demand.
+        let recomputed = cache.projection(Int.self, variant: "probe", primary: "payload-0") { 0 }
+        XCTAssertEqual(recomputed, 0)
+    }
+
+    // MARK: - ToolJSON fence wiring
+
+    func testDecodeArgsIsFencedAndDeterministic() {
+        let cache = ToolCardProjectionCache()
+        let json = "{\"path\": \"a/b/c.swift\", \"max_depth\": 3}"
+
+        let first = ToolJSON.decodeArgs(ProbeArgs.self, from: json, cache: cache)
+        let second = ToolJSON.decodeArgs(ProbeArgs.self, from: json, cache: cache)
+
+        XCTAssertEqual(first, ProbeArgs(path: "a/b/c.swift", maxDepth: 3))
+        XCTAssertEqual(first, second)
+        let metrics = cache.metricsSnapshot()
+        XCTAssertEqual(metrics.missCount, 1)
+        XCTAssertEqual(metrics.hitCount, 1)
+    }
+
+    func testDecodeResultIsFencedIncludingEnvelopeUnwrapping() {
+        let cache = ToolCardProjectionCache()
+        let json = "{\"ok\": {\"status\": \"done\"}}"
+
+        let first = ToolJSON.decodeResult(ProbeResult.self, from: json, cache: cache)
+        XCTAssertEqual(first, ProbeResult(status: "done"))
+
+        let missesAfterFirst = cache.metricsSnapshot().missCount
+        let second = ToolJSON.decodeResult(ProbeResult.self, from: json, cache: cache)
+        XCTAssertEqual(second, first)
+        XCTAssertEqual(cache.metricsSnapshot().missCount, missesAfterFirst, "repeat decode must not derive again")
+    }
+
+    func testRawObjectAndStructuredResultObjectAreFenced() {
+        let cache = ToolCardProjectionCache()
+        let json = "{\"status\": \"completed\", \"count\": 2}"
+
+        let rawFirst = ToolJSON.rawObject(from: json, cache: cache)
+        XCTAssertEqual(rawFirst?["status"] as? String, "completed")
+        let structuredFirst = ToolJSON.structuredResultObject(from: json, cache: cache)
+        XCTAssertEqual(structuredFirst?["count"] as? Int, 2)
+
+        let missesAfterFirst = cache.metricsSnapshot().missCount
+        _ = ToolJSON.rawObject(from: json, cache: cache)
+        _ = ToolJSON.structuredResultObject(from: json, cache: cache)
+        XCTAssertEqual(cache.metricsSnapshot().missCount, missesAfterFirst)
+    }
+
+    func testDistinctPayloadRevisionsDeriveFreshProjections() {
+        let cache = ToolCardProjectionCache()
+        let first = ToolJSON.decodeArgs(ProbeArgs.self, from: "{\"path\": \"one\"}", cache: cache)
+        let second = ToolJSON.decodeArgs(ProbeArgs.self, from: "{\"path\": \"two\"}", cache: cache)
+
+        XCTAssertEqual(first?.path, "one")
+        XCTAssertEqual(second?.path, "two")
+        XCTAssertEqual(cache.metricsSnapshot().missCount, 2)
+    }
+
+    // MARK: - Status classification fence
+
+    func testStatusResolutionIsFencedAcrossRepeatedEvaluation() {
+        let cache = ToolCardProjectionCache()
+        let raw = "{\"is_error\": false, \"status\": \"completed\"}"
+
+        let first = ToolResultStatusResolver.resolve(toolIsError: nil, raw: raw, fallback: .neutral, cache: cache)
+        XCTAssertEqual(first, .success)
+
+        let missesAfterFirst = cache.metricsSnapshot().missCount
+        for _ in 0 ..< 3 {
+            let repeated = ToolResultStatusResolver.resolve(toolIsError: nil, raw: raw, fallback: .neutral, cache: cache)
+            XCTAssertEqual(repeated, .success)
+        }
+        XCTAssertEqual(cache.metricsSnapshot().missCount, missesAfterFirst, "repeat resolution must not classify again")
+    }
+
+    func testStatusResolutionKeepsInputVariantsIsolated() {
+        let cache = ToolCardProjectionCache()
+        let raw = "{\"note\": \"no status keys\"}"
+
+        let asFailure = ToolResultStatusResolver.resolve(toolIsError: true, raw: raw, fallback: .neutral, cache: cache)
+        let asFallback = ToolResultStatusResolver.resolve(toolIsError: nil, raw: raw, fallback: .neutral, cache: cache)
+        let asRunningFallback = ToolResultStatusResolver.resolve(toolIsError: nil, raw: raw, fallback: .running, cache: cache)
+
+        XCTAssertEqual(asFailure, .failure)
+        XCTAssertEqual(asFallback, .neutral)
+        XCTAssertEqual(asRunningFallback, .running)
+    }
+
+    func testStatusResolutionMatchesUnfencedBehaviorAcrossRepresentativePayloads() {
+        let payloads: [(raw: String?, toolIsError: Bool?, expected: ToolCardStatus)] = [
+            (nil, true, .failure),
+            (nil, false, .success),
+            (nil, nil, .neutral),
+            ("{\"is_error\": true}", nil, .failure),
+            ("{\"exit_code\": 0, \"type\": \"command_execution\"}", nil, .success),
+            ("{\"errors\": [\"boom\"]}", nil, .failure),
+            ("{\"warning\": \"partial\"}", nil, .warning),
+            ("{\"ok\": true}", nil, .success)
+        ]
+
+        for payload in payloads {
+            // Two independent caches must agree: the projection is a pure
+            // function of the payload, never cross-contaminated state.
+            let one = ToolResultStatusResolver.resolve(
+                toolIsError: payload.toolIsError,
+                raw: payload.raw,
+                fallback: .neutral,
+                cache: ToolCardProjectionCache()
+            )
+            let two = ToolResultStatusResolver.resolve(
+                toolIsError: payload.toolIsError,
+                raw: payload.raw,
+                fallback: .neutral,
+                cache: ToolCardProjectionCache()
+            )
+            XCTAssertEqual(one, payload.expected, "payload: \(payload.raw ?? "nil")")
+            XCTAssertEqual(one, two, "payload: \(payload.raw ?? "nil")")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a bounded, content-keyed tool-card presentation projection cache
- fence argument/result decoding, structured-result extraction, raw JSON parsing, and status classification behind immutable input keys
- route ToolCards-layer raw-object parsing through the projection boundary
- add focused regression coverage for deterministic reuse, failed derivations, revision changes, key isolation, and bounded eviction

## Why

SwiftUI tool-card bodies repeatedly evaluate while transcripts stream and surrounding presentation state changes. Several deterministic JSON and status derivations were still performed from raw payloads on those render paths. This change keeps the canonical transcript and runtime authorities unchanged while ensuring those derivations are computed once per unique immutable input within a bounded in-memory cache.

Current main already cached `BashResultCard` parsing through `BashToolResultParser.Cache`, so this PR leaves that seam intact and fences the remaining ToolCards-layer chokepoints instead.

## Scope and non-goals

- no tool-schema or persisted-transcript changes
- no new transcript, tool, routing, or lifecycle authority
- no card redesign or sidebar changes
- no runtime/provider behavior changes
- no package or target split

## Validation

- `make dev-test FILTER=ToolCardProjectionFenceTests` — 12/12 passed
- `./conductor test --filter ToolCard` — 43/43 passed
- `make dev-lint` — passed
- `make dev-run` — build/package/launch completed successfully from this exact commit
- mandatory commit and push contribution preflights — passed
- independent Fable 5 High review — no must-fix findings

The path-selected PR-ready lane passed its safety and lint phases. Its full root-test phase continued making progress with no reported test failures but hit conductor's 60-minute timeout, so it is not represented as a full local suite pass. Hosted exact-head CI remains required.

## Performance evidence and residual risks

This PR removes repeated decoding/classification, but a cache hit still hashes and compares the payload key. The process-wide cache is bounded to 512 entries and uses wholesale eviction, which may cause recomputation bursts on very long transcripts. No before/after live CPU or frame-cadence measurement is claimed here; that remains a measured follow-up using the debug performance diagnostics.
