### PR TITLE
Establish neutral agent execution contracts

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
@@ -566,7 +566,7 @@ final class AgentModeRunService {
         }
         session.pendingInstructions.insert(contentsOf: providerTexts, at: 0)
         session.isDirty = true
-        hooks.presentation.updateBindings(session)
+        hooks.bindingObservation.updateBindings(session)
         hooks.persistence.scheduleSave(tabID)
     }
 
@@ -861,7 +861,7 @@ final class AgentModeRunService {
     ) {
         guard !drafts.isEmpty else { return }
         let combined = drafts.joined(separator: "\n")
-        hooks.presentation.restoreDraftText(tabID, combined, "Restored queued steering messages", strategy)
+        hooks.queuedWorkRecovery.restoreDraftText(tabID, combined, "Restored queued steering messages", strategy)
     }
 
     private func restoreAllQueuedDraftsForExecutionLocationChange(
@@ -877,7 +877,7 @@ final class AgentModeRunService {
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         .filter { !$0.isEmpty }
         guard !drafts.isEmpty else { return }
-        hooks.presentation.restoreDraftText(tabID, drafts.joined(separator: "\n"), "Restored queued messages after changing execution location", strategy)
+        hooks.queuedWorkRecovery.restoreDraftText(tabID, drafts.joined(separator: "\n"), "Restored queued messages after changing execution location", strategy)
     }
 
     /// Concatenates all queued Claude steering draft texts and restores them to the composer.

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RepoPromptDomainRuntime
 
 @MainActor
 final class AgentModeRunService {
@@ -28,18 +29,10 @@ final class AgentModeRunService {
         let childAgentRunWaitDrainTimeoutSeconds: TimeInterval
     }
 
-    enum CancellationIntent {
-        case userStop
-        case executionLocationChange
-        case runtimeShutdown
-    }
-
-    enum CancellationCompletion: Equatable {
-        /// Return after canonical terminal publication and synchronous provider detachment.
-        case terminalPublished
-        /// Also wait for the exactly-once attempt/provider teardown closure to return.
-        case terminalTeardownCompleted
-    }
+    /// Neutral command/cancellation contracts shared with the direct/headless
+    /// composition. See `DomainAgentRunExecutionContracts`.
+    typealias CancellationIntent = DomainAgentRunCancellationIntent
+    typealias CancellationCompletion = DomainAgentRunCancellationCompletion
 
     /// Strategy for restoring draft text back to the composer.
     enum DraftRestorationStrategy: Equatable {
@@ -51,64 +44,6 @@ final class AgentModeRunService {
         /// caller has already composed the restored draft together with any
         /// newer typing, so applying the event again must not re-prepend.
         case replaceAlways
-    }
-
-    struct Hooks {
-        let estimateRuntimeTokens: (String) -> Int
-        let addUserInputTokensToActiveNonCodexTurn: (Int, AgentModeViewModel.TabSession) -> Void
-        let startNonCodexTurnAccountingIfNeeded: (AgentModeViewModel.TabSession, String) -> Void
-        let reserveAttachmentsForTurn: ([AgentImageAttachment], AgentModeViewModel.TabSession) -> UUID?
-        let markAttachmentsConsumed: (AgentModeViewModel.TabSession, UUID?) -> Void
-        let stageConsumedAttachmentFilesForDeferredCleanup: ([AgentImageAttachment], AgentModeViewModel.TabSession) -> Void
-        let consumeDeferredAttachmentCleanup: (AgentModeViewModel.TabSession, Bool) -> Void
-        let finalizeAttachmentsForTurn: (AgentModeViewModel.TabSession, UUID?, AgentModeViewModel.AttachmentTurnDisposition) -> Void
-        let setAgentRunActive: (UUID, Bool) -> Void
-        let updateBindings: (AgentModeViewModel.TabSession) -> Void
-        let requestUIRefresh: (UUID, Bool) -> Void
-        let scheduleSave: (UUID) -> Void
-        let notifyAgentTurnComplete: (AgentModeViewModel.TabSession) -> Void
-        let handleHeadlessStreamResult: (AIStreamResult, AgentModeViewModel.TabSession, UUID, UUID) async -> Void
-        let buildHeadlessAgentMessage: (AgentModeViewModel.TabSession, String, UUID, [AgentImageAttachment]) -> AgentMessage
-        let finalizeStreamingItems: (AgentModeViewModel.TabSession) -> Void
-        let finalizePendingToolCalls: (AgentModeViewModel.TabSession, AgentSessionRunState) -> Void
-        let finalizePendingToolCallsWithUpperBound: (AgentModeViewModel.TabSession, AgentSessionRunState, Int?) -> Void
-        let finalizeNonCodexTurnUsage: (AgentModeViewModel.TabSession, Int?, Int?, Int?) -> Void
-        let cancelPendingQuestion: (AgentModeViewModel.TabSession) -> Void
-        let cancelPendingApproval: (AgentModeViewModel.TabSession) -> Void
-        let cancelPendingApplyEditsReview: (AgentModeViewModel.TabSession, String) -> Void
-        let cancelPendingWorktreeMergeReview: (AgentModeViewModel.TabSession, String) -> Void
-        let flushPendingAssistantDelta: (AgentModeViewModel.TabSession) -> Void
-        let clearPendingAssistantDelta: (AgentModeViewModel.TabSession) -> Void
-        let prepareTerminalPublication: (AgentModeViewModel.TabSession) -> Void
-        let makeTerminalPublicationEnvelope: (
-            AgentModeViewModel.TabSession,
-            AgentRunOwnership,
-            AgentSessionRunState,
-            UUID?
-        ) -> AgentRunTerminalPublicationEnvelope?
-        let publishTerminalCommit: (
-            AgentModeViewModel.TabSession,
-            AgentRunTerminalCommitRevision,
-            AgentRunEpochTransitionKind?
-        ) async -> AgentRunTerminalPublicationResult
-        let startFollowUpRun: (UUID, String) -> Void
-        /// Restore queued steering draft text back to the composer.
-        let restoreDraftText: (_ tabID: UUID, _ text: String, _ message: String, _ strategy: DraftRestorationStrategy) -> Void
-        /// Augment queued steering text with skill context, tagged files, and attachment rendering before submit.
-        let augmentUserMessageForProviderSend: (
-            _ text: String,
-            _ attachments: [AgentImageAttachment],
-            _ taggedFileAttachments: [AgentTaggedFileAttachment],
-            _ session: AgentModeViewModel.TabSession?
-        ) async -> String
-        /// Stages a transcript handoff for fresh-session resume recovery.
-        let stageResumeRecoveryHandoffIfNeeded: (_ session: AgentModeViewModel.TabSession) async -> Void
-        /// Prepends a staged handoff payload to provider-facing text.
-        let prependPendingHandoffIfNeeded: (_ text: String, _ session: AgentModeViewModel.TabSession) -> String
-        /// Records whether a staged handoff payload was accepted by the provider send attempt.
-        let recordPendingHandoffSendOutcome: (_ session: AgentModeViewModel.TabSession, _ didSend: Bool) -> Void
-        /// Wakes MCP waiters once a steering instruction has actually been delivered to the provider.
-        let signalMCPInstructionDelivered: (_ session: AgentModeViewModel.TabSession) async -> Void
     }
 
     private let dependencies: Dependencies
@@ -442,10 +377,10 @@ final class AgentModeRunService {
                 }
                 let steeringUserInputTokens = dequeuedUserInputTokens.count == steeringBatch.count
                     ? dequeuedUserInputTokens.reduce(0, +)
-                    : hooks.estimateRuntimeTokens(providerTextForSend)
-                hooks.addUserInputTokensToActiveNonCodexTurn(steeringUserInputTokens, session)
+                    : hooks.usage.estimateRuntimeTokens(providerTextForSend)
+                hooks.usage.addUserInputTokensToActiveNonCodexTurn(steeringUserInputTokens, session)
 
-                let augmentedSteeringText = await hooks.augmentUserMessageForProviderSend(
+                let augmentedSteeringText = await hooks.providerInput.augmentUserMessageForProviderSend(
                     providerTextForSend,
                     steeringBatch.flatMap(\.attachments),
                     steeringBatch.flatMap(\.taggedFileAttachments),
@@ -459,9 +394,9 @@ final class AgentModeRunService {
                     targetRunAttemptID: runAttemptID,
                     targetController: controller
                 )
-                hooks.recordPendingHandoffSendOutcome(session, sent)
+                hooks.providerInput.recordPendingHandoffSendOutcome(session, sent)
                 if sent {
-                    await hooks.signalMCPInstructionDelivered(session)
+                    await hooks.continuation.signalMCPInstructionDelivered(session)
                 }
                 if !sent {
                     releaseSupersedingProtectionIfUnused()
@@ -495,7 +430,7 @@ final class AgentModeRunService {
 
     private func failBeforeProviderStartup(session: AgentModeViewModel.TabSession, message: String) async {
         let ownership = session.activeRunOwnership ?? session.beginRunAttempt(source: "runService.startupFailure")
-        hooks.recordPendingHandoffSendOutcome(session, false)
+        hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
             session: session,
             ownership: ownership,
@@ -626,13 +561,13 @@ final class AgentModeRunService {
                 session.pendingInstructions.insert(contentsOf: providerTexts, at: 0)
             }
             session.mcpFollowUpRunPending = true
-            hooks.startFollowUpRun(tabID, first)
+            hooks.continuation.startFollowUpRun(tabID, first)
             return
         }
         session.pendingInstructions.insert(contentsOf: providerTexts, at: 0)
         session.isDirty = true
-        hooks.updateBindings(session)
-        hooks.scheduleSave(tabID)
+        hooks.presentation.updateBindings(session)
+        hooks.persistence.scheduleSave(tabID)
     }
 
     /// Claims superseding protection for the currently outstanding Claude turn when
@@ -840,7 +775,7 @@ final class AgentModeRunService {
                     return session.pendingNonCodexUserInputTokenQueue.removeFirst()
                 }()
 
-                let augmentedSteeringText = await hooks.augmentUserMessageForProviderSend(
+                let augmentedSteeringText = await hooks.providerInput.augmentUserMessageForProviderSend(
                     steering.providerText,
                     steering.attachments,
                     steering.taggedFileAttachments,
@@ -853,9 +788,9 @@ final class AgentModeRunService {
                     attachments: []
                 )
                 steeringDebugLog("[AgentRunSteeringWake] Claude flush send completed id=\(steering.id) tab=\(tabID) runID=\(runID) attempt=\(runAttemptID) sent=\(sent)")
-                hooks.recordPendingHandoffSendOutcome(session, sent)
+                hooks.providerInput.recordPendingHandoffSendOutcome(session, sent)
                 if sent {
-                    await hooks.signalMCPInstructionDelivered(session)
+                    await hooks.continuation.signalMCPInstructionDelivered(session)
                 }
                 if !sent {
                     // Re-insert the failed instruction so it's included in the restore
@@ -926,7 +861,7 @@ final class AgentModeRunService {
     ) {
         guard !drafts.isEmpty else { return }
         let combined = drafts.joined(separator: "\n")
-        hooks.restoreDraftText(tabID, combined, "Restored queued steering messages", strategy)
+        hooks.presentation.restoreDraftText(tabID, combined, "Restored queued steering messages", strategy)
     }
 
     private func restoreAllQueuedDraftsForExecutionLocationChange(
@@ -942,7 +877,7 @@ final class AgentModeRunService {
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         .filter { !$0.isEmpty }
         guard !drafts.isEmpty else { return }
-        hooks.restoreDraftText(tabID, drafts.joined(separator: "\n"), "Restored queued messages after changing execution location", strategy)
+        hooks.presentation.restoreDraftText(tabID, drafts.joined(separator: "\n"), "Restored queued messages after changing execution location", strategy)
     }
 
     /// Concatenates all queued Claude steering draft texts and restores them to the composer.
@@ -980,10 +915,10 @@ final class AgentModeRunService {
             }
             return
         }
-        hooks.cancelPendingQuestion(session)
-        hooks.cancelPendingApproval(session)
-        hooks.cancelPendingApplyEditsReview(session, "Run cancelled")
-        hooks.cancelPendingWorktreeMergeReview(session, "Run cancelled")
+        hooks.interactions.cancelPendingQuestion(session)
+        hooks.interactions.cancelPendingApproval(session)
+        hooks.interactions.cancelPendingApplyEditsReview(session, "Run cancelled")
+        hooks.interactions.cancelPendingWorktreeMergeReview(session, "Run cancelled")
 
         // Cancel steering flush tasks first so they don't race with cleanup.
         session.claudeSteeringFlushTask?.cancel()
@@ -1021,14 +956,9 @@ final class AgentModeRunService {
         }
 
         // Cancel all active MCP tool executions for this run (all providers) before stopping providers.
-        let cancellationReason = switch intent {
-        case .userStop: "user_stop"
-        case .executionLocationChange: "execution_location_change"
-        case .runtimeShutdown: "runtime_shutdown"
-        }
         cancelToolsBeforeStoppingProvider(
             session: session,
-            reason: cancellationReason
+            reason: intent.cancellationReason
         )
 
         let ownership = session.activeRunOwnership ?? session.beginRunAttempt(source: "runService.cancel")

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
@@ -10,9 +10,9 @@ import Foundation
 // - Canonical lifecycle/durable settlement stays owned by the domain layer
 //   (`DomainAgentRunSessionStore`); `TerminalSettlementHooks` only adapts into
 //   that authority and must remain exactly-once per run attempt ownership.
-// - Presentation and persistence hooks are host projections. They must never
-//   become backend authority: a headless host may implement them as no-ops
-//   without changing run semantics.
+// - Presentation, binding-observation, queued-work recovery, and persistence
+//   hooks are host projections. They must never become backend authority: a
+//   headless host may implement them as no-ops without changing run semantics.
 // - `AgentModeViewModel.TabSession` still appears in these signatures because
 //   the app host is the only adopter today. The grouping is the contract seam;
 //   neutralizing the session parameter is the provider-migration step (PR 3).
@@ -44,10 +44,27 @@ extension AgentModeRunService {
     /// Authority: presentation projection.
     struct RunPresentationHooks {
         let setAgentRunActive: (UUID, Bool) -> Void
-        let updateBindings: (AgentModeViewModel.TabSession) -> Void
         let requestUIRefresh: (UUID, Bool) -> Void
         let notifyAgentTurnComplete: (AgentModeViewModel.TabSession) -> Void
-        /// Restore queued steering draft text back to the composer.
+    }
+
+    /// Session binding/run-state observation invoked from the central run
+    /// execution routing points. Not UI-only: alongside presentation binding
+    /// updates, the app host also observes MCP-controlled session state from
+    /// this callback, so it is classified as host binding observation rather
+    /// than pure presentation.
+    ///
+    /// Authority: host binding/state observation projection. Never
+    /// authoritative for run lifecycle decisions.
+    struct RunBindingObservationHooks {
+        let updateBindings: (AgentModeViewModel.TabSession) -> Void
+    }
+
+    /// Recovery of queued, undelivered user work when a run settles before
+    /// delivery (restoring queued steering text back into the host composer).
+    ///
+    /// Authority: queued-work recovery projection.
+    struct QueuedWorkRecoveryHooks {
         let restoreDraftText: (_ tabID: UUID, _ text: String, _ message: String, _ strategy: DraftRestorationStrategy) -> Void
     }
 
@@ -134,6 +151,8 @@ extension AgentModeRunService {
         let usage: UsageAccountingHooks
         let attachments: AttachmentLifecycleHooks
         let presentation: RunPresentationHooks
+        let bindingObservation: RunBindingObservationHooks
+        let queuedWorkRecovery: QueuedWorkRecoveryHooks
         let persistence: RunPersistenceHooks
         let transcript: TranscriptProjectionHooks
         let providerInput: ProviderInputAssemblyHooks

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+// MARK: - Authority-classified run execution hooks
+
+// `AgentModeRunService.Hooks` is the host-supplied callback surface used by the
+// run service, the terminal commit barrier, and the provider runners. Each hook
+// group below is classified by the authority it belongs to, so the reusable
+// execution boundary stays explicit about ownership:
+//
+// - Canonical lifecycle/durable settlement stays owned by the domain layer
+//   (`DomainAgentRunSessionStore`); `TerminalSettlementHooks` only adapts into
+//   that authority and must remain exactly-once per run attempt ownership.
+// - Presentation and persistence hooks are host projections. They must never
+//   become backend authority: a headless host may implement them as no-ops
+//   without changing run semantics.
+// - `AgentModeViewModel.TabSession` still appears in these signatures because
+//   the app host is the only adopter today. The grouping is the contract seam;
+//   neutralizing the session parameter is the provider-migration step (PR 3).
+
+extension AgentModeRunService {
+    /// Token/usage accounting projection for non-Codex turns.
+    ///
+    /// Authority: usage accounting (host-side projection of provider activity).
+    struct UsageAccountingHooks {
+        let estimateRuntimeTokens: (String) -> Int
+        let addUserInputTokensToActiveNonCodexTurn: (Int, AgentModeViewModel.TabSession) -> Void
+        let startNonCodexTurnAccountingIfNeeded: (AgentModeViewModel.TabSession, String) -> Void
+        let finalizeNonCodexTurnUsage: (AgentModeViewModel.TabSession, Int?, Int?, Int?) -> Void
+    }
+
+    /// Attachment file lifecycle for one turn (reserve → consume → finalize).
+    ///
+    /// Authority: persistence/durable turn resources.
+    struct AttachmentLifecycleHooks {
+        let reserveAttachmentsForTurn: ([AgentImageAttachment], AgentModeViewModel.TabSession) -> UUID?
+        let markAttachmentsConsumed: (AgentModeViewModel.TabSession, UUID?) -> Void
+        let stageConsumedAttachmentFilesForDeferredCleanup: ([AgentImageAttachment], AgentModeViewModel.TabSession) -> Void
+        let consumeDeferredAttachmentCleanup: (AgentModeViewModel.TabSession, Bool) -> Void
+        let finalizeAttachmentsForTurn: (AgentModeViewModel.TabSession, UUID?, AgentModeViewModel.AttachmentTurnDisposition) -> Void
+    }
+
+    /// UI-only callbacks. Never authoritative for run lifecycle decisions.
+    ///
+    /// Authority: presentation projection.
+    struct RunPresentationHooks {
+        let setAgentRunActive: (UUID, Bool) -> Void
+        let updateBindings: (AgentModeViewModel.TabSession) -> Void
+        let requestUIRefresh: (UUID, Bool) -> Void
+        let notifyAgentTurnComplete: (AgentModeViewModel.TabSession) -> Void
+        /// Restore queued steering draft text back to the composer.
+        let restoreDraftText: (_ tabID: UUID, _ text: String, _ message: String, _ strategy: DraftRestorationStrategy) -> Void
+    }
+
+    /// Host persistence scheduling for session/tab state.
+    ///
+    /// Authority: persistence projection.
+    struct RunPersistenceHooks {
+        let scheduleSave: (UUID) -> Void
+    }
+
+    /// Transcript projection of provider stream events and terminal finalization.
+    ///
+    /// Authority: transcript projection.
+    struct TranscriptProjectionHooks {
+        let handleHeadlessStreamResult: (AIStreamResult, AgentModeViewModel.TabSession, UUID, UUID) async -> Void
+        let finalizeStreamingItems: (AgentModeViewModel.TabSession) -> Void
+        let finalizePendingToolCalls: (AgentModeViewModel.TabSession, AgentSessionRunState) -> Void
+        let finalizePendingToolCallsWithUpperBound: (AgentModeViewModel.TabSession, AgentSessionRunState, Int?) -> Void
+        let flushPendingAssistantDelta: (AgentModeViewModel.TabSession) -> Void
+        let clearPendingAssistantDelta: (AgentModeViewModel.TabSession) -> Void
+    }
+
+    /// Provider-facing input assembly (messages, handoff payloads).
+    ///
+    /// Authority: provider capability inputs.
+    struct ProviderInputAssemblyHooks {
+        let buildHeadlessAgentMessage: (AgentModeViewModel.TabSession, String, UUID, [AgentImageAttachment]) -> AgentMessage
+        /// Augment queued steering text with skill context, tagged files, and attachment rendering before submit.
+        let augmentUserMessageForProviderSend: (
+            _ text: String,
+            _ attachments: [AgentImageAttachment],
+            _ taggedFileAttachments: [AgentTaggedFileAttachment],
+            _ session: AgentModeViewModel.TabSession?
+        ) async -> String
+        /// Stages a transcript handoff for fresh-session resume recovery.
+        let stageResumeRecoveryHandoffIfNeeded: (_ session: AgentModeViewModel.TabSession) async -> Void
+        /// Prepends a staged handoff payload to provider-facing text.
+        let prependPendingHandoffIfNeeded: (_ text: String, _ session: AgentModeViewModel.TabSession) -> String
+        /// Records whether a staged handoff payload was accepted by the provider send attempt.
+        let recordPendingHandoffSendOutcome: (_ session: AgentModeViewModel.TabSession, _ didSend: Bool) -> Void
+    }
+
+    /// Cancellation of pending approvals/questions/reviews when a run settles.
+    ///
+    /// Authority: approval/interaction brokerage.
+    struct RunInteractionHooks {
+        let cancelPendingQuestion: (AgentModeViewModel.TabSession) -> Void
+        let cancelPendingApproval: (AgentModeViewModel.TabSession) -> Void
+        let cancelPendingApplyEditsReview: (AgentModeViewModel.TabSession, String) -> Void
+        let cancelPendingWorktreeMergeReview: (AgentModeViewModel.TabSession, String) -> Void
+    }
+
+    /// Adapter into the canonical durable terminal settlement authority
+    /// (`DomainAgentRunSessionStore` behind the host's publication surface).
+    ///
+    /// Authority: canonical lifecycle command/event adaptation. The terminal
+    /// commit barrier drives these exactly once per settled run attempt.
+    struct TerminalSettlementHooks {
+        let prepareTerminalPublication: (AgentModeViewModel.TabSession) -> Void
+        let makeTerminalPublicationEnvelope: (
+            AgentModeViewModel.TabSession,
+            AgentRunOwnership,
+            AgentSessionRunState,
+            UUID?
+        ) -> AgentRunTerminalPublicationEnvelope?
+        let publishTerminalCommit: (
+            AgentModeViewModel.TabSession,
+            AgentRunTerminalCommitRevision,
+            AgentRunEpochTransitionKind?
+        ) async -> AgentRunTerminalPublicationResult
+    }
+
+    /// Continuation of a settled or steered run (follow-up starts, MCP wakes).
+    ///
+    /// Authority: lifecycle command issuance back into the host.
+    struct RunContinuationHooks {
+        let startFollowUpRun: (UUID, String) -> Void
+        /// Wakes MCP waiters once a steering instruction has actually been delivered to the provider.
+        let signalMCPInstructionDelivered: (_ session: AgentModeViewModel.TabSession) async -> Void
+    }
+
+    /// Composite host callback surface for run execution, grouped by authority.
+    struct Hooks {
+        let usage: UsageAccountingHooks
+        let attachments: AttachmentLifecycleHooks
+        let presentation: RunPresentationHooks
+        let persistence: RunPersistenceHooks
+        let transcript: TranscriptProjectionHooks
+        let providerInput: ProviderInputAssemblyHooks
+        let interactions: RunInteractionHooks
+        let terminalSettlement: TerminalSettlementHooks
+        let continuation: RunContinuationHooks
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -295,7 +295,7 @@ final class AgentRunTerminalCommitBarrier {
         session.lastTerminalCommitRevision = revision
         session.lastTerminalPublicationResult = nil
 
-        hooks.presentation.updateBindings(session)
+        hooks.bindingObservation.updateBindings(session)
         if request.notifyTurnComplete {
             hooks.presentation.notifyAgentTurnComplete(session)
         }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -135,7 +135,7 @@ final class AgentRunTerminalCommitBarrier {
         {
             recordRejection("duplicate_commit", request: request)
             if session.lastTerminalPublicationResult?.isResolved != true {
-                session.lastTerminalPublicationResult = await hooks.publishTerminalCommit(
+                session.lastTerminalPublicationResult = await hooks.terminalSettlement.publishTerminalCommit(
                     session,
                     existingRevision,
                     existingRevision.successorKind
@@ -146,7 +146,7 @@ final class AgentRunTerminalCommitBarrier {
                 revision: existingRevision,
                 publicationResult: session.lastTerminalPublicationResult
             ) {
-                hooks.startFollowUpRun(session.tabID, followUpInstruction)
+                hooks.continuation.startFollowUpRun(session.tabID, followUpInstruction)
             }
             if let providerSuccessor = request.providerSuccessor,
                providerSuccessor.id == existingRevision.providerSuccessorID,
@@ -177,7 +177,7 @@ final class AgentRunTerminalCommitBarrier {
 
         session.terminalCommitInProgress = true
         recordTerminalBarrierState(true, request: request)
-        hooks.flushPendingAssistantDelta(session)
+        hooks.transcript.flushPendingAssistantDelta(session)
         guard validatesOwnership(request) else {
             session.terminalCommitInProgress = false
             recordTerminalBarrierState(false, request: request)
@@ -185,10 +185,10 @@ final class AgentRunTerminalCommitBarrier {
             return nil
         }
 
-        hooks.finalizeStreamingItems(session)
-        hooks.finalizePendingToolCalls(session, request.terminalState)
+        hooks.transcript.finalizeStreamingItems(session)
+        hooks.transcript.finalizePendingToolCalls(session, request.terminalState)
         if request.finalizeNonCodexUsage {
-            hooks.finalizeNonCodexTurnUsage(session, nil, nil, nil)
+            hooks.usage.finalizeNonCodexTurnUsage(session, nil, nil, nil)
         }
 
         let queuedInstruction = request.terminalState == .completed && request.supportsFollowUp
@@ -205,8 +205,8 @@ final class AgentRunTerminalCommitBarrier {
             session.mcpFollowUpRunPending = true
         }
 
-        hooks.cancelPendingQuestion(session)
-        hooks.cancelPendingApproval(session)
+        hooks.interactions.cancelPendingQuestion(session)
+        hooks.interactions.cancelPendingApproval(session)
         let reviewCancellationReason = switch request.terminalState {
         case .completed:
             "Run completed before review decision"
@@ -217,9 +217,9 @@ final class AgentRunTerminalCommitBarrier {
         default:
             "Run finished"
         }
-        hooks.cancelPendingApplyEditsReview(session, reviewCancellationReason)
-        hooks.cancelPendingWorktreeMergeReview(session, reviewCancellationReason)
-        hooks.finalizeAttachmentsForTurn(
+        hooks.interactions.cancelPendingApplyEditsReview(session, reviewCancellationReason)
+        hooks.interactions.cancelPendingWorktreeMergeReview(session, reviewCancellationReason)
+        hooks.attachments.finalizeAttachmentsForTurn(
             session,
             request.attachmentReservationID,
             request.attachmentDisposition
@@ -260,8 +260,8 @@ final class AgentRunTerminalCommitBarrier {
         session.waitingPrompt = nil
         session.runState = request.terminalState
         _ = session.endRunAttempt(ifCurrent: request.ownership, source: request.source)
-        hooks.setAgentRunActive(session.tabID, false)
-        hooks.prepareTerminalPublication(session)
+        hooks.presentation.setAgentRunActive(session.tabID, false)
+        hooks.terminalSettlement.prepareTerminalPublication(session)
         if let runID = request.expectedRunID, let terminalTurnID {
             AgentModeProcessRunIdentity.retainProcessRunID(
                 runID,
@@ -283,7 +283,7 @@ final class AgentRunTerminalCommitBarrier {
             sourceItemsRevision: session.sourceItemsRevision,
             assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
             providerDrainGeneration: request.providerDrainGeneration,
-            mcpPublicationEnvelope: hooks.makeTerminalPublicationEnvelope(
+            mcpPublicationEnvelope: hooks.terminalSettlement.makeTerminalPublicationEnvelope(
                 session,
                 request.ownership,
                 request.terminalState,
@@ -295,12 +295,12 @@ final class AgentRunTerminalCommitBarrier {
         session.lastTerminalCommitRevision = revision
         session.lastTerminalPublicationResult = nil
 
-        hooks.updateBindings(session)
+        hooks.presentation.updateBindings(session)
         if request.notifyTurnComplete {
-            hooks.notifyAgentTurnComplete(session)
+            hooks.presentation.notifyAgentTurnComplete(session)
         }
-        hooks.scheduleSave(session.tabID)
-        session.lastTerminalPublicationResult = await hooks.publishTerminalCommit(
+        hooks.persistence.scheduleSave(session.tabID)
+        session.lastTerminalPublicationResult = await hooks.terminalSettlement.publishTerminalCommit(
             session,
             revision,
             successorKind
@@ -329,7 +329,7 @@ final class AgentRunTerminalCommitBarrier {
         request.postCommit()
 
         if let followUpInstruction {
-            hooks.startFollowUpRun(session.tabID, followUpInstruction)
+            hooks.continuation.startFollowUpRun(session.tabID, followUpInstruction)
         }
         if request.completion == .terminalTeardownCompleted {
             await teardownTask?.value

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -91,14 +91,14 @@ final class ACPIntegratedAgentModeRunner {
         runRequest: ACPRunRequest,
         makeLease: @escaping (_ runID: UUID) -> MCPBootstrapLease
     ) async {
-        let attachmentReservationID = hooks.reserveAttachmentsForTurn(attachments, session)
+        let attachmentReservationID = hooks.attachments.reserveAttachmentsForTurn(attachments, session)
 
         if initialMessageForRun != initialUserMessage,
            !session.pendingNonCodexUserInputTokenQueue.isEmpty
         {
-            session.pendingNonCodexUserInputTokenQueue[0] = hooks.estimateRuntimeTokens(initialMessageForRun)
+            session.pendingNonCodexUserInputTokenQueue[0] = hooks.usage.estimateRuntimeTokens(initialMessageForRun)
         }
-        hooks.startNonCodexTurnAccountingIfNeeded(session, initialMessageForRun)
+        hooks.usage.startNonCodexTurnAccountingIfNeeded(session, initialMessageForRun)
         session.activeReasoningItemID = nil
         session.reasoningItemIDsByGroupID.removeAll()
         session.codexReasoningSegmentsByKey.removeAll()
@@ -107,7 +107,7 @@ final class ACPIntegratedAgentModeRunner {
         let runAttemptID = ownership.attemptID
         session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .preparingRuntime)
         session.runState = .running
-        hooks.setAgentRunActive(tabID, true)
+        hooks.presentation.setAgentRunActive(tabID, true)
         setRunningStatus(initialTransportStatusText(for: runRequest.agentKind), source: .transport, session: session, urgent: true)
 
         let freshRunRequest = runRequest
@@ -341,7 +341,7 @@ final class ACPIntegratedAgentModeRunner {
             return false
         }
 
-        let agentMessage = hooks.buildHeadlessAgentMessage(
+        let agentMessage = hooks.providerInput.buildHeadlessAgentMessage(
             session,
             messageForRun,
             runID,
@@ -397,7 +397,7 @@ final class ACPIntegratedAgentModeRunner {
               let ownership = session.activeRunOwnership,
               ownership.attemptID == runAttemptID
         else { return }
-        hooks.recordPendingHandoffSendOutcome(session, false)
+        hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
             session: session,
             ownership: ownership,
@@ -428,7 +428,7 @@ final class ACPIntegratedAgentModeRunner {
               let ownership = session.activeRunOwnership,
               ownership.attemptID == runAttemptID
         else { return }
-        hooks.recordPendingHandoffSendOutcome(session, false)
+        hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
             session: session,
             ownership: ownership,
@@ -496,8 +496,8 @@ final class ACPIntegratedAgentModeRunner {
             }
             var initialMessageForPromptTurn = initialMessageForRun
             if bootstrap.didFallbackToNewSessionAfterLoadFailure {
-                await hooks.stageResumeRecoveryHandoffIfNeeded(session)
-                initialMessageForPromptTurn = hooks.prependPendingHandoffIfNeeded(initialMessageForRun, session)
+                await hooks.providerInput.stageResumeRecoveryHandoffIfNeeded(session)
+                initialMessageForPromptTurn = hooks.providerInput.prependPendingHandoffIfNeeded(initialMessageForRun, session)
             }
             applyProviderSessionIdentity(
                 bootstrap.providerSessionIdentity,
@@ -506,8 +506,8 @@ final class ACPIntegratedAgentModeRunner {
             )
             _ = syncACPSelectedModelFromRegistryIfNeeded(agentKind: runRequest.agentKind, session: session)
             session.isDirty = true
-            hooks.scheduleSave(session.tabID)
-            hooks.updateBindings(session)
+            hooks.persistence.scheduleSave(session.tabID)
+            hooks.presentation.updateBindings(session)
 
             try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
             await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
@@ -690,15 +690,15 @@ final class ACPIntegratedAgentModeRunner {
     ) async {
         log("prompt turn begin prepare=\(prepareControllerForNextTurn)", runID: runID)
         setRunningStatus("Thinking…", source: .transport, session: session, urgent: true)
-        let agentMessage = hooks.buildHeadlessAgentMessage(
+        let agentMessage = hooks.providerInput.buildHeadlessAgentMessage(
             session,
             initialMessageForRun,
             runID,
             attachments
         )
-        hooks.recordPendingHandoffSendOutcome(session, true)
-        hooks.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
-        hooks.markAttachmentsConsumed(session, attachmentReservationID)
+        hooks.providerInput.recordPendingHandoffSendOutcome(session, true)
+        hooks.attachments.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
+        hooks.attachments.markAttachmentsConsumed(session, attachmentReservationID)
 
         if prepareControllerForNextTurn {
             let prepared = await controller.prepareForNextTurn()
@@ -804,8 +804,8 @@ final class ACPIntegratedAgentModeRunner {
         }
         guard changed else { return }
         session.isDirty = true
-        hooks.scheduleSave(session.tabID)
-        hooks.updateBindings(session)
+        hooks.persistence.scheduleSave(session.tabID)
+        hooks.presentation.updateBindings(session)
     }
 
     private func applyRequestedSessionModeIfNeeded(
@@ -876,7 +876,7 @@ final class ACPIntegratedAgentModeRunner {
             }
             switch event {
             case let .stream(result):
-                await hooks.handleHeadlessStreamResult(result, session, runID, runAttemptID)
+                await hooks.transcript.handleHeadlessStreamResult(result, session, runID, runAttemptID)
             case let .approvalRequested(request):
                 session.pendingApproval = request
                 session.runState = .waitingForApproval
@@ -888,7 +888,7 @@ final class ACPIntegratedAgentModeRunner {
                         session.runState = .running
                         setRunningStatus("Thinking…", source: .transport, session: session, urgent: true)
                     } else {
-                        hooks.updateBindings(session)
+                        hooks.presentation.updateBindings(session)
                     }
                 }
             case let .terminal(state, errorText):
@@ -922,7 +922,7 @@ final class ACPIntegratedAgentModeRunner {
         guard let ownership = session.activeRunOwnership,
               ownership.attemptID == runAttemptID
         else { return }
-        hooks.recordPendingHandoffSendOutcome(session, false)
+        hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
             session: session,
             ownership: ownership,
@@ -1051,15 +1051,15 @@ final class ACPIntegratedAgentModeRunner {
         let normalizedSource = value == nil ? nil : source
         guard session.runningStatusText != value || session.runningStatusSource != normalizedSource else {
             if urgent {
-                hooks.updateBindings(session)
-                hooks.requestUIRefresh(session.tabID, true)
+                hooks.presentation.updateBindings(session)
+                hooks.presentation.requestUIRefresh(session.tabID, true)
             }
             return
         }
         session.runningStatusText = value
         session.runningStatusSource = normalizedSource
-        hooks.updateBindings(session)
-        hooks.requestUIRefresh(session.tabID, urgent)
+        hooks.presentation.updateBindings(session)
+        hooks.presentation.requestUIRefresh(session.tabID, urgent)
     }
 
     private func initialTransportStatusText(for _: AgentProviderKind) -> String {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -507,7 +507,7 @@ final class ACPIntegratedAgentModeRunner {
             _ = syncACPSelectedModelFromRegistryIfNeeded(agentKind: runRequest.agentKind, session: session)
             session.isDirty = true
             hooks.persistence.scheduleSave(session.tabID)
-            hooks.presentation.updateBindings(session)
+            hooks.bindingObservation.updateBindings(session)
 
             try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
             await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
@@ -805,7 +805,7 @@ final class ACPIntegratedAgentModeRunner {
         guard changed else { return }
         session.isDirty = true
         hooks.persistence.scheduleSave(session.tabID)
-        hooks.presentation.updateBindings(session)
+        hooks.bindingObservation.updateBindings(session)
     }
 
     private func applyRequestedSessionModeIfNeeded(
@@ -888,7 +888,7 @@ final class ACPIntegratedAgentModeRunner {
                         session.runState = .running
                         setRunningStatus("Thinking…", source: .transport, session: session, urgent: true)
                     } else {
-                        hooks.presentation.updateBindings(session)
+                        hooks.bindingObservation.updateBindings(session)
                     }
                 }
             case let .terminal(state, errorText):
@@ -1051,14 +1051,14 @@ final class ACPIntegratedAgentModeRunner {
         let normalizedSource = value == nil ? nil : source
         guard session.runningStatusText != value || session.runningStatusSource != normalizedSource else {
             if urgent {
-                hooks.presentation.updateBindings(session)
+                hooks.bindingObservation.updateBindings(session)
                 hooks.presentation.requestUIRefresh(session.tabID, true)
             }
             return
         }
         session.runningStatusText = value
         session.runningStatusSource = normalizedSource
-        hooks.presentation.updateBindings(session)
+        hooks.bindingObservation.updateBindings(session)
         hooks.presentation.requestUIRefresh(session.tabID, urgent)
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
@@ -50,14 +50,14 @@ final class ClaudeIntegratedAgentModeRunner {
         attachments: [AgentImageAttachment],
         makeLease: (_ runID: UUID) -> MCPBootstrapLease
     ) async {
-        let attachmentReservationID = hooks.reserveAttachmentsForTurn(attachments, session)
+        let attachmentReservationID = hooks.attachments.reserveAttachmentsForTurn(attachments, session)
 
         if initialMessageForRun != initialUserMessage,
            !session.pendingNonCodexUserInputTokenQueue.isEmpty
         {
-            session.pendingNonCodexUserInputTokenQueue[0] = hooks.estimateRuntimeTokens(initialMessageForRun)
+            session.pendingNonCodexUserInputTokenQueue[0] = hooks.usage.estimateRuntimeTokens(initialMessageForRun)
         }
-        hooks.startNonCodexTurnAccountingIfNeeded(session, initialMessageForRun)
+        hooks.usage.startNonCodexTurnAccountingIfNeeded(session, initialMessageForRun)
         session.activeReasoningItemID = nil
         session.reasoningItemIDsByGroupID.removeAll()
         session.codexReasoningSegmentsByKey.removeAll()
@@ -87,8 +87,8 @@ final class ClaudeIntegratedAgentModeRunner {
         session.pendingSupersedingTurnCompletions = 0
         session.claudeSupersedingProtectedTurnIDs.removeAll()
         session.claudeExpectedTurnIDs.removeAll()
-        hooks.setAgentRunActive(tabID, true)
-        hooks.updateBindings(session)
+        hooks.presentation.setAgentRunActive(tabID, true)
+        hooks.presentation.updateBindings(session)
 
         session.agentTask = Task { [weak self, weak session] in
             guard let self, let session else { return }
@@ -121,7 +121,7 @@ final class ClaudeIntegratedAgentModeRunner {
                     provider: providerName,
                     outcome: sent ? "ready" : (Task.isCancelled ? "cancelled" : "failed")
                 )
-                self.hooks.recordPendingHandoffSendOutcome(session, sent)
+                self.hooks.providerInput.recordPendingHandoffSendOutcome(session, sent)
                 guard sent else {
                     await self.finalize(
                         session: session,
@@ -135,8 +135,8 @@ final class ClaudeIntegratedAgentModeRunner {
                     return
                 }
 
-                self.hooks.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
-                self.hooks.markAttachmentsConsumed(session, attachmentReservationID)
+                self.hooks.attachments.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
+                self.hooks.attachments.markAttachmentsConsumed(session, attachmentReservationID)
                 _ = await lease.releaseWhenRouted()
 
                 guard let events = await self.claudeCoordinator.events(for: session) else {
@@ -201,7 +201,7 @@ final class ClaudeIntegratedAgentModeRunner {
                         reasoningDebug("stream reasoning run=\(runID.uuidString) attempt=\(runAttemptID.uuidString) tab=\(session.tabID.uuidString) len=\(text.count) snippet=\(reasoningDebugSnippet(text))")
                     }
                 #endif
-                await hooks.handleHeadlessStreamResult(result, session, runID, runAttemptID)
+                await hooks.transcript.handleHeadlessStreamResult(result, session, runID, runAttemptID)
             case let .runtimeInit(status):
                 // Persist provider session ID as soon as it becomes available from
                 // runtime init events (initialize response or system/init stream).
@@ -218,7 +218,7 @@ final class ClaudeIntegratedAgentModeRunner {
                         codexRolloutPath: session.codexRolloutPath
                     )
                     session.isDirty = true
-                    hooks.scheduleSave(session.tabID)
+                    hooks.persistence.scheduleSave(session.tabID)
                 }
                 if status.isRepoPromptServerFailed {
                     return ConsumeEventsOutcome(
@@ -235,7 +235,7 @@ final class ClaudeIntegratedAgentModeRunner {
                 session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
                 session.setRunningStatus(nil, source: nil)
                 session.runState = .waitingForApproval
-                hooks.updateBindings(session)
+                hooks.presentation.updateBindings(session)
             case let .approvalCancelled(requestID):
                 if session.pendingApproval?.requestID == .claudeControl(requestID) {
                     session.pendingApproval = nil
@@ -244,7 +244,7 @@ final class ClaudeIntegratedAgentModeRunner {
                         session.setRunningStatus("Thinking…", source: .transport)
                         session.runState = .running
                     }
-                    hooks.updateBindings(session)
+                    hooks.presentation.updateBindings(session)
                 }
             case let .turnCompleted(turnID, turnStatus):
                 guard session.claudeExpectedTurnIDs.contains(turnID) else {
@@ -265,8 +265,8 @@ final class ClaudeIntegratedAgentModeRunner {
                     if !session.runState.isActive {
                         session.runState = .running
                     }
-                    hooks.setAgentRunActive(session.tabID, true)
-                    hooks.updateBindings(session)
+                    hooks.presentation.setAgentRunActive(session.tabID, true)
+                    hooks.presentation.updateBindings(session)
                     continue eventLoop
                 }
                 // No superseding turn expected — terminal for this run.
@@ -292,8 +292,8 @@ final class ClaudeIntegratedAgentModeRunner {
                     #endif
                     let errorItem = AgentChatItem.error(trimmed, sequenceIndex: session.nextSequenceIndex)
                     session.appendItem(errorItem)
-                    hooks.updateBindings(session)
-                    hooks.scheduleSave(session.tabID)
+                    hooks.presentation.updateBindings(session)
+                    hooks.persistence.scheduleSave(session.tabID)
                 }
             }
         }
@@ -321,7 +321,7 @@ final class ClaudeIntegratedAgentModeRunner {
         ownership: AgentRunOwnership,
         attachmentReservationID: UUID?
     ) async {
-        hooks.recordPendingHandoffSendOutcome(session, false)
+        hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
             session: session,
             ownership: ownership,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
@@ -88,7 +88,7 @@ final class ClaudeIntegratedAgentModeRunner {
         session.claudeSupersedingProtectedTurnIDs.removeAll()
         session.claudeExpectedTurnIDs.removeAll()
         hooks.presentation.setAgentRunActive(tabID, true)
-        hooks.presentation.updateBindings(session)
+        hooks.bindingObservation.updateBindings(session)
 
         session.agentTask = Task { [weak self, weak session] in
             guard let self, let session else { return }
@@ -235,7 +235,7 @@ final class ClaudeIntegratedAgentModeRunner {
                 session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
                 session.setRunningStatus(nil, source: nil)
                 session.runState = .waitingForApproval
-                hooks.presentation.updateBindings(session)
+                hooks.bindingObservation.updateBindings(session)
             case let .approvalCancelled(requestID):
                 if session.pendingApproval?.requestID == .claudeControl(requestID) {
                     session.pendingApproval = nil
@@ -244,7 +244,7 @@ final class ClaudeIntegratedAgentModeRunner {
                         session.setRunningStatus("Thinking…", source: .transport)
                         session.runState = .running
                     }
-                    hooks.presentation.updateBindings(session)
+                    hooks.bindingObservation.updateBindings(session)
                 }
             case let .turnCompleted(turnID, turnStatus):
                 guard session.claudeExpectedTurnIDs.contains(turnID) else {
@@ -266,7 +266,7 @@ final class ClaudeIntegratedAgentModeRunner {
                         session.runState = .running
                     }
                     hooks.presentation.setAgentRunActive(session.tabID, true)
-                    hooks.presentation.updateBindings(session)
+                    hooks.bindingObservation.updateBindings(session)
                     continue eventLoop
                 }
                 // No superseding turn expected — terminal for this run.
@@ -292,7 +292,7 @@ final class ClaudeIntegratedAgentModeRunner {
                     #endif
                     let errorItem = AgentChatItem.error(trimmed, sequenceIndex: session.nextSequenceIndex)
                     session.appendItem(errorItem)
-                    hooks.presentation.updateBindings(session)
+                    hooks.bindingObservation.updateBindings(session)
                     hooks.persistence.scheduleSave(session.tabID)
                 }
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedAgentModeRunner.swift
@@ -33,7 +33,7 @@ final class CodexIntegratedAgentModeRunner {
             createdOwnership = true
             session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .preparingRuntime)
         }
-        let attachmentReservationID = hooks.reserveAttachmentsForTurn(attachments, session)
+        let attachmentReservationID = hooks.attachments.reserveAttachmentsForTurn(attachments, session)
 
         let sendTask = Task<CodexAgentModeCoordinator.NativeSendOutcome, Never> { [weak self, weak session] in
             guard let self, let session else {
@@ -51,7 +51,7 @@ final class CodexIntegratedAgentModeRunner {
                 let outcome = CodexAgentModeCoordinator.NativeSendOutcome.failed(
                     message: "MCP catalog registration failed before Agent launch."
                 )
-                hooks.recordPendingHandoffSendOutcome(session, false)
+                hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
                 if createdOwnership {
                     session.endRunAttempt(ifCurrent: ownership, source: "codex.mcpBootstrapRejected")
                 }
@@ -66,7 +66,7 @@ final class CodexIntegratedAgentModeRunner {
                 attachmentReservationID: attachmentReservationID,
                 terminalizeRejectedSend: createdOwnership
             )
-            hooks.recordPendingHandoffSendOutcome(session, outcome.didSend)
+            hooks.providerInput.recordPendingHandoffSendOutcome(session, outcome.didSend)
             switch outcome {
             case .sent:
                 session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .running)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
@@ -24,14 +24,14 @@ final class HeadlessAgentModeRunner {
         attachments: [AgentImageAttachment],
         makeLease: (_ runID: UUID) -> MCPBootstrapLease
     ) async {
-        let attachmentReservationID = hooks.reserveAttachmentsForTurn(attachments, session)
+        let attachmentReservationID = hooks.attachments.reserveAttachmentsForTurn(attachments, session)
 
         if initialMessageForRun != initialUserMessage,
            !session.pendingNonCodexUserInputTokenQueue.isEmpty
         {
-            session.pendingNonCodexUserInputTokenQueue[0] = hooks.estimateRuntimeTokens(initialMessageForRun)
+            session.pendingNonCodexUserInputTokenQueue[0] = hooks.usage.estimateRuntimeTokens(initialMessageForRun)
         }
-        hooks.startNonCodexTurnAccountingIfNeeded(session, initialMessageForRun)
+        hooks.usage.startNonCodexTurnAccountingIfNeeded(session, initialMessageForRun)
 
         let runID = AgentModeProcessRunIdentity.startFreshProcessRun(for: session)
         let lease = makeLease(runID)
@@ -46,8 +46,8 @@ final class HeadlessAgentModeRunner {
         session.runningStatusText = nil
         session.runningStatusSource = nil
         session.runState = .running
-        hooks.setAgentRunActive(tabID, true)
-        hooks.updateBindings(session)
+        hooks.presentation.setAgentRunActive(tabID, true)
+        hooks.presentation.updateBindings(session)
 
         guard session.selectedAgent != .codexExec else {
             await terminalCommitBarrier.commit(.init(
@@ -110,7 +110,7 @@ final class HeadlessAgentModeRunner {
                     return
                 }
 
-                let agentMessage = self.hooks.buildHeadlessAgentMessage(
+                let agentMessage = self.hooks.providerInput.buildHeadlessAgentMessage(
                     session,
                     initialMessageForRun,
                     runID,
@@ -137,7 +137,7 @@ final class HeadlessAgentModeRunner {
         ownership: AgentRunOwnership,
         attachmentReservationID: UUID?
     ) async {
-        hooks.recordPendingHandoffSendOutcome(session, false)
+        hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
             session: session,
             ownership: ownership,
@@ -174,9 +174,9 @@ final class HeadlessAgentModeRunner {
             let stream = try await provider.streamAgentMessage(initialMessage, runID: runID)
             providerInitializationCompleted = true
             await lease.providerInitializationCompleted(provider: session.selectedAgent.rawValue, outcome: "ready")
-            hooks.recordPendingHandoffSendOutcome(session, true)
-            hooks.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
-            hooks.markAttachmentsConsumed(session, attachmentReservationID)
+            hooks.providerInput.recordPendingHandoffSendOutcome(session, true)
+            hooks.attachments.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
+            hooks.attachments.markAttachmentsConsumed(session, attachmentReservationID)
             _ = await lease.releaseWhenRouted()
             if let ownership = session.activeRunOwnership, ownership.attemptID == runAttemptID {
                 session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .running)
@@ -186,7 +186,7 @@ final class HeadlessAgentModeRunner {
                 guard !Task.isCancelled else { break }
                 guard session.isCurrentRunAttempt(ownership, expectedRunID: runID) else { return }
                 session.recordRunProgress(ownership: ownership, kind: .providerEvent, stage: .running)
-                await hooks.handleHeadlessStreamResult(result, session, runID, runAttemptID)
+                await hooks.transcript.handleHeadlessStreamResult(result, session, runID, runAttemptID)
             }
 
             guard session.runID == runID,
@@ -216,7 +216,7 @@ final class HeadlessAgentModeRunner {
             if !providerInitializationCompleted {
                 await lease.providerInitializationCompleted(provider: session.selectedAgent.rawValue, outcome: "cancelled")
             }
-            hooks.recordPendingHandoffSendOutcome(session, false)
+            hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
             await terminalCommitBarrier.commit(.init(
                 session: session,
                 ownership: ownership,
@@ -238,7 +238,7 @@ final class HeadlessAgentModeRunner {
             if !providerInitializationCompleted {
                 await lease.providerInitializationCompleted(provider: session.selectedAgent.rawValue, outcome: "failed")
             }
-            hooks.recordPendingHandoffSendOutcome(session, false)
+            hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
             await terminalCommitBarrier.commit(.init(
                 session: session,
                 ownership: ownership,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
@@ -47,7 +47,7 @@ final class HeadlessAgentModeRunner {
         session.runningStatusSource = nil
         session.runState = .running
         hooks.presentation.setAgentRunActive(tabID, true)
-        hooks.presentation.updateBindings(session)
+        hooks.bindingObservation.updateBindings(session)
 
         guard session.selectedAgent != .codexExec else {
             await terminalCommitBarrier.commit(.init(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -2150,163 +2150,181 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             childAgentRunWaitDrainTimeoutSeconds: Self.childAgentRunWaitDrainTimeoutSeconds
         )
         let hooks = AgentModeRunService.Hooks(
-            estimateRuntimeTokens: { text in
-                Self.estimateRuntimeTokens(for: text)
-            },
-            addUserInputTokensToActiveNonCodexTurn: { [weak self] tokens, session in
-                self?.addUserInputTokensToActiveNonCodexTurn(tokens, for: session)
-            },
-            startNonCodexTurnAccountingIfNeeded: { [weak self] session, initialMessage in
-                self?.startNonCodexTurnAccountingIfNeeded(for: session, initialMessage: initialMessage)
-            },
-            reserveAttachmentsForTurn: { [weak self] attachments, session in
-                self?.reserveAttachmentsForTurn(attachments, session: session)
-            },
-            markAttachmentsConsumed: { [weak self] session, reservationID in
-                self?.markAttachmentsConsumed(for: session, reservationID: reservationID)
-            },
-            stageConsumedAttachmentFilesForDeferredCleanup: { [weak self] attachments, session in
-                self?.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session: session)
-            },
-            consumeDeferredAttachmentCleanup: { [weak self] session, shouldDeleteFiles in
-                self?.consumeDeferredAttachmentCleanup(for: session, shouldDeleteFiles: shouldDeleteFiles)
-            },
-            finalizeAttachmentsForTurn: { [weak self] session, reservationID, disposition in
-                self?.finalizeAttachmentsForTurn(for: session, reservationID: reservationID, disposition: disposition)
-            },
-            setAgentRunActive: { [weak self] tabID, isActive in
-                self?.setAgentRunActive(tabID, isActive: isActive)
-            },
-            updateBindings: { [weak self] session in
-                guard let self else { return }
-                updateBindingsFromSession(session)
-                handleObservedMCPStateChange(for: session)
-            },
-            requestUIRefresh: { [weak self] tabID, urgent in
-                self?.requestUIRefresh(tabID: tabID, urgent: urgent)
-            },
-            scheduleSave: { [weak self] tabID in
-                self?.scheduleSave(for: tabID)
-            },
-            notifyAgentTurnComplete: { [weak self] session in
-                self?.notifyAgentTurnComplete(for: session)
-            },
-            handleHeadlessStreamResult: { [weak self] result, session, runID, runAttemptID in
-                await self?.handleStreamResult(result, session: session, runID: runID, runAttemptID: runAttemptID)
-            },
-            buildHeadlessAgentMessage: { [weak self] session, initialMessage, runID, attachments in
-                self?.buildHeadlessAgentMessage(
-                    session: session,
-                    initialMessageForRun: initialMessage,
-                    runID: runID,
-                    attachments: attachments
-                )
-                    ?? AgentMessage(systemPrompt: "", userMessage: initialMessage)
-            },
-            finalizeStreamingItems: { [weak self] session in
-                self?.finalizeStreamingItems(in: session)
-            },
-            finalizePendingToolCalls: { [weak self] session, terminalState in
-                _ = self?.finalizePendingToolCalls(
-                    in: session,
-                    terminalState: terminalState,
-                    includeExplicitRepoPromptToolCalls: AgentTranscriptQualityRepair.shouldFinalizeExplicitRepoPromptTools(
-                        context: .liveTerminal(agentKind: session.selectedAgent)
+            usage: .init(
+                estimateRuntimeTokens: { text in
+                    Self.estimateRuntimeTokens(for: text)
+                },
+                addUserInputTokensToActiveNonCodexTurn: { [weak self] tokens, session in
+                    self?.addUserInputTokensToActiveNonCodexTurn(tokens, for: session)
+                },
+                startNonCodexTurnAccountingIfNeeded: { [weak self] session, initialMessage in
+                    self?.startNonCodexTurnAccountingIfNeeded(for: session, initialMessage: initialMessage)
+                },
+                finalizeNonCodexTurnUsage: { [weak self] session, promptTokens, completionTokens, contextUsedTokens in
+                    self?.finalizeNonCodexTurnUsageIfNeeded(
+                        for: session,
+                        promptTokens: promptTokens,
+                        completionTokens: completionTokens,
+                        contextUsedTokens: contextUsedTokens
                     )
-                )
-            },
-            finalizePendingToolCallsWithUpperBound: { [weak self] session, terminalState, maxSequenceIndexExclusive in
-                _ = self?.finalizePendingToolCalls(
-                    in: session,
-                    terminalState: terminalState,
-                    includeExplicitRepoPromptToolCalls: AgentTranscriptQualityRepair.shouldFinalizeExplicitRepoPromptTools(
-                        context: .liveTerminal(agentKind: session.selectedAgent)
-                    ),
-                    maxSequenceIndexExclusive: maxSequenceIndexExclusive
-                )
-            },
-            finalizeNonCodexTurnUsage: { [weak self] session, promptTokens, completionTokens, contextUsedTokens in
-                self?.finalizeNonCodexTurnUsageIfNeeded(
-                    for: session,
-                    promptTokens: promptTokens,
-                    completionTokens: completionTokens,
-                    contextUsedTokens: contextUsedTokens
-                )
-            },
-            cancelPendingQuestion: { [weak self] session in
-                self?.cancelPendingQuestion(for: session)
-            },
-            cancelPendingApproval: { [weak self] session in
-                self?.cancelPendingApproval(for: session)
-            },
-            cancelPendingApplyEditsReview: { [weak self] session, reason in
-                self?.cancelPendingApplyEditsReview(for: session, reason: reason)
-            },
-            cancelPendingWorktreeMergeReview: { [weak self] session, reason in
-                self?.cancelPendingWorktreeMergeReview(for: session, reason: reason)
-            },
-            flushPendingAssistantDelta: { [weak self] session in
-                self?.flushPendingAssistantDelta(session)
-            },
-            clearPendingAssistantDelta: { [weak self] session in
-                self?.clearPendingAssistantDelta(session)
-            },
-            prepareTerminalPublication: { [weak self] session in
-                self?.prepareTerminalPublication(for: session)
-            },
-            makeTerminalPublicationEnvelope: { [weak self] session, ownership, terminalState, providerRunID in
-                self?.makeTerminalPublicationEnvelope(
-                    for: session,
-                    ownership: ownership,
-                    terminalState: terminalState,
-                    providerRunID: providerRunID
-                )
-            },
-            publishTerminalCommit: { [weak self] session, revision, successorKind in
-                guard let self else { return .rejected(reason: "view_model_deallocated") }
-                let result = await publishTerminalCommit(
-                    revision,
-                    successorKind: successorKind,
-                    for: session
-                )
-                if result.isResolved,
-                   let sessionID = session.activeAgentSessionID,
-                   let runID = revision.expectedRunID
-                {
-                    mcpRemoveAgentRunOracleReviewContext(sessionID: sessionID, runID: runID)
                 }
-                return result
-            },
-            startFollowUpRun: { [weak self] tabID, initialMessage in
-                Task { [weak self] in
-                    await self?.startAgentRun(tabID: tabID, initialMessage: initialMessage)
+            ),
+            attachments: .init(
+                reserveAttachmentsForTurn: { [weak self] attachments, session in
+                    self?.reserveAttachmentsForTurn(attachments, session: session)
+                },
+                markAttachmentsConsumed: { [weak self] session, reservationID in
+                    self?.markAttachmentsConsumed(for: session, reservationID: reservationID)
+                },
+                stageConsumedAttachmentFilesForDeferredCleanup: { [weak self] attachments, session in
+                    self?.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session: session)
+                },
+                consumeDeferredAttachmentCleanup: { [weak self] session, shouldDeleteFiles in
+                    self?.consumeDeferredAttachmentCleanup(for: session, shouldDeleteFiles: shouldDeleteFiles)
+                },
+                finalizeAttachmentsForTurn: { [weak self] session, reservationID, disposition in
+                    self?.finalizeAttachmentsForTurn(for: session, reservationID: reservationID, disposition: disposition)
                 }
-            },
-            restoreDraftText: { [weak self] tabID, text, message, strategy in
-                self?.restoreComposerDraft(tabID: tabID, text: text, message: message, strategy: strategy)
-            },
-            augmentUserMessageForProviderSend: { [weak self] text, attachments, taggedFileAttachments, session in
-                guard let self else { return text }
-                return await augmentUserMessageForProviderSend(
-                    text,
-                    attachments: attachments,
-                    taggedFileAttachments: taggedFileAttachments,
-                    agent: session?.selectedAgent,
-                    session: session
-                )
-            },
-            stageResumeRecoveryHandoffIfNeeded: { [weak self] session in
-                await self?.stageResumeRecoveryHandoffIfNeeded(for: session)
-            },
-            prependPendingHandoffIfNeeded: { [weak self] text, session in
-                self?.prependPendingHandoffIfNeeded(text, session: session) ?? text
-            },
-            recordPendingHandoffSendOutcome: { [weak self] session, didSend in
-                self?.recordPendingHandoffSendOutcome(for: session, didSend: didSend)
-            },
-            signalMCPInstructionDelivered: { [weak self] session in
-                await self?.signalMCPInstructionDelivered(for: session)
-            }
+            ),
+            presentation: .init(
+                setAgentRunActive: { [weak self] tabID, isActive in
+                    self?.setAgentRunActive(tabID, isActive: isActive)
+                },
+                updateBindings: { [weak self] session in
+                    guard let self else { return }
+                    updateBindingsFromSession(session)
+                    handleObservedMCPStateChange(for: session)
+                },
+                requestUIRefresh: { [weak self] tabID, urgent in
+                    self?.requestUIRefresh(tabID: tabID, urgent: urgent)
+                },
+                notifyAgentTurnComplete: { [weak self] session in
+                    self?.notifyAgentTurnComplete(for: session)
+                },
+                restoreDraftText: { [weak self] tabID, text, message, strategy in
+                    self?.restoreComposerDraft(tabID: tabID, text: text, message: message, strategy: strategy)
+                }
+            ),
+            persistence: .init(
+                scheduleSave: { [weak self] tabID in
+                    self?.scheduleSave(for: tabID)
+                }
+            ),
+            transcript: .init(
+                handleHeadlessStreamResult: { [weak self] result, session, runID, runAttemptID in
+                    await self?.handleStreamResult(result, session: session, runID: runID, runAttemptID: runAttemptID)
+                },
+                finalizeStreamingItems: { [weak self] session in
+                    self?.finalizeStreamingItems(in: session)
+                },
+                finalizePendingToolCalls: { [weak self] session, terminalState in
+                    _ = self?.finalizePendingToolCalls(
+                        in: session,
+                        terminalState: terminalState,
+                        includeExplicitRepoPromptToolCalls: AgentTranscriptQualityRepair.shouldFinalizeExplicitRepoPromptTools(
+                            context: .liveTerminal(agentKind: session.selectedAgent)
+                        )
+                    )
+                },
+                finalizePendingToolCallsWithUpperBound: { [weak self] session, terminalState, maxSequenceIndexExclusive in
+                    _ = self?.finalizePendingToolCalls(
+                        in: session,
+                        terminalState: terminalState,
+                        includeExplicitRepoPromptToolCalls: AgentTranscriptQualityRepair.shouldFinalizeExplicitRepoPromptTools(
+                            context: .liveTerminal(agentKind: session.selectedAgent)
+                        ),
+                        maxSequenceIndexExclusive: maxSequenceIndexExclusive
+                    )
+                },
+                flushPendingAssistantDelta: { [weak self] session in
+                    self?.flushPendingAssistantDelta(session)
+                },
+                clearPendingAssistantDelta: { [weak self] session in
+                    self?.clearPendingAssistantDelta(session)
+                }
+            ),
+            providerInput: .init(
+                buildHeadlessAgentMessage: { [weak self] session, initialMessage, runID, attachments in
+                    self?.buildHeadlessAgentMessage(
+                        session: session,
+                        initialMessageForRun: initialMessage,
+                        runID: runID,
+                        attachments: attachments
+                    )
+                        ?? AgentMessage(systemPrompt: "", userMessage: initialMessage)
+                },
+                augmentUserMessageForProviderSend: { [weak self] text, attachments, taggedFileAttachments, session in
+                    guard let self else { return text }
+                    return await augmentUserMessageForProviderSend(
+                        text,
+                        attachments: attachments,
+                        taggedFileAttachments: taggedFileAttachments,
+                        agent: session?.selectedAgent,
+                        session: session
+                    )
+                },
+                stageResumeRecoveryHandoffIfNeeded: { [weak self] session in
+                    await self?.stageResumeRecoveryHandoffIfNeeded(for: session)
+                },
+                prependPendingHandoffIfNeeded: { [weak self] text, session in
+                    self?.prependPendingHandoffIfNeeded(text, session: session) ?? text
+                },
+                recordPendingHandoffSendOutcome: { [weak self] session, didSend in
+                    self?.recordPendingHandoffSendOutcome(for: session, didSend: didSend)
+                }
+            ),
+            interactions: .init(
+                cancelPendingQuestion: { [weak self] session in
+                    self?.cancelPendingQuestion(for: session)
+                },
+                cancelPendingApproval: { [weak self] session in
+                    self?.cancelPendingApproval(for: session)
+                },
+                cancelPendingApplyEditsReview: { [weak self] session, reason in
+                    self?.cancelPendingApplyEditsReview(for: session, reason: reason)
+                },
+                cancelPendingWorktreeMergeReview: { [weak self] session, reason in
+                    self?.cancelPendingWorktreeMergeReview(for: session, reason: reason)
+                }
+            ),
+            terminalSettlement: .init(
+                prepareTerminalPublication: { [weak self] session in
+                    self?.prepareTerminalPublication(for: session)
+                },
+                makeTerminalPublicationEnvelope: { [weak self] session, ownership, terminalState, providerRunID in
+                    self?.makeTerminalPublicationEnvelope(
+                        for: session,
+                        ownership: ownership,
+                        terminalState: terminalState,
+                        providerRunID: providerRunID
+                    )
+                },
+                publishTerminalCommit: { [weak self] session, revision, successorKind in
+                    guard let self else { return .rejected(reason: "view_model_deallocated") }
+                    let result = await publishTerminalCommit(
+                        revision,
+                        successorKind: successorKind,
+                        for: session
+                    )
+                    if result.isResolved,
+                       let sessionID = session.activeAgentSessionID,
+                       let runID = revision.expectedRunID
+                    {
+                        mcpRemoveAgentRunOracleReviewContext(sessionID: sessionID, runID: runID)
+                    }
+                    return result
+                }
+            ),
+            continuation: .init(
+                startFollowUpRun: { [weak self] tabID, initialMessage in
+                    Task { [weak self] in
+                        await self?.startAgentRun(tabID: tabID, initialMessage: initialMessage)
+                    }
+                },
+                signalMCPInstructionDelivered: { [weak self] session in
+                    await self?.signalMCPInstructionDelivered(for: session)
+                }
+            )
         )
         let toolTrackingHooks = makeToolTrackingHooks()
         // Wire hooks so per-tab Claude handlers get proper viewmodel callbacks.

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -2190,17 +2190,21 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 setAgentRunActive: { [weak self] tabID, isActive in
                     self?.setAgentRunActive(tabID, isActive: isActive)
                 },
-                updateBindings: { [weak self] session in
-                    guard let self else { return }
-                    updateBindingsFromSession(session)
-                    handleObservedMCPStateChange(for: session)
-                },
                 requestUIRefresh: { [weak self] tabID, urgent in
                     self?.requestUIRefresh(tabID: tabID, urgent: urgent)
                 },
                 notifyAgentTurnComplete: { [weak self] session in
                     self?.notifyAgentTurnComplete(for: session)
-                },
+                }
+            ),
+            bindingObservation: .init(
+                updateBindings: { [weak self] session in
+                    guard let self else { return }
+                    updateBindingsFromSession(session)
+                    handleObservedMCPStateChange(for: session)
+                }
+            ),
+            queuedWorkRecovery: .init(
                 restoreDraftText: { [weak self] tabID, text, message, strategy in
                     self?.restoreComposerDraft(tabID: tabID, text: text, message: message, strategy: strategy)
                 }

--- a/Sources/RepoPromptDomainRuntime/DomainAgentRunExecutionContracts.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainAgentRunExecutionContracts.swift
@@ -14,7 +14,7 @@ import Foundation
 ///
 /// This is a command-side contract: hosts translate user or lifecycle actions
 /// into one of these intents before asking their execution layer to stop a run.
-package enum DomainAgentRunCancellationIntent: String, Codable, Equatable, Hashable, Sendable {
+package enum DomainAgentRunCancellationIntent: Equatable, Hashable {
     /// The user explicitly stopped the run.
     case userStop
     /// The run is being stopped because its execution location (worktree/cwd)
@@ -38,7 +38,7 @@ package enum DomainAgentRunCancellationIntent: String, Codable, Equatable, Hasha
 ///
 /// Terminal settlement is exactly-once: waiting for `terminalTeardownCompleted`
 /// never re-runs teardown, it only awaits the single claimed teardown closure.
-package enum DomainAgentRunCancellationCompletion: String, Equatable, Hashable, Sendable {
+package enum DomainAgentRunCancellationCompletion: Equatable, Hashable {
     /// Return after canonical terminal publication and synchronous provider
     /// detachment.
     case terminalPublished
@@ -52,8 +52,8 @@ package enum DomainAgentRunCancellationCompletion: String, Equatable, Hashable, 
 /// canonical settlement surface (`DomainAgentRunSessionStore.publishTerminal`
 /// via a `DomainAgentRunTerminalPublicationEnvelope`); the store enforces
 /// exactly-once publication per epoch regardless of host.
-package struct DomainAgentRunTerminalOutcome: Equatable, Hashable, Sendable {
-    package enum Kind: String, Codable, Equatable, Hashable, Sendable {
+package struct DomainAgentRunTerminalOutcome: Equatable, Hashable {
+    package enum Kind: String, Codable, Equatable, Hashable {
         case completed
         case cancelled
         case failed

--- a/Sources/RepoPromptDomainRuntime/DomainAgentRunExecutionContracts.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainAgentRunExecutionContracts.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// MARK: - Neutral Agent run execution contracts
+
+//
+// These types define the provider-neutral, presentation-free command and result
+// vocabulary shared by every Agent run execution host (the app-hosted Agent Mode
+// runtime and the direct/headless composition). They intentionally carry no
+// session, tab, transcript, or UI state: canonical durable lifecycle remains
+// owned by `DomainAgentRunSessionStore`, and hosts adapt these values into their
+// own projection layers.
+
+/// Why an Agent run is being cancelled.
+///
+/// This is a command-side contract: hosts translate user or lifecycle actions
+/// into one of these intents before asking their execution layer to stop a run.
+package enum DomainAgentRunCancellationIntent: String, Codable, Equatable, Hashable, Sendable {
+    /// The user explicitly stopped the run.
+    case userStop
+    /// The run is being stopped because its execution location (worktree/cwd)
+    /// is changing; queued undelivered work should be restored, not replayed.
+    case executionLocationChange
+    /// The hosting runtime is shutting down (window close, app termination).
+    case runtimeShutdown
+
+    /// Canonical machine-readable reason string used when cancelling dependent
+    /// resources (for example active MCP tool executions) for this intent.
+    package var cancellationReason: String {
+        switch self {
+        case .userStop: "user_stop"
+        case .executionLocationChange: "execution_location_change"
+        case .runtimeShutdown: "runtime_shutdown"
+        }
+    }
+}
+
+/// How far a cancellation request must settle before returning to the caller.
+///
+/// Terminal settlement is exactly-once: waiting for `terminalTeardownCompleted`
+/// never re-runs teardown, it only awaits the single claimed teardown closure.
+package enum DomainAgentRunCancellationCompletion: String, Equatable, Hashable, Sendable {
+    /// Return after canonical terminal publication and synchronous provider
+    /// detachment.
+    case terminalPublished
+    /// Also wait for the exactly-once attempt/provider teardown to finish.
+    case terminalTeardownCompleted
+}
+
+/// Provider-neutral terminal result of one Agent run execution.
+///
+/// Exactly one outcome may settle a run. Hosts map an outcome into their
+/// canonical settlement surface (`DomainAgentRunSessionStore.publishTerminal`
+/// via a `DomainAgentRunTerminalPublicationEnvelope`); the store enforces
+/// exactly-once publication per epoch regardless of host.
+package struct DomainAgentRunTerminalOutcome: Equatable, Hashable, Sendable {
+    package enum Kind: String, Codable, Equatable, Hashable, Sendable {
+        case completed
+        case cancelled
+        case failed
+    }
+
+    package let kind: Kind
+    /// Final assistant-visible text for the run, when the provider produced one.
+    package let assistantText: String?
+    /// Failure classification carried explicitly so hosts preserve their own
+    /// diagnosis instead of re-deriving it from display text.
+    package let failureReason: DomainAgentRunSnapshot.FailureReason?
+
+    private init(
+        kind: Kind,
+        assistantText: String?,
+        failureReason: DomainAgentRunSnapshot.FailureReason?
+    ) {
+        self.kind = kind
+        self.assistantText = assistantText
+        self.failureReason = failureReason
+    }
+
+    package static func completed(assistantText: String?) -> DomainAgentRunTerminalOutcome {
+        DomainAgentRunTerminalOutcome(kind: .completed, assistantText: assistantText, failureReason: nil)
+    }
+
+    package static func cancelled(
+        assistantText: String? = nil
+    ) -> DomainAgentRunTerminalOutcome {
+        DomainAgentRunTerminalOutcome(kind: .cancelled, assistantText: assistantText, failureReason: .cancelled)
+    }
+
+    package static func failed(
+        assistantText: String?,
+        reason: DomainAgentRunSnapshot.FailureReason = .agentError
+    ) -> DomainAgentRunTerminalOutcome {
+        DomainAgentRunTerminalOutcome(kind: .failed, assistantText: assistantText, failureReason: reason)
+    }
+
+    /// Canonical snapshot status for this outcome.
+    package var snapshotStatus: DomainAgentRunSnapshot.Status {
+        switch kind {
+        case .completed: .completed
+        case .cancelled: .cancelled
+        case .failed: .failed
+        }
+    }
+}

--- a/Sources/RepoPromptMCP/DirectHeadlessProviderCoordinator.swift
+++ b/Sources/RepoPromptMCP/DirectHeadlessProviderCoordinator.swift
@@ -160,15 +160,13 @@ actor DirectHeadlessProviderCoordinator {
                     request: capturedRequest,
                     carrierEnvironment: capturedCarrierEnvironment
                 )
-                await finishAgent(sessionID: sessionID, status: .completed, text: text, reason: nil)
+                await finishAgent(sessionID: sessionID, outcome: .completed(assistantText: text))
             } catch is CancellationError {
-                await finishAgent(sessionID: sessionID, status: .cancelled, text: nil, reason: .cancelled)
+                await finishAgent(sessionID: sessionID, outcome: .cancelled())
             } catch {
                 await finishAgent(
                     sessionID: sessionID,
-                    status: .failed,
-                    text: error.localizedDescription,
-                    reason: .agentError
+                    outcome: .failed(assistantText: error.localizedDescription)
                 )
             }
         }
@@ -329,17 +327,24 @@ actor DirectHeadlessProviderCoordinator {
         }
     }
 
+    /// Settles one agent run through the neutral terminal-outcome contract.
+    /// The canonical exactly-once settlement stays owned by
+    /// `DomainAgentRunSessionStore.publishTerminal`.
     private func finishAgent(
         sessionID: UUID,
-        status: DomainAgentRunSnapshot.Status,
-        text: String?,
-        reason: DomainAgentRunSnapshot.FailureReason?
+        outcome: DomainAgentRunTerminalOutcome
     ) async {
         guard var record = agents[sessionID] else { return }
-        record.latestText = text
+        record.latestText = outcome.assistantText
         record.task = nil
         agents[sessionID] = record
-        let terminal = snapshot(record: record, status: status, statusText: text, assistantText: text, failure: reason)
+        let terminal = snapshot(
+            record: record,
+            status: outcome.snapshotStatus,
+            statusText: outcome.assistantText,
+            assistantText: outcome.assistantText,
+            failure: outcome.failureReason
+        )
         _ = await runtime.agentSessionStore.publishTerminal(
             DomainAgentRunTerminalPublicationEnvelope(epoch: record.epoch, snapshot: terminal),
             registration: record.registration,

--- a/Tests/RepoPromptDomainRuntimeTests/DomainAgentRunExecutionContractsTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainAgentRunExecutionContractsTests.swift
@@ -53,9 +53,13 @@ final class DomainAgentRunExecutionContractsTests: XCTestCase {
         )
     }
 
-    // MARK: - Exactly-once terminal settlement through the canonical store
+    // MARK: - Compatibility with the store's pre-existing exactly-once settlement
 
-    func testOutcomeMappedTerminalPublicationIsExactlyOncePerEpoch() async {
+    // The exactly-once-per-epoch guarantee is pre-existing
+    // `DomainAgentRunSessionStore` behavior, not something the outcome mapping
+    // introduces; this test only verifies that outcome-mapped publication
+    // composes with that store behavior unchanged.
+    func testOutcomeMappedTerminalPublicationRemainsCompatibleWithStoreExactlyOnceSemantics() async {
         let identity = makeIdentity()
         let store = makeSessionStore(identity: identity, profile: "execution-contracts-once")
         let sessionID = UUID()

--- a/Tests/RepoPromptDomainRuntimeTests/DomainAgentRunExecutionContractsTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainAgentRunExecutionContractsTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+@testable import RepoPromptDomainRuntime
+import XCTest
+
+/// Contract tests for the neutral Agent run execution vocabulary shared by the
+/// app-hosted runtime and the direct/headless composition.
+final class DomainAgentRunExecutionContractsTests: XCTestCase {
+    // MARK: - Command/cancellation contracts
+
+    func testCancellationIntentCanonicalReasonStringsAreStable() {
+        XCTAssertEqual(DomainAgentRunCancellationIntent.userStop.cancellationReason, "user_stop")
+        XCTAssertEqual(
+            DomainAgentRunCancellationIntent.executionLocationChange.cancellationReason,
+            "execution_location_change"
+        )
+        XCTAssertEqual(
+            DomainAgentRunCancellationIntent.runtimeShutdown.cancellationReason,
+            "runtime_shutdown"
+        )
+    }
+
+    func testExecutionContractTypesAreSendableValueTypes() {
+        // Compile-time Sendable checks: these calls fail to compile if any
+        // contract type loses Sendable conformance or value semantics.
+        assertSendable(DomainAgentRunCancellationIntent.userStop)
+        assertSendable(DomainAgentRunCancellationCompletion.terminalPublished)
+        assertSendable(DomainAgentRunTerminalOutcome.completed(assistantText: "done"))
+    }
+
+    // MARK: - Terminal outcome result contracts
+
+    func testTerminalOutcomeMapsToCanonicalSnapshotStatus() {
+        XCTAssertEqual(DomainAgentRunTerminalOutcome.completed(assistantText: "ok").snapshotStatus, .completed)
+        XCTAssertEqual(DomainAgentRunTerminalOutcome.cancelled().snapshotStatus, .cancelled)
+        XCTAssertEqual(
+            DomainAgentRunTerminalOutcome.failed(assistantText: "boom").snapshotStatus,
+            .failed
+        )
+    }
+
+    func testTerminalOutcomeCarriesExplicitFailureClassification() {
+        XCTAssertNil(DomainAgentRunTerminalOutcome.completed(assistantText: nil).failureReason)
+        XCTAssertEqual(DomainAgentRunTerminalOutcome.cancelled().failureReason, .cancelled)
+        XCTAssertEqual(
+            DomainAgentRunTerminalOutcome.failed(assistantText: "agent exploded").failureReason,
+            .agentError
+        )
+        // Hosts preserve their own diagnosis; the contract must not re-derive
+        // classification from display text.
+        XCTAssertEqual(
+            DomainAgentRunTerminalOutcome.failed(assistantText: "timed out", reason: .timeout).failureReason,
+            .timeout
+        )
+    }
+
+    // MARK: - Exactly-once terminal settlement through the canonical store
+
+    func testOutcomeMappedTerminalPublicationIsExactlyOncePerEpoch() async {
+        let identity = makeIdentity()
+        let store = makeSessionStore(identity: identity, profile: "execution-contracts-once")
+        let sessionID = UUID()
+        let registration = await store.register(sessionID: sessionID)
+        let epoch: DomainAgentRunTurnEpoch
+        switch await store.beginEpoch(
+            registration: registration,
+            activationID: UUID(),
+            expectedCurrentEpoch: nil,
+            transitionKind: .initial
+        ) {
+        case let .accepted(value):
+            epoch = value
+        case let .stale(current):
+            XCTFail("unexpected stale epoch begin: \(String(describing: current))")
+            return
+        case let .rejected(reason):
+            XCTFail("unexpected rejected epoch begin: \(reason)")
+            return
+        }
+
+        let outcome = DomainAgentRunTerminalOutcome.failed(assistantText: "provider failed", reason: .agentError)
+        let terminal = makeSnapshot(sessionID: sessionID, outcome: outcome)
+        let envelope = DomainAgentRunTerminalPublicationEnvelope(epoch: epoch, snapshot: terminal)
+        let commitID = UUID()
+
+        let first = await store.publishTerminal(
+            envelope,
+            registration: registration,
+            commitID: commitID,
+            successorKind: nil
+        )
+        XCTAssertEqual(first, .accepted(successorEpoch: nil))
+
+        // Same commit replays idempotently without re-publishing.
+        let replay = await store.publishTerminal(
+            envelope,
+            registration: registration,
+            commitID: commitID,
+            successorKind: nil
+        )
+        XCTAssertEqual(replay, .accepted(successorEpoch: nil))
+
+        // A different terminal commit for the same epoch must be rejected.
+        let competing = await store.publishTerminal(
+            envelope,
+            registration: registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+        XCTAssertEqual(competing, .rejected(reason: "different_commit_already_published"))
+
+        let settled = await store.snapshot(for: registration)
+        XCTAssertEqual(settled?.status, .failed)
+        XCTAssertEqual(settled?.failureReason, .agentError)
+    }
+
+    // MARK: - Helpers
+
+    private func assertSendable(_ value: some Sendable & Equatable) {
+        XCTAssertEqual(value, value)
+    }
+
+    private func makeSnapshot(
+        sessionID: UUID,
+        outcome: DomainAgentRunTerminalOutcome
+    ) -> DomainAgentRunSnapshot {
+        DomainAgentRunSnapshot(
+            sessionID: sessionID,
+            runID: sessionID,
+            tabID: nil,
+            sessionName: nil,
+            agentRaw: "codexExec",
+            agentDisplayName: "Codex CLI",
+            modelRaw: nil,
+            reasoningEffortRaw: nil,
+            status: outcome.snapshotStatus,
+            statusText: outcome.assistantText,
+            latestAssistantPreview: outcome.assistantText,
+            interaction: nil,
+            transcriptItemCount: outcome.assistantText == nil ? 0 : 1,
+            updatedAt: Date(),
+            parentSessionID: nil,
+            failureReason: outcome.failureReason,
+            worktreeBindings: [],
+            activeWorktreeMerges: []
+        )
+    }
+
+    private func makeIdentity() -> DomainRuntimeIdentity {
+        DomainRuntimeIdentity(
+            runtimeID: UUID(),
+            lifecycleGeneration: 1,
+            processID: 42,
+            mode: .standalone,
+            createdAt: Date()
+        )
+    }
+
+    private func makeSessionStore(
+        identity: DomainRuntimeIdentity,
+        profile: String
+    ) -> DomainAgentRunSessionStore {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rpce-execution-contracts-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let configuration = DomainRuntimeConfiguration(
+            mode: identity.mode,
+            profileIdentifier: profile,
+            storageDirectory: root,
+            eventDirectory: root.appendingPathComponent("Events"),
+            temporaryDirectory: root.appendingPathComponent("Temporary"),
+            externalReloadInterval: nil
+        )
+        return DomainAgentRunSessionStore(
+            identity: identity,
+            persistence: DomainPersistenceCoordinator(configuration: configuration, identity: identity),
+            profileIdentifier: profile
+        )
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -1632,9 +1632,13 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             ),
             presentation: .init(
                 setAgentRunActive: { _, isActive in recorder.record("run-active:\(isActive)") },
-                updateBindings: { _ in recorder.record("bindings") },
                 requestUIRefresh: { _, _ in },
-                notifyAgentTurnComplete: { _ in },
+                notifyAgentTurnComplete: { _ in }
+            ),
+            bindingObservation: .init(
+                updateBindings: { _ in recorder.record("bindings") }
+            ),
+            queuedWorkRecovery: .init(
                 restoreDraftText: { _, text, _, _ in recorder.record("draft:\(text)") }
             ),
             persistence: .init(

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -1617,47 +1617,65 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             recorder.record("commit:\(revision.commitID.uuidString)")
         }
         return AgentModeRunService.Hooks(
-            estimateRuntimeTokens: { $0.count },
-            addUserInputTokensToActiveNonCodexTurn: { tokens, _ in recorder.record("tokens:\(tokens)") },
-            startNonCodexTurnAccountingIfNeeded: { _, _ in },
-            reserveAttachmentsForTurn: { _, _ in nil },
-            markAttachmentsConsumed: { _, _ in },
-            stageConsumedAttachmentFilesForDeferredCleanup: { _, _ in },
-            consumeDeferredAttachmentCleanup: { _, _ in },
-            finalizeAttachmentsForTurn: { _, _, disposition in recorder.record("attachments:\(disposition)") },
-            setAgentRunActive: { _, isActive in recorder.record("run-active:\(isActive)") },
-            updateBindings: { _ in recorder.record("bindings") },
-            requestUIRefresh: { _, _ in },
-            scheduleSave: { _ in recorder.record("save") },
-            notifyAgentTurnComplete: { _ in },
-            handleHeadlessStreamResult: { _, _, _, _ in },
-            buildHeadlessAgentMessage: { _, text, _, _ in AgentMessage(userMessage: text) },
-            finalizeStreamingItems: { _ in },
-            finalizePendingToolCalls: { _, _ in },
-            finalizePendingToolCallsWithUpperBound: { _, _, _ in },
-            finalizeNonCodexTurnUsage: { _, _, _, _ in },
-            cancelPendingQuestion: { _ in },
-            cancelPendingApproval: { _ in },
-            cancelPendingApplyEditsReview: { _, _ in },
-            cancelPendingWorktreeMergeReview: { _, _ in },
-            flushPendingAssistantDelta: flushPendingAssistantDelta,
-            clearPendingAssistantDelta: { _ in },
-            prepareTerminalPublication: { _ in recorder.record("prepare-publication") },
-            makeTerminalPublicationEnvelope: makeTerminalPublicationEnvelope ?? { _, _, _, _ in nil },
-            publishTerminalCommit: { session, revision, successorKind in
-                if let publishTerminalCommitResult {
-                    return await publishTerminalCommitResult(session, revision, successorKind)
+            usage: .init(
+                estimateRuntimeTokens: { $0.count },
+                addUserInputTokensToActiveNonCodexTurn: { tokens, _ in recorder.record("tokens:\(tokens)") },
+                startNonCodexTurnAccountingIfNeeded: { _, _ in },
+                finalizeNonCodexTurnUsage: { _, _, _, _ in }
+            ),
+            attachments: .init(
+                reserveAttachmentsForTurn: { _, _ in nil },
+                markAttachmentsConsumed: { _, _ in },
+                stageConsumedAttachmentFilesForDeferredCleanup: { _, _ in },
+                consumeDeferredAttachmentCleanup: { _, _ in },
+                finalizeAttachmentsForTurn: { _, _, disposition in recorder.record("attachments:\(disposition)") }
+            ),
+            presentation: .init(
+                setAgentRunActive: { _, isActive in recorder.record("run-active:\(isActive)") },
+                updateBindings: { _ in recorder.record("bindings") },
+                requestUIRefresh: { _, _ in },
+                notifyAgentTurnComplete: { _ in },
+                restoreDraftText: { _, text, _, _ in recorder.record("draft:\(text)") }
+            ),
+            persistence: .init(
+                scheduleSave: { _ in recorder.record("save") }
+            ),
+            transcript: .init(
+                handleHeadlessStreamResult: { _, _, _, _ in },
+                finalizeStreamingItems: { _ in },
+                finalizePendingToolCalls: { _, _ in },
+                finalizePendingToolCallsWithUpperBound: { _, _, _ in },
+                flushPendingAssistantDelta: flushPendingAssistantDelta,
+                clearPendingAssistantDelta: { _ in }
+            ),
+            providerInput: .init(
+                buildHeadlessAgentMessage: { _, text, _, _ in AgentMessage(userMessage: text) },
+                augmentUserMessageForProviderSend: { text, _, _, _ in text },
+                stageResumeRecoveryHandoffIfNeeded: { _ in },
+                prependPendingHandoffIfNeeded: { text, _ in text },
+                recordPendingHandoffSendOutcome: { _, didSend in recorder.record("handoff:\(didSend)") }
+            ),
+            interactions: .init(
+                cancelPendingQuestion: { _ in },
+                cancelPendingApproval: { _ in },
+                cancelPendingApplyEditsReview: { _, _ in },
+                cancelPendingWorktreeMergeReview: { _, _ in }
+            ),
+            terminalSettlement: .init(
+                prepareTerminalPublication: { _ in recorder.record("prepare-publication") },
+                makeTerminalPublicationEnvelope: makeTerminalPublicationEnvelope ?? { _, _, _, _ in nil },
+                publishTerminalCommit: { session, revision, successorKind in
+                    if let publishTerminalCommitResult {
+                        return await publishTerminalCommitResult(session, revision, successorKind)
+                    }
+                    await publishTerminalCommit(session, revision)
+                    return .accepted(successorEpoch: nil)
                 }
-                await publishTerminalCommit(session, revision)
-                return .accepted(successorEpoch: nil)
-            },
-            startFollowUpRun: startFollowUpRun ?? { _, _ in },
-            restoreDraftText: { _, text, _, _ in recorder.record("draft:\(text)") },
-            augmentUserMessageForProviderSend: { text, _, _, _ in text },
-            stageResumeRecoveryHandoffIfNeeded: { _ in },
-            prependPendingHandoffIfNeeded: { text, _ in text },
-            recordPendingHandoffSendOutcome: { _, didSend in recorder.record("handoff:\(didSend)") },
-            signalMCPInstructionDelivered: { _ in recorder.record("delivered") }
+            ),
+            continuation: .init(
+                startFollowUpRun: startFollowUpRun ?? { _, _ in },
+                signalMCPInstructionDelivered: { _ in recorder.record("delivered") }
+            )
         )
     }
 

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPRoutingReadinessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPRoutingReadinessTests.swift
@@ -641,44 +641,62 @@ final class CodexMCPRoutingReadinessTests: XCTestCase {
 
     private func makeHooks(recorder: TerminalPublicationRecorder) -> AgentModeRunService.Hooks {
         AgentModeRunService.Hooks(
-            estimateRuntimeTokens: { $0.count },
-            addUserInputTokensToActiveNonCodexTurn: { _, _ in },
-            startNonCodexTurnAccountingIfNeeded: { _, _ in },
-            reserveAttachmentsForTurn: { _, _ in nil },
-            markAttachmentsConsumed: { _, _ in },
-            stageConsumedAttachmentFilesForDeferredCleanup: { _, _ in },
-            consumeDeferredAttachmentCleanup: { _, _ in },
-            finalizeAttachmentsForTurn: { _, _, _ in },
-            setAgentRunActive: { _, _ in },
-            updateBindings: { _ in },
-            requestUIRefresh: { _, _ in },
-            scheduleSave: { _ in },
-            notifyAgentTurnComplete: { _ in },
-            handleHeadlessStreamResult: { _, _, _, _ in },
-            buildHeadlessAgentMessage: { _, text, _, _ in AgentMessage(userMessage: text) },
-            finalizeStreamingItems: { _ in },
-            finalizePendingToolCalls: { _, _ in },
-            finalizePendingToolCallsWithUpperBound: { _, _, _ in },
-            finalizeNonCodexTurnUsage: { _, _, _, _ in },
-            cancelPendingQuestion: { _ in },
-            cancelPendingApproval: { _ in },
-            cancelPendingApplyEditsReview: { _, _ in },
-            cancelPendingWorktreeMergeReview: { _, _ in },
-            flushPendingAssistantDelta: { _ in },
-            clearPendingAssistantDelta: { _ in },
-            prepareTerminalPublication: { _ in },
-            makeTerminalPublicationEnvelope: { _, _, _, _ in nil },
-            publishTerminalCommit: { _, revision, _ in
-                recorder.record(revision.terminalState)
-                return .accepted(successorEpoch: nil)
-            },
-            startFollowUpRun: { _, _ in },
-            restoreDraftText: { _, _, _, _ in },
-            augmentUserMessageForProviderSend: { text, _, _, _ in text },
-            stageResumeRecoveryHandoffIfNeeded: { _ in },
-            prependPendingHandoffIfNeeded: { text, _ in text },
-            recordPendingHandoffSendOutcome: { _, _ in },
-            signalMCPInstructionDelivered: { _ in }
+            usage: .init(
+                estimateRuntimeTokens: { $0.count },
+                addUserInputTokensToActiveNonCodexTurn: { _, _ in },
+                startNonCodexTurnAccountingIfNeeded: { _, _ in },
+                finalizeNonCodexTurnUsage: { _, _, _, _ in }
+            ),
+            attachments: .init(
+                reserveAttachmentsForTurn: { _, _ in nil },
+                markAttachmentsConsumed: { _, _ in },
+                stageConsumedAttachmentFilesForDeferredCleanup: { _, _ in },
+                consumeDeferredAttachmentCleanup: { _, _ in },
+                finalizeAttachmentsForTurn: { _, _, _ in }
+            ),
+            presentation: .init(
+                setAgentRunActive: { _, _ in },
+                updateBindings: { _ in },
+                requestUIRefresh: { _, _ in },
+                notifyAgentTurnComplete: { _ in },
+                restoreDraftText: { _, _, _, _ in }
+            ),
+            persistence: .init(
+                scheduleSave: { _ in }
+            ),
+            transcript: .init(
+                handleHeadlessStreamResult: { _, _, _, _ in },
+                finalizeStreamingItems: { _ in },
+                finalizePendingToolCalls: { _, _ in },
+                finalizePendingToolCallsWithUpperBound: { _, _, _ in },
+                flushPendingAssistantDelta: { _ in },
+                clearPendingAssistantDelta: { _ in }
+            ),
+            providerInput: .init(
+                buildHeadlessAgentMessage: { _, text, _, _ in AgentMessage(userMessage: text) },
+                augmentUserMessageForProviderSend: { text, _, _, _ in text },
+                stageResumeRecoveryHandoffIfNeeded: { _ in },
+                prependPendingHandoffIfNeeded: { text, _ in text },
+                recordPendingHandoffSendOutcome: { _, _ in }
+            ),
+            interactions: .init(
+                cancelPendingQuestion: { _ in },
+                cancelPendingApproval: { _ in },
+                cancelPendingApplyEditsReview: { _, _ in },
+                cancelPendingWorktreeMergeReview: { _, _ in }
+            ),
+            terminalSettlement: .init(
+                prepareTerminalPublication: { _ in },
+                makeTerminalPublicationEnvelope: { _, _, _, _ in nil },
+                publishTerminalCommit: { _, revision, _ in
+                    recorder.record(revision.terminalState)
+                    return .accepted(successorEpoch: nil)
+                }
+            ),
+            continuation: .init(
+                startFollowUpRun: { _, _ in },
+                signalMCPInstructionDelivered: { _ in }
+            )
         )
     }
 }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPRoutingReadinessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPRoutingReadinessTests.swift
@@ -656,9 +656,13 @@ final class CodexMCPRoutingReadinessTests: XCTestCase {
             ),
             presentation: .init(
                 setAgentRunActive: { _, _ in },
-                updateBindings: { _ in },
                 requestUIRefresh: { _, _ in },
-                notifyAgentTurnComplete: { _ in },
+                notifyAgentTurnComplete: { _ in }
+            ),
+            bindingObservation: .init(
+                updateBindings: { _ in }
+            ),
+            queuedWorkRecovery: .init(
                 restoreDraftText: { _, _, _, _ in }
             ),
             persistence: .init(


### PR DESCRIPTION
## Summary

This is PR 2 in the thin-presentation/headless-runtime architecture series, following merged #754.

- add neutral domain contracts for run cancellation intent, cancellation completion, and explicit terminal outcomes
- classify the existing `AgentModeRunService` hook bag into named authority groups without creating a second lifecycle authority
- adopt the explicit terminal outcome contract in the direct headless runner while preserving `DomainAgentRunSessionStore` as the canonical exactly-once settlement authority
- update the app host and runner call sites mechanically to use the classified seams
- add focused contract and lifecycle coverage

An independent Fable 5 High review identified authority-label and accidental serialization commitments. The follow-up commit removes those commitments, separates binding observation and queued-work recovery from presentation, and clarifies the tests' compatibility claims.

## Authority boundaries

- **canonical session/lifecycle authority:** `DomainAgentRunSessionStore`
- **execution contracts:** `RepoPromptDomainRuntime`
- **host projections:** presentation, binding observation, queued-work recovery, persistence, transcript, usage, and attachments
- **transitional app type:** `AgentModeViewModel.TabSession` remains in hook signatures for this PR; neutralizing that parameter is intentionally deferred to the next boundary-enforcement PR

## Validation

Passed locally:

- `DomainAgentRunExecutionContractsTests`: 5/5
- `CodexMCPRoutingReadinessTests`: 8/8
- strict `make dev-lint`: clean (0/1464 SwiftFormat findings; SwiftLint strict clean)
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-swift-build PRODUCT=repoprompt-mcp`
- commit and immediate push preflights, including staged/outgoing secret scans and repository guardrails

Lifecycle evidence:

- the pre-review implementation checkpoint passed `AgentModeRunServiceLifecycleTests`: 34/34
- the post-review rerun passed 33/34; the remaining fake-ACP bootstrap timeout reproduced in the exact same test on the clean merged-#754 checkpoint, before PR2 code is present

`pr-ready` was attempted with the repository-pinned SwiftFormat 0.61.1. Safety, outgoing-range, secrets, guardrails, and lint passed. The full root suite hit its 3600-second bound and also reported failures in unrelated Agent-context/CodeMap suites. This PR does not weaken, retry, or inflate those tests; hosted exact-head CI remains authoritative.

## Non-goals / follow-ups

- no second session or lifecycle authority
- no `TabSession` replacement yet
- no provider/runtime rewrite
- no UI redesign
- no broad module split
- app-host failure presentation still needs to consume explicit failure classification instead of display-text inference in the next boundary PR
