### PR TITLE
Agent Mode: classify terminal failures at settlement

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RepoPromptDomainRuntime
 
 // MARK: - Authority-classified run execution hooks
 
@@ -128,7 +129,8 @@ extension AgentModeRunService {
             AgentModeViewModel.TabSession,
             AgentRunOwnership,
             AgentSessionRunState,
-            UUID?
+            UUID?,
+            DomainAgentRunSnapshot.FailureReason?
         ) -> AgentRunTerminalPublicationEnvelope?
         let publishTerminalCommit: (
             AgentModeViewModel.TabSession,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -1,8 +1,19 @@
 import Foundation
+import RepoPromptDomainRuntime
 
 extension AgentSessionRunState {
     var isTerminalForCommit: Bool {
         self == .completed || self == .cancelled || self == .failed
+    }
+
+    /// MCP snapshot status equivalent of a committed terminal run state.
+    var mcpTerminalSnapshotStatus: DomainAgentRunSnapshot.Status? {
+        switch self {
+        case .completed: .completed
+        case .failed: .failed
+        case .cancelled: .cancelled
+        case .idle, .running, .waitingForUser, .waitingForQuestion, .waitingForApproval: nil
+        }
     }
 }
 
@@ -10,6 +21,7 @@ struct AgentRunTerminalCommitRevision: Equatable {
     let commitID: UUID
     let ownership: AgentRunOwnership
     let terminalState: AgentSessionRunState
+    let failureReason: DomainAgentRunSnapshot.FailureReason?
     let expectedRunID: UUID?
     let sourceItemsRevision: Int
     let assistantDeltaFlushGeneration: UInt64
@@ -38,6 +50,7 @@ final class AgentRunTerminalCommitBarrier {
         let source: String
         let completion: AgentModeRunService.CancellationCompletion
         let errorText: String?
+        let failureReason: DomainAgentRunSnapshot.FailureReason?
         let attachmentReservationID: UUID?
         let attachmentDisposition: AgentModeViewModel.AttachmentTurnDisposition
         let finalizeNonCodexUsage: Bool
@@ -57,6 +70,7 @@ final class AgentRunTerminalCommitBarrier {
             source: String,
             completion: AgentModeRunService.CancellationCompletion = .terminalPublished,
             errorText: String? = nil,
+            failureReason: DomainAgentRunSnapshot.FailureReason? = nil,
             attachmentReservationID: UUID? = nil,
             attachmentDisposition: AgentModeViewModel.AttachmentTurnDisposition,
             finalizeNonCodexUsage: Bool,
@@ -75,6 +89,7 @@ final class AgentRunTerminalCommitBarrier {
             self.source = source
             self.completion = completion
             self.errorText = errorText
+            self.failureReason = failureReason
             self.attachmentReservationID = attachmentReservationID
             self.attachmentDisposition = attachmentDisposition
             self.finalizeNonCodexUsage = finalizeNonCodexUsage
@@ -275,10 +290,14 @@ final class AgentRunTerminalCommitBarrier {
         } else {
             providerSuccessor?.transitionKind
         }
+        // Resolved exactly once at settlement; the publication envelope is built
+        // before the revision is stored, so the reason is threaded explicitly.
+        let failureReason = resolveTerminalFailureReason(request: request, session: session)
         let revision = AgentRunTerminalCommitRevision(
             commitID: UUID(),
             ownership: request.ownership,
             terminalState: request.terminalState,
+            failureReason: failureReason,
             expectedRunID: request.expectedRunID,
             sourceItemsRevision: session.sourceItemsRevision,
             assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
@@ -287,7 +306,8 @@ final class AgentRunTerminalCommitBarrier {
                 session,
                 request.ownership,
                 request.terminalState,
-                request.expectedRunID
+                request.expectedRunID,
+                failureReason
             ),
             successorKind: successorKind,
             providerSuccessorID: providerSuccessor?.id
@@ -343,6 +363,29 @@ final class AgentRunTerminalCommitBarrier {
             )
         #endif
         return revision
+    }
+
+    /// Settles the terminal failure classification for a commit. Runs after the
+    /// transcript flush/finalization and after any request error item has been
+    /// appended, so the failed-state text classification sees the same latest
+    /// settled error text the publication snapshot projects today.
+    private func resolveTerminalFailureReason(
+        request: Request,
+        session: AgentModeViewModel.TabSession
+    ) -> DomainAgentRunSnapshot.FailureReason? {
+        switch request.terminalState {
+        case .cancelled:
+            return .cancelled
+        case .failed:
+            if let failureReason = request.failureReason {
+                return failureReason
+            }
+            let settledFailureText = AgentTranscriptIO.latestErrorText(from: session.transcript, latestTurnOnly: true)
+                ?? AgentTranscriptIO.latestErrorText(from: session.transcript, latestTurnOnly: false)
+            return DomainAgentRunSnapshot.FailureReason.classify(status: .failed, statusText: settledFailureText)
+        default:
+            return nil
+        }
     }
 
     private func notifyProviderSuccessor(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -649,6 +649,11 @@ extension AgentModeViewModel {
         func beginPersistentBindingTransition() -> UInt64 {
             bindingTransitionGeneration &+= 1
             bindingTransitionInProgress = true
+            // Terminal commit revisions are scoped to the binding captured by
+            // their run ownership. A rebind must not carry that runtime-only
+            // classification or publication result into another session.
+            lastTerminalCommitRevision = nil
+            lastTerminalPublicationResult = nil
             authoritativeHydratedBinding = nil
             authoritativeHydratedBindingTransitionGeneration = nil
             return bindingTransitionGeneration

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -792,13 +792,15 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             for session: TabSession,
             ownership: AgentRunOwnership,
             terminalState: AgentSessionRunState,
-            providerRunID: UUID? = nil
+            providerRunID: UUID? = nil,
+            failureReason: AgentRunMCPSnapshot.FailureReason? = nil
         ) -> AgentRunTerminalPublicationEnvelope? {
             makeTerminalPublicationEnvelope(
                 for: session,
                 ownership: ownership,
                 terminalState: terminalState,
-                providerRunID: providerRunID
+                providerRunID: providerRunID,
+                failureReason: failureReason
             )
         }
 
@@ -2295,12 +2297,13 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 prepareTerminalPublication: { [weak self] session in
                     self?.prepareTerminalPublication(for: session)
                 },
-                makeTerminalPublicationEnvelope: { [weak self] session, ownership, terminalState, providerRunID in
+                makeTerminalPublicationEnvelope: { [weak self] session, ownership, terminalState, providerRunID, failureReason in
                     self?.makeTerminalPublicationEnvelope(
                         for: session,
                         ownership: ownership,
                         terminalState: terminalState,
-                        providerRunID: providerRunID
+                        providerRunID: providerRunID,
+                        failureReason: failureReason
                     )
                 },
                 publishTerminalCommit: { [weak self] session, revision, successorKind in
@@ -4992,7 +4995,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         for session: TabSession,
         ownership: AgentRunOwnership,
         terminalState: AgentSessionRunState,
-        providerRunID: UUID?
+        providerRunID: UUID?,
+        failureReason: AgentRunMCPSnapshot.FailureReason?
     ) -> AgentRunTerminalPublicationEnvelope? {
         guard let epoch = ownership.turnEpoch,
               let context = session.mcpControlContext,
@@ -5002,7 +5006,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
               let snapshot = mcpSnapshot(
                   for: session,
                   canonicalTerminalState: terminalState,
-                  canonicalProviderRunID: providerRunID
+                  canonicalProviderRunID: providerRunID,
+                  canonicalFailureReason: failureReason
               )
         else {
             return nil
@@ -5429,7 +5434,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     func mcpSnapshot(
         for session: TabSession,
         canonicalTerminalState: AgentSessionRunState? = nil,
-        canonicalProviderRunID: UUID? = nil
+        canonicalProviderRunID: UUID? = nil,
+        canonicalFailureReason: AgentRunMCPSnapshot.FailureReason? = nil
     ) -> AgentRunMCPSnapshot? {
         guard let context = session.mcpControlContext else { return nil }
         let interaction = canonicalTerminalState == nil ? mcpPendingInteraction(for: session) : nil
@@ -5540,7 +5546,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             if let name = ownerValidatedSessionIndex[resolvedSessionID]?.name { return name }
             return "Agent Session"
         }()
-        let failureReason = AgentRunMCPSnapshot.FailureReason.classify(status: status, statusText: resolvedStatusText)
         let providerRunID: UUID? = if canonicalTerminalState != nil {
             canonicalProviderRunID ?? AgentModeProcessRunIdentity.mostRecentTranscriptProcessRunID(for: session)
         } else if status.isTerminal {
@@ -5548,6 +5553,25 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         } else {
             session.runID
         }
+        let failureReason: AgentRunMCPSnapshot.FailureReason? = {
+            if let canonicalFailureReason {
+                return canonicalFailureReason
+            }
+            // Live post-terminal polls reuse the reason stamped by the terminal
+            // commit barrier; the terminal-state and run-identity guards keep a
+            // stale revision from another terminal state/attempt from
+            // contaminating this snapshot. Text classification remains only as
+            // the restored/legacy fallback.
+            if canonicalTerminalState == nil,
+               let revision = session.lastTerminalCommitRevision,
+               let stampedReason = revision.failureReason,
+               revision.terminalState.mcpTerminalSnapshotStatus == status,
+               revision.expectedRunID == providerRunID
+            {
+                return stampedReason
+            }
+            return AgentRunMCPSnapshot.FailureReason.classify(status: status, statusText: resolvedStatusText)
+        }()
         return AgentRunMCPSnapshot(
             sessionID: resolvedSessionID,
             runID: providerRunID,

--- a/Sources/RepoPromptDomainRuntime/DomainAgentSessionModels.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainAgentSessionModels.swift
@@ -400,6 +400,10 @@ package struct DomainAgentRunSnapshot: Equatable, Sendable {
         case agentError = "agent_error"
         case cancelled
 
+        /// Fallback heuristic for restored/legacy snapshots whose terminal
+        /// settlement did not stamp a canonical failure reason. Live terminal
+        /// classification is resolved exactly once by the terminal settlement
+        /// authority; this text inference must not become the primary path.
         package static func classify(status: Status, statusText: String?) -> FailureReason? {
             if status == .cancelled { return .cancelled }
             guard status == .failed else { return nil }

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -711,6 +711,59 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
     }
 
+    func testPersistentBindingTransitionInvalidatesNilRunIDFailureStamp() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil
+        )
+        let ownership = session.beginRunAttempt(source: "test.bindingTransitionFailureStamp")
+        session.transcript = AgentTranscriptIO.buildTranscript(
+            from: [
+                .user("question", sequenceIndex: 0),
+                .error("Run timed out waiting for the provider", sequenceIndex: 1)
+            ],
+            terminalState: .failed,
+            compact: false
+        )
+        session.runState = .failed
+        XCTAssertTrue(session.endRunAttempt(ifCurrent: ownership, source: "test.bindingTransitionFailureStamp"))
+        session.lastTerminalCommitRevision = AgentRunTerminalCommitRevision(
+            commitID: UUID(),
+            ownership: ownership,
+            terminalState: .failed,
+            failureReason: .processCrash,
+            expectedRunID: nil,
+            sourceItemsRevision: session.sourceItemsRevision,
+            assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
+            providerDrainGeneration: session.providerTerminalDrainGeneration,
+            mcpPublicationEnvelope: nil,
+            successorKind: nil,
+            providerSuccessorID: nil
+        )
+        session.lastTerminalPublicationResult = .accepted(successorEpoch: nil)
+
+        let originalBinding = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
+        XCTAssertEqual(originalBinding.failureReason, .processCrash)
+
+        let replacementSessionID = UUID()
+        _ = viewModel.test_installPersistentSessionBinding(
+            sessionID: replacementSessionID,
+            on: session
+        )
+
+        XCTAssertNil(session.lastTerminalCommitRevision)
+        XCTAssertNil(session.lastTerminalPublicationResult)
+        let rebound = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
+        XCTAssertEqual(rebound.status, .failed)
+        XCTAssertEqual(rebound.failureReason, .timeout)
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+    }
+
     func testRestoredTerminalSnapshotWithoutMatchingRevisionFallsBackToTextClassification() async throws {
         let viewModel = makeViewModel()
         let sessionID = UUID()

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -50,6 +50,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             commitID: UUID(),
             ownership: firstOwnership,
             terminalState: .completed,
+            failureReason: nil,
             expectedRunID: nil,
             sourceItemsRevision: session.sourceItemsRevision,
             assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
@@ -653,6 +654,106 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
     }
 
+    func testLiveTerminalSnapshotPrefersStampedFailureReasonOverDisplayTextClassification() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        let runID = UUID()
+        session.runID = runID
+        let ownership = session.beginRunAttempt(source: "test.stampedFailureReason")
+        session.transcript = AgentTranscriptIO.buildTranscript(
+            from: [
+                .user("question", sequenceIndex: 0),
+                .error("Run timed out waiting for the provider", sequenceIndex: 1)
+            ],
+            terminalState: .failed,
+            compact: false
+        )
+        session.runState = .failed
+        session.mcpFollowUpRunPending = false
+
+        let envelope = try XCTUnwrap(viewModel.test_makeTerminalPublicationEnvelope(
+            for: session,
+            ownership: ownership,
+            terminalState: .failed,
+            providerRunID: runID,
+            failureReason: .processCrash
+        ))
+        XCTAssertEqual(envelope.snapshot.status, .failed)
+        XCTAssertEqual(envelope.snapshot.failureReason, .processCrash)
+
+        session.lastTerminalCommitRevision = AgentRunTerminalCommitRevision(
+            commitID: UUID(),
+            ownership: ownership,
+            terminalState: .failed,
+            failureReason: .processCrash,
+            expectedRunID: runID,
+            sourceItemsRevision: session.sourceItemsRevision,
+            assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
+            providerDrainGeneration: session.providerTerminalDrainGeneration,
+            mcpPublicationEnvelope: nil,
+            successorKind: nil,
+            providerSuccessorID: nil
+        )
+        let livePoll = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
+        XCTAssertEqual(livePoll.status, .failed)
+        XCTAssertEqual(livePoll.statusText, "Run timed out waiting for the provider")
+        XCTAssertEqual(livePoll.failureReason, .processCrash)
+        XCTAssertEqual(livePoll.asObject()["failure_reason"]?.stringValue, "process_crash")
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+    }
+
+    func testRestoredTerminalSnapshotWithoutMatchingRevisionFallsBackToTextClassification() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil
+        )
+        let ownership = session.beginRunAttempt(source: "test.restoredFallback")
+        session.transcript = AgentTranscriptIO.buildTranscript(
+            from: [
+                .user("question", sequenceIndex: 0),
+                .error("Run timed out waiting for the provider", sequenceIndex: 1)
+            ],
+            terminalState: .failed,
+            compact: false
+        )
+        session.runState = .idle
+
+        let restored = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
+        XCTAssertEqual(restored.status, .failed)
+        XCTAssertEqual(restored.failureReason, .timeout)
+
+        session.lastTerminalCommitRevision = AgentRunTerminalCommitRevision(
+            commitID: UUID(),
+            ownership: ownership,
+            terminalState: .failed,
+            failureReason: .processCrash,
+            expectedRunID: UUID(),
+            sourceItemsRevision: session.sourceItemsRevision,
+            assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
+            providerDrainGeneration: session.providerTerminalDrainGeneration,
+            mcpPublicationEnvelope: nil,
+            successorKind: nil,
+            providerSuccessorID: nil
+        )
+        let unrelatedAttempt = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
+        XCTAssertEqual(unrelatedAttempt.failureReason, .timeout)
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+    }
+
     func testControlledTerminalPublicationRejectsMissingCanonicalEnvelope() async throws {
         let viewModel = makeViewModel()
         let sessionID = UUID()
@@ -668,6 +769,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             commitID: UUID(),
             ownership: ownership,
             terminalState: .completed,
+            failureReason: nil,
             expectedRunID: nil,
             sourceItemsRevision: session.sourceItemsRevision,
             assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -923,6 +923,70 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         XCTAssertEqual(recorder.events.count(where: { $0 == "assistant-flush" }), 1)
     }
 
+    func testFailedTerminalCommitStampsFailureReasonAndDuplicateSettlementPreservesIt() async throws {
+        let recorder = LifecycleRecorder()
+        var envelopeFailureReasons: [AgentRunMCPSnapshot.FailureReason?] = []
+        var publishedFailureReasons: [AgentRunMCPSnapshot.FailureReason?] = []
+        var publicationAttempts = 0
+        let hooks = makeHooks(
+            recorder: recorder,
+            publishTerminalCommitResult: { _, revision, _ in
+                publicationAttempts += 1
+                publishedFailureReasons.append(revision.failureReason)
+                return publicationAttempts == 1
+                    ? .rejected(reason: "test_transient_rejection")
+                    : .accepted(successorEpoch: nil)
+            },
+            makeTerminalPublicationEnvelope: { _, _, _, _, failureReason in
+                envelopeFailureReasons.append(failureReason)
+                return nil
+            }
+        )
+        let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.runID = UUID()
+        session.runState = .running
+        let ownership = session.beginRunAttempt(source: "test.failureReasonStamp")
+        session.transcript = AgentTranscriptIO.buildTranscript(
+            from: [
+                .user("question", sequenceIndex: 0),
+                .error("Provider request timed out after 60 seconds", sequenceIndex: 1)
+            ],
+            compact: false
+        )
+        let request = AgentRunTerminalCommitBarrier.Request(
+            session: session,
+            ownership: ownership,
+            expectedRunID: session.runID,
+            terminalState: .failed,
+            source: "test.failureReasonStamp",
+            attachmentDisposition: .deleteFiles,
+            finalizeNonCodexUsage: false,
+            supportsFollowUp: false,
+            notifyTurnComplete: false
+        )
+
+        let firstResult = await barrier.commit(request)
+        let first = try XCTUnwrap(firstResult)
+        XCTAssertEqual(first.failureReason, .timeout)
+        XCTAssertEqual(envelopeFailureReasons, [.timeout])
+        XCTAssertEqual(publishedFailureReasons, [.timeout])
+
+        session.transcript = AgentTranscriptIO.buildTranscript(
+            from: [
+                .user("question", sequenceIndex: 0),
+                .error("transport closed unexpectedly", sequenceIndex: 1)
+            ],
+            compact: false
+        )
+        let duplicateResult = await barrier.commit(request)
+        let duplicate = try XCTUnwrap(duplicateResult)
+        XCTAssertEqual(duplicate, first)
+        XCTAssertEqual(duplicate.failureReason, .timeout)
+        XCTAssertEqual(envelopeFailureReasons, [.timeout])
+        XCTAssertEqual(publishedFailureReasons, [.timeout, .timeout])
+    }
+
     func testQueuedFollowUpStartsOnlyAfterCanonicalSuccessorPublicationResolves() async {
         let recorder = LifecycleRecorder()
         let sessionID = UUID()
@@ -955,7 +1019,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                     ? .rejected(reason: "test_transient_rejection")
                     : .accepted(successorEpoch: successor)
             },
-            makeTerminalPublicationEnvelope: { _, _, _, _ in
+            makeTerminalPublicationEnvelope: { _, _, _, _, _ in
                 .init(epoch: epoch, snapshot: .expired(sessionID: sessionID))
             },
             startFollowUpRun: { _, text in recorder.record("follow-up:\(text)") }
@@ -1606,7 +1670,8 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             AgentModeViewModel.TabSession,
             AgentRunOwnership,
             AgentSessionRunState,
-            UUID?
+            UUID?,
+            AgentRunMCPSnapshot.FailureReason?
         ) -> AgentRunTerminalPublicationEnvelope?)? = nil,
         startFollowUpRun: ((UUID, String) -> Void)? = nil
     ) -> AgentModeRunService.Hooks {
@@ -1667,7 +1732,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             ),
             terminalSettlement: .init(
                 prepareTerminalPublication: { _ in recorder.record("prepare-publication") },
-                makeTerminalPublicationEnvelope: makeTerminalPublicationEnvelope ?? { _, _, _, _ in nil },
+                makeTerminalPublicationEnvelope: makeTerminalPublicationEnvelope ?? { _, _, _, _, _ in nil },
                 publishTerminalCommit: { session, revision, successorKind in
                     if let publishTerminalCommitResult {
                         return await publishTerminalCommitResult(session, revision, successorKind)

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPRoutingReadinessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPRoutingReadinessTests.swift
@@ -691,7 +691,7 @@ final class CodexMCPRoutingReadinessTests: XCTestCase {
             ),
             terminalSettlement: .init(
                 prepareTerminalPublication: { _ in },
-                makeTerminalPublicationEnvelope: { _, _, _, _ in nil },
+                makeTerminalPublicationEnvelope: { _, _, _, _, _ in nil },
                 publishTerminalCommit: { _, revision, _ in
                     recorder.record(revision.terminalState)
                     return .accepted(successorEpoch: nil)


### PR DESCRIPTION
## Summary

- resolve Agent Mode terminal failure reasons once in `AgentRunTerminalCommitBarrier`, after transcript/error settlement
- carry the canonical reason through the terminal publication envelope and reuse it for live post-terminal MCP snapshots
- retain text classification only as the restored/legacy fallback, with terminal-state and run-identity guards against stale revisions
- add regression coverage for duplicate settlement stability, live stamped-reason precedence, restored fallback, and routing hook compatibility

## Architecture / compatibility

- the terminal commit barrier remains the single settlement authority
- no new persistence format or parallel session authority
- no MCP wire-value changes; existing `failure_reason` raw values are preserved
- structured provider failure reasons can be threaded into the new request field in a later bounded follow-up

## Validation

- `make dev-test FILTER='AgentModeRunServiceLifecycleTests/testFailedTerminalCommitStampsFailureReasonAndDuplicateSettlementPreservesIt'` — passed (1/1)
- `make dev-test FILTER='AgentModeMCPWaitEpochTests/testLiveTerminalSnapshotPrefersStampedFailureReasonOverDisplayTextClassification'` — passed (1/1)
- restored/legacy fallback regression passed in the initial `AgentModeMCPWaitEpochTests` suite run
- `make dev-test FILTER=CodexMCPRoutingReadinessTests` — passed (8/8)
- `make dev-lint` — passed
- contribution `commit` and `push` preflights — passed, including redacted secret scans and repository/headless-runtime guardrails
- independent Fable 5 High review — **APPROVE WITH FOLLOW-UPS**, no blocking findings

### Full-root PR-ready lane

The computed PR-ready lane passed guardrails, outgoing-range secret scan, and lint, then the full root test process reached its repository-wide 3600-second timeout. Before timeout it reported failures outside this PR's terminal-settlement files:

- `CodeMapBuildAdmissionTests.testCodemapBuildAdmissionPreservesForegroundPriorityAndOwnerRoundRobin`
- two `CodemapAutomaticSelectionGraphNativeTests` timeout cases
- `DirectHeadlessStdioTransportTests.testParentProcessChangeAndReadFailureHaveExplicitProvenance`
- `MCPAskOracleWorktreeTests.testAskOraclePackagesMultipleBoundRootsWithoutCanonicalLeak`
- `PersistentAgentModeMCPReadFileConnectionTests.testWorktreeReadCoverageCertificateFailsClosedAcrossStaleStateAndLifecycleReplacement`

The exact changed-path regressions above are green. The PR-ready timing receipt is local/ignored under `.build/validation-artifacts/pr-ready/`.

## Review follow-ups (not part of this PR)

1. Thread structured provider/runtime errors into `Request.failureReason` so live failure classification no longer needs the settlement-time text fallback.
2. Consolidate duplicate run-state-to-snapshot-status mappings when the terminal path moves further into `RepoPromptDomainRuntime`.
