### PR TITLE
fix: make agent read_file selection converge

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift
@@ -44,9 +44,33 @@ final class MCPReadFileAutoSelectionCoordinator {
         let tabID: UUID
     }
 
+    enum AutomaticCodemapDisposition: Hashable {
+        case preserve
+        case disableAutomaticPreservingManual
+
+        func merging(_ other: AutomaticCodemapDisposition) -> AutomaticCodemapDisposition {
+            if self == .disableAutomaticPreservingManual || other == .disableAutomaticPreservingManual {
+                return .disableAutomaticPreservingManual
+            }
+            return .preserve
+        }
+    }
+
     enum Intent: Equatable {
-        case full(paths: [String])
-        case slices(entries: [WorkspaceSelectionSliceInput])
+        case full(
+            paths: [String],
+            automaticCodemapDisposition: AutomaticCodemapDisposition = .preserve
+        )
+        case slices(
+            entries: [WorkspaceSelectionSliceInput],
+            automaticCodemapDisposition: AutomaticCodemapDisposition = .preserve
+        )
+
+        var automaticCodemapDisposition: AutomaticCodemapDisposition {
+            switch self {
+            case let .full(_, disposition), let .slices(_, disposition): disposition
+            }
+        }
     }
 
     /// Exact normalized physical coverage requested by one complete canonical batch.
@@ -60,19 +84,20 @@ final class MCPReadFileAutoSelectionCoordinator {
 
         let fullPaths: [String]
         let slices: [Slice]
+        let automaticCodemapDisposition: AutomaticCodemapDisposition
 
         init?(intent: Intent, resolvedPaths: [String]) {
             var fullPathKeys = Set<String>()
             var rangesByPath: [String: [LineRange]] = [:]
 
             switch intent {
-            case let .full(paths):
+            case let .full(paths, _):
                 guard paths.count == resolvedPaths.count else { return nil }
                 for resolvedPath in resolvedPaths {
                     guard let path = Self.normalizedPhysicalPath(resolvedPath) else { return nil }
                     fullPathKeys.insert(path)
                 }
-            case let .slices(entries):
+            case let .slices(entries, _):
                 guard entries.count == resolvedPaths.count else { return nil }
                 for (entry, resolvedPath) in zip(entries, resolvedPaths) {
                     guard let path = Self.normalizedPhysicalPath(resolvedPath) else { return nil }
@@ -84,10 +109,18 @@ final class MCPReadFileAutoSelectionCoordinator {
                 }
             }
 
-            self.init(fullPathKeys: fullPathKeys, rangesByPath: rangesByPath)
+            self.init(
+                fullPathKeys: fullPathKeys,
+                rangesByPath: rangesByPath,
+                automaticCodemapDisposition: intent.automaticCodemapDisposition
+            )
         }
 
-        private init(fullPathKeys: Set<String>, rangesByPath: [String: [LineRange]]) {
+        private init(
+            fullPathKeys: Set<String>,
+            rangesByPath: [String: [LineRange]],
+            automaticCodemapDisposition: AutomaticCodemapDisposition
+        ) {
             fullPaths = fullPathKeys.sorted()
             slices = rangesByPath.keys
                 .filter { !fullPathKeys.contains($0) }
@@ -98,6 +131,7 @@ final class MCPReadFileAutoSelectionCoordinator {
                     }
                     return ranges.isEmpty ? nil : Slice(path: path, ranges: ranges)
                 }
+            self.automaticCodemapDisposition = automaticCodemapDisposition
         }
 
         func merging(_ other: CoverageIdentity) -> CoverageIdentity {
@@ -107,10 +141,19 @@ final class MCPReadFileAutoSelectionCoordinator {
             for slice in other.slices {
                 rangesByPath[slice.path, default: []].append(contentsOf: slice.ranges)
             }
-            return CoverageIdentity(fullPathKeys: fullPathKeys, rangesByPath: rangesByPath)
+            return CoverageIdentity(
+                fullPathKeys: fullPathKeys,
+                rangesByPath: rangesByPath,
+                automaticCodemapDisposition: automaticCodemapDisposition.merging(other.automaticCodemapDisposition)
+            )
         }
 
         func isCovered(by physicalSelection: StoredSelection) -> Bool {
+            if automaticCodemapDisposition == .disableAutomaticPreservingManual,
+               physicalSelection.codemapAutoEnabled
+            {
+                return false
+            }
             let selectedPathKeys = Set(StoredSelectionPathNormalization.standardizedPaths(physicalSelection.selectedPaths))
             let normalizedSlices = StoredSelectionPathNormalization.standardizedSlices(physicalSelection.slices)
 
@@ -137,6 +180,32 @@ final class MCPReadFileAutoSelectionCoordinator {
             let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
             guard trimmed.hasPrefix("/") else { return nil }
             return StandardizedPath.absolute((trimmed as NSString).expandingTildeInPath)
+        }
+    }
+
+    static func authoritativeReadSelection(
+        _ expected: StoredSelection,
+        isPreservedBy candidate: StoredSelection
+    ) -> Bool {
+        let expectedWithoutAutomaticCodemaps = StoredSelection(
+            selectedPaths: expected.selectedPaths,
+            manualCodemapPaths: expected.manualCodemapPaths,
+            slices: expected.slices,
+            codemapAutoEnabled: false
+        )
+        return authoritativeSelection(expectedWithoutAutomaticCodemaps, isPreservedBy: candidate)
+    }
+
+    static func authoritativeSelection(
+        _ expected: StoredSelection,
+        isPreservedBy candidate: StoredSelection,
+        automaticCodemapDisposition: AutomaticCodemapDisposition
+    ) -> Bool {
+        switch automaticCodemapDisposition {
+        case .preserve:
+            authoritativeSelection(expected, isPreservedBy: candidate)
+        case .disableAutomaticPreservingManual:
+            authoritativeReadSelection(expected, isPreservedBy: candidate)
         }
     }
 
@@ -204,6 +273,7 @@ final class MCPReadFileAutoSelectionCoordinator {
         private(set) var fullPaths: [String] = []
         private(set) var sliceEntries: [WorkspaceSelectionSliceInput] = []
         private(set) var coverageIdentity: CoverageIdentity?
+        private(set) var automaticCodemapDisposition: AutomaticCodemapDisposition = .preserve
 
         private var fullPathKeys = Set<String>()
         private var slicePathOrder: [String] = []
@@ -218,6 +288,7 @@ final class MCPReadFileAutoSelectionCoordinator {
         }
 
         mutating func merge(_ intent: Intent, coverageIdentity incomingCoverageIdentity: CoverageIdentity? = nil) {
+            automaticCodemapDisposition = automaticCodemapDisposition.merging(intent.automaticCodemapDisposition)
             if coveragePermitted {
                 if let incomingCoverageIdentity {
                     coverageIdentity = coverageIdentity?.merging(incomingCoverageIdentity) ?? incomingCoverageIdentity
@@ -227,7 +298,7 @@ final class MCPReadFileAutoSelectionCoordinator {
                 }
             }
             switch intent {
-            case let .full(paths):
+            case let .full(paths, _):
                 for rawPath in paths {
                     guard let path = Self.trimmed(rawPath),
                           let key = StoredSelectionPathNormalization.standardizedPath(path)
@@ -238,7 +309,7 @@ final class MCPReadFileAutoSelectionCoordinator {
                     sliceRangesByPath.removeValue(forKey: key)
                     originalSlicePathByKey.removeValue(forKey: key)
                 }
-            case let .slices(entries):
+            case let .slices(entries, _):
                 for entry in entries {
                     guard let path = Self.trimmed(entry.path),
                           let key = StoredSelectionPathNormalization.standardizedPath(path),

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1862,7 +1862,8 @@ extension MCPServerViewModel {
         selection: StoredSelection,
         lookupContext: WorkspaceLookupContext,
         contextKey: MCPReadFileAutoSelectionCoordinator.ContextKey,
-        expectedBaseSelection: StoredSelection
+        expectedBaseSelection: StoredSelection,
+        automaticCodemapDisposition: MCPReadFileAutoSelectionCoordinator.AutomaticCodemapDisposition
     ) async -> ReadFileAutoSelectionAuthoritativeResult? {
         guard isReadFileAutoSelectionContextCurrent(contextKey) else { return nil }
 
@@ -1900,7 +1901,8 @@ extension MCPServerViewModel {
         )
         guard MCPReadFileAutoSelectionCoordinator.authoritativeSelection(
             expectedBaseForPreservation,
-            isPreservedBy: persistedSelection
+            isPreservedBy: persistedSelection,
+            automaticCodemapDisposition: automaticCodemapDisposition
         ),
             let target = currentReadFileAutoSelectionTab(for: contextKey)
         else { return nil }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -1547,11 +1547,11 @@ final class MCPServerViewModel: ObservableObject {
             guard let self else { throw MCPError.internalError("Window deallocated while building file tree") }
             return try await buildStoreBackedFileTreeResult(mode: mode, maxDepth: maxDepth, startPath: startPath, lookupContext: lookupContext)
         },
-        readSelectedAuthorizedGitArtifact: { [weak self] requestedPath, resolvedPath, startLine1Based, lineCount, metadata, lookupContext in
+        readSelectedAuthorizedGitArtifact: { [weak self] requestedPath, translatedLookupPath, startLine1Based, lineCount, metadata, lookupContext in
             guard let self else { throw MCPError.internalError("Window deallocated while reading selected Git artifact") }
             return try await readSelectedAuthorizedGitArtifact(
                 requestedPath: requestedPath,
-                resolvedPath: resolvedPath,
+                translatedLookupPath: translatedLookupPath,
                 startLine1Based: startLine1Based,
                 lineCount: lineCount,
                 metadata: metadata,
@@ -1562,12 +1562,12 @@ final class MCPServerViewModel: ObservableObject {
             guard let self else { throw MCPError.internalError("Window deallocated while reading file") }
             return try await readFile(path: path, startLine1Based: startLine1Based, lineCount: lineCount, lookupRootScope: lookupRootScope)
         },
-        enqueueReadFileAutoSelection: { [weak self] reply, requestedPath, resolvedPhysicalPath, metadata in
+        enqueueReadFileAutoSelection: { [weak self] reply, requestedPath, absolutePhysicalPath, metadata in
             guard let self else { throw MCPError.internalError("Window deallocated while enqueuing read_file auto-selection") }
             try await enqueueReadFileAutoSelection(
                 reply: reply,
                 requestedPath: requestedPath,
-                resolvedPhysicalPath: resolvedPhysicalPath,
+                absolutePhysicalPath: absolutePhysicalPath,
                 metadata: metadata
             )
         },
@@ -4299,7 +4299,7 @@ final class MCPServerViewModel: ObservableObject {
     private func enqueueReadFileAutoSelection(
         reply: ToolResultDTOs.ReadFileReply,
         requestedPath: String,
-        resolvedPhysicalPath: String,
+        absolutePhysicalPath: String,
         metadata: RequestMetadata
     ) async throws {
         #if DEBUG || EDIT_FLOW_PERF
@@ -4357,9 +4357,15 @@ final class MCPServerViewModel: ObservableObject {
         }
         let intent: MCPReadFileAutoSelectionCoordinator.Intent = switch selection {
         case let .full(path):
-            .full(paths: [path])
+            .full(
+                paths: [path],
+                automaticCodemapDisposition: .disableAutomaticPreservingManual
+            )
         case let .slice(entry):
-            .slices(entries: [WorkspaceSelectionSliceInput(path: entry.path, ranges: entry.ranges)])
+            .slices(
+                entries: [WorkspaceSelectionSliceInput(path: entry.path, ranges: entry.ranges)],
+                automaticCodemapDisposition: .disableAutomaticPreservingManual
+            )
         }
         EditFlowPerf.end(
             EditFlowPerf.Stage.ReadFile.AutoSelect.selectionProjection,
@@ -4373,7 +4379,7 @@ final class MCPServerViewModel: ObservableObject {
         )
         let coverageIdentity = MCPReadFileAutoSelectionCoordinator.CoverageIdentity(
             intent: intent,
-            resolvedPaths: [resolvedPhysicalPath]
+            resolvedPaths: [absolutePhysicalPath]
         )
         let key = try readFileAutoSelectionContextKey(resolvedContext: resolvedContext, metadata: metadata)
         let accepted = readFileAutoSelectionCoordinator.enqueue(
@@ -4881,12 +4887,12 @@ final class MCPServerViewModel: ObservableObject {
 
     @MainActor
     private func authoritativeReadFileAutoSelectionResult(
-        mirrorKey: MCPReadFileAutoSelectionCoordinator.TabMirrorKey?,
         changed: Bool,
+        key: MCPReadFileAutoSelectionCoordinator.ContextKey,
         missReason: ReadFileAutoSelectionCoverageCertificateMissReason
     ) -> MCPReadFileAutoSelectionCoordinator.CanonicalApplyResult {
         MCPReadFileAutoSelectionCoordinator.CanonicalApplyResult(
-            mirrorKey: mirrorKey,
+            mirrorKey: changed ? key.mirrorKey : nil,
             disposition: changed ? .changed : .semanticNoOp,
             coverageCertificateOutcome: .authoritativeFallback(missReason)
         )
@@ -4901,7 +4907,17 @@ final class MCPServerViewModel: ObservableObject {
         // The bound tab context is a routable working snapshot, not canonical selection authority.
         // Handoffs and delayed mirrors can leave it behind the stored compose-tab selection, so
         // every additive read/search batch must rebase on the latest canonical value.
-        var selection = base
+        var selection = switch batch.automaticCodemapDisposition {
+        case .preserve:
+            base
+        case .disableAutomaticPreservingManual:
+            StoredSelection(
+                selectedPaths: base.selectedPaths,
+                manualCodemapPaths: base.manualCodemapPaths,
+                slices: base.slices,
+                codemapAutoEnabled: false
+            )
+        }
 
         if !batch.fullPaths.isEmpty {
             let addResult = await addStoredSelectionPaths(
@@ -4976,8 +4992,8 @@ final class MCPServerViewModel: ObservableObject {
         guard case let .miss(missReason) = certificateLookup else { return .unchanged }
         guard isReadFileAutoSelectionContextCurrent(key), readFileAutoSelectionContext(for: key) != nil else {
             return authoritativeReadFileAutoSelectionResult(
-                mirrorKey: nil,
                 changed: false,
+                key: key,
                 missReason: missReason
             )
         }
@@ -5007,7 +5023,7 @@ final class MCPServerViewModel: ObservableObject {
         } else {
             sliceRebaseCandidates = batch.sliceEntries.map(\.path)
         }
-        var observedCanonicalChange = false
+        var verifiedCanonicalChange = false
 
         // A file projection can register its slice-rebase task after the first wait. Each bounded
         // attempt revalidates path quiescence, the canonical base, and the full persisted result so
@@ -5034,7 +5050,8 @@ final class MCPServerViewModel: ObservableObject {
             )
             if !MCPReadFileAutoSelectionCoordinator.authoritativeSelection(
                 initialSelection,
-                isPreservedBy: authoritativeLookupContext.logicalizeSelection(selection)
+                isPreservedBy: authoritativeLookupContext.logicalizeSelection(selection),
+                automaticCodemapDisposition: batch.automaticCodemapDisposition
             ) {
                 guard let batchIdentity,
                       batchIdentity.isCovered(
@@ -5054,10 +5071,11 @@ final class MCPServerViewModel: ObservableObject {
                 selection: selection,
                 lookupContext: authoritativeLookupContext,
                 contextKey: key,
-                expectedBaseSelection: initialSelection
+                expectedBaseSelection: initialSelection,
+                automaticCodemapDisposition: batch.automaticCodemapDisposition
             ) else { continue }
 
-            observedCanonicalChange = observedCanonicalChange || !authoritativeResult.canonicalUnchanged
+            verifiedCanonicalChange = verifiedCanonicalChange || !authoritativeResult.canonicalUnchanged
             let minted = await mintReadFileAutoSelectionCoverageCertificate(
                 batch: batch,
                 authoritativeResult: authoritativeResult,
@@ -5067,8 +5085,8 @@ final class MCPServerViewModel: ObservableObject {
             )
             if minted {
                 return authoritativeReadFileAutoSelectionResult(
-                    mirrorKey: observedCanonicalChange ? key.mirrorKey : nil,
-                    changed: observedCanonicalChange,
+                    changed: verifiedCanonicalChange,
+                    key: key,
                     missReason: missReason
                 )
             }
@@ -5092,10 +5110,10 @@ final class MCPServerViewModel: ObservableObject {
             if let batchIdentity,
                batchIdentity.isCovered(by: authoritativeLookupContext.physicalizeSelection(finalSelection))
             {
-                let changed = observedCanonicalChange || finalSelection != initialSelection
+                let changed = verifiedCanonicalChange || finalSelection != initialSelection
                 return authoritativeReadFileAutoSelectionResult(
-                    mirrorKey: changed ? key.mirrorKey : nil,
                     changed: changed,
+                    key: key,
                     missReason: missReason
                 )
             }
@@ -5103,8 +5121,8 @@ final class MCPServerViewModel: ObservableObject {
 
         evictReadFileAutoSelectionCoverageCertificate(for: key)
         return authoritativeReadFileAutoSelectionResult(
-            mirrorKey: nil,
-            changed: false,
+            changed: verifiedCanonicalChange,
+            key: key,
             missReason: missReason
         )
     }
@@ -5229,7 +5247,10 @@ final class MCPServerViewModel: ObservableObject {
             )
             return
         }
-        let intent = MCPReadFileAutoSelectionCoordinator.Intent.slices(entries: entries)
+        let intent = MCPReadFileAutoSelectionCoordinator.Intent.slices(
+            entries: entries,
+            automaticCodemapDisposition: .preserve
+        )
         let coverageIdentity = MCPReadFileAutoSelectionCoordinator.CoverageIdentity(
             intent: intent,
             resolvedPaths: resolvedPhysicalPaths
@@ -6040,12 +6061,12 @@ final class MCPServerViewModel: ObservableObject {
     /// Returns both the content slice and metadata about the shown range.
     private func readSelectedAuthorizedGitArtifact(
         requestedPath: String,
-        resolvedPath: String,
+        translatedLookupPath: String,
         startLine1Based: Int?,
         lineCount: Int?,
         metadata: RequestMetadata,
         lookupContext: WorkspaceLookupContext
-    ) async throws -> (reply: ToolResultDTOs.ReadFileReply, shouldAutoSelect: Bool)? {
+    ) async throws -> ToolResultDTOs.ReadFileReply? {
         guard var resolvedContext = try? resolveTabContextSnapshot(
             from: metadata,
             toolName: MCPWindowToolName.readFile
@@ -6062,7 +6083,7 @@ final class MCPServerViewModel: ObservableObject {
         )
         let targetsGitData = isGitDataArtifactRequest(
             requestedPath,
-            resolvedPath: resolvedPath,
+            resolvedPath: translatedLookupPath,
             capability: reviewGitContext.artifactCapability
         )
         guard let capability = reviewGitContext.artifactCapability else {
@@ -6082,7 +6103,7 @@ final class MCPServerViewModel: ObservableObject {
                 store: promptVM.workspaceFileContextStore
             )
         )
-        let requestedCandidates = Set([requestedPath, resolvedPath].map {
+        let requestedCandidates = Set([requestedPath, translatedLookupPath].map {
             $0.trimmingCharacters(in: .whitespacesAndNewlines)
         })
         guard let entry = authorization.entries.first(where: { entry in
@@ -6110,7 +6131,7 @@ final class MCPServerViewModel: ObservableObject {
                 lineCount: lineCount,
                 displayPath: displayPath
             )
-            return (preparedReply.reply, false)
+            return preparedReply.reply
         } catch WorkspaceInteractiveReadRangeError.limitWithNegativeStart {
             throw MCPError.invalidParams("limit parameter is not allowed with negative start_line. Use start_line=-N to read the last N lines.")
         } catch WorkspaceInteractiveReadRangeError.zeroStart {
@@ -6144,7 +6165,7 @@ final class MCPServerViewModel: ObservableObject {
         startLine1Based: Int? = nil,
         lineCount: Int? = nil,
         lookupRootScope: WorkspaceLookupRootScope = .visibleWorkspace
-    ) async throws -> (reply: ToolResultDTOs.ReadFileReply, shouldAutoSelect: Bool) {
+    ) async throws -> MCPAppFileReadResult {
         try await MCPToolWorkCountDiagnostics.withReadFileInvocation { [self] in
             try await readFileBody(
                 path: path,
@@ -6160,7 +6181,7 @@ final class MCPServerViewModel: ObservableObject {
         startLine1Based: Int? = nil,
         lineCount: Int? = nil,
         lookupRootScope: WorkspaceLookupRootScope = .visibleWorkspace
-    ) async throws -> (reply: ToolResultDTOs.ReadFileReply, shouldAutoSelect: Bool) {
+    ) async throws -> MCPAppFileReadResult {
         try Task.checkCancellation()
         let store = promptVM.workspaceFileContextStore
         let readableService = WorkspaceReadableFileService(store: store)
@@ -6205,7 +6226,6 @@ final class MCPServerViewModel: ObservableObject {
 
         let preparedContent: WorkspaceInteractiveReadPreparedContent
         let displayPath: String
-        let shouldAutoSelect: Bool
         let cacheHit: Bool
         switch readableFile {
         case let .workspace(file):
@@ -6224,7 +6244,6 @@ final class MCPServerViewModel: ObservableObject {
                 fullPath: file.standardizedFullPath,
                 visibleRoots: roots
             )
-            shouldAutoSelect = true
         case let .external(externalFile):
             do {
                 let full = try await readableService.readAlwaysReadableExternalFile(externalFile)
@@ -6240,7 +6259,6 @@ final class MCPServerViewModel: ObservableObject {
             }
             cacheHit = false
             displayPath = externalFile.displayPath
-            shouldAutoSelect = false
         }
 
         let preparedReply: MCPReadFileToolProjection.PreparedReply
@@ -6265,7 +6283,15 @@ final class MCPServerViewModel: ObservableObject {
             returnedLines: preparedReply.returnedLineCount,
             cacheHit: cacheHit
         )
-        return (preparedReply.reply, shouldAutoSelect)
+        switch readableFile {
+        case let .workspace(file):
+            return .workspace(
+                reply: preparedReply.reply,
+                absolutePhysicalPath: file.standardizedFullPath
+            )
+        case .external:
+            return .nonSelecting(reply: preparedReply.reply)
+        }
     }
 
     /// Performs a file action (create, delete, or move/rename)

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAppPhysicalCapabilityAdapters.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAppPhysicalCapabilityAdapters.swift
@@ -12,6 +12,14 @@ struct MCPFileActionMutationAcknowledgement {
     let freshness: String
 }
 
+enum MCPAppFileReadResult {
+    case workspace(
+        reply: ToolResultDTOs.ReadFileReply,
+        absolutePhysicalPath: String
+    )
+    case nonSelecting(reply: ToolResultDTOs.ReadFileReply)
+}
+
 /// Namespace for independently injected app-process capability families.
 /// No provider receives an unrestricted aggregate of every app capability.
 enum MCPAppPhysicalCapabilityAdapters {
@@ -276,19 +284,19 @@ enum MCPAppPhysicalCapabilityAdapters {
     typealias BuildCodeStructureDTO = @MainActor @Sendable (_ files: [WorkspaceFileRecord], _ request: MCPServerViewModel.CodeStructureRequest, _ includePathNotFoundIssue: Bool, _ requestedPaths: [String], _ lookupContext: WorkspaceLookupContext) async throws -> ToolResultDTOs.CodeStructureReplyDTO
     typealias ResolveFilesForCodeStructure = @MainActor @Sendable (_ paths: [String], _ lookupRootScope: WorkspaceLookupRootScope, _ maximumSeedCount: Int) async throws -> [WorkspaceFileRecord]
     typealias BuildStoreBackedFileTreeResult = @MainActor @Sendable (_ mode: String, _ maxDepth: Int?, _ startPath: String?, _ lookupContext: WorkspaceLookupContext) async throws -> (result: FileTreeResult, rootCount: Int)
-    typealias ReadFile = @MainActor @Sendable (_ path: String, _ startLine1Based: Int?, _ lineCount: Int?, _ lookupRootScope: WorkspaceLookupRootScope) async throws -> (reply: ToolResultDTOs.ReadFileReply, shouldAutoSelect: Bool)
+    typealias ReadFile = @MainActor @Sendable (_ path: String, _ startLine1Based: Int?, _ lineCount: Int?, _ lookupRootScope: WorkspaceLookupRootScope) async throws -> MCPAppFileReadResult
     typealias ReadSelectedAuthorizedGitArtifact = @MainActor @Sendable (
         _ requestedPath: String,
-        _ resolvedPath: String,
+        _ translatedLookupPath: String,
         _ startLine1Based: Int?,
         _ lineCount: Int?,
         _ metadata: MCPServerViewModel.RequestMetadata,
         _ lookupContext: WorkspaceLookupContext
-    ) async throws -> (reply: ToolResultDTOs.ReadFileReply, shouldAutoSelect: Bool)?
+    ) async throws -> ToolResultDTOs.ReadFileReply?
     typealias EnqueueReadFileAutoSelection = @MainActor @Sendable (
         _ reply: ToolResultDTOs.ReadFileReply,
         _ requestedPath: String,
-        _ resolvedPhysicalPath: String,
+        _ absolutePhysicalPath: String,
         _ metadata: MCPServerViewModel.RequestMetadata
     ) async throws -> Void
     typealias DrainReadFileAutoSelection = @MainActor @Sendable (_ metadata: MCPServerViewModel.RequestMetadata, _ requirement: MCPReadFileAutoSelectionCoordinator.DrainRequirement) async throws -> MCPReadFileAutoSelectionCoordinator.DrainResult

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -398,27 +398,27 @@ final class MCPFileToolProvider: MCPAppToolProviding {
             authority.lookupContext
         }
         try Task.checkCancellation()
-        let (worktreeScope, resolvedPath) = EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerPathTranslation) {
+        let (worktreeScope, translatedLookupPath) = EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerPathTranslation) {
             let worktreeScope = ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: lookupContext.bindingProjection)
-            let resolvedPath = lookupContext.translateInputPath(path)
-            return (worktreeScope, resolvedPath)
+            let translatedLookupPath = lookupContext.translateInputPath(path)
+            return (worktreeScope, translatedLookupPath)
         }
         try Task.checkCancellation()
-        var readResult: (reply: ToolResultDTOs.ReadFileReply, shouldAutoSelect: Bool)
+        let unprojectedReadResult: MCPAppFileReadResult
         do {
-            readResult = try await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerReadEnvelope) {
-                if let artifact = try await dependencies.files.readSelectedAuthorizedGitArtifact(
+            unprojectedReadResult = try await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerReadEnvelope) {
+                if let artifactReply = try await dependencies.files.readSelectedAuthorizedGitArtifact(
                     path,
-                    resolvedPath,
+                    translatedLookupPath,
                     startLine1Based,
                     limit,
                     metadata,
                     lookupContext
                 ) {
-                    return artifact
+                    return .nonSelecting(reply: artifactReply)
                 }
                 return try await dependencies.files.readFile(
-                    resolvedPath,
+                    translatedLookupPath,
                     startLine1Based,
                     limit,
                     lookupContext.rootScope
@@ -431,39 +431,55 @@ final class MCPFileToolProvider: MCPAppToolProviding {
             ))
         }
         try Task.checkCancellation()
-        let projectedDisplayPath = readResult.reply.displayPath.map { displayPath in
+        let unprojectedReply = switch unprojectedReadResult {
+        case let .workspace(reply, _), let .nonSelecting(reply): reply
+        }
+        let projectedDisplayPath = unprojectedReply.displayPath.map { displayPath in
             lookupContext.bindingProjection?.projectedLogicalDisplayPath(forPhysicalPath: displayPath) ?? displayPath
         }
-        readResult = try await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerReplyProjection) {
+        let readResult: MCPAppFileReadResult = try await EditFlowPerf.measure(
+            EditFlowPerf.Stage.ReadFile.providerReplyProjection
+        ) {
             let reply = try await MCPReadFileToolProjection.projectReply(
-                readResult.reply,
+                unprojectedReply,
                 displayPath: projectedDisplayPath,
                 worktreeScope: worktreeScope
             )
-            return (reply, readResult.shouldAutoSelect)
+            return switch unprojectedReadResult {
+            case let .workspace(_, absolutePhysicalPath):
+                .workspace(reply: reply, absolutePhysicalPath: absolutePhysicalPath)
+            case .nonSelecting:
+                .nonSelecting(reply: reply)
+            }
         }
         try Task.checkCancellation()
+        let autoSelectOutcome = switch readResult {
+        case .workspace: "attempted"
+        case .nonSelecting: "skipped"
+        }
         try await EditFlowPerf.measure(
             EditFlowPerf.Stage.ReadFile.providerAutoSelect,
-            EditFlowPerf.Dimensions(outcome: readResult.shouldAutoSelect ? "attempted" : "skipped")
+            EditFlowPerf.Dimensions(outcome: autoSelectOutcome)
         ) {
-            if readResult.shouldAutoSelect {
-                let reply = readResult.reply
+            if case let .workspace(reply, absolutePhysicalPath) = readResult {
                 try await sideEffects.submitAndWait(fingerprint: "read_file_auto_selection") { [weak self] in
                     guard let self else { throw CancellationError() }
                     try await applyReadFileSideEffect(
                         reply: reply,
                         requestedPath: path,
-                        resolvedPath: resolvedPath,
+                        absolutePhysicalPath: absolutePhysicalPath,
                         metadata: metadata
                     )
                 }
             }
         }
         try Task.checkCancellation()
+        let projectedReply = switch readResult {
+        case let .workspace(reply, _), let .nonSelecting(reply): reply
+        }
         let value = try await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerValueEncoding) {
             try await MCPProviderProjectionWorker.encode(
-                readResult.reply,
+                projectedReply,
                 toolName: MCPWindowToolName.readFile
             )
         }
@@ -884,13 +900,13 @@ final class MCPFileToolProvider: MCPAppToolProviding {
     private func applyReadFileSideEffect(
         reply: ToolResultDTOs.ReadFileReply,
         requestedPath: String,
-        resolvedPath: String,
+        absolutePhysicalPath: String,
         metadata: MCPServerViewModel.RequestMetadata
     ) async throws {
         try await dependencies.files.enqueueReadFileAutoSelection(
             reply,
             requestedPath,
-            resolvedPath,
+            absolutePhysicalPath,
             metadata
         )
         // Historical read_file completion guaranteed queue admission, not completion of the

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -60,6 +60,27 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         #endif
     }
 
+    func testAgentOwnedBackToBackRelativeReadsUnionCanonicalAndPresentedSelection() async throws {
+        #if DEBUG
+            try await withFixture(agentOwned: true) { fixture in
+                try await runCheckpoint(fixture: fixture, scenario: .agentOwnedRelativeReadBurst)
+            }
+        #else
+            throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
+        #endif
+    }
+
+    func testVerifiedCanonicalReadChangeSchedulesMirrorAfterCoverageCertificationExhaustion() async throws {
+        #if DEBUG
+            try await withFixture(agentOwned: true) { fixture in
+                try await fixture.installWorktreeBinding()
+                try await runCheckpoint(fixture: fixture, scenario: .coverageCertificationExhaustion)
+            }
+        #else
+            throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
+        #endif
+    }
+
     func testAgentOwnedExplicitSetPersistsForIndependentCanonicalLookup() async throws {
         #if DEBUG
             try await withFixture(agentOwned: true) { fixture in
@@ -241,6 +262,8 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             case rebindDuringPersistence
             case agentOwnedCanonicalSelection
             case agentOwnedSequentialReadUnion
+            case agentOwnedRelativeReadBurst
+            case coverageCertificationExhaustion
             case agentOwnedExplicitSetIndependentLookup
             case protectedSelectionIdentity
             case agentOwnedNoRangeNonEmptyWorktreeFile
@@ -255,6 +278,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             var requiresSerialReadPrelude: Bool {
                 switch self {
                 case .agentOwnedNoRangeNonEmptyWorktreeFile, .agentOwnedSequentialReadUnion,
+                     .agentOwnedRelativeReadBurst, .coverageCertificationExhaustion,
                      .protectedSelectionIdentity, .manageSelectionGetCanonicalHandover,
                      .worktreeCoverageCertificateRepeats,
                      .worktreeCoverageCertificatePersistenceBoundary, .worktreeCoverageCertificateFailClosed,
@@ -448,6 +472,10 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 try await assertAgentOwnedCanonicalSelection(fixture: fixture)
             case .agentOwnedSequentialReadUnion:
                 try await assertAgentOwnedSequentialReadUnion(fixture: fixture)
+            case .agentOwnedRelativeReadBurst:
+                try await assertAgentOwnedRelativeReadBurst(fixture: fixture)
+            case .coverageCertificationExhaustion:
+                try await assertCoverageCertificationExhaustion(fixture: fixture)
             case .agentOwnedExplicitSetIndependentLookup:
                 try await assertAgentOwnedExplicitSetIndependentLookup(fixture: fixture)
             case .protectedSelectionIdentity:
@@ -1414,7 +1442,10 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             )
             let physicalPath = try fixture.worktreeFileURL.path
             try fixture.removeWorktreeDirectory()
-            let intent = MCPReadFileAutoSelectionCoordinator.Intent.full(paths: [fixture.fileURL.path])
+            let intent = MCPReadFileAutoSelectionCoordinator.Intent.full(
+                paths: [fixture.fileURL.path],
+                automaticCodemapDisposition: .disableAutomaticPreservingManual
+            )
             let coverage = try XCTUnwrap(MCPReadFileAutoSelectionCoordinator.CoverageIdentity(
                 intent: intent,
                 resolvedPaths: [physicalPath]
@@ -1531,6 +1562,186 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             let liveSelection = fixture.window.workspaceFilesViewModel.snapshotSelection()
             XCTAssertEqual(Set(liveSelection.selectedPaths), Set(expectedPaths))
             XCTAssertEqual(liveSelection.slices, expectedSlices)
+        }
+
+        func assertAgentOwnedRelativeReadBurst(fixture: Fixture) async throws {
+            try await clearSelection(fixture: fixture, id: 3)
+            let canonicalGate = PersistentAsyncGate()
+            fixture.window.mcpServer.setReadFileAutoSelectionCanonicalApplyGateForTesting {
+                await canonicalGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                fixture.window.mcpServer.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
+                Task { await canonicalGate.release() }
+            }
+
+            let fullText = try await readFile(
+                fixture: fixture,
+                id: 4,
+                path: Fixture.fixtureRelativePath
+            )
+            XCTAssertTrue(fullText.contains(Fixture.sentinelContent), fullText)
+            try await requireGateStarted(canonicalGate)
+
+            let slicedText = try await readFile(
+                fixture: fixture,
+                id: 5,
+                path: Fixture.liveRelativePath,
+                startLine: 2,
+                limit: 2
+            )
+            XCTAssertTrue(slicedText.contains("**Lines**: 2–3"), slicedText)
+
+            await canonicalGate.release()
+            await assertReadFileAutoSelectionSettled(fixture: fixture)
+
+            let expectedPaths = [fixture.fileURL.path, fixture.liveFileURL.path]
+            let expectedSlices = [fixture.liveFileURL.path: [LineRange(start: 2, end: 3)]]
+            assertCanonicalSelection(
+                fixture: fixture,
+                selectedPaths: expectedPaths,
+                slices: expectedSlices,
+                codemapAutoEnabled: false
+            )
+            let final = try fixture.readFileAutoSelectionContextSnapshot()
+            XCTAssertEqual(
+                final.coverageCertificateMissReasonCounts[.uncertifiableBatch] ?? 0,
+                0,
+                "Relative workspace reads must carry certifiable absolute physical identities"
+            )
+
+            let identity = WorkspaceSelectionIdentity(
+                workspaceID: fixture.workspaceID,
+                tabID: fixture.tabID
+            )
+            let currentSelection = try XCTUnwrap(
+                fixture.window.workspaceManager.composeTab(for: identity)?.selection
+            )
+            let manualCodemapPath = fixture.rootURL.appendingPathComponent("Sources/CanonicalOnly.swift").path
+            let manualSelection = StoredSelection(
+                selectedPaths: currentSelection.selectedPaths,
+                manualCodemapPaths: [manualCodemapPath],
+                slices: currentSelection.slices,
+                codemapAutoEnabled: false
+            )
+            let persistedManualSelection = await fixture.window.selectionCoordinator.persistSelection(
+                manualSelection,
+                for: identity,
+                source: .mcpTabContext,
+                mirrorToUIIfActive: true,
+                expectedCurrentSelection: currentSelection
+            )
+            XCTAssertEqual(persistedManualSelection, manualSelection)
+
+            _ = try await readFile(
+                fixture: fixture,
+                id: 6,
+                path: Fixture.fixtureRelativePath
+            )
+            await assertReadFileAutoSelectionSettled(fixture: fixture)
+            assertCanonicalSelection(
+                fixture: fixture,
+                selectedPaths: expectedPaths,
+                slices: expectedSlices,
+                manualCodemapPaths: [manualCodemapPath],
+                codemapAutoEnabled: false
+            )
+            let liveSelection = fixture.window.workspaceFilesViewModel.snapshotSelection()
+            XCTAssertEqual(liveSelection.manualCodemapPaths, [manualCodemapPath])
+            XCTAssertFalse(liveSelection.codemapAutoEnabled)
+        }
+
+        func assertCoverageCertificationExhaustion(fixture: Fixture) async throws {
+            try await clearSelection(fixture: fixture, id: 3)
+            let contextKey = try fixture.readFileAutoSelectionContextKey()
+            XCTAssertNil(try fixture.readFileAutoSelectionCoverageCertificate())
+            let mirrorGate = PersistentAsyncGate()
+            var finalRevalidationGates: [PersistentAsyncGate] = []
+            fixture.window.mcpServer.setReadFileAutoSelectionFinalRevalidationHandlerForTesting {
+                let revalidationGate = PersistentAsyncGate()
+                let completed = PersistentAsyncSignal()
+                finalRevalidationGates.append(revalidationGate)
+                fixture.window.workspaceManager.fileManager.debugRegisterSliceRebaseTask(
+                    fullPath: fixture.liveFileURL.path
+                ) {
+                    await fixture.window.workspaceManager.rebaseSlicesForFileAcrossTabs(
+                        fullPath: fixture.liveFileURL.path,
+                        asyncTransform: { _, ranges in
+                            await revalidationGate.markStartedAndWaitForRelease()
+                            return ranges
+                        }
+                    )
+                    await completed.mark()
+                }
+                let didStart = await revalidationGate.waitUntilStarted()
+                XCTAssertTrue(didStart, "Slice rebase did not start during final revalidation")
+                let didComplete = await self.waitUntilMarked(completed, timeout: .seconds(3))
+                XCTAssertTrue(didComplete, "Slice rebase did not complete during final revalidation")
+            }
+            fixture.window.mcpServer.setReadFileAutoSelectionMirrorGateForTesting {
+                await mirrorGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                fixture.window.mcpServer.setReadFileAutoSelectionFinalRevalidationHandlerForTesting(nil)
+                fixture.window.mcpServer.setReadFileAutoSelectionMirrorGateForTesting(nil)
+                for gate in finalRevalidationGates {
+                    Task { await gate.release() }
+                }
+                Task { await mirrorGate.release() }
+            }
+
+            let text = try await readFile(
+                fixture: fixture,
+                id: 4,
+                path: fixture.liveFileURL.path,
+                startLine: 2,
+                limit: 2
+            )
+            XCTAssertTrue(text.contains("**Lines**: 2–3"), text)
+            for expectedCount in 1 ... 3 {
+                let deadline = ContinuousClock.now + .seconds(3)
+                while finalRevalidationGates.count < expectedCount, ContinuousClock.now < deadline {
+                    try? await Task.sleep(for: .milliseconds(10))
+                }
+                guard finalRevalidationGates.count >= expectedCount else {
+                    XCTFail("Timed out waiting for final revalidation attempt \(expectedCount)")
+                    throw PersistentAsyncGateTimeoutError()
+                }
+                await finalRevalidationGates[expectedCount - 1].release()
+            }
+
+            let canonicalDrain = await fixture.window.mcpServer.readFileAutoSelectionCoordinator.drain(
+                .canonicalSelection,
+                for: contextKey
+            )
+            XCTAssertEqual(canonicalDrain, .completed)
+            XCTAssertEqual(finalRevalidationGates.count, 3)
+            let expectedSlices = [fixture.liveFileURL.path: [LineRange(start: 2, end: 3)]]
+            assertCanonicalSelection(
+                fixture: fixture,
+                selectedPaths: [fixture.liveFileURL.path],
+                slices: expectedSlices,
+                codemapAutoEnabled: false,
+                expectHeaderMirror: false
+            )
+
+            let final = try fixture.readFileAutoSelectionContextSnapshot()
+            XCTAssertEqual(final.changedApplyCount, 1)
+            XCTAssertEqual(final.semanticNoOpApplyCount, 0)
+            XCTAssertEqual(final.coverageCertificateMissReasonCounts[.noCertificate], 1)
+            XCTAssertNil(try fixture.readFileAutoSelectionCoverageCertificate())
+            let mirrorStarted = await mirrorGate.waitUntilStarted()
+            XCTAssertTrue(mirrorStarted, "Verified canonical persistence must schedule a presentation mirror")
+            guard mirrorStarted else { return }
+
+            await mirrorGate.release()
+            await assertReadFileAutoSelectionSettled(fixture: fixture)
+            assertCanonicalSelection(
+                fixture: fixture,
+                selectedPaths: [fixture.liveFileURL.path],
+                slices: expectedSlices,
+                codemapAutoEnabled: false
+            )
         }
 
         func assertAgentOwnedExplicitSetIndependentLookup(fixture: Fixture) async throws {
@@ -1890,7 +2101,8 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 try Self.assertSuccessfulResponse(addWorktreeOnly, id: 4)
                 try await Task.sleep(for: .milliseconds(250))
                 let expectedPeerSelection = StoredSelection(
-                    selectedPaths: [fixture.liveFileURL.path, fixture.worktreeOnlyLogicalURL.path]
+                    selectedPaths: [fixture.liveFileURL.path, fixture.worktreeOnlyLogicalURL.path],
+                    codemapAutoEnabled: false
                 )
                 XCTAssertEqual(
                     Set(fixture.window.workspaceManager.composeTab(
@@ -1917,7 +2129,8 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                     ).isEmpty
                 )
                 let completedSelection = StoredSelection(
-                    selectedPaths: [fixture.liveFileURL.path, fixture.worktreeOnlyLogicalURL.path]
+                    selectedPaths: [fixture.liveFileURL.path, fixture.worktreeOnlyLogicalURL.path],
+                    codemapAutoEnabled: false
                 )
                 XCTAssertEqual(
                     Set(fixture.window.workspaceManager.composeTab(
@@ -2089,12 +2302,20 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             fixture: Fixture,
             selectedPaths: [String],
             slices: [String: [LineRange]],
+            manualCodemapPaths: [String]? = nil,
+            codemapAutoEnabled: Bool? = nil,
             expectHeaderMirror: Bool = true
         ) {
             let stored = fixture.window.workspaceManager.composeTab(with: fixture.tabID)
             XCTAssertEqual(stored?.selection.selectedPaths, selectedPaths)
             XCTAssertEqual(stored?.selection.slices, slices)
             XCTAssertEqual(stored?.activeAgentSessionID, Fixture.agentSessionID)
+            if let manualCodemapPaths {
+                XCTAssertEqual(stored?.selection.manualCodemapPaths, manualCodemapPaths)
+            }
+            if let codemapAutoEnabled {
+                XCTAssertEqual(stored?.selection.codemapAutoEnabled, codemapAutoEnabled)
+            }
 
             let header = fixture.window.promptManager.currentComposeTabs.first { $0.id == fixture.tabID }
             if expectHeaderMirror {
@@ -2102,6 +2323,12 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                     + "readAutoSelection=\(fixture.window.mcpServer.readFileAutoSelectionDiagnosticsSnapshot())"
                 XCTAssertEqual(header?.selection.selectedPaths, selectedPaths, failureContext)
                 XCTAssertEqual(header?.selection.slices, slices, failureContext)
+                if let manualCodemapPaths {
+                    XCTAssertEqual(header?.selection.manualCodemapPaths, manualCodemapPaths, failureContext)
+                }
+                if let codemapAutoEnabled {
+                    XCTAssertEqual(header?.selection.codemapAutoEnabled, codemapAutoEnabled, failureContext)
+                }
             }
             XCTAssertEqual(header?.activeAgentSessionID, Fixture.agentSessionID)
         }
@@ -2379,6 +2606,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 searchSliceSelection?.slices[fixture.fileURL.path],
                 [LineRange(start: 3, end: 7)]
             )
+            XCTAssertEqual(searchSliceSelection?.codemapAutoEnabled, true)
 
             let fullSet = try await fixture.socketClient.request(
                 id: 8,
@@ -2824,6 +3052,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         let persistentAgentModeCheckpoint = "replacement-physical-worktree-read"
         let persistentAgentModeReplacementLineTwo = 22
         """
+        static let fixtureRelativePath = "Sources/PersistentAgentModeFixture.swift"
         static let liveRelativePath = "Tests/RepoPromptTests/MCP/GeneratedOracleExportFileWriterTests.swift"
         static let worktreeOnlyRelativePath = "Tests/RepoPromptTests/MCP/WorktreeOnlySelection.swift"
         static let largeWorktreeRelativePath = "Tests/RepoPromptTests/MCP/SessionWorktree6500.swift"
@@ -2929,7 +3158,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             let rootURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent("PersistentAgentModeMCPReadFileConnectionTests", isDirectory: true)
                 .appendingPathComponent(UUID().uuidString, isDirectory: true)
-            let fileURL = rootURL.appendingPathComponent("Sources/PersistentAgentModeFixture.swift")
+            let fileURL = rootURL.appendingPathComponent(fixtureRelativePath)
             let canonicalOnlyFileURL = rootURL.appendingPathComponent("Sources/CanonicalOnly.swift")
             let liveFileURL = rootURL.appendingPathComponent(liveRelativePath)
             let liveContents = try liveContents()
@@ -3299,7 +3528,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                     at: worktreeRootURL.appendingPathComponent("Sources/CanonicalOnly.swift")
                 )
             }
-            let worktreeFileURL = worktreeRootURL.appendingPathComponent("Sources/PersistentAgentModeFixture.swift")
+            let worktreeFileURL = worktreeRootURL.appendingPathComponent(Self.fixtureRelativePath)
             let worktreeLiveFileURL = worktreeRootURL.appendingPathComponent(Self.liveRelativePath)
             let worktreeOnlyFileURL = worktreeRootURL.appendingPathComponent(Self.worktreeOnlyRelativePath)
             let largeWorktreeFileURL = worktreeRootURL.appendingPathComponent(Self.largeWorktreeRelativePath)
@@ -3434,7 +3663,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
 
         var worktreeFileURL: URL {
             get throws {
-                try XCTUnwrap(worktreeRootURL).appendingPathComponent("Sources/PersistentAgentModeFixture.swift")
+                try XCTUnwrap(worktreeRootURL).appendingPathComponent(Self.fixtureRelativePath)
             }
         }
 
@@ -3510,7 +3739,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             let replacementRootURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent("PersistentAgentModeMCPReadFileConnectionTests-Worktree-B", isDirectory: true)
                 .appendingPathComponent(UUID().uuidString, isDirectory: true)
-            let replacementFileURL = replacementRootURL.appendingPathComponent("Sources/PersistentAgentModeFixture.swift")
+            let replacementFileURL = replacementRootURL.appendingPathComponent(Self.fixtureRelativePath)
             let replacementLiveFileURL = replacementRootURL.appendingPathComponent(Self.liveRelativePath)
             let replacementWorktreeOnlyFileURL = replacementRootURL.appendingPathComponent(Self.worktreeOnlyRelativePath)
             try FileManager.default.createDirectory(

--- a/Tests/RepoPromptTests/MCP/MCPReadFileAutoSelectionCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadFileAutoSelectionCoordinatorTests.swift
@@ -67,6 +67,49 @@ final class MCPReadFileAutoSelectionCoordinatorTests: XCTestCase {
         XCTAssertEqual(batch.coverageIdentity?.slices.map(\.path), ["/worktree/B.swift"])
     }
 
+    func testReadDispositionDominatesSearchAndRequiresDistinctCoverageCertificate() throws {
+        let entry = WorkspaceSelectionSliceInput(
+            path: "Logical/A.swift",
+            ranges: [LineRange(start: 10, end: 20)]
+        )
+        let searchIntent = MCPReadFileAutoSelectionCoordinator.Intent.slices(
+            entries: [entry],
+            automaticCodemapDisposition: .preserve
+        )
+        let readIntent = MCPReadFileAutoSelectionCoordinator.Intent.slices(
+            entries: [entry],
+            automaticCodemapDisposition: .disableAutomaticPreservingManual
+        )
+        let searchCoverage = try XCTUnwrap(MCPReadFileAutoSelectionCoordinator.CoverageIdentity(
+            intent: searchIntent,
+            resolvedPaths: ["/worktree/A.swift"]
+        ))
+        let readCoverage = try XCTUnwrap(MCPReadFileAutoSelectionCoordinator.CoverageIdentity(
+            intent: readIntent,
+            resolvedPaths: ["/worktree/A.swift"]
+        ))
+        let automaticSelection = StoredSelection(
+            selectedPaths: ["/worktree/A.swift"],
+            slices: ["/worktree/A.swift": entry.ranges],
+            codemapAutoEnabled: true
+        )
+
+        XCTAssertNotEqual(searchCoverage, readCoverage)
+        XCTAssertTrue(searchCoverage.isCovered(by: automaticSelection))
+        XCTAssertFalse(readCoverage.isCovered(by: automaticSelection))
+
+        var batch = MCPReadFileAutoSelectionCoordinator.CanonicalBatch(
+            intent: searchIntent,
+            coverageIdentity: searchCoverage
+        )
+        batch.merge(readIntent, coverageIdentity: readCoverage)
+        XCTAssertEqual(batch.automaticCodemapDisposition, .disableAutomaticPreservingManual)
+        XCTAssertEqual(
+            batch.coverageIdentity?.automaticCodemapDisposition,
+            .disableAutomaticPreservingManual
+        )
+    }
+
     func testCoverageIdentityRequiresExactPhysicalPathsAndChecksFullAndSliceCoverage() throws {
         XCTAssertNil(MCPReadFileAutoSelectionCoordinator.CoverageIdentity(
             intent: .full(paths: ["A.swift"]),
@@ -181,6 +224,39 @@ final class MCPReadFileAutoSelectionCoordinatorTests: XCTestCase {
                 label
             )
         }
+    }
+
+    func testAuthoritativeReadSelectionDisablesAutomaticCodemapsAndPreservesManualEntries() {
+        let expected = StoredSelection(
+            selectedPaths: ["/workspace/A.swift"],
+            manualCodemapPaths: ["/workspace/Manual.swift"],
+            codemapAutoEnabled: true
+        )
+        let readCandidate = StoredSelection(
+            selectedPaths: ["/workspace/A.swift", "/workspace/B.swift"],
+            manualCodemapPaths: ["/workspace/Manual.swift"],
+            codemapAutoEnabled: false
+        )
+
+        XCTAssertTrue(MCPReadFileAutoSelectionCoordinator.authoritativeReadSelection(
+            expected,
+            isPreservedBy: readCandidate
+        ))
+        XCTAssertFalse(MCPReadFileAutoSelectionCoordinator.authoritativeReadSelection(
+            expected,
+            isPreservedBy: StoredSelection(
+                selectedPaths: readCandidate.selectedPaths,
+                manualCodemapPaths: readCandidate.manualCodemapPaths,
+                codemapAutoEnabled: true
+            )
+        ))
+        XCTAssertFalse(MCPReadFileAutoSelectionCoordinator.authoritativeReadSelection(
+            expected,
+            isPreservedBy: StoredSelection(
+                selectedPaths: readCandidate.selectedPaths,
+                codemapAutoEnabled: false
+            )
+        ))
     }
 
     func testDiagnosticsAccountCertificateHitsFallbacksAndMissReasons() async throws {

--- a/Tests/RepoPromptTests/MCP/MCPReadFileExactAbsoluteCatalogFastPathTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadFileExactAbsoluteCatalogFastPathTests.swift
@@ -41,7 +41,7 @@ final class MCPReadFileExactAbsoluteCatalogFastPathTests: XCTestCase {
         do {
             let caseLabel = "testProviderTranslationPrecedesScopedReadDependencyCall"
             let providerSource = try source("Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift")
-            let translation = try XCTUnwrap(providerSource.range(of: "let resolvedPath = lookupContext.translateInputPath(path)"), caseLabel)
+            let translation = try XCTUnwrap(providerSource.range(of: "let translatedLookupPath = lookupContext.translateInputPath(path)"), caseLabel)
             let authorizedRead = try XCTUnwrap(
                 providerSource.range(of: "dependencies.files.readSelectedAuthorizedGitArtifact("),
                 caseLabel


### PR DESCRIPTION
Had been finding Agent Mode `read_file` returning content while the selected context either lost relative reads or failed to present a verified canonical update. Initial investigation found reads also triggering automatic dependency CodeMaps instead of selecting only the returned file content or slice.

This patch carries authoritative workspace identity through the read boundary and makes read selection converge across canonical storage and presentation without changing `file_search` CodeMap behavior.

## Summary

- Carry absolute physical workspace identity with selecting `read_file` results
- Keep Git artifacts and external reads explicitly non-selecting
- Preserve additive full-file and slice selection across relative back-to-back reads
- Mirror verified canonical changes after coverage-certificate retries are exhausted
- Disable automatic CodeMaps for read-selected content while preserving manual CodeMaps
- Preserve automatic CodeMap behavior for search-only selection
- Prevent search coverage certificates from satisfying a later read-specific mode transition

## Implementation Notes

- Workspace reads return a typed selecting result containing `WorkspaceFileRecord.standardizedFullPath`
- Provider path translation remains limited to lookup and display projection
- Read and search intents carry distinct CodeMap dispositions through coalescing and coverage identity
- Read disposition dominates mixed batches; generic selection preservation remains strict
- Verified canonical mutation determines terminal changed/mirror disposition

## Review Approach

- The patch received focused maintainability and full integration reviews covering physical identity, canonical persistence, mirror convergence, CodeMap behavior, and test determinism
- Review findings identified a search-only CodeMap regression and missing production-path manual CodeMap coverage; both were fixed with regressions

## Validation

Passed locally:

- `make dev-test FILTER=RepoPromptTests.PersistentAgentModeMCPReadFileConnectionTests` — 23 tests
- `make dev-test FILTER=RepoPromptTests.MCPReadFileAutoSelectionCoordinatorTests` — 19 tests
- `make dev-test FILTER=RepoPromptTests.MCPReadFileExactAbsoluteCatalogFastPathTests` — 9 tests
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make guardrails`
- Final packaged-app MCP smoke

I also confirmed in the live CE debug app that a full read and a sliced read produce the expected Selected Context.

The full root suite was run; remaining failures and the terminal timeout were unrelated existing issues in Agent-run, Codex liveness, and Git-policy tests.