### PR TITLE
Agent Mode: extract run-attempt lifecycle authority

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunAttemptLifecycle.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunAttemptLifecycle.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+// MARK: - App-host run-attempt lifecycle facade
+
+/// Single named owner of one tab-session's transient run-attempt lifecycle and
+/// terminal-settlement bookkeeping.
+///
+/// This type consolidates what used to be a stored field cluster on
+/// `AgentModeViewModel.TabSession` (run identity, the attempt tracker, provider
+/// drain generation, the terminal-commit phase flag, the settled terminal
+/// revision/publication result, and exactly-once terminal resources) behind
+/// named single-writer operations.
+///
+/// Authority boundaries:
+/// - Canonical durable lifecycle stays owned by `DomainAgentRunSessionStore`;
+///   this facade never publishes durable state and never makes settlement
+///   decisions.
+/// - `AgentRunTerminalCommitBarrier` remains the only settlement driver; the
+///   phased terminal-commit operations below exist so the barrier's observable
+///   ordering (revision staged before publication resolves; the in-progress
+///   flag cleared only after publication and teardown registration) stays
+///   representable across its suspension points.
+/// - Live tab/session binding remains owned by `TabSession`; binding currency
+///   validation composes this facade's attempt check with the session's own
+///   binding comparison.
+///
+/// The facade is provider-neutral and presentation-free: it must not touch
+/// transcript, UI, persistence, provider, or MCP state, must not launch tasks,
+/// and must not retain the barrier or hooks.
+@MainActor
+final class AgentRunAttemptLifecycle {
+    /// Atomic snapshot of the host-owned values captured when an attempt
+    /// begins. Carries no live session or provider references.
+    struct AttemptContext {
+        let tabID: UUID
+        let persistentSessionID: UUID?
+        let persistentBindingGeneration: UUID?
+        let bindingTransitionGeneration: UInt64
+        let turnEpoch: AgentRunTurnEpoch?
+
+        init(
+            tabID: UUID,
+            persistentSessionID: UUID?,
+            persistentBindingGeneration: UUID? = nil,
+            bindingTransitionGeneration: UInt64 = 0,
+            turnEpoch: AgentRunTurnEpoch? = nil
+        ) {
+            self.tabID = tabID
+            self.persistentSessionID = persistentSessionID
+            self.persistentBindingGeneration = persistentBindingGeneration
+            self.bindingTransitionGeneration = bindingTransitionGeneration
+            self.turnEpoch = turnEpoch
+        }
+    }
+
+    // MARK: Owned state (externally read-only)
+
+    private var tracker = AgentRunLifecycleTracker()
+
+    /// Provider process run identity for the active or most recent run.
+    private(set) var currentRunID: UUID?
+    private(set) var providerTerminalDrainGeneration: UInt64 = 0
+    private(set) var terminalCommitInProgress = false
+    private(set) var lastTerminalCommitRevision: AgentRunTerminalCommitRevision?
+    private(set) var lastTerminalPublicationResult: AgentRunTerminalPublicationResult?
+    private(set) var terminalResources: AgentRunAttemptTerminalResources?
+
+    var activeOwnership: AgentRunOwnership? {
+        tracker.activeOwnership
+    }
+
+    var liveness: AgentRunLivenessSnapshot? {
+        tracker.liveness
+    }
+
+    // MARK: Attempt lifecycle
+
+    /// Begins a new run attempt: resets the transient terminal-settlement state
+    /// and starts tracker ownership from the supplied context.
+    ///
+    /// Intentionally preserves `currentRunID`: the app host installs the fresh
+    /// process run identity before beginning the attempt.
+    @discardableResult
+    func beginAttempt(context: AttemptContext, attemptID: UUID = UUID()) -> AgentRunOwnership {
+        assert(
+            terminalResources == nil || terminalResources?.isClaimed == true,
+            "Beginning a run attempt with unclaimed terminal resources leaks the prior attempt's teardown"
+        )
+        terminalResources = nil
+        terminalCommitInProgress = false
+        lastTerminalCommitRevision = nil
+        lastTerminalPublicationResult = nil
+        providerTerminalDrainGeneration = 0
+        return tracker.begin(
+            tabID: context.tabID,
+            persistentSessionID: context.persistentSessionID,
+            persistentBindingGeneration: context.persistentBindingGeneration,
+            bindingTransitionGeneration: context.bindingTransitionGeneration,
+            attemptID: attemptID,
+            turnEpoch: context.turnEpoch
+        )
+    }
+
+    /// Ends tracker ownership only. Never clears the run ID, terminal revision,
+    /// publication result, or terminal resources implicitly.
+    @discardableResult
+    func endAttempt(ifCurrent ownership: AgentRunOwnership) -> Bool {
+        tracker.end(ifCurrent: ownership)
+    }
+
+    func isCurrentAttempt(_ ownership: AgentRunOwnership, expectedRunID: UUID? = nil) -> Bool {
+        guard activeOwnership == ownership else { return false }
+        if let expectedRunID {
+            return currentRunID == expectedRunID
+        }
+        return true
+    }
+
+    @discardableResult
+    func recordProgress(
+        ownership: AgentRunOwnership,
+        kind: AgentRunLivenessSignalKind,
+        stage: AgentRunLifecycleStage,
+        retryIntent: AgentRunRetryIntent = .none,
+        timestampUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) -> AgentRunProgressAcceptance {
+        tracker.record(
+            ownership: ownership,
+            kind: kind,
+            stage: stage,
+            retryIntent: retryIntent,
+            timestampUptimeNanoseconds: timestampUptimeNanoseconds
+        )
+    }
+
+    @discardableResult
+    func acceptProgress(_ signal: AgentRunProgressSignal) -> AgentRunProgressAcceptance {
+        tracker.accept(signal)
+    }
+
+    // MARK: Run identity
+
+    func installRunID(_ runID: UUID) {
+        currentRunID = runID
+    }
+
+    /// Clears the run ID only when it still matches the caller's run, so stale
+    /// provider cleanup cannot clear a successor run's identity.
+    @discardableResult
+    func clearRunID(ifCurrent runID: UUID) -> Bool {
+        guard currentRunID == runID else { return false }
+        currentRunID = nil
+        return true
+    }
+
+    func clearRunID() {
+        currentRunID = nil
+    }
+
+    // MARK: Provider terminal drain generation
+
+    func bumpProviderTerminalDrainGeneration() {
+        providerTerminalDrainGeneration &+= 1
+    }
+
+    // MARK: Terminal resources (exactly-once teardown)
+
+    func installTerminalResources(
+        ownership: AgentRunOwnership,
+        prepare: @escaping AgentRunAttemptTerminalResources.Prepare
+    ) {
+        guard isCurrentAttempt(ownership) else { return }
+        terminalResources = AgentRunAttemptTerminalResources(
+            ownership: ownership,
+            prepare: prepare
+        )
+    }
+
+    /// Claims the installed terminal teardown exactly once for the matching
+    /// ownership. A stale-ownership claim attempt leaves the resources
+    /// installed for the owning attempt.
+    func claimTerminalTeardown(
+        ownership: AgentRunOwnership,
+        terminalState: AgentSessionRunState
+    ) -> AgentRunAttemptTerminalResources.Teardown? {
+        guard let resources = terminalResources else { return nil }
+        let teardown = resources.claim(for: ownership, terminalState: terminalState)
+        if resources.isClaimed {
+            terminalResources = nil
+        }
+        return teardown
+    }
+
+    // MARK: Phased terminal commit
+
+    // The terminal commit is not one operation: a revision becomes visible
+    // before canonical publication resolves, and the in-progress flag clears
+    // only after publication and teardown registration. The phases below map
+    // one-to-one onto the barrier's existing mutation points and must not be
+    // collapsed.
+
+    /// Acquires the terminal-commit phase. Returns `false` when a commit is
+    /// already in progress.
+    @discardableResult
+    func beginTerminalCommit() -> Bool {
+        guard !terminalCommitInProgress else { return false }
+        terminalCommitInProgress = true
+        return true
+    }
+
+    /// Releases the phase after a post-acquisition validation failure without
+    /// touching the staged revision or publication result.
+    func abortTerminalCommit() {
+        terminalCommitInProgress = false
+    }
+
+    /// Stores the settled revision and clears the prior publication result.
+    /// Does not end the terminal-commit phase.
+    func stageTerminalRevision(_ revision: AgentRunTerminalCommitRevision) {
+        lastTerminalCommitRevision = revision
+        lastTerminalPublicationResult = nil
+    }
+
+    /// Records the canonical publication result. Intentionally unguarded: a
+    /// duplicate-commit retry records a result while no terminal commit is in
+    /// progress, and a binding transition may clear the revision while
+    /// publication is suspended.
+    func recordTerminalPublicationResult(_ result: AgentRunTerminalPublicationResult) {
+        lastTerminalPublicationResult = result
+    }
+
+    /// Ends the terminal-commit phase, preserving revision and result.
+    func completeTerminalCommit() {
+        terminalCommitInProgress = false
+    }
+
+    /// A rebind must not carry the runtime-only terminal classification or
+    /// publication result into another session. Clears only the revision and
+    /// result; ownership, run ID, drain generation, and any active
+    /// terminal-commit phase are preserved.
+    func invalidateTerminalRevisionForBindingTransition() {
+        lastTerminalCommitRevision = nil
+        lastTerminalPublicationResult = nil
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -150,11 +150,14 @@ final class AgentRunTerminalCommitBarrier {
         {
             recordRejection("duplicate_commit", request: request)
             if session.lastTerminalPublicationResult?.isResolved != true {
-                session.lastTerminalPublicationResult = await hooks.terminalSettlement.publishTerminalCommit(
+                // Duplicate retry: records a result while no terminal commit is
+                // in progress; the facade operation is intentionally unguarded.
+                let retriedResult = await hooks.terminalSettlement.publishTerminalCommit(
                     session,
                     existingRevision,
                     existingRevision.successorKind
                 )
+                session.runLifecycle.recordTerminalPublicationResult(retriedResult)
             }
             if let followUpInstruction = takeQueuedFollowUpIfReady(
                 session: session,
@@ -190,11 +193,12 @@ final class AgentRunTerminalCommitBarrier {
         }
         let terminalTurnID = session.items.last(where: { $0.kind == .user })?.id
 
-        session.terminalCommitInProgress = true
+        let acquiredTerminalCommitPhase = session.runLifecycle.beginTerminalCommit()
+        assert(acquiredTerminalCommitPhase, "Terminal commit phase acquisition must succeed after the in-progress guard")
         recordTerminalBarrierState(true, request: request)
         hooks.transcript.flushPendingAssistantDelta(session)
         guard validatesOwnership(request) else {
-            session.terminalCommitInProgress = false
+            session.runLifecycle.abortTerminalCommit()
             recordTerminalBarrierState(false, request: request)
             recordRejection("ownership_changed_during_drain", request: request)
             return nil
@@ -250,7 +254,7 @@ final class AgentRunTerminalCommitBarrier {
               session.providerTerminalDrainGeneration == request.providerDrainGeneration,
               request.providerBuffersAreDrained()
         else {
-            session.terminalCommitInProgress = false
+            session.runLifecycle.abortTerminalCommit()
             recordTerminalBarrierState(false, request: request)
             recordRejection("ownership_or_drain_changed_before_commit", request: request)
             return nil
@@ -312,19 +316,19 @@ final class AgentRunTerminalCommitBarrier {
             successorKind: successorKind,
             providerSuccessorID: providerSuccessor?.id
         )
-        session.lastTerminalCommitRevision = revision
-        session.lastTerminalPublicationResult = nil
+        session.runLifecycle.stageTerminalRevision(revision)
 
         hooks.bindingObservation.updateBindings(session)
         if request.notifyTurnComplete {
             hooks.presentation.notifyAgentTurnComplete(session)
         }
         hooks.persistence.scheduleSave(session.tabID)
-        session.lastTerminalPublicationResult = await hooks.terminalSettlement.publishTerminalCommit(
+        let publicationResult = await hooks.terminalSettlement.publishTerminalCommit(
             session,
             revision,
             successorKind
         )
+        session.runLifecycle.recordTerminalPublicationResult(publicationResult)
         let followUpInstruction = takeQueuedFollowUpIfReady(
             session: session,
             revision: revision,
@@ -344,7 +348,7 @@ final class AgentRunTerminalCommitBarrier {
             ownership: request.ownership,
             tabID: session.tabID
         )
-        session.terminalCommitInProgress = false
+        session.runLifecycle.completeTerminalCommit()
         recordTerminalBarrierState(false, request: request)
         request.postCommit()
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -6544,7 +6544,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         finalizePendingToolCalls(in: session, turnStatus: turnStatus)
         finalizeLingeringRunningCommandExecutionResults(in: session, turnStatus: turnStatus)
         reconcilePersistedCodexCommandStatusIfNeeded(session: session, force: true)
-        session.providerTerminalDrainGeneration &+= 1
+        session.bumpProviderTerminalDrainGeneration()
     }
 
     private func finalizeCodexRun(

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
@@ -64,7 +64,7 @@ final class HeadlessAgentModeRunner {
                 notifyTurnComplete: false,
                 prepareProviderState: {
                     session.provider = nil
-                    session.runID = nil
+                    session.clearRunID(ifCurrent: runID)
                     return nil
                 }
             ))
@@ -80,9 +80,7 @@ final class HeadlessAgentModeRunner {
         session.provider = provider
         session.installRunAttemptTerminalResources(ownership: ownership) { terminalState in
             session.provider = nil
-            if session.runID == runID {
-                session.runID = nil
-            }
+            session.clearRunID(ifCurrent: runID)
             return {
                 switch terminalState {
                 case .failed:
@@ -151,7 +149,7 @@ final class HeadlessAgentModeRunner {
             notifyTurnComplete: false,
             prepareProviderState: {
                 session.provider = nil
-                session.runID = nil
+                session.clearRunID(ifCurrent: runID)
                 return nil
             }
         ))
@@ -208,7 +206,7 @@ final class HeadlessAgentModeRunner {
                 notifyTurnComplete: true,
                 prepareProviderState: {
                     session.provider = nil
-                    session.runID = nil
+                    session.clearRunID(ifCurrent: runID)
                     return nil
                 }
             ))
@@ -230,7 +228,7 @@ final class HeadlessAgentModeRunner {
                 notifyTurnComplete: false,
                 prepareProviderState: {
                     session.provider = nil
-                    session.runID = nil
+                    session.clearRunID(ifCurrent: runID)
                     return nil
                 }
             ))
@@ -253,7 +251,7 @@ final class HeadlessAgentModeRunner {
                 notifyTurnComplete: false,
                 prepareProviderState: {
                     session.provider = nil
-                    session.runID = nil
+                    session.clearRunID(ifCurrent: runID)
                     return nil
                 }
             ))

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -418,11 +418,32 @@ extension AgentModeViewModel {
         var instructionTimeoutTask: Task<Void, Never>?
         var instructionWaitID: UUID?
 
-        // Agent run
-        var runID: UUID?
-        private(set) var runLifecycleTracker = AgentRunLifecycleTracker()
+        /// Agent run — transient run-attempt lifecycle/settlement state is owned by
+        /// the extracted `AgentRunAttemptLifecycle` facade. The properties below are
+        /// stable forwarders so existing call sites keep working; mutation happens
+        /// through the facade's named operations.
+        let runLifecycle = AgentRunAttemptLifecycle()
+
+        var runID: UUID? {
+            get { runLifecycle.currentRunID }
+            set {
+                if let newValue {
+                    runLifecycle.installRunID(newValue)
+                } else {
+                    runLifecycle.clearRunID()
+                }
+            }
+        }
+
+        /// Clears the run ID only when it still matches the caller's run, so a
+        /// stale cleanup cannot clear a successor run's identity.
+        @discardableResult
+        func clearRunID(ifCurrent runID: UUID) -> Bool {
+            runLifecycle.clearRunID(ifCurrent: runID)
+        }
+
         var activeRunOwnership: AgentRunOwnership? {
-            runLifecycleTracker.activeOwnership
+            runLifecycle.activeOwnership
         }
 
         var activeRunAttemptID: UUID? {
@@ -430,7 +451,7 @@ extension AgentModeViewModel {
         }
 
         var activeRunLiveness: AgentRunLivenessSnapshot? {
-            runLifecycleTracker.liveness
+            runLifecycle.liveness
         }
 
         var provider: HeadlessAgentProvider?
@@ -539,11 +560,30 @@ extension AgentModeViewModel {
         var assistantDeltaFlushTask: Task<Void, Never>?
         var assistantDeltaTaskGeneration: UInt64 = 0
         var assistantDeltaFlushGeneration: UInt64 = 0
-        var providerTerminalDrainGeneration: UInt64 = 0
-        var terminalCommitInProgress: Bool = false
-        var lastTerminalCommitRevision: AgentRunTerminalCommitRevision?
-        var lastTerminalPublicationResult: AgentRunTerminalPublicationResult?
-        var runAttemptTerminalResources: AgentRunAttemptTerminalResources?
+        var providerTerminalDrainGeneration: UInt64 {
+            runLifecycle.providerTerminalDrainGeneration
+        }
+
+        func bumpProviderTerminalDrainGeneration() {
+            runLifecycle.bumpProviderTerminalDrainGeneration()
+        }
+
+        var terminalCommitInProgress: Bool {
+            runLifecycle.terminalCommitInProgress
+        }
+
+        var lastTerminalCommitRevision: AgentRunTerminalCommitRevision? {
+            runLifecycle.lastTerminalCommitRevision
+        }
+
+        var lastTerminalPublicationResult: AgentRunTerminalPublicationResult? {
+            runLifecycle.lastTerminalPublicationResult
+        }
+
+        var runAttemptTerminalResources: AgentRunAttemptTerminalResources? {
+            runLifecycle.terminalResources
+        }
+
         /// Handoff payload (injected into provider-facing text on first user send).
         /// Cleared only after the provider accepts the turn.
         var pendingHandoff: PendingHandoffState = .init()
@@ -652,8 +692,7 @@ extension AgentModeViewModel {
             // Terminal commit revisions are scoped to the binding captured by
             // their run ownership. A rebind must not carry that runtime-only
             // classification or publication result into another session.
-            lastTerminalCommitRevision = nil
-            lastTerminalPublicationResult = nil
+            runLifecycle.invalidateTerminalRevisionForBindingTransition()
             authoritativeHydratedBinding = nil
             authoritativeHydratedBindingTransitionGeneration = nil
             return bindingTransitionGeneration
@@ -718,33 +757,22 @@ extension AgentModeViewModel {
             ownership: AgentRunOwnership,
             prepare: @escaping AgentRunAttemptTerminalResources.Prepare
         ) {
-            guard isCurrentRunAttempt(ownership) else { return }
-            runAttemptTerminalResources = AgentRunAttemptTerminalResources(
-                ownership: ownership,
-                prepare: prepare
-            )
+            runLifecycle.installTerminalResources(ownership: ownership, prepare: prepare)
         }
 
         func claimRunAttemptTerminalTeardown(
             ownership: AgentRunOwnership,
             terminalState: AgentSessionRunState
         ) -> AgentRunAttemptTerminalResources.Teardown? {
-            guard let resources = runAttemptTerminalResources else { return nil }
-            let teardown = resources.claim(for: ownership, terminalState: terminalState)
-            if resources.isClaimed {
-                runAttemptTerminalResources = nil
-            }
-            return teardown
+            runLifecycle.claimTerminalTeardown(ownership: ownership, terminalState: terminalState)
         }
 
         @discardableResult
         func beginRunAttempt(source: String, attemptID: UUID = UUID()) -> AgentRunOwnership {
-            assert(runAttemptTerminalResources == nil || runAttemptTerminalResources?.isClaimed == true)
-            runAttemptTerminalResources = nil
-            terminalCommitInProgress = false
-            lastTerminalCommitRevision = nil
-            lastTerminalPublicationResult = nil
-            providerTerminalDrainGeneration = 0
+            // Host-specific responsibilities stay here: Codex routing resets and
+            // exactly-once MCP prepared-epoch consumption. The neutral attempt
+            // initialization (terminal-state reset + tracker begin) is delegated
+            // to the facade, which preserves the installed run ID.
             codexAuthoritativeActiveTurn = nil
             codexAnonymousActiveTurn = nil
             codexRoutingObservedTurnID = nil
@@ -757,13 +785,15 @@ extension AgentModeViewModel {
                     mcpControlContext = context
                 }
             }
-            let ownership = runLifecycleTracker.begin(
-                tabID: tabID,
-                persistentSessionID: activeAgentSessionID,
-                persistentBindingGeneration: persistentSessionBindingIdentity?.generation,
-                bindingTransitionGeneration: bindingTransitionGeneration,
-                attemptID: attemptID,
-                turnEpoch: turnEpoch
+            let ownership = runLifecycle.beginAttempt(
+                context: .init(
+                    tabID: tabID,
+                    persistentSessionID: activeAgentSessionID,
+                    persistentBindingGeneration: persistentSessionBindingIdentity?.generation,
+                    bindingTransitionGeneration: bindingTransitionGeneration,
+                    turnEpoch: turnEpoch
+                ),
+                attemptID: attemptID
             )
             #if DEBUG
                 AgentModePerfDiagnostics.increment("run.lifecycle.attempt.started")
@@ -785,11 +815,7 @@ extension AgentModeViewModel {
         }
 
         func isCurrentRunAttempt(_ ownership: AgentRunOwnership, expectedRunID: UUID? = nil) -> Bool {
-            guard activeRunOwnership == ownership else { return false }
-            if let expectedRunID {
-                return runID == expectedRunID
-            }
-            return true
+            runLifecycle.isCurrentAttempt(ownership, expectedRunID: expectedRunID)
         }
 
         func isCurrentRunAttemptForCurrentBinding(
@@ -812,7 +838,7 @@ extension AgentModeViewModel {
             retryIntent: AgentRunRetryIntent = .none,
             timestampUptimeNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds
         ) -> AgentRunProgressAcceptance {
-            let result = runLifecycleTracker.record(
+            let result = runLifecycle.recordProgress(
                 ownership: ownership,
                 kind: kind,
                 stage: stage,
@@ -825,14 +851,14 @@ extension AgentModeViewModel {
 
         @discardableResult
         func acceptRunProgress(_ signal: AgentRunProgressSignal) -> AgentRunProgressAcceptance {
-            let result = runLifecycleTracker.accept(signal)
+            let result = runLifecycle.acceptProgress(signal)
             recordRunProgressDiagnostic(result, kind: signal.kind, stage: signal.stage)
             return result
         }
 
         @discardableResult
         func endRunAttempt(ifCurrent ownership: AgentRunOwnership, source: String) -> Bool {
-            guard runLifecycleTracker.end(ifCurrent: ownership) else { return false }
+            guard runLifecycle.endAttempt(ifCurrent: ownership) else { return false }
             recordRunAttemptEnded(ownership, source: source)
             return true
         }
@@ -840,7 +866,7 @@ extension AgentModeViewModel {
         @discardableResult
         func endCurrentRunAttempt(source: String) -> Bool {
             guard let ownership = activeRunOwnership else { return false }
-            guard runLifecycleTracker.end(ifCurrent: ownership) else { return false }
+            guard runLifecycle.endAttempt(ifCurrent: ownership) else { return false }
             recordRunAttemptEnded(ownership, source: source)
             return true
         }

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -690,7 +690,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         XCTAssertEqual(envelope.snapshot.status, .failed)
         XCTAssertEqual(envelope.snapshot.failureReason, .processCrash)
 
-        session.lastTerminalCommitRevision = AgentRunTerminalCommitRevision(
+        session.runLifecycle.stageTerminalRevision(AgentRunTerminalCommitRevision(
             commitID: UUID(),
             ownership: ownership,
             terminalState: .failed,
@@ -702,7 +702,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             mcpPublicationEnvelope: nil,
             successorKind: nil,
             providerSuccessorID: nil
-        )
+        ))
         let livePoll = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
         XCTAssertEqual(livePoll.status, .failed)
         XCTAssertEqual(livePoll.statusText, "Run timed out waiting for the provider")
@@ -732,7 +732,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         )
         session.runState = .failed
         XCTAssertTrue(session.endRunAttempt(ifCurrent: ownership, source: "test.bindingTransitionFailureStamp"))
-        session.lastTerminalCommitRevision = AgentRunTerminalCommitRevision(
+        session.runLifecycle.stageTerminalRevision(AgentRunTerminalCommitRevision(
             commitID: UUID(),
             ownership: ownership,
             terminalState: .failed,
@@ -744,8 +744,8 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             mcpPublicationEnvelope: nil,
             successorKind: nil,
             providerSuccessorID: nil
-        )
-        session.lastTerminalPublicationResult = .accepted(successorEpoch: nil)
+        ))
+        session.runLifecycle.recordTerminalPublicationResult(.accepted(successorEpoch: nil))
 
         let originalBinding = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
         XCTAssertEqual(originalBinding.failureReason, .processCrash)
@@ -789,7 +789,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         XCTAssertEqual(restored.status, .failed)
         XCTAssertEqual(restored.failureReason, .timeout)
 
-        session.lastTerminalCommitRevision = AgentRunTerminalCommitRevision(
+        session.runLifecycle.stageTerminalRevision(AgentRunTerminalCommitRevision(
             commitID: UUID(),
             ownership: ownership,
             terminalState: .failed,
@@ -801,7 +801,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             mcpPublicationEnvelope: nil,
             successorKind: nil,
             providerSuccessorID: nil
-        )
+        ))
         let unrelatedAttempt = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
         XCTAssertEqual(unrelatedAttempt.failureReason, .timeout)
         await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -733,7 +733,10 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         session.runID = UUID()
         session.runState = .running
         let codexOwnership = session.beginRunAttempt(source: "test.codex")
-        session.providerTerminalDrainGeneration = 4
+        for _ in 0 ..< 4 {
+            session.bumpProviderTerminalDrainGeneration()
+        }
+        XCTAssertEqual(session.providerTerminalDrainGeneration, 4)
         _ = session.endRunAttempt(ifCurrent: codexOwnership, source: "test.rotate")
 
         let claudeOwnership = session.beginRunAttempt(source: "test.claude")

--- a/Tests/RepoPromptTests/AgentMode/AgentRunAttemptLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentRunAttemptLifecycleTests.swift
@@ -1,0 +1,371 @@
+import Foundation
+import XCTest
+@_spi(TestSupport) @testable import RepoPromptApp
+
+/// Deterministic unit coverage for the extracted app-host run-attempt
+/// lifecycle facade, plus characterization of the `TabSession` forwarding
+/// behavior the facade must preserve (run-ID survival across attempt begin,
+/// binding-transition invalidation scope, and drain-generation reset).
+@MainActor
+final class AgentRunAttemptLifecycleTests: XCTestCase {
+    private func makeContext(
+        tabID: UUID = UUID(),
+        persistentSessionID: UUID? = nil,
+        bindingTransitionGeneration: UInt64 = 0
+    ) -> AgentRunAttemptLifecycle.AttemptContext {
+        AgentRunAttemptLifecycle.AttemptContext(
+            tabID: tabID,
+            persistentSessionID: persistentSessionID,
+            persistentBindingGeneration: nil,
+            bindingTransitionGeneration: bindingTransitionGeneration,
+            turnEpoch: nil
+        )
+    }
+
+    private func makeRevision(
+        ownership: AgentRunOwnership,
+        expectedRunID: UUID? = nil
+    ) -> AgentRunTerminalCommitRevision {
+        AgentRunTerminalCommitRevision(
+            commitID: UUID(),
+            ownership: ownership,
+            terminalState: .completed,
+            failureReason: nil,
+            expectedRunID: expectedRunID,
+            sourceItemsRevision: 0,
+            assistantDeltaFlushGeneration: 0,
+            providerDrainGeneration: 0,
+            mcpPublicationEnvelope: nil,
+            successorKind: nil,
+            providerSuccessorID: nil
+        )
+    }
+
+    // MARK: - Attempt begin/end
+
+    func testBeginAttemptCapturesContextResetsTerminalStateAndPreservesRunID() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let tabID = UUID()
+        let persistentSessionID = UUID()
+        let runID = UUID()
+
+        lifecycle.installRunID(runID)
+        lifecycle.bumpProviderTerminalDrainGeneration()
+        let staleOwnership = lifecycle.beginAttempt(context: makeContext(tabID: tabID))
+        lifecycle.stageTerminalRevision(makeRevision(ownership: staleOwnership))
+        lifecycle.recordTerminalPublicationResult(.accepted(successorEpoch: nil))
+        XCTAssertTrue(lifecycle.beginTerminalCommit())
+        lifecycle.completeTerminalCommit()
+        lifecycle.bumpProviderTerminalDrainGeneration()
+
+        let ownership = lifecycle.beginAttempt(
+            context: makeContext(
+                tabID: tabID,
+                persistentSessionID: persistentSessionID,
+                bindingTransitionGeneration: 3
+            )
+        )
+
+        XCTAssertEqual(ownership.binding.tabID, tabID)
+        XCTAssertEqual(ownership.binding.persistentSessionID, persistentSessionID)
+        XCTAssertEqual(ownership.binding.bindingTransitionGeneration, 3)
+        XCTAssertEqual(lifecycle.activeOwnership, ownership)
+        XCTAssertEqual(lifecycle.liveness?.stage, .starting)
+        // The run ID installed before the attempt begins must survive.
+        XCTAssertEqual(lifecycle.currentRunID, runID)
+        // The transient terminal-settlement cluster resets.
+        XCTAssertEqual(lifecycle.providerTerminalDrainGeneration, 0)
+        XCTAssertFalse(lifecycle.terminalCommitInProgress)
+        XCTAssertNil(lifecycle.lastTerminalCommitRevision)
+        XCTAssertNil(lifecycle.lastTerminalPublicationResult)
+        XCTAssertNil(lifecycle.terminalResources)
+    }
+
+    func testEndAttemptOnlyEndsMatchingOwnershipAndPreservesSettledState() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let runID = UUID()
+        lifecycle.installRunID(runID)
+        let ownership = lifecycle.beginAttempt(context: makeContext())
+        let revision = makeRevision(ownership: ownership)
+        lifecycle.stageTerminalRevision(revision)
+        lifecycle.recordTerminalPublicationResult(.accepted(successorEpoch: nil))
+
+        let staleOwnership = AgentRunOwnership(
+            binding: AgentRunBindingIdentity(tabID: UUID(), persistentSessionID: nil)
+        )
+        XCTAssertFalse(lifecycle.endAttempt(ifCurrent: staleOwnership))
+        XCTAssertEqual(lifecycle.activeOwnership, ownership)
+
+        XCTAssertTrue(lifecycle.endAttempt(ifCurrent: ownership))
+        XCTAssertNil(lifecycle.activeOwnership)
+        XCTAssertNil(lifecycle.liveness)
+        // Ending the attempt never implicitly clears settled/terminal state.
+        XCTAssertEqual(lifecycle.currentRunID, runID)
+        XCTAssertEqual(lifecycle.lastTerminalCommitRevision, revision)
+        XCTAssertEqual(lifecycle.lastTerminalPublicationResult, .accepted(successorEpoch: nil))
+    }
+
+    func testIsCurrentAttemptValidatesOwnershipAndExpectedRunID() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let runID = UUID()
+        lifecycle.installRunID(runID)
+        let ownership = lifecycle.beginAttempt(context: makeContext())
+
+        XCTAssertTrue(lifecycle.isCurrentAttempt(ownership))
+        XCTAssertTrue(lifecycle.isCurrentAttempt(ownership, expectedRunID: runID))
+        XCTAssertFalse(lifecycle.isCurrentAttempt(ownership, expectedRunID: UUID()))
+
+        let foreignOwnership = AgentRunOwnership(
+            binding: AgentRunBindingIdentity(tabID: UUID(), persistentSessionID: nil)
+        )
+        XCTAssertFalse(lifecycle.isCurrentAttempt(foreignOwnership))
+        XCTAssertFalse(lifecycle.isCurrentAttempt(foreignOwnership, expectedRunID: runID))
+    }
+
+    // MARK: - Progress passthrough
+
+    func testProgressPassthroughAcceptsCurrentAndRejectsStaleOwnership() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let ownership = lifecycle.beginAttempt(context: makeContext())
+        // The tracker stamps `begin` with the current uptime clock, so progress
+        // timestamps must be later than that baseline to stay monotonic.
+        let base = DispatchTime.now().uptimeNanoseconds
+
+        let accepted = lifecycle.recordProgress(
+            ownership: ownership,
+            kind: .stageTransition,
+            stage: .running,
+            timestampUptimeNanoseconds: base + 10
+        )
+        guard case let .accepted(snapshot) = accepted else {
+            return XCTFail("Expected accepted progress, got \(accepted)")
+        }
+        XCTAssertEqual(snapshot.stage, .running)
+        XCTAssertEqual(snapshot.lastRealProgressUptimeNanoseconds, base + 10)
+
+        let staleOwnership = AgentRunOwnership(
+            binding: AgentRunBindingIdentity(tabID: UUID(), persistentSessionID: nil)
+        )
+        let rejected = lifecycle.recordProgress(
+            ownership: staleOwnership,
+            kind: .providerEvent,
+            stage: .running,
+            timestampUptimeNanoseconds: base + 20
+        )
+        guard case .rejected(.staleOwnership) = rejected else {
+            return XCTFail("Expected staleOwnership rejection, got \(rejected)")
+        }
+        XCTAssertEqual(lifecycle.liveness?.stage, .running)
+    }
+
+    func testHeartbeatProgressDoesNotAdvanceRealProgressTimestamp() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let ownership = lifecycle.beginAttempt(context: makeContext())
+        // The tracker stamps `begin` with the current uptime clock, so progress
+        // timestamps must be later than that baseline to stay monotonic.
+        let base = DispatchTime.now().uptimeNanoseconds
+        _ = lifecycle.recordProgress(
+            ownership: ownership,
+            kind: .providerEvent,
+            stage: .running,
+            timestampUptimeNanoseconds: base + 10
+        )
+        let heartbeat = lifecycle.recordProgress(
+            ownership: ownership,
+            kind: .heartbeat,
+            stage: .running,
+            timestampUptimeNanoseconds: base + 30
+        )
+        guard case let .accepted(snapshot) = heartbeat else {
+            return XCTFail("Expected accepted heartbeat, got \(heartbeat)")
+        }
+        XCTAssertEqual(snapshot.lastRealProgressUptimeNanoseconds, base + 10)
+        XCTAssertEqual(snapshot.lastHeartbeatUptimeNanoseconds, base + 30)
+        XCTAssertEqual(snapshot.lastSignalUptimeNanoseconds, base + 30)
+    }
+
+    // MARK: - Run identity
+
+    func testClearRunIDIfCurrentIsStaleSafe() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let firstRunID = UUID()
+        lifecycle.installRunID(firstRunID)
+
+        // A successor run replaces the identity before the stale cleanup runs.
+        let successorRunID = UUID()
+        lifecycle.installRunID(successorRunID)
+
+        XCTAssertFalse(lifecycle.clearRunID(ifCurrent: firstRunID))
+        XCTAssertEqual(lifecycle.currentRunID, successorRunID)
+
+        XCTAssertTrue(lifecycle.clearRunID(ifCurrent: successorRunID))
+        XCTAssertNil(lifecycle.currentRunID)
+
+        lifecycle.installRunID(firstRunID)
+        lifecycle.clearRunID()
+        XCTAssertNil(lifecycle.currentRunID)
+    }
+
+    // MARK: - Terminal resources
+
+    func testTerminalResourcesInstallRequiresCurrentOwnershipAndClaimIsExactlyOnce() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let ownership = lifecycle.beginAttempt(context: makeContext())
+        let staleOwnership = AgentRunOwnership(
+            binding: AgentRunBindingIdentity(tabID: UUID(), persistentSessionID: nil)
+        )
+
+        lifecycle.installTerminalResources(ownership: staleOwnership) { _ in nil }
+        XCTAssertNil(lifecycle.terminalResources)
+
+        var preparedStates: [AgentSessionRunState] = []
+        var teardownRuns = 0
+        lifecycle.installTerminalResources(ownership: ownership) { terminalState in
+            preparedStates.append(terminalState)
+            return { teardownRuns += 1 }
+        }
+        XCTAssertNotNil(lifecycle.terminalResources)
+
+        // A stale-ownership claim leaves the resources installed for the owner.
+        XCTAssertNil(lifecycle.claimTerminalTeardown(ownership: staleOwnership, terminalState: .cancelled))
+        XCTAssertNotNil(lifecycle.terminalResources)
+        XCTAssertEqual(preparedStates, [])
+
+        let teardown = lifecycle.claimTerminalTeardown(ownership: ownership, terminalState: .failed)
+        XCTAssertNotNil(teardown)
+        XCTAssertEqual(preparedStates, [.failed])
+        XCTAssertNil(lifecycle.terminalResources)
+        // Claiming prepares but never executes the teardown.
+        XCTAssertEqual(teardownRuns, 0)
+
+        // A second claim finds nothing.
+        XCTAssertNil(lifecycle.claimTerminalTeardown(ownership: ownership, terminalState: .failed))
+    }
+
+    // MARK: - Phased terminal commit
+
+    func testTerminalCommitPhaseIsExclusiveAndPhasesAreIndependent() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let ownership = lifecycle.beginAttempt(context: makeContext())
+
+        XCTAssertTrue(lifecycle.beginTerminalCommit())
+        XCTAssertFalse(lifecycle.beginTerminalCommit(), "Only one terminal commit phase may be active")
+
+        let revision = makeRevision(ownership: ownership)
+        lifecycle.recordTerminalPublicationResult(.rejected(reason: "prior"))
+        lifecycle.stageTerminalRevision(revision)
+        XCTAssertEqual(lifecycle.lastTerminalCommitRevision, revision)
+        XCTAssertNil(
+            lifecycle.lastTerminalPublicationResult,
+            "Staging a revision clears the prior publication result"
+        )
+        XCTAssertTrue(lifecycle.terminalCommitInProgress, "Staging must not end the commit phase")
+
+        lifecycle.recordTerminalPublicationResult(.accepted(successorEpoch: nil))
+        XCTAssertTrue(lifecycle.terminalCommitInProgress, "Recording a result must not end the commit phase")
+
+        lifecycle.completeTerminalCommit()
+        XCTAssertFalse(lifecycle.terminalCommitInProgress)
+        XCTAssertEqual(lifecycle.lastTerminalCommitRevision, revision)
+        XCTAssertEqual(lifecycle.lastTerminalPublicationResult, .accepted(successorEpoch: nil))
+    }
+
+    func testAbortTerminalCommitClearsOnlyThePhaseFlag() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let ownership = lifecycle.beginAttempt(context: makeContext())
+        let revision = makeRevision(ownership: ownership)
+        lifecycle.stageTerminalRevision(revision)
+        lifecycle.recordTerminalPublicationResult(.stale)
+        XCTAssertTrue(lifecycle.beginTerminalCommit())
+
+        lifecycle.abortTerminalCommit()
+
+        XCTAssertFalse(lifecycle.terminalCommitInProgress)
+        XCTAssertEqual(lifecycle.lastTerminalCommitRevision, revision)
+        XCTAssertEqual(lifecycle.lastTerminalPublicationResult, .stale)
+    }
+
+    func testBindingTransitionInvalidationClearsOnlyRevisionAndResult() {
+        let lifecycle = AgentRunAttemptLifecycle()
+        let runID = UUID()
+        lifecycle.installRunID(runID)
+        let ownership = lifecycle.beginAttempt(context: makeContext())
+        lifecycle.bumpProviderTerminalDrainGeneration()
+        lifecycle.stageTerminalRevision(makeRevision(ownership: ownership))
+        lifecycle.recordTerminalPublicationResult(.accepted(successorEpoch: nil))
+        XCTAssertTrue(lifecycle.beginTerminalCommit())
+
+        lifecycle.invalidateTerminalRevisionForBindingTransition()
+
+        XCTAssertNil(lifecycle.lastTerminalCommitRevision)
+        XCTAssertNil(lifecycle.lastTerminalPublicationResult)
+        XCTAssertEqual(lifecycle.activeOwnership, ownership)
+        XCTAssertEqual(lifecycle.currentRunID, runID)
+        XCTAssertEqual(lifecycle.providerTerminalDrainGeneration, 1)
+        XCTAssertTrue(
+            lifecycle.terminalCommitInProgress,
+            "Rebind invalidation must not release an in-flight terminal commit phase"
+        )
+
+        // Characterize the existing reentrant order: a publication result
+        // recorded after invalidation is stored without restoring the revision.
+        lifecycle.recordTerminalPublicationResult(.rejected(reason: "activation_replaced"))
+        XCTAssertNil(lifecycle.lastTerminalCommitRevision)
+        XCTAssertEqual(lifecycle.lastTerminalPublicationResult, .rejected(reason: "activation_replaced"))
+    }
+
+    // MARK: - TabSession forwarding characterization
+
+    func testTabSessionBeginRunAttemptPreservesRunIDAndResetsDrainGeneration() {
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        let runID = UUID()
+        session.runID = runID
+
+        let first = session.beginRunAttempt(source: "test.forwarding")
+        for _ in 0 ..< 3 {
+            session.bumpProviderTerminalDrainGeneration()
+        }
+        XCTAssertEqual(session.providerTerminalDrainGeneration, 3)
+        XCTAssertTrue(session.isCurrentRunAttempt(first, expectedRunID: runID))
+        XCTAssertTrue(session.endRunAttempt(ifCurrent: first, source: "test.forwarding"))
+
+        let second = session.beginRunAttempt(source: "test.forwarding")
+        XCTAssertEqual(session.providerTerminalDrainGeneration, 0)
+        XCTAssertEqual(session.runID, runID, "beginRunAttempt must preserve the installed run ID")
+        XCTAssertEqual(session.activeRunAttemptID, second.attemptID)
+        XCTAssertNotEqual(first.attemptID, second.attemptID)
+    }
+
+    func testTabSessionPersistentBindingTransitionInvalidatesSettledRevisionOnly() {
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        let runID = UUID()
+        session.runID = runID
+        let ownership = session.beginRunAttempt(source: "test.rebind")
+        session.runLifecycle.stageTerminalRevision(makeRevision(ownership: ownership, expectedRunID: runID))
+        session.runLifecycle.recordTerminalPublicationResult(.accepted(successorEpoch: nil))
+
+        _ = session.beginPersistentBindingTransition()
+
+        XCTAssertNil(session.lastTerminalCommitRevision)
+        XCTAssertNil(session.lastTerminalPublicationResult)
+        XCTAssertEqual(session.runID, runID)
+        XCTAssertEqual(session.activeRunOwnership, ownership)
+        XCTAssertFalse(
+            session.isCurrentRunAttemptForCurrentBinding(ownership),
+            "An in-progress binding transition must reject binding-scoped currency"
+        )
+    }
+
+    func testTabSessionClearRunIDIfCurrentDoesNotClearSuccessorRun() {
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        let firstRunID = UUID()
+        session.runID = firstRunID
+        let successorRunID = UUID()
+        session.runID = successorRunID
+
+        XCTAssertFalse(session.clearRunID(ifCurrent: firstRunID))
+        XCTAssertEqual(session.runID, successorRunID)
+        XCTAssertTrue(session.clearRunID(ifCurrent: successorRunID))
+        XCTAssertNil(session.runID)
+    }
+}


### PR DESCRIPTION
## Summary

- extract the app-host transient run-attempt state cluster from `AgentModeViewModel.TabSession` into a provider-neutral `AgentRunAttemptLifecycle` owner
- preserve `DomainAgentRunSessionStore` as the sole durable authority and `AgentRunTerminalCommitBarrier` as the sole settlement driver
- replace direct terminal-settlement mutations with explicit phased operations that preserve duplicate-publication, rebind, teardown, and suspension ordering
- make headless runner run-ID cleanup stale-safe without changing persisted or wire formats
- add deterministic facade and forwarding characterization coverage

## Architecture boundaries

This is a bounded modular-monolith seam, not a second runtime:

- no new package or target
- no hook-signature neutralization
- no direct-headless provider rewrite
- no persistence or MCP wire changes
- no protocol that hides/downcasts `TabSession`
- no UI redesign

`DomainAgentRunSessionStore` remains canonical for durable session lifecycle. The new facade owns only transient app-host attempt state; the terminal barrier still decides and sequences settlement.

## Validation

- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-format-check` — 0/1466 files require formatting
- `make dev-lint` — SwiftFormat + SwiftLint strict passed
- `AgentRunAttemptLifecycleTests` — 13/13 passed
- `AgentModeMCPWaitEpochTests` — 16/16 passed
- `AgentModeRunServiceLifecycleTests` — 34/35 in combined run; sole fake-ACP bootstrap timeout passed in isolation in 2.76s, with no timeout/assertion weakening
- mandatory commit and push contribution preflights passed
- independent Claude Fable 5 High review completed with no blocking findings

## Follow-ups intentionally deferred

- migrate remaining coordinator/service unconditional `runID = nil` sites to stale-safe operations, then remove the compatibility setter
- narrow terminal-phase API visibility further when the next module seam makes that boundary enforceable

These are staged cleanup opportunities, not parallel authorities or correctness regressions introduced here.