### PR TITLE
Make agent run identity teardown stale-safe

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeProcessRunIdentity.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeProcessRunIdentity.swift
@@ -34,11 +34,28 @@ enum AgentModeProcessRunIdentity {
 
     static func startFreshProcessRun(for session: AgentModeViewModel.TabSession) -> UUID {
         let runID = UUID()
-        session.runID = runID
+        session.installRunID(runID)
         return runID
     }
 
+    /// Returns the live process run ID, installing a fresh one when none is
+    /// present. Use on start/resume paths that reuse an in-flight identity.
+    static func ensureProcessRunID(for session: AgentModeViewModel.TabSession) -> UUID {
+        if let existing = session.runID {
+            return existing
+        }
+        return startFreshProcessRun(for: session)
+    }
+
+    /// Host-authoritative force reset: unconditionally clears whatever run
+    /// identity is present, including a successor's. Reserved for transitions
+    /// whose contract is "no run may survive" (tab/window close, session
+    /// delete, provider identity change, workspace switch, execution-location
+    /// change, user cancel). The caller's authority decision and this call must
+    /// not be separated by a suspension point unless a successor started during
+    /// that suspension is also invalid in the new context. Run-scoped cleanup
+    /// must use `TabSession.clearRunID(ifCurrent:)` instead.
     static func clearProcessRunID(for session: AgentModeViewModel.TabSession) {
-        session.runID = nil
+        session.runLifecycle.forceClearRunID()
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
@@ -1025,7 +1025,9 @@ final class AgentModeRunService {
                     }
                 }
                 session.provider = nil
-                session.runID = nil
+                // Barrier-validated: the terminal-commit barrier re-checked
+                // expectedRunID synchronously before invoking this closure.
+                AgentModeProcessRunIdentity.clearProcessRunID(for: session)
                 guard let provider, !hasAttemptTerminalResources else { return nil }
                 return { await provider.dispose() }
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunAttemptLifecycle.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunAttemptLifecycle.swift
@@ -153,7 +153,13 @@ final class AgentRunAttemptLifecycle {
         return true
     }
 
-    func clearRunID() {
+    /// Host-authoritative force reset: unconditionally clears the run ID,
+    /// including a successor's. Reserved for teardown paths whose contract is
+    /// "no run may survive this transition" (tab/window close, session delete,
+    /// provider identity change, workspace switch, execution-location change).
+    /// Run-scoped cleanup must use `clearRunID(ifCurrent:)` instead. Callers
+    /// reach this through `AgentModeProcessRunIdentity.clearProcessRunID(for:)`.
+    func forceClearRunID() {
         currentRunID = nil
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
@@ -262,8 +262,7 @@ final class ClaudeAgentModeCoordinator {
         guard session.selectedAgent.usesClaudeNativeRuntime else { return }
         await awaitPendingClaudeResumeTransferIfNeeded(for: session)
 
-        let runID = session.runID ?? UUID()
-        session.runID = runID
+        let runID = AgentModeProcessRunIdentity.ensureProcessRunID(for: session)
         let launchModelRaw = session.selectedModelRaw
         let runtimeVariant = session.selectedAgent.claudeRuntimeVariant ?? .standard
         let runtimePermission = effectiveClaudeRuntimePermission(for: session)
@@ -593,14 +592,18 @@ final class ClaudeAgentModeCoordinator {
                 throw ControllerLifecycleError.superseded
             }
             await stopToolTracking(detached, for: session)
-            session.runID = nil
+            // Run-scoped retry: if a successor installed its own run identity
+            // while tool tracking stopped, this fresh-start retry is superseded
+            // and must not touch the successor's state.
+            guard session.clearRunID(ifCurrent: runID) else {
+                throw ControllerLifecycleError.superseded
+            }
             session.providerSessionID = nil
             session.providerCleanupHandle = nil
             session.isDirty = true
             viewModel?.scheduleSave(for: session.tabID)
 
-            let freshRunID = UUID()
-            session.runID = freshRunID
+            let freshRunID = AgentModeProcessRunIdentity.startFreshProcessRun(for: session)
             let retryWorkspacePath = try workspacePathProvider(session)
             let launchSettings = ControllerLaunchSettings(
                 runtimeVariant: runtimeVariant,
@@ -1003,7 +1006,9 @@ final class ClaudeAgentModeCoordinator {
         if detached == nil {
             clearClaudeControllerLaunchMetadata(for: session)
         }
-        session.runID = nil
+        // Force reset: user cancel / provider identity transition — no run
+        // survives, and this synchronous path decides that authoritatively.
+        AgentModeProcessRunIdentity.clearProcessRunID(for: session)
         session.pendingSupersedingTurnCompletions = 0
         session.claudeSupersedingProtectedTurnIDs.removeAll()
         return detached
@@ -1180,7 +1185,32 @@ final class ClaudeAgentModeCoordinator {
             invalidateControllerRetirement(for: session)
             clearClaudeControllerLaunchMetadata(for: session)
         }
-        session.runID = nil
+        if clearTabScopedCoordinatorState {
+            // Force semantics: every tab-scoped caller is tab/context-terminal
+            // (window/tab close, session delete, execution-location change), so
+            // any run present — including one that started during the awaits
+            // above — must not survive.
+            AgentModeProcessRunIdentity.clearProcessRunID(for: session)
+        } else {
+            // Detached background teardown owns only the run it was handed. If
+            // a different live identity is visible (the discarded session was
+            // re-adopted or gained a successor during the awaits above), skip
+            // the session-state tail entirely — preserving only the ID while
+            // clearing adjacent run/presentation state would be split-brain.
+            // Only the detached run's tool tracking still needs reaping, and
+            // that cleanup is run-scoped.
+            let detachedIdentityCurrent: Bool = {
+                guard let detachedRunID else { return session.runID == nil }
+                if session.clearRunID(ifCurrent: detachedRunID) { return true }
+                // Common path: an earlier authoritative teardown (user cancel,
+                // workspace-switch cancel) already cleared this run's identity.
+                return session.runID == nil
+            }()
+            guard detachedIdentityCurrent else {
+                await clearClaudeToolTracking(for: session, matchingRunID: detachedRunID)
+                return
+            }
+        }
         session.pendingSupersedingTurnCompletions = 0
         session.claudeSupersedingProtectedTurnIDs.removeAll()
         session.clearClaudeReasoningStatus(clearDisplayedStatus: true)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -4505,7 +4505,9 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             reason: "Codex queued follow-up was cancelled because the controller was replaced."
         )
         if !preserveRunID {
-            session.runID = nil
+            // Force reset: controller invalidation for reconnect is decided
+            // synchronously against the expected controller instance.
+            AgentModeProcessRunIdentity.clearProcessRunID(for: session)
         }
         if let controllerToShutdown {
             retireCodexController(
@@ -4833,9 +4835,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     return existingRunID
                 }
             }
-            let freshRunID = UUID()
-            session.runID = freshRunID
-            return freshRunID
+            return AgentModeProcessRunIdentity.startFreshProcessRun(for: session)
         }()
 
         func prepareCodexController() async -> (any CodexSessionControlling)? {
@@ -8408,7 +8408,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     markCodexReconnectNeeded(for: session, source: "idle-timeout", scheduleSave: false)
                 }
                 logCodex("[AgentModeVM][CodexIdle] shutting down idle app-server for tab \(tabID) reason=\(reason)")
-                await shutdownCodexSession(session)
+                await shutdownCodexSession(session, reclaimOnlyIfStillIdle: true)
                 viewModel?.requestUIRefresh(tabID: tabID, urgent: true)
                 viewModel?.scheduleSave(for: tabID)
             }
@@ -9233,7 +9233,9 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         cancelCodexThreadNameSync(for: session.tabID)
         cancelCodexTabScopedControllerTasks(for: session.tabID)
         clearCodexControllerRuntimeState(for: session)
-        session.runID = nil
+        // Force reset: user cancel is decided synchronously (expectedRunID was
+        // captured by the caller in the same main-actor region).
+        AgentModeProcessRunIdentity.clearProcessRunID(for: session)
         clearCodexNativeToolLiveness(session)
         settleCodexComputerUseActivationAfterTurn(session, reason: "user-cancel")
         if let controller {
@@ -9290,7 +9292,8 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         _ session: AgentModeViewModel.TabSession,
         clearTabScopedCoordinatorState: Bool = true,
         detachedRunID: UUID? = nil,
-        preserveNonCodexRunState: Bool = false
+        preserveNonCodexRunState: Bool = false,
+        reclaimOnlyIfStillIdle: Bool = false
     ) async {
         let shutdownRunID = clearTabScopedCoordinatorState ? session.runID : detachedRunID
         if clearTabScopedCoordinatorState {
@@ -9320,8 +9323,29 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             )
         }
         await awaitCodexControllerRetirement(for: session.tabID)
+        if reclaimOnlyIfStillIdle {
+            // Idle reclaim races live submission: a follow-up that started while
+            // the retirement drained owns the tab now, and it may have reused
+            // the prior run ID, so run-ID staleness cannot detect it. Skip the
+            // entire remaining tab-scoped tail unless the session is still idle.
+            guard session.activeRunOwnership == nil,
+                  !session.runState.isActive,
+                  session.codexController == nil
+            else {
+                logCodex("[AgentModeVM][CodexIdle] skipping idle reclaim tail for tab \(session.tabID); session is no longer idle")
+                return
+            }
+        }
         if !preserveNonCodexRunState {
-            session.runID = nil
+            if clearTabScopedCoordinatorState {
+                // Force semantics: tab/context-terminal callers require that no
+                // run identity survives, including a successor's.
+                AgentModeProcessRunIdentity.clearProcessRunID(for: session)
+            } else if let shutdownRunID {
+                // Detached background teardown owns only the run it was handed;
+                // a live successor's identity must survive.
+                session.clearRunID(ifCurrent: shutdownRunID)
+            }
         }
         if clearTabScopedCoordinatorState {
             await stopCodexToolTrackingAndWait(for: session)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -419,20 +419,20 @@ extension AgentModeViewModel {
         var instructionWaitID: UUID?
 
         /// Agent run — transient run-attempt lifecycle/settlement state is owned by
-        /// the extracted `AgentRunAttemptLifecycle` facade. The properties below are
-        /// stable forwarders so existing call sites keep working; mutation happens
-        /// through the facade's named operations.
+        /// the extracted `AgentRunAttemptLifecycle` facade. Run identity is
+        /// read-only here; mutation happens only through the named operations
+        /// below (`installRunID`, `clearRunID(ifCurrent:)`) or the
+        /// host-authoritative `AgentModeProcessRunIdentity.clearProcessRunID(for:)`.
         let runLifecycle = AgentRunAttemptLifecycle()
 
         var runID: UUID? {
-            get { runLifecycle.currentRunID }
-            set {
-                if let newValue {
-                    runLifecycle.installRunID(newValue)
-                } else {
-                    runLifecycle.clearRunID()
-                }
-            }
+            runLifecycle.currentRunID
+        }
+
+        /// Installs the provider process run identity for a starting or resumed
+        /// run. The installing path owns the identity until it is cleared.
+        func installRunID(_ runID: UUID) {
+            runLifecycle.installRunID(runID)
         }
 
         /// Clears the run ID only when it still matches the caller's run, so a

--- a/Sources/RepoPrompt/Features/Diagnostics/AgentMode/Stress/AgentModeViewModel+StressHarnessSupport.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/AgentMode/Stress/AgentModeViewModel+StressHarnessSupport.swift
@@ -54,7 +54,7 @@
             session.waitingPrompt = nil
             session.runningStatusText = nil
             session.runState = .idle
-            session.runID = nil
+            AgentModeProcessRunIdentity.clearProcessRunID(for: session)
             session.endCurrentRunAttempt(source: "stress.reset")
             session.provider = nil
             session.agentTask?.cancel()

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -166,7 +166,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
                 startedAt: Date()
             )
         ])
-        session.runID = runID
+        session.installRunID(runID)
         let ownership = session.beginRunAttempt(source: "test.canonical")
         session.runState = .completed
         session.mcpFollowUpRunPending = true
@@ -175,7 +175,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         XCTAssertEqual(projected.status, .running)
         XCTAssertEqual(projected.runID, runID)
 
-        session.runID = nil
+        AgentModeProcessRunIdentity.clearProcessRunID(for: session)
         let queuedProjection = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
         XCTAssertEqual(queuedProjection.status, .running)
         XCTAssertNil(queuedProjection.runID)
@@ -503,7 +503,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         let controller = EpochTestCodexController()
         let runID = UUID()
         backgroundSession.selectedAgent = .codexExec
-        backgroundSession.runID = runID
+        backgroundSession.installRunID(runID)
         backgroundSession.runState = .running
         let ownership = backgroundSession.beginRunAttempt(source: "test.backgroundTerminal")
         backgroundSession.codexController = controller
@@ -584,7 +584,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
             let runID = UUID()
             session.selectedAgent = .openCode
-            session.runID = runID
+            session.installRunID(runID)
             session.runState = .running
             let ownership = session.beginRunAttempt(source: "test.finalContentDiagnostic")
             let runAttemptID = try XCTUnwrap(session.activeRunAttemptID)
@@ -667,7 +667,7 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         )
         await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
         let runID = UUID()
-        session.runID = runID
+        session.installRunID(runID)
         let ownership = session.beginRunAttempt(source: "test.stampedFailureReason")
         session.transcript = AgentTranscriptIO.buildTranscript(
             from: [

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -36,7 +36,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 sequenceIndex: 3
             )
         ], reason: .persistedSessionHydration)
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .running
         let ownership = session.beginRunAttempt(source: "test.correlationIndex")
 
@@ -159,7 +159,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             let session = AgentModeViewModel.TabSession(tabID: UUID())
             session.selectedAgent = .codexExec
             session.runState = .running
-            session.runID = UUID()
+            session.installRunID(UUID())
             let ownership = session.beginRunAttempt(source: "test.reusedCodexVariant")
 
             let outcome = await harness.service.startRun(
@@ -703,7 +703,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let recorder = LifecycleRecorder()
         let barrier = AgentRunTerminalCommitBarrier(hooks: makeHooks(recorder: recorder))
         let session = AgentModeViewModel.TabSession(tabID: UUID())
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .running
         let staleOwnership = session.beginRunAttempt(source: "test.stale")
         session.endRunAttempt(ifCurrent: staleOwnership, source: "test.rotate")
@@ -730,7 +730,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let recorder = LifecycleRecorder()
         let barrier = AgentRunTerminalCommitBarrier(hooks: makeHooks(recorder: recorder))
         let session = AgentModeViewModel.TabSession(tabID: UUID())
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .running
         let codexOwnership = session.beginRunAttempt(source: "test.codex")
         for _ in 0 ..< 4 {
@@ -825,7 +825,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .codexExec
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test.codexBufferedCancellation")
         let baselineDrainGeneration = session.providerTerminalDrainGeneration
         session.codexController = controller
@@ -899,7 +899,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         )
         let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
         let session = AgentModeViewModel.TabSession(tabID: UUID())
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .running
         let ownership = session.beginRunAttempt(source: "test.retryPublication")
         let request = AgentRunTerminalCommitBarrier.Request(
@@ -947,7 +947,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         )
         let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
         let session = AgentModeViewModel.TabSession(tabID: UUID())
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .running
         let ownership = session.beginRunAttempt(source: "test.failureReasonStamp")
         session.transcript = AgentTranscriptIO.buildTranscript(
@@ -1029,7 +1029,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         )
         let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
         let session = AgentModeViewModel.TabSession(tabID: UUID())
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .running
         session.pendingInstructions = ["continue"]
         let ownership = session.beginRunAttempt(source: "test.followUpPublication")
@@ -1071,7 +1071,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         )
         let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
         let session = AgentModeViewModel.TabSession(tabID: UUID())
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .running
         session.pendingInstructions = ["unrelated generic instruction"]
         let ownership = session.beginRunAttempt(source: "test.providerSuccessor")
@@ -1124,7 +1124,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .cursor
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test.blockedPublication")
 
         let firstCancelTask = Task {
@@ -1179,7 +1179,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .cursor
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test.slowDisposal")
         session.provider = provider
 
@@ -1222,7 +1222,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .cursor
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test.awaitTeardown")
         session.provider = provider
 
@@ -1265,7 +1265,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .cursor
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test.lateAwaitTeardown")
         session.provider = provider
 
@@ -1309,7 +1309,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .cursor
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test.executionLocation")
         session.provider = provider
 
@@ -1351,7 +1351,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             )
             let session = AgentModeViewModel.TabSession(tabID: UUID())
             session.runState = .running
-            session.runID = UUID()
+            session.installRunID(UUID())
             session.beginRunAttempt(source: "test")
 
             switch row {
@@ -1456,7 +1456,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         let runID = UUID()
         session.selectedAgent = .codexExec
-        session.runID = runID
+        session.installRunID(runID)
         session.runState = .running
         session.codexConversationID = "lifecycle"
         session.codexController = controller
@@ -1783,7 +1783,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let harness = makeHarness(recorder: recorder, workspacePathProvider: { _ in workspace.path })
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .openCode
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .completed
         session.acpController = controller
         return RetainedACPFixture(
@@ -1798,7 +1798,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .claudeCode
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test")
         session.claudeController = controller
         return session
@@ -1825,7 +1825,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .openCode
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test")
         session.acpController = controller
         return session

--- a/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
@@ -70,7 +70,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         codexSession.replaceItems([.user("codex transcript", sequenceIndex: 1)])
         codexSession.codexController = controller
         codexSession.runState = .running
-        codexSession.runID = UUID()
+        codexSession.installRunID(UUID())
         codexSession.testInstallPersistentSessionBinding(sessionID: UUID())
         codexSession.beginRunAttempt(source: "managed-logout-test")
         claudeSession.selectedAgent = .claudeCode
@@ -103,7 +103,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         lingeringSession.replaceItems([.assistant("preserved transcript", sequenceIndex: 1)])
         lingeringSession.runState = .running
         let unrelatedRunID = UUID()
-        lingeringSession.runID = unrelatedRunID
+        lingeringSession.installRunID(unrelatedRunID)
         plainClaudeSession.selectedAgent = .claudeCode
         plainClaudeSession.runState = .running
 
@@ -130,7 +130,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         let agentSessionID = UUID()
         let attemptID = UUID()
         runningSession.runState = .running
-        runningSession.runID = runID
+        runningSession.installRunID(runID)
         runningSession.testInstallPersistentSessionBinding(sessionID: agentSessionID)
         runningSession.beginRunAttempt(source: "test", attemptID: attemptID)
         idleSession.runState = .idle
@@ -161,11 +161,11 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         let targetRunID = UUID()
         let otherRunID = UUID()
         targetSession.runState = .running
-        targetSession.runID = targetRunID
+        targetSession.installRunID(targetRunID)
         targetSession.testInstallPersistentSessionBinding(sessionID: UUID())
         targetSession.beginRunAttempt(source: "test")
         otherSession.runState = .running
-        otherSession.runID = otherRunID
+        otherSession.installRunID(otherRunID)
         otherSession.testInstallPersistentSessionBinding(sessionID: UUID())
         otherSession.beginRunAttempt(source: "test")
         let cancelTarget = vm.makeRunCancelTarget(tabID: targetTabID, session: targetSession)
@@ -190,12 +190,12 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         vm.ensureSession(for: tabID)
         let session = try XCTUnwrap(vm.sessions[tabID])
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.testInstallPersistentSessionBinding(sessionID: UUID())
         session.beginRunAttempt(source: "test")
         let staleTarget = vm.makeRunCancelTarget(tabID: tabID, session: session)
         let newerRunID = UUID()
-        session.runID = newerRunID
+        session.installRunID(newerRunID)
 
         let accepted = await vm.cancelAgentRun(target: staleTarget, completion: .terminalPublished)
 
@@ -214,7 +214,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         vm.ensureSession(for: tabID)
         let session = try XCTUnwrap(vm.sessions[tabID])
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.testInstallPersistentSessionBinding(sessionID: UUID())
         session.beginRunAttempt(source: "test")
         let staleTarget = vm.makeRunCancelTarget(tabID: tabID, session: session)
@@ -237,7 +237,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         vm.ensureSession(for: tabID)
         let session = try XCTUnwrap(vm.sessions[tabID])
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.testInstallPersistentSessionBinding(sessionID: UUID())
         session.beginRunAttempt(source: "test")
         let staleTarget = vm.makeRunCancelTarget(tabID: tabID, session: session)
@@ -304,7 +304,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         let liveRunID = UUID()
         let liveAttemptID = UUID()
         session.runState = .running
-        session.runID = liveRunID
+        session.installRunID(liveRunID)
         session.beginRunAttempt(source: "test.liveRunStarted", attemptID: liveAttemptID)
         let result = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send to live run", target: target)
 
@@ -326,7 +326,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         session.testInstallPersistentSessionBinding(sessionID: UUID())
         session.runState = .running
         let liveRunID = UUID()
-        session.runID = liveRunID
+        session.installRunID(liveRunID)
         let firstOwnership = session.beginRunAttempt(source: "test.firstAttempt", attemptID: UUID())
         let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
         XCTAssertEqual(target.route, .existingAgentSession)
@@ -356,7 +356,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         session.selectedAgent = .codexExec
         session.testInstallPersistentSessionBinding(sessionID: UUID())
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test")
         let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
         let firstResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send once", target: target)
@@ -594,7 +594,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         session.selectedAgent = .codexExec
         session.testInstallPersistentSessionBinding(sessionID: UUID())
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test")
         vm.storeDraftText(for: tabID, "submitted draft")
         let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
@@ -640,7 +640,7 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         let linkedSessionID = UUID()
         sourceSession.testInstallPersistentSessionBinding(sessionID: linkedSessionID)
         sourceSession.runState = .running
-        sourceSession.runID = UUID()
+        sourceSession.installRunID(UUID())
         sourceSession.beginRunAttempt(source: "test.linked")
         var createCalled = false
 

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -625,7 +625,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             sequenceIndex: inactiveSession.nextSequenceIndex
         )
         inactiveSession.appendItem(bashItem)
-        inactiveSession.runID = runID
+        inactiveSession.installRunID(runID)
         inactiveSession.runState = .running
         inactiveSession.runningStatusText = "Background work"
         inactiveSession.activeAgentRunStartedAt = startedAt

--- a/Tests/RepoPromptTests/AgentMode/AgentRunAttemptLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentRunAttemptLifecycleTests.swift
@@ -202,7 +202,7 @@ final class AgentRunAttemptLifecycleTests: XCTestCase {
         XCTAssertNil(lifecycle.currentRunID)
 
         lifecycle.installRunID(firstRunID)
-        lifecycle.clearRunID()
+        lifecycle.forceClearRunID()
         XCTAssertNil(lifecycle.currentRunID)
     }
 
@@ -319,7 +319,7 @@ final class AgentRunAttemptLifecycleTests: XCTestCase {
     func testTabSessionBeginRunAttemptPreservesRunIDAndResetsDrainGeneration() {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         let runID = UUID()
-        session.runID = runID
+        session.installRunID(runID)
 
         let first = session.beginRunAttempt(source: "test.forwarding")
         for _ in 0 ..< 3 {
@@ -339,7 +339,7 @@ final class AgentRunAttemptLifecycleTests: XCTestCase {
     func testTabSessionPersistentBindingTransitionInvalidatesSettledRevisionOnly() {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         let runID = UUID()
-        session.runID = runID
+        session.installRunID(runID)
         let ownership = session.beginRunAttempt(source: "test.rebind")
         session.runLifecycle.stageTerminalRevision(makeRevision(ownership: ownership, expectedRunID: runID))
         session.runLifecycle.recordTerminalPublicationResult(.accepted(successorEpoch: nil))
@@ -359,9 +359,9 @@ final class AgentRunAttemptLifecycleTests: XCTestCase {
     func testTabSessionClearRunIDIfCurrentDoesNotClearSuccessorRun() {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         let firstRunID = UUID()
-        session.runID = firstRunID
+        session.installRunID(firstRunID)
         let successorRunID = UUID()
-        session.runID = successorRunID
+        session.installRunID(successorRunID)
 
         XCTAssertFalse(session.clearRunID(ifCurrent: firstRunID))
         XCTAssertEqual(session.runID, successorRunID)

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -414,6 +414,62 @@ extension AgentModeRunServiceLifecycleTests {
         XCTAssertTrue(recorder.contains("claude:shutdown"))
     }
 
+    // MARK: - Shutdown run-identity scoping
+
+    func testShutdownClaudeSessionDetachedVariantScopesRunIdentityToDetachedRun() async {
+        let recorder = LifecycleRecorder()
+        let harness = makeHarness(recorder: recorder)
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        let detachedRunID = UUID()
+        let successorRunID = UUID()
+        session.installRunID(successorRunID)
+        session.pendingSupersedingTurnCompletions = 3
+
+        await harness.host.claudeCoordinator.shutdownClaudeSession(
+            session,
+            clearTabScopedCoordinatorState: false,
+            detachedRunID: detachedRunID
+        )
+        XCTAssertEqual(
+            session.runID,
+            successorRunID,
+            "detached background teardown owns only the run it was handed"
+        )
+        XCTAssertEqual(
+            session.pendingSupersedingTurnCompletions,
+            3,
+            "a stale detached teardown must skip the successor's adjacent run state, not just its ID"
+        )
+
+        session.installRunID(detachedRunID)
+        await harness.host.claudeCoordinator.shutdownClaudeSession(
+            session,
+            clearTabScopedCoordinatorState: false,
+            detachedRunID: detachedRunID
+        )
+        XCTAssertNil(session.runID, "detached teardown clears its own run when still current")
+        XCTAssertEqual(
+            session.pendingSupersedingTurnCompletions,
+            0,
+            "an owning detached teardown performs the full session-state tail"
+        )
+    }
+
+    func testShutdownClaudeSessionForceClearsRunIdentityOnTabTerminalPath() async {
+        // Tab/context-terminal shutdown is a force reset by contract: any run
+        // present — including one installed after shutdown began — must not
+        // survive the transition. This pins the clobber as intent, not accident.
+        let recorder = LifecycleRecorder()
+        let harness = makeHarness(recorder: recorder)
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        session.installRunID(UUID())
+
+        await harness.host.claudeCoordinator.shutdownClaudeSession(session)
+        XCTAssertNil(session.runID)
+    }
+
     private func resolvedClaudeLaunchPolicy(
         profile: AgentProviderPermissionProfile,
         harness: LifecycleHarness

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -449,7 +449,7 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
 
         XCTAssertTrue(session.endRunAttempt(ifCurrent: attemptA, source: "test.watchdog.attemptA.terminal"))
         let attemptB = session.beginRunAttempt(source: "test.watchdog.attemptB")
-        session.runID = runID
+        session.installRunID(runID)
         session.runState = .running
         session.codexController = controller
         session.codexWatchdogState = .init()
@@ -2320,7 +2320,7 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
             )
         }
         await drainGate.waitUntilWaiting()
-        session.runID = UUID()
+        session.installRunID(UUID())
         drainGate.release()
 
         let outcome = await sendTask.value
@@ -2898,6 +2898,103 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         XCTAssertEqual(session.runState, .completed)
     }
 
+    // MARK: - Shutdown run-identity scoping
+
+    func testIdleReclaimShutdownSkipsTailWhenSuccessorStartsDuringRetirement() async {
+        let shutdownGate = LivenessSnapshotReadGate()
+        let controller = LivenessFakeCodexController(
+            snapshot: .idle,
+            shutdownGate: shutdownGate
+        )
+        let viewModel = makeViewModel(controller: controller)
+        let session = viewModel.session(for: UUID())
+        session.selectedAgent = .codexExec
+        // Post-run idle shape: a completed run's identity is retained for
+        // follow-up reuse; no attempt ownership is active.
+        let retainedRunID = UUID()
+        session.installRunID(retainedRunID)
+        session.runState = .completed
+        session.codexController = controller
+
+        let shutdownTask = Task {
+            await viewModel.test_codexCoordinator.shutdownCodexSession(
+                session,
+                reclaimOnlyIfStillIdle: true
+            )
+        }
+        await shutdownGate.waitUntilWaiting()
+
+        // A follow-up begins while the idle reclaim is suspended in controller
+        // retirement. Codex follow-ups reuse the retained run ID, so run-ID
+        // staleness alone cannot detect the successor — the reclaim tail must
+        // key off idle/ownership/controller state instead.
+        let successorController = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
+        let successorOwnership = session.beginRunAttempt(source: "test.idleReclaimSuccessor")
+        session.runState = .running
+        session.codexController = successorController
+        XCTAssertEqual(session.runID, retainedRunID)
+
+        shutdownGate.release()
+        await shutdownTask.value
+
+        XCTAssertEqual(
+            session.runID,
+            retainedRunID,
+            "idle reclaim must not clear a successor's (reused) run identity"
+        )
+        XCTAssertEqual(session.activeRunOwnership, successorOwnership)
+        XCTAssertNotNil(session.codexController)
+        XCTAssertEqual(session.runState, .running)
+    }
+
+    func testIdleReclaimShutdownClearsRetainedRunIdentityWhenStillIdle() async {
+        let controller = LivenessFakeCodexController(snapshot: .idle)
+        let viewModel = makeViewModel(controller: controller)
+        let session = viewModel.session(for: UUID())
+        session.selectedAgent = .codexExec
+        session.installRunID(UUID())
+        session.runState = .completed
+        session.codexController = controller
+
+        await viewModel.test_codexCoordinator.shutdownCodexSession(
+            session,
+            reclaimOnlyIfStillIdle: true
+        )
+
+        XCTAssertNil(session.runID, "still-idle reclaim performs the normal shutdown tail")
+        XCTAssertNil(session.codexController)
+        XCTAssertEqual(controller.shutdownCountSync(), 1)
+    }
+
+    func testDetachedShutdownScopesRunIdentityClearToDetachedRun() async {
+        let controller = LivenessFakeCodexController(snapshot: .idle)
+        let viewModel = makeViewModel(controller: controller)
+        let session = viewModel.session(for: UUID())
+        session.selectedAgent = .codexExec
+        let detachedRunID = UUID()
+        let successorRunID = UUID()
+        session.installRunID(successorRunID)
+
+        await viewModel.test_codexCoordinator.shutdownCodexSession(
+            session,
+            clearTabScopedCoordinatorState: false,
+            detachedRunID: detachedRunID
+        )
+        XCTAssertEqual(
+            session.runID,
+            successorRunID,
+            "detached teardown owns only the run it was handed"
+        )
+
+        session.installRunID(detachedRunID)
+        await viewModel.test_codexCoordinator.shutdownCodexSession(
+            session,
+            clearTabScopedCoordinatorState: false,
+            detachedRunID: detachedRunID
+        )
+        XCTAssertNil(session.runID, "detached teardown clears its own run when still current")
+    }
+
     private func makeCommandToolItem(
         turnID: String = "turn",
         itemID: UUID,
@@ -2962,7 +3059,9 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
     ) -> AgentModeViewModel.TabSession {
         let session = viewModel.session(for: UUID())
         session.selectedAgent = .codexExec
-        session.runID = runID
+        if let runID {
+            session.installRunID(runID)
+        }
         session.runState = .running
         session.beginRunAttempt(source: "test.codexLiveness")
         session.codexController = controller
@@ -3166,6 +3265,7 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
     private let postReattachActiveTurnIDs: [String]?
     private let snapshotReadGate: LivenessSnapshotReadGate?
     private let postReattachSnapshotReadGate: LivenessSnapshotReadGate?
+    private let shutdownGate: LivenessSnapshotReadGate?
     private var pendingTurnFailure: CodexNativeSessionController.TurnFailure?
 
     init(
@@ -3186,6 +3286,7 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
         postReattachActiveTurnIDs: [String]? = nil,
         snapshotReadGate: LivenessSnapshotReadGate? = nil,
         postReattachSnapshotReadGate: LivenessSnapshotReadGate? = nil,
+        shutdownGate: LivenessSnapshotReadGate? = nil,
         pendingTurnFailure: CodexNativeSessionController.TurnFailure? = nil
     ) {
         snapshotStatuses = if let snapshotSequence, !snapshotSequence.isEmpty {
@@ -3208,6 +3309,7 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
         self.postReattachActiveTurnIDs = postReattachActiveTurnIDs
         self.snapshotReadGate = snapshotReadGate
         self.postReattachSnapshotReadGate = postReattachSnapshotReadGate
+        self.shutdownGate = shutdownGate
         self.pendingTurnFailure = pendingTurnFailure
     }
 
@@ -3413,6 +3515,9 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
     func cancelCurrentTurn() async {}
     func shutdown() async {
         shutdownCount += 1
+        if let shutdownGate {
+            await shutdownGate.wait()
+        }
     }
 
     func respondToServerRequest(id: CodexAppServerRequestID, result: [String: Any]) async {}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
@@ -168,7 +168,7 @@ final class CodexFallbackFIFOTests: XCTestCase {
         XCTAssertNil(controller.test_authoritativeLifecycleTurnID)
 
         let nextRunID = UUID()
-        session.runID = nextRunID
+        session.installRunID(nextRunID)
         session.runState = .running
         session.beginRunAttempt(source: "test.codexFallback.reuse")
         session.codexPendingTurnKind = .user
@@ -873,7 +873,7 @@ final class CodexFallbackFIFOTests: XCTestCase {
         let session = viewModel.session(for: UUID())
         let runID = UUID()
         session.selectedAgent = .codexExec
-        session.runID = runID
+        session.installRunID(runID)
         session.runState = .running
         session.beginRunAttempt(source: "test.codexFallback")
         session.codexController = controller
@@ -922,7 +922,7 @@ final class CodexFallbackFIFOTests: XCTestCase {
         }
         let runID = UUID()
         session.selectedAgent = .codexExec
-        session.runID = runID
+        session.installRunID(runID)
         session.runState = .running
         session.beginRunAttempt(source: "test.codexFallback.mcp")
         session.codexController = controller

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexSteerAckTrackerTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexSteerAckTrackerTests.swift
@@ -245,7 +245,7 @@ final class CodexSteerAckTrackerTests: XCTestCase {
 
         let replacementController = AckTrackerCodexController(gate: AckTrackerSteerGate())
         let replacementRunID = UUID()
-        session.runID = replacementRunID
+        session.installRunID(replacementRunID)
         session.runState = .running
         session.beginRunAttempt(source: "test.codexAckReplacementNoWake.replacement")
         session.codexController = replacementController
@@ -408,7 +408,7 @@ final class CodexSteerAckTrackerTests: XCTestCase {
         )
         viewModel.test_setMCPControlledTabIDs([tabID])
         session.selectedAgent = .codexExec
-        session.runID = runID
+        session.installRunID(runID)
         session.runState = .running
         session.beginRunAttempt(source: source)
         session.codexController = controller

--- a/Tests/RepoPromptTests/AgentMode/WorkspaceSwitchCleanupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/WorkspaceSwitchCleanupTests.swift
@@ -60,7 +60,7 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         let session = viewModel.session(for: tabID)
         session.selectedAgent = .openCode
         session.provider = provider
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .running
 
         await viewModel.handleWorkspaceSwitch(nil)
@@ -126,7 +126,7 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         )
         let session = viewModel.session(for: UUID())
         session.selectedAgent = .openCode
-        session.runID = oldRunID
+        session.installRunID(oldRunID)
         session.runState = .running
 
         await viewModel.handleWorkspaceSwitch(nil)
@@ -150,7 +150,7 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         )
         let oldSession = viewModel.session(for: tabID)
         oldSession.selectedAgent = .openCode
-        oldSession.runID = oldRunID
+        oldSession.installRunID(oldRunID)
         oldSession.mcpControlContext = makeMCPControlContext(sessionID: mcpSessionID)
 
         await viewModel.handleWorkspaceSwitch(nil)
@@ -175,14 +175,14 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         oldSession.selectedAgent = .openCode
         oldSession.provider = provider
         oldSession.providerSessionID = "old-provider-session"
-        oldSession.runID = oldRunID
+        oldSession.installRunID(oldRunID)
         oldSession.runState = .running
 
         await viewModel.handleWorkspaceSwitch(nil)
         let newSession = viewModel.session(for: tabID)
         newSession.selectedAgent = .openCode
         newSession.providerSessionID = "new-provider-session"
-        newSession.runID = newRunID
+        newSession.installRunID(newRunID)
         newSession.runState = .running
 
         try await provider.waitUntilDisposeIsSuspended(timeoutNanoseconds: fullSuiteAsyncTimeoutNanoseconds)

--- a/Tests/RepoPromptTests/MCP/AgentRunWaitDrainIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWaitDrainIntegrationTests.swift
@@ -93,7 +93,7 @@ final class AgentRunWaitDrainIntegrationTests: XCTestCase {
 
             let session = await harness.viewModel.ensureSessionReady(tabID: UUID())
             session.selectedAgent = .openCode
-            session.runID = harness.parentRunID
+            session.installRunID(harness.parentRunID)
             session.runState = .running
             _ = session.beginRunAttempt(source: "test.staleManualWake")
 
@@ -146,7 +146,7 @@ final class AgentRunWaitDrainIntegrationTests: XCTestCase {
             let sessionID = UUID()
             let session = await harness.viewModel.ensureSessionReady(tabID: UUID())
             session.selectedAgent = selectedAgent
-            session.runID = harness.parentRunID
+            session.installRunID(harness.parentRunID)
             session.runState = .running
             _ = session.beginRunAttempt(source: "test.staleProviderWake")
             _ = harness.viewModel.test_installPersistentSessionBinding(
@@ -207,7 +207,7 @@ final class AgentRunWaitDrainIntegrationTests: XCTestCase {
         if let ownership = session.activeRunOwnership {
             session.endRunAttempt(ifCurrent: ownership, source: source)
         }
-        session.runID = UUID()
+        session.installRunID(UUID())
         _ = session.beginRunAttempt(source: source)
         session.runState = .running
     }

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -1406,7 +1406,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
             in: window
         )
         let sourceRunID = UUID()
-        viewModel.session(for: sourceTabID).runID = sourceRunID
+        viewModel.session(for: sourceTabID).installRunID(sourceRunID)
         let source = AgentRunOracleReviewSource.captured(.init(
             sourceTabID: sourceTabID,
             workspaceID: workspaceID,
@@ -2549,7 +2549,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         let sessionID = try XCTUnwrap(session.activeAgentSessionID)
         session.hasLoadedPersistedState = true
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.providerSessionID = "stable-provider-identity"
         session.codexConversationID = "stable-codex-identity"
         let primaryBinding = makeBinding(
@@ -2638,7 +2638,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         session.hasLoadedPersistedState = true
         session.hasSentFirstMessage = true
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test")
         session.providerSessionID = "provider-from-old-cwd"
         session.worktreeBindings = [makeBinding(logicalRoot: root.path, worktreeRoot: oldWorktree.path)]
@@ -2689,7 +2689,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         let sessionID = UUID()
         session.testInstallPersistentSessionBinding(sessionID: sessionID)
         session.runState = .running
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.providerSessionID = "managed-old-identity"
         let oldBinding = makeBinding(logicalRoot: root.path, worktreeRoot: oldWorktree.path, worktreeID: "wt_old")
         let newBinding = makeBinding(logicalRoot: root.path, worktreeRoot: newWorktree.path, worktreeID: "wt_new")

--- a/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
@@ -1298,7 +1298,7 @@ import XCTest
                         let runID = UUID()
                         targetRunID = runID
                         let session = viewModel.session(for: tabID)
-                        session.runID = runID
+                        session.installRunID(runID)
                         session.runState = .running
                         guard viewModel.mcpBindPendingAgentRunOracleReviewContext(
                             tabID: tabID,
@@ -1609,7 +1609,7 @@ import XCTest
                         let runID = UUID()
                         targetRunID = runID
                         let session = viewModel.session(for: tabID)
-                        session.runID = runID
+                        session.installRunID(runID)
                         session.runState = .running
                         guard viewModel.mcpBindPendingAgentRunOracleReviewContext(
                             tabID: tabID,
@@ -2024,7 +2024,7 @@ import XCTest
                                 sessionID: sourceSessionID
                             )
                             sourceSession.worktreeBindings = bindings
-                            sourceSession.runID = sourceRunID
+                            sourceSession.installRunID(sourceRunID)
                             try window.mcpServer.bindTabForConnection(
                                 connectionID: startConnectionID,
                                 clientName: sourceClientName,
@@ -2068,7 +2068,7 @@ import XCTest
                             let runID = UUID()
                             targetRunID = runID
                             let session = viewModel.session(for: tabID)
-                            session.runID = runID
+                            session.installRunID(runID)
                             session.runState = .running
                             guard viewModel.mcpBindPendingAgentRunOracleReviewContext(
                                 tabID: tabID,


### PR DESCRIPTION
## Summary

- make `TabSession.runID` getter-only and route mutation through named install, run-scoped clear, or explicit host-authoritative force-reset operations
- make Claude retry and detached teardown preserve successor state after suspension points
- protect Codex idle reclaim with fresh ownership/run-state/controller checks so same-run-ID follow-ups survive controller retirement
- retain intentional force semantics for tab/context-terminal teardown and add deterministic regression coverage

## Why

PR #763 extracted run-attempt lifecycle authority, but direct `runID` writes still blurred run-scoped cleanup and host-authoritative reset. This closes that bypass and fixes the post-await successor-clobber windows without adding a parallel authority or changing persistence/wire formats.

## Validation

- `AgentRunAttemptLifecycleTests`: 13/13
- `CodexAgentModeCoordinatorLivenessTests`: 71/71
- `AgentModeRunServiceLifecycleTests`: 37/37
- `AgentModeStopSubmitTargetTests`: 28/28
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-lint` (SwiftFormat clean; SwiftLint strict)
- commit/push preflights, staged/outgoing secret scans, and repository/headless guardrails
- independent Fable 5 High review: approved, no must-fix findings

## Non-goals

- no provider or hook rewrite
- no persistence/wire changes
- no `codexEventTaskRunID` consolidation
- no UI changes

## Follow-ups

Independent review noted three non-blocking follow-ups: harden same-run-ID Claude detached teardown, audit Codex detached pre-await prefix scoping, and add a coordinator-level Claude retry supersession harness. These are pre-existing exposures/test gaps and are not widened by this PR.
