### PR TITLE
Add W0-W2 MCP latency measurement foundation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status codex-acquire codex-status codex-update-candidate resolve build run test guardrails codex-schema-check conductor-selftest ci-app-test-runner-selftest release-selftest release-sync-cli-version release-preflight release-artifact install-local-production xcode xcode-open xcode-generate xcode-check xcode-validate xcode-generator-test xcode-clean dev-status dev-build dev-swift-build dev-run dev-launch-existing dev-codex-schema-check dev-test dev-provider-test dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
+.PHONY: help doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status codex-acquire codex-status codex-update-candidate resolve build run test guardrails codex-schema-check conductor-selftest ci-app-test-runner-selftest release-selftest release-sync-cli-version release-preflight release-artifact install-local-production xcode xcode-open xcode-generate xcode-check xcode-validate xcode-generator-test xcode-clean dev-status dev-build dev-swift-build dev-run dev-launch-existing dev-codex-schema-check dev-mcp-latency dev-mcp-latency-client-build dev-mcp-latency-debug-server-build dev-mcp-latency-server-build dev-test dev-provider-test dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
 
 PRODUCT ?= all
 CODEX_ARCH ?= all
@@ -21,6 +21,10 @@ help:
 	@printf '  %-30s %s\n' 'dev-run' 'Coordinated debug app build and launch'
 	@printf '  %-30s %s\n' 'dev-launch-existing' 'Launch existing coordinated debug app without building'
 	@printf '  %-30s %s\n' 'dev-codex-schema-check' 'Coordinated Codex app-server schema validation'
+	@printf '  %-30s %s\n' 'dev-mcp-latency' 'Coordinated MCP latency fixture/run/analyze; set MCP_LATENCY_ARGS="..."'
+	@printf '  %-30s %s\n' 'dev-mcp-latency-client-build' 'Build legacy client-only optimized diagnostic CLI'
+	@printf '  %-30s %s\n' 'dev-mcp-latency-debug-server-build' 'Package isolated DEBUG attribution app (never launches)'
+	@printf '  %-30s %s\n' 'dev-mcp-latency-server-build' 'Package isolated release-optimized diagnostic app (never launches)'
 	@printf '  %-30s %s\n' 'dev-test' 'Coordinated test run; override with FILTER=name'
 	@printf '  %-30s %s\n' 'dev-provider-test' 'Run provider package tests; override with FILTER=name'
 	@printf '  %-30s %s\n' 'dev-smoke' 'Run non-disruptive live debug app smoke checks'
@@ -204,6 +208,18 @@ dev-launch-existing:
 
 dev-codex-schema-check:
 	./conductor codex-schema-check
+
+dev-mcp-latency:
+	./conductor mcp-latency -- $(MCP_LATENCY_ARGS)
+
+dev-mcp-latency-client-build:
+	./conductor mcp-latency-client-build
+
+dev-mcp-latency-debug-server-build:
+	./conductor mcp-latency-debug-server-build
+
+dev-mcp-latency-server-build:
+	./conductor mcp-latency-server-build
 
 dev-test:
 	./conductor test$(if $(TEST_PRODUCT), --test-product $(TEST_PRODUCT))$(if $(FILTER), --filter $(FILTER))

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,8 @@ let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent().pa
 let environment = ProcessInfo.processInfo.environment
 let sentryEnabled = environment["REPOPROMPT_ENABLE_SENTRY"] == "1"
 let benchmarkTestsEnabled = environment["RPCE_ENABLE_BENCHMARK_TESTS"] == "1"
+let mcpLatencyTraceEnabled = environment["RPCE_ENABLE_MCP_LATENCY_TRACE"] == "1"
+let mcpLatencyDiagnosticsEnabled = environment["RPCE_ENABLE_MCP_LATENCY_DIAGNOSTICS"] == "1"
 
 var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-log.git", exact: "1.6.3"),
@@ -77,6 +79,10 @@ var repoPromptAppSwiftSettings: [SwiftSetting] = [
     ])
 ]
 
+if mcpLatencyDiagnosticsEnabled {
+    repoPromptAppSwiftSettings.append(.define("MCP_LATENCY_DIAGNOSTICS"))
+}
+
 var repoPromptTestDependencies: [Target.Dependency] = [
     "RepoPromptApp",
     "RepoPromptDomainRuntime",
@@ -93,6 +99,27 @@ var repoPromptTestSwiftSettings: [SwiftSetting] = [
 var repoPromptCodeMapTestSwiftSettings: [SwiftSetting] = [
     .define("DEBUG", .when(configuration: .debug))
 ]
+
+var repoPromptMCPSwiftSettings: [SwiftSetting] = [
+    .define("DEBUG", .when(configuration: .debug))
+]
+if mcpLatencyTraceEnabled {
+    repoPromptMCPSwiftSettings.append(.define("MCP_LATENCY_TRACE"))
+}
+
+var repoPromptDomainRuntimeSwiftSettings: [SwiftSetting] = [
+    .define("DEBUG", .when(configuration: .debug))
+]
+if mcpLatencyDiagnosticsEnabled {
+    repoPromptDomainRuntimeSwiftSettings.append(.define("MCP_LATENCY_DIAGNOSTICS"))
+}
+
+var repoPromptSharedSwiftSettings: [SwiftSetting] = [
+    .define("DEBUG", .when(configuration: .debug))
+]
+if mcpLatencyDiagnosticsEnabled {
+    repoPromptSharedSwiftSettings.append(.define("MCP_LATENCY_DIAGNOSTICS"))
+}
 
 if sentryEnabled {
     let sentryDependency = Target.Dependency.product(name: "Sentry", package: "sentry-cocoa")
@@ -135,9 +162,7 @@ let package = Package(
                 .product(name: "MCP", package: "swift-sdk")
             ],
             path: "Sources/RepoPromptDomainRuntime",
-            swiftSettings: swift6LanguageMode + [
-                .define("DEBUG", .when(configuration: .debug))
-            ]
+            swiftSettings: swift6LanguageMode + repoPromptDomainRuntimeSwiftSettings
         ),
         .target(
             name: "RepoPromptWorkspaceCore",
@@ -183,14 +208,12 @@ let package = Package(
             name: "RepoPromptMCP",
             dependencies: ["RepoPromptShared", "RepoPromptDomainRuntime", "RepoPromptCodeMapCore", "RepoPromptC", .product(name: "Logging", package: "swift-log"), .product(name: "MCP", package: "swift-sdk"), .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"), .product(name: "SystemPackage", package: "swift-system")],
             path: "Sources/RepoPromptMCP",
-            swiftSettings: [.define("DEBUG", .when(configuration: .debug))]
+            swiftSettings: repoPromptMCPSwiftSettings
         ),
         .target(
             name: "RepoPromptShared",
             path: "Sources/RepoPromptShared",
-            swiftSettings: swift6LanguageMode + [
-                .define("DEBUG", .when(configuration: .debug))
-            ]
+            swiftSettings: swift6LanguageMode + repoPromptSharedSwiftSettings
         ),
         .target(name: "CSwiftPCRE2", path: "Sources/CSwiftPCRE2", exclude: ["deps/sljit/sljit_src/sljitNativeARM_64.c", "deps/sljit/sljit_src/sljitSerialize.c", "deps/sljit/sljit_src/sljitUtils.c", "deps/sljit/sljit_src/sljitNativeX86_common.c", "deps/sljit/sljit_src/sljitNativeX86_64.c", "deps/sljit/sljit_src/sljitNativeX86_32.c", "deps/sljit/sljit_src/allocator_src/sljitWXExecAllocatorPosix.c", "deps/sljit/sljit_src/allocator_src/sljitProtExecAllocatorPosix.c", "deps/sljit/sljit_src/allocator_src/sljitExecAllocatorPosix.c", "deps/sljit/sljit_src/allocator_src/sljitExecAllocatorCore.c", "deps/sljit/sljit_src/allocator_src/sljitExecAllocatorApple.c"], publicHeadersPath: "include", cSettings: [.headerSearchPath("include"), .headerSearchPath("src"), .define("PCRE2_CODE_UNIT_WIDTH", to: "8"), .define("HAVE_CONFIG_H")]),
         .target(name: "RepoPromptC", path: "Sources/RepoPromptC", publicHeadersPath: "include", cSettings: [.headerSearchPath("include")]),

--- a/Scripts/Fixtures/mcp-tool-latency/v1/matrix.json
+++ b/Scripts/Fixtures/mcp-tool-latency/v1/matrix.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": 1,
+  "fixture_seed": "mcp-tool-latency-v1-2026-07-29",
+  "fixture_inventory": {
+    "manifest_location": "external_sibling",
+    "workspace_roots": "populated_roots_plus_empty_root",
+    "digest_scope": "measured_payload_files_only"
+  },
+  "work_count_authority": "docs/investigations/mcp-tool-throughput-wi3-baseline-2026-06-11.md",
+  "wi3_authority": {
+    "source": "docs/investigations/mcp-tool-throughput-wi3-baseline-2026-06-11.md",
+    "baseline_commit": "6f8fcbb",
+    "snapshot_surfaces": ["mcp_read_search_runtime_snapshot", "mcp_read_search_admission_snapshot"],
+    "lane_capacities": {"connection_ordinary":1,"connection_file_search":4,"store_file_search":4},
+    "parity_counter_groups": ["catalog_rebuilds","search_rebuilds","ui_projection_rebuilds","freshness","watchers_crawls","content_reads","git_processes"],
+    "workload_matrices": [
+      {"id":"same-connection-ordinary-burst","expected_signature":"ordinary limit 1; FIFO queue/acquire/release","execution":{"enabled_by_default":true,"mode":"same_connection_burst","row_id":"tree-roots","request_count":4}},
+      {"id":"same-connection-mixed-ordinary-search","expected_signature":"ordinary limit 1 and connection file_search limit 4 remain independent"},
+      {"id":"distinct-connections-one-window","expected_signature":"per-connection 1+4 lanes converge on one store search lane of 4","execution":{"enabled_by_default":true,"mode":"distinct_connections","row_id":"search-content-few","connection_count":5}},
+      {"id":"distinct-windows-one-physical-root","expected_signature":"per-window watchers, crawls, indexes, and freshness flights remain visible as duplication"},
+      {"id":"short-versus-long-agent-transcript","expected_signature":"observer scan and callback work remain correlated to one request identity"}
+    ]
+  },
+  "sample_discipline": {"cold_samples":10,"warmups_discarded":3,"warm_samples_per_repeat":30,"warm_repeats":3},
+  "rows": [
+    {"id":"tree-roots","tool":"get_file_tree","arguments":{"type":"roots"},"profiles":["real","small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"tree-auto","tool":"get_file_tree","arguments":{},"profiles":["real","small","medium"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"tree-full","tool":"get_file_tree","arguments":{"mode":"full"},"profiles":["real","small","medium"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"tree-full-large-preflight","tool":"get_file_tree","arguments":{"mode":"full"},"profiles":["large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":false,"requires":"bounded response-size preflight"},
+    {"id":"tree-folders","tool":"get_file_tree","arguments":{"mode":"folders"},"profiles":["real","small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"tree-selected","tool":"get_file_tree","arguments":{"mode":"selected"},"profiles":["real","small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true,"requires":"pinned selection fixture"},
+    {"id":"tree-subtree-depth-2","tool":"get_file_tree","arguments":{"path":"${FIXTURE_SUBTREE}","max_depth":2},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"tree-empty-root","tool":"get_file_tree","arguments":{"path":"${FIXTURE_EMPTY_ROOT}","max_depth":2},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":false,"requires":"empty root attached to workspace"},
+    {"id":"tree-worktree-auto","tool":"get_file_tree","arguments":{},"profiles":["real"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":false,"requires":"worktree-bound context"},
+    {"id":"search-path-literal","tool":"file_search","arguments":{"pattern":"Duplicate.swift","mode":"path","regex":false,"max_results":50},"profiles":["real","small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"search-path-wildcard","tool":"file_search","arguments":{"pattern":"*Duplicate.swift","mode":"path","regex":false,"max_results":1000},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"search-content-few","tool":"file_search","arguments":{"pattern":"LATENCY_RARE","mode":"content","regex":false,"max_results":50,"context_lines":0},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"search-content-context-2","tool":"file_search","arguments":{"pattern":"LATENCY_RARE","mode":"content","regex":false,"max_results":50,"context_lines":2},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"search-content-zero","tool":"file_search","arguments":{"pattern":"LATENCY_ZERO_MATCH","mode":"content","regex":false,"max_results":50},"profiles":["real","small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"search-content-capped","tool":"file_search","arguments":{"pattern":"LATENCY_COMMON","mode":"content","regex":false,"max_results":1000,"context_lines":0},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"cap_hit_success","expected_outcome_by_profile":{"small":"success","medium":"cap_hit_success","large":"cap_hit_success"},"enabled_by_default":true},
+    {"id":"search-content-regex","tool":"file_search","arguments":{"pattern":"LATENCY_(COMMON|RARE)","mode":"content","regex":true,"max_results":50},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"cap_hit_success","enabled_by_default":true},
+    {"id":"search-both","tool":"file_search","arguments":{"pattern":"Duplicate|LATENCY_RARE","mode":"both","regex":true,"max_results":50},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"cap_hit_success","expected_outcome_by_profile":{"small":"success","medium":"cap_hit_success","large":"cap_hit_success"},"enabled_by_default":true},
+    {"id":"search-count-only","tool":"file_search","arguments":{"pattern":"LATENCY_COMMON","mode":"content","regex":false,"count_only":true,"max_results":1000},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"cap_hit_success","expected_outcome_by_profile":{"small":"success","medium":"cap_hit_success","large":"cap_hit_success"},"enabled_by_default":true},
+    {"id":"search-scoped","tool":"file_search","arguments":{"pattern":"LATENCY_COMMON","mode":"content","regex":false,"filter":{"paths":["${FIXTURE_SUBTREE}"]},"max_results":1000},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"search-worktree","tool":"file_search","arguments":{"pattern":"LATENCY_COMMON","mode":"content","regex":false,"max_results":50},"profiles":["real"],"formats":["formatted","raw"],"expected_outcome":"cap_hit_success","enabled_by_default":false,"requires":"worktree-bound context"},
+    {"id":"workspace-ordinary","tool":"workspace_context","arguments":{"include":["prompt","selection","code","tokens"]},"profiles":["real","small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"workspace-envelope","tool":"workspace_context","arguments":{"include":["prompt","selection","code","files","tree","tokens"]},"profiles":["small","medium"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"read-small-control","tool":"read_file","arguments":{"path":"${FIXTURE_SMALL_FILE}","start_line":1,"limit":8},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"success","enabled_by_default":true},
+    {"id":"retryable-readiness-control","tool":"file_search","arguments":{"pattern":"LATENCY_RARE","mode":"content","regex":false,"max_results":10},"profiles":["small","medium","large"],"formats":["formatted","raw"],"expected_outcome":"retryable_error","enabled_by_default":false,"requires":"intentionally unready store cohort"},
+    {"id":"expected-timeout-backpressure-control","tool":"get_file_tree","arguments":{"mode":"full"},"profiles":["large"],"formats":["formatted","raw"],"expected_outcome":"expected_timeout","enabled_by_default":false,"requires":"separate bounded timeout cohort after response-size preflight"}
+  ]
+}

--- a/Scripts/build_mcp_latency_client.sh
+++ b/Scripts/build_mcp_latency_client.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${REPO_ROOT}/.build/mcp-latency/optimized"
+SCRATCH_DIR="${OUTPUT_DIR}/scratch"
+ARTIFACT_PATH="${OUTPUT_DIR}/repoprompt-mcp"
+MANIFEST_PATH="${OUTPUT_DIR}/artifact-manifest.json"
+
+cd "${REPO_ROOT}"
+mkdir -p "${OUTPUT_DIR}" "${SCRATCH_DIR}"
+RPCE_ENABLE_MCP_LATENCY_TRACE=1 swift build \
+  --scratch-path "${SCRATCH_DIR}" \
+  -c release \
+  --product repoprompt-mcp
+BIN_DIR="$(RPCE_ENABLE_MCP_LATENCY_TRACE=1 swift build \
+  --scratch-path "${SCRATCH_DIR}" \
+  -c release \
+  --show-bin-path)"
+install -m 0755 "${BIN_DIR}/repoprompt-mcp" "${ARTIFACT_PATH}"
+
+python3 - "${REPO_ROOT}" "${ARTIFACT_PATH}" "${MANIFEST_PATH}" <<'PY'
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+
+repo = pathlib.Path(sys.argv[1])
+artifact = pathlib.Path(sys.argv[2])
+manifest = pathlib.Path(sys.argv[3])
+payload = {
+    "schema_version": 1,
+    "artifact_kind": "optimized_mcp_latency_diagnostic_client",
+    "configuration": "release",
+    "commit": subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True,
+        text=True, capture_output=True,
+    ).stdout.strip(),
+    "enabled_defines": ["MCP_LATENCY_TRACE"],
+    "ordinary_release_artifact": False,
+    "product_path": str(artifact),
+    "sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+}
+temporary = manifest.with_suffix(".json.tmp")
+temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+temporary.replace(manifest)
+PY
+
+printf 'Optimized MCP latency diagnostic client: %s\n' "${ARTIFACT_PATH}"
+printf 'Artifact manifest: %s\n' "${MANIFEST_PATH}"

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -38,7 +38,7 @@ from debug_app_process import ProcessIdentityError, matching_processes, terminat
 
 PROTOCOL_VERSION = 11
 TERMINAL_STATES = {"completed", "failed", "canceled"}
-LANE_NAMES = {"build", "debugArtifact", "liveApp", "release", "style"}
+LANE_NAMES = {"build", "debugArtifact", "mcpLatencyArtifact", "liveApp", "release", "style"}
 LOG_TAIL_LINES = 30
 BUILD_CACHE_DIAGNOSTIC_MAX_ROWS = 12
 SUMMARY_VERSION = 1
@@ -101,6 +101,10 @@ IMPLEMENTED_OPERATIONS = {
     "app",
     "smoke",
     "diagnostics",
+    "mcp-latency",
+    "mcp-latency-client-build",
+    "mcp-latency-debug-server-build",
+    "mcp-latency-server-build",
     "release",
 }
 
@@ -152,12 +156,18 @@ Operation commands:
     (without --launch/--packaged-app, requires the CE debug app to already be running and CLI installed)
   ./conductor diagnostics agent-mode-on [--log-file <path>]
   ./conductor diagnostics build-cache [--limit <n>]
+  ./conductor mcp-latency -- fixture --profile small --output /absolute/external/path
+  ./conductor mcp-latency -- run <matrix args...>     # existing app only; never performs lifecycle actions
+  ./conductor mcp-latency -- analyze <aggregate args...>
+  ./conductor mcp-latency-client-build              # legacy client-only optimized diagnostic CLI
+  ./conductor mcp-latency-debug-server-build        # isolated DEBUG attribution app; never launches
+  ./conductor mcp-latency-server-build              # isolated release-optimized diagnostic app; never launches
   ./conductor release preflight|artifact|package|local-install
 
 Foundation validation operation:
   ./conductor sleep <seconds> [--lane <lane>]... [--message <text>] [--exit-code <n>]
   ./conductor fake-sleep <seconds> [same options]
-  valid lanes: build, debugArtifact, liveApp, release, style
+  valid lanes: build, debugArtifact, mcpLatencyArtifact, liveApp, release, style
 
 Global operation flags:
   --async              enqueue and return a ticket immediately
@@ -1059,7 +1069,9 @@ def is_launch_capable_job(operation: str, args: Dict[str, Any]) -> bool:
 
 
 def operation_requires_global_heavy_slot(operation: str, args: Dict[str, Any]) -> bool:
-    if operation in {"swift-build", "build", "package", "test", "provider-test", "install-debug-cli"}:
+    if operation in {"swift-build", "build", "package", "test", "provider-test", "install-debug-cli", "mcp-latency-client-build", "mcp-latency-debug-server-build", "mcp-latency-server-build"}:
+        return True
+    if operation == "mcp-latency" and (args.get("toolArgs") or [None])[0] == "run":
         return True
     if operation in {"sleep", "fake-sleep"} and "build" in set(args.get("lanes") or []):
         return True
@@ -1422,6 +1434,37 @@ class OperationRegistry:
                 return self._internal_argv("diagnostics_agent_mode_on", dict(args)), ["debugArtifact", "liveApp"], cwd, env, effective_timeout
             if subcommand == "build-cache":
                 return self._internal_argv("diagnostics_build_cache", dict(args)), lanes, cwd, env, effective_timeout
+        if operation == "mcp-latency-client-build":
+            return [script("build_mcp_latency_client.sh")], ["build", "mcpLatencyArtifact"], cwd, env, effective_timeout
+        if operation == "mcp-latency-debug-server-build":
+            env["REPOPROMPT_DEBUG_APP_BUNDLE"] = str(
+                self.repo_root / ".build/mcp-latency/debug-server/RepoPrompt.app"
+            )
+            env["ALLOW_ADHOC_SIGNING"] = "1"
+            return [script("package_app.sh"), "debug"], ["build", "mcpLatencyArtifact"], cwd, env, effective_timeout
+        if operation == "mcp-latency-server-build":
+            return [script("package_app.sh"), "mcp-latency-diagnostic"], ["build", "mcpLatencyArtifact"], cwd, env, effective_timeout
+        if operation == "mcp-latency":
+            tool_args = [str(value) for value in args.get("toolArgs", [])]
+            if not tool_args:
+                raise ConductorError("mcp-latency requires fixture, run, or analyze arguments")
+            subcommand = tool_args[0]
+            if subcommand == "fixture":
+                return [sys.executable, script("mcp-latency/generate_fixture.py"), *tool_args[1:]], lanes, cwd, env, effective_timeout
+            if subcommand in {"run", "analyze"}:
+                if subcommand == "run":
+                    try:
+                        configuration = tool_args[tool_args.index("--configuration") + 1]
+                    except (ValueError, IndexError) as error:
+                        raise ConductorError("mcp-latency run requires --configuration debug|optimized") from error
+                    if configuration == "debug":
+                        lanes = ["debugArtifact", "liveApp"]
+                    elif configuration == "optimized":
+                        lanes = ["mcpLatencyArtifact", "liveApp"]
+                    else:
+                        raise ConductorError("mcp-latency run requires --configuration debug|optimized")
+                return [sys.executable, script("mcp-latency/run_latency_matrix.py"), *tool_args], lanes, cwd, env, effective_timeout
+            raise ConductorError("mcp-latency subcommand must be fixture, run, or analyze")
         if operation == "release":
             subcommand = args.get("subcommand")
             if subcommand == "package":
@@ -1511,6 +1554,8 @@ class OperationRegistry:
             return RELEASE_TIMEOUT_SECONDS
         if operation == "smoke" and args.get("agentRun"):
             return MEDIUM_TIMEOUT_SECONDS
+        if operation in {"mcp-latency", "mcp-latency-server-build"}:
+            return RELEASE_ARTIFACT_TIMEOUT_SECONDS
         if operation == "diagnostics":
             return SHORT_TIMEOUT_SECONDS
         return MEDIUM_TIMEOUT_SECONDS
@@ -4633,6 +4678,9 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
         "format-tools-status",
         "check-format-tools",
         "install-format-tools",
+        "mcp-latency-client-build",
+        "mcp-latency-debug-server-build",
+        "mcp-latency-server-build",
     }:
         parse_no_args(f"conductor {operation}", rest)
     elif operation == "swift-build":
@@ -4731,6 +4779,10 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
             if ns.limit <= 0:
                 raise ConductorError("diagnostics build-cache --limit must be greater than zero")
             args["limit"] = ns.limit
+    elif operation == "mcp-latency":
+        if not rest or rest[0] != "--" or len(rest) < 2:
+            raise ConductorError("usage: ./conductor mcp-latency -- fixture|run|analyze <arguments...>")
+        args["toolArgs"] = rest[1:]
     elif operation == "release":
         parser = argparse.ArgumentParser(prog="conductor release")
         parser.add_argument("subcommand", choices=["preflight", "artifact", "package", "local-install"])

--- a/Scripts/guardrails.sh
+++ b/Scripts/guardrails.sh
@@ -9,3 +9,5 @@ cd "$ROOT_DIR"
 ./Scripts/swiftpm_notice_guardrails.sh
 ./Scripts/codex_vendor_guardrails.sh
 ./Scripts/headless_runtime_guardrails.sh
+python3 Scripts/test_mcp_tool_latency.py
+python3 Scripts/test_mcp_latency_diagnostic_artifact.py

--- a/Scripts/mcp-latency/generate_fixture.py
+++ b/Scripts/mcp-latency/generate_fixture.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Generate deterministic MCP latency workspaces outside this repository."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+SCHEMA_VERSION = 1
+SEED = "mcp-tool-latency-v1-2026-07-29"
+MANIFEST_SUFFIX = ".manifest.json"
+PROFILES = {
+    "small": (500, 1),
+    "medium": (10_000, 2),
+    "large": (50_000, 4),
+}
+
+
+class FixtureError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class FixtureSpec:
+    name: str
+    file_count: int
+    root_count: int
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def ensure_external_output(output: Path, repo: Path | None = None) -> Path:
+    repo = (repo or repository_root()).resolve()
+    resolved = output.expanduser().resolve()
+    if resolved == repo or repo in resolved.parents:
+        raise FixtureError("fixture output must be outside the repository")
+    return resolved
+
+
+def manifest_path_for_output(output: Path) -> Path:
+    return output.with_name(f"{output.name}{MANIFEST_SUFFIX}")
+
+
+def relative_file_path(index: int, root_index: int) -> Path:
+    extension = ("swift", "txt", "md", "json")[index % 4]
+    basename = "Duplicate.swift" if index % 113 == 0 else f"file_{index:06d}.{extension}"
+    components = [
+        f"root-{root_index + 1}",
+        f"fanout-{index % 64:02d}",
+        f"branch-{(index // 64) % 16:02d}",
+    ]
+    if index % 97 == 0:
+        components.extend(f"deep-{depth}" for depth in range(8))
+    return Path(*components, basename)
+
+
+def file_content(index: int, root_index: int) -> bytes:
+    markers = [
+        f"seed={SEED}",
+        f"file_index={index}",
+        f"root_index={root_index}",
+        "LATENCY_COMMON",
+    ]
+    if index % 97 == 0:
+        markers.append("LATENCY_RARE")
+    if index % 211 == 0:
+        markers.append("literal.with.regex[characters]")
+    markers.append(f"payload={'x' * (32 + index % 127)}")
+    return ("\n".join(markers) + "\n").encode("utf-8")
+
+
+def manifest_digest(entries: Iterable[tuple[str, bytes]]) -> str:
+    digest = hashlib.sha256()
+    for relative, payload in sorted(entries):
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(payload)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def generate_fixture(output: Path, spec: FixtureSpec, *, repo: Path | None = None) -> dict[str, object]:
+    output = ensure_external_output(output, repo)
+    manifest_path = manifest_path_for_output(output)
+    if output.exists():
+        raise FixtureError(f"fixture output already exists: {output}")
+    if manifest_path.exists():
+        raise FixtureError(f"fixture manifest already exists: {manifest_path}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{output.name}.tmp-", dir=output.parent))
+    temporary_manifest = temporary.with_name(f"{temporary.name}{MANIFEST_SUFFIX}")
+    entries: list[tuple[str, bytes]] = []
+    root_counts = [0] * spec.root_count
+    maximum_depth = 0
+    total_bytes = 0
+    try:
+        (temporary / "empty-root").mkdir()
+        for index in range(spec.file_count):
+            root_index = index % spec.root_count
+            relative = relative_file_path(index, root_index)
+            payload = file_content(index, root_index)
+            target = temporary / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(payload)
+            entries.append((relative.as_posix(), payload))
+            root_counts[root_index] += 1
+            maximum_depth = max(maximum_depth, len(relative.parts) - 1)
+            total_bytes += len(payload)
+
+        expected = {
+            "content_literal_LATENCY_COMMON": spec.file_count,
+            "content_literal_LATENCY_RARE": sum(1 for index in range(spec.file_count) if index % 97 == 0),
+            "content_regex_literal_with_regex_characters": sum(
+                1 for index in range(spec.file_count) if index % 211 == 0
+            ),
+            "path_duplicate_basename": sum(1 for index in range(spec.file_count) if index % 113 == 0),
+            "zero_match": 0,
+        }
+        manifest: dict[str, object] = {
+            "schema_version": SCHEMA_VERSION,
+            "generator": "Scripts/mcp-latency/generate_fixture.py",
+            "profile": spec.name,
+            "seed": SEED,
+            "root_count": spec.root_count,
+            "root_file_counts": root_counts,
+            "file_count": spec.file_count,
+            "total_file_bytes": total_bytes,
+            "workspace_inventory": {
+                "manifest_location": "external_sibling",
+                "root_paths": [
+                    *(f"root-{index + 1}" for index in range(spec.root_count)),
+                    "empty-root",
+                ],
+                "populated_root_count": spec.root_count,
+                "empty_root_count": 1,
+                "workspace_root_count": spec.root_count + 1,
+                "measured_file_count": spec.file_count,
+                "measured_file_bytes": total_bytes,
+                "digest_scope": "measured_payload_files_only",
+            },
+            "maximum_relative_directory_depth": maximum_depth,
+            "expected_search_counts": expected,
+            "digest_algorithm": "sha256(relative-path\\0content\\0)",
+            "digest": manifest_digest(entries),
+        }
+        temporary_manifest.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        os.rename(temporary, output)
+        os.rename(temporary_manifest, manifest_path)
+        return manifest
+    except BaseException:
+        shutil.rmtree(temporary, ignore_errors=True)
+        temporary_manifest.unlink(missing_ok=True)
+        if output.exists() and not manifest_path.exists():
+            shutil.rmtree(output, ignore_errors=True)
+        raise
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True, choices=sorted(PROFILES))
+    parser.add_argument("--output", required=True, help="new external directory; must not be inside the checkout")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    count, roots = PROFILES[args.profile]
+    try:
+        manifest = generate_fixture(Path(args.output), FixtureSpec(args.profile, count, roots))
+    except FixtureError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/mcp-latency/run_latency_matrix.py
+++ b/Scripts/mcp-latency/run_latency_matrix.py
@@ -1,0 +1,2968 @@
+#!/usr/bin/env python3
+"""Run or analyze paired MCP tool latency cohorts against an already-running CE app.
+
+This command never builds, launches, relaunches, or stops the app. Invoke live runs
+through `make dev-mcp-latency` / `./conductor mcp-latency` so existing-app
+measurement is serialized on the configuration-specific artifact and liveApp lanes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Iterable
+
+SCHEMA_VERSION = 1
+TRACE_ENV = "RP_MCP_LATENCY_TRACE_PATH"
+DEBUG_TOOL = "__repoprompt_debug_diagnostics"
+
+
+def new_invocation_id() -> str:
+    """Match Foundation UUID.uuidString casing for exact client/server joins."""
+    return str(uuid.uuid4()).upper()
+
+
+def canonical_invocation_id(value: Any) -> str:
+    """Canonicalize UUID spelling without weakening exact request-identity joins."""
+    text = str(value)
+    try:
+        return str(uuid.UUID(text)).upper()
+    except ValueError:
+        return text
+
+
+TERMINAL_OUTCOMES = {"cancelled", "timeout", "transport_closed"}
+UNEXPECTED_TERMINAL_OUTCOMES = {"cancelled", "timeout", "transport_closed"}
+SUCCESS_EXPECTATIONS = {"success", "cap_hit_success"}
+INCLUSIVE_STAGES = {
+    "EditFlow.Search.ProviderTotal",
+    "EditFlow.Search.ProviderWorkspaceSearchAwait",
+    "EditFlow.Search.WorkspaceReadinessAcquireGate",
+    "EditFlow.Search.RootScopeAvailabilityGate",
+    "EditFlow.Search.DTOBuild",
+    "EditFlow.FileTree.ProviderTotal",
+    "EditFlow.FileTree.BridgeTotal",
+    "EditFlow.FileTree.RenderAttempt",
+    "EditFlow.FormattedOutput.SearchTreeAssembly",
+    "EditFlow.MCPToolCall.FormatResult",
+    "EditFlow.MCPToolCall.CompletionObservers",
+}
+DERIVED_SEARCH_CORE_STAGE = "Derived.Search.CoreScanRemainder"
+DERIVED_SEARCH_READINESS_SCOPE_STAGE = "Derived.Search.ReadinessAndScopeGateExclusive"
+DERIVED_SEARCH_TREE_STAGE = "Derived.FormattedOutput.SearchTreeAssemblyExclusive"
+RESIDUAL_OVERLAP_TOLERANCE_MS = 0.01
+DIRECT_STAGE_CHILDREN = {
+    "EditFlow.Search.ProviderTotal": {
+        "EditFlow.Search.ProviderRequestMetadata",
+        "EditFlow.Search.ProviderLookupContextResolution",
+        "EditFlow.Search.ProviderWorkspaceSearchAwait",
+        "EditFlow.Search.DTOBuild",
+        "EditFlow.Search.ProviderValueEncoding",
+    },
+    "EditFlow.Search.ProviderWorkspaceSearchAwait": {
+        "EditFlow.Search.BroadAdmissionWait",
+        "EditFlow.Search.IngressFreshnessWait",
+        "EditFlow.Search.WorkspaceReadinessAcquireGate",
+        "EditFlow.Search.RootScopeAvailabilityGate",
+    },
+    "EditFlow.Search.WorkspaceReadinessAcquireGate": {
+        "EditFlow.Search.WorkspaceReadinessValidationGate",
+    },
+    "EditFlow.Search.RootScopeAvailabilityGate": {
+        "EditFlow.Search.WorkspaceReadinessValidationGate",
+    },
+    "EditFlow.Search.DTOBuild": {
+        "EditFlow.Search.DTOBuild.Assembly",
+    },
+    "EditFlow.FileTree.ProviderTotal": {
+        "EditFlow.FileTree.ProviderArgumentParsing",
+        "EditFlow.FileTree.ProviderRequestMetadata",
+        "EditFlow.FileTree.ProviderLookupContextResolution",
+        "EditFlow.FileTree.ProviderIngressFreshnessWait",
+        "EditFlow.FileTree.ProviderSelectionDrain",
+        "EditFlow.FileTree.BridgeTotal",
+        "EditFlow.FileTree.DTOAssembly",
+        "EditFlow.FileTree.ProviderValueEncoding",
+    },
+    "EditFlow.FileTree.BridgeTotal": {
+        "EditFlow.FileTree.SettingsSnapshot",
+        "EditFlow.FileTree.SelectionPhysicalization",
+        "EditFlow.FileTree.SnapshotConstruction",
+        "EditFlow.FileTree.CodemapMarkerProjection",
+        "EditFlow.FileTree.LogicalProjection",
+        "EditFlow.FileTree.RenderAttempt",
+    },
+    "EditFlow.FileTree.RenderAttempt": {
+        "EditFlow.FileTree.RenderIndexPreparation",
+        "EditFlow.FileTree.RenderTokenEstimation",
+    },
+    "EditFlow.FormattedOutput.SearchTreeAssembly": {
+        "EditFlow.FormattedOutput.SearchSnippetAssembly",
+    },
+    "EditFlow.MCPToolCall.CompletionObservers": {
+        "EditFlow.MCPToolCall.CompletionObserverResultEncoding",
+        "EditFlow.MCPToolCall.CompletionObserverCallbacks",
+    },
+}
+LEAF_STAGES = {
+    "EditFlow.MCPToolCall.LimiterWait",
+    "EditFlow.MCPToolCall.HandlerResultHandoff",
+    "EditFlow.MCPToolCall.CompletionObserverResultEncoding",
+    "EditFlow.MCPToolCall.CompletionObserverCallbacks",
+    "EditFlow.Search.BroadAdmissionWait",
+    "EditFlow.Search.IngressFreshnessWait",
+    "EditFlow.Search.WorkspaceReadinessValidationGate",
+    "EditFlow.Search.DTOBuild.Assembly",
+    "EditFlow.Search.ProviderValueEncoding",
+    "EditFlow.FileTree.ProviderArgumentParsing",
+    "EditFlow.FileTree.ProviderRequestMetadata",
+    "EditFlow.FileTree.ProviderLookupContextResolution",
+    "EditFlow.FileTree.ProviderIngressFreshnessWait",
+    "EditFlow.FileTree.ProviderSelectionDrain",
+    "EditFlow.FileTree.SettingsSnapshot",
+    "EditFlow.FileTree.SelectionPhysicalization",
+    "EditFlow.FileTree.SnapshotConstruction",
+    "EditFlow.FileTree.CodemapMarkerProjection",
+    "EditFlow.FileTree.LogicalProjection",
+    "EditFlow.FileTree.RenderIndexPreparation",
+    "EditFlow.FileTree.RenderTokenEstimation",
+    "EditFlow.FileTree.DTOAssembly",
+    "EditFlow.FileTree.ProviderValueEncoding",
+    "EditFlow.FormattedOutput.Decode",
+    "EditFlow.FormattedOutput.PromptEnvelopeProbeDecode",
+    "EditFlow.FormattedOutput.PromptContextDecode",
+    "EditFlow.FormattedOutput.SearchSnippetAssembly",
+    "EditFlow.FormattedOutput.FileTreeAssembly",
+    "EditFlow.FormattedOutput.WorkspaceContextAssembly",
+    "EditFlow.FormattedOutput.GenericFallbackAssembly",
+}
+SELECTOR_ACTIONS = {
+    "EditFlow.Search.ProviderValueEncoding": "W5",
+    "EditFlow.Search.DTOBuild.Assembly": "W4",
+    "EditFlow.MCPToolCall.CompletionObserverResultEncoding": "S5-C2-follow-up",
+    "EditFlow.MCPToolCall.CompletionObserverCallbacks": "S5-C2-follow-up",
+    "Boundary.S7S8.SDKEncode": "S5-C2-follow-up",
+    "Boundary.S8S9.TransportWrite": "S5-C2-follow-up",
+    "Boundary.C1C2.ClientOutput": "S5-C2-follow-up",
+    DERIVED_SEARCH_TREE_STAGE: "W3",
+    "EditFlow.FormattedOutput.SearchSnippetAssembly": "W3",
+    "EditFlow.FileTree.CodemapMarkerProjection": "W6a",
+    "EditFlow.FileTree.RenderIndexPreparation": "W6b",
+    "EditFlow.FileTree.RenderTokenEstimation": "W6b",
+    "EditFlow.FormattedOutput.PromptEnvelopeProbeDecode": "W7",
+    "EditFlow.Search.BroadAdmissionWait": "search-follow-up",
+    "EditFlow.Search.IngressFreshnessWait": "search-follow-up",
+    "EditFlow.Search.WorkspaceReadinessValidationGate": "search-follow-up",
+    DERIVED_SEARCH_READINESS_SCOPE_STAGE: "search-follow-up",
+    DERIVED_SEARCH_CORE_STAGE: "search-follow-up",
+}
+SERVER_CAPTURE_MODE = "mcp_latency_evidence"
+SERVER_SAMPLE_CAPACITY_UNIT = "unique_stage_dimension_request_keys"
+SERVER_PERCENTILE_SEMANTICS = "unavailable_online_aggregation"
+SEGMENTED_CAPTURE_LAYOUT = "segmented_canonical_matrix_v1"
+SEGMENTED_CAPTURE_CONTRACT_VERSION = 1
+SEGMENTED_CAPTURE_STRATEGY = "ordinary_row_client_mode_and_wi3_workload"
+SEGMENTED_CAPTURE_MAX_ORDINARY_INVOCATIONS = 256
+SERVER_STAGE_NAME_ALLOWLIST = sorted(LEAF_STAGES | INCLUSIVE_STAGES)
+LIFECYCLE_BOUNDARIES = (
+    ("s0_s1_permit_wait_ms", "MCP.ToolCall.Received", "MCP.ToolCall.PermitAcquired"),
+    ("s1_s2_pre_provider_ms", "MCP.ToolCall.PermitAcquired", "MCP.ToolCall.ResolvedProviderBegan"),
+    ("s2_s3_provider_ms", "MCP.ToolCall.ResolvedProviderBegan", "MCP.ToolCall.ResolvedProviderEnded"),
+    ("s3_s4_pre_format_ms", "MCP.ToolCall.ResolvedProviderEnded", "MCP.ToolCall.FormatResultBegan"),
+    ("s4_s5_format_ms", "MCP.ToolCall.FormatResultBegan", "MCP.ToolCall.FormatResultReturned"),
+    ("s5_s6_completion_observers_ms", "MCP.ToolCall.FormatResultReturned", "MCP.ToolCall.CompletionObserverReturned"),
+    ("s6_s7_handler_handoff_ms", "MCP.ToolCall.CompletionObserverReturned", "MCP.ToolCall.HandlerResultReady"),
+)
+LIFECYCLE_EVENT_ALLOWLIST = sorted({
+    event_name
+    for _, start_name, end_name in LIFECYCLE_BOUNDARIES
+    for event_name in (start_name, end_name)
+})
+DELIVERY_BOUNDARIES = (
+    ("s7_s8_sdk_encode_ms", "handler_result_ready", "sdk_encode_completed"),
+    ("s8_s9_transport_write_ms", "sdk_encode_completed", "transport_write_completed"),
+    ("handler_to_write_ms", "handler_result_ready", "transport_write_completed"),
+)
+WI3_MATRIX_IDS = {
+    "same-connection-ordinary-burst",
+    "same-connection-mixed-ordinary-search",
+    "distinct-connections-one-window",
+    "distinct-windows-one-physical-root",
+    "short-versus-long-agent-transcript",
+}
+WI3_COUNTER_GROUPS = {
+    "catalog_rebuilds",
+    "search_rebuilds",
+    "ui_projection_rebuilds",
+    "freshness",
+    "watchers_crawls",
+    "content_reads",
+    "git_processes",
+}
+
+
+class MatrixError(RuntimeError):
+    pass
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_matrix() -> Path:
+    return repo_root() / "Scripts/Fixtures/mcp-tool-latency/v1/matrix.json"
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def current_source_fingerprint() -> str:
+    process = subprocess.run(
+        [sys.executable, str(repo_root() / "Scripts/source_tree_fingerprint.py"),
+         "--repo", str(repo_root())],
+        text=True, capture_output=True,
+    )
+    if process.returncode:
+        raise MatrixError(process.stderr.strip() or "source fingerprint failed")
+    digest = process.stdout.strip()
+    if len(digest) != 64:
+        raise MatrixError("source fingerprint returned an invalid digest")
+    return digest
+
+
+def resolve_cli(argument: str | None) -> Path:
+    candidates = [
+        argument,
+        os.environ.get("REPOPROMPT_DEBUG_CLI_INSTALL_PATH"),
+        shutil.which("rpce-cli-debug"),
+        str(Path.home() / "Library/Application Support/RepoPrompt CE/repoprompt_ce_cli_debug"),
+    ]
+    for candidate in candidates:
+        if candidate:
+            path = Path(candidate).expanduser()
+            if path.is_file() and os.access(path, os.X_OK):
+                return path.resolve()
+    raise MatrixError("CE CLI not found; pass --cli or install rpce-cli-debug")
+
+
+def new_capture_directory(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    if resolved.exists():
+        raise MatrixError(f"capture directory must be new: {resolved}")
+    resolved.mkdir(parents=True, mode=0o700)
+    os.chmod(resolved, 0o700)
+    return resolved
+
+
+def replace_variables(value: Any, variables: dict[str, str]) -> Any:
+    if isinstance(value, str):
+        for key, replacement in variables.items():
+            value = value.replace("${" + key + "}", replacement)
+        if "${" in value:
+            raise MatrixError(f"unresolved matrix variable: {value}")
+        return value
+    if isinstance(value, list):
+        return [replace_variables(item, variables) for item in value]
+    if isinstance(value, dict):
+        return {key: replace_variables(item, variables) for key, item in value.items()}
+    return value
+
+
+def validate_fixture_manifest_location(
+    fixture_root: Path | None,
+    fixture_manifest: Path | None,
+) -> None:
+    if fixture_root is None:
+        if fixture_manifest is not None:
+            raise MatrixError("fixture manifest requires --fixture-root")
+        return
+    if fixture_manifest is None:
+        raise MatrixError("generated fixture workspace requires --fixture-manifest")
+    root = fixture_root.expanduser().resolve()
+    manifest = fixture_manifest.expanduser().resolve()
+    if manifest == root or root in manifest.parents:
+        raise MatrixError("fixture manifest must reside outside the measured workspace")
+
+
+def fixture_variables(fixture_root: Path | None) -> dict[str, str]:
+    if fixture_root is None:
+        return {}
+    root = fixture_root.expanduser().resolve()
+    return {
+        "FIXTURE_ROOT": str(root),
+        "FIXTURE_SUBTREE": str(root / "root-1" / "fanout-00"),
+        "FIXTURE_EMPTY_ROOT": str(root / "empty-root"),
+        "FIXTURE_SMALL_FILE": str(root / "root-1" / "fanout-00" / "branch-00" / "deep-0" / "deep-1" / "deep-2" / "deep-3" / "deep-4" / "deep-5" / "deep-6" / "deep-7" / "Duplicate.swift"),
+    }
+
+
+def load_wi3_authority(matrix_path: Path) -> dict[str, Any]:
+    matrix = load_json(matrix_path)
+    if matrix.get("schema_version") != SCHEMA_VERSION:
+        raise MatrixError("unsupported matrix schema")
+    authority = matrix.get("wi3_authority")
+    if not isinstance(authority, dict):
+        raise MatrixError("matrix is missing the WI-3 authority contract")
+    if authority.get("source") != matrix.get("work_count_authority"):
+        raise MatrixError("WI-3 authority source must match work_count_authority")
+    matrix_ids = {item.get("id") for item in authority.get("workload_matrices", []) if isinstance(item, dict)}
+    if matrix_ids != WI3_MATRIX_IDS:
+        raise MatrixError("WI-3 workload matrix contract is incomplete")
+    counter_groups = set(authority.get("parity_counter_groups", []))
+    if counter_groups != WI3_COUNTER_GROUPS:
+        raise MatrixError("WI-3 work-count parity groups are incomplete")
+    capacities = authority.get("lane_capacities")
+    if capacities != {"connection_ordinary": 1, "connection_file_search": 4, "store_file_search": 4}:
+        raise MatrixError("WI-3 lane capacities do not match the authoritative baseline")
+    return authority
+
+
+def load_rows(matrix_path: Path, profile: str, include_manual: bool, variables: dict[str, str]) -> list[dict[str, Any]]:
+    matrix = load_json(matrix_path)
+    if matrix.get("schema_version") != SCHEMA_VERSION:
+        raise MatrixError("unsupported matrix schema")
+    load_wi3_authority(matrix_path)
+    rows = []
+    seen = set()
+    for source in matrix.get("rows", []):
+        row_id = source.get("id")
+        if not isinstance(row_id, str) or not row_id or row_id in seen:
+            raise MatrixError("matrix row identifiers must be unique non-empty strings")
+        seen.add(row_id)
+        if profile not in source.get("profiles", []):
+            continue
+        if not include_manual and not source.get("enabled_by_default", False):
+            continue
+        row = replace_variables(source, variables)
+        expected_by_profile = row.pop("expected_outcome_by_profile", None)
+        if expected_by_profile is not None:
+            if not isinstance(expected_by_profile, dict) or profile not in expected_by_profile:
+                raise MatrixError(f"matrix row {row_id} lacks an expected outcome for profile {profile}")
+            row["expected_outcome"] = expected_by_profile[profile]
+        rows.append(row)
+    if not rows:
+        raise MatrixError(f"matrix has no rows for profile {profile}")
+    return rows
+
+
+def selector_required_wi3_matrix_ids(authority: dict[str, Any]) -> list[str]:
+    return sorted(
+        str(workload["id"])
+        for workload in authority["workload_matrices"]
+        if isinstance(workload.get("execution"), dict)
+        and workload["execution"].get("enabled_by_default") is True
+    )
+
+
+def sample_discipline(matrix_path: Path) -> dict[str, int]:
+    value = load_json(matrix_path).get("sample_discipline")
+    required = {"cold_samples", "warmups_discarded", "warm_samples_per_repeat", "warm_repeats"}
+    if not isinstance(value, dict) or set(value) != required:
+        raise MatrixError("matrix sample_discipline contract is incomplete")
+    result = {key: int(value[key]) for key in required}
+    if any(number <= 0 for number in result.values()):
+        raise MatrixError("matrix sample discipline values must be positive")
+    return result
+
+
+def resolve_sample_discipline(matrix_path: Path, args: argparse.Namespace) -> dict[str, Any]:
+    declared = sample_discipline(matrix_path)
+    if args.cohort == "warm":
+        warmups = declared["warmups_discarded"] if args.warmups is None else args.warmups
+        repeats = declared["warm_repeats"] if args.repeats is None else args.repeats
+        samples = declared["warm_samples_per_repeat"] if args.samples_per_repeat is None else args.samples_per_repeat
+        if warmups < declared["warmups_discarded"] or repeats < declared["warm_repeats"] or samples < declared["warm_samples_per_repeat"]:
+            raise MatrixError("warm sample overrides cannot be below the matrix-declared discipline")
+        return {"cohort": "warm", "warmups": warmups, "repeats": repeats, "samples_per_repeat": samples,
+                "declared": declared, "activation_id": None, "cold_sample_index": None}
+    if args.warmups not in (None, 0) or args.repeats not in (None, 1) or args.samples_per_repeat not in (None, 1):
+        raise MatrixError("a cold activation run records exactly one sample with no warmups")
+    if not args.activation_id or args.cold_sample_index is None:
+        raise MatrixError("cold runs require --activation-id and --cold-sample-index")
+    if not 1 <= args.cold_sample_index <= declared["cold_samples"]:
+        raise MatrixError("--cold-sample-index is outside the declared cold campaign")
+    return {"cohort": "cold", "warmups": 0, "repeats": 1, "samples_per_repeat": 1,
+            "declared": declared, "activation_id": args.activation_id, "cold_sample_index": args.cold_sample_index}
+
+
+def command_text(tool: str, arguments: dict[str, Any]) -> str:
+    payload = json.dumps(arguments, separators=(",", ":"), sort_keys=True)
+    return f"{tool} {payload}"
+
+
+def classify_process(returncode: int, stderr: str, response: bytes) -> tuple[str, bool]:
+    """Fallback classification used only when the authoritative trace is absent."""
+    lowered = stderr.lower()
+    if "timed out" in lowered or "timeout" in lowered:
+        return "timeout", True
+    if "transport closed" in lowered or "connection closed" in lowered or "broken pipe" in lowered:
+        return "transport_closed", True
+    if returncode:
+        return "client_error", True
+    return ("success", False) if response else ("client_error", True)
+
+
+def classify_sample(trace: dict[str, Any] | None, returncode: int, stderr: str, response: bytes) -> tuple[str, bool]:
+    if trace is not None:
+        outcome = str(trace.get("outcome") or "client_error")
+        return outcome, bool(trace.get("is_error")) or outcome != "success"
+    return classify_process(returncode, stderr, response)
+
+
+def validate_expected(sample: dict[str, Any]) -> None:
+    expected = sample["expected_outcome"]
+    actual = sample["outcome"]
+    if expected in SUCCESS_EXPECTATIONS and actual != "success":
+        raise MatrixError(f"{sample['sample_id']} expected {expected}, got {actual}")
+    if expected == "cap_hit_success" and sample.get("cap_hit") is not True:
+        raise MatrixError(f"{sample['sample_id']} expected a response cap to be hit")
+    if expected == "retryable_error" and actual != "tool_error":
+        raise MatrixError(f"{sample['sample_id']} expected retryable error, got {actual}")
+    if expected == "expected_timeout" and actual != "timeout":
+        raise MatrixError(f"{sample['sample_id']} expected timeout, got {actual}")
+
+
+def invalid_connection_cohorts(samples: Iterable[dict[str, Any]]) -> dict[str, str]:
+    invalid: dict[str, str] = {}
+    terminal: dict[str, str] = {}
+    for sample in samples:
+        cohort = str(sample.get("connection_cohort") or "")
+        sample_id = str(sample.get("sample_id") or "unknown")
+        if cohort in terminal:
+            invalid.setdefault(cohort, f"{sample_id} occurs after terminal sample {terminal[cohort]}")
+            continue
+        outcome = sample.get("outcome")
+        expected = sample.get("expected_outcome")
+        if outcome in TERMINAL_OUTCOMES:
+            terminal[cohort] = sample_id
+            if expected != "expected_timeout":
+                invalid.setdefault(cohort, f"{sample_id} has unexpected terminal outcome {outcome}")
+        if len(sample.get("client_trace", [])) != 1:
+            invalid.setdefault(cohort, f"{sample_id} has missing or duplicate client trace")
+    return invalid
+
+
+def validate_connection_cohorts(samples: Iterable[dict[str, Any]]) -> None:
+    invalid = invalid_connection_cohorts(samples)
+    if invalid:
+        raise MatrixError("; ".join(f"{cohort}: {reason}" for cohort, reason in sorted(invalid.items())))
+
+
+def validate_delivery_terminals(
+    events: list[dict[str, Any]],
+    lifecycle_events: list[dict[str, Any]],
+    samples: list[dict[str, Any]],
+) -> None:
+    request_connections: dict[str, tuple[str, int | None]] = {}
+    for event in lifecycle_events:
+        identity = event.get("request_identity")
+        if not isinstance(identity, dict):
+            continue
+        invocation_id = identity.get("app_invocation_id")
+        connection_id = identity.get("connection_id")
+        if invocation_id and connection_id:
+            generation = identity.get("connection_generation")
+            request_connections[canonical_invocation_id(invocation_id)] = (
+                str(connection_id), int(generation) if isinstance(generation, int) else None,
+            )
+    expected_timeout_ids = {
+        canonical_invocation_id(sample["invocation_id"])
+        for sample in samples
+        if sample.get("expected_outcome") == "expected_timeout"
+    }
+    missing_correlations = sorted(expected_timeout_ids - set(request_connections))
+    if missing_correlations:
+        raise MatrixError(
+            "expected-timeout requests omitted authoritative server correlation: "
+            + ", ".join(missing_correlations)
+        )
+    expected_connections = {request_connections[invocation_id] for invocation_id in expected_timeout_ids}
+    retained_connections = {
+        request_connections[canonical_invocation_id(sample["invocation_id"])]
+        for sample in samples
+        if sample.get("expected_outcome") != "expected_timeout"
+        and canonical_invocation_id(sample["invocation_id"]) in request_connections
+    }
+    terminal_counts = Counter(
+        (str(event["connection_id"]), int(event["connection_generation"])
+         if isinstance(event.get("connection_generation"), int) else None)
+        for event in events
+        if (event.get("terminal_reason") or event.get("phase") == "connection_terminal")
+        and event.get("connection_id")
+    )
+    terminal_connections = set(terminal_counts)
+    unexpected = (terminal_connections & retained_connections) - expected_connections
+    if unexpected:
+        rendered = ", ".join(
+            f"{connection}@{generation}"
+            for connection, generation in sorted(unexpected, key=lambda item: (item[0], str(item[1])))
+        )
+        raise MatrixError(
+            "server delivery capture terminalized a retained connection cohort: " + rendered
+        )
+    for connection in expected_connections:
+        if terminal_counts[connection] != 1:
+            raise MatrixError(
+                "expected-timeout connection requires exactly one authoritative terminal event: "
+                f"{connection[0]}@{connection[1]} got {terminal_counts[connection]}"
+            )
+
+
+def baseline_key(sample: dict[str, Any]) -> str:
+    return "/".join((sample["row_id"], sample["format"], sample["client_mode"]))
+
+
+def apply_baseline(
+    samples: list[dict[str, Any]],
+    sidecar: Path,
+    update: bool,
+    wi3_work_count_signature: dict[str, Any] | None = None,
+) -> None:
+    grouped: dict[str, set[tuple[str, int]]] = defaultdict(set)
+    for sample in samples:
+        grouped[baseline_key(sample)].add((sample["response_sha256"], sample["response_byte_count"]))
+    unstable = [key for key, values in grouped.items() if len(values) != 1]
+    if unstable:
+        raise MatrixError("response bytes changed within cohort: " + ", ".join(unstable))
+    current = {
+        key: {"sha256": next(iter(values))[0], "byte_count": next(iter(values))[1]}
+        for key, values in grouped.items()
+    }
+    if update:
+        payload: dict[str, Any] = {"schema_version": SCHEMA_VERSION, "responses": current}
+        if wi3_work_count_signature is not None:
+            payload["wi3_work_count_parity"] = wi3_work_count_signature
+        save_json(sidecar, payload)
+        return
+    if not sidecar.is_file():
+        raise MatrixError(f"baseline sidecar missing: {sidecar}; use --update-baseline after reviewing outputs")
+    expected_payload = load_json(sidecar)
+    expected = expected_payload.get("responses", {})
+    failures = sorted(
+        key for key in set(current) | set(expected)
+        if current.get(key) != expected.get(key)
+    )
+    if failures:
+        raise MatrixError("response parity mismatch (missing, extra, or changed): " + ", ".join(failures))
+    if wi3_work_count_signature is not None:
+        expected_work_counts = expected_payload.get("wi3_work_count_parity")
+        if expected_work_counts is None:
+            raise MatrixError("WI-3 work-count baseline missing; update the reviewed DEBUG sidecar")
+        if expected_work_counts != wi3_work_count_signature:
+            raise MatrixError("WI-3 work-count parity mismatch")
+
+
+def read_trace(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise MatrixError(f"invalid trace JSON at {path}:{line_number}") from error
+        forbidden = {"arguments", "path", "content", "output_text", "result_text"}.intersection(value)
+        if forbidden:
+            raise MatrixError(f"trace contains forbidden fields: {sorted(forbidden)}")
+        records.append(value)
+    return records
+
+
+def run_cli(command: list[str], *, cwd: Path, env: dict[str, str], timeout: float) -> subprocess.CompletedProcess[bytes]:
+    try:
+        return subprocess.run(command, cwd=cwd, env=env, capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired as error:
+        stdout = error.stdout or b""
+        stderr = (error.stderr or b"") + b"\nrunner timeout"
+        return subprocess.CompletedProcess(command, 124, stdout, stderr)
+
+
+def call_debug_tool(cli: Path, window_id: int, payload: dict[str, Any], timeout: float) -> Any:
+    routed = {**payload, "_windowID": window_id}
+    command = [str(cli), "--raw-json", "-w", str(window_id), "-c", DEBUG_TOOL, "-j", json.dumps(routed)]
+    process = run_cli(command, cwd=repo_root(), env={key: value for key, value in os.environ.items() if key != TRACE_ENV}, timeout=timeout)
+    if process.returncode:
+        raise MatrixError(process.stderr.decode("utf-8", errors="replace").strip() or "debug diagnostics call failed")
+    return json.loads(process.stdout.decode("utf-8"))
+
+
+def find_named_object(value: Any, key: str) -> Any:
+    if isinstance(value, dict):
+        if key in value:
+            return value[key]
+        for child in value.values():
+            found = find_named_object(child, key)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = find_named_object(child, key)
+            if found is not None:
+                return found
+    return None
+
+
+def probe_server_app_identity(
+    cli: Path, window_id: int, timeout: float, expected_configuration: str,
+) -> dict[str, Any]:
+    response = call_debug_tool(
+        cli, window_id, {"op": "mcp_latency_server_identity"}, timeout,
+    )
+    identity = find_named_object(response, "server_app_identity")
+    if not isinstance(identity, dict):
+        raise MatrixError("server identity probe returned no server_app_identity")
+    if identity.get("identity_authority") != "server_process":
+        raise MatrixError("server identity probe is not process-authoritative")
+    if identity.get("app_configuration") != expected_configuration:
+        raise MatrixError(
+            f"server configuration mismatch: expected {expected_configuration}, "
+            f"got {identity.get('app_configuration')}"
+        )
+    if identity.get("diagnostic_surface") != "mcp_latency_v1":
+        raise MatrixError("server identity probe returned the wrong diagnostic surface")
+    for field in ("process_identifier", "bundle_path", "executable_path", "executable_sha256"):
+        if not identity.get(field):
+            raise MatrixError(f"server identity probe omitted {field}")
+    return identity
+
+
+def validate_optimized_artifact_manifest(path: Path) -> dict[str, Any]:
+    path = path.expanduser().resolve()
+    manifest = load_json(path)
+    required = {
+        "artifact_kind": "optimized_mcp_latency_diagnostic_server",
+        "ordinary_release_artifact": False,
+        "swift_configuration": "release",
+        "server_diagnostic_configuration": "optimized_diagnostic",
+        "diagnostic_surface": "mcp_latency_v1",
+        "signing_mode": "mcp-latency-diagnostic-adhoc",
+        "secure_storage_backend": "alternate-in-memory",
+        "enabled_defines_by_target": {
+            "RepoPromptApp": ["MCP_LATENCY_DIAGNOSTICS"],
+            "RepoPromptDomainRuntime": ["MCP_LATENCY_DIAGNOSTICS"],
+            "RepoPromptMCP": ["MCP_LATENCY_TRACE"],
+            "RepoPromptShared": ["MCP_LATENCY_DIAGNOSTICS"],
+        },
+    }
+    for field, expected in required.items():
+        if manifest.get(field) != expected:
+            raise MatrixError(f"optimized server artifact manifest mismatch: {field}")
+    for field in ("artifact_id", "commit", "source_fingerprint_sha256", "bundle_path",
+                  "bundle_identifier", "executable_path", "executable_sha256",
+                  "embedded_cli_path", "embedded_cli_sha256", "provenance_path",
+                  "provenance_sha256"):
+        if not manifest.get(field):
+            raise MatrixError(f"optimized server artifact manifest omitted {field}")
+    canonical_root = (repo_root() / ".build/mcp-latency/optimized-server").resolve()
+    if path != canonical_root / "artifact-manifest.json":
+        raise MatrixError("optimized server artifact manifest is not at the canonical isolated path")
+    bundle = Path(manifest["bundle_path"]).resolve()
+    if bundle != canonical_root / "RepoPrompt.app":
+        raise MatrixError("optimized server bundle is not at the canonical isolated path")
+    if manifest.get("bundle_identifier") != "com.pvncher.repoprompt.ce.mcp-latency-diagnostic":
+        raise MatrixError("optimized server bundle identifier mismatch")
+    executable = Path(manifest["executable_path"]).resolve()
+    embedded_cli = Path(manifest["embedded_cli_path"]).resolve()
+    provenance = Path(manifest["provenance_path"]).resolve()
+    try:
+        bundle.relative_to(path.parent)
+        executable.relative_to(bundle)
+        embedded_cli.relative_to(bundle)
+        provenance.relative_to(bundle)
+    except ValueError as error:
+        raise MatrixError("optimized server artifact member escapes its isolated artifact root") from error
+    for member, digest_field in (
+        (executable, "executable_sha256"),
+        (embedded_cli, "embedded_cli_sha256"),
+        (provenance, "provenance_sha256"),
+    ):
+        if not member.is_file():
+            raise MatrixError(f"optimized server artifact member is missing: {member}")
+        if sha256_bytes(member.read_bytes()) != manifest[digest_field]:
+            raise MatrixError(f"optimized server artifact member hash mismatch: {digest_field}")
+    provenance_payload = load_json(provenance)
+    for field in ("artifact_id", "artifact_kind", "ordinary_release_artifact",
+                  "swift_configuration", "server_diagnostic_configuration",
+                  "diagnostic_surface", "enabled_defines_by_target", "commit", "dirty",
+                  "source_fingerprint_sha256"):
+        if provenance_payload.get(field) != manifest.get(field):
+            raise MatrixError(f"optimized server provenance mismatch: {field}")
+    return manifest
+
+
+def validate_runtime_artifact_identity(identity: dict[str, Any], artifact: dict[str, Any]) -> None:
+    for field in ("bundle_path", "bundle_identifier", "signing_mode", "secure_storage_backend",
+                  "executable_path", "executable_sha256", "embedded_cli_path",
+                  "embedded_cli_sha256", "provenance_sha256"):
+        if identity.get(field) != artifact.get(field):
+            raise MatrixError(f"running optimized server does not match artifact manifest: {field}")
+    provenance = identity.get("provenance")
+    if not isinstance(provenance, dict) or provenance.get("artifact_id") != artifact.get("artifact_id"):
+        raise MatrixError("running optimized server provenance artifact ID mismatch")
+    for field in ("commit", "dirty", "source_fingerprint_sha256"):
+        if provenance.get(field) != artifact.get(field):
+            raise MatrixError(f"running optimized server provenance mismatch: {field}")
+
+
+def runtime_work_counters(payload: Any) -> dict[str, int]:
+    runtime = find_named_object(payload, "runtime")
+    if not isinstance(runtime, dict):
+        raise MatrixError("WI-3 runtime snapshot is missing `runtime`")
+    counters: defaultdict[str, int] = defaultdict(int)
+    for window in runtime.get("windows", []):
+        if not isinstance(window, dict):
+            continue
+        store = window.get("store_work") or {}
+        catalog = store.get("catalog_rebuild") or {}
+        shards = store.get("root_catalog_shards") or {}
+        counters["catalog_rebuild_count"] += int(catalog.get("count", 0))
+        counters["catalog_shard_build_count"] += int(shards.get("total_build_count", 0))
+        counters["catalog_shard_backstop_count"] += int(shards.get("total_backstop_count", 0))
+        counters["catalog_shadow_comparison_count"] += int(shards.get("shadow_comparison_count", 0))
+        counters["catalog_shadow_mismatch_count"] += int(shards.get("shadow_mismatch_count", 0))
+        counters["catalog_invalidation_event_count"] += len(store.get("invalidations", []))
+
+        search = window.get("search_rebuild") or {}
+        counters["search_rebuild_count"] += int(search.get("count", 0))
+        counters["search_debounce_cancellation_count"] += int(search.get("debounce_cancellation_count", 0))
+        counters["search_stale_discarded_count"] += int(search.get("stale_discarded_count", 0))
+
+        projection = window.get("ui_index_rebuild") or {}
+        counters["ui_projection_rebuild_count"] += int(projection.get("count", 0))
+        counters["ui_projection_visited_folder_count"] += int(projection.get("visited_folder_count", 0))
+        counters["ui_projection_visited_file_count"] += int(projection.get("visited_file_count", 0))
+
+        for root in window.get("roots", []):
+            if not isinstance(root, dict):
+                continue
+            counters["crawl_count"] += int(root.get("crawl_count", 0))
+            counters["active_watcher_count"] += 1 if root.get("watcher_active") is True else 0
+            barrier = root.get("barrier") or {}
+            for field in ("launch_count", "join_count", "successor_count", "coalesced_successor_count", "completion_count", "noop_count"):
+                counters["freshness_barrier_" + field] += int(barrier.get(field, 0))
+            freshness = root.get("freshness") or {}
+            for field in ("flush_call_count", "noop_flush_count", "debounce_cancellation_count", "watcher_batch_count", "watcher_batch_event_count"):
+                counters["freshness_" + field] += int(freshness.get(field, 0))
+
+    for duplication in runtime.get("physical_root_duplication", []):
+        if not isinstance(duplication, dict):
+            continue
+        counters["duplicated_window_count"] += int(duplication.get("window_count", 0))
+        counters["duplication_watcher_count"] += int(duplication.get("watcher_count", 0))
+        counters["duplication_crawl_count"] += int(duplication.get("crawl_count", 0))
+        counters["current_freshness_flight_count"] += int(duplication.get("current_freshness_flight_count", 0))
+        counters["total_freshness_flight_launch_count"] += int(duplication.get("total_freshness_flight_launch_count", 0))
+
+    tool_work = runtime.get("tool_work") or {}
+    reads = [item for item in tool_work.get("read_file_invocations", []) if isinstance(item, dict)]
+    counters["read_file_invocation_count"] = len(reads)
+    counters["read_file_full_bytes"] = sum(int(item.get("read_bytes", 0)) for item in reads)
+    counters["read_file_returned_bytes"] = sum(int(item.get("returned_bytes", 0)) for item in reads)
+    counters["read_file_returned_lines"] = sum(int(item.get("returned_lines", 0)) for item in reads)
+    counters["read_file_cache_hit_count"] = sum(1 for item in reads if item.get("cache_hit") is True)
+    git = [item for item in tool_work.get("git_invocations", []) if isinstance(item, dict)]
+    counters["git_invocation_count"] = len(git)
+    counters["git_command_count"] = sum(int(item.get("command_count", 0)) for item in git)
+    return dict(sorted(counters.items()))
+
+
+def observed_lane_capacities(runtime_payload: Any, admission_payload: Any) -> dict[str, int]:
+    runtime = find_named_object(runtime_payload, "runtime")
+    admission = find_named_object(admission_payload, "admission")
+    if not isinstance(runtime, dict) or not isinstance(admission, dict):
+        raise MatrixError("WI-3 lane-capacity snapshots are incomplete")
+    limiter = runtime.get("limiter") or {}
+    lanes = limiter.get("lanes") or {}
+    store_capacities = {
+        int(item.get("configuration", {}).get("active_capacity", 0))
+        for item in admission.get("lanes", [])
+        if isinstance(item, dict)
+    }
+    if len(store_capacities) != 1:
+        raise MatrixError("WI-3 store search lanes do not share one authoritative capacity")
+    return {
+        "connection_ordinary": int((lanes.get("ordinary") or {}).get("limit", 0)),
+        "connection_file_search": int((lanes.get("file_search") or {}).get("limit", 0)),
+        "store_file_search": next(iter(store_capacities)),
+    }
+
+
+def project_wi3_work_counts(
+    runtime_before: Any,
+    runtime_after: Any,
+    admission_before: Any,
+    admission_after: Any,
+    authority: dict[str, Any],
+    executed_matrix_ids: Iterable[str] = (),
+) -> dict[str, Any]:
+    expected_capacities = authority["lane_capacities"]
+    before_capacities = observed_lane_capacities(runtime_before, admission_before)
+    after_capacities = observed_lane_capacities(runtime_after, admission_after)
+    if before_capacities != expected_capacities or after_capacities != expected_capacities:
+        raise MatrixError("observed lane capacities do not match the WI-3 authority")
+    before = runtime_work_counters(runtime_before)
+    after = runtime_work_counters(runtime_after)
+    names = sorted(set(before) | set(after))
+    deltas = {name: max(0, after.get(name, 0) - before.get(name, 0)) for name in names}
+    declared_matrix_ids = {item["id"] for item in authority["workload_matrices"]}
+    matrix_ids = sorted(set(executed_matrix_ids))
+    if not set(matrix_ids).issubset(declared_matrix_ids):
+        raise MatrixError("executed WI-3 workload IDs are not declared by the authority")
+    gauge_names = {
+        "active_watcher_count",
+        "current_freshness_flight_count",
+        "duplicated_window_count",
+        "duplication_watcher_count",
+    }
+    gauge_before = {name: before.get(name, 0) for name in sorted(gauge_names)}
+    gauge_after = {name: after.get(name, 0) for name in sorted(gauge_names)}
+    parity_signature = {
+        "authority_baseline_commit": authority["baseline_commit"],
+        "workload_matrix_ids": matrix_ids,
+        "lane_capacities": after_capacities,
+        "counter_deltas": deltas,
+        "gauge_before": gauge_before,
+        "gauge_after": gauge_after,
+    }
+    return {
+        "authority_source": authority["source"],
+        "snapshot_surfaces": authority["snapshot_surfaces"],
+        "workload_matrices": [
+            item for item in authority["workload_matrices"] if item["id"] in set(matrix_ids)
+        ],
+        "lane_capacity_evidence": {
+            "expected": expected_capacities,
+            "before": before_capacities,
+            "after": after_capacities,
+            "matches_authority": True,
+        },
+        "counter_before": before,
+        "counter_after": after,
+        "counter_deltas": deltas,
+        "gauge_before": gauge_before,
+        "gauge_after": gauge_after,
+        "parity_signature": parity_signature,
+    }
+
+
+def response_is_json(response: bytes) -> bool:
+    try:
+        json.loads(response.decode("utf-8"))
+        return True
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+
+
+def response_hit_cap(response: bytes) -> bool:
+    try:
+        decoded = json.loads(response.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        text = response.decode("utf-8", errors="replace")
+        return "Partial (limit reached)" in text or "results trimmed by response size cap" in text
+
+    def contains_cap(value: Any) -> bool:
+        if isinstance(value, dict):
+            if value.get("limit_hit") is True or value.get("size_limit_hit") is True:
+                return True
+            return any(contains_cap(child) for child in value.values())
+        if isinstance(value, list):
+            return any(contains_cap(child) for child in value)
+        return False
+
+    return contains_cap(decoded)
+
+
+def invocation_arguments(row: dict[str, Any], output_format: str, window_id: int, invocation_id: str) -> dict[str, Any]:
+    arguments = {**row.get("arguments", {}), "_windowID": window_id, "_latencyTraceID": invocation_id}
+    if output_format == "raw":
+        arguments["_rawJSON"] = True
+    else:
+        arguments.pop("_rawJSON", None)
+    return arguments
+
+
+def create_sample(
+    row: dict[str, Any],
+    output_format: str,
+    client_mode: str,
+    cohort: str,
+    cohort_kind: str,
+    invocation_id: str,
+    response: bytes,
+    process: subprocess.CompletedProcess[bytes],
+    trace_records: list[dict[str, Any]],
+    elapsed_ms: float | None,
+    phase: str = "recorded",
+    workload_matrix_id: str | None = None,
+) -> dict[str, Any]:
+    matching = [record for record in trace_records if record.get("invocation_id") == invocation_id]
+    trace = matching[0] if len(matching) == 1 else None
+    outcome, is_error = classify_sample(
+        trace,
+        process.returncode,
+        process.stderr.decode("utf-8", errors="replace"),
+        response,
+    )
+    sample = {
+        "sample_id": f"{row['id']}:{output_format}:{client_mode}:r{row.get('_repeat', 0)}:s{row.get('_sample', 0)}:{invocation_id}",
+        "invocation_id": invocation_id,
+        "row_id": row["id"],
+        "tool": row["tool"],
+        "format": output_format,
+        "client_mode": client_mode,
+        "cohort_kind": cohort_kind,
+        "phase": phase,
+        "connection_cohort": cohort,
+        "expected_outcome": row["expected_outcome"],
+        "outcome": outcome,
+        "is_error": is_error,
+        "process_elapsed_ms": round(elapsed_ms, 3) if elapsed_ms is not None else None,
+        "response_byte_count": len(response),
+        "response_sha256": sha256_bytes(response),
+        "response_is_json": response_is_json(response),
+        "returncode": process.returncode,
+        "repeat_ordinal": row.get("_repeat", 0),
+        "sample_ordinal": row.get("_sample", 0),
+        "cap_hit": response_hit_cap(response),
+        "client_trace": matching,
+    }
+    if workload_matrix_id is not None:
+        sample["workload_matrix_id"] = workload_matrix_id
+    return sample
+
+
+def run_fresh(
+    cli: Path,
+    window_id: int,
+    rows: list[dict[str, Any]],
+    capture: Path,
+    timeout: float,
+    cohort_kind: str,
+    phase: str,
+) -> list[dict[str, Any]]:
+    samples = []
+    for ordinal, row in enumerate(rows):
+        for output_format in row["formats"]:
+            invocation_id = new_invocation_id()
+            arguments = invocation_arguments(row, output_format, window_id, invocation_id)
+            trace = capture / "traces" / f"fresh-{phase}-{ordinal:05d}-{output_format}-{invocation_id}.jsonl"
+            trace.parent.mkdir(parents=True, exist_ok=True)
+            env = {**os.environ, TRACE_ENV: str(trace.resolve())}
+            command = [str(cli)]
+            if output_format == "raw":
+                command.append("--raw-json")
+            command.extend(["-w", str(window_id), "-c", row["tool"], "-j", json.dumps(arguments, separators=(",", ":"), sort_keys=True)])
+            started = time.perf_counter_ns()
+            process = run_cli(command, cwd=repo_root(), env=env, timeout=timeout)
+            elapsed = (time.perf_counter_ns() - started) / 1_000_000
+            response = process.stdout
+            raw_path = capture / "responses" / f"fresh-{phase}-{ordinal:05d}-{output_format}-{invocation_id}.out"
+            raw_path.parent.mkdir(parents=True, exist_ok=True)
+            raw_path.write_bytes(response)
+            records = read_trace(trace)
+            sample = create_sample(
+                row, output_format, "fresh", f"fresh-{invocation_id}", cohort_kind,
+                invocation_id, response, process, records, elapsed, phase,
+            )
+            sample["trace_file"] = str(trace.relative_to(capture))
+            samples.append(sample)
+    return samples
+
+
+def run_fresh_with_recovery(
+    cli: Path,
+    window_id: int,
+    rows: list[dict[str, Any]],
+    capture: Path,
+    timeout: float,
+    cohort_kind: str,
+    phase: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    retained: list[dict[str, Any]] = []
+    discarded_invalid: list[dict[str, Any]] = []
+    for row in rows:
+        for generation in range(2):
+            generation_samples = run_fresh(
+                cli, window_id, [row], capture, timeout, cohort_kind,
+                f"{phase}-g{generation}",
+            )
+            for sample in generation_samples:
+                sample["phase"] = phase
+            invalid = invalid_connection_cohorts(generation_samples)
+            if not invalid:
+                retained.extend(generation_samples)
+                break
+            for sample in generation_samples:
+                sample["discard_reason"] = next(iter(invalid.values()))
+            discarded_invalid.extend(generation_samples)
+        else:
+            raise MatrixError(
+                f"fresh row {row['id']} remained invalid after reconnect"
+            )
+    return retained, discarded_invalid
+
+
+def run_persistent_generation(
+    cli: Path,
+    window_id: int,
+    warmup_rows_for_generation: list[dict[str, Any]],
+    recorded_rows: list[dict[str, Any]],
+    capture: Path,
+    timeout: float,
+    cohort_kind: str,
+    generation: int,
+    cohort_label: str,
+) -> list[dict[str, Any]]:
+    cohort = f"persistent-{cohort_label}-g{generation}"
+    trace = (capture / "traces" / f"{cohort}.jsonl").resolve()
+    trace.parent.mkdir(parents=True, exist_ok=True)
+    command = [str(cli), "-w", str(window_id)]
+    ordered: list[tuple[dict[str, Any], str, str, Path, str]] = []
+    all_rows = [(row, "warmup") for row in warmup_rows_for_generation] + [(row, "recorded") for row in recorded_rows]
+    for ordinal, (row, phase) in enumerate(all_rows):
+        for output_format in row["formats"]:
+            invocation_id = new_invocation_id()
+            arguments = invocation_arguments(row, output_format, window_id, invocation_id)
+            response_path = (capture / "responses" / f"{cohort}-{phase}-{ordinal:05d}-{output_format}-{invocation_id}.out").resolve()
+            response_path.parent.mkdir(parents=True, exist_ok=True)
+            command.extend(["-e", f"{command_text(row['tool'], arguments)} > {shlex.quote(str(response_path))}"])
+            ordered.append((row, output_format, invocation_id, response_path, phase))
+    env = {**os.environ, TRACE_ENV: str(trace)}
+    process = run_cli(command, cwd=repo_root(), env=env, timeout=timeout * max(1, len(ordered)))
+    traces = read_trace(trace)
+    samples = []
+    for row, output_format, invocation_id, response_path, phase in ordered:
+        response = response_path.read_bytes() if response_path.exists() else b""
+        sample = create_sample(
+            row, output_format, "persistent", cohort, cohort_kind, invocation_id,
+            response, process, traces, None, phase,
+        )
+        sample["trace_file"] = str(trace.relative_to(capture))
+        samples.append(sample)
+    return samples
+
+
+def run_persistent_with_recovery(
+    cli: Path,
+    window_id: int,
+    warmup_rows_for_generation: list[dict[str, Any]],
+    recorded_rows: list[dict[str, Any]],
+    capture: Path,
+    timeout: float,
+    cohort_kind: str,
+    cohort_label: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    discarded_invalid: list[dict[str, Any]] = []
+    for generation in range(2):
+        generation_samples = run_persistent_generation(
+            cli, window_id, warmup_rows_for_generation, recorded_rows, capture,
+            timeout, cohort_kind, generation, cohort_label,
+        )
+        invalid = invalid_connection_cohorts(generation_samples)
+        if not invalid:
+            warmups = [sample for sample in generation_samples if sample["phase"] == "warmup"]
+            recorded = [sample for sample in generation_samples if sample["phase"] == "recorded"]
+            return recorded, warmups, discarded_invalid
+        for sample in generation_samples:
+            sample["discard_reason"] = next(iter(invalid.values()))
+        discarded_invalid.extend(generation_samples)
+    raise MatrixError(f"persistent cohort {cohort_label} remained invalid after reconnect and re-warm")
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, math.ceil(len(ordered) * fraction) - 1))
+    return ordered[index]
+
+
+def validate_capture_contract(capture: dict[str, Any]) -> None:
+    expected = {
+        "capture_mode": SERVER_CAPTURE_MODE,
+        "sample_capacity_unit": SERVER_SAMPLE_CAPACITY_UNIT,
+        "percentile_semantics": SERVER_PERCENTILE_SEMANTICS,
+        "lifecycle_capture_contract": "s0_s7_required_boundaries",
+        "stage_capture_contract": "w2_selector_stages",
+    }
+    for field, value in expected.items():
+        if capture.get(field) != value:
+            raise MatrixError(f"server capture contract mismatch: {field}")
+    if capture.get("lifecycle_event_allowlist") != LIFECYCLE_EVENT_ALLOWLIST:
+        raise MatrixError("server capture lifecycle allowlist mismatch")
+    if capture.get("stage_name_allowlist") != SERVER_STAGE_NAME_ALLOWLIST:
+        raise MatrixError("server capture stage allowlist mismatch")
+
+
+def validate_capture_begin(capture: dict[str, Any]) -> None:
+    validate_capture_contract(capture)
+    if capture.get("active") is not True:
+        raise MatrixError("server capture begin did not activate evidence mode")
+
+
+def validate_capture_integrity(capture: dict[str, Any]) -> None:
+    validate_capture_contract(capture)
+    for field in ("dropped_sample_count", "dropped_lifecycle_event_count"):
+        if int(capture.get(field, 0)) != 0:
+            raise MatrixError(f"debug capture has nonzero {field}")
+    if capture.get("active") is True:
+        raise MatrixError("debug capture was not finished")
+
+    stages = capture.get("stages")
+    if not isinstance(stages, list):
+        raise MatrixError("server capture stages are missing")
+    retained = int(capture.get("retained_sample_count", -1))
+    dropped = int(capture.get("dropped_sample_count", -1))
+    ignored = int(capture.get("ignored_out_of_contract_sample_count", -1))
+    if int(capture.get("retained_aggregate_key_count", -1)) != len(stages):
+        raise MatrixError("server capture aggregate-key count mismatch")
+    if sum(int(stage.get("sample_count", -1)) for stage in stages) != retained:
+        raise MatrixError("server capture retained sample accounting mismatch")
+    if int(capture.get("observed_sample_count", -1)) != retained + dropped + ignored:
+        raise MatrixError("server capture observed sample accounting mismatch")
+    for stage in stages:
+        if stage.get("stage_name") not in SERVER_STAGE_NAME_ALLOWLIST:
+            raise MatrixError("server capture retained an out-of-contract stage")
+        if stage.get("p50_ms") is not None or stage.get("p95_ms") is not None:
+            raise MatrixError("server evidence capture unexpectedly retained per-span percentiles")
+        for field in ("total_ms", "max_ms"):
+            if not isinstance(stage.get(field), (int, float)) or isinstance(stage.get(field), bool):
+                raise MatrixError(f"server evidence capture has invalid {field}")
+
+    lifecycle = capture.get("lifecycle_events")
+    if not isinstance(lifecycle, list):
+        raise MatrixError("server capture lifecycle events are missing")
+    if any(event.get("event_name") not in LIFECYCLE_EVENT_ALLOWLIST for event in lifecycle):
+        raise MatrixError("server capture retained an out-of-contract lifecycle event")
+    retained_lifecycle = int(capture.get("retained_lifecycle_event_count", -1))
+    dropped_lifecycle = int(capture.get("dropped_lifecycle_event_count", -1))
+    ignored_lifecycle = int(capture.get("ignored_out_of_contract_lifecycle_event_count", -1))
+    if retained_lifecycle != len(lifecycle):
+        raise MatrixError("server capture retained lifecycle accounting mismatch")
+    if int(capture.get("observed_lifecycle_event_count", -1)) \
+            != retained_lifecycle + dropped_lifecycle + ignored_lifecycle:
+        raise MatrixError("server capture observed lifecycle accounting mismatch")
+
+
+def parse_dimensions(raw: str) -> dict[str, str]:
+    return dict(part.split("=", 1) for part in raw.split() if "=" in part)
+
+
+def cohort_key(sample: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (sample["row_id"], sample["format"], sample["client_mode"], sample["cohort_kind"])
+
+
+def cohort_payload(key: tuple[str, str, str, str]) -> dict[str, str]:
+    return dict(zip(("row_id", "format", "client_mode", "cohort_kind"), key))
+
+
+def validate_trace_records(samples: list[dict[str, Any]], configuration: str) -> None:
+    seen: set[str] = set()
+    expected_configuration = "debug" if configuration == "debug" else "optimized_diagnostic"
+    for sample in samples:
+        records = sample.get("client_trace", [])
+        if len(records) != 1:
+            raise MatrixError(f"{sample.get('sample_id', 'unknown')} has missing or duplicate C0-C2 trace records")
+        trace = records[0]
+        invocation_id = str(trace.get("invocation_id") or "")
+        if invocation_id != sample.get("invocation_id") or invocation_id in seen:
+            raise MatrixError("client trace invocation identity is missing, duplicated, or mismatched")
+        seen.add(invocation_id)
+        if trace.get("output_format") != sample.get("format"):
+            raise MatrixError(f"{sample['sample_id']} trace output format mismatch")
+        if trace.get("diagnostic_configuration") != expected_configuration:
+            raise MatrixError(
+                f"{sample['sample_id']} was not emitted by the requested {configuration} diagnostic artifact"
+            )
+
+
+def validate_format_pairs(samples: list[dict[str, Any]]) -> None:
+    grouped: dict[tuple[str, str, str, int, int], dict[str, dict[str, Any]]] = defaultdict(dict)
+    for sample in samples:
+        if sample.get("phase") != "recorded" or sample.get("cohort_kind") == "wi3":
+            continue
+        key = (
+            sample["row_id"], sample["client_mode"], sample["cohort_kind"],
+            int(sample["repeat_ordinal"]), int(sample["sample_ordinal"]),
+        )
+        output_format = sample["format"]
+        if output_format in grouped[key]:
+            raise MatrixError(f"duplicate formatted/raw sample coordinate for {key}: {output_format}")
+        grouped[key][output_format] = sample
+    for key, pair in grouped.items():
+        if set(pair) != {"formatted", "raw"}:
+            raise MatrixError(f"formatted/raw cohort is incomplete for {key}")
+        formatted, raw = pair["formatted"], pair["raw"]
+        if formatted["invocation_id"] == raw["invocation_id"]:
+            raise MatrixError(f"formatted/raw requests reused one invocation identity for {key}")
+        if formatted["outcome"] == "success" and raw["outcome"] == "success" \
+                and formatted["response_sha256"] == raw["response_sha256"]:
+            raise MatrixError(f"formatted/raw response digests are identical for {key}")
+        if formatted["outcome"] == "success":
+            trace = formatted["client_trace"][0]
+            if int(trace.get("text_content_block_count", 0)) < 1 or int(trace.get("returned_text_bytes", 0)) < 1:
+                raise MatrixError(f"formatted response lacks a rendered text block for {key}")
+            if formatted.get("response_is_json") is True:
+                raise MatrixError(f"formatted response unexpectedly contains raw JSON for {key}")
+        if raw["outcome"] == "success":
+            trace = raw["client_trace"][0]
+            if int(trace.get("content_block_count", 0)) != 1 or int(trace.get("text_content_block_count", 0)) != 1:
+                raise MatrixError(f"raw response is not exactly one text content block for {key}")
+            if raw.get("response_is_json") is not True:
+                raise MatrixError(f"raw response is not valid JSON for {key}")
+
+
+def transport_identity_key(identity: dict[str, Any]) -> tuple[str, int, str, int] | None:
+    connection_id = identity.get("connection_id")
+    generation = identity.get("connection_generation")
+    request_id = identity.get("jsonrpc_request_id")
+    ordinal = identity.get("request_ordinal")
+    if not connection_id or not isinstance(generation, int) or not request_id or not isinstance(ordinal, int):
+        return None
+    return str(connection_id), generation, str(request_id), ordinal
+
+
+def phase_index(events: list[dict[str, Any]], *, lifecycle: bool) -> dict[str, dict[str, list[float]]]:
+    grouped: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for event in events:
+        identity = event.get("request_identity") if lifecycle else None
+        invocation_id = (
+            identity.get("app_invocation_id") if isinstance(identity, dict) else event.get("app_invocation_id")
+        )
+        phase = event.get("event_name") if lifecycle else event.get("phase")
+        timestamp = event.get("offset_ms") if lifecycle else event.get("monotonic_uptime_ms")
+        if invocation_id and isinstance(phase, str) and isinstance(timestamp, (int, float)):
+            grouped[canonical_invocation_id(invocation_id)][phase].append(float(timestamp))
+    return {key: dict(value) for key, value in grouped.items()}
+
+
+def transport_phase_index(
+    events: list[dict[str, Any]],
+) -> dict[tuple[str, int, str, int], dict[str, list[float]]]:
+    grouped: dict[tuple[str, int, str, int], dict[str, list[float]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for event in events:
+        key = transport_identity_key(event)
+        phase = event.get("phase")
+        timestamp = event.get("monotonic_uptime_ms")
+        if key and isinstance(phase, str) and isinstance(timestamp, (int, float)):
+            grouped[key][phase].append(float(timestamp))
+    return {key: dict(value) for key, value in grouped.items()}
+
+
+def lifecycle_transport_keys(
+    events: list[dict[str, Any]],
+) -> dict[str, set[tuple[str, int, str, int]]]:
+    grouped: dict[str, set[tuple[str, int, str, int]]] = defaultdict(set)
+    for event in events:
+        identity = event.get("request_identity")
+        if not isinstance(identity, dict):
+            continue
+        invocation_id = identity.get("app_invocation_id")
+        key = transport_identity_key(identity)
+        if invocation_id and key:
+            grouped[canonical_invocation_id(invocation_id)].add(key)
+    return dict(grouped)
+
+
+def stage_attribution_report(
+    samples: list[dict[str, Any]], capture: dict[str, Any], require_server: bool,
+) -> dict[str, Any]:
+    per_stage: defaultdict[str, dict[str, int]] = defaultdict(
+        lambda: {"identified_sample_count": 0, "unidentified_sample_count": 0}
+    )
+    identified_request_ids: set[str] = set()
+    unidentified_stages: list[str] = []
+    for bucket in capture.get("stages", []):
+        stage = str(bucket.get("stage_name") or "")
+        if stage not in LEAF_STAGES and stage not in INCLUSIVE_STAGES:
+            continue
+        sample_count = int(bucket.get("sample_count", 0))
+        identity = bucket.get("request_identity")
+        invocation_id = identity.get("app_invocation_id") if isinstance(identity, dict) else None
+        if invocation_id:
+            per_stage[stage]["identified_sample_count"] += sample_count
+            identified_request_ids.add(canonical_invocation_id(invocation_id))
+        else:
+            per_stage[stage]["unidentified_sample_count"] += sample_count
+            if sample_count > 0:
+                unidentified_stages.append(stage)
+    successful_request_ids = {
+        canonical_invocation_id(sample["invocation_id"])
+        for sample in samples
+        if sample.get("phase") == "recorded" and sample.get("outcome") == "success"
+    }
+    missing_request_ids = sorted(successful_request_ids - identified_request_ids)
+    report = {
+        "status": "complete" if not unidentified_stages and not missing_request_ids else "invalid",
+        "identified_sample_count": sum(row["identified_sample_count"] for row in per_stage.values()),
+        "unidentified_sample_count": sum(row["unidentified_sample_count"] for row in per_stage.values()),
+        "missing_successful_request_ids": missing_request_ids,
+        "per_stage": [
+            {"stage": stage, **counts}
+            for stage, counts in sorted(per_stage.items())
+        ],
+    }
+    if require_server and unidentified_stages:
+        raise MatrixError(
+            "recorded leaf/inclusive stage samples lack request identity: "
+            + ", ".join(sorted(set(unidentified_stages)))
+        )
+    if require_server and missing_request_ids:
+        raise MatrixError(
+            "successful recorded requests lack leaf/inclusive stage samples: "
+            + ", ".join(missing_request_ids)
+        )
+    return report
+
+
+def joined_request_evidence(
+    samples: list[dict[str, Any]],
+    capture: dict[str, Any],
+    delivery_events: list[dict[str, Any]],
+    require_server: bool,
+) -> list[dict[str, Any]]:
+    stage_attribution_report(samples, capture, require_server)
+    stage_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for stage in capture.get("stages", []):
+        identity = stage.get("request_identity")
+        invocation_id = identity.get("app_invocation_id") if isinstance(identity, dict) else None
+        if invocation_id:
+            stage_index[canonical_invocation_id(invocation_id)].append(stage)
+    lifecycle_events = capture.get("lifecycle_events", [])
+    lifecycle = phase_index(lifecycle_events, lifecycle=True)
+    delivery = phase_index(delivery_events, lifecycle=False)
+    delivery_by_transport_identity = transport_phase_index(delivery_events)
+    transport_keys_by_invocation = lifecycle_transport_keys(lifecycle_events)
+    evidence = []
+    for sample in samples:
+        invocation_id = canonical_invocation_id(sample["invocation_id"])
+        trace = sample["client_trace"][0]
+        transport_keys = transport_keys_by_invocation.get(invocation_id, set())
+        delivery_phases = dict(delivery.get(invocation_id, {}))
+        delivery_join_identity = None
+        if len(transport_keys) == 1:
+            transport_key = next(iter(transport_keys))
+            for phase, timestamps in delivery_by_transport_identity.get(transport_key, {}).items():
+                delivery_phases.setdefault(phase, timestamps)
+            delivery_join_identity = {
+                "connection_id": transport_key[0],
+                "connection_generation": transport_key[1],
+                "jsonrpc_request_id": transport_key[2],
+                "request_ordinal": transport_key[3],
+            }
+        item = {
+            "sample": sample,
+            "trace": trace,
+            "stage_buckets": stage_index.get(invocation_id, []),
+            "lifecycle_phases": lifecycle.get(invocation_id, {}),
+            "delivery_phases": delivery_phases,
+            "delivery_join_identity": delivery_join_identity,
+            "boundaries": {
+                "c0_c1_client_call_ms": float(trace.get("call_duration_ms", 0)),
+                "c1_c2_client_output_ms": float(trace.get("print_duration_ms", 0)),
+                "c0_c2_client_total_ms": float(trace.get("call_duration_ms", 0))
+                    + float(trace.get("print_duration_ms", 0)),
+            },
+        }
+        if require_server and sample.get("outcome") == "success":
+            if len(transport_keys) != 1 or delivery_join_identity is None:
+                raise MatrixError(
+                    f"{sample['sample_id']} lacks one exact transport request-identity tuple"
+                )
+            for label, start, end in LIFECYCLE_BOUNDARIES:
+                starts = item["lifecycle_phases"].get(start, [])
+                ends = item["lifecycle_phases"].get(end, [])
+                if len(starts) != 1 or len(ends) != 1 or ends[0] < starts[0]:
+                    raise MatrixError(f"{sample['sample_id']} lacks exact request-identity boundary {label}")
+                item["boundaries"][label] = ends[0] - starts[0]
+            for label, start, end in DELIVERY_BOUNDARIES:
+                starts = item["delivery_phases"].get(start, [])
+                ends = item["delivery_phases"].get(end, [])
+                if len(starts) != 1 or len(ends) != 1 or ends[0] < starts[0]:
+                    raise MatrixError(f"{sample['sample_id']} lacks exact request-identity boundary {label}")
+                item["boundaries"][label] = ends[0] - starts[0]
+            capture_start = capture.get("capture_start_uptime_ms")
+            received = item["lifecycle_phases"].get("MCP.ToolCall.Received", [])
+            writes = item["delivery_phases"].get("transport_write_completed", [])
+            if not isinstance(capture_start, (int, float)) or len(received) != 1 or len(writes) != 1:
+                raise MatrixError(f"{sample['sample_id']} lacks exact request-identity boundary s0_s9_server_total_ms")
+            received_uptime = float(capture_start) + received[0]
+            if writes[0] < received_uptime:
+                raise MatrixError(f"{sample['sample_id']} has negative request-identity boundary s0_s9_server_total_ms")
+            item["boundaries"]["s0_s9_server_total_ms"] = writes[0] - received_uptime
+        evidence.append(item)
+    return evidence
+
+
+def per_request_stage_totals(item: dict[str, Any]) -> tuple[dict[str, float], dict[str, int], list[dict[str, Any]]]:
+    totals: defaultdict[str, float] = defaultdict(float)
+    spans: defaultdict[str, int] = defaultdict(int)
+    relevant_buckets = []
+    for bucket in item["stage_buckets"]:
+        stage = str(bucket.get("stage_name") or "")
+        if stage not in LEAF_STAGES and stage not in INCLUSIVE_STAGES:
+            continue
+        totals[stage] += float(bucket.get("total_ms", 0))
+        spans[stage] += int(bucket.get("sample_count", 0))
+        relevant_buckets.append(bucket)
+    return dict(totals), dict(spans), relevant_buckets
+
+
+def signed_parent_minus_children_residual(
+    parent_ms: float,
+    child_total_ms: float,
+    *,
+    envelope: str,
+    request_id: str,
+) -> float:
+    """Preserve signed residuals; reject overlap beyond aggregate rounding noise.
+
+    Server aggregates are serialized to 0.001 ms. The widest current residual
+    subtracts fewer than ten rounded terms, so 0.01 ms bounds accumulated
+    serialization noise without concealing measurable parent/child overlap.
+    """
+    residual = parent_ms - child_total_ms
+    if residual < -RESIDUAL_OVERLAP_TOLERANCE_MS:
+        raise MatrixError(
+            f"{request_id} has invalid {envelope} residual: "
+            f"parent={parent_ms:.6f}ms children={child_total_ms:.6f}ms "
+            f"residual={residual:.6f}ms tolerance={RESIDUAL_OVERLAP_TOLERANCE_MS:.3f}ms"
+        )
+    return residual
+
+
+def summarize_request_values(
+    values: dict[tuple[tuple[str, str, str, str], str], list[tuple[float, int]]]
+) -> list[dict[str, Any]]:
+    result = []
+    for (key, stage), observations in values.items():
+        durations = [value for value, _ in observations]
+        result.append({
+            "cohort": cohort_payload(key),
+            "stage": stage,
+            "request_count": len(durations),
+            "span_count": sum(spans for _, spans in observations),
+            "p50_ms": round(percentile(durations, 0.5), 3),
+            "p95_ms": round(percentile(durations, 0.95), 3),
+            "total_ms": round(sum(durations), 3),
+        })
+    return sorted(result, key=lambda item: (item["p50_ms"], item["p95_ms"]), reverse=True)
+
+
+def stage_and_boundary_summaries(evidence: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    leaf_values: defaultdict[tuple[tuple[str, str, str, str], str], list[tuple[float, int]]] = defaultdict(list)
+    parent_values: defaultdict[tuple[tuple[str, str, str, str], str], list[tuple[float, int]]] = defaultdict(list)
+    boundary_values: defaultdict[tuple[tuple[str, str, str, str], str], list[tuple[float, int]]] = defaultdict(list)
+    boundary_names = {
+        "s0_s1_permit_wait_ms": "Boundary.S0S1.PermitWait",
+        "s1_s2_pre_provider_ms": "Boundary.S1S2.PreProvider",
+        "s2_s3_provider_ms": "Boundary.S2S3.Provider",
+        "s3_s4_pre_format_ms": "Boundary.S3S4.PreFormat",
+        "s4_s5_format_ms": "Boundary.S4S5.Format",
+        "s5_s6_completion_observers_ms": "Boundary.S5S6.CompletionObservers",
+        "s6_s7_handler_handoff_ms": "Boundary.S6S7.HandlerHandoff",
+        "s7_s8_sdk_encode_ms": "Boundary.S7S8.SDKEncode",
+        "s8_s9_transport_write_ms": "Boundary.S8S9.TransportWrite",
+        "handler_to_write_ms": "Boundary.S7S9.HandlerToWrite",
+        "s0_s9_server_total_ms": "Boundary.S0S9.ServerTotal",
+        "c0_c1_client_call_ms": "Boundary.C0C1.ClientCall",
+        "c1_c2_client_output_ms": "Boundary.C1C2.ClientOutput",
+        "c0_c2_client_total_ms": "Boundary.C0C2.ClientTotal",
+    }
+    for item in evidence:
+        sample = item["sample"]
+        if sample.get("phase") != "recorded" or sample.get("outcome") != "success":
+            continue
+        key = cohort_key(sample)
+        totals, spans, _ = per_request_stage_totals(item)
+        for stage, duration in totals.items():
+            target = parent_values if stage in INCLUSIVE_STAGES else leaf_values
+            target[(key, stage)].append((duration, spans.get(stage, 0)))
+        request_id = str(sample.get("sample_id") or sample.get("app_invocation_id") or "unknown-request")
+        tree = totals.get("EditFlow.FormattedOutput.SearchTreeAssembly")
+        if tree is not None:
+            snippet = totals.get("EditFlow.FormattedOutput.SearchSnippetAssembly", 0)
+            residual = signed_parent_minus_children_residual(
+                tree,
+                snippet,
+                envelope="EditFlow.FormattedOutput.SearchTreeAssembly",
+                request_id=request_id,
+            )
+            leaf_values[(key, DERIVED_SEARCH_TREE_STAGE)].append((residual, spans.get("EditFlow.FormattedOutput.SearchTreeAssembly", 0)))
+        acquire = totals.get("EditFlow.Search.WorkspaceReadinessAcquireGate", 0)
+        scope = totals.get("EditFlow.Search.RootScopeAvailabilityGate", 0)
+        if acquire > 0 or scope > 0:
+            validation = totals.get("EditFlow.Search.WorkspaceReadinessValidationGate", 0)
+            residual = signed_parent_minus_children_residual(
+                acquire + scope,
+                validation,
+                envelope="EditFlow.Search.ReadinessAndScopeGates",
+                request_id=request_id,
+            )
+            leaf_values[(key, DERIVED_SEARCH_READINESS_SCOPE_STAGE)].append((
+                residual,
+                spans.get("EditFlow.Search.WorkspaceReadinessAcquireGate", 0)
+                    + spans.get("EditFlow.Search.RootScopeAvailabilityGate", 0),
+            ))
+        for metric, stage in boundary_names.items():
+            if metric in item["boundaries"]:
+                boundary_values[(key, stage)].append((float(item["boundaries"][metric]), 1))
+    return (
+        summarize_request_values(leaf_values),
+        summarize_request_values(parent_values),
+        summarize_request_values(boundary_values),
+    )
+
+
+def client_summaries(evidence: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: defaultdict[tuple[str, str, str, str], dict[str, list[float]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for item in evidence:
+        sample = item["sample"]
+        if sample.get("phase") != "recorded" or sample.get("outcome") != "success":
+            continue
+        trace = item["trace"]
+        key = cohort_key(sample)
+        call = float(trace.get("call_duration_ms", 0))
+        output = float(trace.get("print_duration_ms", 0))
+        grouped[key]["call_ms"].append(call)
+        grouped[key]["print_ms"].append(output)
+        grouped[key]["total_ms"].append(call + output)
+    return [
+        {
+            "cohort": cohort_payload(key),
+            **{
+                metric: {
+                    "p50_ms": round(percentile(values, 0.5), 3),
+                    "p95_ms": round(percentile(values, 0.95), 3),
+                    "sample_count": len(values),
+                }
+                for metric, values in metrics.items()
+            },
+        }
+        for key, metrics in sorted(grouped.items())
+    ]
+
+
+def boundary_denominators(
+    evidence: list[dict[str, Any]], metric: str, interval_name: str,
+) -> list[dict[str, Any]]:
+    grouped: defaultdict[tuple[str, str, str, str], list[float]] = defaultdict(list)
+    for item in evidence:
+        sample = item["sample"]
+        if sample.get("phase") == "recorded" and sample.get("outcome") == "success":
+            value = item["boundaries"].get(metric)
+            if value is not None:
+                grouped[cohort_key(sample)].append(float(value))
+    return [
+        {
+            "cohort": cohort_payload(key),
+            "interval_name": interval_name,
+            "p50_ms": round(percentile(values, 0.5), 3),
+            "p95_ms": round(percentile(values, 0.95), 3),
+            "sample_count": len(values),
+        }
+        for key, values in sorted(grouped.items())
+    ]
+
+
+def attribution_summary(evidence: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: defaultdict[tuple[str, str, str], dict[str, dict[str, list[float]]]] = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(list))
+    )
+    metrics = [label for label, _, _ in LIFECYCLE_BOUNDARIES if label.startswith(("s5_", "s6_"))]
+    metrics += [label for label, _, _ in DELIVERY_BOUNDARIES if label != "handler_to_write_ms"]
+    metrics += ["c0_c1_client_call_ms", "c1_c2_client_output_ms"]
+    for item in evidence:
+        sample = item["sample"]
+        if sample.get("phase") != "recorded" or sample.get("outcome") != "success":
+            continue
+        key = (sample["row_id"], sample["client_mode"], sample["cohort_kind"])
+        for metric in metrics:
+            if metric in item["boundaries"]:
+                grouped[key][sample["format"]][metric].append(float(item["boundaries"][metric]))
+    result = []
+    for key, formats in sorted(grouped.items()):
+        per_format = {
+            fmt: {
+                metric: {
+                    "p50_ms": round(percentile(values, 0.5), 3),
+                    "p95_ms": round(percentile(values, 0.95), 3),
+                    "sample_count": len(values),
+                }
+                for metric, values in values_by_metric.items()
+            }
+            for fmt, values_by_metric in formats.items()
+        }
+        deltas = {}
+        for metric in metrics:
+            formatted = per_format.get("formatted", {}).get(metric, {}).get("p50_ms")
+            raw = per_format.get("raw", {}).get(metric, {}).get("p50_ms")
+            if formatted is not None and raw is not None:
+                deltas[metric] = round(formatted - raw, 3)
+        result.append({
+            "row_id": key[0], "client_mode": key[1], "cohort_kind": key[2],
+            "per_format": per_format, "formatted_minus_raw_p50_ms": deltas,
+        })
+    return result
+
+
+def stage_total(item: dict[str, Any], stage: str, scan_kind: str | None = None) -> float:
+    total = 0.0
+    for bucket in item["stage_buckets"]:
+        if bucket.get("stage_name") != stage:
+            continue
+        if scan_kind is not None and parse_dimensions(str(bucket.get("sanitized_dimensions") or "")).get("scanKind") != scan_kind:
+            continue
+        total += float(bucket.get("total_ms", 0))
+    return total
+
+
+def remainder_summaries(evidence: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    values: defaultdict[tuple[tuple[str, str, str, str], str, str | None], list[float]] = defaultdict(list)
+    provider_children = {
+        "EditFlow.FileTree.ProviderArgumentParsing", "EditFlow.FileTree.ProviderRequestMetadata",
+        "EditFlow.FileTree.ProviderLookupContextResolution", "EditFlow.FileTree.ProviderIngressFreshnessWait",
+        "EditFlow.FileTree.ProviderSelectionDrain", "EditFlow.FileTree.DTOAssembly",
+        "EditFlow.FileTree.ProviderValueEncoding",
+    }
+    bridge_children = {
+        "EditFlow.FileTree.SettingsSnapshot", "EditFlow.FileTree.SelectionPhysicalization",
+        "EditFlow.FileTree.SnapshotConstruction", "EditFlow.FileTree.CodemapMarkerProjection",
+        "EditFlow.FileTree.LogicalProjection", "EditFlow.FileTree.RenderAttempt",
+    }
+    formatted_children = {
+        stage for stage in LEAF_STAGES if stage.startswith("EditFlow.FormattedOutput.")
+    } - {"EditFlow.FormattedOutput.SearchSnippetAssembly"}
+    observer_children = DIRECT_STAGE_CHILDREN["EditFlow.MCPToolCall.CompletionObservers"]
+    search_workspace_children = DIRECT_STAGE_CHILDREN["EditFlow.Search.ProviderWorkspaceSearchAwait"]
+    for item in evidence:
+        sample = item["sample"]
+        if sample.get("phase") != "recorded" or sample.get("outcome") != "success":
+            continue
+        key = cohort_key(sample)
+        request_id = str(sample.get("sample_id") or sample.get("app_invocation_id") or "unknown-request")
+        totals, _, _ = per_request_stage_totals(item)
+        bridge_total = stage_total(item, "EditFlow.FileTree.BridgeTotal")
+        provider_child_total = sum(totals.get(name, 0) for name in provider_children)
+        if bridge_total > 0:
+            provider_child_total += bridge_total
+        else:
+            # The roots branch builds its settings/snapshot directly without the bridge envelope.
+            provider_child_total += totals.get("EditFlow.FileTree.SettingsSnapshot", 0)
+            provider_child_total += totals.get("EditFlow.FileTree.SnapshotConstruction", 0)
+        formatted_child_total = sum(
+            totals.get(name, 0)
+            for name in formatted_children
+            if name != "EditFlow.FormattedOutput.SearchTreeAssembly"
+        )
+        # The tree envelope already contains snippets; use its inclusive duration for
+        # the FormatResult remainder while ranking tree-minus-snippet separately.
+        formatted_child_total += stage_total(item, "EditFlow.FormattedOutput.SearchTreeAssembly")
+        cases = [
+            (
+                "EditFlow.Search.ProviderWorkspaceSearchAwait",
+                sum(totals.get(name, 0) for name in search_workspace_children),
+                DERIVED_SEARCH_CORE_STAGE,
+            ),
+            ("EditFlow.FileTree.ProviderTotal", provider_child_total, None),
+            ("EditFlow.FileTree.BridgeTotal", sum(totals.get(name, 0) for name in bridge_children)
+             + stage_total(item, "EditFlow.FileTree.RenderIndexPreparation", "root_filter"), None),
+            ("EditFlow.FileTree.RenderAttempt", stage_total(item, "EditFlow.FileTree.RenderTokenEstimation")
+             + stage_total(item, "EditFlow.FileTree.RenderIndexPreparation", "selected_folder_index"), None),
+            ("EditFlow.MCPToolCall.FormatResult", formatted_child_total, None),
+            ("EditFlow.MCPToolCall.CompletionObservers", sum(totals.get(name, 0) for name in observer_children), None),
+        ]
+        for envelope, child_total, derived_stage in cases:
+            envelope_total = stage_total(item, envelope)
+            if envelope_total > 0:
+                values[(key, envelope, derived_stage)].append(signed_parent_minus_children_residual(
+                    envelope_total,
+                    child_total,
+                    envelope=envelope,
+                    request_id=request_id,
+                ))
+    return [
+        {
+            "cohort": cohort_payload(key), "envelope": envelope,
+            **({"stage": derived_stage} if derived_stage else {}),
+            "request_count": len(durations),
+            "p50_ms": round(percentile(durations, 0.5), 3),
+            "p95_ms": round(percentile(durations, 0.95), 3),
+            "total_ms": round(sum(durations), 3),
+        }
+        for (key, envelope, derived_stage), durations in sorted(
+            values.items(), key=lambda item: (item[0][0], item[0][1], item[0][2] or "")
+        )
+    ]
+
+
+def response_signature(samples: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    grouped: defaultdict[str, set[tuple[Any, ...]]] = defaultdict(set)
+    counts: defaultdict[str, int] = defaultdict(int)
+    for sample in samples:
+        if sample.get("phase") != "recorded":
+            continue
+        if sample.get("cohort_kind") == "wi3":
+            key = "/".join((
+                "wi3", str(sample.get("workload_matrix_id")),
+                str(sample.get("connection_cohort")), str(sample.get("sample_ordinal")),
+                sample["row_id"], sample["format"], sample["client_mode"],
+            ))
+        else:
+            key = "ordinary/" + baseline_key(sample)
+        trace = sample["client_trace"][0]
+        contract = (
+            sample["response_sha256"], int(sample["response_byte_count"]),
+            trace.get("output_format"), trace.get("outcome"), bool(trace.get("is_error")),
+            int(trace.get("content_block_count", 0)),
+            int(trace.get("text_content_block_count", 0)),
+            int(trace.get("returned_text_bytes", 0)),
+        )
+        grouped[key].add(contract)
+        counts[key] += 1
+    result = {}
+    for key, values in grouped.items():
+        if len(values) != 1:
+            raise MatrixError(f"response or ordered content-block contract changed within paired cohort: {key}")
+        digest, size, output_format, outcome, is_error, blocks, text_blocks, text_bytes = next(iter(values))
+        result[key] = {
+            "sha256": digest, "byte_count": size, "sample_count": counts[key],
+            "output_format": output_format, "outcome": outcome, "is_error": is_error,
+            "content_block_count": blocks, "text_content_block_count": text_blocks,
+            "returned_text_bytes": text_bytes,
+        }
+    return result
+
+
+def combine_stage_attribution_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
+    per_stage: defaultdict[str, dict[str, int]] = defaultdict(
+        lambda: {"identified_sample_count": 0, "unidentified_sample_count": 0}
+    )
+    missing: set[str] = set()
+    for report in reports:
+        missing.update(report.get("missing_successful_request_ids", []))
+        for row in report.get("per_stage", []):
+            stage = str(row["stage"])
+            per_stage[stage]["identified_sample_count"] += int(row["identified_sample_count"])
+            per_stage[stage]["unidentified_sample_count"] += int(row["unidentified_sample_count"])
+    unidentified = sum(row["unidentified_sample_count"] for row in per_stage.values())
+    return {
+        "status": "complete" if not missing and unidentified == 0 else "invalid",
+        "identified_sample_count": sum(row["identified_sample_count"] for row in per_stage.values()),
+        "unidentified_sample_count": unidentified,
+        "missing_successful_request_ids": sorted(missing),
+        "per_stage": [
+            {"stage": stage, **counts} for stage, counts in sorted(per_stage.items())
+        ],
+    }
+
+
+def load_server_request_evidence(
+    input_dir: Path,
+    manifest: dict[str, Any],
+    samples: list[dict[str, Any]],
+    discarded_warmups: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    index_path = input_dir / "server-capture.json"
+    index = load_json(index_path)
+    declared_layout = manifest.get("server_capture_layout")
+    index_layout = index.get("layout")
+    if declared_layout == SEGMENTED_CAPTURE_LAYOUT and index_layout != SEGMENTED_CAPTURE_LAYOUT:
+        raise MatrixError("segmented run manifest points to a non-segmented capture index")
+    if declared_layout not in (None, index_layout):
+        raise MatrixError("server capture manifest/index layout mismatch")
+    if index_layout != SEGMENTED_CAPTURE_LAYOUT:
+        capture = find_named_object(index, "capture") or {}
+        validate_capture_integrity(capture)
+        delivery_drops = int(find_named_object(index, "delivery_dropped_event_count") or 0)
+        if delivery_drops:
+            raise MatrixError(f"server delivery capture dropped {delivery_drops} events")
+        delivery_events = find_named_object(index, "delivery_events") or []
+        validate_delivery_terminals(delivery_events, capture.get("lifecycle_events", []), samples)
+        attribution = stage_attribution_report(samples, capture, require_server=True)
+        return joined_request_evidence(samples, capture, delivery_events, True), attribution
+
+    plan = manifest.get("capture_segment_plan")
+    if not isinstance(plan, list):
+        raise MatrixError("segmented run manifest omitted its capture plan")
+    verified_plan_hash = capture_segment_plan_sha256(plan)
+    if manifest.get("capture_segment_plan_sha256") != verified_plan_hash:
+        raise MatrixError("segmented run manifest capture plan hash mismatch")
+    if manifest.get("capture_segment_index_sha256") != sha256_bytes(index_path.read_bytes()):
+        raise MatrixError("segmented run capture index hash mismatch")
+    validate_segment_index_contract(index, plan)
+    if manifest.get("status") != "completed":
+        raise MatrixError("segmented run manifest is not complete")
+    if manifest.get("accepted_capture_segment_count") != len(plan) \
+            or manifest.get("completed_capture_segment_count") != len(plan):
+        raise MatrixError("segmented run did not complete every planned segment")
+    all_executed = samples + discarded_warmups
+    by_segment: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for sample in all_executed:
+        segment_id = sample.get("capture_segment_id")
+        if not segment_id:
+            raise MatrixError("segmented run sample omitted capture_segment_id")
+        by_segment[str(segment_id)].append(sample)
+    evidence: list[dict[str, Any]] = []
+    reports: list[dict[str, Any]] = []
+    root = input_dir.resolve()
+    seen_invocations: set[str] = set()
+    for entry in index["segments"]:
+        segment_id = str(entry["segment_id"])
+        relative = Path(str(entry.get("artifact_path", "")))
+        artifact = (input_dir / relative).resolve()
+        try:
+            artifact.relative_to(root)
+        except ValueError as error:
+            raise MatrixError(f"capture segment artifact escapes output directory: {relative}") from error
+        if not artifact.is_file():
+            raise MatrixError(f"capture segment artifact is missing: {relative}")
+        if sha256_bytes(artifact.read_bytes()) != entry.get("artifact_sha256"):
+            raise MatrixError(f"capture segment artifact hash mismatch: {segment_id}")
+        segment_samples = by_segment.pop(segment_id, [])
+        expected_invocations = [canonical_invocation_id(value) for value in entry.get("invocation_ids", [])]
+        actual_invocations = [canonical_invocation_id(sample["invocation_id"]) for sample in segment_samples]
+        if len(actual_invocations) != len(set(actual_invocations)) \
+                or sorted(actual_invocations) != sorted(expected_invocations):
+            raise MatrixError(f"capture segment invocation membership mismatch: {segment_id}")
+        validate_segment_sample_coordinates(entry, segment_samples)
+        duplicate = seen_invocations.intersection(actual_invocations)
+        if duplicate:
+            raise MatrixError("invocation identity appears in multiple capture segments")
+        seen_invocations.update(actual_invocations)
+        payload = load_json(artifact)
+        classified_setup_ids = validate_capture_request_membership(payload, segment_samples)
+        if entry.get("classified_setup_request_ids") != classified_setup_ids:
+            raise MatrixError(f"capture segment setup-request classification mismatch: {segment_id}")
+        validate_capture_segment_payload(payload, segment_samples, manifest["configuration"])
+        capture = find_named_object(payload, "capture") or {}
+        delivery_events = find_named_object(payload, "delivery_events") or []
+        recorded = [sample for sample in segment_samples if sample.get("phase") == "recorded"]
+        reports.append(stage_attribution_report(recorded, capture, require_server=True))
+        evidence.extend(joined_request_evidence(recorded, capture, delivery_events, True))
+    if by_segment:
+        raise MatrixError("run contains samples assigned to an unplanned capture segment")
+    if len(seen_invocations) != len(all_executed):
+        raise MatrixError("segmented capture invocation coverage is incomplete")
+    attribution = combine_stage_attribution_reports(reports)
+    if attribution["status"] != "complete":
+        raise MatrixError("segmented stage attribution merge is incomplete")
+    return evidence, attribution
+
+
+def aggregate(input_dir: Path) -> dict[str, Any]:
+    run = load_json(input_dir / "run.json")
+    manifest = load_json(input_dir / "manifest.json")
+    matrix_path = Path(manifest.get("matrix", default_matrix()))
+    authority = load_wi3_authority(matrix_path)
+    samples = list(run.get("samples", []))
+    discarded_warmups = list(run.get("discarded_warmups", []))
+    validate_connection_cohorts(samples)
+    cohort_kinds = {sample.get("cohort_kind") for sample in samples}
+    if cohort_kinds != {manifest.get("cohort_kind")} and cohort_kinds != {manifest.get("cohort_kind"), "wi3"}:
+        raise MatrixError("aggregation refuses mixed cold/warm cohort kinds")
+    validate_trace_records(samples + discarded_warmups, manifest["configuration"])
+    validate_format_pairs(samples)
+
+    require_server = manifest["configuration"] in {"debug", "optimized"}
+    if require_server:
+        if manifest.get("server_capture_mode") != SERVER_CAPTURE_MODE:
+            raise MatrixError("run manifest omitted the authoritative server capture mode")
+        if not (input_dir / "server-capture.json").is_file():
+            raise MatrixError(f"{manifest['configuration']} aggregation requires server capture")
+        evidence, attribution = load_server_request_evidence(
+            input_dir, manifest, samples, discarded_warmups,
+        )
+    else:
+        attribution = {
+            "status": "not_applicable_client_only",
+            "identified_sample_count": 0,
+            "unidentified_sample_count": 0,
+            "missing_successful_request_ids": [],
+            "per_stage": [],
+        }
+        evidence = joined_request_evidence(samples, {}, [], require_server=False)
+    leaves, parents, boundary_rankings = stage_and_boundary_summaries(evidence)
+    remainders = remainder_summaries(evidence)
+    leaves.extend({
+        "cohort": row["cohort"], "stage": row["stage"],
+        "request_count": row["request_count"], "span_count": row["request_count"],
+        "p50_ms": row["p50_ms"], "p95_ms": row["p95_ms"], "total_ms": row["total_ms"],
+    } for row in remainders if row.get("stage"))
+    leaves.sort(key=lambda item: (item["p50_ms"], item["p95_ms"]), reverse=True)
+    client = client_summaries(evidence)
+    server_denominators = boundary_denominators(
+        evidence, "s0_s9_server_total_ms", "Boundary.S0S9.ServerTotal",
+    )
+    handler_denominators = boundary_denominators(
+        evidence, "handler_to_write_ms", "Boundary.S7S9.HandlerToWrite",
+    )
+
+    work_count_files = {
+        "runtime_before": input_dir / "runtime-before.json",
+        "runtime_after": input_dir / "runtime-after.json",
+        "admission_before": input_dir / "admission-before.json",
+        "admission_after": input_dir / "admission-after.json",
+    }
+    present = {name for name, path in work_count_files.items() if path.is_file()}
+    if present and len(present) != len(work_count_files):
+        raise MatrixError("incomplete WI-3 work-count capture: " + ", ".join(sorted(set(work_count_files) - present)))
+    executed_wi3 = sorted(set(run.get("executed_wi3_matrix_ids", [])))
+    required_wi3 = selector_required_wi3_matrix_ids(authority)
+    if present:
+        wi3_work_counts = project_wi3_work_counts(
+            load_json(work_count_files["runtime_before"]), load_json(work_count_files["runtime_after"]),
+            load_json(work_count_files["admission_before"]), load_json(work_count_files["admission_after"]),
+            authority, executed_wi3,
+        )
+        wi3_work_counts["availability"] = "captured"
+        wi3_work_counts["selector_ready"] = executed_wi3 == required_wi3
+        wi3_work_counts["selector_required_matrix_ids"] = required_wi3
+    else:
+        wi3_work_counts = {
+            "availability": "not_captured", "authority_source": authority["source"],
+            "selector_ready": False, "selector_required_matrix_ids": required_wi3,
+            "workload_matrices": [
+                item for item in authority["workload_matrices"] if item["id"] in set(executed_wi3)
+            ],
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "completed",
+        "configuration": manifest["configuration"],
+        "cohort_kind": manifest["cohort_kind"],
+        "leaf_rankings": leaves,
+        "boundary_rankings": boundary_rankings,
+        "inclusive_envelopes": parents,
+        "selector_eligibility_denominator": "Boundary.S0S9.ServerTotal",
+        "s0_s9_server_denominators": server_denominators,
+        "handler_to_write_denominators": handler_denominators,
+        "stage_attribution": attribution,
+        "unattributed_remainders": remainders,
+        "residual_policy": {
+            "semantics": "signed_parent_minus_declared_children",
+            "overlap_tolerance_ms": RESIDUAL_OVERLAP_TOLERANCE_MS,
+            "material_negative_residual": "aggregation_refused",
+        },
+        "client_c0_c2": client,
+        "s5_c2_attribution": attribution_summary(evidence),
+        "selector": {
+            "status": "refused", "selected": None,
+            "refusal_reasons": ["single-configuration evidence cannot satisfy paired DEBUG + optimized-persistent gates"],
+        },
+        "wi3_work_counts": wi3_work_counts,
+        "executed_wi3_matrix_ids": executed_wi3,
+        "work_count_authority": authority["source"],
+        "response_signature": response_signature(samples),
+    }
+
+
+def matching_key(cohort: dict[str, str], include_client_mode: bool = True) -> tuple[str, ...]:
+    values = (cohort["row_id"], cohort["format"], cohort["cohort_kind"])
+    return values + ((cohort["client_mode"],) if include_client_mode else ())
+
+
+def mechanical_selector(
+    leaves: list[dict[str, Any]],
+    boundaries: list[dict[str, Any]],
+    server_denominator_rows: list[dict[str, Any]],
+    optimized_client_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    candidates = [row for row in leaves + boundaries if row["stage"] in SELECTOR_ACTIONS and row["cohort"]["cohort_kind"] == "warm"]
+    server_totals = {matching_key(row["cohort"]): row["p50_ms"] for row in server_denominator_rows}
+    optimized = {
+        matching_key(row["cohort"], include_client_mode=False): row["total_ms"]["p50_ms"]
+        for row in optimized_client_rows
+        if row["cohort"]["client_mode"] == "persistent" and row["cohort"]["cohort_kind"] == "warm"
+    }
+    refusal = []
+    if not candidates:
+        refusal.append("DEBUG candidate leaf universe is empty")
+    if any(matching_key(row["cohort"]) not in server_totals for row in candidates):
+        refusal.append("real MCP.ToolCall.Received to transport-write S0-S9 denominator is absent")
+    if any(matching_key(row["cohort"], include_client_mode=False) not in optimized for row in candidates):
+        refusal.append("matching optimized warm persistent C0-C2 denominator is absent")
+    if refusal:
+        return {"status": "refused", "selected": None, "refusal_reasons": sorted(set(refusal))}
+
+    qualifying = []
+    for row in candidates:
+        server = server_totals[matching_key(row["cohort"])]
+        client = optimized[matching_key(row["cohort"], include_client_mode=False)]
+        absolute = row["p50_ms"] >= 10 and server > 0 and row["p50_ms"] / server >= 0.15
+        tail = row["p95_ms"] >= 25
+        client_share = client > 0 and row["p50_ms"] / client >= 0.15
+        if absolute or tail or client_share:
+            qualified = dict(row)
+            qualified["eligibility_denominator_interval"] = "Boundary.S0S9.ServerTotal"
+            qualified["s0_s9_server_total_p50_ms"] = server
+            qualified["optimized_persistent_c0_c2_p50_ms"] = client
+            qualifying.append(qualified)
+    qualifying.sort(key=lambda item: (item["p50_ms"], item["p95_ms"]), reverse=True)
+    if not qualifying:
+        return {"status": "no_qualifying_stage", "selected": None, "dominant_leaf": None,
+                "policy": "no stage qualifies; stop after investigation"}
+    dominant = qualifying[0]
+    return {"status": "selected", "selected": SELECTOR_ACTIONS[dominant["stage"]],
+            "dominant_leaf": dominant, "policy": "first matching dominant cost by request-level exclusive time"}
+
+
+def authoritative_paired_server_identity(
+    debug_manifest: dict[str, Any], optimized_manifest: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    debug_identity = debug_manifest.get("server_app_identity")
+    optimized_identity = optimized_manifest.get("server_app_identity")
+    if not isinstance(debug_identity, dict) or not isinstance(optimized_identity, dict):
+        raise MatrixError("paired cohort lacks authoritative server app identity/configuration")
+    if debug_manifest.get("server_app_identity_end") != debug_identity \
+            or optimized_manifest.get("server_app_identity_end") != optimized_identity:
+        raise MatrixError("paired cohort server identity changed during collection")
+    if debug_identity.get("identity_authority") != "server_process" \
+            or optimized_identity.get("identity_authority") != "server_process":
+        raise MatrixError("paired cohort server app identity/configuration is not authoritative")
+    if debug_identity.get("app_configuration") != "debug" \
+            or debug_identity.get("swift_configuration") != "debug":
+        raise MatrixError("paired DEBUG cohort did not use a DEBUG server")
+    if optimized_identity.get("app_configuration") != "optimized_diagnostic" \
+            or optimized_identity.get("swift_configuration") != "release" \
+            or optimized_identity.get("ordinary_release_artifact") is not False:
+        raise MatrixError("paired optimized cohort did not use the release-optimized diagnostic server")
+    if debug_identity.get("executable_sha256") == optimized_identity.get("executable_sha256"):
+        raise MatrixError("paired cohorts unexpectedly used the same server executable")
+    return {"debug": debug_identity, "optimized": optimized_identity}
+
+
+def make_server_authorization_explicit(
+    selector: dict[str, Any], server_identity: dict[str, Any],
+) -> dict[str, Any]:
+    result = dict(selector)
+    result["server_app_configuration"] = server_identity.get("app_configuration")
+    if result.get("status") == "selected" \
+            and server_identity.get("app_configuration") == "optimized_diagnostic" \
+            and server_identity.get("swift_configuration") == "release" \
+            and server_identity.get("ordinary_release_artifact") is False \
+            and server_identity.get("identity_authority") == "server_process" \
+            and server_identity.get("diagnostic_surface") == "mcp_latency_v1" \
+            and server_identity.get("signing_mode") == "mcp-latency-diagnostic-adhoc" \
+            and server_identity.get("secure_storage_backend") == "alternate-in-memory":
+        result["production_authorized"] = True
+        result["authorization_note"] = (
+            "authorized by paired DEBUG attribution and the verified release-optimized "
+            "server/client diagnostic cohort; exactly one candidate may proceed"
+        )
+    else:
+        result["production_authorized"] = False
+    return result
+
+
+def paired_aggregate(debug_dir: Path, optimized_dir: Path) -> dict[str, Any]:
+    debug_manifest = load_json(debug_dir / "manifest.json")
+    optimized_manifest = load_json(optimized_dir / "manifest.json")
+    if debug_manifest.get("configuration") != "debug" or optimized_manifest.get("configuration") != "optimized":
+        raise MatrixError("paired analysis requires DEBUG then optimized inputs")
+    debug_completed = float(debug_manifest.get("completed_at_epoch", 0))
+    optimized_created = float(optimized_manifest.get("created_at_epoch", 0))
+    if debug_completed <= 0 or optimized_created <= debug_completed:
+        raise MatrixError("paired analysis requires the completed DEBUG cohort before optimized collection")
+    paired_contract_fields = (
+        "commit", "source_fingerprint_sha256", "profile", "wi3_authority_sha256",
+        "cohort_kind", "matrix_sha256", "sample_discipline", "client_modes",
+        "server_capture_mode", "server_capture_layout", "capture_segment_contract_version",
+        "capture_segment_strategy", "capture_segment_max_ordinary_invocations",
+        "capture_segment_plan_sha256", "planned_capture_segment_count", "planned_row_ids",
+    )
+    for field in paired_contract_fields:
+        if debug_manifest.get(field) != optimized_manifest.get(field):
+            raise MatrixError(f"paired cohort manifest mismatch: {field}")
+    if debug_manifest.get("client_modes") != ["fresh", "persistent"]:
+        raise MatrixError("paired production authorization requires the canonical fresh+persistent client modes")
+    verified_plan_hashes: list[str] = []
+    for label, manifest in (("DEBUG", debug_manifest), ("optimized", optimized_manifest)):
+        if manifest.get("status") != "completed":
+            raise MatrixError(f"paired {label} cohort is not complete")
+        if manifest.get("server_capture_layout") != SEGMENTED_CAPTURE_LAYOUT:
+            raise MatrixError(f"paired {label} cohort did not use the canonical segmented capture layout")
+        if manifest.get("capture_segment_contract_version") != SEGMENTED_CAPTURE_CONTRACT_VERSION:
+            raise MatrixError(f"paired {label} cohort has an unsupported capture segment contract")
+        plan = manifest.get("capture_segment_plan")
+        if not isinstance(plan, list):
+            raise MatrixError(f"paired {label} cohort omitted its capture segment plan")
+        verified_plan_hash = capture_segment_plan_sha256(plan)
+        if manifest.get("capture_segment_plan_sha256") != verified_plan_hash:
+            raise MatrixError(f"paired {label} cohort capture segment plan hash mismatch")
+        verified_plan_hashes.append(verified_plan_hash)
+        planned_count = manifest.get("planned_capture_segment_count")
+        if planned_count != len(plan) or manifest.get("completed_capture_segment_count") != planned_count:
+            raise MatrixError(f"paired {label} cohort omitted a capture segment")
+    if len(set(verified_plan_hashes)) != 1:
+        raise MatrixError("paired cohorts have different verified capture segment plans")
+    identities = authoritative_paired_server_identity(debug_manifest, optimized_manifest)
+    optimized_artifact = optimized_manifest.get("optimized_server_artifact")
+    if not isinstance(optimized_artifact, dict):
+        raise MatrixError("paired optimized cohort omitted its server artifact manifest")
+    validate_runtime_artifact_identity(identities["optimized"], optimized_artifact)
+    if optimized_artifact.get("commit") != optimized_manifest.get("commit") \
+            or optimized_artifact.get("source_fingerprint_sha256") != optimized_manifest.get("source_fingerprint_sha256"):
+        raise MatrixError("optimized artifact source identity does not match paired collection")
+    debug_provenance = identities["debug"].get("provenance")
+    if not isinstance(debug_provenance, dict) \
+            or debug_provenance.get("commit") != debug_manifest.get("commit") \
+            or debug_provenance.get("source_fingerprint_sha256") != debug_manifest.get("source_fingerprint_sha256"):
+        raise MatrixError("DEBUG server provenance does not match paired collection sources")
+    debug_fixture = (debug_manifest.get("fixture_manifest") or {}).get("digest")
+    optimized_fixture = (optimized_manifest.get("fixture_manifest") or {}).get("digest")
+    if debug_fixture != optimized_fixture:
+        raise MatrixError("paired fixture digest mismatch")
+    debug = aggregate(debug_dir)
+    optimized = aggregate(optimized_dir)
+    if debug["response_signature"] != optimized["response_signature"]:
+        raise MatrixError("DEBUG/optimized exact response parity mismatch")
+    if debug["wi3_work_counts"].get("availability") != "captured":
+        raise MatrixError("paired selector requires DEBUG WI-3 capacity/work-count evidence")
+    required_wi3 = debug["wi3_work_counts"].get("selector_required_matrix_ids", [])
+    if debug.get("executed_wi3_matrix_ids") != required_wi3:
+        raise MatrixError("paired selector requires every enabled DEBUG WI-3 admission cohort")
+    if optimized.get("executed_wi3_matrix_ids") != required_wi3:
+        raise MatrixError("paired selector requires matching optimized WI-3 admission cohorts")
+    debug_selector = mechanical_selector(
+        debug["leaf_rankings"], debug["boundary_rankings"],
+        debug["s0_s9_server_denominators"], optimized["client_c0_c2"],
+    )
+    optimized_selector = mechanical_selector(
+        optimized["leaf_rankings"], optimized["boundary_rankings"],
+        optimized["s0_s9_server_denominators"], optimized["client_c0_c2"],
+    )
+    if debug_selector.get("status") != "selected" \
+            or optimized_selector.get("status") != "selected" \
+            or debug_selector.get("selected") != optimized_selector.get("selected"):
+        selector = {
+            "status": "refused",
+            "selected": None,
+            "production_authorized": False,
+            "debug_selector": debug_selector,
+            "optimized_selector": optimized_selector,
+            "refusal_reasons": [
+                "DEBUG attribution and release-optimized server/client evidence did not select the same candidate"
+            ],
+        }
+    else:
+        selector = dict(optimized_selector)
+        selector["debug_attribution"] = debug_selector
+        selector = make_server_authorization_explicit(selector, identities["optimized"])
+    return {
+        "schema_version": SCHEMA_VERSION, "status": "completed", "paired": True,
+        "server_app_identities": identities,
+        "debug": debug, "optimized": optimized, "selector": selector,
+    }
+
+
+def matrix_row_by_id(matrix_path: Path, row_id: str, variables: dict[str, str]) -> dict[str, Any]:
+    for source in load_json(matrix_path).get("rows", []):
+        if source.get("id") == row_id:
+            return replace_variables(source, variables)
+    raise MatrixError(f"WI-3 execution references unknown row: {row_id}")
+
+
+def run_concurrent_batch_process(
+    cli: Path,
+    window_id: int,
+    row: dict[str, Any],
+    request_count: int,
+    capture: Path,
+    timeout: float,
+    workload_matrix_id: str,
+    connection_ordinal: int,
+    generation: int = 0,
+) -> list[dict[str, Any]]:
+    cohort = f"wi3-{workload_matrix_id}-g{generation}-c{connection_ordinal}"
+    trace = (capture / "traces" / f"{cohort}.jsonl").resolve()
+    trace.parent.mkdir(parents=True, exist_ok=True)
+    requests = []
+    request_metadata = []
+    for ordinal in range(request_count):
+        invocation_id = new_invocation_id()
+        output_path = (capture / "responses" / f"{cohort}-s{ordinal}-{invocation_id}.out").resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        requests.append({
+            "invocation_id": invocation_id,
+            "tool": row["tool"],
+            "output_format": "formatted",
+            "output_path": str(output_path),
+            "arguments": invocation_arguments(row, "formatted", window_id, invocation_id),
+        })
+        request_metadata.append((ordinal, invocation_id, output_path))
+    batch_path = (capture / "batches" / f"{cohort}.json").resolve()
+    batch_path.parent.mkdir(parents=True, exist_ok=True)
+    save_json(batch_path, requests)
+    env = {**os.environ, TRACE_ENV: str(trace)}
+    process = run_cli(
+        [str(cli), "-w", str(window_id), "--latency-concurrent-batch", str(batch_path)],
+        cwd=repo_root(), env=env, timeout=timeout * max(1, request_count),
+    )
+    traces = read_trace(trace)
+    samples = []
+    for ordinal, invocation_id, output_path in request_metadata:
+        response = output_path.read_bytes() if output_path.exists() else b""
+        invocation_row = {**row, "_repeat": -2, "_sample": ordinal}
+        sample = create_sample(
+            invocation_row, "formatted", "persistent_concurrent", cohort, "wi3",
+            invocation_id, response, process, traces, None, "recorded", workload_matrix_id,
+        )
+        sample["trace_file"] = str(trace.relative_to(capture))
+        samples.append(sample)
+    return samples
+
+
+def run_wi3_cohorts(
+    cli: Path,
+    window_id: int,
+    matrix_path: Path,
+    authority: dict[str, Any],
+    variables: dict[str, str],
+    capture: Path,
+    timeout: float,
+) -> tuple[list[dict[str, Any]], list[str], list[dict[str, Any]]]:
+    samples: list[dict[str, Any]] = []
+    executed: list[str] = []
+    discarded_invalid: list[dict[str, Any]] = []
+    for workload in authority["workload_matrices"]:
+        execution = workload.get("execution")
+        if not isinstance(execution, dict) or execution.get("enabled_by_default") is not True:
+            continue
+        workload_id = workload["id"]
+        row = matrix_row_by_id(matrix_path, str(execution["row_id"]), variables)
+        mode = execution.get("mode")
+        for generation in range(2):
+            generation_samples: list[dict[str, Any]] = []
+            if mode == "same_connection_burst":
+                generation_samples.extend(run_concurrent_batch_process(
+                    cli, window_id, row, int(execution["request_count"]), capture,
+                    timeout, workload_id, 0, generation,
+                ))
+            elif mode == "distinct_connections":
+                connection_count = int(execution["connection_count"])
+                with ThreadPoolExecutor(max_workers=connection_count) as executor:
+                    futures = [
+                        executor.submit(
+                            run_concurrent_batch_process, cli, window_id, row, 1,
+                            capture, timeout, workload_id, ordinal, generation,
+                        )
+                        for ordinal in range(connection_count)
+                    ]
+                    for future in futures:
+                        generation_samples.extend(future.result())
+            else:
+                raise MatrixError(f"unsupported WI-3 execution mode: {mode}")
+            invalid = invalid_connection_cohorts(generation_samples)
+            if not invalid:
+                samples.extend(generation_samples)
+                executed.append(workload_id)
+                break
+            for sample in generation_samples:
+                sample["discard_reason"] = next(iter(invalid.values()))
+            discarded_invalid.extend(generation_samples)
+        else:
+            raise MatrixError(f"WI-3 workload {workload_id} remained invalid after re-cohorting")
+    validate_connection_cohorts(samples)
+    return samples, executed, discarded_invalid
+
+
+def expanded_rows(rows: list[dict[str, Any]], repeats: int, samples_per_repeat: int) -> list[dict[str, Any]]:
+    return [
+        {**row, "_repeat": repeat, "_sample": sample}
+        for repeat in range(repeats)
+        for sample in range(samples_per_repeat)
+        for row in rows
+    ]
+
+
+def warmup_rows(rows: list[dict[str, Any]], warmups: int) -> list[dict[str, Any]]:
+    return [{**row, "_repeat": -1, "_sample": sample} for sample in range(warmups) for row in rows]
+
+
+def expected_ordinary_segment_coordinates(
+    row: dict[str, Any], client_mode: str, discipline: dict[str, Any], terminal: bool,
+) -> list[list[Any]]:
+    coordinates: list[list[Any]] = []
+    if terminal:
+        for output_format in row["formats"]:
+            coordinates.append([row["id"], client_mode, output_format, "recorded", 0, 0])
+        return coordinates
+    for sample in range(discipline["warmups"]):
+        for output_format in row["formats"]:
+            coordinates.append([row["id"], client_mode, output_format, "warmup", -1, sample])
+    for repeat in range(discipline["repeats"]):
+        for sample in range(discipline["samples_per_repeat"]):
+            for output_format in row["formats"]:
+                coordinates.append([row["id"], client_mode, output_format, "recorded", repeat, sample])
+    return coordinates
+
+
+def sample_coordinate(sample: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        sample.get("row_id"), sample.get("client_mode"), sample.get("format"),
+        sample.get("phase"), sample.get("repeat_ordinal"), sample.get("sample_ordinal"),
+    )
+
+
+def validate_segment_sample_coordinates(spec: dict[str, Any], samples: list[dict[str, Any]]) -> None:
+    expected = Counter(tuple(item) for item in spec.get("expected_sample_coordinates", []))
+    actual = Counter(sample_coordinate(sample) for sample in samples)
+    if actual != expected:
+        missing = list((expected - actual).elements())[:5]
+        extra = list((actual - expected).elements())[:5]
+        raise MatrixError(
+            f"segment {spec['segment_id']} sample coordinate mismatch; "
+            f"missing={missing}, extra={extra}"
+        )
+
+
+def capture_segment_plan(
+    rows: list[dict[str, Any]],
+    client_modes: list[str],
+    discipline: dict[str, Any],
+    authority: dict[str, Any],
+    include_wi3: bool,
+) -> list[dict[str, Any]]:
+    plan: list[dict[str, Any]] = []
+    for row in rows:
+        terminal = row["expected_outcome"] == "expected_timeout"
+        for client_mode in client_modes:
+            coordinates = expected_ordinary_segment_coordinates(
+                row, client_mode, discipline, terminal,
+            )
+            ordinary_invocations = len(coordinates)
+            if ordinary_invocations > SEGMENTED_CAPTURE_MAX_ORDINARY_INVOCATIONS:
+                raise MatrixError(
+                    f"row {row['id']} requires {ordinary_invocations} invocations, exceeding "
+                    f"the segmented capture bound {SEGMENTED_CAPTURE_MAX_ORDINARY_INVOCATIONS}"
+                )
+            ordinal = len(plan)
+            plan.append({
+                "ordinal": ordinal,
+                "segment_id": f"{ordinal:03d}-ordinary-{client_mode}-{row['id']}",
+                "kind": "expected_terminal" if terminal else "ordinary",
+                "client_mode": client_mode,
+                "row_ids": [row["id"]],
+                "workload_matrix_id": None,
+                "expected_invocation_count": ordinary_invocations,
+                "expected_sample_coordinates": coordinates,
+            })
+    if include_wi3:
+        for workload in authority["workload_matrices"]:
+            execution = workload.get("execution")
+            if not isinstance(execution, dict) or execution.get("enabled_by_default") is not True:
+                continue
+            ordinal = len(plan)
+            if execution.get("mode") == "same_connection_burst":
+                invocation_count = int(execution["request_count"])
+                sample_ordinals = range(invocation_count)
+            elif execution.get("mode") == "distinct_connections":
+                invocation_count = int(execution["connection_count"])
+                sample_ordinals = [0] * invocation_count
+            else:
+                raise MatrixError(f"unsupported WI-3 execution mode: {execution.get('mode')}")
+            coordinates = [
+                [str(execution["row_id"]), "persistent_concurrent", "formatted", "recorded", -2, sample]
+                for sample in sample_ordinals
+            ]
+            plan.append({
+                "ordinal": ordinal,
+                "segment_id": f"{ordinal:03d}-wi3-{workload['id']}",
+                "kind": "wi3",
+                "client_mode": "persistent_concurrent",
+                "row_ids": [str(execution["row_id"])],
+                "workload_matrix_id": workload["id"],
+                "expected_invocation_count": invocation_count,
+                "expected_sample_coordinates": coordinates,
+            })
+    return plan
+
+
+def capture_segment_plan_sha256(plan: list[dict[str, Any]]) -> str:
+    return sha256_bytes(json.dumps(plan, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+
+
+def run_wi3_workload_generation(
+    cli: Path,
+    window_id: int,
+    matrix_path: Path,
+    workload: dict[str, Any],
+    variables: dict[str, str],
+    capture: Path,
+    timeout: float,
+    generation: int,
+) -> list[dict[str, Any]]:
+    execution = workload.get("execution")
+    if not isinstance(execution, dict) or execution.get("enabled_by_default") is not True:
+        raise MatrixError(f"WI-3 workload {workload.get('id')} is not enabled")
+    workload_id = str(workload["id"])
+    row = matrix_row_by_id(matrix_path, str(execution["row_id"]), variables)
+    mode = execution.get("mode")
+    if mode == "same_connection_burst":
+        return run_concurrent_batch_process(
+            cli, window_id, row, int(execution["request_count"]), capture,
+            timeout, workload_id, 0, generation,
+        )
+    if mode == "distinct_connections":
+        samples: list[dict[str, Any]] = []
+        connection_count = int(execution["connection_count"])
+        with ThreadPoolExecutor(max_workers=connection_count) as executor:
+            futures = [
+                executor.submit(
+                    run_concurrent_batch_process, cli, window_id, row, 1,
+                    capture, timeout, workload_id, ordinal, generation,
+                )
+                for ordinal in range(connection_count)
+            ]
+            for future in futures:
+                samples.extend(future.result())
+        return samples
+    raise MatrixError(f"unsupported WI-3 execution mode: {mode}")
+
+
+def capture_request_ids(capture: dict[str, Any]) -> set[str]:
+    request_ids: set[str] = set()
+    for stage in capture.get("stages", []):
+        identity = stage.get("request_identity")
+        invocation_id = identity.get("app_invocation_id") if isinstance(identity, dict) else None
+        if invocation_id:
+            request_ids.add(canonical_invocation_id(invocation_id))
+    for event in capture.get("lifecycle_events", []):
+        identity = event.get("request_identity")
+        invocation_id = identity.get("app_invocation_id") if isinstance(identity, dict) else None
+        if invocation_id:
+            request_ids.add(canonical_invocation_id(invocation_id))
+    return request_ids
+
+
+def validate_capture_request_membership(
+    payload: dict[str, Any], samples: list[dict[str, Any]],
+) -> list[str]:
+    capture = find_named_object(payload, "capture") or {}
+    delivery_events = find_named_object(payload, "delivery_events") or []
+    expected_ids = {canonical_invocation_id(sample["invocation_id"]) for sample in samples}
+    foreign_capture_ids = capture_request_ids(capture) - expected_ids
+    modes = {sample.get("client_mode") for sample in samples}
+    if foreign_capture_ids and not modes <= {"persistent", "persistent_concurrent"}:
+        raise MatrixError(
+            "capture segment contains foreign lifecycle/stage request identities: "
+            + ", ".join(sorted(foreign_capture_ids))
+        )
+    lifecycle_by_id: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    stage_by_id: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for event in capture.get("lifecycle_events", []):
+        identity = event.get("request_identity")
+        invocation_id = identity.get("app_invocation_id") if isinstance(identity, dict) else None
+        if invocation_id:
+            lifecycle_by_id[canonical_invocation_id(invocation_id)].append(event)
+    for stage in capture.get("stages", []):
+        identity = stage.get("request_identity")
+        invocation_id = identity.get("app_invocation_id") if isinstance(identity, dict) else None
+        if invocation_id:
+            stage_by_id[canonical_invocation_id(invocation_id)].append(stage)
+    classified_setup_ids: list[str] = []
+    required_lifecycle = Counter(LIFECYCLE_EVENT_ALLOWLIST)
+    for invocation_id in sorted(foreign_capture_ids):
+        lifecycle = lifecycle_by_id.get(invocation_id, [])
+        stages = stage_by_id.get(invocation_id, [])
+        lifecycle_names = Counter(str(event.get("event_name")) for event in lifecycle)
+        lifecycle_tools = {
+            parse_dimensions(str(event.get("sanitized_dimensions") or "")).get("tool")
+            for event in lifecycle
+        }
+        stage_tools = {
+            parse_dimensions(str(stage.get("sanitized_dimensions") or "")).get("tool")
+            for stage in stages
+        }
+        if lifecycle_names != required_lifecycle \
+                or lifecycle_tools != {"bind_context"} \
+                or not stages \
+                or stage_tools != {"bind_context"} \
+                or any(not str(stage.get("stage_name", "")).startswith("EditFlow.MCPToolCall.") for stage in stages):
+            raise MatrixError(
+                "capture segment contains unclassified foreign lifecycle/stage request identity: "
+                + invocation_id
+            )
+        classified_setup_ids.append(invocation_id)
+    # Fresh CLI connections emit initialization/list handshake delivery events, and
+    # capture-begin's own response is necessarily observed after the recorder reset.
+    # They carry no workload lifecycle/stage identity and are never joined by timing.
+    # Workload delivery phases are accepted only by exact invocation identity or the
+    # stable transport tuple in joined_request_evidence; terminal events are checked
+    # independently against retained workload connections.
+    _ = delivery_events
+    return classified_setup_ids
+
+
+def validate_capture_segment_payload(
+    payload: dict[str, Any],
+    samples: list[dict[str, Any]],
+    configuration: str,
+) -> None:
+    capture = find_named_object(payload, "capture") or {}
+    validate_capture_integrity(capture)
+    delivery_drops = int(find_named_object(payload, "delivery_dropped_event_count") or 0)
+    if delivery_drops:
+        raise MatrixError(f"capture segment dropped {delivery_drops} delivery events")
+    validate_trace_records(samples, configuration)
+    validate_connection_cohorts(samples)
+    for sample in samples:
+        validate_expected(sample)
+    delivery_events = find_named_object(payload, "delivery_events") or []
+    validate_delivery_terminals(delivery_events, capture.get("lifecycle_events", []), samples)
+    joined_request_evidence(samples, capture, delivery_events, require_server=True)
+    validate_capture_request_membership(payload, samples)
+
+
+def validate_segment_index_contract(
+    index: dict[str, Any],
+    plan: list[dict[str, Any]],
+) -> None:
+    if index.get("layout") != SEGMENTED_CAPTURE_LAYOUT:
+        raise MatrixError("segmented capture index layout mismatch")
+    if index.get("capture_mode") != SERVER_CAPTURE_MODE:
+        raise MatrixError("segmented capture index mode mismatch")
+    if index.get("segment_plan_sha256") != capture_segment_plan_sha256(plan):
+        raise MatrixError("segmented capture plan hash mismatch")
+    entries = index.get("segments")
+    if not isinstance(entries, list):
+        raise MatrixError("segmented capture index omitted segments")
+    expected = [(item["ordinal"], item["segment_id"]) for item in plan]
+    actual = [(item.get("ordinal"), item.get("segment_id")) for item in entries]
+    if actual != expected:
+        raise MatrixError("segmented capture index is missing, duplicated, extra, or reordered")
+    for spec, entry in zip(plan, entries):
+        for field, expected_value in spec.items():
+            if entry.get(field) != expected_value:
+                raise MatrixError(
+                    f"segmented capture index contract mismatch for {spec['segment_id']}: {field}"
+                )
+
+
+def collect_capture_segment(
+    cli: Path,
+    window_id: int,
+    output: Path,
+    spec: dict[str, Any],
+    configuration: str,
+    max_samples: int,
+    timeout: float,
+    execute_attempt: Any,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]]:
+    discarded_invalid: list[dict[str, Any]] = []
+    for attempt in range(2):
+        begin_started = time.perf_counter_ns()
+        begin_payload = call_debug_tool(
+            cli, window_id,
+            {"op": "mcp_read_search_capture_begin", "label": spec["segment_id"],
+             "max_samples": max_samples}, timeout,
+        )
+        begin_duration_ms = (time.perf_counter_ns() - begin_started) / 1_000_000
+        validate_capture_begin(find_named_object(begin_payload, "capture") or {})
+        workload_started = time.perf_counter_ns()
+        workload_error: BaseException | None = None
+        recorded: list[dict[str, Any]] = []
+        warmups: list[dict[str, Any]] = []
+        try:
+            recorded, warmups = execute_attempt(attempt)
+        except BaseException as error:
+            workload_error = error
+        workload_duration_ms = (time.perf_counter_ns() - workload_started) / 1_000_000
+        snapshot_started = time.perf_counter_ns()
+        try:
+            payload = call_debug_tool(
+                cli, window_id,
+                {"op": "mcp_read_search_capture_snapshot", "finish": True, "include_timeline": True},
+                timeout,
+            )
+        except BaseException as error:
+            save_json(output / "capture-finish-error.json", {
+                "segment_id": spec["segment_id"], "attempt": attempt, "error": str(error),
+            })
+            raise
+        snapshot_duration_ms = (time.perf_counter_ns() - snapshot_started) / 1_000_000
+        if workload_error is not None:
+            raise workload_error
+        executed = recorded + warmups
+        capture = find_named_object(payload, "capture") or {}
+        validate_capture_integrity(capture)
+        delivery_drops = int(find_named_object(payload, "delivery_dropped_event_count") or 0)
+        if delivery_drops:
+            raise MatrixError(f"capture segment dropped {delivery_drops} delivery events")
+        classified_setup_ids = validate_capture_request_membership(payload, executed)
+        invocation_ids = [sample["invocation_id"] for sample in executed]
+        if len(invocation_ids) != len(set(invocation_ids)):
+            raise MatrixError(f"segment {spec['segment_id']} reused an invocation identity")
+        if len(invocation_ids) != int(spec["expected_invocation_count"]):
+            raise MatrixError(
+                f"segment {spec['segment_id']} invocation count mismatch: "
+                f"expected {spec['expected_invocation_count']}, got {len(invocation_ids)}"
+            )
+        validate_segment_sample_coordinates(spec, executed)
+        invalid = invalid_connection_cohorts(executed)
+        if invalid:
+            attempt_path = output / "server-capture-attempts" / f"{spec['segment_id']}-a{attempt}.json"
+            save_json(attempt_path, payload)
+            for sample in executed:
+                sample["capture_segment_attempt_id"] = f"{spec['segment_id']}-a{attempt}"
+                sample["discard_reason"] = next(iter(invalid.values()))
+            discarded_invalid.extend(executed)
+            if attempt == 0:
+                continue
+            raise MatrixError(f"segment {spec['segment_id']} remained invalid after re-cohorting")
+        for sample in executed:
+            sample["capture_segment_id"] = spec["segment_id"]
+        validate_capture_segment_payload(payload, executed, configuration)
+        relative_path = Path("server-capture-segments") / f"{spec['segment_id']}.json"
+        artifact_path = output / relative_path
+        save_json(artifact_path, payload)
+        artifact_sha256 = sha256_bytes(artifact_path.read_bytes())
+        entry = {
+            **spec,
+            "artifact_path": str(relative_path),
+            "artifact_sha256": artifact_sha256,
+            "invocation_ids": invocation_ids,
+            "classified_setup_request_ids": classified_setup_ids,
+            "attempt": attempt,
+            "timing": {
+                "begin_duration_ms": round(begin_duration_ms, 3),
+                "workload_duration_ms": round(workload_duration_ms, 3),
+                "snapshot_duration_ms": round(snapshot_duration_ms, 3),
+            },
+        }
+        return recorded, warmups, discarded_invalid, entry
+    raise MatrixError(f"segment {spec['segment_id']} did not complete")
+
+
+def run_matrix(args: argparse.Namespace) -> int:
+    optimized_artifact = None
+    if args.configuration == "optimized":
+        if not args.server_artifact_manifest:
+            raise MatrixError("optimized collection requires --server-artifact-manifest")
+        optimized_artifact = validate_optimized_artifact_manifest(Path(args.server_artifact_manifest))
+        cli = resolve_cli(args.cli or optimized_artifact["embedded_cli_path"])
+        if cli != Path(optimized_artifact["embedded_cli_path"]).resolve():
+            raise MatrixError("optimized collection must use the diagnostic app's embedded CLI")
+        if sha256_bytes(cli.read_bytes()) != optimized_artifact["embedded_cli_sha256"]:
+            raise MatrixError("optimized collection CLI hash does not match the artifact manifest")
+    else:
+        if args.server_artifact_manifest:
+            raise MatrixError("DEBUG collection must not use --server-artifact-manifest")
+        cli = resolve_cli(args.cli)
+
+    source_fingerprint = current_source_fingerprint()
+    if optimized_artifact is not None \
+            and optimized_artifact["source_fingerprint_sha256"] != source_fingerprint:
+        raise MatrixError("optimized server artifact was built from a different source-tree state")
+    output = new_capture_directory(Path(args.output))
+    fixture_root = Path(args.fixture_root) if args.fixture_root else None
+    fixture_manifest_path = Path(args.fixture_manifest) if args.fixture_manifest else None
+    validate_fixture_manifest_location(fixture_root, fixture_manifest_path)
+    variables = fixture_variables(fixture_root)
+    matrix_path = Path(args.matrix).expanduser().resolve()
+    authority = load_wi3_authority(matrix_path)
+    discipline = resolve_sample_discipline(matrix_path, args)
+    rows = load_rows(matrix_path, args.profile, args.include_manual, variables)
+    include_wi3 = discipline["cohort"] == "warm" and not args.skip_wi3
+    segment_plan = capture_segment_plan(rows, args.client_mode, discipline, authority, include_wi3)
+    segment_plan_hash = capture_segment_plan_sha256(segment_plan)
+    fixture_manifest = load_json(fixture_manifest_path) if fixture_manifest_path else None
+    expected_server_configuration = "debug" if args.configuration == "debug" else "optimized_diagnostic"
+    server_app_identity = probe_server_app_identity(
+        cli, args.window_id, args.timeout, expected_server_configuration,
+    )
+    if optimized_artifact is not None:
+        validate_runtime_artifact_identity(server_app_identity, optimized_artifact)
+
+    metadata = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "collecting",
+        "configuration": args.configuration,
+        "cohort_kind": discipline["cohort"],
+        "profile": args.profile,
+        "client_modes": args.client_mode,
+        "created_at_epoch": time.time(),
+        "commit": subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo_root(), text=True, capture_output=True,
+        ).stdout.strip(),
+        "source_fingerprint_sha256": source_fingerprint,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cli": str(cli),
+        "server_app_identity": server_app_identity,
+        "server_app_configuration": server_app_identity.get("app_configuration"),
+        "optimized_server_artifact": optimized_artifact,
+        "fixture_manifest": fixture_manifest,
+        "matrix": str(matrix_path),
+        "matrix_sha256": sha256_bytes(matrix_path.read_bytes()),
+        "wi3_authority": authority,
+        "wi3_authority_sha256": sha256_bytes(
+            json.dumps(authority, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        ),
+        "sample_discipline": discipline,
+        "server_capture_mode": SERVER_CAPTURE_MODE,
+        "server_capture_layout": SEGMENTED_CAPTURE_LAYOUT,
+        "capture_segment_contract_version": SEGMENTED_CAPTURE_CONTRACT_VERSION,
+        "capture_segment_strategy": SEGMENTED_CAPTURE_STRATEGY,
+        "capture_segment_max_ordinary_invocations": SEGMENTED_CAPTURE_MAX_ORDINARY_INVOCATIONS,
+        "capture_segment_plan": segment_plan,
+        "capture_segment_plan_sha256": segment_plan_hash,
+        "planned_capture_segment_count": len(segment_plan),
+        "planned_row_ids": [row["id"] for row in rows],
+    }
+    save_json(output / "manifest.json", metadata)
+    segment_index = {
+        "schema_version": SCHEMA_VERSION,
+        "layout": SEGMENTED_CAPTURE_LAYOUT,
+        "capture_mode": SERVER_CAPTURE_MODE,
+        "segment_plan_sha256": segment_plan_hash,
+        "segments": [],
+    }
+    save_json(output / "server-capture.json", segment_index)
+
+    samples: list[dict[str, Any]] = []
+    discarded_warmups: list[dict[str, Any]] = []
+    discarded_invalid: list[dict[str, Any]] = []
+    executed_wi3: list[str] = []
+    row_by_id = {row["id"]: row for row in rows}
+    workload_by_id = {str(item["id"]): item for item in authority["workload_matrices"]}
+
+    if args.configuration == "debug":
+        save_json(output / "runtime-before.json", call_debug_tool(
+            cli, args.window_id,
+            {"op": "mcp_read_search_runtime_snapshot", "window_id": args.window_id,
+             "recent_publication_limit": 16, "root_limit": 256}, args.timeout,
+        ))
+        save_json(output / "admission-before.json", call_debug_tool(
+            cli, args.window_id,
+            {"op": "mcp_read_search_admission_snapshot", "window_id": args.window_id},
+            args.timeout,
+        ))
+
+    for spec in segment_plan:
+        if spec["kind"] == "wi3":
+            workload = workload_by_id.get(str(spec["workload_matrix_id"]))
+            if workload is None:
+                raise MatrixError(f"planned WI-3 workload is absent: {spec['workload_matrix_id']}")
+
+            def execute_attempt(attempt: int, workload: dict[str, Any] = workload) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+                return run_wi3_workload_generation(
+                    cli, args.window_id, matrix_path, workload, variables, output,
+                    args.timeout, attempt,
+                ), []
+        else:
+            row = row_by_id.get(str(spec["row_ids"][0]))
+            if row is None:
+                raise MatrixError(f"planned ordinary row is absent: {spec['row_ids'][0]}")
+            terminal = spec["kind"] == "expected_terminal"
+            row_warmups = [] if terminal else warmup_rows([row], discipline["warmups"])
+            row_recorded = expanded_rows(
+                [row], 1 if terminal else discipline["repeats"],
+                1 if terminal else discipline["samples_per_repeat"],
+            )
+
+            def execute_attempt(
+                attempt: int,
+                row_warmups: list[dict[str, Any]] = row_warmups,
+                row_recorded: list[dict[str, Any]] = row_recorded,
+                spec: dict[str, Any] = spec,
+            ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+                if spec["client_mode"] == "fresh":
+                    warmup_samples = run_fresh(
+                        cli, args.window_id, row_warmups, output, args.timeout,
+                        discipline["cohort"], "warmup",
+                    )
+                    recorded_samples = run_fresh(
+                        cli, args.window_id, row_recorded, output, args.timeout,
+                        discipline["cohort"], "recorded",
+                    )
+                    return recorded_samples, warmup_samples
+                generation_samples = run_persistent_generation(
+                    cli, args.window_id, row_warmups, row_recorded, output,
+                    args.timeout, discipline["cohort"], attempt, spec["segment_id"],
+                )
+                return (
+                    [sample for sample in generation_samples if sample["phase"] == "recorded"],
+                    [sample for sample in generation_samples if sample["phase"] == "warmup"],
+                )
+
+        recorded, warmups, invalid, entry = collect_capture_segment(
+            cli, args.window_id, output, spec, args.configuration,
+            args.max_samples, args.timeout, execute_attempt,
+        )
+        samples.extend(recorded)
+        discarded_warmups.extend(warmups)
+        discarded_invalid.extend(invalid)
+        if spec["kind"] == "wi3":
+            executed_wi3.append(str(spec["workload_matrix_id"]))
+        segment_index["segments"].append(entry)
+        save_json(output / "server-capture.json", segment_index)
+        metadata["accepted_capture_segment_count"] = len(segment_index["segments"])
+        metadata["rejected_capture_attempt_count"] = len({
+            str(sample["capture_segment_attempt_id"])
+            for sample in discarded_invalid
+            if sample.get("capture_segment_attempt_id")
+        })
+        save_json(output / "manifest.json", metadata)
+
+    validate_segment_index_contract(segment_index, segment_plan)
+    validate_connection_cohorts(samples)
+    for sample in samples:
+        validate_expected(sample)
+    validate_format_pairs(samples)
+
+    if args.configuration == "debug":
+        save_json(output / "runtime-after.json", call_debug_tool(
+            cli, args.window_id,
+            {"op": "mcp_read_search_runtime_snapshot", "window_id": args.window_id,
+             "recent_publication_limit": 16, "root_limit": 256}, args.timeout,
+        ))
+        save_json(output / "admission-after.json", call_debug_tool(
+            cli, args.window_id,
+            {"op": "mcp_read_search_admission_snapshot", "window_id": args.window_id},
+            args.timeout,
+        ))
+
+    server_app_identity_end = probe_server_app_identity(
+        cli, args.window_id, args.timeout, expected_server_configuration,
+    )
+    if server_app_identity_end != server_app_identity:
+        raise MatrixError("server app identity changed during cohort collection")
+    if optimized_artifact is not None:
+        validate_runtime_artifact_identity(server_app_identity_end, optimized_artifact)
+    metadata["status"] = "completed"
+    metadata["server_app_identity_end"] = server_app_identity_end
+    metadata["completed_at_epoch"] = time.time()
+    metadata["accepted_capture_segment_count"] = len(segment_index["segments"])
+    metadata["completed_capture_segment_count"] = len(segment_index["segments"])
+    metadata["capture_segment_index_sha256"] = sha256_bytes(
+        (output / "server-capture.json").read_bytes()
+    )
+    save_json(output / "manifest.json", metadata)
+
+    run = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "completed",
+        "samples": samples,
+        "discarded_warmups": discarded_warmups,
+        "discarded_invalid_cohorts": discarded_invalid,
+        "executed_wi3_matrix_ids": executed_wi3,
+    }
+    save_json(output / "run.json", run)
+    summary = aggregate(output)
+    wi3_signature = summary["wi3_work_counts"].get("parity_signature")
+    baseline_samples = [sample for sample in samples if sample.get("cohort_kind") != "wi3"]
+    apply_baseline(baseline_samples, Path(args.baseline), args.update_baseline, wi3_signature)
+    save_json(output / "aggregate.json", summary)
+    print(json.dumps({
+        "output": str(output), "samples": len(samples), "segments": len(segment_plan),
+        "selector": summary["selector"],
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+def analyze_command(args: argparse.Namespace) -> int:
+    if args.debug_input or args.optimized_input:
+        if not args.debug_input or not args.optimized_input:
+            raise MatrixError("paired analyze requires both --debug-input and --optimized-input")
+        summary = paired_aggregate(
+            Path(args.debug_input).expanduser().resolve(),
+            Path(args.optimized_input).expanduser().resolve(),
+        )
+    elif args.input:
+        summary = aggregate(Path(args.input).expanduser().resolve())
+    else:
+        raise MatrixError("analyze requires --input or the paired input options")
+    save_json(Path(args.output), summary)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run = subparsers.add_parser("run", help="run against an already-running CE app; performs no lifecycle action")
+    run.add_argument("--configuration", required=True, choices=("debug", "optimized"))
+    run.add_argument("--cohort", required=True, choices=("cold", "warm"))
+    run.add_argument("--profile", required=True, choices=("real", "small", "medium", "large"))
+    run.add_argument("--client-mode", action="append", choices=("fresh", "persistent"), required=True)
+    run.add_argument("--window-id", type=int, default=1)
+    run.add_argument("--cli")
+    run.add_argument("--server-artifact-manifest")
+    run.add_argument("--matrix", default=str(default_matrix()))
+    run.add_argument("--fixture-root")
+    run.add_argument("--fixture-manifest")
+    run.add_argument("--output", required=True)
+    run.add_argument("--baseline", required=True)
+    run.add_argument("--update-baseline", action="store_true")
+    run.add_argument("--include-manual", action="store_true")
+    run.add_argument("--skip-wi3", action="store_true")
+    run.add_argument("--activation-id")
+    run.add_argument("--cold-sample-index", type=int)
+    run.add_argument("--timeout", type=float, default=180)
+    run.add_argument("--warmups", type=int)
+    run.add_argument("--repeats", type=int)
+    run.add_argument("--samples-per-repeat", type=int)
+    run.add_argument("--max-samples", type=int, default=100_000)
+    analyze = subparsers.add_parser("analyze")
+    analyze.add_argument("--input")
+    analyze.add_argument("--debug-input")
+    analyze.add_argument("--optimized-input")
+    analyze.add_argument("--output", required=True)
+    args = parser.parse_args(argv)
+    if args.command == "run":
+        if args.timeout <= 0:
+            parser.error("--timeout must be greater than zero")
+        if args.warmups is not None and args.warmups < 0:
+            parser.error("--warmups must be non-negative")
+        if args.repeats is not None and args.repeats <= 0:
+            parser.error("--repeats must be greater than zero")
+        if args.samples_per_repeat is not None and args.samples_per_repeat <= 0:
+            parser.error("--samples-per-repeat must be greater than zero")
+        if not 100 <= args.max_samples <= 100_000:
+            parser.error("--max-samples must be between 100 and 100000")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parse_args(argv or sys.argv[1:])
+        return run_matrix(args) if args.command == "run" else analyze_command(args)
+    except (MatrixError, OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONF="${1:-debug}"
+PACKAGE_MODE="${1:-debug}"
+case "$PACKAGE_MODE" in
+    debug|release) SWIFT_CONFIGURATION="$PACKAGE_MODE" ;;
+    mcp-latency-diagnostic) SWIFT_CONFIGURATION="release" ;;
+    *) echo "ERROR: Unsupported package mode '$PACKAGE_MODE'." >&2; exit 2 ;;
+esac
+CONF="$PACKAGE_MODE"
+IS_MCP_LATENCY_DIAGNOSTIC=0
+[[ "$PACKAGE_MODE" == "mcp-latency-diagnostic" ]] && IS_MCP_LATENCY_DIAGNOSTIC=1
 ROOT_DIR="${REPOPROMPT_RELEASE_SOURCE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 CONTROL_PLANE_SCRIPTS_DIR="${REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR:-$ROOT_DIR/Scripts}"
 RUN_WITHOUT_GITHUB_TOKENS="$CONTROL_PLANE_SCRIPTS_DIR/run_without_github_tokens.sh"
@@ -83,9 +91,11 @@ trap 'finish $?' EXIT
 
 BUNDLE_ID_OVERRIDE="${BUNDLE_ID:-}"
 RELEASE_BUILD_NUMBER_OVERRIDE="${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}"
-# Invalidate public-release manifests before metadata parsing, checks, or builds
-# so failed non-public packaging cannot leave stale release metadata behind.
-remove_stale_artifact_manifests
+# The diagnostic package has an isolated non-release manifest authority and must not
+# remove or replace ordinary release manifests.
+if (( ! IS_MCP_LATENCY_DIAGNOSTIC )); then
+    remove_stale_artifact_manifests
+fi
 source "$CONTROL_PLANE_SCRIPTS_DIR/load_release_metadata.sh"
 load_release_metadata "$ROOT_DIR"
 if [[ -n "$RELEASE_BUILD_NUMBER_OVERRIDE" ]]; then
@@ -95,14 +105,32 @@ if [[ -n "$RELEASE_BUILD_NUMBER_OVERRIDE" ]]; then
 fi
 APP_NAME="${APP_NAME:-RepoPrompt}"; DISPLAY_NAME="${DISPLAY_NAME:-RepoPrompt CE}"; BASE_BUNDLE_ID="${BUNDLE_ID:-com.pvncher.repoprompt.ce}"; MARKETING_VERSION="${MARKETING_VERSION:-0.1.0}"; BUILD_NUMBER="${BUILD_NUMBER:-1}"; SIGNING_TEAM_ID="${SIGNING_TEAM_ID:-648A27MST5}"
 ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
+MCP_LATENCY_ARTIFACT_ROOT="$ROOT_DIR/.build/mcp-latency/optimized-server"
+MCP_LATENCY_ARTIFACT_MANIFEST="$MCP_LATENCY_ARTIFACT_ROOT/artifact-manifest.json"
+MCP_LATENCY_PROVENANCE_FILENAME="RepoPromptMCPLatencyDiagnosticProvenance.json"
 SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/$CONF"
 
 IS_RELEASE=0
 [[ "$CONF" == "release" ]] && IS_RELEASE=1
 if (( IS_RELEASE )); then
     BUNDLE_ID="${BUNDLE_ID_OVERRIDE:-$BASE_BUNDLE_ID}"
+elif (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+    [[ -z "$BUNDLE_ID_OVERRIDE" ]] || fail "The MCP latency diagnostic bundle identifier is fixed and cannot be overridden."
+    BUNDLE_ID="$BASE_BUNDLE_ID.mcp-latency-diagnostic"
 else
     BUNDLE_ID="${BUNDLE_ID_OVERRIDE:-${DEBUG_BUNDLE_ID:-$BASE_BUNDLE_ID.debug}}"
+fi
+
+if (( IS_RELEASE )) && { truthy "${RPCE_ENABLE_MCP_LATENCY_DIAGNOSTICS:-}" || truthy "${RPCE_ENABLE_MCP_LATENCY_TRACE:-}"; }; then
+    fail "Ordinary release packaging refuses MCP latency diagnostic compile gates. Use the isolated mcp-latency-diagnostic mode."
+fi
+if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+    truthy "${REPOPROMPT_ENABLE_SENTRY:-}" && fail "MCP latency diagnostic packaging does not link Sentry."
+    truthy "${REPOPROMPT_UPLOAD_SENTRY_SYMBOLS:-}" && fail "MCP latency diagnostic packaging does not upload symbols."
+    truthy "${LOCAL_SELF_SIGNED_RELEASE:-}" && fail "MCP latency diagnostic packaging does not use release signing modes."
+    [[ -z "${SIGN_IDENTITY:-}" ]] || fail "MCP latency diagnostic packaging is always isolated ad-hoc signing; do not set SIGN_IDENTITY."
+    export RPCE_ENABLE_MCP_LATENCY_DIAGNOSTICS=1
+    export RPCE_ENABLE_MCP_LATENCY_TRACE=1
 fi
 
 phase "Checking build environment"
@@ -128,6 +156,10 @@ LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE="$ROOT_DIR/AppBundle/RepoPrompt.local-se
 APP_ENTITLEMENTS=""
 USE_ADHOC_SIGNING=0
 USE_LOCAL_SELF_SIGNED_RELEASE=0
+if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+    USE_ADHOC_SIGNING=1
+    SIGN_IDENTITY="-"
+fi
 DEBUG_STORAGE_BACKEND_MARKER="alternate-in-memory"
 SIGNING_MODE_MARKER="debug-apple-development"
 warn_adhoc_signing(){
@@ -153,7 +185,7 @@ if [[ "$LOCAL_SELF_SIGNED_RELEASE" == "1" || "$LOCAL_SELF_SIGNED_RELEASE" == "tr
     echo "WARNING: Building a local-only self-signed production app."
     echo "WARNING: This app is for installation on this Mac only. It is not notarized and must not be uploaded to GitHub Releases."
 fi
-if [[ -z "$SIGN_IDENTITY" ]] && (( ! IS_RELEASE )) && [[ "$PREFER_STABLE_DEBUG_SIGNING" == "1" || "$PREFER_STABLE_DEBUG_SIGNING" == "true" ]]; then
+if [[ -z "$SIGN_IDENTITY" ]] && (( ! IS_RELEASE )) && (( ! IS_MCP_LATENCY_DIAGNOSTIC )) && [[ "$PREFER_STABLE_DEBUG_SIGNING" == "1" || "$PREFER_STABLE_DEBUG_SIGNING" == "true" ]]; then
     AUTO_SIGN_IDENTITY="$(security find-identity -v -p codesigning 2>/dev/null | awk -F'"' '/"Apple Development: / { print $2; exit }')"
     if [[ -n "$AUTO_SIGN_IDENTITY" ]]; then
         SIGN_IDENTITY="$AUTO_SIGN_IDENTITY"
@@ -187,7 +219,10 @@ else
     fi
 fi
 
-if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
+if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+    DEBUG_STORAGE_BACKEND_MARKER="alternate-in-memory"
+    SIGNING_MODE_MARKER="mcp-latency-diagnostic-adhoc"
+elif (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
     DEBUG_STORAGE_BACKEND_MARKER="keychain"
     SIGNING_MODE_MARKER="local-self-signed"
 elif (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
@@ -208,7 +243,10 @@ fi
 printf 'Debug secure storage backend marker: %s\n' "$DEBUG_STORAGE_BACKEND_MARKER"
 printf 'Signing mode marker: %s\n' "$SIGNING_MODE_MARKER"
 
-SWIFT_BUILD_ARGS=(-c "$CONF")
+SWIFT_BUILD_ARGS=(-c "$SWIFT_CONFIGURATION")
+if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+    SWIFT_BUILD_ARGS+=(--scratch-path "$MCP_LATENCY_ARTIFACT_ROOT/scratch")
+fi
 if sentry_linking_enabled; then
     SWIFT_BUILD_ARGS+=(-debug-info-format dwarf)
 fi
@@ -249,26 +287,37 @@ if (( PUBLIC_UNIVERSAL_RELEASE )); then
         "$CONTROL_PLANE_SCRIPTS_DIR/build_swiftpm_release_products.sh" "$BUILD_DIR"
 else
     phase "Patching KeyboardShortcuts resource lookup"
-    run "$CONTROL_PLANE_SCRIPTS_DIR/patch_keyboard_shortcuts_resource_lookup.sh" "$ROOT_DIR"
+    if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+        run env REPOPROMPT_SWIFTPM_SCRATCH_PATH="$MCP_LATENCY_ARTIFACT_ROOT/scratch" \
+            "$CONTROL_PLANE_SCRIPTS_DIR/patch_keyboard_shortcuts_resource_lookup.sh" "$ROOT_DIR"
+    else
+        run "$CONTROL_PLANE_SCRIPTS_DIR/patch_keyboard_shortcuts_resource_lookup.sh" "$ROOT_DIR"
+    fi
 
-    phase "Building $APP_NAME ($CONF, host-native)"
+    phase "Building $APP_NAME ($SWIFT_CONFIGURATION, host-native; package mode $PACKAGE_MODE)"
     run "$RUN_WITHOUT_GITHUB_TOKENS" swift build "${SWIFT_BUILD_ARGS[@]}" --product "$APP_NAME"
 
-    phase "Building repoprompt-mcp ($CONF, host-native)"
+    phase "Building repoprompt-mcp ($SWIFT_CONFIGURATION, host-native; package mode $PACKAGE_MODE)"
     run "$RUN_WITHOUT_GITHUB_TOKENS" swift build "${SWIFT_BUILD_ARGS[@]}" --product repoprompt-mcp
 
     phase "Resolving build artifact paths"
-    echo_cmd "$RUN_WITHOUT_GITHUB_TOKENS" swift build -c "$CONF" --show-bin-path
-    BUILD_DIR="$("$RUN_WITHOUT_GITHUB_TOKENS" swift build -c "$CONF" --show-bin-path)"
+    echo_cmd "$RUN_WITHOUT_GITHUB_TOKENS" swift build "${SWIFT_BUILD_ARGS[@]}" --show-bin-path
+    BUILD_DIR="$("$RUN_WITHOUT_GITHUB_TOKENS" swift build "${SWIFT_BUILD_ARGS[@]}" --show-bin-path)"
 fi
-if (( PUBLIC_UNIVERSAL_RELEASE )); then
+if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+    APP_BUNDLE="$MCP_LATENCY_ARTIFACT_ROOT/$APP_NAME.app"
+elif (( PUBLIC_UNIVERSAL_RELEASE )); then
     APP_BUNDLE="$ROOT_DIR/.build/release/$APP_NAME.app"
 elif (( IS_RELEASE )); then
     APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 else
     APP_BUNDLE="${REPOPROMPT_DEBUG_APP_BUNDLE:-$HOME/Library/Application Support/RepoPrompt CE/DebugApps/$APP_NAME.app}"
 fi
-COMPAT_APP_BUNDLE="$ROOT_DIR/.build/$CONF/$APP_NAME.app"
+if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+    COMPAT_APP_BUNDLE="$APP_BUNDLE"
+else
+    COMPAT_APP_BUNDLE="$ROOT_DIR/.build/$CONF/$APP_NAME.app"
+fi
 CLI_PATH="$BUILD_DIR/repoprompt-mcp"
 printf 'BUILD_DIR=%s\nAPP_BUNDLE=%s\nCOMPAT_APP_BUNDLE=%s\nCLI_PATH=%s\nAD_HOC_SIGNING=%s\nARCHITECTURE_POLICY=%s\n' "$BUILD_DIR" "$APP_BUNDLE" "$COMPAT_APP_BUNDLE" "$CLI_PATH" "$USE_ADHOC_SIGNING" "$ARCHITECTURE_POLICY"
 
@@ -366,8 +415,20 @@ run install_name_tool -add_rpath @executable_path/../Frameworks "$APP_BUNDLE/Con
 run "$CONTROL_PLANE_SCRIPTS_DIR/validate_app_architectures.sh" "$APP_BUNDLE" "$ARCHITECTURE_POLICY" "Pre-sign packaged app"
 
 if (( ! IS_RELEASE )); then
-    phase "Writing debug bundle provenance"
-    ROOT_DIR_FOR_PROVENANCE="$ROOT_DIR" APP_BUNDLE_FOR_PROVENANCE="$APP_BUNDLE" python3 - <<'PY'
+    if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+        phase "Writing optimized MCP latency diagnostic provenance"
+        PROVENANCE_FILENAME="$MCP_LATENCY_PROVENANCE_FILENAME"
+    else
+        phase "Writing debug bundle provenance"
+        PROVENANCE_FILENAME="RepoPromptDebugProvenance.json"
+    fi
+    SOURCE_FINGERPRINT_SHA256="$(python3 "$CONTROL_PLANE_SCRIPTS_DIR/source_tree_fingerprint.py" --repo "$ROOT_DIR")"
+    ROOT_DIR_FOR_PROVENANCE="$ROOT_DIR" \
+        APP_BUNDLE_FOR_PROVENANCE="$APP_BUNDLE" \
+        PACKAGE_MODE_FOR_PROVENANCE="$PACKAGE_MODE" \
+        PROVENANCE_FILENAME="$PROVENANCE_FILENAME" \
+        SOURCE_FINGERPRINT_SHA256="$SOURCE_FINGERPRINT_SHA256" \
+        python3 - <<'PY'
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -376,9 +437,12 @@ import json
 import os
 import subprocess
 import time
+import uuid
 
 root = Path(os.environ["ROOT_DIR_FOR_PROVENANCE"]).resolve()
 bundle = Path(os.environ["APP_BUNDLE_FOR_PROVENANCE"])
+package_mode = os.environ["PACKAGE_MODE_FOR_PROVENANCE"]
+filename = os.environ["PROVENANCE_FILENAME"]
 
 def git(args: list[str]) -> str | None:
     try:
@@ -400,15 +464,32 @@ payload = {
     "branch": git(["rev-parse", "--abbrev-ref", "HEAD"]),
     "commit": git(["rev-parse", "HEAD"]),
     "dirty": bool(status),
+    "source_fingerprint_sha256": os.environ["SOURCE_FINGERPRINT_SHA256"],
     "buildTimeEpoch": now,
     "buildTimeISO": datetime.fromtimestamp(now, timezone.utc).astimezone().isoformat(timespec="seconds"),
 }
-path = bundle / "Contents" / "Resources" / "RepoPromptDebugProvenance.json"
+if package_mode == "mcp-latency-diagnostic":
+    payload.update({
+        "schema_version": 1,
+        "artifact_id": str(uuid.uuid4()),
+        "artifact_kind": "optimized_mcp_latency_diagnostic_server",
+        "ordinary_release_artifact": False,
+        "swift_configuration": "release",
+        "server_diagnostic_configuration": "optimized_diagnostic",
+        "diagnostic_surface": "mcp_latency_v1",
+        "enabled_defines_by_target": {
+            "RepoPromptApp": ["MCP_LATENCY_DIAGNOSTICS"],
+            "RepoPromptDomainRuntime": ["MCP_LATENCY_DIAGNOSTICS"],
+            "RepoPromptMCP": ["MCP_LATENCY_TRACE"],
+            "RepoPromptShared": ["MCP_LATENCY_DIAGNOSTICS"],
+        },
+    })
+path = bundle / "Contents" / "Resources" / filename
 path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-print(f"Debug bundle provenance: {path}")
+print(f"Bundle provenance: {path}")
 PY
     run python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_json.py" \
-        "$APP_BUNDLE/Contents/Resources/RepoPromptDebugProvenance.json"
+        "$APP_BUNDLE/Contents/Resources/$PROVENANCE_FILENAME"
 fi
 
 phase "Signing app bundle"
@@ -509,6 +590,13 @@ if (( PUBLIC_UNIVERSAL_RELEASE )); then
 fi
 run "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Packaged app MCP helper layout"
 run "$RUN_WITHOUT_GITHUB_TOKENS" "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh" "$APP_BUNDLE" "Packaged app MCP helper"
+if (( IS_MCP_LATENCY_DIAGNOSTIC )); then
+    phase "Writing optimized MCP latency diagnostic artifact manifest"
+    run python3 "$CONTROL_PLANE_SCRIPTS_DIR/write_mcp_latency_diagnostic_manifest.py" \
+        --app "$APP_BUNDLE" \
+        --output "$MCP_LATENCY_ARTIFACT_MANIFEST" \
+        --artifact-root "$MCP_LATENCY_ARTIFACT_ROOT"
+fi
 if truthy "${REPOPROMPT_UPLOAD_SENTRY_SYMBOLS:-}"; then
     sentry_linking_enabled || fail "REPOPROMPT_UPLOAD_SENTRY_SYMBOLS requires REPOPROMPT_ENABLE_SENTRY=1."
     require_sentry_upload_credentials

--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -717,6 +717,7 @@ allowed_tracked_docs=(
   "docs/architecture/codex-app-server-schema-gate.md"
   "docs/architecture/compose.md"
   "docs/architecture/headless-mcp-runtime.md"
+  "docs/architecture/mcp-tool-latency-diagnostics.md"
   "docs/architecture/provider-plugins.md"
   "docs/architecture/settings-persistence.md"
   "docs/architecture/source-layout.md"

--- a/Scripts/source_tree_fingerprint.py
+++ b/Scripts/source_tree_fingerprint.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Compute a deterministic fingerprint of non-ignored repository source state."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+
+class FingerprintError(RuntimeError):
+    pass
+
+
+def source_tree_fingerprint(repo: Path) -> str:
+    root = repo.expanduser().resolve()
+    process = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        capture_output=True,
+        check=False,
+    )
+    if process.returncode:
+        raise FingerprintError(process.stderr.decode("utf-8", errors="replace").strip() or "git ls-files failed")
+    digest = hashlib.sha256()
+    for raw_relative in sorted(item for item in process.stdout.split(b"\0") if item):
+        relative = raw_relative.decode("utf-8", errors="surrogateescape")
+        path = root / relative
+        encoded_path = os.fsencode(relative)
+        digest.update(len(encoded_path).to_bytes(8, "big"))
+        digest.update(encoded_path)
+        if path.is_symlink():
+            payload = os.fsencode(os.readlink(path))
+            kind = b"L"
+        elif path.is_file():
+            payload = path.read_bytes()
+            kind = b"F"
+        else:
+            payload = b""
+            kind = b"D"
+        digest.update(kind)
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", type=Path, required=True)
+    args = parser.parse_args()
+    print(source_tree_fingerprint(args.repo))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except FingerprintError as error:
+        raise SystemExit(f"ERROR: {error}")

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -232,6 +232,62 @@ class LifecycleQueueTests(LifecycleTestCase):
         self.assertEqual(cwd, repo_root)
         self.assertEqual(timeout, conductor.SHORT_TIMEOUT_SECONDS)
 
+    def test_mcp_latency_coordinates_artifacts_and_never_adds_lifecycle_actions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = conductor.OperationRegistry(Path(tmp))
+            fixture_argv, fixture_lanes, _cwd, _env, _timeout = registry.prepare({
+                "operation": "mcp-latency",
+                "args": {"toolArgs": ["fixture", "--profile", "small", "--output", "/tmp/fixture"]},
+            })
+            debug_argv, debug_lanes, _cwd, _env, _timeout = registry.prepare({
+                "operation": "mcp-latency",
+                "args": {"toolArgs": ["run", "--configuration", "debug"]},
+            })
+            optimized_argv, optimized_lanes, _cwd, _env, _timeout = registry.prepare({
+                "operation": "mcp-latency",
+                "args": {"toolArgs": ["run", "--configuration", "optimized"]},
+            })
+            analyze_argv, analyze_lanes, _cwd, _env, _timeout = registry.prepare({
+                "operation": "mcp-latency",
+                "args": {"toolArgs": ["analyze", "--input", "/tmp/input", "--output", "/tmp/output"]},
+            })
+            client_argv, client_lanes, _cwd, _env, _timeout = registry.prepare({
+                "operation": "mcp-latency-client-build", "args": {},
+            })
+            debug_server_argv, debug_server_lanes, _cwd, debug_server_env, _timeout = registry.prepare({
+                "operation": "mcp-latency-debug-server-build", "args": {},
+            })
+            server_argv, server_lanes, _cwd, _env, server_timeout = registry.prepare({
+                "operation": "mcp-latency-server-build", "args": {},
+            })
+
+        self.assertEqual(Path(fixture_argv[1]).name, "generate_fixture.py")
+        self.assertEqual(fixture_lanes, [])
+        self.assertEqual(Path(debug_argv[1]).name, "run_latency_matrix.py")
+        self.assertEqual(debug_lanes, ["debugArtifact", "liveApp"])
+        self.assertEqual(Path(optimized_argv[1]).name, "run_latency_matrix.py")
+        self.assertEqual(optimized_lanes, ["mcpLatencyArtifact", "liveApp"])
+        self.assertEqual(Path(analyze_argv[1]).name, "run_latency_matrix.py")
+        self.assertEqual(analyze_lanes, [])
+        self.assertEqual(Path(client_argv[0]).name, "build_mcp_latency_client.sh")
+        self.assertEqual(client_lanes, ["build", "mcpLatencyArtifact"])
+        self.assertEqual(Path(debug_server_argv[0]).name, "package_app.sh")
+        self.assertEqual(debug_server_argv[1], "debug")
+        self.assertEqual(debug_server_lanes, ["build", "mcpLatencyArtifact"])
+        self.assertTrue(debug_server_env["REPOPROMPT_DEBUG_APP_BUNDLE"].endswith(
+            ".build/mcp-latency/debug-server/RepoPrompt.app"
+        ))
+        self.assertEqual(debug_server_env["ALLOW_ADHOC_SIGNING"], "1")
+        self.assertEqual(Path(server_argv[0]).name, "package_app.sh")
+        self.assertEqual(server_argv[1], "mcp-latency-diagnostic")
+        self.assertEqual(server_lanes, ["build", "mcpLatencyArtifact"])
+        self.assertEqual(server_timeout, conductor.RELEASE_ARTIFACT_TIMEOUT_SECONDS)
+        for argv in (debug_argv, optimized_argv, client_argv, debug_server_argv, server_argv):
+            joined = " ".join(argv)
+            self.assertNotIn("__operation_runner", joined)
+            self.assertNotIn("open ", joined)
+            self.assertNotIn("app stop", joined)
+
     def test_release_artifact_delegates_release_script_with_release_lanes_and_extended_timeout(self) -> None:
         tmp, state = self.make_state()
         self.addCleanup(tmp.cleanup)

--- a/Scripts/test_mcp_latency_diagnostic_artifact.py
+++ b/Scripts/test_mcp_latency_diagnostic_artifact.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Focused guardrails for the isolated optimized MCP latency app manifest."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import plistlib
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "Scripts/write_mcp_latency_diagnostic_manifest.py"
+
+
+def load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+manifest_writer = load_module("mcp_latency_manifest_writer", MODULE_PATH)
+fingerprint = load_module("source_tree_fingerprint", ROOT / "Scripts/source_tree_fingerprint.py")
+
+
+class MCPLatencyDiagnosticArtifactTests(unittest.TestCase):
+    def test_source_fingerprint_tracks_nonignored_worktree_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            subprocess.run(["git", "init", "-q", str(repo)], check=True)
+            (repo / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+            (repo / "tracked.txt").write_text("one", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", ".gitignore", "tracked.txt"], check=True)
+            first = fingerprint.source_tree_fingerprint(repo)
+            (repo / "tracked.txt").write_text("two", encoding="utf-8")
+            second = fingerprint.source_tree_fingerprint(repo)
+            self.assertNotEqual(first, second)
+            (repo / "ignored.txt").write_text("ignored mutation", encoding="utf-8")
+            self.assertEqual(second, fingerprint.source_tree_fingerprint(repo))
+
+    def test_optimized_server_surface_is_a_closed_timing_only_allowlist(self) -> None:
+        source = (ROOT / "Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+MCPLatencyDiagnostics.swift").read_text(encoding="utf-8")
+        operations = set(re.findall(r'case \w+ = "([^"]+)"', source))
+        self.assertEqual(operations, {
+            "mcp_latency_server_identity",
+            "mcp_read_search_capture_begin",
+            "mcp_read_search_capture_snapshot",
+        })
+        for forbidden in (
+            "restart", "shutdown", "seed", "sleep", "fault", "large_response",
+            "sparkle", "routing", "workspace", "runtime_snapshot", "admission_snapshot",
+        ):
+            self.assertNotIn(f'case {forbidden}', source.lower())
+
+        package = (ROOT / "Scripts/package_app.sh").read_text(encoding="utf-8")
+        self.assertIn("Ordinary release packaging refuses MCP latency diagnostic compile gates", package)
+        self.assertIn('COMPAT_APP_BUNDLE="$APP_BUNDLE"', package)
+        self.assertIn('SIGN_IDENTITY="-"', package)
+
+    def make_artifact(self, root: Path) -> tuple[Path, Path, Path]:
+        app = root / "RepoPrompt.app"
+        macos = app / "Contents/MacOS"
+        resources = app / "Contents/Resources"
+        macos.mkdir(parents=True)
+        resources.mkdir(parents=True)
+        for name, payload in (("RepoPrompt", b"optimized-server"), ("repoprompt-mcp", b"optimized-client")):
+            executable = macos / name
+            executable.write_bytes(payload)
+            os.chmod(executable, 0o755)
+        with (app / "Contents/Info.plist").open("wb") as handle:
+            plistlib.dump({
+                "CFBundleIdentifier": "com.pvncher.repoprompt.ce.mcp-latency-diagnostic",
+                "CFBundleExecutable": "RepoPrompt",
+                "RepoPromptSigningMode": "mcp-latency-diagnostic-adhoc",
+                "RepoPromptDebugSecureStorageBackend": "alternate-in-memory",
+            }, handle)
+        provenance = {
+            "schema_version": 1,
+            "artifact_id": "artifact-identity",
+            "artifact_kind": manifest_writer.ARTIFACT_KIND,
+            "ordinary_release_artifact": False,
+            "swift_configuration": "release",
+            "server_diagnostic_configuration": "optimized_diagnostic",
+            "diagnostic_surface": "mcp_latency_v1",
+            "enabled_defines_by_target": manifest_writer.EXPECTED_DEFINES,
+            "commit": "a" * 40,
+            "dirty": True,
+            "source_fingerprint_sha256": "b" * 64,
+        }
+        provenance_path = resources / manifest_writer.PROVENANCE_NAME
+        provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
+        return app, root / "artifact-manifest.json", provenance_path
+
+    def test_manifest_records_exact_isolated_release_optimized_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            app, output, _provenance = self.make_artifact(root)
+            payload = manifest_writer.build_manifest(app, output, root)
+
+        self.assertEqual(payload["artifact_kind"], manifest_writer.ARTIFACT_KIND)
+        self.assertEqual(payload["swift_configuration"], "release")
+        self.assertEqual(payload["server_diagnostic_configuration"], "optimized_diagnostic")
+        self.assertEqual(payload["enabled_defines_by_target"], manifest_writer.EXPECTED_DEFINES)
+        self.assertEqual(set(payload["enabled_defines_by_target"]), {
+            "RepoPromptApp", "RepoPromptDomainRuntime", "RepoPromptMCP", "RepoPromptShared",
+        })
+        self.assertFalse(any(
+            "DEBUG" in defines for defines in payload["enabled_defines_by_target"].values()
+        ))
+        self.assertFalse(payload["ordinary_release_artifact"])
+        self.assertEqual(payload["source_fingerprint_sha256"], "b" * 64)
+        self.assertEqual(payload["signing_mode"], "mcp-latency-diagnostic-adhoc")
+        self.assertEqual(payload["secure_storage_backend"], "alternate-in-memory")
+        self.assertEqual(len(payload["executable_sha256"]), 64)
+        self.assertEqual(len(payload["embedded_cli_sha256"]), 64)
+        self.assertTrue(payload["bundle_identifier"].endswith(".mcp-latency-diagnostic"))
+
+    def test_manifest_rejects_escaping_output_and_tampered_provenance(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            app, output, provenance_path = self.make_artifact(root)
+            with self.assertRaisesRegex(manifest_writer.ManifestError, "escapes"):
+                manifest_writer.build_manifest(app, root.parent / "escaped.json", root)
+
+            provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+            provenance["enabled_defines_by_target"]["RepoPromptApp"].append("DEBUG")
+            provenance_path.write_text(json.dumps(provenance), encoding="utf-8")
+            with self.assertRaisesRegex(manifest_writer.ManifestError, "target defines"):
+                manifest_writer.build_manifest(app, output, root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_mcp_tool_latency.py
+++ b/Scripts/test_mcp_tool_latency.py
@@ -1,0 +1,917 @@
+#!/usr/bin/env python3
+"""Deterministic contract tests for the MCP latency fixture/matrix tooling."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX = ROOT / "Scripts/Fixtures/mcp-tool-latency/v1/matrix.json"
+
+
+def load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fixture = load_module("mcp_latency_fixture", ROOT / "Scripts/mcp-latency/generate_fixture.py")
+runner = load_module("mcp_latency_runner", ROOT / "Scripts/mcp-latency/run_latency_matrix.py")
+
+
+class MCPToolLatencyToolingTests(unittest.TestCase):
+    @staticmethod
+    def sample(
+        invocation_id: str,
+        output_format: str = "formatted",
+        client_mode: str = "fresh",
+        row_id: str = "search-content-few",
+    ) -> dict[str, object]:
+        response = b"formatted output\n" if output_format == "formatted" else b'{"data":{"results":[]}}\n'
+        return {
+            "sample_id": f"{row_id}:{output_format}:{client_mode}:{invocation_id}",
+            "invocation_id": invocation_id,
+            "row_id": row_id,
+            "tool": "file_search",
+            "format": output_format,
+            "client_mode": client_mode,
+            "cohort_kind": "warm",
+            "phase": "recorded",
+            "connection_cohort": f"{client_mode}-0",
+            "expected_outcome": "success",
+            "outcome": "success",
+            "is_error": False,
+            "response_sha256": runner.sha256_bytes(response),
+            "response_byte_count": len(response),
+            "response_is_json": output_format == "raw",
+            "repeat_ordinal": 0,
+            "sample_ordinal": 0,
+            "client_trace": [{
+                "invocation_id": invocation_id,
+                "output_format": output_format,
+                "diagnostic_configuration": "debug",
+                "outcome": "success",
+                "is_error": False,
+                "call_duration_ms": 30,
+                "print_duration_ms": 4,
+                "content_block_count": 1,
+                "text_content_block_count": 1,
+                "returned_text_bytes": len(response),
+            }],
+        }
+
+    @staticmethod
+    def capture_payload() -> dict[str, object]:
+        lifecycle = [{"event_name": name} for name in runner.LIFECYCLE_EVENT_ALLOWLIST]
+        return {
+            "capture_mode": runner.SERVER_CAPTURE_MODE,
+            "sample_capacity_unit": runner.SERVER_SAMPLE_CAPACITY_UNIT,
+            "percentile_semantics": runner.SERVER_PERCENTILE_SEMANTICS,
+            "lifecycle_capture_contract": "s0_s7_required_boundaries",
+            "lifecycle_event_allowlist": runner.LIFECYCLE_EVENT_ALLOWLIST,
+            "stage_capture_contract": "w2_selector_stages",
+            "stage_name_allowlist": runner.SERVER_STAGE_NAME_ALLOWLIST,
+            "active": False,
+            "retained_sample_count": 3,
+            "dropped_sample_count": 0,
+            "ignored_out_of_contract_sample_count": 7,
+            "observed_sample_count": 10,
+            "retained_aggregate_key_count": 1,
+            "stages": [{
+                "stage_name": "EditFlow.Search.DTOBuild.Assembly",
+                "sample_count": 3,
+                "p50_ms": None,
+                "p95_ms": None,
+                "total_ms": 12.5,
+                "max_ms": 5.0,
+            }],
+            "retained_lifecycle_event_count": len(lifecycle),
+            "dropped_lifecycle_event_count": 0,
+            "ignored_out_of_contract_lifecycle_event_count": 11,
+            "observed_lifecycle_event_count": len(lifecycle) + 11,
+            "lifecycle_events": lifecycle,
+        }
+
+    @staticmethod
+    def server_evidence(invocation_id: str, base: float) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+        lifecycle_names = [runner.LIFECYCLE_BOUNDARIES[0][1]]
+        lifecycle_names.extend(boundary[2] for boundary in runner.LIFECYCLE_BOUNDARIES)
+        lifecycle = [{
+            "event_name": name,
+            "offset_ms": base + ordinal,
+            "request_identity": {
+                "app_invocation_id": invocation_id,
+                "connection_id": f"connection-{invocation_id}",
+                "connection_generation": 1,
+                "jsonrpc_request_id": f"string:rpc-{invocation_id}",
+                "request_ordinal": 1,
+            },
+        } for ordinal, name in enumerate(lifecycle_names)]
+        delivery_names = [runner.DELIVERY_BOUNDARIES[0][1]]
+        delivery_names.extend(boundary[2] for boundary in runner.DELIVERY_BOUNDARIES[:2])
+        delivery = [{
+            "app_invocation_id": invocation_id,
+            "connection_id": f"connection-{invocation_id}",
+            "connection_generation": 1,
+            "jsonrpc_request_id": f"string:rpc-{invocation_id}",
+            "request_ordinal": 1,
+            "phase": name,
+            "monotonic_uptime_ms": base + 20 + ordinal,
+        } for ordinal, name in enumerate(delivery_names)]
+        return lifecycle, delivery
+
+    def test_runner_uses_canonical_hidden_diagnostics_tool(self) -> None:
+        self.assertEqual(runner.DEBUG_TOOL, "__repoprompt_debug_diagnostics")
+
+    def test_runner_invocation_ids_match_foundation_uuid_casing(self) -> None:
+        invocation_id = runner.new_invocation_id()
+        self.assertEqual(invocation_id, invocation_id.upper())
+        self.assertRegex(invocation_id, r"^[0-9A-F]{8}(?:-[0-9A-F]{4}){3}-[0-9A-F]{12}$")
+        self.assertEqual(runner.canonical_invocation_id(invocation_id.lower()), invocation_id)
+        self.assertEqual(runner.canonical_invocation_id("non-uuid-fixture-id"), "non-uuid-fixture-id")
+
+    def test_server_and_runner_selector_stage_allowlists_match(self) -> None:
+        source = (ROOT / "Sources/RepoPromptDomainRuntime/Diffing/EditFlowPerf.swift").read_text()
+        start = source.index("mcpLatencyStageNameAllowlist")
+        end = source.index("private static let sampleLimitRange", start)
+        declared = {
+            line.split('"')[1]
+            for line in source[start:end].splitlines()
+            if '"EditFlow.' in line
+        }
+        self.assertEqual(declared, set(runner.SERVER_STAGE_NAME_ALLOWLIST))
+        authorities = sorted((ROOT / "Sources").rglob("EditFlowPerf.swift"))
+        self.assertEqual(authorities, [ROOT / "Sources/RepoPromptDomainRuntime/Diffing/EditFlowPerf.swift"])
+
+    def test_latency_request_claiming_uses_exact_invocation_identity_without_fallback(self) -> None:
+        registry = (ROOT / "Sources/RepoPrompt/Infrastructure/MCP/MCPRequestTimelineRegistry.swift").read_text()
+        self.assertIn("appInvocationID: UUID", registry)
+        self.assertIn("matches.count == 1", registry)
+        self.assertNotIn("originalToolName", registry)
+        self.assertNotIn("pending.startIndex", registry)
+        manager = (ROOT / "Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift").read_text()
+        start = manager.index("let diagnosticLatencyTraceID")
+        end = manager.index("EditFlowPerf.lifecycleEvent", start)
+        latency_join = manager[start:end]
+        self.assertIn("appInvocationID: diagnosticLatencyTraceID", latency_join)
+        self.assertIn("claimed.isCompleteLatencyEvidenceIdentity", latency_join)
+        self.assertNotIn("originalToolName", latency_join)
+
+    def test_latency_trace_surfaces_are_compile_gated_out_of_ordinary_release(self) -> None:
+        def stripping_gate(source: str, condition: str) -> str:
+            output: list[str] = []
+            gated_depth = 0
+            for line in source.splitlines():
+                directive = line.strip()
+                if gated_depth:
+                    if directive.startswith("#if"):
+                        gated_depth += 1
+                    elif directive == "#endif":
+                        gated_depth -= 1
+                    continue
+                if directive == f"#if {condition}":
+                    gated_depth = 1
+                    continue
+                output.append(line)
+            self.assertEqual(gated_depth, 0)
+            return "\n".join(output)
+
+        normalizer = (ROOT / "Sources/RepoPromptDomainRuntime/MCPToolArgsNormalizer.swift").read_text()
+        self.assertIn("package static func diagnosticLatencyTraceID", normalizer)
+        ordinary_normalizer = stripping_gate(normalizer, "DEBUG || MCP_LATENCY_DIAGNOSTICS")
+        self.assertNotIn("_latencyTraceID", ordinary_normalizer)
+        bridge = (ROOT / "Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift").read_text()
+        ordinary_bridge = stripping_gate(bridge, "DEBUG || MCP_LATENCY_DIAGNOSTICS")
+        self.assertNotIn("_latencyTraceID", ordinary_bridge)
+
+        trace_sources = [
+            ROOT / "Sources/RepoPromptMCP/Exec/ExecOptions.swift",
+            ROOT / "Sources/RepoPromptMCP/Exec/ExecMCPService.swift",
+            ROOT / "Sources/RepoPromptMCP/main.swift",
+        ]
+        for path in trace_sources:
+            ordinary_source = stripping_gate(path.read_text(), "DEBUG || MCP_LATENCY_TRACE")
+            self.assertNotIn("latencyConcurrentBatch", ordinary_source, path.name)
+            self.assertNotIn("--latency-concurrent-batch", ordinary_source, path.name)
+
+        package = (ROOT / "Package.swift").read_text()
+        self.assertIn("if mcpLatencyTraceEnabled {", package)
+        self.assertIn('repoPromptMCPSwiftSettings.append(.define("MCP_LATENCY_TRACE"))', package)
+        self.assertIn("if mcpLatencyDiagnosticsEnabled {", package)
+        self.assertIn('repoPromptDomainRuntimeSwiftSettings.append(.define("MCP_LATENCY_DIAGNOSTICS"))', package)
+        packaging = (ROOT / "Scripts/package_app.sh").read_text()
+        self.assertIn("Ordinary release packaging refuses MCP latency diagnostic compile gates", packaging)
+
+    def test_fixture_is_deterministic_and_external(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            first = fixture.generate_fixture(base / "first", fixture.FixtureSpec("test", 227, 2), repo=ROOT)
+            second = fixture.generate_fixture(base / "second", fixture.FixtureSpec("test", 227, 2), repo=ROOT)
+            self.assertEqual(first, second)
+            self.assertEqual(first["file_count"], 227)
+            self.assertEqual(first["root_file_counts"], [114, 113])
+            self.assertEqual(first["maximum_relative_directory_depth"], 11)
+            self.assertEqual(first["expected_search_counts"]["path_duplicate_basename"], 3)
+            self.assertEqual(len(first["digest"]), 64)
+            first_root = base / "first"
+            manifest_path = fixture.manifest_path_for_output(first_root)
+            self.assertTrue(manifest_path.is_file())
+            self.assertFalse((first_root / "mcp-latency-fixture-manifest.json").exists())
+            self.assertEqual(json.loads(manifest_path.read_text()), first)
+            measured_files = sorted(path for path in first_root.rglob("*") if path.is_file())
+            measured_entries = [
+                (path.relative_to(first_root).as_posix(), path.read_bytes())
+                for path in measured_files
+            ]
+            inventory = first["workspace_inventory"]
+            self.assertEqual(len(measured_files), inventory["measured_file_count"])
+            self.assertEqual(sum(path.stat().st_size for path in measured_files), inventory["measured_file_bytes"])
+            self.assertEqual(fixture.manifest_digest(measured_entries), first["digest"])
+            self.assertEqual(
+                sorted(path.name for path in first_root.iterdir() if path.is_dir()),
+                sorted(inventory["root_paths"]),
+            )
+            self.assertEqual(inventory["workspace_root_count"], 3)
+            self.assertTrue((first_root / "empty-root").is_dir())
+            self.assertFalse(any((first_root / "empty-root").iterdir()))
+            matrix = json.loads(MATRIX.read_text())
+            self.assertEqual(matrix["fixture_inventory"]["manifest_location"], "external_sibling")
+            self.assertEqual(matrix["fixture_inventory"]["digest_scope"], inventory["digest_scope"])
+            with self.assertRaises(runner.MatrixError):
+                runner.new_capture_directory(first_root)
+
+    def test_fixture_manifest_must_be_outside_measured_workspace(self) -> None:
+        root = Path("/tmp/rpce-fixture")
+        with self.assertRaisesRegex(runner.MatrixError, "requires --fixture-manifest"):
+            runner.validate_fixture_manifest_location(root, None)
+        with self.assertRaisesRegex(runner.MatrixError, "outside the measured workspace"):
+            runner.validate_fixture_manifest_location(root, root / "manifest.json")
+        runner.validate_fixture_manifest_location(root, root.with_name("rpce-fixture.manifest.json"))
+
+    def test_fixture_rejects_repository_output(self) -> None:
+        with self.assertRaises(fixture.FixtureError):
+            fixture.ensure_external_output(ROOT / "local-fixture", repo=ROOT)
+
+    def test_matrix_expansion_is_deterministic_and_manual_rows_are_gated(self) -> None:
+        variables = runner.fixture_variables(Path("/tmp/mcp-latency-fixture"))
+        ordinary = runner.load_rows(MATRIX, "small", False, variables)
+        manual = runner.load_rows(MATRIX, "small", True, variables)
+        self.assertGreater(len(manual), len(ordinary))
+        self.assertEqual(len({row["id"] for row in manual}), len(manual))
+        self.assertFalse(any("${" in json.dumps(row) for row in manual))
+        self.assertNotIn("tree-full-large-preflight", {row["id"] for row in ordinary})
+        small_outcomes = {row["id"]: row["expected_outcome"] for row in ordinary}
+        medium_outcomes = {
+            row["id"]: row["expected_outcome"]
+            for row in runner.load_rows(MATRIX, "medium", False, variables)
+        }
+        self.assertEqual(small_outcomes["search-content-capped"], "success")
+        self.assertEqual(medium_outcomes["search-content-capped"], "cap_hit_success")
+        self.assertEqual(small_outcomes["search-scoped"], "success")
+        authority = runner.load_wi3_authority(MATRIX)
+        self.assertEqual({item["id"] for item in authority["workload_matrices"]}, runner.WI3_MATRIX_IDS)
+        self.assertEqual(set(authority["parity_counter_groups"]), runner.WI3_COUNTER_GROUPS)
+
+    def test_declared_warm_and_cold_sample_discipline_is_enforced(self) -> None:
+        warm = argparse.Namespace(
+            cohort="warm", warmups=None, repeats=None, samples_per_repeat=None,
+            activation_id=None, cold_sample_index=None,
+        )
+        resolved = runner.resolve_sample_discipline(MATRIX, warm)
+        self.assertEqual((resolved["warmups"], resolved["repeats"], resolved["samples_per_repeat"]), (3, 3, 30))
+        warm.warmups = 2
+        with self.assertRaisesRegex(runner.MatrixError, "matrix-declared discipline"):
+            runner.resolve_sample_discipline(MATRIX, warm)
+
+        cold = argparse.Namespace(
+            cohort="cold", warmups=None, repeats=None, samples_per_repeat=None,
+            activation_id="activation-1", cold_sample_index=1,
+        )
+        resolved = runner.resolve_sample_discipline(MATRIX, cold)
+        self.assertEqual((resolved["warmups"], resolved["repeats"], resolved["samples_per_repeat"]), (0, 1, 1))
+        cold.activation_id = None
+        with self.assertRaisesRegex(runner.MatrixError, "activation-id"):
+            runner.resolve_sample_discipline(MATRIX, cold)
+
+    def test_baseline_sidecar_records_exact_keyset_bytes_and_work_counts(self) -> None:
+        sample = {
+            "row_id": "tree-auto", "format": "formatted", "client_mode": "fresh",
+            "response_sha256": runner.sha256_bytes(b"exact\n"), "response_byte_count": 6,
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            sidecar = Path(temporary) / "baseline.json"
+            work_counts = {"counter_deltas": {"read_file_invocation_count": 1}}
+            runner.apply_baseline([sample], sidecar, True, work_counts)
+            runner.apply_baseline([sample], sidecar, False, work_counts)
+            with self.assertRaisesRegex(runner.MatrixError, "work-count parity"):
+                runner.apply_baseline([sample], sidecar, False, {"counter_deltas": {"read_file_invocation_count": 2}})
+            payload = runner.load_json(sidecar)
+            payload["responses"]["stale/raw/fresh"] = {"sha256": "stale", "byte_count": 1}
+            runner.save_json(sidecar, payload)
+            with self.assertRaisesRegex(runner.MatrixError, "missing, extra, or changed"):
+                runner.apply_baseline([sample], sidecar, False)
+
+    def test_formatted_and_raw_requests_are_distinct_and_validated(self) -> None:
+        row = {"arguments": {"pattern": "needle", "_rawJSON": True}}
+        formatted_args = runner.invocation_arguments(row, "formatted", 7, "formatted-id")
+        raw_args = runner.invocation_arguments(row, "raw", 7, "raw-id")
+        self.assertNotIn("_rawJSON", formatted_args)
+        self.assertTrue(raw_args["_rawJSON"])
+        self.assertNotEqual(formatted_args["_latencyTraceID"], raw_args["_latencyTraceID"])
+
+        formatted = self.sample("formatted-id", "formatted")
+        raw = self.sample("raw-id", "raw")
+        runner.validate_format_pairs([formatted, raw])
+        raw["response_sha256"] = formatted["response_sha256"]
+        with self.assertRaisesRegex(runner.MatrixError, "digests are identical"):
+            runner.validate_format_pairs([formatted, raw])
+
+    def test_leaf_universe_and_selector_mapping_use_fully_qualified_candidates(self) -> None:
+        required = {
+            "EditFlow.MCPToolCall.LimiterWait",
+            "EditFlow.MCPToolCall.HandlerResultHandoff",
+            "EditFlow.MCPToolCall.CompletionObserverResultEncoding",
+            "EditFlow.MCPToolCall.CompletionObserverCallbacks",
+            "EditFlow.Search.DTOBuild.Assembly",
+            "EditFlow.Search.ProviderValueEncoding",
+            "EditFlow.FormattedOutput.PromptEnvelopeProbeDecode",
+            "EditFlow.FormattedOutput.PromptContextDecode",
+            "EditFlow.FileTree.ProviderValueEncoding",
+        }
+        self.assertTrue(required.issubset(runner.LEAF_STAGES))
+        self.assertEqual(runner.SELECTOR_ACTIONS["EditFlow.Search.DTOBuild.Assembly"], "W4")
+        self.assertEqual(runner.SELECTOR_ACTIONS["EditFlow.Search.ProviderValueEncoding"], "W5")
+        self.assertNotIn("EditFlow.FileTree.DTOAssembly", runner.SELECTOR_ACTIONS)
+        self.assertNotIn("EditFlow.FileTree.ProviderValueEncoding", runner.SELECTOR_ACTIONS)
+        self.assertIn("EditFlow.Search.ProviderWorkspaceSearchAwait", runner.INCLUSIVE_STAGES)
+        self.assertIn("EditFlow.Search.ProviderTotal", runner.INCLUSIVE_STAGES)
+        self.assertIn("EditFlow.Search.WorkspaceReadinessAcquireGate", runner.INCLUSIVE_STAGES)
+        self.assertIn("EditFlow.Search.RootScopeAvailabilityGate", runner.INCLUSIVE_STAGES)
+        self.assertIn("EditFlow.FormattedOutput.SearchTreeAssembly", runner.INCLUSIVE_STAGES)
+        self.assertNotIn("EditFlow.Search.ProviderWorkspaceSearchAwait", runner.LEAF_STAGES)
+        self.assertNotIn("EditFlow.FormattedOutput.SearchTreeAssembly", runner.LEAF_STAGES)
+        ancestors = set(runner.DIRECT_STAGE_CHILDREN)
+        self.assertFalse(ancestors & runner.LEAF_STAGES)
+        self.assertEqual(runner.SELECTOR_ACTIONS[runner.DERIVED_SEARCH_CORE_STAGE], "search-follow-up")
+        self.assertEqual(runner.SELECTOR_ACTIONS[runner.DERIVED_SEARCH_READINESS_SCOPE_STAGE], "search-follow-up")
+        self.assertEqual(runner.SELECTOR_ACTIONS[runner.DERIVED_SEARCH_TREE_STAGE], "W3")
+
+    def test_server_identity_pairing_requires_distinct_stable_configurations(self) -> None:
+        debug_identity = {
+            "identity_authority": "server_process", "app_configuration": "debug",
+            "swift_configuration": "debug", "ordinary_release_artifact": False,
+            "process_identifier": 7, "bundle_path": "/Debug/RepoPrompt.app",
+            "executable_path": "/Debug/RepoPrompt.app/Contents/MacOS/RepoPrompt",
+            "executable_sha256": "a" * 64,
+        }
+        optimized_identity = {
+            "identity_authority": "server_process", "app_configuration": "optimized_diagnostic",
+            "swift_configuration": "release", "ordinary_release_artifact": False,
+            "process_identifier": 9, "bundle_path": "/Optimized/RepoPrompt.app",
+            "executable_path": "/Optimized/RepoPrompt.app/Contents/MacOS/RepoPrompt",
+            "executable_sha256": "b" * 64,
+        }
+        debug = {
+            "server_app_identity": debug_identity,
+            "server_app_identity_end": dict(debug_identity),
+        }
+        optimized = {
+            "server_app_identity": optimized_identity,
+            "server_app_identity_end": dict(optimized_identity),
+        }
+        self.assertEqual(
+            runner.authoritative_paired_server_identity(debug, optimized),
+            {"debug": debug_identity, "optimized": optimized_identity},
+        )
+        optimized["server_app_identity_end"]["process_identifier"] = 10
+        with self.assertRaisesRegex(runner.MatrixError, "changed during collection"):
+            runner.authoritative_paired_server_identity(debug, optimized)
+
+    def test_only_verified_optimized_server_selection_can_authorize(self) -> None:
+        debug_identity = {
+            "app_configuration": "debug", "swift_configuration": "debug",
+            "ordinary_release_artifact": False,
+        }
+        optimized_identity = {
+            "identity_authority": "server_process",
+            "app_configuration": "optimized_diagnostic", "swift_configuration": "release",
+            "ordinary_release_artifact": False, "diagnostic_surface": "mcp_latency_v1",
+            "signing_mode": "mcp-latency-diagnostic-adhoc",
+            "secure_storage_backend": "alternate-in-memory",
+        }
+        debug_result = runner.make_server_authorization_explicit(
+            {"status": "selected", "selected": "W4"}, debug_identity,
+        )
+        self.assertFalse(debug_result["production_authorized"])
+        optimized_result = runner.make_server_authorization_explicit(
+            {"status": "selected", "selected": "W4"}, optimized_identity,
+        )
+        self.assertTrue(optimized_result["production_authorized"])
+        self.assertEqual(optimized_result["selected"], "W4")
+
+    def test_fresh_invalid_generation_is_discarded_and_recohorted(self) -> None:
+        invalid = self.sample("failed")
+        invalid["client_trace"] = []
+        valid_formatted = self.sample("replacement-formatted")
+        valid_raw = self.sample("replacement-raw", "raw")
+        with mock.patch.object(
+            runner,
+            "run_fresh",
+            side_effect=[[invalid], [valid_formatted, valid_raw]],
+        ) as run_fresh:
+            retained, discarded = runner.run_fresh_with_recovery(
+                Path("/diagnostic-cli"), 1, [{"id": "row"}], Path("/capture"),
+                10, "warm", "recorded",
+            )
+        self.assertEqual(run_fresh.call_count, 2)
+        self.assertEqual([sample["invocation_id"] for sample in retained], [
+            "replacement-formatted", "replacement-raw",
+        ])
+        self.assertEqual([sample["invocation_id"] for sample in discarded], ["failed"])
+        self.assertIn("missing or duplicate client trace", discarded[0]["discard_reason"])
+
+    def test_wi3_invalid_generation_is_discarded_and_recohorted(self) -> None:
+        invalid = self.sample("wi3-failed")
+        invalid["client_trace"] = []
+        invalid["connection_cohort"] = "wi3-burst-g0-c0"
+        valid = self.sample("wi3-replacement")
+        valid["connection_cohort"] = "wi3-burst-g1-c0"
+        authority = {"workload_matrices": [{
+            "id": "burst",
+            "execution": {
+                "enabled_by_default": True, "mode": "same_connection_burst",
+                "row_id": "tree-roots", "request_count": 1,
+            },
+        }]}
+        with mock.patch.object(runner, "matrix_row_by_id", return_value={"id": "tree-roots"}), \
+                mock.patch.object(runner, "run_concurrent_batch_process", side_effect=[[invalid], [valid]]) as batch:
+            retained, executed, discarded = runner.run_wi3_cohorts(
+                Path("/diagnostic-cli"), 1, MATRIX, authority, {}, Path("/capture"), 10,
+            )
+        self.assertEqual(batch.call_count, 2)
+        self.assertEqual([sample["invocation_id"] for sample in retained], ["wi3-replacement"])
+        self.assertEqual(executed, ["burst"])
+        self.assertEqual([sample["invocation_id"] for sample in discarded], ["wi3-failed"])
+
+    def test_terminal_event_invalidates_and_recovery_uses_a_new_cohort(self) -> None:
+        samples = [
+            {"sample_id": "timeout", "connection_cohort": "persistent-0", "outcome": "timeout",
+             "expected_outcome": "expected_timeout", "client_trace": [{"outcome": "timeout"}]},
+            {"sample_id": "later", "connection_cohort": "persistent-0", "outcome": "success",
+             "expected_outcome": "success", "client_trace": [{"outcome": "success"}]},
+        ]
+        invalid = runner.invalid_connection_cohorts(samples)
+        self.assertIn("persistent-0", invalid)
+        self.assertIn("after terminal", invalid["persistent-0"])
+        with self.assertRaisesRegex(runner.MatrixError, "unexpected terminal"):
+            runner.validate_connection_cohorts([{
+                "sample_id": "bad", "connection_cohort": "fresh", "outcome": "transport_closed",
+                "expected_outcome": "success", "client_trace": [{"outcome": "transport_closed"}],
+            }])
+
+    def test_request_identity_joins_out_of_order_lifecycle_and_delivery_events(self) -> None:
+        first = self.sample("request-a")
+        second = self.sample("request-b")
+        first_lifecycle, first_delivery = self.server_evidence("request-a", 100)
+        second_lifecycle, second_delivery = self.server_evidence("request-b", 500)
+        for event in first_delivery:
+            event["app_invocation_id"] = "pre-decode-deterministic-request-a"
+        capture = {
+            "capture_start_uptime_ms": 0,
+            "lifecycle_events": second_lifecycle + first_lifecycle,
+            "stages": [
+                {"stage_name": "EditFlow.Search.DTOBuild.Assembly", "total_ms": 3, "sample_count": 1,
+                 "request_identity": {"app_invocation_id": "request-b"}},
+                {"stage_name": "EditFlow.Search.DTOBuild.Assembly", "total_ms": 7, "sample_count": 1,
+                 "request_identity": {"app_invocation_id": "request-a"}},
+            ],
+        }
+        evidence = runner.joined_request_evidence(
+            [first, second], capture, second_delivery + first_delivery, require_server=True,
+        )
+        by_id = {item["sample"]["invocation_id"]: item for item in evidence}
+        self.assertEqual(by_id["request-a"]["stage_buckets"][0]["total_ms"], 7)
+        self.assertEqual(by_id["request-b"]["stage_buckets"][0]["total_ms"], 3)
+        self.assertEqual(by_id["request-a"]["boundaries"]["handler_to_write_ms"], 2)
+        self.assertEqual(by_id["request-a"]["boundaries"]["s0_s9_server_total_ms"], 22)
+        _, _, boundaries = runner.stage_and_boundary_summaries(evidence)
+        self.assertEqual({row["stage"] for row in boundaries}, {
+            "Boundary.S0S1.PermitWait", "Boundary.S1S2.PreProvider",
+            "Boundary.S2S3.Provider", "Boundary.S3S4.PreFormat", "Boundary.S4S5.Format",
+            "Boundary.S5S6.CompletionObservers", "Boundary.S6S7.HandlerHandoff",
+            "Boundary.S7S8.SDKEncode", "Boundary.S8S9.TransportWrite",
+            "Boundary.S7S9.HandlerToWrite", "Boundary.S0S9.ServerTotal", "Boundary.C0C1.ClientCall",
+            "Boundary.C1C2.ClientOutput", "Boundary.C0C2.ClientTotal",
+        })
+
+    def test_stage_attribution_rejects_detached_and_missing_request_evidence(self) -> None:
+        sample = self.sample("request-a")
+        unidentified = {
+            "stages": [{
+                "stage_name": "EditFlow.Search.ProviderValueEncoding",
+                "total_ms": 4, "sample_count": 1, "request_identity": None,
+            }],
+        }
+        with self.assertRaisesRegex(runner.MatrixError, "lack request identity"):
+            runner.stage_attribution_report([sample], unidentified, require_server=True)
+
+        unrelated = {
+            "stages": [{
+                "stage_name": "EditFlow.Search.ProviderValueEncoding",
+                "total_ms": 4, "sample_count": 1,
+                "request_identity": {"app_invocation_id": "discarded-warmup"},
+            }],
+        }
+        with self.assertRaisesRegex(runner.MatrixError, "lack leaf/inclusive stage samples"):
+            runner.stage_attribution_report([sample], unrelated, require_server=True)
+
+        attributed = {
+            "stages": [{
+                "stage_name": "EditFlow.Search.ProviderValueEncoding",
+                "total_ms": 4, "sample_count": 2,
+                "request_identity": {"app_invocation_id": "request-a"},
+            }],
+        }
+        report = runner.stage_attribution_report([sample], attributed, require_server=True)
+        self.assertEqual(report["status"], "complete")
+        self.assertEqual(report["identified_sample_count"], 2)
+        self.assertEqual(report["unidentified_sample_count"], 0)
+
+    def test_correlated_server_terminal_invalidates_retained_evidence(self) -> None:
+        sample = self.sample("request-a")
+        lifecycle, _ = self.server_evidence("request-a", 100)
+        terminal = [{
+            "phase": "connection_terminal", "terminal_reason": "write_failed",
+            "connection_id": "connection-request-a", "connection_generation": 1,
+        }]
+        with self.assertRaisesRegex(runner.MatrixError, "terminalized a retained connection"):
+            runner.validate_delivery_terminals(terminal, lifecycle, [sample])
+        sample["expected_outcome"] = "expected_timeout"
+        runner.validate_delivery_terminals(terminal, lifecycle, [sample])
+
+    def test_repeated_span_buckets_aggregate_per_request_and_remove_nested_snippets(self) -> None:
+        item = {"stage_buckets": [
+            {"stage_name": "EditFlow.Search.ProviderValueEncoding", "total_ms": 7, "sample_count": 1},
+            {"stage_name": "EditFlow.Search.ProviderValueEncoding", "total_ms": 4, "sample_count": 2},
+            {"stage_name": "EditFlow.FormattedOutput.SearchTreeAssembly", "total_ms": 12, "sample_count": 1},
+            {"stage_name": "EditFlow.FormattedOutput.SearchTreeAssembly", "total_ms": 3, "sample_count": 1},
+            {"stage_name": "EditFlow.FormattedOutput.SearchSnippetAssembly", "total_ms": 5, "sample_count": 2},
+        ]}
+        totals, spans, _ = runner.per_request_stage_totals(item)
+        self.assertEqual(totals["EditFlow.Search.ProviderValueEncoding"], 11)
+        self.assertEqual(spans["EditFlow.Search.ProviderValueEncoding"], 3)
+        self.assertEqual(totals["EditFlow.FormattedOutput.SearchTreeAssembly"], 15)
+        self.assertEqual(totals["EditFlow.FormattedOutput.SearchSnippetAssembly"], 5)
+
+        item["sample"] = self.sample("remainder")
+        item["boundaries"] = {}
+        item["stage_buckets"].append({
+            "stage_name": "EditFlow.MCPToolCall.FormatResult", "total_ms": 20, "sample_count": 1,
+        })
+        remainder = runner.remainder_summaries([item])
+        formatted = next(row for row in remainder if row["envelope"] == "EditFlow.MCPToolCall.FormatResult")
+        self.assertEqual(formatted["p50_ms"], 5)
+        leaves, parents, _ = runner.stage_and_boundary_summaries([item])
+        tree_exclusive = next(row for row in leaves if row["stage"] == runner.DERIVED_SEARCH_TREE_STAGE)
+        self.assertEqual(tree_exclusive["p50_ms"], 10)
+        self.assertTrue(any(
+            row["stage"] == "EditFlow.FormattedOutput.SearchTreeAssembly" for row in parents
+        ))
+
+    def test_search_core_scan_remainder_subtracts_only_declared_gates(self) -> None:
+        item = {"sample": self.sample("search-core"), "boundaries": {}, "stage_buckets": [
+            {"stage_name": "EditFlow.Search.ProviderWorkspaceSearchAwait", "total_ms": 100, "sample_count": 1},
+            {"stage_name": "EditFlow.Search.BroadAdmissionWait", "total_ms": 10, "sample_count": 1},
+            {"stage_name": "EditFlow.Search.IngressFreshnessWait", "total_ms": 5, "sample_count": 1},
+            {"stage_name": "EditFlow.Search.WorkspaceReadinessAcquireGate", "total_ms": 15, "sample_count": 1},
+            {"stage_name": "EditFlow.Search.WorkspaceReadinessValidationGate", "total_ms": 8, "sample_count": 2},
+            {"stage_name": "EditFlow.Search.RootScopeAvailabilityGate", "total_ms": 12, "sample_count": 1},
+        ]}
+        remainder = runner.remainder_summaries([item])
+        core = next(row for row in remainder if row.get("stage") == runner.DERIVED_SEARCH_CORE_STAGE)
+        self.assertEqual(core["envelope"], "EditFlow.Search.ProviderWorkspaceSearchAwait")
+        self.assertEqual(core["p50_ms"], 58)
+        leaves, parents, _ = runner.stage_and_boundary_summaries([item])
+        readiness_scope = next(
+            row for row in leaves if row["stage"] == runner.DERIVED_SEARCH_READINESS_SCOPE_STAGE
+        )
+        self.assertEqual(readiness_scope["p50_ms"], 19)
+        self.assertTrue(any(
+            row["stage"] == "EditFlow.Search.WorkspaceReadinessAcquireGate" for row in parents
+        ))
+
+    def test_signed_residual_preserves_tolerated_negative_rounding_noise(self) -> None:
+        self.assertAlmostEqual(
+            runner.signed_parent_minus_children_residual(
+                10.0,
+                10.005,
+                envelope="test-envelope",
+                request_id="request-rounding",
+            ),
+            -0.005,
+        )
+        self.assertEqual(
+            runner.signed_parent_minus_children_residual(
+                10.0,
+                4.0,
+                envelope="test-envelope",
+                request_id="request-positive",
+            ),
+            6.0,
+        )
+
+    def test_derived_residual_rejects_material_parent_child_overlap(self) -> None:
+        item = {
+            "sample": self.sample("tree-overlap"),
+            "boundaries": {},
+            "stage_buckets": [
+                {
+                    "stage_name": "EditFlow.FormattedOutput.SearchTreeAssembly",
+                    "total_ms": 10.0,
+                    "sample_count": 1,
+                },
+                {
+                    "stage_name": "EditFlow.FormattedOutput.SearchSnippetAssembly",
+                    "total_ms": 10.02,
+                    "sample_count": 1,
+                },
+            ],
+        }
+        with self.assertRaisesRegex(runner.MatrixError, "invalid EditFlow.FormattedOutput.SearchTreeAssembly residual"):
+            runner.stage_and_boundary_summaries([item])
+
+    def test_envelope_remainder_rejects_material_negative_residual(self) -> None:
+        item = {
+            "sample": self.sample("provider-overlap"),
+            "boundaries": {},
+            "stage_buckets": [
+                {
+                    "stage_name": "EditFlow.FileTree.ProviderTotal",
+                    "total_ms": 1.0,
+                    "sample_count": 1,
+                },
+                {
+                    "stage_name": "EditFlow.FileTree.ProviderArgumentParsing",
+                    "total_ms": 1.02,
+                    "sample_count": 1,
+                },
+            ],
+        }
+        with self.assertRaisesRegex(runner.MatrixError, "invalid EditFlow.FileTree.ProviderTotal residual"):
+            runner.remainder_summaries([item])
+
+    def test_selector_requires_s0_s9_and_optimized_persistent_denominators(self) -> None:
+        cohort = {"row_id": "search-content-few", "format": "formatted", "client_mode": "fresh", "cohort_kind": "warm"}
+        leaf = {"cohort": cohort, "stage": "EditFlow.Search.DTOBuild.Assembly", "p50_ms": 30, "p95_ms": 30}
+        handler = {
+            "cohort": cohort, "interval_name": "Boundary.S0S9.ServerTotal",
+            "p50_ms": 40, "p95_ms": 40, "sample_count": 30,
+        }
+        optimized = {
+            "cohort": {**cohort, "client_mode": "persistent"},
+            "total_ms": {"p50_ms": 100, "p95_ms": 110, "sample_count": 30},
+        }
+        selection = runner.mechanical_selector([leaf], [], [handler], [optimized])
+        self.assertEqual(selection["status"], "selected")
+        self.assertEqual(selection["selected"], "W4")
+        self.assertEqual(selection["dominant_leaf"]["eligibility_denominator_interval"], "Boundary.S0S9.ServerTotal")
+        refused = runner.mechanical_selector([leaf], [], [handler], [])
+        self.assertEqual(refused["status"], "refused")
+        self.assertIn("optimized warm persistent", refused["refusal_reasons"][0])
+
+    def test_response_signature_includes_wi3_and_ordered_block_contract(self) -> None:
+        ordinary = self.sample("ordinary")
+        wi3 = self.sample("wi3")
+        wi3.update({
+            "cohort_kind": "wi3", "connection_cohort": "wi3-same-connection-ordinary-burst-c0",
+            "client_mode": "persistent_concurrent", "workload_matrix_id": "same-connection-ordinary-burst",
+            "sample_ordinal": 2,
+        })
+        signature = runner.response_signature([ordinary, wi3])
+        self.assertTrue(any(key.startswith("ordinary/") for key in signature))
+        self.assertTrue(any(key.startswith("wi3/same-connection-ordinary-burst/") for key in signature))
+
+        drift = self.sample("ordinary-drift")
+        drift["client_trace"][0]["content_block_count"] = 2
+        with self.assertRaisesRegex(runner.MatrixError, "content-block contract changed"):
+            runner.response_signature([ordinary, drift])
+
+    def test_wi3_projection_stamps_only_executed_authoritative_cohorts(self) -> None:
+        def runtime(catalog_count: int, reads: list[dict[str, object]]) -> dict[str, object]:
+            return {"runtime": {
+                "limiter": {"lanes": {"ordinary": {"limit": 1}, "file_search": {"limit": 4}}},
+                "windows": [{
+                    "store_work": {"catalog_rebuild": {"count": catalog_count}, "root_catalog_shards": {}, "invalidations": []},
+                    "search_rebuild": {}, "ui_index_rebuild": {}, "roots": [],
+                }],
+                "physical_root_duplication": [],
+                "tool_work": {"read_file_invocations": reads, "git_invocations": []},
+            }}
+
+        admission = {"admission": {"lanes": [{"configuration": {"active_capacity": 4}}]}}
+        authority = runner.load_wi3_authority(MATRIX)
+        executed = ["same-connection-ordinary-burst", "distinct-connections-one-window"]
+        self.assertEqual(runner.selector_required_wi3_matrix_ids(authority), sorted(executed))
+        evidence = runner.project_wi3_work_counts(
+            runtime(2, []),
+            runtime(5, [{"read_bytes": 19, "returned_bytes": 7, "returned_lines": 1, "cache_hit": False}]),
+            admission,
+            admission,
+            authority,
+            executed,
+        )
+        self.assertTrue(evidence["lane_capacity_evidence"]["matches_authority"])
+        self.assertEqual(evidence["counter_deltas"]["catalog_rebuild_count"], 3)
+        self.assertEqual(evidence["counter_deltas"]["read_file_full_bytes"], 19)
+        self.assertEqual(evidence["counter_deltas"]["read_file_returned_bytes"], 7)
+        self.assertEqual(evidence["parity_signature"]["workload_matrix_ids"], sorted(executed))
+        self.assertEqual({item["id"] for item in evidence["workload_matrices"]}, set(executed))
+
+    def test_evidence_capture_contract_accepts_exact_online_totals_and_ignored_events(self) -> None:
+        capture = self.capture_payload()
+        runner.validate_capture_integrity(capture)
+        begin = dict(capture)
+        begin["active"] = True
+        runner.validate_capture_begin(begin)
+
+    def test_evidence_capture_contract_rejects_drops_and_accounting_drift(self) -> None:
+        mutations = {
+            "drops": lambda capture: capture.update(dropped_sample_count=1, observed_sample_count=11),
+            "aggregate_count": lambda capture: capture.update(retained_aggregate_key_count=2),
+            "observed_samples": lambda capture: capture.update(observed_sample_count=11),
+            "percentiles": lambda capture: capture["stages"][0].update(p50_ms=4.0),
+            "lifecycle_event": lambda capture: capture["lifecycle_events"].append({"event_name": "MCP.ToolCall.PermitReleased"}),
+            "stage": lambda capture: capture["stages"][0].update(stage_name="EditFlow.Search.LiteralScan"),
+            "capture_mode": lambda capture: capture.update(capture_mode="exhaustive"),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                capture = self.capture_payload()
+                mutate(capture)
+                with self.assertRaises(runner.MatrixError):
+                    runner.validate_capture_integrity(capture)
+
+    def test_segment_plan_is_deterministic_bounded_and_includes_wi3(self) -> None:
+        rows = [
+            {"id": "row-a", "formats": ["formatted", "raw"], "expected_outcome": "success"},
+            {"id": "row-terminal", "formats": ["formatted"], "expected_outcome": "expected_timeout"},
+        ]
+        discipline = {"warmups": 3, "repeats": 3, "samples_per_repeat": 30}
+        authority = {"workload_matrices": [
+            {"id": "burst", "execution": {
+                "enabled_by_default": True, "mode": "same_connection_burst",
+                "row_id": "row-a", "request_count": 7,
+            }},
+            {"id": "connections", "execution": {
+                "enabled_by_default": True, "mode": "distinct_connections",
+                "row_id": "row-a", "connection_count": 4,
+            }},
+        ]}
+        first = runner.capture_segment_plan(
+            rows, ["fresh", "persistent"], discipline, authority, True,
+        )
+        second = runner.capture_segment_plan(
+            rows, ["fresh", "persistent"], discipline, authority, True,
+        )
+        self.assertEqual(first, second)
+        self.assertEqual(runner.capture_segment_plan_sha256(first), runner.capture_segment_plan_sha256(second))
+        self.assertEqual([item["ordinal"] for item in first], list(range(6)))
+        self.assertEqual(first[0]["expected_invocation_count"], 186)
+        self.assertEqual(first[2]["kind"], "expected_terminal")
+        self.assertEqual(first[-2]["expected_invocation_count"], 7)
+        self.assertEqual(first[-1]["expected_invocation_count"], 4)
+
+        oversized = [{
+            "id": "oversized", "formats": ["formatted", "raw"],
+            "expected_outcome": "success",
+        }]
+        with self.assertRaisesRegex(runner.MatrixError, "exceeding the segmented capture bound"):
+            runner.capture_segment_plan(
+                oversized, ["fresh"],
+                {"warmups": 1, "repeats": 1, "samples_per_repeat": 128},
+                {"workload_matrices": []}, False,
+            )
+
+    def test_segment_index_fails_closed_on_missing_reordered_or_wrong_plan(self) -> None:
+        plan = [
+            {"ordinal": 0, "segment_id": "000-a"},
+            {"ordinal": 1, "segment_id": "001-b"},
+        ]
+        index = {
+            "layout": runner.SEGMENTED_CAPTURE_LAYOUT,
+            "capture_mode": runner.SERVER_CAPTURE_MODE,
+            "segment_plan_sha256": runner.capture_segment_plan_sha256(plan),
+            "segments": [
+                {"ordinal": 0, "segment_id": "000-a"},
+                {"ordinal": 1, "segment_id": "001-b"},
+            ],
+        }
+        runner.validate_segment_index_contract(index, plan)
+        for label, mutate in {
+            "missing": lambda value: value["segments"].pop(),
+            "reordered": lambda value: value["segments"].reverse(),
+            "wrong_hash": lambda value: value.update(segment_plan_sha256="0" * 64),
+            "entry_drift": lambda value: value["segments"][0].update(ordinal=9),
+        }.items():
+            with self.subTest(label=label):
+                changed = json.loads(json.dumps(index))
+                mutate(changed)
+                with self.assertRaises(runner.MatrixError):
+                    runner.validate_segment_index_contract(changed, plan)
+
+    def test_capture_drop_cannot_be_hidden_by_invalid_cohort_retry(self) -> None:
+        sample = self.sample("request-drop")
+        sample["client_trace"] = []
+        payload = self.capture_payload()
+        payload["dropped_sample_count"] = 1
+        payload["retained_sample_count"] = 2
+        begin = self.capture_payload()
+        begin["active"] = True
+        spec = {
+            "segment_id": "000-drop", "expected_invocation_count": 1,
+            "expected_sample_coordinates": [list(runner.sample_coordinate(sample))],
+        }
+        with tempfile.TemporaryDirectory() as temporary, \
+                mock.patch.object(runner, "call_debug_tool", side_effect=[{"capture": begin}, {"capture": payload}]) as call, \
+                mock.patch.object(runner, "save_json") as save:
+            with self.assertRaisesRegex(runner.MatrixError, "dropped_sample_count"):
+                runner.collect_capture_segment(
+                    Path("/diagnostic-cli"), 1, Path(temporary), spec, "debug", 100, 10,
+                    lambda _: ([sample], []),
+                )
+        self.assertEqual(call.call_count, 2)
+        save.assert_not_called()
+
+    def test_expected_timeout_requires_one_correlated_server_terminal(self) -> None:
+        sample = self.sample("request-timeout")
+        sample.update(expected_outcome="expected_timeout", outcome="timeout")
+        with self.assertRaisesRegex(runner.MatrixError, "omitted authoritative server correlation"):
+            runner.validate_delivery_terminals([], [], [sample])
+
+        lifecycle, _ = self.server_evidence("request-timeout", 10)
+        connection = "connection-request-timeout"
+        terminal = {
+            "connection_id": connection, "connection_generation": 1,
+            "phase": "connection_terminal", "terminal_reason": "timeout",
+        }
+        runner.validate_delivery_terminals([terminal], lifecycle, [sample])
+        with self.assertRaisesRegex(runner.MatrixError, "exactly one authoritative terminal"):
+            runner.validate_delivery_terminals([terminal, dict(terminal)], lifecycle, [sample])
+
+    def test_capture_membership_rejects_foreign_stage_or_lifecycle_but_ignores_handshake_delivery(self) -> None:
+        lifecycle, delivery = self.server_evidence("expected-request", 10)
+        delivery[0]["app_invocation_id"] = "predecode-deterministic-request"
+        correlated = {
+            "capture": {"stages": [], "lifecycle_events": lifecycle},
+            "delivery_events": [
+                {"app_invocation_id": "unrelated-handshake-request"}, delivery[0],
+            ],
+        }
+        runner.validate_capture_request_membership(
+            correlated, [self.sample("expected-request")],
+        )
+        lifecycle[0]["request_identity"]["app_invocation_id"] = "foreign-lifecycle-request"
+        with self.assertRaisesRegex(runner.MatrixError, "foreign lifecycle/stage"):
+            runner.validate_capture_request_membership(
+                correlated, [self.sample("expected-request")],
+            )
+
+        setup_identity = {"app_invocation_id": "persistent-bind-setup"}
+        setup = {
+            "capture": {
+                "lifecycle_events": [
+                    {
+                        "event_name": name, "request_identity": setup_identity,
+                        "sanitized_dimensions": "tool=bind_context",
+                    }
+                    for name in runner.LIFECYCLE_EVENT_ALLOWLIST
+                ],
+                "stages": [{
+                    "stage_name": "EditFlow.MCPToolCall.LimiterWait",
+                    "request_identity": setup_identity,
+                    "sanitized_dimensions": "tool=bind_context",
+                }],
+            },
+            "delivery_events": [],
+        }
+        persistent = self.sample("expected-persistent", client_mode="persistent")
+        self.assertEqual(
+            runner.validate_capture_request_membership(setup, [persistent]),
+            ["persistent-bind-setup"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/write_mcp_latency_diagnostic_manifest.py
+++ b/Scripts/write_mcp_latency_diagnostic_manifest.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Write the isolated, non-release MCP latency diagnostic app manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import plistlib
+import platform
+import tempfile
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+ARTIFACT_KIND = "optimized_mcp_latency_diagnostic_server"
+PROVENANCE_NAME = "RepoPromptMCPLatencyDiagnosticProvenance.json"
+EXPECTED_DEFINES = {
+    "RepoPromptApp": ["MCP_LATENCY_DIAGNOSTICS"],
+    "RepoPromptDomainRuntime": ["MCP_LATENCY_DIAGNOSTICS"],
+    "RepoPromptMCP": ["MCP_LATENCY_TRACE"],
+    "RepoPromptShared": ["MCP_LATENCY_DIAGNOSTICS"],
+}
+
+
+class ManifestError(RuntimeError):
+    pass
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_within(path: Path, root: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    try:
+        resolved.relative_to(root.expanduser().resolve())
+    except ValueError as error:
+        raise ManifestError(f"path escapes diagnostic artifact root: {resolved}") from error
+    return resolved
+
+
+def build_manifest(app: Path, output: Path, artifact_root: Path) -> dict[str, Any]:
+    root = artifact_root.expanduser().resolve()
+    app = require_within(app, root)
+    output = require_within(output, root)
+    executable = require_within(app / "Contents/MacOS/RepoPrompt", root)
+    helper = require_within(app / "Contents/MacOS/repoprompt-mcp", root)
+    provenance_path = require_within(app / "Contents/Resources" / PROVENANCE_NAME, root)
+    info_path = require_within(app / "Contents/Info.plist", root)
+    for path in (executable, helper, provenance_path, info_path):
+        if not path.is_file():
+            raise ManifestError(f"missing diagnostic artifact member: {path}")
+    if not os.access(executable, os.X_OK) or not os.access(helper, os.X_OK):
+        raise ManifestError("diagnostic app executables must be executable")
+
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    if provenance.get("artifact_kind") != ARTIFACT_KIND:
+        raise ManifestError("diagnostic provenance artifact kind mismatch")
+    if provenance.get("ordinary_release_artifact") is not False:
+        raise ManifestError("diagnostic provenance must be explicitly non-release")
+    if provenance.get("swift_configuration") != "release":
+        raise ManifestError("diagnostic server must use Swift release configuration")
+    if provenance.get("server_diagnostic_configuration") != "optimized_diagnostic":
+        raise ManifestError("diagnostic server configuration mismatch")
+    if provenance.get("diagnostic_surface") != "mcp_latency_v1":
+        raise ManifestError("diagnostic surface mismatch")
+    if provenance.get("enabled_defines_by_target") != EXPECTED_DEFINES:
+        raise ManifestError("diagnostic target defines mismatch")
+    artifact_id = provenance.get("artifact_id")
+    if not isinstance(artifact_id, str) or not artifact_id:
+        raise ManifestError("diagnostic provenance must include an artifact ID")
+    if not isinstance(provenance.get("commit"), str) or not provenance["commit"]:
+        raise ManifestError("diagnostic provenance must include a commit identity")
+    if not isinstance(provenance.get("dirty"), bool):
+        raise ManifestError("diagnostic provenance must record dirty state")
+    source_fingerprint = provenance.get("source_fingerprint_sha256")
+    if not isinstance(source_fingerprint, str) or len(source_fingerprint) != 64:
+        raise ManifestError("diagnostic provenance must include a source fingerprint")
+
+    with info_path.open("rb") as handle:
+        info = plistlib.load(handle)
+    bundle_id = info.get("CFBundleIdentifier")
+    if bundle_id != "com.pvncher.repoprompt.ce.mcp-latency-diagnostic":
+        raise ManifestError("diagnostic bundle identifier must use the fixed isolated identity")
+    signing_mode = info.get("RepoPromptSigningMode")
+    storage_backend = info.get("RepoPromptDebugSecureStorageBackend")
+    if signing_mode != "mcp-latency-diagnostic-adhoc":
+        raise ManifestError("diagnostic signing mode marker mismatch")
+    if storage_backend != "alternate-in-memory":
+        raise ManifestError("diagnostic secure-storage marker mismatch")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_id": artifact_id,
+        "artifact_kind": ARTIFACT_KIND,
+        "ordinary_release_artifact": False,
+        "swift_configuration": "release",
+        "server_diagnostic_configuration": "optimized_diagnostic",
+        "diagnostic_surface": "mcp_latency_v1",
+        "enabled_defines_by_target": provenance.get("enabled_defines_by_target"),
+        "commit": provenance.get("commit"),
+        "dirty": provenance.get("dirty"),
+        "source_fingerprint_sha256": source_fingerprint,
+        "bundle_path": str(app),
+        "signing_mode": signing_mode,
+        "secure_storage_backend": storage_backend,
+        "bundle_identifier": bundle_id,
+        "executable_path": str(executable),
+        "executable_sha256": sha256(executable),
+        "embedded_cli_path": str(helper),
+        "embedded_cli_sha256": sha256(helper),
+        "provenance_path": str(provenance_path),
+        "provenance_sha256": sha256(provenance_path),
+        "architecture": platform.machine(),
+    }
+
+
+def write_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--artifact-root", type=Path, required=True)
+    args = parser.parse_args()
+    payload = build_manifest(args.app, args.output, args.artifact_root)
+    write_atomic(args.output.expanduser().resolve(), payload)
+    print(args.output.expanduser().resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ManifestError as error:
+        raise SystemExit(f"ERROR: {error}")

--- a/Sources/RepoPrompt/Features/CodeMap/CodeMapExtractor+Snapshots.swift
+++ b/Sources/RepoPrompt/Features/CodeMap/CodeMapExtractor+Snapshots.swift
@@ -15,9 +15,16 @@ enum WorkspaceFileTreePresentationRenderer {
         let normalizedMode = snapshot.mode.lowercased()
         let shouldFilterRootsToSelection = snapshot.onlyIncludeRootsWithSelectedFiles
             && (normalizedMode != "full" || !snapshot.selectedFileIDs.isEmpty)
-        let effectiveRoots = shouldFilterRootsToSelection
-            ? snapshot.roots.filter { snapshotFolderContainsSelectedFile($0, selectedFileIDs: snapshot.selectedFileIDs) }
-            : snapshot.roots
+        let effectiveRoots = EditFlowPerf.measure(
+            EditFlowPerf.Stage.FileTree.renderIndexPreparation,
+            EditFlowPerf.Dimensions(scanKind: "root_filter")
+        ) {
+            shouldFilterRootsToSelection
+                ? snapshot.roots.filter {
+                    snapshotFolderContainsSelectedFile($0, selectedFileIDs: snapshot.selectedFileIDs)
+                }
+                : snapshot.roots
+        }
         guard !effectiveRoots.isEmpty else { return "" }
 
         var cachedSelectedFolderIDs: Set<UUID>? = nil
@@ -27,8 +34,16 @@ enum WorkspaceFileTreePresentationRenderer {
                 cachedSelectedFolderIDs = []
                 return []
             }
-            let computed = effectiveRoots.reduce(into: Set<UUID>()) { acc, root in
-                acc.formUnion(snapshotFolderIDsContainingSelectedFiles(rootFolder: root, selectedFileIDs: snapshot.selectedFileIDs))
+            let computed = EditFlowPerf.measure(
+                EditFlowPerf.Stage.FileTree.renderIndexPreparation,
+                EditFlowPerf.Dimensions(scanKind: "selected_folder_index")
+            ) {
+                effectiveRoots.reduce(into: Set<UUID>()) { acc, root in
+                    acc.formUnion(snapshotFolderIDsContainingSelectedFiles(
+                        rootFolder: root,
+                        selectedFileIDs: snapshot.selectedFileIDs
+                    ))
+                }
             }
             cachedSelectedFolderIDs = computed
             return computed
@@ -38,8 +53,19 @@ enum WorkspaceFileTreePresentationRenderer {
             mode: String,
             depthLimit: Int?,
             tokenBudget: Int?,
-            siblingCap: Int?
+            siblingCap: Int?,
+            attemptLabel: String,
+            attemptOrdinal: Int,
+            attemptCount: Int
         ) -> (tree: String, usedSelectedMarker: Bool, truncated: Bool) {
+            let dimensions = EditFlowPerf.Dimensions(
+                taskCount: attemptCount,
+                workloadClass: attemptLabel,
+                serialPosition: attemptOrdinal
+            )
+            let attemptState = EditFlowPerf.begin(EditFlowPerf.Stage.FileTree.renderAttempt, dimensions)
+            defer { EditFlowPerf.end(EditFlowPerf.Stage.FileTree.renderAttempt, attemptState, dimensions) }
+
             var parts: [String] = []
             var usedSelectedMarker = false
             var hitBudget = false
@@ -73,10 +99,20 @@ enum WorkspaceFileTreePresentationRenderer {
                 usedSelectedMarker = usedSelectedMarker || usedSelection
 
                 if let currentRemaining = remaining {
-                    let consumedTokens = text.isEmpty ? 0 : max(
-                        1,
-                        TokenCalculationService.estimateTokens(for: text)
-                    )
+                    let consumedTokens = EditFlowPerf.measure(
+                        EditFlowPerf.Stage.FileTree.renderTokenEstimation,
+                        EditFlowPerf.Dimensions(
+                            taskCount: attemptCount,
+                            workloadClass: attemptLabel,
+                            scanKind: "per_root_budget",
+                            serialPosition: attemptOrdinal
+                        )
+                    ) {
+                        text.isEmpty ? 0 : max(
+                            1,
+                            TokenCalculationService.estimateTokens(for: text)
+                        )
+                    }
                     remaining = max(0, currentRemaining - consumedTokens)
                 }
 
@@ -100,7 +136,21 @@ enum WorkspaceFileTreePresentationRenderer {
         }
 
         if normalizedMode != "auto" {
-            let built = buildOnce(mode: snapshot.mode, depthLimit: snapshot.maxDepth, tokenBudget: nil, siblingCap: nil)
+            let explicitAttemptLabel = switch normalizedMode {
+            case "full": "explicitFull"
+            case "folders": "explicitFolders"
+            case "selected": "explicitSelected"
+            default: "explicitOther"
+            }
+            let built = buildOnce(
+                mode: snapshot.mode,
+                depthLimit: snapshot.maxDepth,
+                tokenBudget: nil,
+                siblingCap: nil,
+                attemptLabel: explicitAttemptLabel,
+                attemptOrdinal: 1,
+                attemptCount: 1
+            )
             return finalizeSnapshotTree(
                 tree: built.tree,
                 includeLegend: snapshot.includeLegend,
@@ -118,32 +168,46 @@ enum WorkspaceFileTreePresentationRenderer {
         }
 
         let attempts: [Attempt] = [.fullUnlimited, .fullDepth3, .foldersUnlimited, .foldersDepth3, .selectedOnly]
-        for attempt in attempts {
-            let (mode, depthCap, noteParts): (String, Int?, [String]) = switch attempt {
+        for (attemptIndex, attempt) in attempts.enumerated() {
+            let (mode, depthCap, noteParts, attemptLabel): (String, Int?, [String], String) = switch attempt {
             case .fullUnlimited:
-                ("full", nil, [])
+                ("full", nil, [], "fullUnlimited")
             case .fullDepth3:
-                ("full", 3, ["depth cap 3"])
+                ("full", 3, ["depth cap 3"], "fullDepth3")
             case .foldersUnlimited:
-                ("folders", nil, snapshot.selectedFileIDs.isEmpty ? ["directory-only view"] : ["directory-only view", "selected files shown"])
+                ("folders", nil, snapshot.selectedFileIDs.isEmpty ? ["directory-only view"] : ["directory-only view", "selected files shown"], "foldersUnlimited")
             case .foldersDepth3:
-                ("folders", 3, snapshot.selectedFileIDs.isEmpty ? ["directory-only view", "depth cap 3"] : ["directory-only view", "depth cap 3", "selected files shown"])
+                ("folders", 3, snapshot.selectedFileIDs.isEmpty ? ["directory-only view", "depth cap 3"] : ["directory-only view", "depth cap 3", "selected files shown"], "foldersDepth3")
             case .selectedOnly:
-                ("selected", nil, ["selected-only view"])
+                ("selected", nil, ["selected-only view"], "selectedOnly")
             }
 
             let built = buildOnce(
                 mode: mode,
                 depthLimit: depthCap,
                 tokenBudget: snapshotAutoTokenBudget,
-                siblingCap: snapshotMaxChildrenPerFolderAutoCap
+                siblingCap: snapshotMaxChildrenPerFolderAutoCap,
+                attemptLabel: attemptLabel,
+                attemptOrdinal: attemptIndex + 1,
+                attemptCount: attempts.count
             )
             guard !built.tree.isEmpty else { continue }
             guard !built.truncated else { continue }
 
             var text = built.tree
             let usedCodeMapMarker = snapshot.showCodeMapMarkers && text.contains(snapshotCodeMapMark)
-            if TokenCalculationService.estimateTokens(for: text) <= snapshotAutoTokenBudget {
+            let estimatedTokens = EditFlowPerf.measure(
+                EditFlowPerf.Stage.FileTree.renderTokenEstimation,
+                EditFlowPerf.Dimensions(
+                    taskCount: attempts.count,
+                    workloadClass: attemptLabel,
+                    scanKind: "final_budget",
+                    serialPosition: attemptIndex + 1
+                )
+            ) {
+                TokenCalculationService.estimateTokens(for: text)
+            }
+            if estimatedTokens <= snapshotAutoTokenBudget {
                 text = finalizeSnapshotTree(
                     tree: text,
                     includeLegend: snapshot.includeLegend,

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnostics.swift
@@ -1,5 +1,6 @@
 // MARK: - Hidden DEBUG Diagnostics Surface
 
+import CryptoKit
 import Foundation
 import MCP
 
@@ -25,6 +26,8 @@ import MCP
             }
 
             switch op {
+            case "mcp_latency_server_identity":
+                return debugDiagnosticsResult(Self.debugLatencyServerAppIdentityPayload())
             case "ping":
                 return await debugDiagnosticsResult(debugPingPayload(connectionID: connectionID, op: op, arguments: arguments))
             case "connection_snapshot":
@@ -222,6 +225,47 @@ import MCP
             default:
                 return debugDiagnosticsError(op: op, code: "unknown_op", message: "Unknown debug diagnostics op: \(op)")
             }
+        }
+
+        nonisolated static func debugLatencyServerAppIdentityPayload() -> [String: Any] {
+            let bundle = Bundle.main
+            let executableURL = bundle.executableURL?.standardizedFileURL
+            let executableData = executableURL.flatMap { try? Data(contentsOf: $0, options: [.mappedIfSafe]) }
+            let executableSHA256 = executableData.map {
+                SHA256.hash(data: $0).map { String(format: "%02x", $0) }.joined()
+            }
+            let provenanceURL = bundle.url(
+                forResource: "RepoPromptDebugProvenance",
+                withExtension: "json"
+            )
+            let provenanceData = provenanceURL.flatMap { try? Data(contentsOf: $0) }
+            let provenance = provenanceData.flatMap {
+                try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
+            }
+            let provenanceSHA256 = provenanceData.map {
+                SHA256.hash(data: $0).map { String(format: "%02x", $0) }.joined()
+            }
+            let identity: [String: Any] = [
+                "identity_authority": "server_process",
+                "app_configuration": "debug",
+                "swift_configuration": "debug",
+                "diagnostic_surface": "mcp_latency_v1",
+                "ordinary_release_artifact": false,
+                "process_identifier": ProcessInfo.processInfo.processIdentifier,
+                "bundle_path": bundle.bundleURL.standardizedFileURL.path,
+                "executable_path": executableURL?.path ?? NSNull(),
+                "executable_sha256": executableSHA256 ?? NSNull(),
+                "bundle_identifier": bundle.bundleIdentifier ?? NSNull(),
+                "marketing_version": bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? NSNull(),
+                "build_number": bundle.object(forInfoDictionaryKey: "CFBundleVersion") ?? NSNull(),
+                "provenance": provenance ?? NSNull(),
+                "provenance_sha256": provenanceSHA256 ?? NSNull()
+            ]
+            return [
+                "ok": true,
+                "op": "mcp_latency_server_identity",
+                "server_app_identity": identity
+            ]
         }
 
         nonisolated func debugDiagnosticsResult(_ object: [String: Any], isError: Bool = false) -> CallTool.Result {

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
@@ -21,10 +21,14 @@ import RepoPromptShared
                 return debugDiagnosticsError(op: op, code: "invalid_params", message: "`max_samples` must be an integer between 100 and 100000.")
             }
 
-            MCPResponseDeliveryTracer.resetDebugEvents()
-            MCPToolWorkCountDiagnostics.resetDebugHistory()
-            switch EditFlowPerf.beginDebugCapture(label: label, maxSamples: maxSamples) {
+            switch EditFlowPerf.beginDebugCapture(
+                label: label,
+                maxSamples: maxSamples,
+                mode: .mcpLatencyEvidence
+            ) {
             case let .started(snapshot):
+                MCPResponseDeliveryTracer.resetDebugEvents()
+                MCPToolWorkCountDiagnostics.resetDebugHistory()
                 return debugDiagnosticsResult([
                     "ok": true,
                     "op": op,
@@ -43,11 +47,13 @@ import RepoPromptShared
             let finish = debugBool(arguments, "finish") ?? true
             let includeTimeline = debugBool(arguments, "include_timeline") ?? true
             let snapshot = EditFlowPerf.debugCaptureSnapshot(finish: finish)
+            let delivery = MCPResponseDeliveryTracer.debugCaptureSnapshot(finish: finish)
             return debugDiagnosticsResult([
                 "ok": true,
                 "op": op,
                 "capture": snapshot.payload(includeTimeline: includeTimeline),
-                "delivery_events": MCPResponseDeliveryTracer.debugEventSnapshot().map(\.payload)
+                "delivery_events": delivery.events.map(\.payload),
+                "delivery_dropped_event_count": delivery.droppedEventCount
             ])
         }
 

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+MCPLatencyDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+MCPLatencyDiagnostics.swift
@@ -1,0 +1,166 @@
+// MARK: - Optimized MCP latency diagnostic surface
+
+import CryptoKit
+import Foundation
+import MCP
+import RepoPromptShared
+
+#if MCP_LATENCY_DIAGNOSTICS && !DEBUG
+    extension ServerNetworkManager {
+        enum MCPLatencyDiagnosticOperation: String, CaseIterable {
+            case serverIdentity = "mcp_latency_server_identity"
+            case captureBegin = "mcp_read_search_capture_begin"
+            case captureSnapshot = "mcp_read_search_capture_snapshot"
+        }
+
+        private static let mcpLatencyDiagnosticsToolName = "__repoprompt_debug_diagnostics"
+
+        nonisolated static func isMCPLatencyDiagnosticsToolName(_ toolName: String) -> Bool {
+            toolName == mcpLatencyDiagnosticsToolName
+        }
+
+        func handleMCPLatencyDiagnosticsTool(arguments: [String: Value]) -> CallTool.Result {
+            guard let rawOperation = arguments["op"]?.stringValue,
+                  let operation = MCPLatencyDiagnosticOperation(rawValue: rawOperation)
+            else {
+                return mcpLatencyDiagnosticsError(
+                    code: "unknown_op",
+                    message: "Only bounded MCP latency identity and capture operations are available in this optimized diagnostic build."
+                )
+            }
+
+            switch operation {
+            case .serverIdentity:
+                return mcpLatencyDiagnosticsResult(Self.mcpLatencyServerIdentityPayload())
+            case .captureBegin:
+                return mcpLatencyCaptureBegin(arguments: arguments)
+            case .captureSnapshot:
+                return mcpLatencyCaptureSnapshot(arguments: arguments)
+            }
+        }
+
+        private func mcpLatencyCaptureBegin(arguments: [String: Value]) -> CallTool.Result {
+            guard let rawLabel = arguments["label"]?.stringValue else {
+                return mcpLatencyDiagnosticsError(code: "invalid_params", message: "Missing required string argument `label`.")
+            }
+            let label = String(rawLabel.unicodeScalars.filter {
+                CharacterSet.alphanumerics.contains($0) || $0 == "-" || $0 == "_"
+            }.prefix(96))
+            guard !label.isEmpty else {
+                return mcpLatencyDiagnosticsError(code: "invalid_params", message: "`label` must contain an alphanumeric character.")
+            }
+            let maxSamples = arguments["max_samples"]?.intValue ?? 20000
+            guard (100 ... 100_000).contains(maxSamples) else {
+                return mcpLatencyDiagnosticsError(code: "invalid_params", message: "`max_samples` must be an integer between 100 and 100000.")
+            }
+
+            switch EditFlowPerf.beginDebugCapture(
+                label: label,
+                maxSamples: maxSamples,
+                mode: .mcpLatencyEvidence
+            ) {
+            case let .started(snapshot):
+                MCPResponseDeliveryTracer.resetDebugEvents()
+                return mcpLatencyDiagnosticsResult([
+                    "ok": true,
+                    "op": MCPLatencyDiagnosticOperation.captureBegin.rawValue,
+                    "capture": snapshot.payload()
+                ])
+            case let .busy(snapshot):
+                return mcpLatencyDiagnosticsError(
+                    code: "capture_busy",
+                    message: "An MCP latency capture is already active with label `\(snapshot.label)`."
+                )
+            }
+        }
+
+        private func mcpLatencyCaptureSnapshot(arguments: [String: Value]) -> CallTool.Result {
+            let finish = arguments["finish"]?.boolValue ?? true
+            let includeTimeline = arguments["include_timeline"]?.boolValue ?? true
+            let capture = EditFlowPerf.debugCaptureSnapshot(finish: finish)
+            let delivery = MCPResponseDeliveryTracer.debugCaptureSnapshot(finish: finish)
+            return mcpLatencyDiagnosticsResult([
+                "ok": true,
+                "op": MCPLatencyDiagnosticOperation.captureSnapshot.rawValue,
+                "capture": capture.payload(includeTimeline: includeTimeline),
+                "delivery_events": delivery.events.map(\.payload),
+                "delivery_dropped_event_count": delivery.droppedEventCount
+            ])
+        }
+
+        private nonisolated static func mcpLatencyServerIdentityPayload() -> [String: Any] {
+            let bundle = Bundle.main
+            let executableURL = bundle.executableURL?.standardizedFileURL
+            let executableData = executableURL.flatMap { try? Data(contentsOf: $0, options: [.mappedIfSafe]) }
+            let executableSHA256 = executableData.map { SHA256.hash(data: $0).hexString }
+            let helperURL = bundle.bundleURL
+                .appendingPathComponent("Contents/MacOS/repoprompt-mcp")
+                .standardizedFileURL
+            let helperData = try? Data(contentsOf: helperURL, options: [.mappedIfSafe])
+            let provenanceURL = bundle.url(
+                forResource: "RepoPromptMCPLatencyDiagnosticProvenance",
+                withExtension: "json"
+            )
+            let provenanceData = provenanceURL.flatMap { try? Data(contentsOf: $0) }
+            let provenance = provenanceData.flatMap {
+                try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
+            }
+            let helperSHA256 = helperData.map { SHA256.hash(data: $0).hexString }
+            let provenanceSHA256 = provenanceData.map { SHA256.hash(data: $0).hexString }
+            let identity: [String: Any] = [
+                "identity_authority": "server_process",
+                "app_configuration": "optimized_diagnostic",
+                "swift_configuration": "release",
+                "diagnostic_surface": "mcp_latency_v1",
+                "ordinary_release_artifact": false,
+                "process_identifier": ProcessInfo.processInfo.processIdentifier,
+                "bundle_path": bundle.bundleURL.standardizedFileURL.path,
+                "executable_path": executableURL?.path ?? NSNull(),
+                "executable_sha256": executableSHA256 ?? NSNull(),
+                "embedded_cli_path": helperURL.path,
+                "embedded_cli_sha256": helperSHA256 ?? NSNull(),
+                "bundle_identifier": bundle.bundleIdentifier ?? NSNull(),
+                "signing_mode": bundle.object(forInfoDictionaryKey: "RepoPromptSigningMode") ?? NSNull(),
+                "secure_storage_backend": bundle.object(forInfoDictionaryKey: "RepoPromptDebugSecureStorageBackend") ?? NSNull(),
+                "marketing_version": bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? NSNull(),
+                "build_number": bundle.object(forInfoDictionaryKey: "CFBundleVersion") ?? NSNull(),
+                "provenance": provenance ?? NSNull(),
+                "provenance_sha256": provenanceSHA256 ?? NSNull()
+            ]
+            return [
+                "ok": true,
+                "op": MCPLatencyDiagnosticOperation.serverIdentity.rawValue,
+                "server_app_identity": identity
+            ]
+        }
+
+        private nonisolated func mcpLatencyDiagnosticsResult(
+            _ object: [String: Any],
+            isError: Bool = false
+        ) -> CallTool.Result {
+            let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+            let text = data.flatMap { String(data: $0, encoding: .utf8) } ?? "{\"ok\":false}"
+            return CallTool.Result(
+                content: [MCP.Tool.Content.text(text: text, annotations: nil, _meta: nil)],
+                isError: isError
+            )
+        }
+
+        private nonisolated func mcpLatencyDiagnosticsError(
+            code: String,
+            message: String
+        ) -> CallTool.Result {
+            mcpLatencyDiagnosticsResult([
+                "ok": false,
+                "code": code,
+                "error": message
+            ], isError: true)
+        }
+    }
+
+    private extension SHA256.Digest {
+        var hexString: String {
+            map { String(format: "%02x", $0) }.joined()
+        }
+    }
+#endif

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -2451,7 +2451,7 @@ actor ServerNetworkManager {
         let effectiveProgressState = progressContext
             ?? (connectionID == currentConnectionID ? currentProgressState : nil)
         return try await $currentProgressState.withValue(effectiveProgressState) {
-            #if DEBUG || EDIT_FLOW_PERF
+            #if DEBUG || EDIT_FLOW_PERF || MCP_LATENCY_DIAGNOSTICS
                 let effectiveLifecycleCorrelation = lifecycleCorrelation ?? EditFlowPerf.currentLifecycleCorrelation
                 guard let effectiveLifecycleCorrelation else {
                     return try await $currentConnectionID.withValue(connectionID, operation: operation)
@@ -10905,30 +10905,49 @@ actor ServerNetworkManager {
                     }
                 }
             #endif
-            #if DEBUG
-                let transportRequestIdentity = MCPRequestTimelineRegistry.shared.claimToolRequest(
-                    connectionID: connectionID.uuidString,
-                    originalToolName: originalName
-                )
-                let inheritedRequestIdentity = transportRequestIdentity?.fillingMissingFields(
-                    from: MCPRequestTimelineContext.current
-                ) ?? MCPRequestTimelineContext.current
-                let fallbackConnectionGeneration = await requestTimelineConnectionGeneration(for: connectionID)
-                let requestIdentity = MCPRequestTimelineIdentity(
-                    jsonRPCRequestID: inheritedRequestIdentity?.jsonRPCRequestID,
-                    connectionID: inheritedRequestIdentity?.connectionID ?? connectionID.uuidString,
-                    connectionGeneration: inheritedRequestIdentity?.connectionGeneration ?? fallbackConnectionGeneration,
-                    appInvocationID: inheritedRequestIdentity?.appInvocationID,
-                    requestOrdinal: inheritedRequestIdentity?.requestOrdinal
-                )
-                let invocationID = requestIdentity.appInvocationID.flatMap { UUID(uuidString: $0) } ?? UUID()
-                let resolvedRequestIdentity: MCPRequestTimelineIdentity? = MCPRequestTimelineIdentity(
-                    jsonRPCRequestID: requestIdentity.jsonRPCRequestID,
-                    connectionID: requestIdentity.connectionID,
-                    connectionGeneration: requestIdentity.connectionGeneration,
-                    appInvocationID: invocationID.uuidString,
-                    requestOrdinal: requestIdentity.requestOrdinal
-                )
+            #if MCP_LATENCY_DIAGNOSTICS && !DEBUG
+                if Self.isMCPLatencyDiagnosticsToolName(toolName) {
+                    guard let limiterResolution = await connectionCallLimiterResolution(for: connectionID) else {
+                        return Self.executionContractToolErrorResult(
+                            rawJSON: false,
+                            code: "tool_execution_connection_terminal",
+                            message: "The MCP connection is closing."
+                        )
+                    }
+                    return await withConnectionCallPermit(
+                        connectionID: connectionID,
+                        lane: .ordinary,
+                        resolution: limiterResolution,
+                        cancellationResult: {
+                            Self.executionContractToolErrorResult(
+                                rawJSON: false,
+                                code: "tool_execution_connection_terminal",
+                                message: "The MCP connection is closing."
+                            )
+                        }
+                    ) {
+                        await self.handleMCPLatencyDiagnosticsTool(arguments: params.arguments ?? [:])
+                    }
+                }
+            #endif
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+                let diagnosticLatencyTraceID = MCPToolArgsNormalizer.diagnosticLatencyTraceID(params: params.arguments)
+                let invocationID = diagnosticLatencyTraceID ?? UUID()
+                let resolvedRequestIdentity: MCPRequestTimelineIdentity? = if let diagnosticLatencyTraceID,
+                                                                              let claimed = MCPRequestTimelineRegistry.shared.claimToolRequest(
+                                                                                  connectionID: connectionID.uuidString,
+                                                                                  appInvocationID: diagnosticLatencyTraceID
+                                                                              ),
+                                                                              claimed.appInvocationID == diagnosticLatencyTraceID.uuidString,
+                                                                              claimed.isCompleteLatencyEvidenceIdentity
+                {
+                    claimed
+                } else {
+                    nil
+                }
+                if let resolvedRequestIdentity {
+                    MCPRequestTimelineRegistry.shared.updateResponseIdentity(to: resolvedRequestIdentity)
+                }
                 let lifecycleCorrelation = EditFlowPerf.makeLifecycleCorrelationIfActive(
                     requestIdentity: resolvedRequestIdentity
                 )
@@ -11275,10 +11294,18 @@ actor ServerNetworkManager {
                 EditFlowPerf.Stage.MCPToolCall.limiterEnvelope,
                 EditFlowPerf.Dimensions(toolName: toolName)
             ) {
-                let limiterWaitState = EditFlowPerf.begin(
-                    EditFlowPerf.Stage.MCPToolCall.limiterWait,
-                    EditFlowPerf.Dimensions(toolName: toolName)
-                )
+                #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+                    let limiterWaitState = EditFlowPerf.begin(
+                        EditFlowPerf.Stage.MCPToolCall.limiterWait,
+                        EditFlowPerf.Dimensions(toolName: toolName),
+                        debugCaptureRequestIdentity: resolvedRequestIdentity
+                    )
+                #else
+                    let limiterWaitState = EditFlowPerf.begin(
+                        EditFlowPerf.Stage.MCPToolCall.limiterWait,
+                        EditFlowPerf.Dimensions(toolName: toolName)
+                    )
+                #endif
                 EditFlowPerf.lifecycleEvent(
                     EditFlowPerf.Lifecycle.MCPToolCall.limiterWaitBegan,
                     correlation: lifecycleCorrelation,
@@ -12395,6 +12422,10 @@ actor ServerNetworkManager {
                                                         await self.debugBeforeToolResultFormattingForTesting?(connectionID, toolName)
                                                     #endif
                                                     // Build well‑structured, human‑readable content blocks for the result
+                                                    EditFlowPerf.lifecycleEvent(
+                                                        EditFlowPerf.Lifecycle.MCPToolCall.formatResultBegan,
+                                                        EditFlowPerf.Dimensions(toolName: toolName)
+                                                    )
                                                     let contentBlocks = EditFlowPerf.measure(
                                                         EditFlowPerf.Stage.MCPToolCall.formatResult,
                                                         EditFlowPerf.Dimensions(toolName: toolName)
@@ -12521,6 +12552,10 @@ actor ServerNetworkManager {
                                                 await self.debugBeforeToolResultFormattingForTesting?(connectionID, toolName)
                                             #endif
                                             // Build well‑structured, human‑readable content blocks for the result
+                                            EditFlowPerf.lifecycleEvent(
+                                                EditFlowPerf.Lifecycle.MCPToolCall.formatResultBegan,
+                                                EditFlowPerf.Dimensions(toolName: toolName)
+                                            )
                                             let contentBlocks = EditFlowPerf.measure(
                                                 EditFlowPerf.Stage.MCPToolCall.formatResult,
                                                 EditFlowPerf.Dimensions(toolName: toolName)
@@ -14493,6 +14528,64 @@ actor ServerNetworkManager {
                         activeCount: releasedSnapshot.activePermitCount, admissionClass: lane.rawValue,
                         queueDepth: releasedSnapshot.waiterCount, windowID: ownerWindowID, runID: ownerRunID,
                         ownerResource: ownerResource, permitActive: false, publicationPending: true, terminalBarrier: false
+                    )
+                )
+                throw error
+            }
+        }
+    }
+
+#elseif MCP_LATENCY_DIAGNOSTICS
+    extension MCPDomainConnectionCallLimiters {
+        func withPermit<T: Sendable>(
+            lane: MCPConnectionCallLane,
+            toolName: String? = nil,
+            lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation? = nil,
+            ownerResource: String? = nil,
+            ownerWindowID: Int? = nil,
+            ownerRunID: String? = nil,
+            _ operation: @Sendable () async throws -> T
+        ) async throws -> T {
+            EditFlowPerf.lifecycleEvent(
+                EditFlowPerf.Lifecycle.MCPToolCall.permitQueued,
+                correlation: lifecycleCorrelation,
+                EditFlowPerf.Dimensions(
+                    toolName: toolName, outcome: "queued", admissionClass: lane.rawValue,
+                    windowID: ownerWindowID, runID: ownerRunID, ownerResource: ownerResource,
+                    permitActive: false
+                )
+            )
+            do {
+                let result = try await withPermit(lane: lane) {
+                    EditFlowPerf.lifecycleEvent(
+                        EditFlowPerf.Lifecycle.MCPToolCall.permitAcquired,
+                        correlation: lifecycleCorrelation,
+                        EditFlowPerf.Dimensions(
+                            toolName: toolName, outcome: "acquired", admissionClass: lane.rawValue,
+                            windowID: ownerWindowID, runID: ownerRunID, ownerResource: ownerResource,
+                            permitActive: true
+                        )
+                    )
+                    return try await operation()
+                }
+                EditFlowPerf.lifecycleEvent(
+                    EditFlowPerf.Lifecycle.MCPToolCall.permitReleased,
+                    correlation: lifecycleCorrelation,
+                    EditFlowPerf.Dimensions(
+                        toolName: toolName, outcome: "completed", admissionClass: lane.rawValue,
+                        windowID: ownerWindowID, runID: ownerRunID, ownerResource: ownerResource,
+                        permitActive: false, publicationPending: true
+                    )
+                )
+                return result
+            } catch {
+                EditFlowPerf.lifecycleEvent(
+                    EditFlowPerf.Lifecycle.MCPToolCall.permitReleased,
+                    correlation: lifecycleCorrelation,
+                    EditFlowPerf.Dimensions(
+                        toolName: toolName, outcome: error is CancellationError ? "cancelled" : "failed",
+                        admissionClass: lane.rawValue, windowID: ownerWindowID, runID: ownerRunID,
+                        ownerResource: ownerResource, permitActive: false, publicationPending: true
                     )
                 )
                 throw error

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPRequestTimelineRegistry.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPRequestTimelineRegistry.swift
@@ -1,4 +1,4 @@
-#if DEBUG
+#if DEBUG || MCP_LATENCY_DIAGNOSTICS
     import Foundation
     import RepoPromptShared
 
@@ -24,7 +24,6 @@
         }
 
         private struct PendingRequest {
-            let tool: String?
             let identity: MCPRequestTimelineIdentity
         }
 
@@ -33,7 +32,7 @@
         private var pendingToolRequestsByConnection: [ConnectionKey: [PendingRequest]] = [:]
         private var identitiesByResponseKey: [ResponseKey: MCPRequestTimelineIdentity] = [:]
 
-        private init() {}
+        init() {}
 
         func recordAcceptedFrame(
             _ frame: Data,
@@ -64,12 +63,14 @@
                     id: summary.id,
                     method: summary.method,
                     tool: summary.tool,
-                    requestOrdinal: ordinal
+                    requestOrdinal: ordinal,
+                    appInvocationID: summary.appInvocationID
                 )
                 let identity = MCPRequestTimelineIdentity(
                     jsonRPCRequestID: summary.id,
                     connectionID: correlationConnectionID,
                     connectionGeneration: connectionGeneration,
+                    appInvocationID: summary.appInvocationID,
                     requestOrdinal: ordinal
                 )
                 recorded.append(RecordedMessage(metadata: metadata, identity: identity))
@@ -78,7 +79,6 @@
                     identitiesByResponseKey[ResponseKey(connection: key, id: id)] = identity
                     if summary.method == "tools/call" {
                         pendingToolRequestsByConnection[key, default: []].append(PendingRequest(
-                            tool: summary.tool,
                             identity: identity
                         ))
                     }
@@ -89,20 +89,52 @@
             return recorded
         }
 
-        func claimToolRequest(connectionID: String, originalToolName: String) -> MCPRequestTimelineIdentity? {
+        func claimToolRequest(
+            connectionID: String,
+            appInvocationID: UUID
+        ) -> MCPRequestTimelineIdentity? {
+            let canonicalInvocationID = appInvocationID.uuidString
             lock.lock()
             defer { lock.unlock() }
-            let keys = pendingToolRequestsByConnection.keys
-                .filter { $0.connectionID == connectionID }
-                .sorted { $0.generation > $1.generation }
-            for key in keys {
-                guard var pending = pendingToolRequestsByConnection[key], !pending.isEmpty else { continue }
-                let index = pending.firstIndex { $0.tool == originalToolName } ?? pending.startIndex
-                let request = pending.remove(at: index)
-                pendingToolRequestsByConnection[key] = pending
-                return request.identity
+
+            var matches: [(ConnectionKey, Int)] = []
+            for (key, pending) in pendingToolRequestsByConnection where key.connectionID == connectionID {
+                for index in pending.indices {
+                    let identity = pending[index].identity
+                    guard identity.appInvocationID == canonicalInvocationID,
+                          identity.isCompleteLatencyEvidenceIdentity
+                    else {
+                        continue
+                    }
+                    matches.append((key, index))
+                }
             }
-            return nil
+            guard matches.count == 1,
+                  let (key, index) = matches.first,
+                  var pending = pendingToolRequestsByConnection[key]
+            else {
+                return nil
+            }
+            let request = pending.remove(at: index)
+            pendingToolRequestsByConnection[key] = pending
+            return request.identity
+        }
+
+        func updateResponseIdentity(to resolvedIdentity: MCPRequestTimelineIdentity) {
+            guard let requestID = resolvedIdentity.jsonRPCRequestID else { return }
+            lock.lock()
+            defer { lock.unlock() }
+            let responseKeys: [ResponseKey] = identitiesByResponseKey.compactMap { key, identity in
+                guard key.id == requestID,
+                      identity.connectionID == resolvedIdentity.connectionID,
+                      identity.connectionGeneration == resolvedIdentity.connectionGeneration,
+                      identity.requestOrdinal == resolvedIdentity.requestOrdinal
+                else { return nil }
+                return key
+            }
+            for key in responseKeys {
+                identitiesByResponseKey[key] = resolvedIdentity
+            }
         }
 
         func recordedResponses(

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -159,7 +159,8 @@ enum ToolOutputFormatter {
             }
         }
 
-        lines.append(contentsOf: searchMatchesTree(dto: dto))
+        let matchTreeLines = searchMatchesTree(dto: dto)
+        lines.append(contentsOf: matchTreeLines)
 
         // Show suggestion if present (e.g., when path filter yields no results)
         if let suggestion = dto.suggestion, !suggestion.isEmpty {
@@ -227,6 +228,21 @@ enum ToolOutputFormatter {
     }
 
     private static func searchMatchesTree(dto: ToolResultDTOs.SearchResultDTO) -> [String] {
+        let dimensions = EditFlowPerf.Dimensions(
+            contentMatchCount: dto.contentMatches,
+            pathMatchCount: dto.pathMatches
+        )
+        let treeState = EditFlowPerf.begin(
+            EditFlowPerf.Stage.FormattedOutput.searchTreeAssembly,
+            dimensions
+        )
+        defer {
+            EditFlowPerf.end(
+                EditFlowPerf.Stage.FormattedOutput.searchTreeAssembly,
+                treeState,
+                dimensions
+            )
+        }
         let pathMatchSet = Set(dto.pathMatchLines)
 
         var includedLookup: [String: Int] = [:]
@@ -2367,9 +2383,23 @@ extension ToolOutputFormatter {
     }
 
     static func formatFileTree(value: Value) -> [MCP.Tool.Content] {
-        if let dto = value.decode(ToolResultDTOs.FileTreeDTO.self) {
-            let text = fileTreeSummary(rootsCount: dto.rootsCount, usesLegend: dto.usesLegend, tree: dto.tree, note: dto.note, worktreeScope: dto.worktreeScope)
-            return [.text(text)]
+        let dto = EditFlowPerf.measure(EditFlowPerf.Stage.FormattedOutput.decode) {
+            value.decode(ToolResultDTOs.FileTreeDTO.self)
+        }
+        if let dto {
+            return EditFlowPerf.measure(
+                EditFlowPerf.Stage.FormattedOutput.fileTreeAssembly,
+                EditFlowPerf.Dimensions(rootCount: dto.rootsCount, resultBytes: dto.tree.utf8.count)
+            ) {
+                let text = fileTreeSummary(
+                    rootsCount: dto.rootsCount,
+                    usesLegend: dto.usesLegend,
+                    tree: dto.tree,
+                    note: dto.note,
+                    worktreeScope: dto.worktreeScope
+                )
+                return [.text(text)]
+            }
         }
         if let s = value.stringValue {
             // Legacy fallback: do not infer legends here; return raw tree text
@@ -2525,12 +2555,31 @@ extension ToolOutputFormatter {
 
     static func formatPromptState(value: Value) -> [MCP.Tool.Content] {
         // Forwarded prompt-tool envelope (e.g. workspace_context op=list_presets/export/select_preset)
-        if value.decode(ToolResultDTOs.PromptToolEnvelope.self) != nil {
+        let promptEnvelope = EditFlowPerf.measure(EditFlowPerf.Stage.FormattedOutput.promptEnvelopeProbeDecode) {
+            value.decode(ToolResultDTOs.PromptToolEnvelope.self)
+        }
+        if promptEnvelope != nil {
             return formatPrompt(value: value)
         }
 
         // New unified DTO
-        if let ctx = value.decode(ToolResultDTOs.PromptContextDTO.self) {
+        let promptContext = EditFlowPerf.measure(EditFlowPerf.Stage.FormattedOutput.promptContextDecode) {
+            value.decode(ToolResultDTOs.PromptContextDTO.self)
+        }
+        if let ctx = promptContext {
+            let assemblyState = EditFlowPerf.begin(
+                EditFlowPerf.Stage.FormattedOutput.workspaceContextAssembly,
+                EditFlowPerf.Dimensions(
+                    fileCount: ctx.selection?.files.count,
+                    contentItemCount: ctx.fileBlocks?.count
+                )
+            )
+            defer {
+                EditFlowPerf.end(
+                    EditFlowPerf.Stage.FormattedOutput.workspaceContextAssembly,
+                    assemblyState
+                )
+            }
             var out: [String] = []
             let selectionCount = ctx.selection?.files.count ?? 0
             let blockCount = ctx.fileBlocks?.count ?? 0
@@ -5428,7 +5477,10 @@ extension ToolOutputFormatter {
     }
 
     static func formatSearch(value: Value) -> [MCP.Tool.Content] {
-        if let dto = value.decode(ToolResultDTOs.SearchResultDTO.self) {
+        let dto = EditFlowPerf.measure(EditFlowPerf.Stage.FormattedOutput.decode) {
+            value.decode(ToolResultDTOs.SearchResultDTO.self)
+        }
+        if let dto {
             if let error = dto.errorMessage, !error.isEmpty {
                 return [.text(searchErrorResults(dto: dto, error: error))]
             }
@@ -5443,6 +5495,17 @@ extension ToolOutputFormatter {
     }
 
     private static func matchSnippetLines(for group: ToolResultDTOs.SearchResultDTO.ContentMatchGroup, adjacency: Int = 2) -> [String] {
+        let snippetState = EditFlowPerf.begin(
+            EditFlowPerf.Stage.FormattedOutput.searchSnippetAssembly,
+            EditFlowPerf.Dimensions(lineCount: group.lines.count)
+        )
+        defer {
+            EditFlowPerf.end(
+                EditFlowPerf.Stage.FormattedOutput.searchSnippetAssembly,
+                snippetState
+            )
+        }
+
         struct LineInfo {
             let text: String
             let isMatch: Bool
@@ -5558,8 +5621,10 @@ extension ToolOutputFormatter {
 
     /// Fallback: present Value as a single fenced JSON block.
     static func formatGeneric(value: Value) -> [MCP.Tool.Content] {
-        let json = prettyJSON(value)
-        return [.text("```json\n\(json)\n```")]
+        EditFlowPerf.measure(EditFlowPerf.Stage.FormattedOutput.genericFallbackAssembly) {
+            let json = prettyJSON(value)
+            return [.text("```json\n\(json)\n```")]
+        }
     }
 
     static func formatAgentRun(args: [String: Value], value: Value) -> [MCP.Tool.Content] {

--- a/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
@@ -463,7 +463,7 @@ public actor UnixSocketMCPTransport: Transport {
         }
 
         let framed = Self.frameWithNewlineIfNeeded(message)
-        #if DEBUG
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
             let recordedResponses: [MCPRequestTimelineRegistry.RecordedMessage] = if let timelineConnectionID {
                 MCPRequestTimelineRegistry.shared.recordedResponses(
                     in: framed,
@@ -531,7 +531,7 @@ public actor UnixSocketMCPTransport: Transport {
         }
         responseDeliveryGate.recordDeliveredServerFrame(framed)
         lastActivityTime = Date()
-        #if DEBUG
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
             if recordedResponses.isEmpty {
                 MCPResponseDeliveryTracer.emitFrame(
                     layer: "app_uds_transport",
@@ -733,7 +733,7 @@ public actor UnixSocketMCPTransport: Transport {
     ) {
         guard !streamFinished else { return }
         responseDeliveryGate.close()
-        #if DEBUG
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
             if let timelineConnectionID {
                 MCPRequestTimelineRegistry.shared.removeConnection(
                     connectionID: timelineConnectionID,
@@ -1118,7 +1118,7 @@ public actor UnixSocketMCPTransport: Transport {
                 responseDeliveryGate.recordAcceptedClientFrame(frame)
                 switch inboundChannel.gate.offer(frame, to: inboundChannel.continuation) {
                 case .accepted:
-                    #if DEBUG
+                    #if DEBUG || MCP_LATENCY_DIAGNOSTICS
                         if let timelineConnectionID {
                             let recorded = MCPRequestTimelineRegistry.shared.recordAcceptedFrame(
                                 frame,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -6796,6 +6796,9 @@ final class MCPServerViewModel: ObservableObject {
         startPath: String?,
         lookupContext: WorkspaceLookupContext = .visibleWorkspace
     ) async throws -> (result: FileTreeResult, rootCount: Int) {
+        let bridgeTotal = EditFlowPerf.begin(EditFlowPerf.Stage.FileTree.bridgeTotal)
+        defer { EditFlowPerf.end(EditFlowPerf.Stage.FileTree.bridgeTotal, bridgeTotal) }
+
         let presentationMode: WorkspaceFileTreePresentationMode
         switch mode.lowercased() {
         case "selected": presentationMode = .selected
@@ -6805,9 +6808,17 @@ final class MCPServerViewModel: ObservableObject {
         default: throw MCPError.invalidParams("invalid mode: \(mode)")
         }
 
-        let filePathDisplay = await MainActor.run { promptVM.filePathDisplayOption }
-        let showCodeMapMarkers = await MainActor.run { !promptVM.codeMapsGloballyDisabled }
-        let selection = try await lookupContext.physicalizeSelection(storedSelectionForCurrentTabContext(includeCodemapPathsWhenSelectedUsage: true))
+        let filePathDisplay = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.settingsSnapshot) {
+            await MainActor.run { promptVM.filePathDisplayOption }
+        }
+        let showCodeMapMarkers = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.settingsSnapshot) {
+            await MainActor.run { !promptVM.codeMapsGloballyDisabled }
+        }
+        let selection = try await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.selectionPhysicalization) {
+            try await lookupContext.physicalizeSelection(storedSelectionForCurrentTabContext(
+                includeCodemapPathsWhenSelectedUsage: true
+            ))
+        }
         let store = promptVM.workspaceFileContextStore
         let fileTree = await store.makeCurrentSnapshotFileTreePresentation(
             selection: selection,

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -302,61 +302,142 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         }
     }
 
+    enum FileTreeRequest: Equatable {
+        case roots
+        case files(mode: String, maxDepth: Int?, startPath: String?)
+    }
+
+    static func parseFileTreeRequest(args: [String: Value]) throws -> FileTreeRequest {
+        let type = args["type"]?.stringValue ?? "files"
+        switch type {
+        case "roots":
+            return .roots
+        case "files":
+            let mode = args["mode"]?.stringValue ?? "auto"
+            let maxDepth: Int?
+            if let maxDepthArg = args["max_depth"] {
+                guard let intValue = maxDepthArg.intValue else {
+                    throw MCPError.invalidParams("max_depth must be an integer")
+                }
+                maxDepth = intValue
+            } else {
+                maxDepth = nil
+            }
+            return .files(mode: mode, maxDepth: maxDepth, startPath: args["path"]?.stringValue)
+        default:
+            throw MCPError.invalidParams("invalid type: \(type)")
+        }
+    }
+
     private func executeGetFileTree(
         args: [String: Value],
         appContext: MCPServerViewModel.DomainReadAppExecutionContext?
     ) async throws -> Value {
         try await withActiveWorktreeStartupBenchmarkTag(appContext: appContext) {
-            let type = args["type"]?.stringValue ?? "files"
-            switch type {
-            case "roots":
-                let filePathDisplay = await MainActor.run { dependencies.context.promptVM.filePathDisplayOption }
-                let lookupContext = await readAuthority(appContext).lookupContext
-                _ = await dependencies.context.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+            let providerTotal = EditFlowPerf.begin(EditFlowPerf.Stage.FileTree.providerTotal)
+            defer { EditFlowPerf.end(EditFlowPerf.Stage.FileTree.providerTotal, providerTotal) }
+
+            let request = try EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerArgumentParsing) {
+                try Self.parseFileTreeRequest(args: args)
+            }
+
+            switch request {
+            case .roots:
+                let filePathDisplay = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.settingsSnapshot) {
+                    await MainActor.run { dependencies.context.promptVM.filePathDisplayOption }
+                }
+                let authority = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerRequestMetadata) {
+                    await readAuthority(appContext)
+                }
+                let lookupContext = EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerLookupContextResolution) {
+                    authority.lookupContext
+                }
+                _ = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerIngressFreshnessWait) {
+                    await dependencies.context.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+                }
                 let worktreeScope = ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: lookupContext.bindingProjection)
-                let snapshot = await dependencies.context.promptVM.workspaceFileContextStore.makeFileTreeSelectionSnapshot(
-                    selection: StoredSelection(),
-                    request: WorkspaceFileTreeSnapshotRequest(mode: .full, filePathDisplay: filePathDisplay, onlyIncludeRootsWithSelectedFiles: false, includeLegend: false, showCodeMapMarkers: false, rootScope: lookupContext.rootScope),
-                    profile: .mcpRead
-                )
-                if snapshot.roots.isEmpty {
-                    let msg = await dependencies.files.workspaceContextMessage(MCPWindowToolName.getFileTree, nil)
-                    return try Value(ToolResultDTOs.FileTreeDTO(rootsCount: 0, usesLegend: false, tree: msg, note: "No workspace loaded", wasTruncated: false, worktreeScope: worktreeScope))
+                let snapshot = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.snapshotConstruction) {
+                    await dependencies.context.promptVM.workspaceFileContextStore.makeFileTreeSelectionSnapshot(
+                        selection: StoredSelection(),
+                        request: WorkspaceFileTreeSnapshotRequest(
+                            mode: .full,
+                            filePathDisplay: filePathDisplay,
+                            onlyIncludeRootsWithSelectedFiles: false,
+                            includeLegend: false,
+                            showCodeMapMarkers: false,
+                            rootScope: lookupContext.rootScope
+                        ),
+                        profile: .mcpRead
+                    )
                 }
-                let rootLines = snapshot.roots.map { root in
-                    lookupContext.bindingProjection?.projectedLogicalDisplayPath(forPhysicalPath: root.fullPath, display: .full) ?? root.fullPath
-                }
-                return try Value(ToolResultDTOs.FileTreeDTO(rootsCount: snapshot.roots.count, usesLegend: false, tree: rootLines.joined(separator: "\n"), note: nil, wasTruncated: false, worktreeScope: worktreeScope))
-            case "files":
-                let mode = args["mode"]?.stringValue ?? "auto"
-                let maxDepth: Int?
-                if let maxDepthArg = args["max_depth"] {
-                    guard let intVal = maxDepthArg.intValue else { throw MCPError.invalidParams("max_depth must be an integer") }
-                    maxDepth = intVal
-                } else {
-                    maxDepth = nil
-                }
-                let authority = await readAuthority(appContext)
-                let metadata = authority.metadata
-                let lookupContext = authority.lookupContext
-                _ = await dependencies.context.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
-                if mode.lowercased() == "selected" {
-                    guard try await dependencies.files.drainReadFileAutoSelection(metadata, .canonicalSelection) == .completed else {
-                        throw CancellationError()
+                let dto = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.dtoAssembly) {
+                    if snapshot.roots.isEmpty {
+                        let msg = await dependencies.files.workspaceContextMessage(MCPWindowToolName.getFileTree, nil)
+                        return ToolResultDTOs.FileTreeDTO(
+                            rootsCount: 0,
+                            usesLegend: false,
+                            tree: msg,
+                            note: "No workspace loaded",
+                            wasTruncated: false,
+                            worktreeScope: worktreeScope
+                        )
                     }
+                    let rootLines = snapshot.roots.map { root in
+                        lookupContext.bindingProjection?.projectedLogicalDisplayPath(
+                            forPhysicalPath: root.fullPath,
+                            display: .full
+                        ) ?? root.fullPath
+                    }
+                    return ToolResultDTOs.FileTreeDTO(
+                        rootsCount: snapshot.roots.count,
+                        usesLegend: false,
+                        tree: rootLines.joined(separator: "\n"),
+                        note: nil,
+                        wasTruncated: false,
+                        worktreeScope: worktreeScope
+                    )
+                }
+                return try EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerValueEncoding) {
+                    try Value(dto)
+                }
+
+            case let .files(mode, maxDepth, startPath):
+                let authority = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerRequestMetadata) {
+                    await readAuthority(appContext)
+                }
+                let metadata = authority.metadata
+                let lookupContext = EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerLookupContextResolution) {
+                    authority.lookupContext
+                }
+                _ = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerIngressFreshnessWait) {
+                    await dependencies.context.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+                }
+                if mode.lowercased() == "selected" {
+                    let drain = try await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerSelectionDrain) {
+                        try await dependencies.files.drainReadFileAutoSelection(metadata, .canonicalSelection)
+                    }
+                    guard drain == .completed else { throw CancellationError() }
                 }
                 let worktreeScope = ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: lookupContext.bindingProjection)
-                let resultAndRootCount = try await dependencies.files.buildStoreBackedFileTreeResult(mode, maxDepth, args["path"]?.stringValue, lookupContext)
-                return try Value(ToolResultDTOs.FileTreeDTO(
-                    rootsCount: resultAndRootCount.rootCount,
-                    usesLegend: resultAndRootCount.result.usesLegend,
-                    tree: resultAndRootCount.result.tree,
-                    note: resultAndRootCount.result.note,
-                    wasTruncated: resultAndRootCount.result.wasTruncated,
-                    worktreeScope: worktreeScope
-                ))
-            default:
-                throw MCPError.invalidParams("invalid type: \(type)")
+                let resultAndRootCount = try await dependencies.files.buildStoreBackedFileTreeResult(
+                    mode,
+                    maxDepth,
+                    startPath,
+                    lookupContext
+                )
+                let dto = EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.dtoAssembly) {
+                    ToolResultDTOs.FileTreeDTO(
+                        rootsCount: resultAndRootCount.rootCount,
+                        usesLegend: resultAndRootCount.result.usesLegend,
+                        tree: resultAndRootCount.result.tree,
+                        note: resultAndRootCount.result.note,
+                        wasTruncated: resultAndRootCount.result.wasTruncated,
+                        worktreeScope: worktreeScope
+                    )
+                }
+                return try EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.providerValueEncoding) {
+                    try Value(dto)
+                }
             }
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -9492,25 +9492,33 @@ actor WorkspaceFileContextStore {
                 )
             }
         #endif
-        let unmarkedSnapshot = await makeFileTreeSelectionSnapshot(
-            selection: selection,
-            request: request,
-            renderableCodemapFileIDs: [],
-            profile: profile
-        )
-        let rootDisplayNames = await lookupContext.logicalRootDisplayNamesByRootID(store: self)
+        let unmarkedSnapshot = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.snapshotConstruction) {
+            await makeFileTreeSelectionSnapshot(
+                selection: selection,
+                request: request,
+                renderableCodemapFileIDs: [],
+                profile: profile
+            )
+        }
+        let rootDisplayNames = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.logicalProjection) {
+            await lookupContext.logicalRootDisplayNamesByRootID(store: self)
+        }
         let renderableCodemapFileIDs = request.showCodeMapMarkers
             ? currentRenderableCodemapFileIDs(rootScope: request.rootScope)
             : Set<UUID>()
-        let snapshot = fileTreeSnapshot(
-            unmarkedSnapshot,
-            renderableCodemapFileIDs: renderableCodemapFileIDs,
-            showCodeMapMarkers: request.showCodeMapMarkers
-        )
-        let logicalSnapshot = snapshot.logicalized(
-            roots: rootRefs(scope: request.rootScope),
-            rootDisplayNamesByRootID: rootDisplayNames
-        )
+        let snapshot = EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.codemapMarkerProjection) {
+            fileTreeSnapshot(
+                unmarkedSnapshot,
+                renderableCodemapFileIDs: renderableCodemapFileIDs,
+                showCodeMapMarkers: request.showCodeMapMarkers
+            )
+        }
+        let logicalSnapshot = EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.logicalProjection) {
+            snapshot.logicalized(
+                roots: rootRefs(scope: request.rootScope),
+                rootDisplayNamesByRootID: rootDisplayNames
+            )
+        }
         return WorkspaceFileTreePresentation(
             content: WorkspaceFileTreePresentationRenderer.render(logicalSnapshot),
             rootCount: logicalSnapshot.roots.count,
@@ -9529,18 +9537,24 @@ actor WorkspaceFileContextStore {
         codemapIssues: [WorkspaceCodemapOperationIssue],
         profile: PathLocateProfile
     ) async -> WorkspaceFileTreePresentation {
-        let snapshot = await makeFileTreeSelectionSnapshot(
-            selection: selection,
-            request: request,
-            renderableCodemapFileIDs: renderableCodemapFileIDs,
-            profile: profile
-        )
+        let snapshot = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.snapshotConstruction) {
+            await makeFileTreeSelectionSnapshot(
+                selection: selection,
+                request: request,
+                renderableCodemapFileIDs: renderableCodemapFileIDs,
+                profile: profile
+            )
+        }
         let roots = rootRefs(scope: request.rootScope)
-        let rootDisplayNames = await lookupContext.logicalRootDisplayNamesByRootID(store: self)
-        let logicalSnapshot = snapshot.logicalized(
-            roots: roots,
-            rootDisplayNamesByRootID: rootDisplayNames
-        )
+        let rootDisplayNames = await EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.logicalProjection) {
+            await lookupContext.logicalRootDisplayNamesByRootID(store: self)
+        }
+        let logicalSnapshot = EditFlowPerf.measure(EditFlowPerf.Stage.FileTree.logicalProjection) {
+            snapshot.logicalized(
+                roots: roots,
+                rootDisplayNamesByRootID: rootDisplayNames
+            )
+        }
         return WorkspaceFileTreePresentation(
             content: WorkspaceFileTreePresentationRenderer.render(logicalSnapshot),
             rootCount: logicalSnapshot.roots.count,

--- a/Sources/RepoPromptDomainRuntime/Diffing/EditFlowPerf.swift
+++ b/Sources/RepoPromptDomainRuntime/Diffing/EditFlowPerf.swift
@@ -1,9 +1,9 @@
 import Foundation
 import RepoPromptShared
-#if DEBUG
+#if DEBUG || MCP_LATENCY_DIAGNOSTICS
     import Synchronization
 #endif
-#if DEBUG || EDIT_FLOW_PERF
+#if DEBUG || EDIT_FLOW_PERF || MCP_LATENCY_DIAGNOSTICS
     import os
 #endif
 
@@ -26,14 +26,15 @@ package enum EditFlowPerf {
     @TaskLocal
     package static var currentFileSystemPublicationCorrelation: LifecycleCorrelation?
 
-    #if DEBUG || EDIT_FLOW_PERF
+    #if DEBUG || EDIT_FLOW_PERF || MCP_LATENCY_DIAGNOSTICS
         package struct IntervalState {
             let signpostState: OSSignpostIntervalState?
-            #if DEBUG
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
                 let debugCaptureEpoch: UInt64?
                 let debugCaptureStartNanoseconds: UInt64?
                 let debugCaptureStageName: String
                 let debugCaptureDimensions: String
+                let debugCaptureRequestIdentity: MCPRequestTimelineIdentity?
             #endif
         }
     #else
@@ -545,6 +546,37 @@ package enum EditFlowPerf {
             package static let flushDeltas: StaticString = "EditFlow.ApplyEdits.FlushDeltas"
         }
 
+        package enum FileTree {
+            package static let providerTotal: StaticString = "EditFlow.FileTree.ProviderTotal"
+            package static let providerArgumentParsing: StaticString = "EditFlow.FileTree.ProviderArgumentParsing"
+            package static let providerRequestMetadata: StaticString = "EditFlow.FileTree.ProviderRequestMetadata"
+            package static let providerLookupContextResolution: StaticString = "EditFlow.FileTree.ProviderLookupContextResolution"
+            package static let providerIngressFreshnessWait: StaticString = "EditFlow.FileTree.ProviderIngressFreshnessWait"
+            package static let providerSelectionDrain: StaticString = "EditFlow.FileTree.ProviderSelectionDrain"
+            package static let bridgeTotal: StaticString = "EditFlow.FileTree.BridgeTotal"
+            package static let settingsSnapshot: StaticString = "EditFlow.FileTree.SettingsSnapshot"
+            package static let selectionPhysicalization: StaticString = "EditFlow.FileTree.SelectionPhysicalization"
+            package static let snapshotConstruction: StaticString = "EditFlow.FileTree.SnapshotConstruction"
+            package static let codemapMarkerProjection: StaticString = "EditFlow.FileTree.CodemapMarkerProjection"
+            package static let logicalProjection: StaticString = "EditFlow.FileTree.LogicalProjection"
+            package static let renderIndexPreparation: StaticString = "EditFlow.FileTree.RenderIndexPreparation"
+            package static let renderAttempt: StaticString = "EditFlow.FileTree.RenderAttempt"
+            package static let renderTokenEstimation: StaticString = "EditFlow.FileTree.RenderTokenEstimation"
+            package static let dtoAssembly: StaticString = "EditFlow.FileTree.DTOAssembly"
+            package static let providerValueEncoding: StaticString = "EditFlow.FileTree.ProviderValueEncoding"
+        }
+
+        package enum FormattedOutput {
+            package static let decode: StaticString = "EditFlow.FormattedOutput.Decode"
+            package static let promptEnvelopeProbeDecode: StaticString = "EditFlow.FormattedOutput.PromptEnvelopeProbeDecode"
+            package static let promptContextDecode: StaticString = "EditFlow.FormattedOutput.PromptContextDecode"
+            package static let searchTreeAssembly: StaticString = "EditFlow.FormattedOutput.SearchTreeAssembly"
+            package static let searchSnippetAssembly: StaticString = "EditFlow.FormattedOutput.SearchSnippetAssembly"
+            package static let fileTreeAssembly: StaticString = "EditFlow.FormattedOutput.FileTreeAssembly"
+            package static let workspaceContextAssembly: StaticString = "EditFlow.FormattedOutput.WorkspaceContextAssembly"
+            package static let genericFallbackAssembly: StaticString = "EditFlow.FormattedOutput.GenericFallbackAssembly"
+        }
+
         package enum Search {
             package static let broadAdmissionWait: StaticString = "EditFlow.Search.BroadAdmissionWait"
             package static let broadAdmissionLeaseHold: StaticString = "EditFlow.Search.BroadAdmissionLeaseHold"
@@ -731,6 +763,7 @@ package enum EditFlowPerf {
             package static let mainActorExited: StaticString = "MCP.ToolCall.MainActorExited"
             package static let publicationOwnershipState: StaticString = "MCP.ToolCall.PublicationOwnershipState"
             package static let completionObserverReturned: StaticString = "MCP.ToolCall.CompletionObserverReturned"
+            package static let formatResultBegan: StaticString = "MCP.ToolCall.FormatResultBegan"
             package static let formatResultReturned: StaticString = "MCP.ToolCall.FormatResultReturned"
             package static let resolvedProviderBegan: StaticString = "MCP.ToolCall.ResolvedProviderBegan"
             package static let resolvedProviderEnded: StaticString = "MCP.ToolCall.ResolvedProviderEnded"
@@ -843,26 +876,76 @@ package enum EditFlowPerf {
         }
     }
 
-    #if DEBUG
+    #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+        package enum DebugCaptureMode: String {
+            case exhaustive
+            case mcpLatencyEvidence = "mcp_latency_evidence"
+
+            var sampleCapacityUnit: String {
+                switch self {
+                case .exhaustive: "elapsed_interval_samples"
+                case .mcpLatencyEvidence: "unique_stage_dimension_request_keys"
+                }
+            }
+
+            var percentileSemantics: String {
+                switch self {
+                case .exhaustive: "exact_nearest_rank"
+                case .mcpLatencyEvidence: "unavailable_online_aggregation"
+                }
+            }
+
+            var lifecycleCaptureContract: String {
+                switch self {
+                case .exhaustive: "all_correlated_events"
+                case .mcpLatencyEvidence: "s0_s7_required_boundaries"
+                }
+            }
+
+            var stageCaptureContract: String {
+                switch self {
+                case .exhaustive: "all_intervals"
+                case .mcpLatencyEvidence: "w2_selector_stages"
+                }
+            }
+        }
+
         package struct DebugCaptureStageAggregate {
             package let stageName: String
             package let sanitizedDimensions: String
             package let sampleCount: Int
-            package let p50MS: Double
-            package let p95MS: Double
+            package let p50MS: Double?
+            package let p95MS: Double?
             package let maxMS: Double
             package let totalMS: Double
+            package let requestIdentity: MCPRequestTimelineIdentity?
 
             package var payload: [String: Any] {
                 [
                     "stage_name": stageName,
                     "sanitized_dimensions": sanitizedDimensions,
                     "sample_count": sampleCount,
-                    "p50_ms": Self.roundedMS(p50MS),
-                    "p95_ms": Self.roundedMS(p95MS),
+                    "p50_ms": Self.optionalRoundedMS(p50MS),
+                    "p95_ms": Self.optionalRoundedMS(p95MS),
                     "max_ms": Self.roundedMS(maxMS),
-                    "total_ms": Self.roundedMS(totalMS)
+                    "total_ms": Self.roundedMS(totalMS),
+                    "request_identity": requestIdentity.map(Self.requestIdentityPayload) ?? NSNull()
                 ]
+            }
+
+            private static func requestIdentityPayload(_ identity: MCPRequestTimelineIdentity) -> [String: Any] {
+                [
+                    "jsonrpc_request_id": identity.jsonRPCRequestID?.description ?? NSNull(),
+                    "connection_id": identity.connectionID ?? NSNull(),
+                    "connection_generation": identity.connectionGeneration ?? NSNull(),
+                    "app_invocation_id": identity.appInvocationID ?? NSNull(),
+                    "request_ordinal": identity.requestOrdinal ?? NSNull()
+                ]
+            }
+
+            private static func optionalRoundedMS(_ value: Double?) -> Any {
+                guard let value else { return NSNull() }
+                return roundedMS(value)
             }
 
             private static func roundedMS(_ value: Double) -> Double {
@@ -905,32 +988,53 @@ package enum EditFlowPerf {
         }
 
         package struct DebugCaptureSnapshot {
+            package let mode: DebugCaptureMode
             package let label: String
             package let active: Bool
             package let startedAt: Date?
             package let finishedAt: Date?
+            package let captureStartUptimeMS: Double?
             package let maxSamples: Int
             package let retainedSampleCount: Int
             package let droppedSampleCount: Int
+            package let ignoredOutOfContractSampleCount: Int
             package let stages: [DebugCaptureStageAggregate]
             package let maxLifecycleEvents: Int
             package let retainedLifecycleEventCount: Int
             package let droppedLifecycleEventCount: Int
+            package let ignoredOutOfContractLifecycleEventCount: Int
             package let lifecycleEvents: [DebugCaptureLifecycleEvent]
 
             package func payload(includeTimeline: Bool = true) -> [String: Any] {
                 var result: [String: Any] = [
+                    "capture_mode": mode.rawValue,
+                    "sample_capacity_unit": mode.sampleCapacityUnit,
+                    "percentile_semantics": mode.percentileSemantics,
+                    "lifecycle_capture_contract": mode.lifecycleCaptureContract,
+                    "lifecycle_event_allowlist": Self.lifecycleEventAllowlistPayload(mode),
+                    "stage_capture_contract": mode.stageCaptureContract,
+                    "stage_name_allowlist": Self.stageNameAllowlistPayload(mode),
                     "label": label,
                     "active": active,
                     "started_at": startedAt?.timeIntervalSince1970 ?? NSNull(),
                     "finished_at": finishedAt?.timeIntervalSince1970 ?? NSNull(),
+                    "capture_start_uptime_ms": captureStartUptimeMS.map(Self.roundedMS) ?? NSNull(),
                     "max_samples": maxSamples,
                     "retained_sample_count": retainedSampleCount,
                     "dropped_sample_count": droppedSampleCount,
+                    "ignored_out_of_contract_sample_count": ignoredOutOfContractSampleCount,
+                    "observed_sample_count": retainedSampleCount
+                        + droppedSampleCount
+                        + ignoredOutOfContractSampleCount,
+                    "retained_aggregate_key_count": stages.count,
                     "stages": stages.map(\.payload),
                     "max_lifecycle_events": maxLifecycleEvents,
                     "retained_lifecycle_event_count": retainedLifecycleEventCount,
                     "dropped_lifecycle_event_count": droppedLifecycleEventCount,
+                    "ignored_out_of_contract_lifecycle_event_count": ignoredOutOfContractLifecycleEventCount,
+                    "observed_lifecycle_event_count": retainedLifecycleEventCount
+                        + droppedLifecycleEventCount
+                        + ignoredOutOfContractLifecycleEventCount,
                     "timeline_included": includeTimeline,
                     "request_timeline_count": requestTimelinePayloads.count,
                     "request_timelines": requestTimelinePayloads,
@@ -940,6 +1044,28 @@ package enum EditFlowPerf {
                     result["lifecycle_events"] = lifecycleEvents.map(\.payload)
                 }
                 return result
+            }
+
+            private static func roundedMS(_ value: Double) -> Double {
+                (value * 1000).rounded() / 1000
+            }
+
+            private static func lifecycleEventAllowlistPayload(_ mode: DebugCaptureMode) -> Any {
+                switch mode {
+                case .exhaustive:
+                    NSNull()
+                case .mcpLatencyEvidence:
+                    DebugCaptureRecorder.mcpLatencyLifecycleEventAllowlist.sorted()
+                }
+            }
+
+            private static func stageNameAllowlistPayload(_ mode: DebugCaptureMode) -> Any {
+                switch mode {
+                case .exhaustive:
+                    NSNull()
+                case .mcpLatencyEvidence:
+                    DebugCaptureRecorder.mcpLatencyStageNameAllowlist.sorted()
+                }
             }
 
             private var requestTimelinePayloads: [[String: Any]] {
@@ -978,11 +1104,24 @@ package enum EditFlowPerf {
         private struct DebugCaptureKey: Hashable {
             let stageName: String
             let sanitizedDimensions: String
+            let appInvocationID: String?
         }
 
         private struct DebugCaptureStart {
             let epoch: UInt64
             let startNanoseconds: UInt64
+        }
+
+        private struct DebugCaptureOnlineAggregate {
+            var sampleCount: Int
+            var totalMS: Double
+            var maxMS: Double
+        }
+
+        private enum DebugLifecycleCaptureDisposition {
+            case inactive
+            case ignored
+            case retain
         }
 
         private final class DebugCaptureActiveHint {
@@ -1016,6 +1155,59 @@ package enum EditFlowPerf {
         }
 
         private final class DebugCaptureRecorder {
+            fileprivate static let mcpLatencyLifecycleEventAllowlist: Set<String> = [
+                "MCP.ToolCall.Received",
+                "MCP.ToolCall.PermitAcquired",
+                "MCP.ToolCall.ResolvedProviderBegan",
+                "MCP.ToolCall.ResolvedProviderEnded",
+                "MCP.ToolCall.FormatResultBegan",
+                "MCP.ToolCall.FormatResultReturned",
+                "MCP.ToolCall.CompletionObserverReturned",
+                "MCP.ToolCall.HandlerResultReady"
+            ]
+            fileprivate static let mcpLatencyStageNameAllowlist: Set<String> = [
+                "EditFlow.FileTree.BridgeTotal",
+                "EditFlow.FileTree.CodemapMarkerProjection",
+                "EditFlow.FileTree.DTOAssembly",
+                "EditFlow.FileTree.LogicalProjection",
+                "EditFlow.FileTree.ProviderArgumentParsing",
+                "EditFlow.FileTree.ProviderIngressFreshnessWait",
+                "EditFlow.FileTree.ProviderLookupContextResolution",
+                "EditFlow.FileTree.ProviderRequestMetadata",
+                "EditFlow.FileTree.ProviderSelectionDrain",
+                "EditFlow.FileTree.ProviderTotal",
+                "EditFlow.FileTree.ProviderValueEncoding",
+                "EditFlow.FileTree.RenderAttempt",
+                "EditFlow.FileTree.RenderIndexPreparation",
+                "EditFlow.FileTree.RenderTokenEstimation",
+                "EditFlow.FileTree.SelectionPhysicalization",
+                "EditFlow.FileTree.SettingsSnapshot",
+                "EditFlow.FileTree.SnapshotConstruction",
+                "EditFlow.FormattedOutput.Decode",
+                "EditFlow.FormattedOutput.FileTreeAssembly",
+                "EditFlow.FormattedOutput.GenericFallbackAssembly",
+                "EditFlow.FormattedOutput.PromptContextDecode",
+                "EditFlow.FormattedOutput.PromptEnvelopeProbeDecode",
+                "EditFlow.FormattedOutput.SearchSnippetAssembly",
+                "EditFlow.FormattedOutput.SearchTreeAssembly",
+                "EditFlow.FormattedOutput.WorkspaceContextAssembly",
+                "EditFlow.MCPToolCall.CompletionObserverCallbacks",
+                "EditFlow.MCPToolCall.CompletionObserverResultEncoding",
+                "EditFlow.MCPToolCall.CompletionObservers",
+                "EditFlow.MCPToolCall.FormatResult",
+                "EditFlow.MCPToolCall.HandlerResultHandoff",
+                "EditFlow.MCPToolCall.LimiterWait",
+                "EditFlow.Search.BroadAdmissionWait",
+                "EditFlow.Search.DTOBuild",
+                "EditFlow.Search.DTOBuild.Assembly",
+                "EditFlow.Search.IngressFreshnessWait",
+                "EditFlow.Search.ProviderTotal",
+                "EditFlow.Search.ProviderValueEncoding",
+                "EditFlow.Search.ProviderWorkspaceSearchAwait",
+                "EditFlow.Search.RootScopeAvailabilityGate",
+                "EditFlow.Search.WorkspaceReadinessAcquireGate",
+                "EditFlow.Search.WorkspaceReadinessValidationGate"
+            ]
             private static let sampleLimitRange = 100 ... 100_000
             private static let lifecycleEventLimit = 20000
 
@@ -1023,6 +1215,7 @@ package enum EditFlowPerf {
             private let activeHint = DebugCaptureActiveHint()
             private var active = false
             private var captureEpoch: UInt64 = 0
+            private var mode = DebugCaptureMode.exhaustive
             private var label = ""
             private var startedAt: Date?
             private var finishedAt: Date?
@@ -1030,10 +1223,14 @@ package enum EditFlowPerf {
             private var maxSamples = 20000
             private var retainedSampleCount = 0
             private var droppedSampleCount = 0
+            private var ignoredOutOfContractSampleCount = 0
             private var samplesByKey: [DebugCaptureKey: [Double]] = [:]
+            private var onlineAggregatesByKey: [DebugCaptureKey: DebugCaptureOnlineAggregate] = [:]
+            private var requestIdentityByKey: [DebugCaptureKey: MCPRequestTimelineIdentity] = [:]
             private var nextLifecycleOrdinal: UInt64 = 1
             private var retainedLifecycleEventCount = 0
             private var droppedLifecycleEventCount = 0
+            private var ignoredOutOfContractLifecycleEventCount = 0
             private var lifecycleEvents: [DebugCaptureLifecycleEvent] = []
 
             var isActive: Bool {
@@ -1045,11 +1242,16 @@ package enum EditFlowPerf {
                 return active
             }
 
-            package func begin(label: String, maxSamples: Int) -> DebugCaptureBeginResult {
+            package func begin(
+                label: String,
+                maxSamples: Int,
+                mode: DebugCaptureMode
+            ) -> DebugCaptureBeginResult {
                 lock.lock()
                 defer { lock.unlock() }
                 guard !active else { return .busy(snapshotLocked()) }
                 captureEpoch += 1
+                self.mode = mode
                 self.label = Self.sanitizedLabel(label)
                 // Defense in depth for non-MCP callers; MCP controls reject out-of-range input earlier.
                 self.maxSamples = Self.clampedMaxSamples(maxSamples)
@@ -1059,10 +1261,14 @@ package enum EditFlowPerf {
                 captureStartNanoseconds = DispatchTime.now().uptimeNanoseconds
                 retainedSampleCount = 0
                 droppedSampleCount = 0
+                ignoredOutOfContractSampleCount = 0
                 samplesByKey.removeAll(keepingCapacity: true)
+                onlineAggregatesByKey.removeAll(keepingCapacity: true)
+                requestIdentityByKey.removeAll(keepingCapacity: true)
                 nextLifecycleOrdinal = 1
                 retainedLifecycleEventCount = 0
                 droppedLifecycleEventCount = 0
+                ignoredOutOfContractLifecycleEventCount = 0
                 lifecycleEvents.removeAll(keepingCapacity: true)
                 activeHint.store(true)
                 return .started(snapshotLocked())
@@ -1083,6 +1289,7 @@ package enum EditFlowPerf {
                 lock.lock()
                 active = false
                 activeHint.store(false)
+                mode = .exhaustive
                 label = ""
                 startedAt = nil
                 finishedAt = nil
@@ -1090,10 +1297,14 @@ package enum EditFlowPerf {
                 maxSamples = 20000
                 retainedSampleCount = 0
                 droppedSampleCount = 0
+                ignoredOutOfContractSampleCount = 0
                 samplesByKey.removeAll(keepingCapacity: false)
+                onlineAggregatesByKey.removeAll(keepingCapacity: false)
+                requestIdentityByKey.removeAll(keepingCapacity: false)
                 nextLifecycleOrdinal = 1
                 retainedLifecycleEventCount = 0
                 droppedLifecycleEventCount = 0
+                ignoredOutOfContractLifecycleEventCount = 0
                 lifecycleEvents.removeAll(keepingCapacity: false)
                 lock.unlock()
             }
@@ -1113,12 +1324,24 @@ package enum EditFlowPerf {
                 return active ? captureEpoch : nil
             }
 
-            package func shouldRecordLifecycleEvent(_ correlation: LifecycleCorrelation) -> Bool {
-                guard let correlationEpoch = correlation.captureEpoch else { return false }
-                if let active = activeHint.loadIfAvailable(), !active { return false }
+            package func lifecycleCaptureDisposition(
+                eventName: String,
+                correlation: LifecycleCorrelation
+            ) -> DebugLifecycleCaptureDisposition {
+                guard let correlationEpoch = correlation.captureEpoch else { return .inactive }
+                if let active = activeHint.loadIfAvailable(), !active { return .inactive }
                 lock.lock()
                 defer { lock.unlock() }
-                return active && correlationEpoch == captureEpoch
+                guard active, correlationEpoch == captureEpoch else { return .inactive }
+                if mode == .mcpLatencyEvidence {
+                    guard correlation.requestIdentity?.isCompleteLatencyEvidenceIdentity == true,
+                          Self.mcpLatencyLifecycleEventAllowlist.contains(eventName)
+                    else {
+                        ignoredOutOfContractLifecycleEventCount += 1
+                        return .ignored
+                    }
+                }
+                return .retain
             }
 
             package func recordLifecycleEvent(
@@ -1136,7 +1359,7 @@ package enum EditFlowPerf {
                 else { return }
                 let ordinal = nextLifecycleOrdinal
                 nextLifecycleOrdinal &+= 1
-                guard retainedLifecycleEventCount < min(maxSamples, Self.lifecycleEventLimit) else {
+                guard retainedLifecycleEventCount < maxLifecycleEventsForCurrentMode else {
                     droppedLifecycleEventCount += 1
                     return
                 }
@@ -1154,19 +1377,67 @@ package enum EditFlowPerf {
                 retainedLifecycleEventCount += 1
             }
 
-            package func record(stageName: String, sanitizedDimensions: String, captureEpoch: UInt64, startNanoseconds: UInt64) {
+            package func record(
+                stageName: String,
+                sanitizedDimensions: String,
+                requestIdentity: MCPRequestTimelineIdentity?,
+                captureEpoch: UInt64,
+                startNanoseconds: UInt64
+            ) {
                 let elapsedNanoseconds = DispatchTime.now().uptimeNanoseconds - startNanoseconds
                 let elapsedMS = Double(elapsedNanoseconds) / 1_000_000.0
                 lock.lock()
                 defer { lock.unlock() }
                 guard active, captureEpoch == self.captureEpoch else { return }
-                guard retainedSampleCount < maxSamples else {
-                    droppedSampleCount += 1
-                    return
+                if mode == .mcpLatencyEvidence {
+                    guard requestIdentity?.isCompleteLatencyEvidenceIdentity == true,
+                          Self.mcpLatencyStageNameAllowlist.contains(stageName)
+                    else {
+                        ignoredOutOfContractSampleCount += 1
+                        return
+                    }
                 }
-                let key = DebugCaptureKey(stageName: stageName, sanitizedDimensions: sanitizedDimensions)
-                samplesByKey[key, default: []].append(elapsedMS)
+                let key = DebugCaptureKey(
+                    stageName: stageName,
+                    sanitizedDimensions: sanitizedDimensions,
+                    appInvocationID: requestIdentity?.appInvocationID
+                )
+                switch mode {
+                case .exhaustive:
+                    guard retainedSampleCount < maxSamples else {
+                        droppedSampleCount += 1
+                        return
+                    }
+                    samplesByKey[key, default: []].append(elapsedMS)
+                case .mcpLatencyEvidence:
+                    if var aggregate = onlineAggregatesByKey[key] {
+                        aggregate.sampleCount += 1
+                        aggregate.totalMS += elapsedMS
+                        aggregate.maxMS = max(aggregate.maxMS, elapsedMS)
+                        onlineAggregatesByKey[key] = aggregate
+                    } else {
+                        guard onlineAggregatesByKey.count < maxSamples else {
+                            droppedSampleCount += 1
+                            return
+                        }
+                        onlineAggregatesByKey[key] = DebugCaptureOnlineAggregate(
+                            sampleCount: 1,
+                            totalMS: elapsedMS,
+                            maxMS: elapsedMS
+                        )
+                    }
+                }
+                if let requestIdentity {
+                    requestIdentityByKey[key] = requestIdentity
+                }
                 retainedSampleCount += 1
+            }
+
+            private var maxLifecycleEventsForCurrentMode: Int {
+                switch mode {
+                case .exhaustive: min(maxSamples, Self.lifecycleEventLimit)
+                case .mcpLatencyEvidence: maxSamples
+                }
             }
 
             private static func clampedMaxSamples(_ maxSamples: Int) -> Int {
@@ -1184,36 +1455,61 @@ package enum EditFlowPerf {
             }
 
             private func snapshotLocked() -> DebugCaptureSnapshot {
-                let stages = samplesByKey.map { key, samples in
-                    let sorted = samples.sorted()
-                    return DebugCaptureStageAggregate(
-                        stageName: key.stageName,
-                        sanitizedDimensions: key.sanitizedDimensions,
-                        sampleCount: sorted.count,
-                        p50MS: nearestRank(sorted, percentile: 0.50),
-                        p95MS: nearestRank(sorted, percentile: 0.95),
-                        maxMS: sorted.last ?? 0,
-                        totalMS: sorted.reduce(0, +)
-                    )
+                let stages: [DebugCaptureStageAggregate] = switch mode {
+                case .exhaustive:
+                    samplesByKey.map { key, samples in
+                        let sorted = samples.sorted()
+                        return DebugCaptureStageAggregate(
+                            stageName: key.stageName,
+                            sanitizedDimensions: key.sanitizedDimensions,
+                            sampleCount: sorted.count,
+                            p50MS: nearestRank(sorted, percentile: 0.50),
+                            p95MS: nearestRank(sorted, percentile: 0.95),
+                            maxMS: sorted.last ?? 0,
+                            totalMS: sorted.reduce(0, +),
+                            requestIdentity: requestIdentityByKey[key]
+                        )
+                    }
+                case .mcpLatencyEvidence:
+                    onlineAggregatesByKey.map { key, aggregate in
+                        DebugCaptureStageAggregate(
+                            stageName: key.stageName,
+                            sanitizedDimensions: key.sanitizedDimensions,
+                            sampleCount: aggregate.sampleCount,
+                            p50MS: nil,
+                            p95MS: nil,
+                            maxMS: aggregate.maxMS,
+                            totalMS: aggregate.totalMS,
+                            requestIdentity: requestIdentityByKey[key]
+                        )
+                    }
                 }
-                .sorted {
-                    if $0.stageName == $1.stageName {
+                let orderedStages = stages.sorted {
+                    if $0.stageName != $1.stageName {
+                        return $0.stageName < $1.stageName
+                    }
+                    if $0.sanitizedDimensions != $1.sanitizedDimensions {
                         return $0.sanitizedDimensions < $1.sanitizedDimensions
                     }
-                    return $0.stageName < $1.stageName
+                    return ($0.requestIdentity?.appInvocationID ?? "")
+                        < ($1.requestIdentity?.appInvocationID ?? "")
                 }
                 return DebugCaptureSnapshot(
+                    mode: mode,
                     label: label,
                     active: active,
                     startedAt: startedAt,
                     finishedAt: finishedAt,
+                    captureStartUptimeMS: captureStartNanoseconds.map { Double($0) / 1_000_000.0 },
                     maxSamples: maxSamples,
                     retainedSampleCount: retainedSampleCount,
                     droppedSampleCount: droppedSampleCount,
-                    stages: stages,
-                    maxLifecycleEvents: min(maxSamples, Self.lifecycleEventLimit),
+                    ignoredOutOfContractSampleCount: ignoredOutOfContractSampleCount,
+                    stages: orderedStages,
+                    maxLifecycleEvents: maxLifecycleEventsForCurrentMode,
                     retainedLifecycleEventCount: retainedLifecycleEventCount,
                     droppedLifecycleEventCount: droppedLifecycleEventCount,
+                    ignoredOutOfContractLifecycleEventCount: ignoredOutOfContractLifecycleEventCount,
                     lifecycleEvents: lifecycleEvents
                 )
             }
@@ -1231,8 +1527,12 @@ package enum EditFlowPerf {
             debugCaptureRecorder.isActive
         }
 
-        package static func beginDebugCapture(label: String, maxSamples: Int) -> DebugCaptureBeginResult {
-            debugCaptureRecorder.begin(label: label, maxSamples: maxSamples)
+        package static func beginDebugCapture(
+            label: String,
+            maxSamples: Int,
+            mode: DebugCaptureMode = .exhaustive
+        ) -> DebugCaptureBeginResult {
+            debugCaptureRecorder.begin(label: label, maxSamples: maxSamples, mode: mode)
         }
 
         package static func debugCaptureSnapshot(finish: Bool) -> DebugCaptureSnapshot {
@@ -1244,7 +1544,7 @@ package enum EditFlowPerf {
         }
     #endif
 
-    #if DEBUG || EDIT_FLOW_PERF
+    #if DEBUG || EDIT_FLOW_PERF || MCP_LATENCY_DIAGNOSTICS
         private static let signposter = OSSignposter(subsystem: "com.repoprompt.edit-flow", category: "perf")
         private static let logger = Logger(subsystem: "com.repoprompt.edit-flow", category: "perf")
         private static let environmentEnabled: Bool = {
@@ -1260,16 +1560,20 @@ package enum EditFlowPerf {
         }
 
         private static var shouldCaptureIntervals: Bool {
-            #if DEBUG
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
                 isDebugCaptureActive
             #else
                 false
             #endif
         }
 
-        private static func makeIntervalState(_ name: StaticString, dimensions: Dimensions) -> IntervalState? {
+        private static func makeIntervalState(
+            _ name: StaticString,
+            dimensions: Dimensions,
+            debugCaptureRequestIdentity: MCPRequestTimelineIdentity? = currentLifecycleCorrelation?.requestIdentity
+        ) -> IntervalState? {
             let signpostState = isEnabled ? signposter.beginInterval(name) : nil
-            #if DEBUG
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
                 let debugCaptureStart = debugCaptureRecorder.startTimestampIfActive()
                 guard signpostState != nil || debugCaptureStart != nil else { return nil }
                 return IntervalState(
@@ -1277,7 +1581,8 @@ package enum EditFlowPerf {
                     debugCaptureEpoch: debugCaptureStart?.epoch,
                     debugCaptureStartNanoseconds: debugCaptureStart?.startNanoseconds,
                     debugCaptureStageName: String(describing: name),
-                    debugCaptureDimensions: dimensions.logDescription
+                    debugCaptureDimensions: dimensions.logDescription,
+                    debugCaptureRequestIdentity: debugCaptureRequestIdentity
                 )
             #else
                 guard signpostState != nil else { return nil }
@@ -1301,15 +1606,36 @@ package enum EditFlowPerf {
             return makeIntervalState(name, dimensions: renderedDimensions)
         }
 
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+            @discardableResult
+            package static func begin(
+                _ name: StaticString,
+                _ dimensions: @autoclosure () -> Dimensions,
+                debugCaptureRequestIdentity: MCPRequestTimelineIdentity?
+            ) -> IntervalState? {
+                guard isEnabled || shouldCaptureIntervals else { return nil }
+                let renderedDimensions = dimensions()
+                if isEnabled {
+                    logDimensions(renderedDimensions)
+                }
+                return makeIntervalState(
+                    name,
+                    dimensions: renderedDimensions,
+                    debugCaptureRequestIdentity: debugCaptureRequestIdentity
+                )
+            }
+        #endif
+
         package static func end(_ name: StaticString, _ state: IntervalState?) {
             guard let state else { return }
-            #if DEBUG
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
                 if let captureEpoch = state.debugCaptureEpoch,
                    let startNanoseconds = state.debugCaptureStartNanoseconds
                 {
                     debugCaptureRecorder.record(
                         stageName: state.debugCaptureStageName,
                         sanitizedDimensions: state.debugCaptureDimensions,
+                        requestIdentity: state.debugCaptureRequestIdentity,
                         captureEpoch: captureEpoch,
                         startNanoseconds: startNanoseconds
                     )
@@ -1326,13 +1652,14 @@ package enum EditFlowPerf {
             if isEnabled {
                 logDimensions(renderedDimensions)
             }
-            #if DEBUG
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
                 if let captureEpoch = state.debugCaptureEpoch,
                    let startNanoseconds = state.debugCaptureStartNanoseconds
                 {
                     debugCaptureRecorder.record(
                         stageName: state.debugCaptureStageName,
                         sanitizedDimensions: renderedDimensions.isEmpty ? state.debugCaptureDimensions : renderedDimensions.logDescription,
+                        requestIdentity: state.debugCaptureRequestIdentity,
                         captureEpoch: captureEpoch,
                         startNanoseconds: startNanoseconds
                     )
@@ -1357,7 +1684,7 @@ package enum EditFlowPerf {
         package static func makeLifecycleCorrelationIfActive(
             requestIdentity: MCPRequestTimelineIdentity? = MCPRequestTimelineContext.current
         ) -> LifecycleCorrelation? {
-            #if DEBUG
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
                 let captureEpoch = debugCaptureRecorder.activeEpochIfActive()
                 guard isEnabled || captureEpoch != nil else { return nil }
                 return LifecycleCorrelation(
@@ -1381,8 +1708,18 @@ package enum EditFlowPerf {
             _ dimensions: @autoclosure () -> Dimensions = Dimensions()
         ) {
             guard let correlation else { return }
-            #if DEBUG
-                let shouldRecord = debugCaptureRecorder.shouldRecordLifecycleEvent(correlation)
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+                let eventName = String(describing: name)
+                let captureDisposition = debugCaptureRecorder.lifecycleCaptureDisposition(
+                    eventName: eventName,
+                    correlation: correlation
+                )
+                let shouldRecord = switch captureDisposition {
+                case .retain:
+                    true
+                case .inactive, .ignored:
+                    false
+                }
                 guard isEnabled || shouldRecord else { return }
             #else
                 guard isEnabled else { return }
@@ -1392,10 +1729,10 @@ package enum EditFlowPerf {
                 logDimensions(renderedDimensions)
                 signposter.emitEvent(name)
             }
-            #if DEBUG
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
                 if shouldRecord {
                     debugCaptureRecorder.recordLifecycleEvent(
-                        eventName: String(describing: name),
+                        eventName: eventName,
                         correlation: correlation,
                         sanitizedDimensions: renderedDimensions.logDescription
                     )

--- a/Sources/RepoPromptDomainRuntime/MCPToolArgsNormalizer.swift
+++ b/Sources/RepoPromptDomainRuntime/MCPToolArgsNormalizer.swift
@@ -163,6 +163,12 @@ package enum MCPToolArgsNormalizer {
                     nestedArgs.removeValue(forKey: "_rawJSON")
                 }
 
+                #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+                    // Diagnostic request identity is hidden from tool providers only in
+                    // builds that compile the latency diagnostic surface.
+                    nestedArgs.removeValue(forKey: "_latencyTraceID")
+                #endif
+
                 if let contextIDValue = nestedArgs["context_id"],
                    let contextIDString = contextIDValue.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
                    let contextID = UUID(uuidString: contextIDString)
@@ -205,6 +211,12 @@ package enum MCPToolArgsNormalizer {
                 raw.removeValue(forKey: "_rawJSON")
             }
 
+            #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+                // Diagnostic request identity is hidden from tool providers only in
+                // builds that compile the latency diagnostic surface.
+                raw.removeValue(forKey: "_latencyTraceID")
+            #endif
+
             if let contextIDValue = raw["context_id"],
                let contextIDString = contextIDValue.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
                let contextID = UUID(uuidString: contextIDString)
@@ -229,6 +241,29 @@ package enum MCPToolArgsNormalizer {
             warnings: warnings
         )
     }
+
+    #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+        package static func diagnosticLatencyTraceID(params: [String: Value]?) -> UUID? {
+            guard let params else { return nil }
+            if let raw = params["_latencyTraceID"]?.stringValue,
+               let id = UUID(uuidString: raw)
+            {
+                return id
+            }
+            if let nested = params["args"]?.objectValue,
+               let raw = nested["_latencyTraceID"]?.stringValue
+            {
+                return UUID(uuidString: raw)
+            }
+            if let encoded = params["args"]?.stringValue,
+               let nested = Value.objectFromJSONString(encoded),
+               let raw = nested["_latencyTraceID"]?.stringValue
+            {
+                return UUID(uuidString: raw)
+            }
+            return nil
+        }
+    #endif
 
     /// Repair malformed edit arguments where replacement text became a property name
     /// Example: {"search": "...", "\tprivate func...": "..."} → {"search": "...", "replace": "..."}
@@ -313,7 +348,10 @@ package enum MCPToolArgsNormalizer {
     }
 
     private static func allowedSiblingKeys(for tool: String) -> Set<String> {
-        let common: Set = ["_tabID", "_windowID", "_rawJSON", "context_id", "path", "verbose", "args", "operation_id"]
+        var common: Set = ["_tabID", "_windowID", "_rawJSON", "context_id", "path", "verbose", "args", "operation_id"]
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+            common.insert("_latencyTraceID")
+        #endif
         switch tool {
         case "bind_context":
             return common.union(["op", "window_id", "working_dirs", "create_if_missing", "tab_name"])

--- a/Sources/RepoPromptMCP/CommandRunner/MCPCommandLatencyDiagnostics.swift
+++ b/Sources/RepoPromptMCP/CommandRunner/MCPCommandLatencyDiagnostics.swift
@@ -1,0 +1,209 @@
+import Darwin
+import Foundation
+import MCP
+
+#if DEBUG || MCP_LATENCY_TRACE
+    /// Opt-in client-side C0-C2 recorder for MCP latency diagnostics.
+    ///
+    /// DEBUG builds include this recorder for local diagnostics. Optimized diagnostic
+    /// builds must opt in with `RPCE_ENABLE_MCP_LATENCY_TRACE=1`; ordinary release
+    /// builds do not compile it. Trace records exclude arguments and returned content.
+    actor MCPCommandLatencyDiagnostics {
+        enum Outcome: String {
+            case success
+            case toolError = "tool_error"
+            case clientError = "client_error"
+            case cancelled
+            case timeout
+            case transportClosed = "transport_closed"
+        }
+
+        enum OutputFormat: String {
+            case formatted
+            case raw
+        }
+
+        struct Invocation {
+            let id: UUID
+            let toolName: String
+            let outputFormat: OutputFormat
+            let c0Nanoseconds: UInt64
+        }
+
+        static let shared = MCPCommandLatencyDiagnostics()
+        static let environmentKey = "RP_MCP_LATENCY_TRACE_PATH"
+        static let requestIdentityArgument = "_latencyTraceID"
+
+        static func prepareInvocation(
+            toolName: String,
+            arguments: [String: Value]?
+        ) -> (invocation: Invocation, arguments: [String: Value]?) {
+            let configured = configuredTracePath() != nil
+            let suppliedID = arguments?[requestIdentityArgument]?.stringValue.flatMap(UUID.init(uuidString:))
+            let invocation = Invocation(
+                id: suppliedID ?? UUID(),
+                toolName: toolName,
+                outputFormat: wantsRawJSON(arguments?["_rawJSON"]) ? .raw : .formatted,
+                c0Nanoseconds: DispatchTime.now().uptimeNanoseconds
+            )
+            guard configured else { return (invocation, arguments) }
+            var tracedArguments = arguments ?? [:]
+            tracedArguments[requestIdentityArgument] = .string(invocation.id.uuidString)
+            return (invocation, tracedArguments)
+        }
+
+        static func outcome(for error: Error) -> Outcome {
+            if error is CancellationError || Task.isCancelled {
+                return .cancelled
+            }
+            if let error = error as? InteractiveSessionError {
+                switch error {
+                case .cancelled:
+                    return .cancelled
+                case .bootstrapResponseTimeout, .toolCallTimeout:
+                    return .timeout
+                case .notConnected, .connectionReset, .serverClosed, .writeFailed, .pollFailed:
+                    return .transportClosed
+                case .socketCreationFailed, .descriptorConfigurationFailed, .pathTooLong,
+                     .connectFailed, .appNotRunning, .approvalDenied, .handshakeFailed:
+                    return .clientError
+                }
+            }
+            if let error = error as? MCPError {
+                switch error {
+                case .connectionClosed, .transportError:
+                    return .transportClosed
+                case .parseError, .invalidRequest, .methodNotFound, .invalidParams,
+                     .internalError, .serverError, .urlElicitationRequired:
+                    return .clientError
+                }
+            }
+            return .clientError
+        }
+
+        private var descriptor: Int32?
+        private var attemptedOpen = false
+
+        func record(
+            invocation: Invocation,
+            c1Nanoseconds: UInt64,
+            c2Nanoseconds: UInt64,
+            result: CallTool.Result?,
+            outcome: Outcome
+        ) {
+            guard let descriptor = traceDescriptor() else { return }
+            let contentBlockCount = result?.content.count ?? 0
+            let textContentBlockCount = result?.content.count(where: { content in
+                if case .text = content { return true }
+                return false
+            }) ?? 0
+            let returnedTextBytes = result?.content.reduce(into: 0) { total, content in
+                if case let .text(text, _, _) = content {
+                    total += text.utf8.count
+                }
+            } ?? 0
+            let c1 = max(invocation.c0Nanoseconds, c1Nanoseconds)
+            let c2 = max(c1, c2Nanoseconds)
+            let payload: [String: Any] = [
+                "schema_version": 1,
+                "diagnostic_configuration": diagnosticConfiguration,
+                "invocation_id": invocation.id.uuidString,
+                "tool_name": sanitizedToolName(invocation.toolName),
+                "output_format": invocation.outputFormat.rawValue,
+                "c0_ns": invocation.c0Nanoseconds,
+                "c1_ns": c1,
+                "c2_ns": c2,
+                "call_duration_ms": milliseconds(from: invocation.c0Nanoseconds, to: c1),
+                "print_duration_ms": milliseconds(from: c1, to: c2),
+                "content_block_count": contentBlockCount,
+                "text_content_block_count": textContentBlockCount,
+                "returned_text_bytes": returnedTextBytes,
+                "is_error": result?.isError == true,
+                "outcome": outcome.rawValue
+            ]
+            guard let data = try? JSONSerialization.data(
+                withJSONObject: payload,
+                options: [.sortedKeys]
+            ) else { return }
+            var line = data
+            line.append(0x0A)
+            line.withUnsafeBytes { bytes in
+                guard let base = bytes.baseAddress else { return }
+                var offset = 0
+                while offset < bytes.count {
+                    let written = Darwin.write(descriptor, base.advanced(by: offset), bytes.count - offset)
+                    if written > 0 {
+                        offset += written
+                    } else if written < 0, errno == EINTR {
+                        continue
+                    } else {
+                        return
+                    }
+                }
+            }
+        }
+
+        private static func wantsRawJSON(_ value: Value?) -> Bool {
+            guard let value else { return false }
+            switch value {
+            case let .bool(flag):
+                return flag
+            case let .int(number):
+                return number != 0
+            case let .double(number):
+                return number != 0
+            case let .string(raw):
+                return ["1", "true", "yes", "y", "on"].contains(
+                    raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                )
+            default:
+                return false
+            }
+        }
+
+        private static func configuredTracePath() -> String? {
+            guard let path = ProcessInfo.processInfo.environment[environmentKey],
+                  path.hasPrefix("/"),
+                  !path.contains("\u{0}")
+            else { return nil }
+            return path
+        }
+
+        private var diagnosticConfiguration: String {
+            #if DEBUG
+                "debug"
+            #else
+                "optimized_diagnostic"
+            #endif
+        }
+
+        private func traceDescriptor() -> Int32? {
+            if attemptedOpen { return descriptor }
+            attemptedOpen = true
+            guard let path = Self.configuredTracePath() else { return nil }
+
+            let flags = O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NOFOLLOW
+            let fd = Darwin.open(path, flags, S_IRUSR | S_IWUSR)
+            guard fd >= 0 else { return nil }
+            guard Darwin.fchmod(fd, S_IRUSR | S_IWUSR) == 0 else {
+                Darwin.close(fd)
+                return nil
+            }
+            descriptor = fd
+            return fd
+        }
+
+        private func sanitizedToolName(_ raw: String) -> String {
+            let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+            let scalars = raw.unicodeScalars.prefix(80).map { scalar in
+                allowed.contains(scalar) ? Character(String(scalar)) : "_"
+            }
+            let value = String(scalars)
+            return value.isEmpty ? "unknown" : value
+        }
+
+        private func milliseconds(from start: UInt64, to end: UInt64) -> Double {
+            Double(end - start) / 1_000_000
+        }
+    }
+#endif

--- a/Sources/RepoPromptMCP/CommandRunner/MCPCommandRunner.swift
+++ b/Sources/RepoPromptMCP/CommandRunner/MCPCommandRunner.swift
@@ -405,8 +405,7 @@ actor MCPCommandRunner {
         if settings.verbose {
             await output("Calling \(name)...", isError: false)
         }
-        let result = try await session.callTool(name: name, arguments: args)
-        await printCallResult(result)
+        let result = try await callAndPrintTool(name: name, arguments: args)
         if result.isError == true {
             throw ToolCallFailedError(toolName: name)
         }
@@ -416,10 +415,56 @@ actor MCPCommandRunner {
         // Note: window_id injection for tools like manage_workspaces is now handled
         // by the app's routing layer (MCPConnectionManager.injectWindowIDIfNeeded)
         let valueArgs = try MCPCommandParser.convertToMCPValues(args)
-        let result = try await session.callTool(name: name, arguments: valueArgs)
-        await printCallResult(result)
+        let result = try await callAndPrintTool(name: name, arguments: valueArgs)
         if result.isError == true {
             throw ToolCallFailedError(toolName: name)
+        }
+    }
+
+    private func callAndPrintTool(
+        name: String,
+        arguments: [String: Value]?
+    ) async throws -> CallTool.Result {
+        #if DEBUG || MCP_LATENCY_TRACE
+            let preparedInvocation = MCPCommandLatencyDiagnostics.prepareInvocation(
+                toolName: name,
+                arguments: arguments
+            )
+            let invocation = preparedInvocation.invocation
+            let callArguments = preparedInvocation.arguments
+        #else
+            let callArguments = arguments
+        #endif
+
+        do {
+            let result = try await session.callTool(name: name, arguments: callArguments)
+            #if DEBUG || MCP_LATENCY_TRACE
+                let c1Nanoseconds = DispatchTime.now().uptimeNanoseconds
+            #endif
+            await printCallResult(result)
+            #if DEBUG || MCP_LATENCY_TRACE
+                let c2Nanoseconds = DispatchTime.now().uptimeNanoseconds
+                await MCPCommandLatencyDiagnostics.shared.record(
+                    invocation: invocation,
+                    c1Nanoseconds: c1Nanoseconds,
+                    c2Nanoseconds: c2Nanoseconds,
+                    result: result,
+                    outcome: result.isError == true ? .toolError : .success
+                )
+            #endif
+            return result
+        } catch {
+            #if DEBUG || MCP_LATENCY_TRACE
+                let returnedNanoseconds = DispatchTime.now().uptimeNanoseconds
+                await MCPCommandLatencyDiagnostics.shared.record(
+                    invocation: invocation,
+                    c1Nanoseconds: returnedNanoseconds,
+                    c2Nanoseconds: returnedNanoseconds,
+                    result: nil,
+                    outcome: MCPCommandLatencyDiagnostics.outcome(for: error)
+                )
+            #endif
+            throw error
         }
     }
 

--- a/Sources/RepoPromptMCP/Exec/ExecMCPService.swift
+++ b/Sources/RepoPromptMCP/Exec/ExecMCPService.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Logging
+import MCP
 import ServiceLifecycle
 
 /// ServiceLifecycle service that runs exec mode (non-interactive command execution).
@@ -112,6 +113,16 @@ actor ExecMCPService: Service {
             fputs("Warning: Failed to bind \(target): \(error)\n", stderr)
         }
 
+        #if DEBUG || MCP_LATENCY_TRACE
+            if let latencyConcurrentBatchPath = options.latencyConcurrentBatchPath {
+                try await runLatencyConcurrentBatch(
+                    at: latencyConcurrentBatchPath,
+                    session: session
+                )
+                return
+            }
+        #endif
+
         // Collect commands to run
         let commands = try collectCommands()
         if commands.isEmpty {
@@ -199,6 +210,128 @@ actor ExecMCPService: Service {
             throw ExecError.commandFailed
         }
     }
+
+    #if DEBUG || MCP_LATENCY_TRACE
+        private struct LatencyConcurrentBatchRequest: Decodable {
+            enum OutputFormat: String, Decodable {
+                case formatted
+                case raw
+            }
+
+            let invocationID: UUID
+            let tool: String
+            let outputFormat: OutputFormat
+            let outputPath: String
+            let arguments: [String: Value]?
+
+            enum CodingKeys: String, CodingKey {
+                case invocationID = "invocation_id"
+                case tool
+                case outputFormat = "output_format"
+                case outputPath = "output_path"
+                case arguments
+            }
+        }
+
+        private func runLatencyConcurrentBatch(
+            at path: String,
+            session: InteractiveMCPClientSession
+        ) async throws {
+            let url = URL(fileURLWithPath: path)
+            let data = try Data(contentsOf: url)
+            let requests = try JSONDecoder().decode([LatencyConcurrentBatchRequest].self, from: data)
+            guard !requests.isEmpty else { throw ExecError.commandFailed }
+            guard Set(requests.map(\.invocationID)).count == requests.count,
+                  Set(requests.map(\.outputPath)).count == requests.count,
+                  requests.allSatisfy({ $0.outputPath.hasPrefix("/") })
+            else { throw ExecError.commandFailed }
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for request in requests {
+                    group.addTask {
+                        var arguments = request.arguments ?? [:]
+                        arguments[MCPCommandLatencyDiagnostics.requestIdentityArgument] = .string(
+                            request.invocationID.uuidString
+                        )
+                        switch request.outputFormat {
+                        case .formatted:
+                            arguments.removeValue(forKey: "_rawJSON")
+                        case .raw:
+                            arguments["_rawJSON"] = .bool(true)
+                        }
+                        let prepared = MCPCommandLatencyDiagnostics.prepareInvocation(
+                            toolName: request.tool,
+                            arguments: arguments
+                        )
+                        do {
+                            let result = try await session.callTool(
+                                name: request.tool,
+                                arguments: prepared.arguments
+                            )
+                            let returned = DispatchTime.now().uptimeNanoseconds
+                            let output = Self.latencyBatchResponseData(result)
+                            try output.write(
+                                to: URL(fileURLWithPath: request.outputPath),
+                                options: .atomic
+                            )
+                            let printed = DispatchTime.now().uptimeNanoseconds
+                            await MCPCommandLatencyDiagnostics.shared.record(
+                                invocation: prepared.invocation,
+                                c1Nanoseconds: returned,
+                                c2Nanoseconds: printed,
+                                result: result,
+                                outcome: result.isError == true ? .toolError : .success
+                            )
+                        } catch {
+                            let returned = DispatchTime.now().uptimeNanoseconds
+                            await MCPCommandLatencyDiagnostics.shared.record(
+                                invocation: prepared.invocation,
+                                c1Nanoseconds: returned,
+                                c2Nanoseconds: returned,
+                                result: nil,
+                                outcome: MCPCommandLatencyDiagnostics.outcome(for: error)
+                            )
+                            throw error
+                        }
+                    }
+                }
+                try await group.waitForAll()
+            }
+        }
+
+        private nonisolated static func latencyBatchResponseData(_ result: CallTool.Result) -> Data {
+            // Match redirected MCPCommandRunner output: successful content blocks are
+            // emitted in order with one trailing newline per output callback. Tool
+            // errors remain on stderr and therefore produce an empty response file.
+            guard result.isError != true else { return Data() }
+            var output = ""
+            for content in result.content {
+                let rendered: [String]
+                switch content {
+                case let .text(text, _, _):
+                    rendered = [text]
+                case let .image(data, mimeType, _, _):
+                    rendered = ["[Image: \(mimeType), \(data.count) bytes]"]
+                case let .audio(data, mimeType, _, _):
+                    rendered = ["[Audio: \(mimeType), \(data.count) bytes]"]
+                case let .resource(resource, _, _):
+                    var lines = ["[Resource: \(resource.uri) (\(resource.mimeType ?? "unknown"))]"]
+                    if let text = resource.text {
+                        lines.append(text)
+                    } else if let blob = resource.blob {
+                        lines.append("[Binary resource: \(blob.count) base64 characters]")
+                    }
+                    rendered = lines
+                case let .resourceLink(uri, name, _, _, mimeType, _):
+                    rendered = ["[Resource Link: \(name) \(uri) (\(mimeType ?? "unknown"))]"]
+                }
+                for line in rendered {
+                    output += line + "\n"
+                }
+            }
+            return Data(output.utf8)
+        }
+    #endif
 
     func shutdown() async throws {
         logger.debug("Shutting down exec MCP service...")

--- a/Sources/RepoPromptMCP/Exec/ExecOptions.swift
+++ b/Sources/RepoPromptMCP/Exec/ExecOptions.swift
@@ -24,6 +24,11 @@ struct ExecOptions {
     /// If true, request raw JSON tool output (server skips markdown formatting).
     var rawJSON: Bool = false
 
+    #if DEBUG || MCP_LATENCY_TRACE
+        /// Diagnostic-only JSON request batch executed concurrently on one connection.
+        var latencyConcurrentBatchPath: String?
+    #endif
+
     /// Commands to execute (from repeated --exec flags).
     var commands: [String] = []
 

--- a/Sources/RepoPromptMCP/Interactive/InteractiveREPL.swift
+++ b/Sources/RepoPromptMCP/Interactive/InteractiveREPL.swift
@@ -606,18 +606,74 @@ actor InteractiveREPL {
         }
     }
 
+    private enum LatencyDiagnosticPrintStyle {
+        case repl
+        case plain
+    }
+
+    private func callAndPrintTool(
+        name: String,
+        arguments: [String: Value]?,
+        style: LatencyDiagnosticPrintStyle
+    ) async throws -> CallTool.Result {
+        #if DEBUG || MCP_LATENCY_TRACE
+            let preparedInvocation = MCPCommandLatencyDiagnostics.prepareInvocation(
+                toolName: name,
+                arguments: arguments
+            )
+            let invocation = preparedInvocation.invocation
+            let callArguments = preparedInvocation.arguments
+        #else
+            let callArguments = arguments
+        #endif
+
+        do {
+            let result = try await session.callTool(name: name, arguments: callArguments)
+            #if DEBUG || MCP_LATENCY_TRACE
+                let c1Nanoseconds = DispatchTime.now().uptimeNanoseconds
+            #endif
+            switch style {
+            case .repl:
+                printCallResult(result)
+            case .plain:
+                printCallResultPlain(result)
+            }
+            #if DEBUG || MCP_LATENCY_TRACE
+                let c2Nanoseconds = DispatchTime.now().uptimeNanoseconds
+                await MCPCommandLatencyDiagnostics.shared.record(
+                    invocation: invocation,
+                    c1Nanoseconds: c1Nanoseconds,
+                    c2Nanoseconds: c2Nanoseconds,
+                    result: result,
+                    outcome: result.isError == true ? .toolError : .success
+                )
+            #endif
+            return result
+        } catch {
+            #if DEBUG || MCP_LATENCY_TRACE
+                let returnedNanoseconds = DispatchTime.now().uptimeNanoseconds
+                await MCPCommandLatencyDiagnostics.shared.record(
+                    invocation: invocation,
+                    c1Nanoseconds: returnedNanoseconds,
+                    c2Nanoseconds: returnedNanoseconds,
+                    result: nil,
+                    outcome: MCPCommandLatencyDiagnostics.outcome(for: error)
+                )
+            #endif
+            throw error
+        }
+    }
+
     private func callTool(name: String, jsonPayload: String?) async throws {
         let args = try MCPCommandParser.parseJSONArgs(jsonPayload)
 
         print("Calling \(name)...")
-        let result = try await session.callTool(name: name, arguments: args)
-        printCallResult(result)
+        _ = try await callAndPrintTool(name: name, arguments: args, style: .repl)
     }
 
     private func callToolWithArgs(name: String, args: [String: UncheckedSendableValue]) async throws {
         let valueArgs = try MCPCommandParser.convertToMCPValues(args)
-        let result = try await session.callTool(name: name, arguments: valueArgs)
-        printCallResult(result)
+        _ = try await callAndPrintTool(name: name, arguments: valueArgs, style: .repl)
     }
 
     private func snapshotTools(to path: String) async throws {
@@ -769,8 +825,7 @@ actor InteractiveREPL {
 
     private func callToolSingleShot(name: String, argsJSON: String?) async throws {
         let args = try MCPCommandParser.parseJSONArgs(argsJSON)
-        let result = try await session.callTool(name: name, arguments: args)
-        printCallResultPlain(result)
+        let result = try await callAndPrintTool(name: name, arguments: args, style: .plain)
 
         // Ensure --call exits non-zero on tool failure
         if result.isError == true {

--- a/Sources/RepoPromptMCP/main.swift
+++ b/Sources/RepoPromptMCP/main.swift
@@ -2695,6 +2695,15 @@ func parseCLIMode() -> CLIMode {
             }
 
         // Exec mode flags
+        #if DEBUG || MCP_LATENCY_TRACE
+            case "--latency-concurrent-batch":
+                isExec = true
+                i = args.index(after: i)
+                if i < args.endIndex {
+                    execOptions.latencyConcurrentBatchPath = args[i]
+                }
+        #endif
+
         case "--exec", "-e":
             isExec = true
             i = args.index(after: i)

--- a/Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift
+++ b/Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift
@@ -119,19 +119,38 @@ public struct JSONRPCBridgeMessageMetadata: Equatable, Sendable {
     public let method: String?
     public let tool: String?
     public let requestOrdinal: UInt64?
+    public let appInvocationID: String?
 
     public init(
         kind: Kind,
         id: JSONRPCBridgeID?,
         method: String?,
         tool: String?,
-        requestOrdinal: UInt64?
+        requestOrdinal: UInt64?,
+        appInvocationID: String? = nil
     ) {
         self.kind = kind
         self.id = id
         self.method = method
         self.tool = tool
         self.requestOrdinal = requestOrdinal
+        self.appInvocationID = appInvocationID
+    }
+}
+
+private enum MCPRequestLatencyTraceIdentity {
+    static func extract(method: String?, arguments: [String: Any]?) -> String? {
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+            guard method == "tools/call",
+                  let raw = arguments?["_latencyTraceID"] as? String,
+                  let id = UUID(uuidString: raw)
+            else {
+                return nil
+            }
+            return id.uuidString
+        #else
+            return nil
+        #endif
     }
 }
 
@@ -158,7 +177,7 @@ public struct MCPResponseDeliveryTraceEvent: Equatable, Sendable, CustomStringCo
     public let permitActive: Bool?
     public let publicationPending: Bool?
     public let terminalBarrier: Bool?
-    #if DEBUG
+    #if DEBUG || MCP_LATENCY_DIAGNOSTICS
         /// Same-process monotonic timestamp used to correlate response delivery with deferred work.
         public let monotonicUptimeMS: Double
     #endif
@@ -203,7 +222,7 @@ public struct MCPResponseDeliveryTraceEvent: Equatable, Sendable, CustomStringCo
         self.activeRequestCount = activeRequestCount
         self.responseInDeliveryCount = responseInDeliveryCount
         self.terminalReason = terminalReason
-        #if DEBUG
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
             self.requestIdentity = MCPRequestTimelineIdentity(
                 jsonRPCRequestID: id,
                 connectionID: connectionID,
@@ -219,7 +238,7 @@ public struct MCPResponseDeliveryTraceEvent: Equatable, Sendable, CustomStringCo
         self.permitActive = permitActive
         self.publicationPending = publicationPending
         self.terminalBarrier = terminalBarrier
-        #if DEBUG
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
             monotonicUptimeMS = ProcessInfo.processInfo.systemUptime * 1000
         #endif
     }
@@ -247,7 +266,7 @@ public struct MCPResponseDeliveryTraceEvent: Equatable, Sendable, CustomStringCo
             "publication_pending": publicationPending ?? NSNull(),
             "terminal_barrier": terminalBarrier ?? NSNull()
         ]
-        #if DEBUG
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
             value["monotonic_uptime_ms"] = monotonicUptimeMS
         #endif
         return value
@@ -283,8 +302,10 @@ public struct MCPResponseDeliveryTraceEvent: Equatable, Sendable, CustomStringCo
 
 public enum MCPResponseDeliveryTracer {
     private static let lock = NSLock()
-    #if DEBUG
+    #if DEBUG || MCP_LATENCY_DIAGNOSTICS
         private nonisolated(unsafe) static var debugEvents: [MCPResponseDeliveryTraceEvent] = []
+        private nonisolated(unsafe) static var debugCaptureActive = false
+        private nonisolated(unsafe) static var debugDroppedEventCount = 0
         private static let maximumDebugEvents = 20000
     #endif
 
@@ -302,18 +323,30 @@ public enum MCPResponseDeliveryTracer {
         _ event: MCPResponseDeliveryTraceEvent,
         to descriptor: Int32 = STDERR_FILENO
     ) {
-        guard event.terminalReason != nil || successTracingEnabled else { return }
-        guard let data = "[MCPResponseDelivery] \(event)\n".data(using: .utf8) else { return }
+        let shouldWrite = event.terminalReason != nil || successTracingEnabled
+        var retainedForCapture = false
+        #if DEBUG || MCP_LATENCY_DIAGNOSTICS
+            if lock.try() {
+                if debugCaptureActive {
+                    retainedForCapture = true
+                    if debugEvents.count < maximumDebugEvents {
+                        debugEvents.append(event)
+                    } else {
+                        debugDroppedEventCount += 1
+                    }
+                }
+                lock.unlock()
+            }
+        #endif
+        guard shouldWrite || retainedForCapture else { return }
+        guard shouldWrite,
+              let data = "[MCPResponseDelivery] \(event)\n".data(using: .utf8)
+        else { return }
         // Terminal tracing must not wait behind another diagnostic emitter or
         // a full stderr pipe. Dropping a contended/unwritable trace is safer
         // than delaying the transport's required terminal exit.
         guard lock.try() else { return }
         defer { lock.unlock() }
-        #if DEBUG
-            if debugEvents.count < maximumDebugEvents {
-                debugEvents.append(event)
-            }
-        #endif
         // Terminal events are emitted even with success tracing disabled, so
         // this path runs during transport failure handling when stderr may
         // already be closed. Best-effort raw write; never FileHandle.write,
@@ -321,10 +354,12 @@ public enum MCPResponseDeliveryTracer {
         BestEffortStderrWriter.writeNonBlocking(data, to: descriptor)
     }
 
-    #if DEBUG
+    #if DEBUG || MCP_LATENCY_DIAGNOSTICS
         public static func resetDebugEvents() {
             lock.lock()
             debugEvents.removeAll(keepingCapacity: true)
+            debugDroppedEventCount = 0
+            debugCaptureActive = true
             lock.unlock()
         }
 
@@ -332,6 +367,17 @@ public enum MCPResponseDeliveryTracer {
             lock.lock()
             defer { lock.unlock() }
             return debugEvents
+        }
+
+        public static func debugCaptureSnapshot(
+            finish: Bool
+        ) -> (events: [MCPResponseDeliveryTraceEvent], droppedEventCount: Int) {
+            lock.lock()
+            defer { lock.unlock() }
+            if finish {
+                debugCaptureActive = false
+            }
+            return (debugEvents, debugDroppedEventCount)
         }
     #endif
 
@@ -359,6 +405,7 @@ public enum MCPResponseDeliveryTracer {
                 id: message?.id,
                 method: message?.method,
                 tool: message?.tool,
+                invocationID: message?.appInvocationID,
                 lifecycleState: message?.kind.rawValue,
                 requestOrdinal: message?.requestOrdinal,
                 framedByteCount: prepared.deliveryFrame?.count ?? prepared.framedByteCount,
@@ -392,6 +439,7 @@ public enum MCPResponseDeliveryTracer {
                 id: summary?.id,
                 method: summary?.method,
                 tool: summary?.tool,
+                invocationID: summary?.appInvocationID,
                 requestOrdinal: summary?.requestOrdinal,
                 framedByteCount: frame.count,
                 framedSHA256: sha256Hex(frame),
@@ -781,7 +829,11 @@ public actor JSONRPCBridgeLedger {
                     id: id,
                     method: method,
                     tool: tool,
-                    requestOrdinal: metadata.ordinal
+                    requestOrdinal: metadata.ordinal,
+                    appInvocationID: MCPRequestLatencyTraceIdentity.extract(
+                        method: method,
+                        arguments: toolArguments
+                    )
                 ))
 
             case let .response(id):
@@ -1259,6 +1311,7 @@ public actor JSONRPCBridgeLedger {
                 id: message?.id,
                 method: message?.method,
                 tool: message?.tool,
+                invocationID: message?.appInvocationID,
                 lifecycleState: message?.kind.rawValue,
                 requestOrdinal: message?.requestOrdinal,
                 framedByteCount: prepared?.framedByteCount,
@@ -1492,6 +1545,13 @@ public enum JSONRPCBridgeFrameInspector {
             let hasID = dictionary.keys.contains("id")
             let id = hasID ? parseID(dictionary["id"]) : nil
             let method = dictionary["method"] as? String
+            let toolArguments: [String: Any]? = if method == "tools/call",
+                                                   let params = dictionary["params"] as? [String: Any]
+            {
+                params["arguments"] as? [String: Any]
+            } else {
+                nil
+            }
             let tool: String? = if method == "tools/call",
                                    let params = dictionary["params"] as? [String: Any]
             {
@@ -1513,7 +1573,11 @@ public enum JSONRPCBridgeFrameInspector {
                 id: id,
                 method: method,
                 tool: tool,
-                requestOrdinal: nil
+                requestOrdinal: nil,
+                appInvocationID: MCPRequestLatencyTraceIdentity.extract(
+                    method: method,
+                    arguments: toolArguments
+                )
             )
         }
     }

--- a/Sources/RepoPromptShared/MCP/MCPRequestTimelineIdentity.swift
+++ b/Sources/RepoPromptShared/MCP/MCPRequestTimelineIdentity.swift
@@ -47,6 +47,22 @@ public struct MCPRequestTimelineIdentity: Equatable, Sendable {
         return "\(hex.prefix(8))-\(hex.dropFirst(8).prefix(4))-\(hex.dropFirst(12).prefix(4))-\(hex.dropFirst(16).prefix(4))-\(hex.dropFirst(20).prefix(12))"
     }
 
+    package var isCompleteLatencyEvidenceIdentity: Bool {
+        guard let jsonRPCRequestID,
+              jsonRPCRequestID != .null,
+              let connectionID,
+              !connectionID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              connectionGeneration != nil,
+              let requestOrdinal,
+              requestOrdinal > 0,
+              let appInvocationID,
+              UUID(uuidString: appInvocationID) != nil
+        else {
+            return false
+        }
+        return true
+    }
+
     public func fillingMissingFields(from fallback: MCPRequestTimelineIdentity?) -> MCPRequestTimelineIdentity {
         MCPRequestTimelineIdentity(
             jsonRPCRequestID: jsonRPCRequestID ?? fallback?.jsonRPCRequestID,

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
@@ -79,6 +79,7 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
             approvalPolicyProvider: { .never },
             sandboxModeProvider: { .readOnly },
             approvalReviewerProvider: { .user },
+            goalSupportEnabledProvider: { true },
             memoriesEnabledProvider: { true }
         )
 

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -507,6 +507,9 @@
             try withIsolatedCaptureCase("testSearchDTOBuildNestedRecorderCapturesOnlyCoarseSanitizedDimensions") {
                 scenarioSearchDTOBuildNestedRecorderCapturesOnlyCoarseSanitizedDimensions()
             }
+            try withIsolatedCaptureCase("testFileTreeAndFormattedOutputRecorderInventoryIsLeafAttributedAndSanitized") {
+                scenarioFileTreeAndFormattedOutputRecorderInventoryIsLeafAttributedAndSanitized()
+            }
             try withIsolatedCaptureCase("testNewReadDispatchStageRecorderCapturesToolDimensionAndFinishes") {
                 try scenarioNewReadDispatchStageRecorderCapturesToolDimensionAndFinishes()
             }
@@ -545,6 +548,7 @@
         private func scenarioHiddenDispatcherRecognizesReadSearchCaptureOperations() throws {
             let diagnostics = try diagnosticsSource()
             XCTAssertTrue(diagnostics.contains("mcp_read_search_capture_begin"))
+            XCTAssertTrue(diagnostics.contains("mode: .mcpLatencyEvidence"))
             XCTAssertTrue(diagnostics.contains("mcp_read_search_capture_snapshot"))
             XCTAssertTrue(diagnostics.contains("mcp_read_search_admission_snapshot"))
             XCTAssertTrue(diagnostics.contains("mcp_read_search_admission_configure"))
@@ -648,7 +652,7 @@
             )
 
             let bridgeLedger = try source("Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift")
-            XCTAssertTrue(bridgeLedger.contains("#if DEBUG\n        /// Same-process monotonic timestamp"))
+            XCTAssertTrue(bridgeLedger.contains("#if DEBUG || MCP_LATENCY_DIAGNOSTICS\n        /// Same-process monotonic timestamp"))
             XCTAssertTrue(bridgeLedger.contains("value[\"monotonic_uptime_ms\"] = monotonicUptimeMS"))
             let coordinator = try source("Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift")
             XCTAssertTrue(coordinator.contains("#if DEBUG\n        enum DebugCanonicalApplyOutcome"))
@@ -665,6 +669,36 @@
             let provider = try source("Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift")
             XCTAssertFalse(provider.contains("mcp_read_file_auto_selection_probe_"))
             XCTAssertFalse(provider.contains("debugDrainReadFileAutoSelection"))
+
+            let traceID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000909"))
+            let traceArguments: [String: Value] = ["_latencyTraceID": .string(traceID.uuidString)]
+            XCTAssertEqual(MCPToolArgsNormalizer.diagnosticLatencyTraceID(params: traceArguments), traceID)
+            XCTAssertNil(MCPToolArgsNormalizer.normalize(
+                params: traceArguments,
+                originalToolName: "file_search",
+                canonicalToolName: "file_search"
+            ).payload["_latencyTraceID"])
+
+            let clientDiagnostics = try source("Sources/RepoPromptMCP/CommandRunner/MCPCommandLatencyDiagnostics.swift")
+            XCTAssertTrue(clientDiagnostics.contains("#if DEBUG || MCP_LATENCY_TRACE"))
+            XCTAssertTrue(clientDiagnostics.contains("RP_MCP_LATENCY_TRACE_PATH"))
+            XCTAssertTrue(clientDiagnostics.contains("O_NOFOLLOW"))
+            XCTAssertTrue(clientDiagnostics.contains("Darwin.fchmod(fd, S_IRUSR | S_IWUSR)"))
+            for forbidden in ["\"arguments\"", "\"path\"", "\"content\"", "\"output_text\"", "\"result_text\""] {
+                XCTAssertFalse(clientDiagnostics.contains(forbidden), forbidden)
+            }
+            let commandRunner = try source("Sources/RepoPromptMCP/CommandRunner/MCPCommandRunner.swift")
+            XCTAssertTrue(commandRunner.contains("MCPCommandLatencyDiagnostics.prepareInvocation("))
+            XCTAssertTrue(commandRunner.contains("arguments: callArguments"))
+            XCTAssertTrue(commandRunner.contains("let c1Nanoseconds = DispatchTime.now().uptimeNanoseconds"))
+            XCTAssertTrue(commandRunner.contains("let c2Nanoseconds = DispatchTime.now().uptimeNanoseconds"))
+            let interactiveREPL = try source("Sources/RepoPromptMCP/Interactive/InteractiveREPL.swift")
+            XCTAssertTrue(interactiveREPL.contains("private func callAndPrintTool("))
+            XCTAssertTrue(interactiveREPL.contains("let result = try await session.callTool(name: name, arguments: callArguments)"))
+            XCTAssertTrue(interactiveREPL.contains("let c1Nanoseconds = DispatchTime.now().uptimeNanoseconds"))
+            XCTAssertTrue(interactiveREPL.contains("let c2Nanoseconds = DispatchTime.now().uptimeNanoseconds"))
+            XCTAssertTrue(interactiveREPL.contains("style: .plain"))
+            XCTAssertTrue(interactiveREPL.contains("style: .repl"))
         }
 
         func testPerStoreAdmissionDebugConfigurationIsFixedCapacityIdleOnlyAndBounded() async {
@@ -808,6 +842,48 @@
             }
         }
 
+        func testDetachedStageCaptureIsRetainedButExplicitlyUnidentified() async throws {
+            let identity = MCPRequestTimelineIdentity(
+                jsonRPCRequestID: .string("detached-stage"),
+                connectionID: UUID().uuidString,
+                connectionGeneration: 1,
+                requestOrdinal: 1
+            )
+            _ = startedCapture(label: "detached-stage-attribution", maxSamples: 100)
+            let correlation = try XCTUnwrap(EditFlowPerf.makeLifecycleCorrelationIfActive(requestIdentity: identity))
+            await EditFlowPerf.$currentLifecycleCorrelation.withValue(correlation) {
+                EditFlowPerf.measure(EditFlowPerf.Stage.Search.dtoAssembly) {}
+                await Task.detached {
+                    EditFlowPerf.measure(EditFlowPerf.Stage.Search.providerValueEncoding) {}
+                }.value
+            }
+
+            let snapshot = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            XCTAssertNotNil(snapshot.captureStartUptimeMS)
+            let structured = try XCTUnwrap(snapshot.stages.first {
+                $0.stageName == "EditFlow.Search.DTOBuild.Assembly"
+            })
+            XCTAssertEqual(structured.requestIdentity?.appInvocationID, identity.appInvocationID)
+            let detached = try XCTUnwrap(snapshot.stages.first {
+                $0.stageName == "EditFlow.Search.ProviderValueEncoding"
+            })
+            XCTAssertNil(detached.requestIdentity)
+        }
+
+        func testDebugLatencyServerIdentityIsServerProcessAuthoritative() throws {
+            let payload = ServerNetworkManager.debugLatencyServerAppIdentityPayload()
+            let identity = try XCTUnwrap(payload["server_app_identity"] as? [String: Any])
+            XCTAssertEqual(identity["identity_authority"] as? String, "server_process")
+            XCTAssertEqual(identity["app_configuration"] as? String, "debug")
+            XCTAssertEqual(
+                (identity["process_identifier"] as? NSNumber)?.int32Value,
+                ProcessInfo.processInfo.processIdentifier
+            )
+            XCTAssertFalse(try XCTUnwrap(identity["bundle_path"] as? String).isEmpty)
+            XCTAssertFalse(try XCTUnwrap(identity["executable_path"] as? String).isEmpty)
+            XCTAssertEqual((identity["executable_sha256"] as? String)?.count, 64)
+        }
+
         func testCorrelatedRequestTimelineJoinsAllWI2StagesAndWorkloadMatrices() throws {
             let connectionID = UUID().uuidString
             let identity = MCPRequestTimelineIdentity(
@@ -904,6 +980,38 @@
             XCTAssertEqual(delivery.count, 7)
             XCTAssertTrue(delivery.allSatisfy { $0.requestIdentity?.appInvocationID == invocationID })
 
+            let transportConnectionID = UUID().uuidString
+            let correlationConnectionID = UUID().uuidString
+            let transportRequestID = "transport-identity-upgrade"
+            let explicitInvocationID = UUID()
+            let requestFrame = Data("""
+            {"jsonrpc":"2.0","id":"\(transportRequestID)","method":"tools/call","params":{"name":"read_file","arguments":{"_latencyTraceID":"\(explicitInvocationID.uuidString)"}}}
+            """.utf8)
+            let registry = MCPRequestTimelineRegistry()
+            _ = registry.recordAcceptedFrame(
+                requestFrame,
+                connectionID: transportConnectionID,
+                correlationConnectionID: correlationConnectionID,
+                connectionGeneration: 19
+            )
+            let resolvedIdentity = try XCTUnwrap(registry.claimToolRequest(
+                connectionID: transportConnectionID,
+                appInvocationID: explicitInvocationID
+            ))
+            XCTAssertTrue(resolvedIdentity.isCompleteLatencyEvidenceIdentity)
+            registry.updateResponseIdentity(to: resolvedIdentity)
+            let responseFrame = Data("""
+            {"jsonrpc":"2.0","id":"\(transportRequestID)","result":{"content":[]}}
+            """.utf8)
+            let recordedResponses = registry.recordedResponses(
+                in: responseFrame,
+                connectionID: transportConnectionID,
+                connectionGeneration: 19
+            )
+            XCTAssertEqual(recordedResponses.count, 1)
+            XCTAssertEqual(recordedResponses.first?.identity, resolvedIdentity)
+            XCTAssertEqual(recordedResponses.first?.identity.appInvocationID, explicitInvocationID.uuidString)
+
             let sources = try [
                 source("Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift"),
                 source("Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift"),
@@ -929,6 +1037,104 @@
             ] {
                 XCTAssertTrue(sources.contains(hook), "Missing WI-2 stage hook: \(hook)")
             }
+        }
+
+        func testConcurrentSameToolRequestsClaimExactIdentityInReverseHandlerOrder() throws {
+            let registry = MCPRequestTimelineRegistry()
+            let connectionID = UUID().uuidString
+            let firstInvocationID = UUID()
+            let secondInvocationID = UUID()
+            let frame = Data("""
+            [
+              {"jsonrpc":"2.0","id":"request-first","method":"tools/call","params":{"name":"file_search","arguments":{"_latencyTraceID":"\(firstInvocationID.uuidString)"}}},
+              {"jsonrpc":"2.0","id":"request-second","method":"tools/call","params":{"name":"file_search","arguments":{"_latencyTraceID":"\(secondInvocationID.uuidString)"}}}
+            ]
+            """.utf8)
+            let recorded = registry.recordAcceptedFrame(
+                frame,
+                connectionID: connectionID,
+                correlationConnectionID: connectionID,
+                connectionGeneration: 7
+            )
+            XCTAssertEqual(recorded.count, 2)
+            XCTAssertNil(registry.claimToolRequest(
+                connectionID: connectionID,
+                appInvocationID: UUID()
+            ))
+
+            let second = try XCTUnwrap(registry.claimToolRequest(
+                connectionID: connectionID,
+                appInvocationID: secondInvocationID
+            ))
+            let first = try XCTUnwrap(registry.claimToolRequest(
+                connectionID: connectionID,
+                appInvocationID: firstInvocationID
+            ))
+            XCTAssertEqual(second.jsonRPCRequestID, .string("request-second"))
+            XCTAssertEqual(second.appInvocationID, secondInvocationID.uuidString)
+            XCTAssertEqual(first.jsonRPCRequestID, .string("request-first"))
+            XCTAssertEqual(first.appInvocationID, firstInvocationID.uuidString)
+            XCTAssertTrue(first.isCompleteLatencyEvidenceIdentity)
+            XCTAssertTrue(second.isCompleteLatencyEvidenceIdentity)
+        }
+
+        func testDuplicateInvocationIdentityFailsClosedWithoutClaimingEitherRequest() {
+            let registry = MCPRequestTimelineRegistry()
+            let connectionID = UUID().uuidString
+            let duplicateInvocationID = UUID()
+            let frame = Data("""
+            [
+              {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"_latencyTraceID":"\(duplicateInvocationID.uuidString)"}}},
+              {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_file","arguments":{"_latencyTraceID":"\(duplicateInvocationID.uuidString)"}}}
+            ]
+            """.utf8)
+            _ = registry.recordAcceptedFrame(
+                frame,
+                connectionID: connectionID,
+                correlationConnectionID: connectionID,
+                connectionGeneration: 8
+            )
+            XCTAssertNil(registry.claimToolRequest(
+                connectionID: connectionID,
+                appInvocationID: duplicateInvocationID
+            ))
+            XCTAssertNil(registry.claimToolRequest(
+                connectionID: connectionID,
+                appInvocationID: duplicateInvocationID
+            ))
+        }
+
+        func testFrameInspectorRecognizesOnlyExactDiagnosticInvocationPath() throws {
+            let invocationID = UUID()
+            let valid = Data("""
+            {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"_latencyTraceID":"\(invocationID.uuidString)"}}}
+            """.utf8)
+            let summary = try XCTUnwrap(JSONRPCBridgeFrameInspector.inspectPermissively(
+                valid,
+                direction: .clientToServer
+            ).first)
+            XCTAssertEqual(summary.appInvocationID, invocationID.uuidString)
+
+            for invalid in [
+                Data("""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"read_file","arguments":{"args":{"_latencyTraceID":"\(invocationID.uuidString)"}}}}
+                """.utf8),
+                Data("""
+                {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read_file","arguments":{"_LatencyTraceID":"\(invocationID.uuidString)"}}}
+                """.utf8),
+                Data("""
+                {"jsonrpc":"2.0","id":4,"method":"ping","params":{"arguments":{"_latencyTraceID":"\(invocationID.uuidString)"}}}
+                """.utf8)
+            ] {
+                XCTAssertNil(JSONRPCBridgeFrameInspector.inspectPermissively(
+                    invalid,
+                    direction: .clientToServer
+                ).first?.appInvocationID)
+            }
+            XCTAssertTrue(JSONRPCBridgeFrameInspector.inspectPermissively(
+                Data("not-json".utf8),
+                direction: .clientToServer
+            ).isEmpty)
         }
 
         func testLimiterDiagnosticsReportPromptQueuedCancellationAndIdleState() async {
@@ -1355,6 +1561,66 @@
             })
         }
 
+        private func scenarioFileTreeAndFormattedOutputRecorderInventoryIsLeafAttributedAndSanitized() {
+            _ = startedCapture(label: "file-tree-formatted-output", maxSamples: 100)
+            let fileTreeStages: [(StaticString, String)] = [
+                (EditFlowPerf.Stage.FileTree.providerTotal, "EditFlow.FileTree.ProviderTotal"),
+                (EditFlowPerf.Stage.FileTree.providerArgumentParsing, "EditFlow.FileTree.ProviderArgumentParsing"),
+                (EditFlowPerf.Stage.FileTree.providerRequestMetadata, "EditFlow.FileTree.ProviderRequestMetadata"),
+                (EditFlowPerf.Stage.FileTree.providerLookupContextResolution, "EditFlow.FileTree.ProviderLookupContextResolution"),
+                (EditFlowPerf.Stage.FileTree.providerIngressFreshnessWait, "EditFlow.FileTree.ProviderIngressFreshnessWait"),
+                (EditFlowPerf.Stage.FileTree.providerSelectionDrain, "EditFlow.FileTree.ProviderSelectionDrain"),
+                (EditFlowPerf.Stage.FileTree.bridgeTotal, "EditFlow.FileTree.BridgeTotal"),
+                (EditFlowPerf.Stage.FileTree.settingsSnapshot, "EditFlow.FileTree.SettingsSnapshot"),
+                (EditFlowPerf.Stage.FileTree.selectionPhysicalization, "EditFlow.FileTree.SelectionPhysicalization"),
+                (EditFlowPerf.Stage.FileTree.snapshotConstruction, "EditFlow.FileTree.SnapshotConstruction"),
+                (EditFlowPerf.Stage.FileTree.codemapMarkerProjection, "EditFlow.FileTree.CodemapMarkerProjection"),
+                (EditFlowPerf.Stage.FileTree.logicalProjection, "EditFlow.FileTree.LogicalProjection"),
+                (EditFlowPerf.Stage.FileTree.renderIndexPreparation, "EditFlow.FileTree.RenderIndexPreparation"),
+                (EditFlowPerf.Stage.FileTree.renderAttempt, "EditFlow.FileTree.RenderAttempt"),
+                (EditFlowPerf.Stage.FileTree.renderTokenEstimation, "EditFlow.FileTree.RenderTokenEstimation"),
+                (EditFlowPerf.Stage.FileTree.dtoAssembly, "EditFlow.FileTree.DTOAssembly"),
+                (EditFlowPerf.Stage.FileTree.providerValueEncoding, "EditFlow.FileTree.ProviderValueEncoding")
+            ]
+            let formattedStages: [(StaticString, String)] = [
+                (EditFlowPerf.Stage.FormattedOutput.decode, "EditFlow.FormattedOutput.Decode"),
+                (EditFlowPerf.Stage.FormattedOutput.promptEnvelopeProbeDecode, "EditFlow.FormattedOutput.PromptEnvelopeProbeDecode"),
+                (EditFlowPerf.Stage.FormattedOutput.promptContextDecode, "EditFlow.FormattedOutput.PromptContextDecode"),
+                (EditFlowPerf.Stage.FormattedOutput.searchTreeAssembly, "EditFlow.FormattedOutput.SearchTreeAssembly"),
+                (EditFlowPerf.Stage.FormattedOutput.searchSnippetAssembly, "EditFlow.FormattedOutput.SearchSnippetAssembly"),
+                (EditFlowPerf.Stage.FormattedOutput.fileTreeAssembly, "EditFlow.FormattedOutput.FileTreeAssembly"),
+                (EditFlowPerf.Stage.FormattedOutput.workspaceContextAssembly, "EditFlow.FormattedOutput.WorkspaceContextAssembly"),
+                (EditFlowPerf.Stage.FormattedOutput.genericFallbackAssembly, "EditFlow.FormattedOutput.GenericFallbackAssembly")
+            ]
+            let dimensions = EditFlowPerf.Dimensions(
+                taskCount: 5,
+                workloadClass: "full/unlimited private/path",
+                fileCount: 50000,
+                rootCount: 4,
+                serialPosition: 1
+            )
+            for (stage, _) in fileTreeStages + formattedStages {
+                EditFlowPerf.measure(stage, dimensions) {}
+            }
+
+            let snapshot = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            XCTAssertEqual(snapshot.retainedSampleCount, fileTreeStages.count + formattedStages.count)
+            XCTAssertEqual(snapshot.droppedSampleCount, 0)
+            XCTAssertEqual(
+                Set(snapshot.stages.map(\.stageName)),
+                Set((fileTreeStages + formattedStages).map(\.1))
+            )
+            XCTAssertTrue(snapshot.stages.allSatisfy {
+                $0.sanitizedDimensions == "taskCount=5 workloadClass=full_unlimited_private_path fileCount=50000 rootCount=4 serialPosition=1"
+            })
+            XCTAssertTrue(snapshot.stages.allSatisfy {
+                !$0.sanitizedDimensions.contains("/")
+                    && !$0.sanitizedDimensions.contains("fixture")
+                    && !$0.sanitizedDimensions.contains("pattern")
+                    && !$0.sanitizedDimensions.contains("content")
+            })
+        }
+
         private func scenarioNewReadDispatchStageRecorderCapturesToolDimensionAndFinishes() throws {
             _ = startedCapture(label: "dispatch-decomposition", maxSamples: 100)
             EditFlowPerf.measure(
@@ -1676,6 +1942,87 @@
             XCTAssertTrue(aggregate.sanitizedDimensions.contains("tool=read_file"))
             XCTAssertFalse(aggregate.sanitizedDimensions.contains("/"))
             XCTAssertFalse(aggregate.sanitizedDimensions.contains("namespace"))
+            XCTAssertEqual(snapshot.mode, .exhaustive)
+            XCTAssertNotNil(aggregate.p50MS)
+            XCTAssertNotNil(aggregate.p95MS)
+
+            EditFlowPerf.resetDebugCaptureForTesting()
+            _ = startedCapture(
+                label: "bounded-evidence",
+                maxSamples: 100,
+                mode: .mcpLatencyEvidence
+            )
+            let evidenceCorrelation = try XCTUnwrap(EditFlowPerf.makeLifecycleCorrelationIfActive(
+                requestIdentity: completeLatencyEvidenceIdentity()
+            ))
+            EditFlowPerf.$currentLifecycleCorrelation.withValue(evidenceCorrelation) {
+                for ordinal in 0 ..< 100 {
+                    EditFlowPerf.measure(
+                        EditFlowPerf.Stage.MCPToolCall.limiterWait,
+                        EditFlowPerf.Dimensions(status: "key-\(ordinal)")
+                    ) {}
+                }
+                EditFlowPerf.measure(
+                    EditFlowPerf.Stage.MCPToolCall.limiterWait,
+                    EditFlowPerf.Dimensions(status: "overflow")
+                ) {}
+                EditFlowPerf.measure(
+                    EditFlowPerf.Stage.MCPToolCall.limiterWait,
+                    EditFlowPerf.Dimensions(status: "key-0")
+                ) {}
+                EditFlowPerf.measure(EditFlowPerf.Stage.MCPToolCall.providerExecution) {}
+            }
+
+            let evidence = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            XCTAssertEqual(evidence.mode, .mcpLatencyEvidence)
+            XCTAssertEqual(evidence.maxSamples, 100)
+            XCTAssertEqual(evidence.retainedSampleCount, 101)
+            XCTAssertEqual(evidence.droppedSampleCount, 1)
+            XCTAssertEqual(evidence.ignoredOutOfContractSampleCount, 1)
+            XCTAssertEqual(evidence.stages.count, 100)
+            XCTAssertEqual(evidence.stages.reduce(0) { $0 + $1.sampleCount }, 101)
+            let repeated = try XCTUnwrap(evidence.stages.first { $0.sampleCount == 2 })
+            XCTAssertTrue(repeated.sanitizedDimensions.contains("status=key-0"))
+            XCTAssertEqual(repeated.sampleCount, 2)
+            XCTAssertNil(repeated.p50MS)
+            XCTAssertNil(repeated.p95MS)
+            XCTAssertGreaterThanOrEqual(repeated.totalMS, repeated.maxMS)
+            let payload = evidence.payload()
+            XCTAssertEqual(payload["capture_mode"] as? String, "mcp_latency_evidence")
+            XCTAssertEqual(payload["sample_capacity_unit"] as? String, "unique_stage_dimension_request_keys")
+            XCTAssertEqual(payload["percentile_semantics"] as? String, "unavailable_online_aggregation")
+            XCTAssertEqual(payload["retained_aggregate_key_count"] as? Int, 100)
+            XCTAssertEqual(payload["ignored_out_of_contract_sample_count"] as? Int, 1)
+            XCTAssertEqual(payload["observed_sample_count"] as? Int, 103)
+            let payloadStages = try XCTUnwrap(payload["stages"] as? [[String: Any]])
+            XCTAssertTrue(payloadStages.allSatisfy { $0["p50_ms"] is NSNull && $0["p95_ms"] is NSNull })
+        }
+
+        func testEvidenceCaptureRejectsIncompleteRequestIdentity() throws {
+            _ = startedCapture(
+                label: "incomplete-evidence",
+                maxSamples: 100,
+                mode: .mcpLatencyEvidence
+            )
+            let incomplete = MCPRequestTimelineIdentity(appInvocationID: UUID().uuidString)
+            let correlation = try XCTUnwrap(EditFlowPerf.makeLifecycleCorrelationIfActive(
+                requestIdentity: incomplete
+            ))
+            EditFlowPerf.$currentLifecycleCorrelation.withValue(correlation) {
+                EditFlowPerf.measure(EditFlowPerf.Stage.MCPToolCall.limiterWait) {}
+                EditFlowPerf.lifecycleEvent(
+                    EditFlowPerf.Lifecycle.MCPToolCall.received,
+                    correlation: correlation
+                )
+            }
+
+            let snapshot = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            XCTAssertEqual(snapshot.retainedSampleCount, 0)
+            XCTAssertEqual(snapshot.ignoredOutOfContractSampleCount, 1)
+            XCTAssertEqual(snapshot.retainedLifecycleEventCount, 0)
+            XCTAssertEqual(snapshot.ignoredOutOfContractLifecycleEventCount, 1)
+            XCTAssertTrue(snapshot.stages.isEmpty)
+            XCTAssertTrue(snapshot.lifecycleEvents.isEmpty)
         }
 
         func testLifecycleTimelinePreservesCorrelationOrderingAndSanitizesDimensions() throws {
@@ -1733,6 +2080,47 @@
             XCTAssertTrue(snapshot.lifecycleEvents[0].sanitizedDimensions.contains("contentSource=unsafe"))
             XCTAssertFalse(snapshot.lifecycleEvents[0].sanitizedDimensions.contains("/"))
             XCTAssertFalse(snapshot.lifecycleEvents[0].sanitizedDimensions.contains("|"))
+
+            EditFlowPerf.resetDebugCaptureForTesting()
+            _ = startedCapture(
+                label: "timeline-evidence",
+                maxSamples: 100,
+                mode: .mcpLatencyEvidence
+            )
+            let evidenceCorrelation = try XCTUnwrap(EditFlowPerf.makeLifecycleCorrelationIfActive(
+                requestIdentity: completeLatencyEvidenceIdentity()
+            ))
+            let required: [StaticString] = [
+                EditFlowPerf.Lifecycle.MCPToolCall.received,
+                EditFlowPerf.Lifecycle.MCPToolCall.permitAcquired,
+                EditFlowPerf.Lifecycle.MCPToolCall.resolvedProviderBegan,
+                EditFlowPerf.Lifecycle.MCPToolCall.resolvedProviderEnded,
+                EditFlowPerf.Lifecycle.MCPToolCall.formatResultBegan,
+                EditFlowPerf.Lifecycle.MCPToolCall.formatResultReturned,
+                EditFlowPerf.Lifecycle.MCPToolCall.completionObserverReturned,
+                EditFlowPerf.Lifecycle.MCPToolCall.handlerResultReady
+            ]
+            for event in required {
+                EditFlowPerf.lifecycleEvent(event, correlation: evidenceCorrelation)
+            }
+            EditFlowPerf.lifecycleEvent(
+                EditFlowPerf.Lifecycle.MCPToolCall.permitReleased,
+                correlation: evidenceCorrelation
+            )
+
+            let evidence = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            XCTAssertEqual(evidence.mode, .mcpLatencyEvidence)
+            XCTAssertEqual(evidence.maxLifecycleEvents, 100)
+            XCTAssertEqual(evidence.retainedLifecycleEventCount, required.count)
+            XCTAssertEqual(evidence.droppedLifecycleEventCount, 0)
+            XCTAssertEqual(evidence.ignoredOutOfContractLifecycleEventCount, 1)
+            XCTAssertEqual(evidence.lifecycleEvents.map(\.eventName), required.map { String(describing: $0) })
+            let payload = evidence.payload()
+            XCTAssertEqual(payload["observed_lifecycle_event_count"] as? Int, required.count + 1)
+            XCTAssertEqual(
+                payload["lifecycle_event_allowlist"] as? [String],
+                required.map { String(describing: $0) }.sorted()
+            )
         }
 
         func testLifecycleTimelineBoundReportsDroppedEventsWithoutConsumingIntervalBudget() throws {
@@ -2112,7 +2500,7 @@
                 $0.stageName == "EditFlow.MCPProviderProjection.WorkerBody"
             })
             XCTAssertEqual(workerStage.sanitizedDimensions, "tool=git outcome=test_projection")
-            XCTAssertGreaterThanOrEqual(workerStage.p50MS, 10)
+            XCTAssertGreaterThanOrEqual(try XCTUnwrap(workerStage.p50MS), 10)
             XCTAssertGreaterThanOrEqual(
                 handoffEvents[3].offsetMS - handoffEvents[2].offsetMS,
                 10,
@@ -2222,14 +2610,31 @@
             }
         }
 
+        private func completeLatencyEvidenceIdentity(
+            invocationID: UUID = UUID()
+        ) -> MCPRequestTimelineIdentity {
+            MCPRequestTimelineIdentity(
+                jsonRPCRequestID: .string("request-\(invocationID.uuidString)"),
+                connectionID: "connection-\(invocationID.uuidString)",
+                connectionGeneration: 1,
+                appInvocationID: invocationID.uuidString,
+                requestOrdinal: 1
+            )
+        }
+
         private func startedCapture(
             label: String,
             maxSamples: Int,
+            mode: EditFlowPerf.DebugCaptureMode = .exhaustive,
             failureLabel: String? = nil,
             file: StaticString = #filePath,
             line: UInt = #line
         ) -> EditFlowPerf.DebugCaptureSnapshot {
-            switch EditFlowPerf.beginDebugCapture(label: label, maxSamples: maxSamples) {
+            switch EditFlowPerf.beginDebugCapture(
+                label: label,
+                maxSamples: maxSamples,
+                mode: mode
+            ) {
             case let .started(snapshot):
                 return snapshot
             case .busy:

--- a/Tests/RepoPromptTests/MCP/MCPToolOutputLatencyParityTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPToolOutputLatencyParityTests.swift
@@ -1,0 +1,842 @@
+#if DEBUG
+    import MCP
+    @testable import RepoPromptApp
+    import XCTest
+
+    final class MCPToolOutputLatencyParityTests: XCTestCase {
+        func testFileTreeRendererModesAndMarkersRemainByteExact() async throws {
+            let selectedID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000101"))
+            let otherID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000102"))
+            let sourceFolder = try WorkspaceFileTreeFolderPresentation(
+                id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000201")),
+                name: "Sources",
+                fullPath: "/fixture/Project/Sources",
+                standardizedFullPath: "/fixture/Project/Sources",
+                standardizedRootPath: "/fixture/Project",
+                children: [
+                    .file(WorkspaceFileTreeFilePresentation(
+                        id: selectedID,
+                        name: "Selected.swift",
+                        fileExtension: "swift",
+                        hasCodeMap: true
+                    )),
+                    .file(WorkspaceFileTreeFilePresentation(
+                        id: otherID,
+                        name: "Other.swift",
+                        fileExtension: "swift",
+                        hasCodeMap: false
+                    ))
+                ]
+            )
+            let root = try WorkspaceFileTreeFolderPresentation(
+                id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000301")),
+                name: "Project",
+                fullPath: "/fixture/Project",
+                standardizedFullPath: "/fixture/Project",
+                standardizedRootPath: "/fixture/Project",
+                children: [
+                    .folder(sourceFolder),
+                    .file(WorkspaceFileTreeFilePresentation(
+                        id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000103")),
+                        name: "README.md",
+                        fileExtension: "md",
+                        hasCodeMap: false
+                    ))
+                ]
+            )
+
+            let unselectedRoot = try WorkspaceFileTreeFolderPresentation(
+                id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000302")),
+                name: "Unselected",
+                fullPath: "/fixture/Unselected",
+                standardizedFullPath: "/fixture/Unselected",
+                standardizedRootPath: "/fixture/Unselected",
+                children: [
+                    .file(WorkspaceFileTreeFilePresentation(
+                        id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000104")),
+                        name: "Only.swift",
+                        fileExtension: "swift",
+                        hasCodeMap: false
+                    ))
+                ]
+            )
+
+            let expectedByMode = [
+                "full": "Project\n├── Sources\n│   ├── Selected.swift * +\n│   └── Other.swift\n└── README.md\n\n\n(* denotes selected files)\n(+ denotes code-map available)",
+                "folders": "Project\n└── Sources\n    └── Selected.swift * +\n\n\n(* denotes selected files)\n(+ denotes code-map available)",
+                "selected": "Project\n└── Sources\n    └── Selected.swift * +\n\n\n(* denotes selected files)\n(+ denotes code-map available)",
+                "auto": "Project\n├── Sources\n│   ├── Selected.swift * +\n│   └── Other.swift\n└── README.md\n\n\n(* denotes selected files)\n(+ denotes code-map available)"
+            ]
+
+            for mode in ["full", "folders", "selected", "auto"] {
+                let snapshot = WorkspaceFileTreePresentationSnapshot(
+                    roots: [root, unselectedRoot],
+                    selectedFileIDs: [selectedID],
+                    mode: mode,
+                    showFullPaths: false,
+                    onlyIncludeRootsWithSelectedFiles: true,
+                    includeLegend: true,
+                    showCodeMapMarkers: true
+                )
+                XCTAssertEqual(
+                    WorkspaceFileTreePresentationRenderer.render(snapshot),
+                    expectedByMode[mode],
+                    mode
+                )
+            }
+
+            let mcpTree = WorkspaceFileTreePresentationRenderer.render(WorkspaceFileTreePresentationSnapshot(
+                roots: [root, unselectedRoot],
+                selectedFileIDs: [selectedID],
+                mode: "full",
+                showFullPaths: false,
+                onlyIncludeRootsWithSelectedFiles: false,
+                includeLegend: true,
+                showCodeMapMarkers: true
+            ))
+            XCTAssertEqual(
+                mcpTree,
+                "Project\n├── Sources\n│   ├── Selected.swift * +\n│   └── Other.swift\n└── README.md\n\n\nUnselected\n└── Only.swift\n\n\n(* denotes selected files)\n(+ denotes code-map available)"
+            )
+
+            let fullPathTree = WorkspaceFileTreePresentationRenderer.render(WorkspaceFileTreePresentationSnapshot(
+                roots: [sourceFolder],
+                selectedFileIDs: [],
+                mode: "full",
+                showFullPaths: true,
+                onlyIncludeRootsWithSelectedFiles: false,
+                includeLegend: false,
+                showCodeMapMarkers: false
+            ))
+            XCTAssertEqual(fullPathTree, "/fixture/Project/Sources\n├── Other.swift\n└── Selected.swift\n")
+
+            let depthCapped = WorkspaceFileTreePresentationRenderer.render(WorkspaceFileTreePresentationSnapshot(
+                roots: [root],
+                selectedFileIDs: [selectedID],
+                mode: "full",
+                showFullPaths: false,
+                onlyIncludeRootsWithSelectedFiles: false,
+                includeLegend: true,
+                showCodeMapMarkers: true,
+                maxDepth: 0
+            ))
+            XCTAssertEqual(
+                depthCapped,
+                "Project\n├── Sources\n│   ├── Selected.swift * +\n│   ├── ...\n└── README.md\n\n\n(* denotes selected files)\n(+ denotes code-map available)"
+            )
+
+            let longName = String(repeating: "Long", count: 120)
+            let generatedChildren: [WorkspaceFileTreeNodePresentation] = try (0 ..< 101).map { index in
+                try .file(WorkspaceFileTreeFilePresentation(
+                    id: XCTUnwrap(UUID(uuidString: String(format: "00000000-0000-0000-0001-%012d", index))),
+                    name: "\(longName)-\(index).swift",
+                    fileExtension: "swift",
+                    hasCodeMap: false
+                ))
+            }
+            let cappedChildren: [WorkspaceFileTreeNodePresentation] = [
+                .file(WorkspaceFileTreeFilePresentation(
+                    id: selectedID,
+                    name: "Selected.swift",
+                    fileExtension: "swift",
+                    hasCodeMap: false
+                ))
+            ] + generatedChildren
+            let cappedRoot = try WorkspaceFileTreeFolderPresentation(
+                id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000303")),
+                name: "Capped",
+                fullPath: "/fixture/Capped",
+                standardizedFullPath: "/fixture/Capped",
+                standardizedRootPath: "/fixture/Capped",
+                children: cappedChildren
+            )
+            XCTAssertEqual(
+                WorkspaceFileTreePresentationRenderer.render(WorkspaceFileTreePresentationSnapshot(
+                    roots: [cappedRoot],
+                    selectedFileIDs: [selectedID],
+                    mode: "auto",
+                    showFullPaths: false,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: true,
+                    showCodeMapMarkers: false
+                )),
+                "Capped\n└── Selected.swift *\n\n\n(* denotes selected files)\nConfig: directory-only view; selected files shown."
+            )
+
+            let duplicateRoot = try WorkspaceFileTreeFolderPresentation(
+                id: XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000304")),
+                name: "DuplicateSafe",
+                fullPath: "/fixture/DuplicateSafe",
+                standardizedFullPath: "/fixture/DuplicateSafe",
+                standardizedRootPath: "/fixture/DuplicateSafe",
+                children: []
+            )
+            let duplicateChild = WorkspaceFileTreeFolderPresentation(
+                id: duplicateRoot.id,
+                name: "Cycle",
+                fullPath: "/fixture/DuplicateSafe/Cycle",
+                standardizedFullPath: "/fixture/DuplicateSafe/Cycle",
+                standardizedRootPath: "/fixture/DuplicateSafe",
+                children: []
+            )
+            let duplicateSafeRoot = WorkspaceFileTreeFolderPresentation(
+                id: duplicateRoot.id,
+                name: duplicateRoot.name,
+                fullPath: duplicateRoot.fullPath,
+                standardizedFullPath: duplicateRoot.standardizedFullPath,
+                standardizedRootPath: duplicateRoot.standardizedRootPath,
+                children: [.folder(duplicateChild)]
+            )
+            XCTAssertEqual(
+                WorkspaceFileTreePresentationRenderer.render(WorkspaceFileTreePresentationSnapshot(
+                    roots: [duplicateSafeRoot],
+                    selectedFileIDs: [],
+                    mode: "full",
+                    showFullPaths: false,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false
+                )),
+                "DuplicateSafe\n"
+            )
+
+            let cancelled = Task {
+                try? await Task.sleep(for: .milliseconds(25))
+                return WorkspaceFileTreePresentationRenderer.render(WorkspaceFileTreePresentationSnapshot(
+                    roots: [root],
+                    selectedFileIDs: [selectedID],
+                    mode: "full",
+                    showFullPaths: false,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: true,
+                    showCodeMapMarkers: true
+                ))
+            }
+            cancelled.cancel()
+            let cancelledOutput = await cancelled.value
+            XCTAssertEqual(cancelledOutput, "")
+        }
+
+        func testFileTreeFormattedRawLegacyAndMalformedContentBlocksRemainByteExact() throws {
+            let dto = ToolResultDTOs.FileTreeDTO(
+                rootsCount: 1,
+                usesLegend: true,
+                tree: "Project\n└── Sources\n    └── Selected.swift * +",
+                note: "depth cap 3",
+                wasTruncated: false
+            )
+            let value = try Value(dto)
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "get_file_tree",
+                    args: [:],
+                    result: value,
+                    emitResources: true
+                )),
+                """
+                ## File Tree ✅
+                - **Roots**: 1
+                - **Selected markers**: yes
+                - **Note**: '...' indicates truncated content
+                - **Config**: depth cap 3
+
+                (* denotes selected files)
+                (+ denotes code-map available)
+
+                Project
+                └── Sources
+                    └── Selected.swift * +
+                """
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "get_file_tree",
+                    args: ["_rawJSON": .bool(true)],
+                    result: value,
+                    emitResources: true
+                )),
+                #"{"note":"depth cap 3","roots_count":1,"tree":"Project\n└── Sources\n    └── Selected.swift * +","uses_legend":true,"was_truncated":false}"#
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatFileTree(value: .string("legacy tree"))),
+                "legacy tree"
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatFileTree(value: .object(["unexpected": .bool(true)]))),
+                """
+                ```json
+                {
+                  "unexpected" : true
+                }
+                ```
+                """
+            )
+
+            let missingPath = try Value(ToolResultDTOs.FileTreeDTO(
+                rootsCount: 0,
+                usesLegend: false,
+                tree: "Loaded roots: Project → /fixture/Project",
+                note: "Requested path is outside the loaded roots",
+                wasTruncated: false,
+                worktreeScope: scope()
+            ))
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatFileTree(value: missingPath)),
+                """
+                ## File Tree ✅
+                - **Roots**: 0
+                - **Selected markers**: no
+                - **Note**: '...' indicates truncated content
+                - **Config**: Requested path is outside the loaded roots
+                - **Scope**: session-bound worktree. Displayed paths use logical/canonical roots; filesystem reads use that bound checkout.
+                - **Root remapping**:
+                  - `Project` → session-bound worktree (worktree `wt_fixture`, name `feature`, branch `feature/latency`, label `Latency Fixture`)
+
+                Loaded roots: Project → /fixture/Project
+                """
+            )
+
+            let empty = try Value(ToolResultDTOs.FileTreeDTO(
+                rootsCount: 0,
+                usesLegend: false,
+                tree: "",
+                note: "No workspace loaded",
+                wasTruncated: false
+            ))
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatFileTree(value: empty)),
+                """
+                ## File Tree ✅
+                - **Roots**: 0
+                - **Selected markers**: no
+                - **Note**: '...' indicates truncated content
+                - **Config**: No workspace loaded
+                """
+            )
+        }
+
+        func testSearchFormattedRawErrorAndOrderingRemainByteExact() throws {
+            let dto = ToolResultDTOs.SearchResultDTO(
+                totalMatches: 2,
+                totalFiles: 1,
+                matchedFiles: 1,
+                searchedFiles: 3,
+                contentMatches: 1,
+                pathMatches: 1,
+                limitHit: false,
+                perFileCounts: [.init(path: "Sources/A.swift", count: 1)],
+                pathMatchLines: ["Sources/A.swift"],
+                contentMatchGroups: [.init(
+                    path: "Sources/A.swift",
+                    lines: [.init(
+                        lineNumber: 2,
+                        lineText: "needle",
+                        contextBefore: [.init(lineNumber: 1, lineText: "before")],
+                        contextAfter: [.init(lineNumber: 4, lineText: "after")]
+                    )]
+                )],
+                suggestion: "Use a narrower scope.",
+                warning: "fixture warning",
+                perFileTotals: [.init(path: "Sources/A.swift", count: 1)]
+            )
+            let value = try Value(dto)
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "file_search",
+                    args: [:],
+                    result: value,
+                    emitResources: true
+                )),
+                """
+                ## Search Results ✅
+                - **Total matches**: 2 across 1 matching file (searched 3 files)
+                - **Content matches**: 1 • **Path matches**: 1
+                - **Status**: Complete (limit not reached)
+                - **Warning**: fixture warning
+                - **Top files**: A.swift (1)
+
+                ### Matches
+                Sources/
+                └── A.swift — 1 match (showing all) • path match
+                                1 │   before
+                                2 │ ▶ needle
+                                  │   ⋮
+                                4 │   after
+
+                ### Suggestion
+                Use a narrower scope.
+                """
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "file_search",
+                    args: ["_rawJSON": .bool(true)],
+                    result: value,
+                    emitResources: true
+                )),
+                "{\"content_match_groups\":[{\"lines\":[{\"context_after\":[{\"line_number\":4,\"line_text\":\"after\"}],\"context_before\":[{\"line_number\":1,\"line_text\":\"before\"}],\"line_number\":2,\"line_text\":\"needle\"}],\"path\":\"Sources/A.swift\"}],\"content_matches\":1,\"limit_hit\":false,\"matched_files\":1,\"path_match_lines\":[\"Sources/A.swift\"],\"path_matches\":1,\"per_file_counts\":[{\"count\":1,\"path\":\"Sources/A.swift\"}],\"per_file_totals\":[{\"count\":1,\"path\":\"Sources/A.swift\"}],\"searched_files\":3,\"suggestion\":\"Use a narrower scope.\",\"total_files\":1,\"total_matches\":2,\"warning\":\"fixture warning\"}"
+            )
+
+            let error = ToolResultDTOs.SearchResultDTO(
+                totalMatches: 0,
+                totalFiles: 0,
+                contentMatches: 0,
+                pathMatches: 0,
+                limitHit: false,
+                perFileCounts: [],
+                pathMatchLines: [],
+                contentMatchGroups: [],
+                errorMessage: "Workspace is still settling.",
+                errorCode: "workspace_freshness_timeout",
+                retryable: true,
+                retryAfterMilliseconds: 1000,
+                suggestion: "Retry this call."
+            )
+            let errorValue = try Value(error)
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatSearch(value: errorValue)),
+                """
+                ## Search Results ⚠️
+                - **Status**: Workspace freshness timed out
+                - **Error**: Workspace is still settling.
+                - **Code**: workspace_freshness_timeout
+                - **Retryable**: yes
+                - **Retry after**: 1000 ms
+                - **Suggestion**: Retry this call.
+                """
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "file_search",
+                    args: ["_rawJSON": .bool(true)],
+                    result: errorValue,
+                    emitResources: true
+                )),
+                #"{"content_match_groups":[],"content_matches":0,"error":"Workspace is still settling.","error_code":"workspace_freshness_timeout","limit_hit":false,"path_match_lines":[],"path_matches":0,"per_file_counts":[],"retry_after_ms":1000,"retryable":true,"suggestion":"Retry this call.","total_files":0,"total_matches":0}"#
+            )
+
+            let countOnlyCapped = try Value(ToolResultDTOs.SearchResultDTO(
+                totalMatches: 100,
+                totalFiles: 2,
+                matchedFiles: 2,
+                searchedFiles: 500,
+                contentMatches: 100,
+                pathMatches: 0,
+                limitHit: true,
+                perFileCounts: [],
+                pathMatchLines: [],
+                contentMatchGroups: [],
+                sizeLimitHit: true,
+                omittedTotal: 95,
+                omittedContentMatches: 95,
+                omittedPathMatches: 0,
+                perFileTotals: [
+                    .init(path: "Sources/A.swift", count: 60),
+                    .init(path: "Tests/B.swift", count: 40)
+                ],
+                worktreeScope: scope()
+            ))
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatSearch(value: countOnlyCapped)),
+                """
+                ## Search Results ✅
+                - **Total matches**: 100 across 2 matching files (searched 500 files)
+                - **Content matches**: 100 • **Path matches**: 0
+                - **Status**: Partial (limit reached)
+                - **Scope**: session-bound worktree. Displayed paths use logical/canonical roots; filesystem searches use that bound checkout.
+                - **Root remapping**:
+                  - `Project` → session-bound worktree (worktree `wt_fixture`, name `feature`, branch `feature/latency`, label `Latency Fixture`)
+                - **Top files**: A.swift (60), B.swift (40)
+                - **Omitted**: 95 results trimmed by response size cap (95 content)
+                """
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatSearch(value: .string("legacy matches"))),
+                "## Search Results ✅\nlegacy matches"
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatSearch(value: .object(["unexpected": .bool(true)]))),
+                """
+                ```json
+                {
+                  "unexpected" : true
+                }
+                ```
+                """
+            )
+        }
+
+        @MainActor
+        func testFileTreeArgumentErrorsPreserveBranchOrdering() throws {
+            XCTAssertEqual(
+                try MCPFileToolProvider.parseFileTreeRequest(args: [
+                    "type": .string("roots"),
+                    "max_depth": .string("not-an-integer")
+                ]),
+                .roots
+            )
+
+            XCTAssertThrowsError(try MCPFileToolProvider.parseFileTreeRequest(args: [
+                "type": .string("bogus"),
+                "max_depth": .string("not-an-integer")
+            ])) { error in
+                XCTAssertTrue(error.localizedDescription.contains("invalid type: bogus"))
+                XCTAssertFalse(error.localizedDescription.contains("max_depth"))
+            }
+
+            XCTAssertThrowsError(try MCPFileToolProvider.parseFileTreeRequest(args: [
+                "type": .string("files"),
+                "max_depth": .string("not-an-integer")
+            ])) { error in
+                XCTAssertTrue(error.localizedDescription.contains("max_depth must be an integer"))
+            }
+        }
+
+        func testMultiBlockAndObserverValueRemainByteExact() throws {
+            let diff = "--- a/Sources/A.swift\n+++ b/Sources/A.swift\n@@ -1 +1 @@\n-old\n+new"
+            let dto = ToolResultDTOs.EditSummary(
+                status: "success",
+                editsRequested: 1,
+                editsApplied: 1,
+                addedLines: 1,
+                deletedLines: 1,
+                totalLinesChanged: 2,
+                totalChunks: 1,
+                results: nil,
+                unifiedDiff: diff,
+                cardUnifiedDiff: diff,
+                note: nil,
+                fileCreated: false,
+                fileOverwritten: false,
+                reviewStatus: nil,
+                rejectionReason: nil,
+                requiresUserApproval: false
+            )
+            let value = try Value(dto)
+            XCTAssertEqual(
+                try textBlocks(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "apply_edits",
+                    args: [:],
+                    result: value,
+                    emitResources: true
+                )),
+                [
+                    """
+                    ## Apply Edits ✅
+                    - **Requested**: 1
+                    - **Applied**: 1
+                    - **Lines changed**: 2
+                    - **Chunks**: 1
+
+                    ### Unified Diff
+                    ```diff
+                    --- a/Sources/A.swift
+                    +++ b/Sources/A.swift
+                    @@ -1 +1 @@
+                    -old
+                    +new
+                    ```
+                    """,
+                    """
+                    ```diff
+                    --- a/Sources/A.swift
+                    +++ b/Sources/A.swift
+                    @@ -1 +1 @@
+                    -old
+                    +new
+                    ```
+                    """
+                ]
+            )
+            XCTAssertEqual(
+                ToolOutputFormatter.rawJSONString(value),
+                "{\"added_lines\":1,\"card_unified_diff\":\"--- a/Sources/A.swift\\n+++ b/Sources/A.swift\\n@@ -1 +1 @@\\n-old\\n+new\",\"deleted_lines\":1,\"edits_applied\":1,\"edits_requested\":1,\"file_created\":false,\"file_overwritten\":false,\"requires_user_approval\":false,\"status\":\"success\",\"total_chunks\":1,\"total_lines_changed\":2,\"unified_diff\":\"--- a/Sources/A.swift\\n+++ b/Sources/A.swift\\n@@ -1 +1 @@\\n-old\\n+new\"}"
+            )
+        }
+
+        func testSearchMultiFileOmissionsDuplicateGroupsAndGapsRemainByteExact() throws {
+            let dto = ToolResultDTOs.SearchResultDTO(
+                totalMatches: 9,
+                totalFiles: 3,
+                matchedFiles: 3,
+                searchedFiles: 12,
+                contentMatches: 7,
+                pathMatches: 2,
+                limitHit: true,
+                perFileCounts: [
+                    .init(path: "Sources/A.swift", count: 2),
+                    .init(path: "Sources/B.swift", count: 1)
+                ],
+                pathMatchLines: ["Sources/A.swift", "Sources/C.swift"],
+                contentMatchGroups: [
+                    .init(path: "Sources/A.swift", lines: [
+                        .init(
+                            lineNumber: 10,
+                            lineText: "first needle",
+                            contextBefore: [.init(lineNumber: 9, lineText: "before first")],
+                            contextAfter: [.init(lineNumber: 11, lineText: "after first")]
+                        )
+                    ]),
+                    .init(path: "Sources/A.swift", lines: [
+                        .init(
+                            lineNumber: 20,
+                            lineText: "second needle",
+                            contextBefore: [.init(lineNumber: 18, lineText: "before second")],
+                            contextAfter: [.init(lineNumber: 22, lineText: "after second")]
+                        )
+                    ]),
+                    .init(path: "Sources/B.swift", lines: [
+                        .init(lineNumber: 3, lineText: "third needle", contextBefore: [], contextAfter: [])
+                    ])
+                ],
+                omittedTotal: 4,
+                omittedContentMatches: 4,
+                omittedPathMatches: 0,
+                perFileTotals: [
+                    .init(path: "Sources/A.swift", count: 5),
+                    .init(path: "Sources/B.swift", count: 2)
+                ]
+            )
+            let value = try Value(dto)
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatSearch(value: value)),
+                """
+                ## Search Results ✅
+                - **Total matches**: 9 across 3 matching files (searched 12 files)
+                - **Content matches**: 7 • **Path matches**: 2
+                - **Status**: Partial (limit reached)
+                - **Top files**: A.swift (5), B.swift (2)
+
+                ### Matches
+                Sources/
+                ├── A.swift — 5 matches (showing first 2) • path match
+                    │           9 │   before first
+                    │          10 │ ▶ first needle
+                    │          11 │   after first
+                    │\u{20}\u{20}\u{20}
+                    │          18 │   before second
+                    │             │   ⋮
+                    │          20 │ ▶ second needle
+                    │             │   ⋮
+                    │          22 │   after second
+                    │       [3 more matches in this file - use higher max_results to see all]
+                ├── B.swift — 2 matches (showing first 1)
+                    │           3 │ ▶ third needle
+                    │       [1 more matches in this file - use higher max_results to see all]
+                └── C.swift — path match
+                """
+            )
+            XCTAssertEqual(
+                ToolOutputFormatter.rawJSONString(value),
+                try onlyText(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "file_search",
+                    args: ["_rawJSON": .bool(true)],
+                    result: value,
+                    emitResources: true
+                ))
+            )
+        }
+
+        func testWorkspaceContextFormattedRawAndMalformedContentBlocksRemainByteExact() throws {
+            let dto = ToolResultDTOs.PromptContextDTO(
+                prompt: "freeze",
+                selection: nil,
+                fileBlocks: nil,
+                codeStructure: nil,
+                fileTree: nil,
+                tokenStats: nil,
+                userTokenStats: nil,
+                tokenStatsNote: nil,
+                copyPreset: nil,
+                copyPresets: nil
+            )
+            let value = try Value(dto)
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "workspace_context",
+                    args: [:],
+                    result: value,
+                    emitResources: true
+                )),
+                """
+                ## Prompt Context ✅
+
+                ### Prompt
+                ```text
+                freeze
+                ```
+                """
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.buildContentBlocks(
+                    toolName: "workspace_context",
+                    args: ["_rawJSON": .bool(true)],
+                    result: value,
+                    emitResources: true
+                )),
+                #"{"prompt":"freeze"}"#
+            )
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatPromptState(value: .object(["unexpected": .string("value")]))),
+                """
+                ```json
+                {
+                  "unexpected" : "value"
+                }
+                ```
+                """
+            )
+
+            let selectedFile = ToolResultDTOs.SelectedFileInfo(
+                path: "Project/App.swift",
+                tokens: 12,
+                renderMode: "full",
+                ranges: nil,
+                isAuto: false,
+                codemapOrigin: nil,
+                copyPreset: nil,
+                rootPath: "/fixture/Project",
+                pathWithinRoot: "App.swift"
+            )
+            let selection = ToolResultDTOs.SelectedFilesReply(
+                files: [selectedFile],
+                totalTokens: 12,
+                fileSlices: nil,
+                summary: .init(
+                    fullCount: 1,
+                    sliceCount: 0,
+                    codemapCount: 0,
+                    fullTokens: 12,
+                    sliceTokens: 0,
+                    codemapTokens: 0
+                )
+            )
+            let comprehensive = try Value(ToolResultDTOs.PromptContextDTO(
+                prompt: "audit prompt",
+                selection: selection,
+                fileBlocks: ["File: Project/App.swift\n```swift\nstruct App {}\n```"],
+                codeStructure: .init(fileCount: 1, content: "struct App {}"),
+                fileTree: .init(
+                    rootsCount: 1,
+                    usesLegend: false,
+                    tree: "Project\n└── App.swift *"
+                ),
+                tokenStats: .init(total: 0, files: 0, prompt: 2, fileTree: 3),
+                userTokenStats: nil,
+                tokenStatsNote: nil,
+                tokenAccounting: .init(
+                    status: "incomplete",
+                    source: "active_tab_published",
+                    refreshPending: true,
+                    incompleteComponents: ["files", "codemap_presentation"]
+                ),
+                copyPreset: nil,
+                copyPresets: nil,
+                worktreeScope: scope()
+            ))
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatPromptState(value: comprehensive)),
+                """
+                ## Prompt Context ✅
+                - **Scope**: session-bound worktree. Displayed paths use logical/canonical roots; filesystem-derived sections use that bound checkout.
+                - **Root remapping**:
+                  - `Project` → session-bound worktree (worktree `wt_fixture`, name `feature`, branch `feature/latency`, label `Latency Fixture`)
+                **Token accounting pending**
+
+                - **Selection**: pending
+                - Prompt: 2
+                - File tree: 3
+                - Token accounting: incomplete from active_tab_published; refresh pending; incomplete: files, codemap_presentation
+                - **Selected files**: 1 total (1 full)
+                - Token breakdown: full 12
+
+                ### Prompt
+                ```text
+                audit prompt
+                ```
+
+                ### Selection
+                1 files • 12 tokens (Auto view)
+
+                ### Selected Files
+                /fixture/Project/
+                └── App.swift — 12 tokens (full)
+
+                ### Selected File Tree
+                Project
+                └── App.swift *
+
+                ### Code Maps
+                - **Files with codemap**: 1
+
+                ```text
+                struct App {}
+                ```
+
+                ### Selected File Contents
+                File: Project/App.swift
+                ```swift
+                struct App {}
+                ```
+                """
+            )
+
+            let promptEnvelope: Value = .object([
+                "op": .string("get"),
+                "prompt": .object([
+                    "prompt": .string("enveloped prompt"),
+                    "lines": .double(1)
+                ])
+            ])
+            XCTAssertEqual(
+                try onlyText(ToolOutputFormatter.formatPromptState(value: promptEnvelope)),
+                """
+                ## Prompt ✅
+                - **Lines**: 1
+
+                ### Prompt
+                ```text
+                enveloped prompt
+                ```
+                """
+            )
+        }
+
+        private func scope() -> ToolResultDTOs.WorktreeScopeDTO {
+            ToolResultDTOs.WorktreeScopeDTO(
+                kind: "session_bound_worktree",
+                displayIdentity: "logical_canonical_root",
+                effectiveIdentity: "bound_worktree_root",
+                rootMappings: [
+                    .init(
+                        logicalRootName: "Project",
+                        logicalRootPath: "Project",
+                        effectiveRootName: "feature",
+                        effectiveRootPath: "session-bound",
+                        worktreeID: "wt_fixture",
+                        worktreeName: "feature",
+                        branch: "feature/latency",
+                        label: "Latency Fixture"
+                    )
+                ]
+            )
+        }
+
+        private func textBlocks(_ blocks: [MCP.Tool.Content]) throws -> [String] {
+            try blocks.map { block in
+                guard case let .text(text, _, _) = block else {
+                    throw NSError(domain: "MCPToolOutputLatencyParityTests", code: 2)
+                }
+                return text
+            }
+        }
+
+        private func onlyText(_ blocks: [MCP.Tool.Content]) throws -> String {
+            XCTAssertEqual(blocks.count, 1)
+            guard case let .text(text, _, _) = try XCTUnwrap(blocks.first) else {
+                throw NSError(domain: "MCPToolOutputLatencyParityTests", code: 1)
+            }
+            return text
+        }
+    }
+#endif

--- a/docs/architecture/mcp-tool-latency-diagnostics.md
+++ b/docs/architecture/mcp-tool-latency-diagnostics.md
@@ -1,0 +1,188 @@
+# MCP tool end-to-end latency diagnostics
+
+This document is the maintained execution contract for the W0-W2 measurement foundation in the local plan `docs/plans/mcp-tool-end-to-end-latency-2026-07-29.md`. It does **not** authorize or implement W3-W7 production optimizations.
+
+The WI-3 investigation at `docs/investigations/mcp-tool-throughput-wi3-baseline-2026-06-11.md` remains authoritative for lane capacities, work-count surfaces, and declared concurrency matrices. The committed matrix transcribes that authority; it is not a replacement baseline. A DEBUG run records before/after runtime and admission snapshots, projects counter deltas and gauges, and stamps only WI-3 workload IDs actually executed by that run.
+
+## Executor and behavior invariants
+
+| Stage owner | Executor / authority |
+| --- | --- |
+| `MCPConnectionManager` | server actor and task-local stable request identity |
+| `MCPFileToolProvider` | `@MainActor`; observation only |
+| `WorkspaceFileContextStore` | actor-isolated snapshot and catalog authority |
+| `StoreBackedWorkspaceSearchLane` | actor-isolated FIFO admission |
+| path-scope filtering | existing detached immutable work and cancellation checks |
+| `ToolOutputFormatter` | synchronous caller executor |
+| `UnixSocketMCPTransport` | transport actor and delivery gate |
+| client recorder | DEBUG or explicit `MCP_LATENCY_TRACE` diagnostic build only |
+
+Instrumentation must preserve the original await order, actor hops, cancellation checks, branch-local validation/error precedence, formatter nesting, text/resources/images/audio behavior, and thrown errors. Inclusive stages are validation envelopes. Only explicitly listed non-overlapping leaf stages and measured boundary intervals are ranked.
+
+## Stable request identity and boundaries
+
+Each runner invocation receives a fresh `_latencyTraceID` UUID. `MCPToolArgsNormalizer` removes this hidden field before provider argument validation while the DEBUG server request task and delivery transport retain the same identity. The runner joins client trace, stage buckets, lifecycle phases, and delivery phases by this UUID—never by tool name or event order.
+
+The diagnostic client recorder measures C0 immediately before `session.callTool`, C1 when it returns or throws, and C2 after rendering/output writing. Ordinary `-c/-j` calls route through `InteractiveREPL.callToolSingleShot`; the persistent `-e` execution path routes through `MCPCommandRunner`/`ExecMCPService`. Both call the same recorder and formatter path. The internal `--latency-concurrent-batch` diagnostic command uses one shared `ClientSession` and concurrently dispatches declared requests; it is unavailable from ordinary production artifacts.
+
+`RP_MCP_LATENCY_TRACE_PATH` must be an absolute, process-unique path. The recorder opens it append-only with `O_NOFOLLOW`, forces mode `0600`, and writes JSONL after C2. It records only invocation UUID, tool, diagnostic configuration, output format, timestamps/durations, content-block/text-byte counts, coarse outcome, and `is_error`. It never records arguments, paths, patterns, payload text, resources, images, or audio. Trace I/O failures do not alter the tool result.
+
+A successful DEBUG or optimized-diagnostic sample must have exactly one request-identity event for every S0-S1, S1-S2, S2-S3, S3-S4, S4-S5, S5-S6, S6-S7, S7-S8, and S8-S9 endpoint, plus one C0-C2 trace. The selector's 15% server denominator is the inclusive `MCP.ToolCall.Received` through `transport_write_completed` S0→S9 interval. S7→S9 remains separately reported. Missing or duplicated identities/boundaries invalidate the cohort.
+
+Repeated spans and dimension buckets are summed per request before percentiles are computed. `Search.ProviderTotal`, `Search.ProviderWorkspaceSearchAwait`, readiness-acquire, root-scope, and the physical search-tree span are inclusive envelopes. The runner derives a search core-scan remainder by subtracting the non-overlapping admission, freshness, readiness-acquire, and root-scope envelopes from `ProviderWorkspaceSearchAwait`; readiness-validation is already nested in the latter two. It separately derives combined readiness/scope-exclusive cost by subtracting validation and derives tree-exclusive cost by subtracting nested snippet spans. Only derived exclusive quantities—not their ancestor envelopes—may enter leaf selection. The static parent/child inventory forbids a physical ancestor from appearing in `LEAF_STAGES`.
+
+Every retained leaf/inclusive bucket must carry an app invocation ID, including work created from detached tasks. Aggregation reports identified/unidentified counts per stage and rejects any unidentified bucket or any successful recorded request with no relevant stage bucket.
+
+## Truly distinct formatted and raw calls
+
+Every row is called twice with different request UUIDs:
+
+- formatted: `_rawJSON` is absent and the ordinary CLI has no global `--raw-json` flag;
+- raw: `_rawJSON=true` is supplied for that request and the redirected result must be exactly one text block containing valid JSON.
+
+A successful pair must have distinct response digests. The formatted trace must report rendered non-empty text and the redirected formatted output must not itself be a JSON document. The raw trace must report exactly one text content block. These checks prevent a raw-only cohort from being mislabeled as formatted/raw evidence.
+
+## Deterministic external fixtures
+
+Python 3 is required. Generate fixtures outside this checkout; the generator rejects repository-local output and existing destinations.
+
+```bash
+make dev-mcp-latency MCP_LATENCY_ARGS='fixture --profile small --output /tmp/rpce-mcp-latency-small'
+make dev-mcp-latency MCP_LATENCY_ARGS='fixture --profile medium --output /tmp/rpce-mcp-latency-medium'
+make dev-mcp-latency MCP_LATENCY_ARGS='fixture --profile large --output /tmp/rpce-mcp-latency-large'
+```
+
+Profiles contain approximately 500 files/one root, 10,000 files/two roots, and 50,000 files/four roots. Each manifest pins the seed, root/file counts, byte count, maximum depth, expected search counts, and SHA-256 over sorted relative path/content pairs. Generated fixtures must not be committed.
+
+The committed matrix is `Scripts/Fixtures/mcp-tool-latency/v1/matrix.json`. It covers tree roots/auto/full/folders/selected/subtree, path/content/regex/both/count-only/context/cap cases, workspace envelopes/raw controls, a read control, and gated worktree/readiness/timeout/large-full rows. Every executable row declares an expected outcome.
+
+## Coordinated no-lifecycle entry points
+
+`./conductor mcp-latency -- ...` is authoritative; `make dev-mcp-latency MCP_LATENCY_ARGS='...'` is its Make alias.
+
+- `fixture` and `analyze` claim no daemon lanes.
+- DEBUG `run` claims `debugArtifact` and `liveApp`; optimized `run` claims `mcpLatencyArtifact` and `liveApp`.
+- None of these commands builds, launches, relaunches, or stops the app.
+- `make dev-mcp-latency-debug-server-build` packages the DEBUG attribution app at `.build/mcp-latency/debug-server/RepoPrompt.app` without touching shared DebugApps.
+- `make dev-mcp-latency-server-build` packages the isolated release-optimized diagnostic app and its matching client under the `build` + `mcpLatencyArtifact` lanes. Both builders perform no lifecycle action.
+- `make dev-mcp-latency-client-build` remains a legacy client-only diagnostic builder and cannot satisfy the optimized-server gate.
+
+Example warm DEBUG cohort after the fixture is open and ready:
+
+```bash
+make dev-mcp-latency MCP_LATENCY_ARGS='run \
+  --configuration debug --cohort warm --profile small \
+  --client-mode fresh --client-mode persistent \
+  --window-id 1 \
+  --fixture-root /tmp/rpce-mcp-latency-small \
+  --fixture-manifest /tmp/rpce-mcp-latency-small.manifest.json \
+  --output /tmp/rpce-mcp-latency-runs/debug-small-1 \
+  --baseline /tmp/rpce-mcp-latency-runs/small-response-baseline.json \
+  --update-baseline'
+```
+
+The matrix-declared warm discipline is authoritative: at least 3 discarded warmups, 3 repeats, and 30 recorded samples per repeat. Lower overrides are rejected. Persistent warmups and recorded calls use the same connection generation. A broken/closed/timed-out unexpected generation is discarded in full, a new connection is established, its warmups are rerun, and only the replacement generation may become evidence.
+
+Server evidence uses `segmented_canonical_matrix_v1`: one bounded capture epoch for every deterministic ordinary `(row, client mode)` pair and one epoch for every enabled WI-3 workload. Each epoch begins from a reset recorder, executes no unrelated control calls, snapshots with `finish=true`, and writes a separately hashed artifact under `server-capture-segments/`. The manifest pins the complete ordered plan and its hash; every plan entry pins row, mode, format, phase, repeat/sample coordinate multiset, expected invocation count, artifact hash, and exact invocation IDs. The index must contain every entry once in order, and both manifests in a paired run must reconstruct to the same plan hash.
+
+Each segment is validated independently for the capture contract, zero stage/lifecycle/delivery drops, exact request membership, exact sample coordinates, expected outcomes, terminal rules, connection integrity, and complete C0-C2/S0-S9 joins. Persistent CLI startup's real `bind_context` request is the sole classified setup exception: it must have a complete one-of-each S0-S7 lifecycle, `tool=bind_context` on every lifecycle/stage record, MCPToolCall-only stages, and its exact identity is retained in the segment index but excluded from workload evidence. Fresh connection protocol handshake delivery records and capture-begin delivery are likewise never joined as workload phases. A rejected connection generation may be retried only after its capture accounting and zero-drop checks pass; rejected raw evidence remains quarantined and never enters aggregates. Expected-timeout rows require exactly one correlated server terminal event. Missing, extra, duplicated, reordered, unclassified-foreign, hash-mismatched, active, dropped, or unfinished segments invalidate the entire campaign.
+
+Offline aggregation reloads and re-hashes every segment, revalidates membership and boundaries, then concatenates request-level evidence before computing global percentiles and running the selector. It never averages per-segment percentiles or invents a cross-segment clock. Legacy monolithic snapshots may be retained as recovery evidence, but a paired production-authorizing result requires the complete segmented layout and canonical `fresh` plus `persistent` client modes.
+
+Cold collection is explicitly one independently activated sample per run. This runner performs no activation:
+
+```bash
+make dev-mcp-latency MCP_LATENCY_ARGS='run \
+  --configuration debug --cohort cold --activation-id activation-01 --cold-sample-index 1 \
+  --profile small --client-mode fresh --window-id 1 \
+  --fixture-root /tmp/rpce-mcp-latency-small \
+  --fixture-manifest /tmp/rpce-mcp-latency-small.manifest.json \
+  --output /tmp/rpce-mcp-latency-runs/debug-small-cold-01 \
+  --baseline /tmp/rpce-mcp-latency-runs/small-cold-baseline.json'
+```
+
+Collect indices 1 through 10 under independently declared activations. Cold and warm samples are never mixed in one analyzed cohort.
+
+Warm DEBUG runs execute the enabled WI-3 same-connection ordinary burst and distinct-connections/one-window cohorts concurrently. Other WI-3 matrices remain declared but are not stamped as executed until an implementation actually runs them. `--skip-wi3` is available for diagnostic iteration, but paired selection hard-fails unless both DEBUG and optimized runs executed the exact enabled WI-3 admission set and DEBUG captured its work-count evidence.
+
+## Optimized diagnostic artifact and paired gate
+
+Build the safe server/client artifact through the coordinated daemon:
+
+```bash
+make dev-mcp-latency-server-build
+```
+
+It uses Swift's `release` configuration with an isolated scratch path and emits only:
+
+```text
+.build/mcp-latency/optimized-server/RepoPrompt.app
+.build/mcp-latency/optimized-server/artifact-manifest.json
+```
+
+This third packaging mode is neither DEBUG packaging nor ordinary release packaging. It uses the fixed `com.pvncher.repoprompt.ce.mcp-latency-diagnostic` bundle identifier, ad-hoc signing, alternate in-memory secure storage, host architecture, and no provisioning/Sentry/public universal/release-manifest/install/compatibility-link path. It rejects explicit release signing, Sentry, local self-signed release, and ordinary release diagnostic gates. Ordinary release packaging separately rejects either diagnostic compile gate. The builder never copies into the shared `DebugApps` bundle and never launches an app.
+
+The server target defines only `MCP_LATENCY_DIAGNOSTICS`; its embedded client defines only `MCP_LATENCY_TRACE`; shared request identity code receives only the server diagnostic define. The optimized hidden server surface accepts the canonical diagnostics tool and exactly three payload-free/timing-only operations: server identity, capture begin, and capture snapshot. DEBUG aliases, runtime mutation, fault injection, restart/shutdown, fixtures, sleeps, update controls, and all other DEBUG operations are not compiled into this artifact. It records bounded sanitized timing stages, lifecycle boundaries, delivery events, drop counts, and process/artifact identity—never arguments or returned content.
+
+The external manifest and embedded provenance record the artifact UUID, commit/dirty state, deterministic non-ignored source-tree fingerprint, exact target defines, release Swift configuration, fixed bundle/signing/storage identity, server and embedded-client paths/hashes, diagnostic surface, and explicit `ordinary_release_artifact: false`. At optimized collection start and end, the runner requires the running PID/bundle/executables/provenance to match that manifest byte-for-byte. The embedded client is mandatory; a PATH/debug/legacy client is rejected.
+
+### Operator-approved live sequence
+
+Building and analyzing are non-lifecycle operations. Launching or quitting either visible app requires explicit operator approval immediately before the action. Do not install either bundle over shared `DebugApps`.
+
+1. Package the isolated DEBUG bundle (`make dev-mcp-latency-debug-server-build`) and optimized diagnostic bundle (`make dev-mcp-latency-server-build`). Neither command launches or installs an app.
+2. With approval, launch the isolated DEBUG build directly (`open -n "$PWD/.build/mcp-latency/debug-server/RepoPrompt.app"`), open the declared workspace/fixture, wait for readiness, and record its window ID. Do not use `make dev-build`/`make dev-run`, because their normal DEBUG package path targets shared `DebugApps`.
+3. Collect DEBUG first with the command shown above, adding `--cli "$PWD/.build/mcp-latency/debug-server/RepoPrompt.app/Contents/MacOS/repoprompt-mcp"`. The runner records DEBUG start/end identity and full C0-C2/S0-S9 capture.
+4. With approval, quit only the visible DEBUG app (`osascript -e 'tell application id "com.pvncher.repoprompt.ce.debug" to quit'`) and verify its exact executable is gone. Ensure no ordinary release RepoPrompt app is using the release socket; stopping one is a separate operator-approved action.
+5. With approval, launch the isolated artifact directly:
+
+   ```bash
+   open -n "$PWD/.build/mcp-latency/optimized-server/RepoPrompt.app"
+   ```
+
+   Open the identical workspace/fixture, wait for equivalent readiness, and record the optimized app's window ID.
+6. Collect the optimized cohort with the identical matrix, fixture, client modes, profile, and sample discipline:
+
+   ```bash
+   make dev-mcp-latency MCP_LATENCY_ARGS='run \
+     --configuration optimized --cohort warm --profile small \
+     --client-mode fresh --client-mode persistent \
+     --window-id 1 \
+     --server-artifact-manifest .build/mcp-latency/optimized-server/artifact-manifest.json \
+     --fixture-root /tmp/rpce-mcp-latency-small \
+     --fixture-manifest /tmp/rpce-mcp-latency-small.manifest.json \
+     --output /tmp/rpce-mcp-latency-runs/optimized-small-1 \
+     --baseline /tmp/rpce-mcp-latency-runs/small-response-baseline.json'
+   ```
+
+7. Analyze only after both complete:
+
+   ```bash
+   make dev-mcp-latency MCP_LATENCY_ARGS='analyze \
+     --debug-input /tmp/rpce-mcp-latency-runs/debug-small-1 \
+     --optimized-input /tmp/rpce-mcp-latency-runs/optimized-small-1 \
+     --output /tmp/rpce-mcp-latency-runs/paired-small.json'
+   ```
+
+8. With approval, quit only the diagnostic bundle (`osascript -e 'tell application id "com.pvncher.repoprompt.ce.mcp-latency-diagnostic" to quit'`).
+
+Paired analysis requires the completed DEBUG cohort to predate optimized collection; identical commit/source fingerprint/profile/cohort/matrix/fixture/sample discipline/canonical fresh-plus-persistent modes/WI-3 authority; the same verified complete segmented plan and index contract; stable, distinct, process-authoritative server identities; exact optimized manifest/bundle/executable/client/provenance identity; zero capture drops; matching enabled WI-3 cohorts; DEBUG work-count evidence; and exact response signatures. It runs the strict selector independently on DEBUG and optimized server-stage evidence. Only the same single selected candidate in both configurations can emit `production_authorized: true`. DEBUG-only, legacy client-only, identity-unstable, mismatched, dropped, or disagreeing evidence remains non-authorizing. This authorizes investigation/implementation of exactly one candidate under the plan; it does not turn diagnostics into product authority or waive that candidate's before/after regression gates.
+
+## Reliability, parity, and selector rules
+
+A run is invalid for any of the following:
+
+- unexpected cancellation, timeout, transport closure, or missing/duplicate client trace;
+- any sample retained after a terminal event on the same connection;
+- active or dropped DEBUG or optimized-diagnostic capture data;
+- missing/duplicated request-identity lifecycle or delivery joins;
+- unidentified leaf/inclusive stage buckets or a successful request with no relevant stage bucket;
+- formatted/raw identity, block-shape, JSON-shape, or digest violations;
+- exact response baseline keys, bytes, counts, or DEBUG WI-3 work-count parity drift;
+- trace JSON containing forbidden payload field names.
+
+Expected timeout rows are isolated as terminal cohorts. Never interpret a fast transport failure as latency.
+
+`aggregate.json` reports request-level leaf P50/P95; every S0-S9 and C0-C2 boundary; inclusive envelopes; explicit remainders; S5-C2 attribution; the named S0→S9 eligibility denominator plus the separately reported S7→S9 boundary; stage-attribution completeness; and executed WI-3 evidence. A server-observed terminal event correlated to a retained request connection invalidates the capture even if the client appeared successful. The paired selector applies the plan thresholds independently to DEBUG and optimized exclusive request costs with real S0-S9 and optimized persistent C0-C2 denominators. It maps at most one dominant fully-qualified stage and authorizes it only when both configurations agree; analysis never edits production code.
+
+Exact Swift parity covers multi-file search ordering/gaps/omissions, duplicate groups, tree modes/markers, malformed workspace fallback, multi-block edit output, raw JSON, and the precise observer `Value`. Guardrails run `python3 Scripts/test_mcp_tool_latency.py` plus `python3 Scripts/test_mcp_latency_diagnostic_artifact.py`, covering deterministic fixtures, declared sampling, exact keyset parity, formatted/raw separation, connection invalidation, request-identity joins, repeated-span aggregation, selector refusal/authorization, WI-3 stamping, capture-drop rejection, isolated paths, exact target defines, and manifest hashes.


### PR DESCRIPTION
## Summary

- establish W0-W2 formatted/raw and Swift parity coverage for MCP read/search/tree/edit output, including deterministic matrix fixtures and exact response baselines
- add stable per-request attribution across client C0-C2, server S0-S9, stage/lifecycle buckets, transport delivery, connection generation, and WI-3 work-count evidence
- add coordinated segmented benchmark tooling for fixture generation, warm/cold collection, fresh/persistent clients, canonical per-row capture epochs, offline aggregation, and strict paired candidate selection
- add isolated DEBUG and release-optimized diagnostic artifact builders with sanitized manifests, fixed diagnostic identity, exact compile gates, source fingerprints, and no shared DebugApps install or lifecycle action
- document the maintained W0-W2 measurement contract, parity/invalidation rules, segmented evidence layout, operator-approved live sequence, and selector requirements

## Validation

- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- focused `CodexNativeSessionControllerGoalConfigTests.testAgentModeDefaultCarriesMemoriesOptInToProcessStartAndThreadStartResume`
- focused `GitBlobCapabilityBoundCatFileTests.testPromisorMissingObjectNeverInvokesRemoteHelper`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`
  - repository guardrails and outgoing-range secret scan
  - conductor selftests
  - Swift format/lint
  - full root test suite
  - `RepoPrompt` and `repoprompt-mcp` product builds
  - Xcode workspace generator tests and full workspace validation
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Scope

This PR contains only the W0-W2 measurement foundation. It includes **no W3-W7 production optimization or production candidate**; diagnostics and analysis do not modify production behavior or authorize an optimization without a future paired evidence result and separate implementation/review.
