### PR TITLE
Add durable conductor build cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ conductor-selftest:
 	python3 Scripts/test_debug_app_process.py
 	python3 Scripts/test_contribution_preflight.py
 	python3 Scripts/test_ci_app_test_runner.py
+	python3 Scripts/test_conductor_cache.py
 	python3 Scripts/test_conductor_output.py
 	python3 Scripts/test_agent_mode_file_tools_benchmark.py
 	python3 Scripts/test_conductor_lifecycle.py

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -2185,7 +2185,7 @@ def _classify_socket_for_recovery(paths: Paths) -> str:
         probe.close()
 
 
-def cleanup_stale_files(paths: Paths) -> DaemonRecoveryResult:
+def cleanup_stale_files(paths: Paths, *, startup_lock_held: bool = False) -> DaemonRecoveryResult:
     evidence_paths = (paths.pid_path, paths.socket_path, paths.daemon_meta_path)
     identities = {path: _path_identity(path) for path in evidence_paths}
     if all(identity is None for identity in identities.values()):
@@ -2216,6 +2216,10 @@ def cleanup_stale_files(paths: Paths) -> DaemonRecoveryResult:
             return DaemonRecoveryResult("ambiguous", False, f"daemon evidence changed during recovery: {path}")
     registry_identity = _path_identity(paths.running_processes_path)
     if registry_identity is not None:
+        # Keep the pre-cleanup inode as a concurrency fence. Worker cleanup may
+        # remove registry-bound attempt sidecars, but it must not replace or
+        # unlink the registry itself. Refreshing this identity afterward would
+        # incorrectly bless a replacement daemon's concurrently written state.
         worker_cleanup = cleanup_running_process_groups(paths)
         if not worker_cleanup.get("safeToForget"):
             return DaemonRecoveryResult(
@@ -2223,19 +2227,34 @@ def cleanup_stale_files(paths: Paths) -> DaemonRecoveryResult:
                 False,
                 "recorded daemon is stale, but worker process-group cleanup lacks exact bounded completion evidence",
             )
-    for path, identity in (*identities.items(), (paths.running_processes_path, registry_identity)):
-        if identity is None:
-            continue
-        if _path_identity(path) != identity:
-            return DaemonRecoveryResult("ambiguous", False, f"daemon evidence changed before cleanup: {path}")
-        with contextlib.suppress(FileNotFoundError):
-            path.unlink()
-    cleanup_reason = "proven pid reuse" if reused_pid_proven else "dead recorded daemon"
-    return DaemonRecoveryResult(
-        "cleaned",
-        True,
-        f"removed stale daemon evidence after {cleanup_reason} and {socket_state} socket proof",
-    )
+    final_identities = (*identities.items(), (paths.running_processes_path, registry_identity))
+
+    def finalize_locked() -> DaemonRecoveryResult:
+        for path, identity in final_identities:
+            if identity is None:
+                continue
+            if _path_identity(path) != identity:
+                return DaemonRecoveryResult("ambiguous", False, f"daemon evidence changed before cleanup: {path}")
+        for path, identity in final_identities:
+            if identity is None:
+                continue
+            with contextlib.suppress(FileNotFoundError):
+                path.unlink()
+        cleanup_reason = "proven pid reuse" if reused_pid_proven else "dead recorded daemon"
+        return DaemonRecoveryResult(
+            "cleaned",
+            True,
+            f"removed stale daemon evidence after {cleanup_reason} and {socket_state} socket proof",
+        )
+
+    if startup_lock_held:
+        return finalize_locked()
+    with paths.lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            return finalize_locked()
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def process_start_token(pid: int) -> Optional[str]:
@@ -5750,7 +5769,11 @@ def request_daemon(paths: Paths, payload: Dict[str, Any], timeout: Optional[floa
     return payload_value
 
 
-def compatible_daemon_status_or_stop_idle_mismatch(paths: Paths) -> Tuple[Optional[Dict[str, Any]], Optional[ConductorError]]:
+def compatible_daemon_status_or_stop_idle_mismatch(
+    paths: Paths,
+    *,
+    startup_lock_held: bool = False,
+) -> Tuple[Optional[Dict[str, Any]], Optional[ConductorError]]:
     try:
         payload = request_daemon(paths, {"type": "status"}, timeout=1.0)
     except ConductorError as exc:
@@ -5774,7 +5797,16 @@ def compatible_daemon_status_or_stop_idle_mismatch(paths: Paths) -> Tuple[Option
             f"daemon protocol mismatch (daemon={protocol}, client={PROTOCOL_VERSION}) could not stop without force; "
             "jobs may have become active. Run './conductor daemon stop --force' after deciding it is safe"
         ) from exc
-    if not wait_until_stopped(paths, timeout=TERMINATE_GRACE_SECONDS + 5.0):
+    stopped = (
+        wait_until_stopped(
+            paths,
+            timeout=TERMINATE_GRACE_SECONDS + 5.0,
+            startup_lock_held=True,
+        )
+        if startup_lock_held
+        else wait_until_stopped(paths, timeout=TERMINATE_GRACE_SECONDS + 5.0)
+    )
+    if not stopped:
         raise ConductorError(
             f"daemon protocol mismatch (daemon={protocol}, client={PROTOCOL_VERSION}) did not stop cleanly; "
             "run './conductor daemon stop --force' after deciding it is safe"
@@ -5812,8 +5844,11 @@ def ensure_daemon(paths: Paths, start_if_needed: bool = True) -> Dict[str, Any]:
 
     with paths.lock_path.open("a+") as lock_file:
         fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        locked_recovery = cleanup_stale_files(paths)
-        payload, locked_contact_error = compatible_daemon_status_or_stop_idle_mismatch(paths)
+        locked_recovery = cleanup_stale_files(paths, startup_lock_held=True)
+        payload, locked_contact_error = compatible_daemon_status_or_stop_idle_mismatch(
+            paths,
+            startup_lock_held=True,
+        )
         if payload is not None:
             return payload
         if locked_recovery.state == "ambiguous":
@@ -5856,10 +5891,13 @@ def ensure_daemon(paths: Paths, start_if_needed: bool = True) -> Dict[str, Any]:
         )
 
 
-def wait_until_stopped(paths: Paths, timeout: float) -> bool:
+def wait_until_stopped(paths: Paths, timeout: float, *, startup_lock_held: bool = False) -> bool:
     deadline = now() + timeout
     while now() < deadline:
-        cleanup_stale_files(paths)
+        if startup_lock_held:
+            cleanup_stale_files(paths, startup_lock_held=True)
+        else:
+            cleanup_stale_files(paths)
         if not paths.socket_path.exists() and not paths.pid_path.exists():
             return True
         time.sleep(0.1)

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -39,7 +39,7 @@ from typing import Any, Deque, Dict, List, Optional, Sequence, Tuple
 
 from debug_app_process import ProcessIdentityError, matching_processes, terminate_matching_processes
 
-PROTOCOL_VERSION = 13
+PROTOCOL_VERSION = 16
 TERMINAL_STATES = {"completed", "failed", "canceled"}
 JOB_PHASES = {
     "queued",
@@ -48,6 +48,7 @@ JOB_PHASES = {
     "runningProcess",
     "canceling",
     "finalizingOutput",
+    "publishingCache",
     "summarizing",
     "terminal",
 }
@@ -56,6 +57,29 @@ LOG_TAIL_LINES = 30
 LOG_TAIL_MAX_BYTES = 64 * 1024
 LOG_TAIL_FRAGMENT_MAX_BYTES = 4 * 1024
 BUILD_CACHE_DIAGNOSTIC_MAX_ROWS = 12
+BUILD_CACHE_SCHEMA_VERSION = 1
+BUILD_CACHE_DEFAULT_LIMIT_BYTES = 40 * 1024 * 1024 * 1024
+BUILD_CACHE_PUBLISH_THROTTLE_SECONDS = 60 * 60.0
+BUILD_CACHE_CLONE_MIN_SECONDS = 60.0
+BUILD_CACHE_CLONE_MAX_SECONDS = 10 * 60.0
+BUILD_CACHE_CLONE_SECONDS_PER_ENTRY = 0.005
+BUILD_CACHE_CLONE_SECONDS_PER_GIB = 5.0
+BUILD_CACHE_RETRY_OVERHEAD_SECONDS = 30.0
+BUILD_CACHE_FORCE_STOP_WAIT_SECONDS = 4 * BUILD_CACHE_CLONE_MAX_SECONDS + BUILD_CACHE_RETRY_OVERHEAD_SECONDS
+BUILD_CACHE_ELIGIBLE_OPERATIONS = {"swift-build", "build", "package", "test", "install-debug-cli"}
+BUILD_CACHE_ENV_KEYS = (
+    "ARCHS",
+    "CC",
+    "CXX",
+    "DEVELOPER_DIR",
+    "ONLY_ACTIVE_ARCH",
+    "OTHER_SWIFT_FLAGS",
+    "REPOPROMPT_ENABLE_SENTRY",
+    "RPCE_ENABLE_BENCHMARK_TESTS",
+    "SDKROOT",
+    "SWIFT_EXEC",
+    "SWIFTFLAGS",
+)
 SUMMARY_VERSION = 1
 SUMMARY_SUCCESS_MAX_LINES = 25
 SUMMARY_FAILURE_MAX_LINES = 100
@@ -203,6 +227,8 @@ Operation commands:
     (without --launch/--packaged-app, requires the CE debug app to already be running and CLI installed)
   ./conductor diagnostics agent-mode-on [--log-file <path>]
   ./conductor diagnostics build-cache [--limit <n>]
+  ./conductor cache status [--limit <n>] [--json]  # read-only; performs no repair or cleanup
+  ./conductor cache drop <compatibility-key> [--json]
   ./conductor release preflight|artifact|package|local-install
 
 Foundation validation operation:
@@ -676,6 +702,778 @@ def ensure_state_dirs(paths: Paths) -> None:
     ensure_private_dir(paths.jobs_dir)
     ensure_private_dir(paths.socket_path.parent)
     ensure_private_dir(machine_lock_dir())
+
+
+@dataclasses.dataclass(frozen=True)
+class BuildCacheSnapshot:
+    key: str
+    payload: Dict[str, Any]
+    toolchain_signature: str
+
+
+@dataclasses.dataclass
+class BuildCacheContext:
+    snapshot: BuildCacheSnapshot
+    observed_generation: int
+    seeded: bool
+    status: Dict[str, Any]
+    outcome_path: Optional[Path] = None
+
+
+def _durable_unlink(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    directory_descriptor = -1
+    try:
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        with contextlib.suppress(OSError):
+            os.fsync(directory_descriptor)
+    except OSError:
+        # The unlink already committed. Directory fsync is a durability
+        # enhancement and must not turn successful cleanup into a failure.
+        pass
+    finally:
+        if directory_descriptor >= 0:
+            os.close(directory_descriptor)
+
+
+def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    replaced = False
+    try:
+        encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+        remaining = memoryview(encoded)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError(errno.EIO, f"short write for {path}")
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(temporary, path)
+        replaced = True
+        directory_descriptor = -1
+        try:
+            directory_descriptor = os.open(path.parent, os.O_RDONLY)
+            with contextlib.suppress(OSError):
+                os.fsync(directory_descriptor)
+        except OSError:
+            # The atomic replace already committed. Directory fsync is a
+            # durability enhancement and must not make callers roll back
+            # successfully published state.
+            pass
+        finally:
+            if directory_descriptor >= 0:
+                os.close(directory_descriptor)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if not replaced:
+            with contextlib.suppress(FileNotFoundError):
+                temporary.unlink()
+
+
+class BuildCacheManager:
+    """Private immutable SwiftPM seed store; kernel locks serialize every key mutation."""
+
+    def __init__(
+        self,
+        repo_root: Path,
+        *,
+        store_root: Optional[Path] = None,
+        probe_provider: Any = None,
+        clone_runner: Any = None,
+        clock: Any = time.time,
+        monotonic: Any = time.monotonic,
+        env: Optional[Dict[str, str]] = None,
+        startup_hygiene: bool = True,
+    ) -> None:
+        self.repo_root = repo_root.resolve()
+        self.env = dict(os.environ if env is None else env)
+        override = self.env.get("REPOPROMPT_DEV_BUILD_CACHE_DIR")
+        self.store_root = (store_root or (Path(override).expanduser() if override else Path.home() / "Library" / "Application Support" / "RepoPrompt CE" / "Conductor" / "BuildCache")).resolve()
+        self.locks_dir = self.store_root / "locks"
+        self._probe_provider = probe_provider or self._probe_toolchain
+        self._clone_runner = clone_runner or self._clone_cow
+        self._clock = clock
+        self._monotonic = monotonic
+        self._startup_advisory_error: Optional[str] = None
+        if startup_hygiene:
+            try:
+                self._ensure_store_dirs()
+                self._sweep_stranded_store_temporaries()
+                self._sweep_repo_build_temporaries(nonblocking=True)
+            except Exception as exc:
+                self._startup_advisory_error = str(exc)[:500]
+
+    def _ensure_store_dirs(self) -> None:
+        ensure_private_dir(self.store_root.parent)
+        ensure_private_dir(self.store_root)
+        ensure_private_dir(self.locks_dir)
+
+    @staticmethod
+    def _remove_owned_temporary(path: Path) -> None:
+        try:
+            info = path.lstat()
+        except FileNotFoundError:
+            return
+        if stat.S_ISDIR(info.st_mode) and not stat.S_ISLNK(info.st_mode):
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+    @staticmethod
+    def _is_store_temporary_name(name: str) -> bool:
+        return re.fullmatch(r"seed\.(?:tmp|previous)-[0-9a-f]{32}", name) is not None
+
+    @staticmethod
+    def _is_repo_temporary_name(name: str) -> bool:
+        return re.fullmatch(r"\.build\.seed-tmp-[0-9a-f]{32}", name) is not None
+
+    @contextlib.contextmanager
+    def _repo_prepare_lock(self, *, nonblocking: bool = False):
+        digest = hashlib.sha256(str(self.repo_root).encode("utf-8")).hexdigest()
+        lock_path = self.locks_dir / f"repo-{digest}.lock"
+        lock_file = lock_path.open("a+", encoding="utf-8")
+        os.chmod(lock_path, 0o600)
+        flags = fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0)
+        try:
+            fcntl.flock(lock_file.fileno(), flags)
+            yield
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            lock_file.close()
+
+    def _remove_repo_build_temporaries_locked(self) -> int:
+        removed = 0
+        for child in self.repo_root.iterdir():
+            if self._is_repo_temporary_name(child.name):
+                self._remove_owned_temporary(child)
+                removed += 1
+        return removed
+
+    def _sweep_repo_build_temporaries(self, *, nonblocking: bool) -> int:
+        try:
+            with self._repo_prepare_lock(nonblocking=nonblocking):
+                return self._remove_repo_build_temporaries_locked()
+        except BlockingIOError:
+            return 0
+
+    def _sweep_stranded_store_temporaries(self) -> Dict[str, int]:
+        removed = 0
+        restored_previous = 0
+        skipped_locked = 0
+        for key_dir in self.store_root.iterdir():
+            if not key_dir.is_dir() or key_dir.is_symlink() or not re.fullmatch(r"[0-9a-f]{64}", key_dir.name):
+                continue
+            try:
+                with self.key_lock(key_dir.name, exclusive=True, nonblocking=True):
+                    candidates = [child for child in key_dir.iterdir() if self._is_store_temporary_name(child.name)]
+                    seed = key_dir / "seed"
+                    meta = self._meta(key_dir.name) or {}
+                    seed_valid = bool(meta and self._validate_seed_at(key_dir.name, meta, seed))
+                    if not seed_valid and meta:
+                        for previous in sorted(
+                            (child for child in candidates if child.name.startswith("seed.previous-")),
+                            key=lambda child: child.name,
+                        ):
+                            if self._validate_seed_at(key_dir.name, meta, previous):
+                                if seed.exists() or seed.is_symlink():
+                                    self._remove_owned_temporary(seed)
+                                os.replace(previous, seed)
+                                candidates.remove(previous)
+                                restored_previous += 1
+                                break
+                    for child in candidates:
+                        self._remove_owned_temporary(child)
+                        removed += 1
+            except BlockingIOError:
+                skipped_locked += 1
+        return {
+            "removed": removed,
+            "restoredPrevious": restored_previous,
+            "skippedLockedKeys": skipped_locked,
+        }
+
+    @staticmethod
+    def configuration_for(operation: str, args: Dict[str, Any]) -> str:
+        if operation == "package":
+            return str(args.get("config") or "debug")
+        return "debug"
+
+    @staticmethod
+    def eligible(operation: str, args: Dict[str, Any]) -> bool:
+        del args
+        return operation in BUILD_CACHE_ELIGIBLE_OPERATIONS
+
+    @staticmethod
+    def retry_job_timeout(
+        attempt_timeout: Optional[float],
+        cleanup_timeout: float,
+    ) -> Optional[float]:
+        if attempt_timeout is None:
+            return None
+        return (
+            max(0.0, attempt_timeout) * 2
+            + max(0.0, cleanup_timeout)
+            + BUILD_CACHE_RETRY_OVERHEAD_SECONDS
+        )
+
+    def _run_probe(self, argv: Sequence[str]) -> str:
+        completed = subprocess.run(
+            list(argv),
+            cwd=str(self.repo_root),
+            stdin=subprocess.DEVNULL,
+            text=True,
+            capture_output=True,
+            timeout=10.0,
+        )
+        if completed.returncode != 0:
+            raise ConductorError(f"build-cache probe failed: {format_argv(argv)}: {completed.stderr.strip()[:500]}")
+        return completed.stdout.strip()
+
+    def _probe_toolchain(self) -> Dict[str, Any]:
+        target_payload = json.loads(self._run_probe(["swift", "-print-target-info"]))
+        target = target_payload.get("target") or {}
+        return {
+            "swiftVersion": self._run_probe(["swift", "--version"]),
+            "sdkBuild": self._run_probe(["/usr/bin/xcrun", "--sdk", "macosx", "--show-sdk-build-version"]),
+            "developerDir": self._run_probe(["/usr/bin/xcode-select", "-p"]),
+            "architecture": os.uname().machine,
+            "destinationTriple": target.get("unversionedTriple") or target.get("triple"),
+        }
+
+    def _manifest_hashes(self) -> List[Dict[str, str]]:
+        candidates = {self.repo_root / "Package.swift", self.repo_root / "Package.resolved"}
+        for base in (self.repo_root / "Packages", self.repo_root / "Vendor"):
+            if base.exists():
+                candidates.update(path for path in base.rglob("Package.swift") if ".build" not in path.parts)
+        rows: List[Dict[str, str]] = []
+        for path in sorted(candidates, key=lambda candidate: str(candidate.relative_to(self.repo_root))):
+            relative = str(path.relative_to(self.repo_root))
+            if not path.is_file():
+                rows.append({"path": relative, "sha256": "missing"})
+                continue
+            rows.append({"path": relative, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()})
+        return rows
+
+    def snapshot(self, configuration: str, job_env: Dict[str, str]) -> BuildCacheSnapshot:
+        toolchain = self._probe_provider()
+        if not isinstance(toolchain, dict):
+            raise ConductorError("build-cache toolchain probe returned invalid data")
+        payload: Dict[str, Any] = {
+            "schemaVersion": BUILD_CACHE_SCHEMA_VERSION,
+            "toolchain": toolchain,
+            "configuration": configuration,
+            "environment": {key: job_env.get(key) for key in BUILD_CACHE_ENV_KEYS},
+            "manifests": self._manifest_hashes(),
+        }
+        encoded = json_dumps(payload).encode("utf-8")
+        toolchain_signature = hashlib.sha256(json_dumps(toolchain).encode("utf-8")).hexdigest()
+        return BuildCacheSnapshot(hashlib.sha256(encoded).hexdigest(), payload, toolchain_signature)
+
+    def _key_dir(self, key: str) -> Path:
+        if not re.fullmatch(r"[0-9a-f]{64}", key):
+            raise ConductorError("invalid build-cache key")
+        return self.store_root / key
+
+    @contextlib.contextmanager
+    def key_lock(self, key: str, *, exclusive: bool, nonblocking: bool = False):
+        self._key_dir(key)
+        # The persistent per-key inode is the cross-process flock authority.
+        # Unlinking a seemingly idle lock can split exclusion when a waiter has
+        # already opened the old inode, so zero-byte lock files are retained.
+        lock_path = self.locks_dir / f"{key}.lock"
+        lock_file = lock_path.open("a+", encoding="utf-8")
+        os.chmod(lock_path, 0o600)
+        flags = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        if nonblocking:
+            flags |= fcntl.LOCK_NB
+        try:
+            fcntl.flock(lock_file.fileno(), flags)
+            yield lock_file
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            lock_file.close()
+
+    @staticmethod
+    def _read_json_file(path: Path) -> Optional[Dict[str, Any]]:
+        try:
+            info = path.lstat()
+            if not stat.S_ISREG(info.st_mode) or (hasattr(os, "getuid") and info.st_uid != os.getuid()):
+                return None
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            return payload if isinstance(payload, dict) else None
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return None
+
+    def _meta(self, key: str) -> Optional[Dict[str, Any]]:
+        return self._read_json_file(self._key_dir(key) / "meta.json")
+
+    @staticmethod
+    def _tree_deadline_for_work(entries: int, size_bytes: int) -> float:
+        scaled = (
+            BUILD_CACHE_CLONE_MIN_SECONDS
+            + max(0, entries) * BUILD_CACHE_CLONE_SECONDS_PER_ENTRY
+            + (max(0, size_bytes) / float(1024**3)) * BUILD_CACHE_CLONE_SECONDS_PER_GIB
+        )
+        return min(BUILD_CACHE_CLONE_MAX_SECONDS, max(BUILD_CACHE_CLONE_MIN_SECONDS, scaled))
+
+    @staticmethod
+    def _tree_deadline_seconds(source: Path) -> float:
+        max_entries = int(
+            (BUILD_CACHE_CLONE_MAX_SECONDS - BUILD_CACHE_CLONE_MIN_SECONDS)
+            / BUILD_CACHE_CLONE_SECONDS_PER_ENTRY
+        )
+        entries = 0
+        size_bytes = 0
+        pending = [source]
+        while pending and entries < max_entries:
+            directory = pending.pop()
+            try:
+                children = os.scandir(directory)
+            except OSError:
+                return BUILD_CACHE_CLONE_MAX_SECONDS
+            with children:
+                for child in children:
+                    entries += 1
+                    if entries >= max_entries:
+                        return BUILD_CACHE_CLONE_MAX_SECONDS
+                    try:
+                        if child.is_dir(follow_symlinks=False):
+                            pending.append(Path(child.path))
+                        else:
+                            size_bytes += child.stat(follow_symlinks=False).st_size
+                    except OSError:
+                        return BUILD_CACHE_CLONE_MAX_SECONDS
+        return BuildCacheManager._tree_deadline_for_work(entries, size_bytes)
+
+    @staticmethod
+    def _clone_deadline_seconds(source: Path) -> float:
+        return BuildCacheManager._tree_deadline_seconds(source)
+
+    @staticmethod
+    def _clone_cow(source: Path, destination: Path) -> bool:
+        try:
+            completed = subprocess.run(
+                [
+                    "/usr/bin/ditto",
+                    "--clone",
+                    "--norsrc",
+                    "--noextattr",
+                    "--noqtn",
+                    "--noacl",
+                    str(source),
+                    str(destination),
+                ],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=BuildCacheManager._clone_deadline_seconds(source),
+            )
+            return completed.returncode == 0 and destination.is_dir() and not destination.is_symlink()
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+
+    @staticmethod
+    def _source_head(repo_root: Path) -> Optional[str]:
+        try:
+            completed = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=str(repo_root),
+                stdin=subprocess.DEVNULL,
+                text=True,
+                capture_output=True,
+                timeout=5.0,
+            )
+            value = completed.stdout.strip()
+            return value if completed.returncode == 0 and re.fullmatch(r"[0-9a-f]{40,64}", value) else None
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+
+    def _validate_seed_at(self, key: str, meta: Dict[str, Any], seed: Path) -> bool:
+        marker = self._read_json_file(seed / ".generation.json")
+        build = seed / ".build"
+        return bool(
+            marker
+            and marker.get("key") == key
+            and marker.get("generation") == meta.get("generation")
+            and build.is_dir()
+            and not build.is_symlink()
+        )
+
+    def _validate_seed(self, key: str, meta: Dict[str, Any]) -> bool:
+        return self._validate_seed_at(key, meta, self._key_dir(key) / "seed")
+
+    def _quarantine_seed(self, key: str, reason: str) -> None:
+        with self.key_lock(key, exclusive=True):
+            key_dir = self._key_dir(key)
+            meta = self._meta(key) or {"key": key, "generation": 0}
+            seed = key_dir / "seed"
+            if seed.exists() and not seed.is_symlink():
+                quarantine = key_dir / f"suspect-{int(self._clock())}-{uuid.uuid4().hex[:8]}"
+                os.replace(seed, quarantine)
+                shutil.rmtree(quarantine, ignore_errors=True)
+            meta["corruptionReason"] = reason[:500]
+            meta["quarantinedAt"] = self._clock()
+            ensure_private_dir(key_dir)
+            _atomic_write_json(key_dir / "meta.json", meta)
+
+    def _advisory_prepare_context(
+        self,
+        configuration: str,
+        error: BaseException,
+        snapshot: Optional[BuildCacheSnapshot] = None,
+        generation: int = 0,
+    ) -> BuildCacheContext:
+        build_dir = self.repo_root / ".build"
+        if build_dir.exists() or build_dir.is_symlink():
+            state = "warmLocalAdvisory" if build_dir.is_dir() and not build_dir.is_symlink() else "unsafeLocalBuildAdvisory"
+        else:
+            state = "cacheAdvisoryCold"
+        effective_snapshot = snapshot or BuildCacheSnapshot("0" * 64, {}, "")
+        status: Dict[str, Any] = {
+            "key": effective_snapshot.key,
+            "configuration": configuration,
+            "storePath": str(self.store_root),
+            "generation": generation,
+            "state": state,
+            "seeded": False,
+            "advisoryFailure": str(error)[:500],
+        }
+        return BuildCacheContext(effective_snapshot, generation, False, status)
+
+    def prepare(self, operation: str, args: Dict[str, Any], job_env: Dict[str, str]) -> Optional[BuildCacheContext]:
+        if (
+            not self.eligible(operation, args)
+            or self.env.get("REPOPROMPT_DEV_BUILD_CACHE_DISABLE") == "1"
+            or not (self.repo_root / "Package.swift").is_file()
+        ):
+            return None
+        configuration = self.configuration_for(operation, args)
+        try:
+            snapshot = self.snapshot(configuration, job_env)
+        except Exception as exc:
+            return self._advisory_prepare_context(configuration, exc)
+        build_dir = self.repo_root / ".build"
+        generation = 0
+        context = BuildCacheContext(
+            snapshot,
+            generation,
+            False,
+            {
+                "key": snapshot.key,
+                "configuration": configuration,
+                "storePath": str(self.store_root),
+                "generation": generation,
+                "state": "coldMiss",
+                "seeded": False,
+            },
+        )
+        startup_advisory_error = self._startup_advisory_error
+        temporary: Optional[Path] = None
+        try:
+            self._ensure_store_dirs()
+            self._startup_advisory_error = None
+            self._sweep_stranded_store_temporaries()
+            with self._repo_prepare_lock():
+                self._remove_repo_build_temporaries_locked()
+                with self.key_lock(snapshot.key, exclusive=False):
+                    meta = self._meta(snapshot.key) or {}
+                    generation = int(meta.get("generation") or 0)
+                    valid_seed = self._validate_seed(snapshot.key, meta) if meta else False
+                context.observed_generation = generation
+                context.status["generation"] = generation
+                if startup_advisory_error:
+                    context.status["startupAdvisoryFailure"] = startup_advisory_error
+                if build_dir.exists() or build_dir.is_symlink():
+                    context.status["state"] = (
+                        "warmLocal" if build_dir.is_dir() and not build_dir.is_symlink() else "unsafeLocalBuild"
+                    )
+                    return context
+                if meta and not valid_seed:
+                    self._quarantine_seed(snapshot.key, "seed generation or shape did not match metadata")
+                    context.status["state"] = "corruptSeedCold"
+                    return context
+                if not valid_seed:
+                    return context
+                temporary = self.repo_root / f".build.seed-tmp-{uuid.uuid4().hex}"
+                started = self._monotonic()
+                with self.key_lock(snapshot.key, exclusive=False):
+                    refreshed_meta = self._meta(snapshot.key) or {}
+                    if int(refreshed_meta.get("generation") or 0) != generation or not self._validate_seed(snapshot.key, refreshed_meta):
+                        context.status["state"] = "generationChangedCold"
+                        return context
+                    cloned = self._clone_runner(self._key_dir(snapshot.key) / "seed" / ".build", temporary)
+                if not cloned:
+                    context.status["state"] = "cloneFailedCold"
+                    return context
+                if build_dir.exists() or build_dir.is_symlink():
+                    context.status["state"] = "localBuildAppeared"
+                    return context
+                provenance = {
+                    "schemaVersion": BUILD_CACHE_SCHEMA_VERSION,
+                    "key": snapshot.key,
+                    "generation": generation,
+                    "sourceHead": meta.get("sourceHead"),
+                    "seedPath": str(self._key_dir(snapshot.key) / "seed"),
+                    "clonedAt": self._clock(),
+                }
+                _atomic_write_json(temporary / ".conductor-cache-provenance.json", provenance)
+                os.replace(temporary, build_dir)
+                temporary = None
+                duration = max(0.0, self._monotonic() - started)
+                context.status.update(
+                    {
+                        "state": "seeded",
+                        "seeded": True,
+                        "cloneSeconds": duration,
+                        "sourceHead": meta.get("sourceHead"),
+                    }
+                )
+                context.seeded = True
+                try:
+                    with self.key_lock(snapshot.key, exclusive=True):
+                        touched = self._meta(snapshot.key) or {}
+                        if int(touched.get("generation") or 0) == generation:
+                            touched["lastUsedAt"] = self._clock()
+                            _atomic_write_json(self._key_dir(snapshot.key) / "meta.json", touched)
+                except Exception as exc:
+                    context.status["advisoryFailure"] = str(exc)[:500]
+                return context
+        except Exception as exc:
+            return self._advisory_prepare_context(configuration, exc, snapshot, generation)
+        finally:
+            if temporary is not None and temporary.exists() and not temporary.is_symlink():
+                shutil.rmtree(temporary, ignore_errors=True)
+
+    @staticmethod
+    def _sanitize_seed(build_dir: Path) -> None:
+        deadline = BuildCacheManager._tree_deadline_seconds(build_dir)
+        for relative in ("xcode", "xcode-custom", ".conductor-cache-provenance.json"):
+            target = build_dir / relative
+            if target.is_dir() and not target.is_symlink():
+                shutil.rmtree(target, ignore_errors=True)
+            else:
+                with contextlib.suppress(FileNotFoundError):
+                    target.unlink()
+        for command, failure in (
+            (
+                [
+                    "/usr/bin/find",
+                    str(build_dir),
+                    "-type",
+                    "d",
+                    "-name",
+                    "ModuleCache",
+                    "-prune",
+                    "-exec",
+                    "/bin/rm",
+                    "-rf",
+                    "{}",
+                    "+",
+                ],
+                "could not exclude path-bound module caches from immutable build-cache seed",
+            ),
+            (
+                ["/usr/bin/find", str(build_dir), "-type", "f", "-name", "*.log", "-delete"],
+                "could not exclude logs from immutable build-cache seed",
+            ),
+        ):
+            completed = subprocess.run(
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=deadline,
+            )
+            if completed.returncode != 0:
+                raise ConductorError(failure)
+
+    @staticmethod
+    def _disk_usage_bytes(path: Path) -> int:
+        completed = subprocess.run(
+            ["/usr/bin/du", "-sk", str(path)],
+            stdin=subprocess.DEVNULL,
+            text=True,
+            capture_output=True,
+            timeout=BuildCacheManager._tree_deadline_seconds(path),
+        )
+        if completed.returncode != 0:
+            raise ConductorError("could not measure immutable build-cache seed")
+        try:
+            return int(completed.stdout.split()[0]) * 1024
+        except (IndexError, ValueError) as exc:
+            raise ConductorError("invalid immutable build-cache disk-usage result") from exc
+
+    def publish(self, context: BuildCacheContext) -> Dict[str, Any]:
+        if not context.snapshot.payload:
+            return {"state": "publicationSkipped", "reason": "compatibility key unavailable"}
+        current = self.snapshot(str(context.snapshot.payload["configuration"]), context.snapshot.payload.get("environment") or {})
+        if current.key != context.snapshot.key:
+            return {"state": "publicationSkipped", "reason": "compatibility key changed during build"}
+        build_dir = self.repo_root / ".build"
+        if not build_dir.is_dir() or build_dir.is_symlink():
+            return {"state": "publicationSkipped", "reason": "successful build directory unavailable"}
+        self._ensure_store_dirs()
+        self._sweep_stranded_store_temporaries()
+        key = context.snapshot.key
+        next_generation = 0
+        size = 0
+        with self.key_lock(key, exclusive=True):
+            key_dir = self._key_dir(key)
+            ensure_private_dir(key_dir)
+            existing = self._meta(key) or {}
+            generation = int(existing.get("generation") or 0)
+            if generation != context.observed_generation:
+                return {"state": "publicationSkipped", "reason": "newer generation already published", "generation": generation}
+            if (
+                existing.get("publishedAt")
+                and self._validate_seed(key, existing)
+                and self._clock() - float(existing["publishedAt"]) < BUILD_CACHE_PUBLISH_THROTTLE_SECONDS
+            ):
+                return {"state": "publicationSkipped", "reason": "publication throttled", "generation": generation}
+            next_generation = generation + 1
+            temporary = key_dir / f"seed.tmp-{uuid.uuid4().hex}"
+            previous = key_dir / f"seed.previous-{uuid.uuid4().hex}"
+            seed = key_dir / "seed"
+            swapped = False
+            publication_committed = False
+            try:
+                ensure_private_dir(temporary)
+                cloned = self._clone_runner(build_dir, temporary / ".build")
+                if not cloned:
+                    return {"state": "publicationSkipped", "reason": "COW publication clone failed"}
+                self._sanitize_seed(temporary / ".build")
+                _atomic_write_json(temporary / ".generation.json", {"key": key, "generation": next_generation})
+                size = self._disk_usage_bytes(temporary / ".build")
+                source_head = self._source_head(self.repo_root)
+                meta = {
+                    "schemaVersion": BUILD_CACHE_SCHEMA_VERSION,
+                    "key": key,
+                    "generation": next_generation,
+                    "toolchainSignature": context.snapshot.toolchain_signature,
+                    "compatibility": context.snapshot.payload,
+                    "sourceHead": source_head,
+                    "publishedAt": self._clock(),
+                    "lastUsedAt": self._clock(),
+                    "sizeBytes": size,
+                    "suspectCount": 0,
+                }
+                if seed.exists():
+                    os.replace(seed, previous)
+                os.replace(temporary, seed)
+                swapped = True
+                _atomic_write_json(key_dir / "meta.json", meta)
+                publication_committed = True
+            except Exception:
+                if swapped:
+                    if previous.exists():
+                        try:
+                            self._remove_owned_temporary(seed)
+                            os.replace(previous, seed)
+                        except Exception:
+                            # Preserve the recoverable previous generation for the next
+                            # locked maintenance sweep rather than deleting it blindly.
+                            pass
+                    else:
+                        with contextlib.suppress(OSError):
+                            self._remove_owned_temporary(seed)
+                elif previous.exists() and not seed.exists():
+                    with contextlib.suppress(OSError):
+                        os.replace(previous, seed)
+                raise
+            finally:
+                if temporary.exists():
+                    with contextlib.suppress(OSError):
+                        self._remove_owned_temporary(temporary)
+                if publication_committed and previous.exists():
+                    with contextlib.suppress(OSError):
+                        self._remove_owned_temporary(previous)
+        retention = self.enforce_retention(context.snapshot.toolchain_signature)
+        return {"state": "published", "key": key, "generation": next_generation, "sizeBytes": size, "retention": retention}
+
+    def confirm_seeded_failure(self, key: str) -> Dict[str, Any]:
+        with self.key_lock(key, exclusive=True):
+            key_dir = self._key_dir(key)
+            meta = self._meta(key) or {"key": key, "generation": 0}
+            count = int(meta.get("suspectCount") or 0) + 1
+            meta["suspectCount"] = count
+            meta["lastSuspectAt"] = self._clock()
+            quarantined = False
+            seed = key_dir / "seed"
+            if count >= 2 and seed.exists() and not seed.is_symlink():
+                quarantine = key_dir / f"suspect-{int(self._clock())}-{uuid.uuid4().hex[:8]}"
+                os.replace(seed, quarantine)
+                shutil.rmtree(quarantine, ignore_errors=True)
+                meta["quarantinedAt"] = self._clock()
+                quarantined = True
+            ensure_private_dir(key_dir)
+            _atomic_write_json(key_dir / "meta.json", meta)
+            return {"suspectCount": count, "quarantined": quarantined}
+
+    def enforce_retention(self, current_toolchain_signature: str) -> Dict[str, Any]:
+        self._ensure_store_dirs()
+        hygiene = self._sweep_stranded_store_temporaries()
+        try:
+            limit = int(self.env.get("REPOPROMPT_DEV_BUILD_CACHE_LIMIT_BYTES") or BUILD_CACHE_DEFAULT_LIMIT_BYTES)
+        except ValueError:
+            limit = BUILD_CACHE_DEFAULT_LIMIT_BYTES
+        rows: List[Tuple[bool, float, int, str]] = []
+        for child in self.store_root.iterdir():
+            if not child.is_dir() or not re.fullmatch(r"[0-9a-f]{64}", child.name):
+                continue
+            meta = self._meta(child.name) or {}
+            rows.append((meta.get("toolchainSignature") == current_toolchain_signature, float(meta.get("lastUsedAt") or 0.0), int(meta.get("sizeBytes") or 0), child.name))
+        total = sum(row[2] for row in rows)
+        evicted: List[str] = []
+        for _same_toolchain, _used, size, key in sorted(rows):
+            if total <= max(0, limit):
+                break
+            try:
+                with self.key_lock(key, exclusive=True, nonblocking=True):
+                    key_dir = self._key_dir(key)
+                    if key_dir.exists() and not key_dir.is_symlink():
+                        shutil.rmtree(key_dir)
+                        total -= size
+                        evicted.append(key)
+            except BlockingIOError:
+                continue
+        return {"limitBytes": limit, "remainingBytes": total, "evictedKeys": evicted, "hygiene": hygiene}
+
+    def status(self, limit: int = BUILD_CACHE_DIAGNOSTIC_MAX_ROWS) -> Dict[str, Any]:
+        entries: List[Dict[str, Any]] = []
+        try:
+            children = list(self.store_root.iterdir())
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            children = []
+        for child in children:
+            if child.is_dir() and not child.is_symlink() and re.fullmatch(r"[0-9a-f]{64}", child.name):
+                meta = self._meta(child.name) or {"key": child.name, "state": "invalidMetadata"}
+                entries.append(meta)
+        entries.sort(key=lambda item: float(item.get("lastUsedAt") or item.get("publishedAt") or 0.0), reverse=True)
+        return {
+            "storePath": str(self.store_root),
+            "readOnly": True,
+            "entryCount": len(entries),
+            "entries": entries[: max(1, min(limit, 100))],
+        }
+
+    def drop(self, key: str) -> bool:
+        with self.key_lock(key, exclusive=True):
+            key_dir = self._key_dir(key)
+            if not key_dir.exists():
+                return False
+            if key_dir.is_symlink():
+                raise ConductorError("refusing symlink build-cache entry")
+            shutil.rmtree(key_dir)
+            return True
 
 
 def machine_lock_dir() -> Path:
@@ -1417,6 +2215,14 @@ def cleanup_stale_files(paths: Paths) -> DaemonRecoveryResult:
         if identity is not None and _path_identity(path) != identity:
             return DaemonRecoveryResult("ambiguous", False, f"daemon evidence changed during recovery: {path}")
     registry_identity = _path_identity(paths.running_processes_path)
+    if registry_identity is not None:
+        worker_cleanup = cleanup_running_process_groups(paths)
+        if not worker_cleanup.get("safeToForget"):
+            return DaemonRecoveryResult(
+                "ambiguous",
+                False,
+                "recorded daemon is stale, but worker process-group cleanup lacks exact bounded completion evidence",
+            )
     for path, identity in (*identities.items(), (paths.running_processes_path, registry_identity)):
         if identity is None:
             continue
@@ -2107,6 +2913,8 @@ class Job:
     error: Optional[str] = None
     result_summary: Optional[str] = None
     cancel_requested: bool = False
+    cancellation_ignored_reason: Optional[str] = None
+    cache_attempt_record_path: Optional[Path] = dataclasses.field(default=None, repr=False)
     cleanup_in_flight: bool = False
     superseded_by_ticket: Optional[str] = None
     superseded_by_operation: Optional[str] = None
@@ -2137,6 +2945,7 @@ class Job:
     output_truncation_reason: Optional[str] = None
     output_bytes_read: int = 0
     tail_bytes: int = 0
+    build_cache: Dict[str, Any] = dataclasses.field(default_factory=dict)
     tail: Deque[str] = dataclasses.field(default_factory=lambda: deque(maxlen=LOG_TAIL_LINES))
 
     def to_payload(self, include_tail: bool = True, include_summary: bool = True) -> Dict[str, Any]:
@@ -2201,6 +3010,11 @@ class Job:
             "error": self.error,
             "resultSummary": self.result_summary,
             "cancelRequested": self.cancel_requested,
+            "cancellationIgnored": self.cancellation_ignored_reason is not None,
+            "cancellationIgnoredReason": self.cancellation_ignored_reason,
+            "cacheAttemptRecoveryRecord": (
+                str(self.cache_attempt_record_path) if self.cache_attempt_record_path is not None else None
+            ),
             "supersededByTicket": self.superseded_by_ticket,
             "supersededByOperation": self.superseded_by_operation,
             "timedOut": self.timed_out,
@@ -2211,6 +3025,7 @@ class Job:
             "lastProgressAction": self.xctest_last_progress_action,
             "lastProgressObservedAt": self.xctest_last_progress_observed_at,
             "diagnosticPaths": [str(path) for path in self.diagnostic_paths],
+            "buildCache": dict(self.build_cache),
         }
         if self.diagnostics:
             payload["diagnostics"] = list(self.diagnostics)
@@ -2254,6 +3069,10 @@ class OperationRegistry:
         "SWIFT_EXEC",
         "CC",
         "CXX",
+        "ARCHS",
+        "ONLY_ACTIVE_ARCH",
+        "OTHER_SWIFT_FLAGS",
+        "SWIFTFLAGS",
         "TMPDIR",
         "HOME",
         "USER",
@@ -2287,6 +3106,9 @@ class OperationRegistry:
     ]
     CONDUCTOR_ENV_KEYS = [
         "REPOPROMPT_DEV_HEAVY_SLOTS",
+        "REPOPROMPT_DEV_BUILD_CACHE_DIR",
+        "REPOPROMPT_DEV_BUILD_CACHE_DISABLE",
+        "REPOPROMPT_DEV_BUILD_CACHE_LIMIT_BYTES",
     ]
     TELEMETRY_ENV_KEYS = [
         "REPOPROMPT_ENABLE_SENTRY",
@@ -2412,7 +3234,7 @@ class OperationRegistry:
         if operation == "debug-cli-status":
             return [script("install_debug_cli.sh"), "status"], lanes, cwd, env, effective_timeout
         if operation == "run":
-            return self._internal_argv("debug_app_build_then_launch", dict(args)), ["liveApp"], cwd, env, effective_timeout
+            return self._internal_argv("debug_app_build_then_launch", dict(args)), ["build", "liveApp"], cwd, env, effective_timeout
         if operation == "app":
             subcommand = args.get("subcommand")
             if subcommand == "stop":
@@ -2423,11 +3245,11 @@ class OperationRegistry:
             if subcommand == "launch-existing":
                 return self._internal_argv("app_launch_existing", dict(args)), ["liveApp"], cwd, env, effective_timeout
             if subcommand == "relaunch":
-                return self._internal_argv("debug_app_build_then_launch", dict(args)), ["liveApp"], cwd, env, effective_timeout
+                return self._internal_argv("debug_app_build_then_launch", dict(args)), ["build", "liveApp"], cwd, env, effective_timeout
         if operation == "smoke":
             lanes = ["debugArtifact", "liveApp"]
             if args.get("launch"):
-                lanes = ["liveApp"]
+                lanes = ["build", "liveApp"]
             elif args.get("packagedApp"):
                 lanes = ["liveApp"]
             smoke_args = dict(args)
@@ -2594,12 +3416,27 @@ class DaemonState:
         self._running_registry_generation = 0
         self._retention_generation = 0
         self._registry_publish_lock = threading.Lock()
+        self._cache_write_lock = threading.Lock()
+        self._cache_write_active_ticket: Optional[str] = None
+        self.build_cache: Optional[BuildCacheManager] = None
         self._daemon_infrastructure_warnings: Deque[Dict[str, Any]] = deque(maxlen=MAX_INFRASTRUCTURE_WARNINGS)
         self._io_worker = ExternalIOWorker(self._record_io_worker_error)
         self._output_pump = ProcessOutputPump(
             self._submit_process_output_chunk,
             self._submit_process_output_line,
         )
+
+    def _build_cache_manager(self, env: Optional[Dict[str, str]] = None) -> BuildCacheManager:
+        desired_env = dict(os.environ if env is None else env)
+        override = desired_env.get("REPOPROMPT_DEV_BUILD_CACHE_DIR")
+        desired_root = (
+            Path(override).expanduser().resolve()
+            if override
+            else (Path.home() / "Library" / "Application Support" / "RepoPrompt CE" / "Conductor" / "BuildCache").resolve()
+        )
+        if self.build_cache is None or self.build_cache.store_root != desired_root:
+            self.build_cache = BuildCacheManager(self.paths.repo_root, env=desired_env)
+        return self.build_cache
 
     def _record_io_worker_error(self, message: str) -> None:
         with self.condition:
@@ -2711,6 +3548,7 @@ class DaemonState:
                     if ticket in self.jobs
                 ],
                 "unlanedCapacity": {"limit": MAX_UNLANED_JOBS, "activeCount": len(self.active_unlaned)},
+                "cacheWriteLane": {"activeTicket": self._cache_write_active_ticket},
                 "runningJobs": running_jobs,
                 "queuedJobs": queued_jobs,
                 "queueDepth": len(self.queue),
@@ -2972,6 +3810,18 @@ class DaemonState:
                 self._retention_pass_locked()
                 return self._job_payload_locked(job, include_tail=True)
             if job.state == "running":
+                if job.phase == "publishingCache":
+                    job.cancellation_ignored_reason = (
+                        "build process already succeeded; immutable cache publication is non-abortable"
+                    )
+                    self._append_system_line_locked(
+                        job,
+                        f"cancellation ignored: {job.cancellation_ignored_reason}\n",
+                    )
+                    payload = self._job_payload_locked(job, include_tail=True)
+                    payload["cancellationPending"] = False
+                    self.condition.notify_all()
+                    return payload
                 job.cancel_requested = True
                 self._set_phase_locked(job, "canceling")
                 self._request_process_cleanup_locked(job, reason="cancellation requested")
@@ -2999,6 +3849,20 @@ class DaemonState:
             self.shutdown_requested = True
             if force:
                 for job in list(active_or_queued):
+                    if job.state == "running" and job.phase == "publishingCache":
+                        # Atomic seed replacement must not be interrupted after a
+                        # successful build. Force-stop waits for the publication's
+                        # already bounded filesystem operations instead of
+                        # signaling or corrupting the committed build result.
+                        job.cancellation_ignored_reason = (
+                            "build process already succeeded; immutable cache publication is non-abortable"
+                        )
+                        self._append_system_line_locked(
+                            job,
+                            f"daemon stop cancellation ignored: {job.cancellation_ignored_reason}\n",
+                        )
+                        running_tickets.append(job.ticket)
+                        continue
                     job.cancel_requested = True
                     if job.state == "queued":
                         job.state = "canceled"
@@ -3016,6 +3880,19 @@ class DaemonState:
                 self._write_running_processes_locked()
                 self.condition.notify_all()
             payload = self.status_payload()
+            if force:
+                publication_wait_tickets = [
+                    job.ticket
+                    for job in active_or_queued
+                    if job.state == "running" and job.phase == "publishingCache"
+                ]
+                payload["forceStop"] = {
+                    "requested": True,
+                    "publicationPolicy": "waitForNonAbortableAtomicPublication",
+                    "publicationWaitTickets": publication_wait_tickets,
+                    "publicationWaitTimeoutSeconds": BUILD_CACHE_FORCE_STOP_WAIT_SECONDS,
+                    "cancellationIgnored": bool(publication_wait_tickets),
+                }
         if force and running_tickets:
             threading.Thread(target=self._force_shutdown_when_canceled, args=(running_tickets,), daemon=True).start()
         else:
@@ -3032,6 +3909,24 @@ class DaemonState:
             for ticket in tickets:
                 job = self.jobs.get(ticket)
                 if not job or job.state != "running":
+                    continue
+                if job.phase == "publishingCache" and job.cancellation_ignored_reason:
+                    # Do not create a second cancellation authority inside the
+                    # atomic publication path. Wait only for the advertised
+                    # bounded allowance; on expiry, keep the daemon available
+                    # and leave the publication worker and build result intact.
+                    publication_deadline = time.monotonic() + BUILD_CACHE_FORCE_STOP_WAIT_SECONDS
+                    while job.state == "running" and job.phase == "publishingCache":
+                        remaining = publication_deadline - time.monotonic()
+                        if remaining <= 0:
+                            self.shutdown_requested = False
+                            self._warn_job_locked(
+                                job,
+                                "buildCachePublicationStopWaitExpired",
+                                "daemon stop --force left non-abortable cache publication running after bounded wait",
+                            )
+                            return
+                        self.condition.wait(timeout=min(PROCESS_TREE_POLL_SECONDS, remaining))
                     continue
                 descendants_alive = self._wait_for_process_tree_exit_locked(
                     job,
@@ -3197,7 +4092,13 @@ class DaemonState:
             return None
         return acquired
 
-    def _publish_started_process_identity(self, job: Job, process: subprocess.Popen[bytes]) -> bool:
+    def _publish_started_process_identity(
+        self,
+        job: Job,
+        process: subprocess.Popen[bytes],
+        *,
+        durable_registry: bool = False,
+    ) -> bool:
         process_pgid: Optional[int] = None
         with contextlib.suppress(OSError):
             process_pgid = os.getpgid(process.pid)
@@ -3216,9 +4117,12 @@ class DaemonState:
             if observed_process_start:
                 job.tracked_processes[process.pid] = observed_process_start
             self._set_phase_locked(job, "runningProcess")
-            self._write_running_processes_locked()
+            if not durable_registry:
+                self._write_running_processes_locked()
             cancel_after_publish = job.cancel_requested and job.superseded_by_ticket is None
             self.condition.notify_all()
+        if durable_registry:
+            self._write_running_processes_durable()
         return cancel_after_publish
 
     def _cleanup_failed_output_registration(self, job: Job, process: subprocess.Popen[bytes]) -> None:
@@ -3275,6 +4179,11 @@ class DaemonState:
         output_channel: Optional[ProcessOutputChannel] = None
         watchdog: Optional[threading.Thread] = None
         global_heavy_slot: Optional[Any] = None
+        cache_manager: Optional[BuildCacheManager] = None
+        cache_context: Optional[BuildCacheContext] = None
+        cache_publish_after_success = False
+        cache_wrapper_gate_read = -1
+        cache_wrapper_gate_write = -1
         try:
             with self.lock:
                 job = self.jobs[ticket]
@@ -3295,6 +4204,46 @@ class DaemonState:
                     return
             argv, _lanes, cwd, env, effective_timeout = self.registry.prepare(request)
             env["REPOPROMPT_CONDUCTOR_JOB_TICKET"] = job.ticket
+            if BuildCacheManager.eligible(job.operation, job.args) and (self.paths.repo_root / "Package.swift").is_file():
+                with self._cache_write_lock:
+                    cache_manager = self._build_cache_manager(env)
+                cache_context = cache_manager.prepare(job.operation, job.args, env)
+                if cache_context is not None:
+                    cache_context.outcome_path = job.log_path.with_suffix(".cache-outcome.json")
+                    with self.condition:
+                        job.build_cache = dict(cache_context.status)
+                        self._append_system_line_locked(
+                            job,
+                            f"build cache {cache_context.status.get('state')}: key={cache_context.status.get('key', 'unavailable')}\n",
+                        )
+                    if cache_context.seeded:
+                        attempt_timeout = effective_timeout
+                        cache_attempt_record_path = job.log_path.with_suffix(".cache-attempt.json")
+                        with self.condition:
+                            job.cache_attempt_record_path = cache_attempt_record_path
+                        cleanup_timeout = BuildCacheManager._tree_deadline_seconds(
+                            self.paths.repo_root / ".build"
+                        )
+                        argv = self.registry._internal_argv(
+                            "cache_retry",
+                            {
+                                "argv": argv,
+                                "key": cache_context.snapshot.key,
+                                "outcomePath": str(cache_context.outcome_path),
+                                "attemptTimeout": attempt_timeout,
+                                "cleanupTimeout": cleanup_timeout,
+                                "attemptRecordPath": str(cache_attempt_record_path),
+                                "ticket": job.ticket,
+                            },
+                        )
+                        effective_timeout = BuildCacheManager.retry_job_timeout(
+                            attempt_timeout,
+                            cleanup_timeout,
+                        )
+                        with self.condition:
+                            job.build_cache["attemptTimeoutSeconds"] = attempt_timeout
+                            job.build_cache["cleanupTimeoutSeconds"] = cleanup_timeout
+                            job.build_cache["retryEnvelopeTimeoutSeconds"] = effective_timeout
             if operation_requires_global_heavy_slot(job.operation, job.args):
                 global_heavy_slot = self._acquire_global_heavy_slot(job.ticket)
                 if global_heavy_slot is None:
@@ -3305,6 +4254,11 @@ class DaemonState:
             output_transport = self._create_process_output_transport(job)
             with self.condition:
                 job.progress_transport = output_transport.kind
+            process_pass_fds: Tuple[int, ...] = ()
+            if cache_context is not None and cache_context.seeded:
+                cache_wrapper_gate_read, cache_wrapper_gate_write = os.pipe()
+                env["REPOPROMPT_CONDUCTOR_CACHE_WRAPPER_GATE_FD"] = str(cache_wrapper_gate_read)
+                process_pass_fds = (cache_wrapper_gate_read,)
             process = subprocess.Popen(
                 argv,
                 cwd=str(cwd),
@@ -3312,8 +4266,12 @@ class DaemonState:
                 stdin=subprocess.DEVNULL,
                 stdout=output_transport.popen_stdout,
                 stderr=output_transport.popen_stderr,
+                pass_fds=process_pass_fds,
                 start_new_session=True,
             )
+            if cache_wrapper_gate_read >= 0:
+                os.close(cache_wrapper_gate_read)
+                cache_wrapper_gate_read = -1
             output_transport.attach_process(process)
             reader_fd = output_transport.transfer_reader()
             try:
@@ -3325,7 +4283,25 @@ class DaemonState:
                 self._cleanup_failed_output_registration(job, process)
                 raise
 
-            cancel_after_publish = self._publish_started_process_identity(job, process)
+            try:
+                cancel_after_publish = self._publish_started_process_identity(
+                    job,
+                    process,
+                    durable_registry=cache_wrapper_gate_write >= 0,
+                )
+                if cache_wrapper_gate_write >= 0:
+                    if os.write(cache_wrapper_gate_write, b"1") != 1:
+                        raise ConductorError("cache retry wrapper gate release was incomplete")
+                    os.close(cache_wrapper_gate_write)
+                    cache_wrapper_gate_write = -1
+            except Exception:
+                if cache_wrapper_gate_write >= 0:
+                    with contextlib.suppress(OSError):
+                        os.close(cache_wrapper_gate_write)
+                    cache_wrapper_gate_write = -1
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    process.wait(timeout=KILL_GRACE_SECONDS)
+                raise
             if cancel_after_publish:
                 with self.condition:
                     current = self.jobs.get(job.ticket)
@@ -3440,8 +4416,16 @@ class DaemonState:
                         self._append_system_line_locked(job, job.error + "\n")
             with self.condition:
                 self._finalize_process_exit_locked(job, exit_code)
-                self._set_phase_locked(job, "summarizing")
-                job.finished_at = now()
+                cache_publish_after_success = bool(
+                    job.state == "completed" and cache_context is not None and cache_manager is not None
+                )
+                if cache_publish_after_success:
+                    job.state = "running"
+                    job.result_summary = "build succeeded; publishing immutable cache seed"
+                    self._set_phase_locked(job, "publishingCache")
+                else:
+                    self._set_phase_locked(job, "summarizing")
+                    job.finished_at = now()
         except Exception as exc:
             if job is not None:
                 with self.condition:
@@ -3453,6 +4437,12 @@ class DaemonState:
                     job.finished_at = now()
                     self._append_system_line_locked(job, f"daemon runner error: {exc}\n")
         finally:
+            if cache_wrapper_gate_read >= 0:
+                with contextlib.suppress(OSError):
+                    os.close(cache_wrapper_gate_read)
+            if cache_wrapper_gate_write >= 0:
+                with contextlib.suppress(OSError):
+                    os.close(cache_wrapper_gate_write)
             if output_channel is not None and output_channel.result is None:
                 with contextlib.suppress(ConductorError):
                     self._output_pump.request_finalization(output_channel)
@@ -3462,11 +4452,59 @@ class DaemonState:
                         job.output_truncated = output_result.truncated
                         job.output_truncation_reason = output_result.reason
                         job.output_bytes_read = output_result.bytes_read
+            # Deliberate ordering: cache publication no longer consumes scarce
+            # machine-wide heavy capacity, while the job retains its per-daemon
+            # build lane through immutable publication. Coordinated mutators of
+            # this checkout's .build remain blocked without stalling unrelated
+            # worktrees behind the global heavy slot.
             self._release_global_heavy_slot(global_heavy_slot)
-            if job is not None and global_heavy_slot is not None:
+            released_heavy_slot = global_heavy_slot is not None
+            global_heavy_slot = None
+            if job is not None and released_heavy_slot:
                 with self.condition:
                     if self.jobs.get(job.ticket) is job:
                         job.global_heavy_admission_state = "released"
+            if job is not None and cache_context is not None and cache_context.outcome_path is not None:
+                outcome = BuildCacheManager._read_json_file(cache_context.outcome_path)
+                if outcome:
+                    with self.condition:
+                        job.build_cache["retry"] = outcome
+                        self._apply_cache_retry_outcome_locked(job, outcome)
+                with contextlib.suppress(FileNotFoundError):
+                    cache_context.outcome_path.unlink()
+            if job is not None and cache_publish_after_success and cache_context is not None and cache_manager is not None:
+                try:
+                    with self._cache_write_lock:
+                        with self.condition:
+                            self._cache_write_active_ticket = job.ticket
+                        try:
+                            publication = cache_manager.publish(cache_context)
+                        finally:
+                            with self.condition:
+                                self._cache_write_active_ticket = None
+                                self.condition.notify_all()
+                    with self.condition:
+                        job.build_cache["publication"] = publication
+                        self._append_system_line_locked(
+                            job,
+                            f"build cache publication {publication.get('state')}: {publication.get('reason') or publication.get('generation', '')}\n",
+                        )
+                except Exception as exc:
+                    with self.condition:
+                        job.build_cache["publication"] = {"state": "publicationFailed", "error": str(exc)[:500]}
+                        self._warn_job_locked(job, "buildCachePublicationFailed", str(exc))
+                finally:
+                    with self.condition:
+                        job.state = "completed"
+                        job.exit_code = 0
+                        job.result_summary = (
+                            "completed successfully; cancellation ignored during non-abortable cache publication"
+                            if job.cancellation_ignored_reason
+                            else "completed successfully"
+                        )
+                        self._set_phase_locked(job, "summarizing")
+                        job.finished_at = now()
+                        self.condition.notify_all()
             if output_transport is not None:
                 output_transport.close_all()
             refresh_after_release = False
@@ -3502,6 +4540,23 @@ class DaemonState:
                 self._append_tail_locked(job, text)
                 self._record_xctest_progress_locked(job, text)
                 self.condition.notify_all()
+
+    @staticmethod
+    def _apply_cache_retry_outcome_locked(job: Job, outcome: Dict[str, Any]) -> None:
+        cold_attempted = bool(outcome.get("coldRetryAttempted"))
+        terminal_timed_out = bool(
+            outcome.get("coldTimedOut") if cold_attempted else outcome.get("seededTimedOut")
+        )
+        if not terminal_timed_out:
+            return
+        attempt = "cold recovery" if cold_attempted else "seeded"
+        timeout = outcome.get("attemptTimeoutSeconds")
+        suffix = f" after {float(timeout):.1f}s" if isinstance(timeout, (int, float)) else ""
+        job.timed_out = True
+        job.state = "failed"
+        job.exit_code = 124
+        job.error = f"{attempt} cache build attempt timed out{suffix}"
+        job.result_summary = job.error
 
     def _finalize_process_exit_locked(self, job: Job, exit_code: int) -> None:
         if job.cancel_requested:
@@ -3995,7 +5050,7 @@ class DaemonState:
                 if current is not None:
                     self._settle_job_log_sequence_locked(current, sequence)
 
-    def _write_running_processes_locked(self) -> None:
+    def _running_processes_payload_locked(self) -> Tuple[int, Dict[str, Any]]:
         self._running_registry_generation += 1
         generation = self._running_registry_generation
         processes = []
@@ -4016,15 +5071,24 @@ class DaemonState:
                         "pgid": job.process_pgid,
                         "processStart": job.process_start,
                         "processGroupIdentityConfirmed": job.process_group_identity_confirmed,
+                        "cacheAttemptRecord": (
+                            job.cache_attempt_record_path.name
+                            if job.cache_attempt_record_path is not None
+                            else None
+                        ),
                     }
                 )
         payload = {
-            "version": 2,
+            "version": 3,
             "generation": generation,
             "updatedAt": now(),
             "daemon": {"pid": os.getpid(), "processStart": self._daemon_start_token},
             "processes": processes,
         }
+        return generation, payload
+
+    def _write_running_processes_locked(self) -> None:
+        generation, payload = self._running_processes_payload_locked()
         if not self._io_worker.submit(self._publish_running_processes, generation, payload):
             self._daemon_infrastructure_warnings.append(
                 {
@@ -4034,21 +5098,21 @@ class DaemonState:
                 }
             )
 
+    def _write_running_processes_durable(self) -> None:
+        with self._registry_publish_lock:
+            with self.condition:
+                generation, payload = self._running_processes_payload_locked()
+            _atomic_write_json(self.paths.running_processes_path, payload)
+
     def _publish_running_processes(self, generation: int, payload: Dict[str, Any]) -> None:
-        temporary = self.paths.running_processes_path.with_name(
-            f".{self.paths.running_processes_path.name}.{generation}.{uuid.uuid4().hex}.tmp"
-        )
-        temporary.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-        os.chmod(temporary, 0o600)
-        try:
-            with self._registry_publish_lock:
-                with self.condition:
-                    if generation != self._running_registry_generation:
-                        return
-                os.replace(temporary, self.paths.running_processes_path)
-        finally:
-            with contextlib.suppress(FileNotFoundError):
-                temporary.unlink()
+        with self._registry_publish_lock:
+            with self.condition:
+                if generation != self._running_registry_generation:
+                    return
+            # The registry is the sole enumeration authority for crash recovery.
+            # Publish it with file and directory fsync before any supplemental
+            # cache-attempt record may be trusted.
+            _atomic_write_json(self.paths.running_processes_path, payload)
 
     def _request_process_cleanup_locked(self, job: Job, reason: str) -> None:
         if job.state != "running" or job.cleanup_in_flight:
@@ -4446,6 +5510,7 @@ def validate_json_shape(value: Any, depth: int = 0) -> None:
 class ThreadedUnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
     daemon_threads = True
     allow_reuse_address = True
+    request_queue_size = MAX_ACTIVE_REQUEST_HANDLERS
 
     def __init__(self, server_address: str, handler_cls: Any, state: DaemonState) -> None:
         self.state = state
@@ -4809,7 +5874,7 @@ def read_running_processes(paths: Paths, invalid: Optional[List[str]] = None) ->
         return []
     except (json.JSONDecodeError, OSError) as exc:
         raise ConductorError(f"could not safely read running-process registry: {exc}") from exc
-    if not isinstance(payload, dict) or payload.get("version", 1) not in {1, 2}:
+    if not isinstance(payload, dict) or payload.get("version", 1) not in {1, 2, 3}:
         raise ConductorError("running-process registry has an unsupported schema")
     processes = payload.get("processes")
     if not isinstance(processes, list):
@@ -4833,39 +5898,290 @@ def read_running_processes(paths: Paths, invalid: Optional[List[str]] = None) ->
     return validated
 
 
-def signal_running_process_groups(paths: Paths, sig: signal.Signals) -> Dict[str, Any]:
-    snapshot = process_table_snapshot()
-    report: Dict[str, Any] = {"verified": [], "skipped": [], "gone": [], "invalid": []}
-    own_pgid = os.getpgrp()
+def _read_cache_attempt_recovery_group(
+    paths: Paths,
+    wrapper: Dict[str, Any],
+    invalid: List[str],
+) -> Tuple[Optional[Dict[str, Any]], Optional[Path]]:
+    record_name = wrapper.get("cacheAttemptRecord")
+    if record_name is None:
+        return None, None
+    ticket = wrapper.get("ticket")
+    if not isinstance(ticket, str) or not ticket or len(ticket) > 128:
+        invalid.append("cache attempt record: missing bounded ticket identity")
+        return None, None
+    expected_name = f"{ticket}.cache-attempt.json"
+    if not isinstance(record_name, str) or record_name != expected_name or Path(record_name).name != record_name:
+        invalid.append(f"cache attempt record for {ticket}: unsafe record path")
+        return None, None
+    record_path = paths.jobs_dir / record_name
     try:
-        processes = read_running_processes(paths, invalid=report["invalid"])
+        info = record_path.lstat()
+    except FileNotFoundError:
+        # The cache runner uses a pipe gate: the detached attempt cannot exec
+        # until this record has been durably replaced. A missing record therefore
+        # means there is no released attempt authority to recover.
+        return None, record_path
+    if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+        invalid.append(f"cache attempt record for {ticket}: unsafe file identity or mode")
+        return None, record_path
+    try:
+        payload = json.loads(record_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        invalid.append(f"cache attempt record for {ticket}: unreadable: {exc}")
+        return None, record_path
+    try:
+        wrapper_pid = int(payload.get("wrapperPID"))
+        attempt_pid = int(payload.get("attemptPID"))
+        attempt_pgid = int(payload.get("attemptPGID"))
+    except (AttributeError, TypeError, ValueError):
+        invalid.append(f"cache attempt record for {ticket}: invalid pid/pgid")
+        return None, record_path
+    wrapper_start = payload.get("wrapperStartToken") if isinstance(payload, dict) else None
+    attempt_start = payload.get("attemptStartToken") if isinstance(payload, dict) else None
+    if not (
+        isinstance(payload, dict)
+        and payload.get("version") == 1
+        and payload.get("state") == "active"
+        and payload.get("ticket") == ticket
+        and wrapper_pid == int(wrapper["pid"])
+        and wrapper_start == wrapper.get("processStart")
+        and attempt_pid > 0
+        and attempt_pgid == attempt_pid
+        and isinstance(attempt_start, str)
+        and attempt_start
+    ):
+        invalid.append(f"cache attempt record for {ticket}: identity binding mismatch")
+        return None, record_path
+    return {
+        "kind": "cacheAttempt",
+        "ticket": ticket,
+        "pid": attempt_pid,
+        "pgid": attempt_pgid,
+        "startToken": attempt_start,
+    }, record_path
+
+
+def _collect_recovery_process_groups(paths: Paths) -> Tuple[List[Dict[str, Any]], List[str], List[Path]]:
+    invalid: List[str] = []
+    record_paths: List[Path] = []
+    try:
+        processes = read_running_processes(paths, invalid=invalid)
     except ConductorError as exc:
-        report["invalid"].append(f"registry: {exc}")
-        processes = []
+        return [], [f"registry: {exc}"], []
+    groups: List[Dict[str, Any]] = []
     for item in processes:
-        pid = int(item["pid"])
-        pgid = int(item["pgid"])
-        if snapshot is None:
-            report["skipped"].append(pid)
-            continue
-        record = snapshot.get(pid)
-        if record is None:
+        attempt, record_path = _read_cache_attempt_recovery_group(paths, item, invalid)
+        if record_path is not None:
+            record_paths.append(record_path)
+        groups.append(
+            {
+                "kind": "wrapper",
+                "ticket": item.get("ticket"),
+                "pid": int(item["pid"]),
+                "pgid": int(item["pgid"]),
+                "startToken": item["processStart"],
+            }
+        )
+        if attempt is not None:
+            # Stop the wrapper first so it cannot publish a successor attempt.
+            # The sidecar remains supplemental evidence bound to this registry
+            # entry and is re-read after wrapper exit before cleanup can finish.
+            groups.append(attempt)
+    return groups, invalid, record_paths
+
+
+def _signal_recovery_group(
+    group: Dict[str, Any],
+    sig: signal.Signals,
+    snapshot: Optional[Dict[int, Tuple[int, str]]],
+    own_pgid: int,
+) -> str:
+    pid = int(group["pid"])
+    pgid = int(group["pgid"])
+    if snapshot is None:
+        return "ambiguous"
+    record = snapshot.get(pid)
+    if record is None:
+        return "gone"
+    if record[1] != group["startToken"]:
+        return "stale"
+    if pgid == own_pgid:
+        return "ambiguous"
+    confirmation = process_table_snapshot()
+    if confirmation is None:
+        return "ambiguous"
+    confirmed = confirmation.get(pid)
+    if confirmed is None:
+        return "gone"
+    if confirmed[1] != group["startToken"]:
+        return "stale"
+    try:
+        if os.getpgid(pid) != pgid:
+            return "ambiguous"
+        os.killpg(pgid, sig)
+        return "verified"
+    except ProcessLookupError:
+        return "gone"
+    except (PermissionError, OSError):
+        return "ambiguous"
+
+
+def signal_running_process_groups(paths: Paths, sig: signal.Signals) -> Dict[str, Any]:
+    groups, invalid, record_paths = _collect_recovery_process_groups(paths)
+    snapshot = process_table_snapshot()
+    report: Dict[str, Any] = {
+        "verified": [],
+        "skipped": [],
+        "gone": [],
+        "invalid": invalid,
+        "groups": [],
+        "recordPaths": [str(path) for path in record_paths],
+    }
+    own_pgid = os.getpgrp()
+    for group in groups:
+        state = _signal_recovery_group(group, sig, snapshot, own_pgid)
+        pid = int(group["pid"])
+        report["groups"].append(
+            {
+                "kind": group["kind"],
+                "ticket": group.get("ticket"),
+                "pid": pid,
+                "pgid": int(group["pgid"]),
+                "startToken": group["startToken"],
+                "state": state,
+            }
+        )
+        if state == "verified":
+            report["verified"].append(pid)
+        elif state == "gone":
             report["gone"].append(pid)
-            continue
-        if record[1] != item["processStart"] or pgid == own_pgid:
+        else:
             report["skipped"].append(pid)
+    report["identityComplete"] = not invalid and all(
+        group["state"] in {"verified", "gone", "stale"} for group in report["groups"]
+    )
+    return report
+
+
+def _live_recovery_targets(targets: List[Dict[str, Any]]) -> Optional[List[Dict[str, Any]]]:
+    snapshot = process_table_snapshot()
+    if snapshot is None:
+        return None
+    live: List[Dict[str, Any]] = []
+    for target in targets:
+        pid = int(target["pid"])
+        record = snapshot.get(pid)
+        if record is None or record[1] != target["startToken"]:
             continue
         try:
-            if os.getpgid(pid) != pgid:
-                report["skipped"].append(pid)
-                continue
-            os.killpg(pgid, sig)
-            report["verified"].append(pid)
+            if os.getpgid(pid) != int(target["pgid"]):
+                return None
+            live.append(target)
         except ProcessLookupError:
-            report["gone"].append(pid)
+            continue
         except (PermissionError, OSError):
-            report["skipped"].append(pid)
-    return report
+            return None
+    return live
+
+
+def _wait_for_recovery_targets_exit(
+    targets: List[Dict[str, Any]],
+    timeout: float,
+) -> Optional[List[Dict[str, Any]]]:
+    if not targets:
+        return []
+    deadline = time.monotonic() + max(0.0, timeout)
+    while True:
+        live = _live_recovery_targets(targets)
+        if live is None or not live or time.monotonic() >= deadline:
+            return live
+        time.sleep(min(PROCESS_TREE_POLL_SECONDS, max(0.0, deadline - time.monotonic())))
+
+
+def _signal_exact_recovery_targets(
+    targets: List[Dict[str, Any]],
+    sig: signal.Signals,
+) -> Tuple[bool, List[Dict[str, Any]]]:
+    snapshot = process_table_snapshot()
+    own_pgid = os.getpgrp()
+    verified: List[Dict[str, Any]] = []
+    complete = True
+    for target in targets:
+        state = _signal_recovery_group(target, sig, snapshot, own_pgid)
+        if state == "verified":
+            verified.append(target)
+        elif state == "ambiguous":
+            complete = False
+    return complete, verified
+
+
+def _settle_recovery_report(
+    report: Dict[str, Any],
+    kinds: set[str],
+) -> Tuple[bool, Optional[Dict[str, Any]], List[Dict[str, Any]]]:
+    targets = [
+        group
+        for group in report["groups"]
+        if group["state"] == "verified" and group["kind"] in kinds
+    ]
+    remaining = _wait_for_recovery_targets_exit(targets, TERMINATE_GRACE_SECONDS)
+    if remaining is None:
+        return False, None, targets
+    kill_report: Optional[Dict[str, Any]] = None
+    if remaining:
+        complete, kill_targets = _signal_exact_recovery_targets(remaining, signal.SIGKILL)
+        kill_report = {
+            "identityComplete": complete,
+            "verified": [int(target["pid"]) for target in kill_targets],
+        }
+        if not complete:
+            return False, kill_report, remaining
+        remaining = _wait_for_recovery_targets_exit(kill_targets, KILL_GRACE_SECONDS)
+        if remaining is None:
+            return False, kill_report, kill_targets
+    return not remaining, kill_report, remaining or []
+
+
+def cleanup_running_process_groups(paths: Paths) -> Dict[str, Any]:
+    # First stop and conclusively settle wrappers. Only wrappers can roll the
+    # sidecar from attempt A to B, so the registry-bound record becomes stable
+    # once their exact identities are gone.
+    initial = signal_running_process_groups(paths, signal.SIGTERM)
+    if not initial["identityComplete"]:
+        return {"safeToForget": False, "term": initial, "kill": None, "remaining": []}
+    wrappers_safe, wrapper_kill, remaining = _settle_recovery_report(initial, {"wrapper"})
+    if not wrappers_safe:
+        return {"safeToForget": False, "term": initial, "kill": wrapper_kill, "remaining": remaining}
+
+    # Re-read after wrapper exit to catch both A->B replacement and a sidecar
+    # published after the initial read. No wrapper remains able to create C.
+    attempts = signal_running_process_groups(paths, signal.SIGTERM)
+    if not attempts["identityComplete"]:
+        return {"safeToForget": False, "term": attempts, "kill": None, "remaining": []}
+    attempts_safe, attempt_kill, remaining = _settle_recovery_report(attempts, {"cacheAttempt"})
+    if not attempts_safe:
+        return {"safeToForget": False, "term": attempts, "kill": attempt_kill, "remaining": remaining}
+
+    final = signal_running_process_groups(paths, signal.SIGTERM)
+    if not final["identityComplete"]:
+        return {"safeToForget": False, "term": final, "kill": None, "remaining": []}
+    final_safe, final_kill, remaining = _settle_recovery_report(final, {"wrapper", "cacheAttempt"})
+    if not final_safe:
+        return {"safeToForget": False, "term": final, "kill": final_kill, "remaining": remaining}
+    verification = signal_running_process_groups(paths, signal.SIGTERM)
+    verified_live = [group for group in verification["groups"] if group["state"] == "verified"]
+    safe = verification["identityComplete"] and not verified_live
+    if safe:
+        for raw_path in verification.get("recordPaths") or []:
+            _durable_unlink(Path(raw_path))
+    return {
+        "safeToForget": safe,
+        "term": initial,
+        "kill": {"wrapper": wrapper_kill, "attempt": attempt_kill, "final": final_kill},
+        "remaining": verified_live,
+        "verification": verification,
+    }
 
 
 def force_stop_unresponsive_daemon(paths: Paths) -> Dict[str, Any]:
@@ -5306,6 +6622,43 @@ def handle_status_command(paths: Paths, argv: List[str]) -> int:
     else:
         render_daemon_status(payload, shorthand=True)
     return 0
+
+
+def handle_cache_command(paths: Paths, argv: List[str]) -> int:
+    if not argv or argv[0] in {"-h", "--help"}:
+        print("Usage: ./conductor cache status [--limit <n>] [--json] | cache drop <key> [--json]")
+        return 0
+    subcommand = argv[0]
+    parser = argparse.ArgumentParser(prog=f"conductor cache {subcommand}")
+    parser.add_argument("--json", action="store_true")
+    if subcommand == "status":
+        parser.add_argument("--limit", type=int, default=BUILD_CACHE_DIAGNOSTIC_MAX_ROWS)
+        ns = parser.parse_args(argv[1:])
+        if ns.limit <= 0:
+            raise ConductorError("cache status limit must be greater than zero")
+        payload = BuildCacheManager(paths.repo_root, startup_hygiene=False).status(ns.limit)
+        if ns.json:
+            print_json(payload)
+        else:
+            print(f"build cache: {payload['storePath']}")
+            print(f"entries: {payload['entryCount']}")
+            for entry in payload["entries"]:
+                print(
+                    f"  {entry.get('key')} generation={entry.get('generation')} "
+                    f"size={format_bytes(entry.get('sizeBytes'))} suspect={entry.get('suspectCount', 0)}"
+                )
+        return 0
+    if subcommand == "drop":
+        parser.add_argument("key")
+        ns = parser.parse_args(argv[1:])
+        dropped = BuildCacheManager(paths.repo_root).drop(ns.key)
+        payload = {"key": ns.key, "dropped": dropped}
+        if ns.json:
+            print_json(payload)
+        else:
+            print("dropped" if dropped else "not found")
+        return 0
+    raise ConductorError(f"unknown cache command '{subcommand}'")
 
 
 def handle_job_command(paths: Paths, argv: List[str]) -> int:
@@ -6345,7 +7698,7 @@ def directory_size_bytes(path: Path) -> Optional[int]:
                         total += stat_result.st_size
         except NotADirectoryError:
             try:
-                total += current.stat(follow_symlinks=False).st_size
+                total += current.lstat().st_size
             except OSError:
                 pass
         except OSError:
@@ -6355,7 +7708,7 @@ def directory_size_bytes(path: Path) -> Optional[int]:
 
 def latest_mtime(path: Path) -> Optional[float]:
     try:
-        return path.stat(follow_symlinks=False).st_mtime
+        return path.lstat().st_mtime
     except OSError:
         return None
 
@@ -6376,6 +7729,16 @@ def operation_diagnostics_build_cache(repo_root: Path, args: Dict[str, Any]) -> 
     current_build = repo_root / ".build"
 
     print("Build cache diagnostics", flush=True)
+    immutable = BuildCacheManager(repo_root, startup_hygiene=False).status(limit)
+    print(f"Immutable seed store: {immutable['storePath']}", flush=True)
+    print(f"Immutable seed entries: {immutable['entryCount']}", flush=True)
+    for entry in immutable["entries"]:
+        print(
+            f"  key={entry.get('key')} generation={entry.get('generation')} "
+            f"size={format_bytes(entry.get('sizeBytes'))} source={entry.get('sourceHead')} "
+            f"suspect={entry.get('suspectCount', 0)}",
+            flush=True,
+        )
     if current_build.exists():
         symlink_note = ""
         if current_build.is_symlink():
@@ -6437,6 +7800,251 @@ def operation_diagnostics_agent_mode_on(repo_root: Path, args: Dict[str, Any]) -
     return 0
 
 
+def run_cache_attempt_gate(read_fd: int, payload_json: str) -> int:
+    try:
+        argv = json.loads(payload_json)
+    except json.JSONDecodeError as exc:
+        raise ConductorError(f"cache attempt gate received invalid argv: {exc}") from exc
+    if not isinstance(argv, list) or not argv or not all(isinstance(item, str) and item for item in argv):
+        raise ConductorError("cache attempt gate requires a non-empty argv")
+    try:
+        release = os.read(read_fd, 1)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(read_fd)
+    if release != b"1":
+        # The parent died or rejected identity publication before releasing the
+        # gate. No build command or descendant was started.
+        return 125
+    try:
+        os.execvpe(argv[0], list(argv), os.environ)
+    except OSError as exc:
+        raise ConductorError(f"cache attempt gate could not exec {argv[0]}: {exc}") from exc
+    return 125
+
+
+def _run_cache_attempt(
+    argv: Sequence[str],
+    repo_root: Path,
+    attempt_timeout: Optional[float],
+    attempt_record_path: Path,
+    ticket: str,
+) -> Tuple[int, bool]:
+    wrapper_start = process_start_token(os.getpid())
+    if not wrapper_start:
+        raise ConductorError("cache retry wrapper lacks an exact process start token")
+    read_fd, write_fd = os.pipe()
+    process: Optional[subprocess.Popen[bytes]] = None
+    gate_released = False
+    record_published = False
+    attempt_reaped = False
+    try:
+        gate_argv = [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "__cache_attempt_gate",
+            str(read_fd),
+            json.dumps(list(argv), separators=(",", ":")),
+        ]
+        process = subprocess.Popen(
+            gate_argv,
+            cwd=str(repo_root),
+            stdin=subprocess.DEVNULL,
+            pass_fds=(read_fd,),
+            start_new_session=True,
+        )
+        os.close(read_fd)
+        read_fd = -1
+        attempt_start = process_start_token(process.pid)
+        try:
+            attempt_pgid = os.getpgid(process.pid)
+        except OSError as exc:
+            raise ConductorError(f"cache attempt process-group identity unavailable: {exc}") from exc
+        if not attempt_start or attempt_pgid != process.pid:
+            raise ConductorError("cache attempt lacks an exact session-leader identity")
+        _atomic_write_json(
+            attempt_record_path,
+            {
+                "version": 1,
+                "state": "active",
+                "ticket": ticket,
+                "wrapperPID": os.getpid(),
+                "wrapperStartToken": wrapper_start,
+                "attemptPID": process.pid,
+                "attemptPGID": attempt_pgid,
+                "attemptStartToken": attempt_start,
+                "publishedAt": now(),
+            },
+        )
+        record_published = True
+        if os.write(write_fd, b"1") != 1:
+            raise ConductorError("cache attempt gate release was incomplete")
+        os.close(write_fd)
+        write_fd = -1
+        gate_released = True
+        try:
+            exit_code = process.wait(timeout=attempt_timeout)
+            attempt_reaped = True
+            return exit_code, False
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=TERMINATE_GRACE_SECONDS)
+                attempt_reaped = True
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                    os.killpg(process.pid, signal.SIGKILL)
+                try:
+                    process.wait(timeout=KILL_GRACE_SECONDS)
+                    attempt_reaped = True
+                except subprocess.TimeoutExpired:
+                    pass
+            if process.poll() is None:
+                raise ConductorError("timed-out cache attempt did not exit after process-group escalation")
+            attempt_reaped = True
+            return 124, True
+    finally:
+        if read_fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(read_fd)
+        if write_fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(write_fd)
+        if process is not None and not gate_released:
+            # EOF keeps the detached gate from execing the real build. Reap it
+            # within a fixed allowance; no descendant can exist before release.
+            try:
+                process.wait(timeout=KILL_GRACE_SECONDS)
+                attempt_reaped = True
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                    process.kill()
+                try:
+                    process.wait(timeout=KILL_GRACE_SECONDS)
+                    attempt_reaped = True
+                except subprocess.TimeoutExpired:
+                    pass
+        if record_published and attempt_reaped:
+            _durable_unlink(attempt_record_path)
+
+
+def _remove_cache_build_for_retry(build_dir: Path, cleanup_timeout: float) -> bool:
+    try:
+        completed = subprocess.run(
+            ["/bin/rm", "-rf", str(build_dir)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=cleanup_timeout,
+        )
+        return completed.returncode == 0 and not build_dir.exists() and not build_dir.is_symlink()
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _await_cache_retry_wrapper_gate() -> None:
+    raw_fd = os.environ.pop("REPOPROMPT_CONDUCTOR_CACHE_WRAPPER_GATE_FD", None)
+    if raw_fd is None:
+        return
+    try:
+        read_fd = int(raw_fd)
+    except ValueError as exc:
+        raise ConductorError("cache retry wrapper gate fd is invalid") from exc
+    if read_fd < 3:
+        raise ConductorError("cache retry wrapper gate requires an inherited private fd")
+    try:
+        release = os.read(read_fd, 1)
+    finally:
+        with contextlib.suppress(OSError):
+            os.close(read_fd)
+    if release != b"1":
+        raise ConductorError("cache retry wrapper was not released after durable registry publication")
+
+
+def operation_cache_retry(repo_root: Path, args: Dict[str, Any]) -> int:
+    _await_cache_retry_wrapper_gate()
+    argv = args.get("argv")
+    key = str(args.get("key") or "")
+    outcome_path = Path(str(args.get("outcomePath") or ""))
+    attempt_record_path = Path(str(args.get("attemptRecordPath") or ""))
+    ticket = str(args.get("ticket") or "")
+    raw_attempt_timeout = args.get("attemptTimeout")
+    raw_cleanup_timeout = args.get("cleanupTimeout", BUILD_CACHE_CLONE_MAX_SECONDS)
+    if not isinstance(argv, list) or not argv or not all(isinstance(item, str) and item for item in argv):
+        raise ConductorError("cache retry requires a non-empty argv")
+    if not re.fullmatch(r"[0-9a-f]{64}", key):
+        raise ConductorError("cache retry requires an exact key")
+    if not ticket or len(ticket) > 128 or attempt_record_path.name != f"{ticket}.cache-attempt.json":
+        raise ConductorError("cache retry requires a ticket-bound attempt record")
+    if attempt_record_path.parent != outcome_path.parent or not attempt_record_path.parent.is_dir():
+        raise ConductorError("cache retry attempt record must share the existing outcome directory")
+    attempt_timeout = None if raw_attempt_timeout is None else float(raw_attempt_timeout)
+    if attempt_timeout is not None and (not math.isfinite(attempt_timeout) or attempt_timeout < 0):
+        raise ConductorError("cache retry attempt timeout must be a finite non-negative number")
+    cleanup_timeout = float(raw_cleanup_timeout)
+    if not math.isfinite(cleanup_timeout) or cleanup_timeout < 0:
+        raise ConductorError("cache retry cleanup timeout must be a finite non-negative number")
+
+    first_code, first_timed_out = _run_cache_attempt(
+        argv,
+        repo_root,
+        attempt_timeout,
+        attempt_record_path,
+        ticket,
+    )
+    if first_code == 0:
+        return 0
+    build_dir = repo_root / ".build"
+    provenance = BuildCacheManager._read_json_file(build_dir / ".conductor-cache-provenance.json")
+    outcome: Dict[str, Any] = {
+        "attemptTimeoutSeconds": attempt_timeout,
+        "cleanupTimeoutSeconds": cleanup_timeout,
+        "seededExitCode": first_code,
+        "seededTimedOut": first_timed_out,
+        "coldRetryAttempted": False,
+    }
+    if not (
+        provenance
+        and provenance.get("key") == key
+        and build_dir.is_dir()
+        and not build_dir.is_symlink()
+    ):
+        outcome["reason"] = "seed provenance unavailable; cold retry refused"
+        if outcome_path.parent.is_dir():
+            _atomic_write_json(outcome_path, outcome)
+        return first_code
+
+    print("seeded build failed; removing the proven seeded .build and retrying cold once", flush=True)
+    if not _remove_cache_build_for_retry(build_dir, cleanup_timeout):
+        outcome["reason"] = "proven seeded .build removal exceeded its bounded cleanup allowance"
+        if outcome_path.parent.is_dir():
+            _atomic_write_json(outcome_path, outcome)
+        return first_code
+    outcome["coldRetryAttempted"] = True
+    cold_code, cold_timed_out = _run_cache_attempt(
+        argv,
+        repo_root,
+        attempt_timeout,
+        attempt_record_path,
+        ticket,
+    )
+    outcome["coldExitCode"] = cold_code
+    outcome["coldTimedOut"] = cold_timed_out
+    outcome["coldSucceeded"] = cold_code == 0
+    if cold_code == 0:
+        try:
+            manager = BuildCacheManager(repo_root)
+            outcome.update(manager.confirm_seeded_failure(key))
+        except Exception as exc:
+            # A successful cold build is authoritative. Suspect bookkeeping is
+            # advisory, but its failure remains visible in the retained outcome.
+            outcome["suspectBookkeepingError"] = str(exc)[:500]
+    if outcome_path.parent.is_dir():
+        _atomic_write_json(outcome_path, outcome)
+    return cold_code
+
+
 def run_operation_runner(payload_json: str) -> int:
     payload = json.loads(payload_json)
     kind = payload.get("kind")
@@ -6444,6 +8052,8 @@ def run_operation_runner(payload_json: str) -> int:
     repo_root = Path(payload.get("repoRoot") or resolve_repo_root()).resolve()
     if kind == "swift_build_all":
         return operation_swift_build_all(repo_root)
+    if kind == "cache_retry":
+        return operation_cache_retry(repo_root, args)
     if kind == "app_stop":
         return operation_app_stop(repo_root, args)
     if kind == "app_status":
@@ -6651,6 +8261,16 @@ def main(argv: List[str]) -> int:
         if len(argv) != 2:
             raise ConductorError("__operation_runner requires one JSON payload argument")
         return run_operation_runner(argv[1])
+    if argv and argv[0] == "__cache_attempt_gate":
+        if len(argv) != 3:
+            raise ConductorError("__cache_attempt_gate requires a read fd and argv JSON")
+        try:
+            read_fd = int(argv[1])
+        except ValueError as exc:
+            raise ConductorError("__cache_attempt_gate requires an integer read fd") from exc
+        if read_fd < 3:
+            raise ConductorError("__cache_attempt_gate requires an inherited private read fd")
+        return run_cache_attempt_gate(read_fd, argv[2])
     if argv and argv[0] == "__daemon":
         parser = argparse.ArgumentParser(prog="conductor.py __daemon")
         parser.add_argument("--repo-root", required=True)
@@ -6673,6 +8293,8 @@ def main(argv: List[str]) -> int:
         return handle_status_command(paths, argv[1:])
     if command == "job":
         return handle_job_command(paths, argv[1:])
+    if command == "cache":
+        return handle_cache_command(paths, argv[1:])
     if command in {"sleep", "fake-sleep"}:
         return handle_sleep_operation(paths, command, argv[1:])
     if command in IMPLEMENTED_OPERATIONS:

--- a/Scripts/test_conductor_cache.py
+++ b/Scripts/test_conductor_cache.py
@@ -1,0 +1,970 @@
+#!/usr/bin/env python3
+"""Deterministic tests for conductor's immutable SwiftPM build-cache store."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import conductor  # noqa: E402
+
+
+class BuildCacheTests(unittest.TestCase):
+    def make_repo(self) -> tuple[tempfile.TemporaryDirectory[str], Path, Path]:
+        temporary = tempfile.TemporaryDirectory()
+        root = Path(temporary.name)
+        repo = root / "repo"
+        store = root / "cache"
+        (repo / "Sources").mkdir(parents=True)
+        (repo / "Packages" / "Local").mkdir(parents=True)
+        (repo / "Package.swift").write_text("// root manifest\n", encoding="utf-8")
+        (repo / "Package.resolved").write_text('{"pins":[]}\n', encoding="utf-8")
+        (repo / "Packages" / "Local" / "Package.swift").write_text("// local manifest\n", encoding="utf-8")
+        (repo / "Sources" / "Feature.swift").write_text("let value = 1\n", encoding="utf-8")
+        return temporary, repo, store
+
+    @staticmethod
+    def probe(version: str = "Swift fixture") -> dict[str, str]:
+        return {
+            "swiftVersion": version,
+            "sdkBuild": "26A1",
+            "developerDir": "/Applications/Xcode.app/Contents/Developer",
+            "architecture": "arm64",
+            "destinationTriple": "arm64-apple-macosx14.0",
+        }
+
+    @staticmethod
+    def clone(source: Path, destination: Path) -> bool:
+        shutil.copytree(source, destination)
+        return True
+
+    def manager(self, repo: Path, store: Path, **kwargs: object) -> conductor.BuildCacheManager:
+        return conductor.BuildCacheManager(
+            repo,
+            store_root=store,
+            probe_provider=kwargs.pop("probe_provider", lambda: self.probe()),
+            clone_runner=kwargs.pop("clone_runner", self.clone),
+            **kwargs,
+        )
+
+    @staticmethod
+    def create_build(repo: Path, content: bytes = b"artifact") -> None:
+        build = repo / ".build"
+        build.mkdir()
+        (build / "artifact.bin").write_bytes(content)
+        (build / "xcode").mkdir()
+        (build / "xcode" / "mutable").write_text("discard", encoding="utf-8")
+        (build / "compile.log").write_text("discard", encoding="utf-8")
+        module_cache = build / "arm64-apple-macosx" / "debug" / "ModuleCache"
+        module_cache.mkdir(parents=True)
+        (module_cache / "path-bound.pcm").write_bytes(b"discard")
+
+    def publish_seed(self, manager: conductor.BuildCacheManager, env: dict[str, str] | None = None) -> tuple[conductor.BuildCacheContext, dict]:
+        context = manager.prepare("build", {}, env or {})
+        self.assertIsNotNone(context)
+        assert context is not None
+        result = manager.publish(context)
+        self.assertEqual(result["state"], "published")
+        return context, result
+
+    def test_key_sensitivity_and_source_exclusion(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        probe_value = [self.probe()]
+        manager = self.manager(repo, store, probe_provider=lambda: dict(probe_value[0]))
+
+        baseline = manager.snapshot("debug", {})
+        (repo / "Sources" / "Feature.swift").write_text("let value = 2\n", encoding="utf-8")
+        self.assertEqual(manager.snapshot("debug", {}).key, baseline.key)
+        self.assertNotEqual(manager.snapshot("release", {}).key, baseline.key)
+        self.assertNotEqual(manager.snapshot("debug", {"REPOPROMPT_ENABLE_SENTRY": "1"}).key, baseline.key)
+        self.assertNotEqual(manager.snapshot("debug", {"CC": "/usr/bin/clang-fixture"}).key, baseline.key)
+        self.assertNotEqual(manager.snapshot("debug", {"CXX": "/usr/bin/clang++-fixture"}).key, baseline.key)
+        (repo / "Package.swift").write_text("// changed manifest\n", encoding="utf-8")
+        self.assertNotEqual(manager.snapshot("debug", {}).key, baseline.key)
+        (repo / "Package.swift").write_text("// root manifest\n", encoding="utf-8")
+        probe_value[0] = self.probe("Swift fixture changed")
+        self.assertNotEqual(manager.snapshot("debug", {}).key, baseline.key)
+
+    def test_atomic_generation_publication_rejects_stale_publisher(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        manager = self.manager(repo, store)
+        first = manager.prepare("build", {}, {})
+        stale = manager.prepare("build", {}, {})
+        assert first is not None and stale is not None
+
+        published = manager.publish(first)
+        rejected = manager.publish(stale)
+        meta = json.loads((store / first.snapshot.key / "meta.json").read_text(encoding="utf-8"))
+        marker = json.loads((store / first.snapshot.key / "seed" / ".generation.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(published["generation"], 1)
+        self.assertEqual(rejected["state"], "publicationSkipped")
+        self.assertEqual(rejected["reason"], "newer generation already published")
+        self.assertEqual(meta["generation"], marker["generation"])
+        self.assertFalse((store / first.snapshot.key / "seed" / ".build" / "xcode").exists())
+        self.assertFalse((store / first.snapshot.key / "seed" / ".build" / "compile.log").exists())
+        self.assertFalse(
+            (store / first.snapshot.key / "seed" / ".build" / "arm64-apple-macosx" / "debug" / "ModuleCache").exists()
+        )
+
+    def test_publish_stage_exceptions_clean_temporary_seed_lifecycle(self) -> None:
+        stages = ("sanitize", "marker", "du", "swap", "meta")
+        for stage in stages:
+            with self.subTest(stage=stage):
+                temporary, repo, store = self.make_repo()
+                try:
+                    self.create_build(repo)
+                    manager = self.manager(repo, store)
+                    context = manager.prepare("build", {}, {})
+                    assert context is not None
+                    real_atomic_write = conductor._atomic_write_json
+                    real_replace = conductor.os.replace
+
+                    def atomic_write(path: Path, payload: dict) -> None:
+                        if stage == "marker" and path.name == ".generation.json":
+                            raise OSError("marker fixture")
+                        if stage == "meta" and path.name == "meta.json":
+                            raise OSError("meta fixture")
+                        real_atomic_write(path, payload)
+
+                    def replace(source: Path, destination: Path) -> None:
+                        if stage == "swap" and source.name.startswith("seed.tmp-") and destination.name == "seed":
+                            raise OSError("swap fixture")
+                        real_replace(source, destination)
+
+                    sanitize = mock.patch.object(
+                        manager,
+                        "_sanitize_seed",
+                        side_effect=OSError("sanitize fixture") if stage == "sanitize" else None,
+                        wraps=manager._sanitize_seed if stage != "sanitize" else None,
+                    )
+                    disk_usage = mock.patch.object(
+                        manager,
+                        "_disk_usage_bytes",
+                        side_effect=OSError("du fixture") if stage == "du" else None,
+                        wraps=manager._disk_usage_bytes if stage != "du" else None,
+                    )
+                    with sanitize, disk_usage, mock.patch.object(conductor, "_atomic_write_json", side_effect=atomic_write), mock.patch.object(
+                        conductor.os, "replace", side_effect=replace
+                    ), self.assertRaises(OSError):
+                        manager.publish(context)
+
+                    key_dir = store / context.snapshot.key
+                    self.assertEqual(list(key_dir.glob("seed.tmp-*")), [])
+                    self.assertEqual(list(key_dir.glob("seed.previous-*")), [])
+                    self.assertFalse((key_dir / "seed").exists())
+                finally:
+                    temporary.cleanup()
+
+    def test_failed_replacement_metadata_write_restores_previous_generation(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        manager = self.manager(repo, store)
+        first_context, _ = self.publish_seed(manager)
+        key_dir = store / first_context.snapshot.key
+        first_artifact = (key_dir / "seed" / ".build" / "artifact.bin").read_bytes()
+        meta_path = key_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["publishedAt"] = 0
+        conductor._atomic_write_json(meta_path, meta)
+        (repo / ".build" / "artifact.bin").write_bytes(b"replacement")
+        replacement = manager.prepare("build", {}, {})
+        assert replacement is not None
+        real_atomic_write = conductor._atomic_write_json
+
+        def atomic_write(path: Path, payload: dict) -> None:
+            if path.name == "meta.json" and payload.get("generation") == 2:
+                raise OSError("replacement meta fixture")
+            real_atomic_write(path, payload)
+
+        with mock.patch.object(conductor, "_atomic_write_json", side_effect=atomic_write), self.assertRaises(OSError):
+            manager.publish(replacement)
+
+        marker = json.loads((key_dir / "seed" / ".generation.json").read_text(encoding="utf-8"))
+        persisted_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertEqual(marker["generation"], 1)
+        self.assertEqual(persisted_meta["generation"], 1)
+        self.assertEqual((key_dir / "seed" / ".build" / "artifact.bin").read_bytes(), first_artifact)
+        self.assertEqual(list(key_dir.glob("seed.tmp-*")), [])
+        self.assertEqual(list(key_dir.glob("seed.previous-*")), [])
+
+    def test_post_replace_directory_fsync_failure_keeps_committed_seed_and_metadata_generation(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        manager = self.manager(repo, store)
+        first_context, _ = self.publish_seed(manager)
+        key_dir = store / first_context.snapshot.key
+        meta_path = key_dir / "meta.json"
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["publishedAt"] = 0
+        conductor._atomic_write_json(meta_path, meta)
+        (repo / ".build" / "artifact.bin").write_bytes(b"replacement")
+        replacement = manager.prepare("build", {}, {})
+        assert replacement is not None
+        real_open = conductor.os.open
+
+        def open_file(path: object, flags: int, mode: int = 0o777, *args: object, **kwargs: object) -> int:
+            if not kwargs.get("dir_fd") and Path(path) == key_dir and flags == os.O_RDONLY:
+                raise OSError("directory fsync open fixture")
+            return real_open(path, flags, mode, *args, **kwargs)
+
+        with mock.patch.object(conductor.os, "open", side_effect=open_file):
+            published = manager.publish(replacement)
+
+        marker = json.loads((key_dir / "seed" / ".generation.json").read_text(encoding="utf-8"))
+        persisted_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        self.assertEqual(published["generation"], 2)
+        self.assertEqual(marker["generation"], 2)
+        self.assertEqual(persisted_meta["generation"], 2)
+        self.assertEqual((key_dir / "seed" / ".build" / "artifact.bin").read_bytes(), b"replacement")
+        self.assertEqual(list(key_dir.glob("seed.previous-*")), [])
+
+    def test_store_hygiene_sweeps_startup_and_maintenance_but_skips_locked_keys(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        first_key = "a" * 64
+        first_dir = store / first_key
+        first_dir.mkdir(parents=True)
+        (first_dir / f"seed.tmp-{'1' * 32}").mkdir()
+        (first_dir / f"seed.previous-{'2' * 32}").mkdir()
+
+        manager = self.manager(repo, store)
+        self.assertEqual(list(first_dir.glob("seed.tmp-*")), [])
+        self.assertEqual(list(first_dir.glob("seed.previous-*")), [])
+
+        (first_dir / f"seed.tmp-{'3' * 32}").mkdir()
+        maintenance = manager.enforce_retention("toolchain")
+        self.assertEqual(maintenance["hygiene"]["removed"], 1)
+
+        locked_key = "b" * 64
+        locked_dir = store / locked_key
+        locked_dir.mkdir()
+        locked_temp = locked_dir / f"seed.tmp-{'4' * 32}"
+        locked_temp.mkdir()
+        real_key_lock = manager.key_lock
+
+        @contextlib.contextmanager
+        def key_lock(key: str, *, exclusive: bool, nonblocking: bool = False):
+            if key == locked_key:
+                raise BlockingIOError()
+            with real_key_lock(key, exclusive=exclusive, nonblocking=nonblocking) as lock_file:
+                yield lock_file
+
+        with mock.patch.object(manager, "key_lock", side_effect=key_lock):
+            result = manager._sweep_stranded_store_temporaries()
+
+        self.assertEqual(result["skippedLockedKeys"], 1)
+        self.assertTrue(locked_temp.exists())
+
+    def test_startup_hygiene_failure_is_advisory_once_prepare_recovers(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        with mock.patch.object(
+            conductor.BuildCacheManager,
+            "_sweep_stranded_store_temporaries",
+            side_effect=OSError("startup hygiene fixture"),
+        ):
+            manager = self.manager(repo, store)
+
+        recovered = manager.prepare("build", {}, {})
+        assert recovered is not None
+        self.assertEqual(recovered.status["state"], "coldMiss")
+        self.assertIn("startup hygiene fixture", recovered.status["startupAdvisoryFailure"])
+
+        subsequent = manager.prepare("build", {}, {})
+        assert subsequent is not None
+        self.assertNotIn("startupAdvisoryFailure", subsequent.status)
+
+    def test_store_hygiene_restores_valid_previous_generation_when_seed_is_missing(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        key = "c" * 64
+        key_dir = store / key
+        previous = key_dir / f"seed.previous-{'5' * 32}"
+        (previous / ".build").mkdir(parents=True)
+        (previous / ".generation.json").write_text(
+            json.dumps({"key": key, "generation": 7}), encoding="utf-8"
+        )
+        (key_dir / "meta.json").write_text(
+            json.dumps({"key": key, "generation": 7}), encoding="utf-8"
+        )
+
+        self.manager(repo, store)
+
+        self.assertTrue((key_dir / "seed" / ".build").is_dir())
+        self.assertFalse(previous.exists())
+
+    def test_prepare_sweeps_only_verified_repo_temporaries_at_start_and_prepare_boundaries(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        startup_temp = repo / f".build.seed-tmp-{'6' * 32}"
+        invalid_name = repo / ".build.seed-tmp-not-cache-owned"
+        startup_temp.mkdir()
+        invalid_name.mkdir()
+
+        manager = self.manager(repo, store)
+        self.assertFalse(startup_temp.exists())
+        self.assertTrue(invalid_name.exists())
+
+        prepare_temp = repo / f".build.seed-tmp-{'7' * 32}"
+        prepare_temp.mkdir()
+        context = manager.prepare("build", {}, {})
+
+        self.assertIsNotNone(context)
+        self.assertFalse(prepare_temp.exists())
+        self.assertTrue(invalid_name.exists())
+
+    def test_prepare_filesystem_failure_is_advisory_and_preserves_warm_build_provenance(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        provenance = repo / ".build" / ".conductor-cache-provenance.json"
+        provenance.write_text('{"fixture":"preserve"}', encoding="utf-8")
+        artifact_before = (repo / ".build" / "artifact.bin").read_bytes()
+        manager = self.manager(repo, store)
+
+        with mock.patch.object(manager, "_remove_repo_build_temporaries_locked", side_effect=OSError("filesystem fixture")):
+            context = manager.prepare("build", {}, {})
+
+        assert context is not None
+        self.assertFalse(context.seeded)
+        self.assertEqual(context.status["state"], "warmLocalAdvisory")
+        self.assertIn("filesystem fixture", context.status["advisoryFailure"])
+        self.assertEqual((repo / ".build" / "artifact.bin").read_bytes(), artifact_before)
+        self.assertEqual(provenance.read_text(encoding="utf-8"), '{"fixture":"preserve"}')
+
+    def test_prepare_store_and_clone_failures_degrade_cold_and_clean_owned_temporary(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        manager = self.manager(repo, store)
+        with mock.patch.object(manager, "_ensure_store_dirs", side_effect=OSError("store fixture")):
+            unavailable = manager.prepare("build", {}, {})
+        assert unavailable is not None
+        self.assertEqual(unavailable.status["state"], "cacheAdvisoryCold")
+        self.assertFalse((repo / ".build").exists())
+
+        self.create_build(repo)
+        context, _ = self.publish_seed(manager)
+        shutil.rmtree(repo / ".build")
+
+        def failing_clone(_source: Path, destination: Path) -> bool:
+            destination.mkdir(parents=True)
+            raise OSError("clone fixture")
+
+        failing = self.manager(repo, store, clone_runner=failing_clone)
+        cold = failing.prepare("build", {}, {})
+        assert cold is not None
+        self.assertEqual(cold.status["state"], "cacheAdvisoryCold")
+        self.assertIn("clone fixture", cold.status["advisoryFailure"])
+        self.assertFalse((repo / ".build").exists())
+        self.assertEqual(list(repo.glob(".build.seed-tmp-*")), [])
+        self.assertEqual(cold.snapshot.key, context.snapshot.key)
+
+    def test_native_clone_uses_supported_ditto_with_entry_bounded_deadline(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            destination = root / "destination"
+            (source / "nested").mkdir(parents=True)
+            (source / "artifact").write_bytes(b"artifact")
+            (source / "nested" / "object").write_bytes(b"object")
+            deadline = conductor.BuildCacheManager._clone_deadline_seconds(source)
+            self.assertGreater(deadline, conductor.BUILD_CACHE_CLONE_MIN_SECONDS)
+            self.assertLessEqual(deadline, conductor.BUILD_CACHE_CLONE_MAX_SECONDS)
+
+            def fake_run(argv: list[str], **kwargs: object) -> mock.Mock:
+                self.assertEqual(
+                    argv,
+                    [
+                        "/usr/bin/ditto",
+                        "--clone",
+                        "--norsrc",
+                        "--noextattr",
+                        "--noqtn",
+                        "--noacl",
+                        str(source),
+                        str(destination),
+                    ],
+                )
+                self.assertEqual(kwargs["timeout"], 123.0)
+                destination.mkdir()
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(conductor.BuildCacheManager, "_clone_deadline_seconds", return_value=123.0), mock.patch.object(
+                conductor.subprocess, "run", side_effect=fake_run
+            ):
+                self.assertTrue(conductor.BuildCacheManager._clone_cow(source, destination))
+
+    def test_tree_maintenance_deadlines_scale_by_entries_and_size_with_bounded_limits(self) -> None:
+        minimum = conductor.BuildCacheManager._tree_deadline_for_work(0, 0)
+        scaled = conductor.BuildCacheManager._tree_deadline_for_work(100, 2 * 1024**3)
+        maximum = conductor.BuildCacheManager._tree_deadline_for_work(10**9, 10**15)
+
+        self.assertEqual(minimum, conductor.BUILD_CACHE_CLONE_MIN_SECONDS)
+        self.assertGreater(scaled, minimum)
+        self.assertLess(scaled, conductor.BUILD_CACHE_CLONE_MAX_SECONDS)
+        self.assertEqual(maximum, conductor.BUILD_CACHE_CLONE_MAX_SECONDS)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            build = Path(tmp) / ".build"
+            build.mkdir()
+            empty_deadline = conductor.BuildCacheManager._tree_deadline_seconds(build)
+            artifact = build / "artifact"
+            artifact.touch()
+            entry_deadline = conductor.BuildCacheManager._tree_deadline_seconds(build)
+            artifact.write_bytes(b"x" * 1024 * 1024)
+            sized_deadline = conductor.BuildCacheManager._tree_deadline_seconds(build)
+            self.assertGreater(entry_deadline, empty_deadline)
+            self.assertGreater(sized_deadline, entry_deadline)
+            calls: list[float] = []
+
+            def fake_run(argv: list[str], **kwargs: object) -> mock.Mock:
+                calls.append(float(kwargs["timeout"]))
+                stdout = "4\tfixture\n" if argv[0] == "/usr/bin/du" else ""
+                return mock.Mock(returncode=0, stdout=stdout)
+
+            with mock.patch.object(
+                conductor.BuildCacheManager,
+                "_tree_deadline_seconds",
+                return_value=137.0,
+            ), mock.patch.object(conductor.subprocess, "run", side_effect=fake_run):
+                conductor.BuildCacheManager._sanitize_seed(build)
+                self.assertEqual(conductor.BuildCacheManager._disk_usage_bytes(build), 4096)
+
+        self.assertEqual(calls, [137.0, 137.0, 137.0])
+
+    def test_status_is_read_only_and_does_not_run_startup_repair(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        manager = self.manager(repo, store, startup_hygiene=False)
+
+        missing = manager.status()
+        self.assertTrue(missing["readOnly"])
+        self.assertEqual(missing["entryCount"], 0)
+        self.assertFalse(store.exists())
+
+        key = "d" * 64
+        stranded = store / key / f"seed.tmp-{'8' * 32}"
+        stranded.mkdir(parents=True)
+        observed = manager.status()
+
+        self.assertTrue(observed["readOnly"])
+        self.assertEqual(observed["entryCount"], 1)
+        self.assertTrue(stranded.exists())
+        self.assertFalse((store / "locks").exists())
+
+    def test_private_clone_is_atomic_and_clone_failure_falls_back_cold(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        manager = self.manager(repo, store)
+        context, _published = self.publish_seed(manager)
+        shutil.rmtree(repo / ".build")
+
+        seeded = manager.prepare("build", {}, {})
+        assert seeded is not None
+        self.assertTrue(seeded.seeded)
+        self.assertEqual(seeded.status["state"], "seeded")
+        self.assertFalse((repo / ".build").is_symlink())
+        provenance = json.loads((repo / ".build" / ".conductor-cache-provenance.json").read_text(encoding="utf-8"))
+        self.assertEqual(provenance["key"], context.snapshot.key)
+        (repo / ".build" / "artifact.bin").write_bytes(b"worktree mutation")
+        self.assertEqual((store / context.snapshot.key / "seed" / ".build" / "artifact.bin").read_bytes(), b"artifact")
+
+        shutil.rmtree(repo / ".build")
+        failing = self.manager(repo, store, clone_runner=lambda _source, _destination: False)
+        cold = failing.prepare("build", {}, {})
+        assert cold is not None
+        self.assertFalse(cold.seeded)
+        self.assertEqual(cold.status["state"], "cloneFailedCold")
+        self.assertFalse((repo / ".build").exists())
+        self.assertEqual(list(repo.glob(".build.seed-tmp-*")), [])
+
+    def test_corrupt_seed_is_quarantined_and_second_confirmed_failure_removes_suspect(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        manager = self.manager(repo, store)
+        context, _published = self.publish_seed(manager)
+        key = context.snapshot.key
+        shutil.rmtree(repo / ".build")
+        (store / key / "seed" / ".generation.json").write_text('{"key":"wrong","generation":1}', encoding="utf-8")
+
+        cold = manager.prepare("build", {}, {})
+        assert cold is not None
+        self.assertEqual(cold.status["state"], "corruptSeedCold")
+        self.assertFalse((store / key / "seed").exists())
+
+        self.create_build(repo)
+        replacement = manager.prepare("build", {}, {})
+        assert replacement is not None
+        manager.publish(replacement)
+        first = manager.confirm_seeded_failure(key)
+        second = manager.confirm_seeded_failure(key)
+        self.assertEqual(first, {"suspectCount": 1, "quarantined": False})
+        self.assertEqual(second, {"suspectCount": 2, "quarantined": True})
+        self.assertFalse((store / key / "seed").exists())
+
+    def test_retention_prefers_toolchain_mismatch_and_skips_locked_key(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo, b"a" * 128)
+        manager = self.manager(repo, store)
+        first, _ = self.publish_seed(manager, {})
+        shutil.rmtree(repo / ".build")
+        self.create_build(repo, b"b" * 128)
+        second_context = manager.prepare("build", {}, {"REPOPROMPT_ENABLE_SENTRY": "1"})
+        assert second_context is not None
+        manager.publish(second_context)
+        first_meta_path = store / first.snapshot.key / "meta.json"
+        first_meta = json.loads(first_meta_path.read_text(encoding="utf-8"))
+        first_meta["toolchainSignature"] = "old-toolchain"
+        conductor._atomic_write_json(first_meta_path, first_meta)
+        manager.env["REPOPROMPT_DEV_BUILD_CACHE_LIMIT_BYTES"] = "0"
+
+        with manager.key_lock(second_context.snapshot.key, exclusive=False):
+            result = manager.enforce_retention(second_context.snapshot.toolchain_signature)
+
+        self.assertIn(first.snapshot.key, result["evictedKeys"])
+        self.assertNotIn(second_context.snapshot.key, result["evictedKeys"])
+        self.assertTrue((store / second_context.snapshot.key).exists())
+
+    def test_successful_job_publishes_only_after_global_heavy_slot_release(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        jobs = repo / "jobs"
+        jobs.mkdir()
+        paths = conductor.Paths(
+            repo_root=repo,
+            repo_hash="cache-order",
+            state_dir=repo,
+            socket_path=repo / "daemon.sock",
+            pid_path=repo / "daemon.pid",
+            lock_path=repo / "daemon.lock",
+            jobs_dir=jobs,
+            daemon_log_path=repo / "daemon.log",
+            daemon_meta_path=repo / "daemon.json",
+            running_processes_path=repo / "running.json",
+        )
+        state = conductor.DaemonState(paths)
+        self.addCleanup(state._output_pump.close)
+        self.addCleanup(state._io_worker.join)
+        job = conductor.Job(
+            ticket="cache-order",
+            request_key=None,
+            fingerprint="fixture",
+            operation="build",
+            args={},
+            lanes=["build"],
+            timeout=None,
+            verbose=False,
+            env={},
+            created_at=conductor.now(),
+            log_path=jobs / "cache-order.log",
+            state="running",
+        )
+        state.jobs[job.ticket] = job
+        state.active_lanes["build"] = job.ticket
+        snapshot = conductor.BuildCacheSnapshot("a" * 64, {"configuration": "debug"}, "toolchain")
+        context = conductor.BuildCacheContext(snapshot, 0, True, {"state": "seeded", "key": snapshot.key})
+        released = []
+        startup_events: list[str] = []
+        original_write = os.write
+
+        def tracked_write(fd: int, payload: bytes) -> int:
+            if payload == b"1":
+                startup_events.append("wrapper-release")
+                return 1
+            return original_write(fd, payload)
+
+        class FakeCache:
+            def prepare(self, *_args: object) -> conductor.BuildCacheContext:
+                return context
+
+            def publish(self, _context: conductor.BuildCacheContext) -> dict:
+                self_test.assertEqual(released, ["lease"])
+                self_test.assertEqual(job.global_heavy_admission_state, "released")
+                self_test.assertEqual(job.state, "running")
+                self_test.assertEqual(job.phase, "publishingCache")
+                self_test.assertIsNone(job.finished_at)
+                self_test.assertEqual(state.active_lanes["build"], job.ticket)
+                mutator_lanes = state.registry.prepare({"operation": "run", "args": {}})[1]
+                waiting = conductor.Job(
+                    ticket="waiting-mutator",
+                    request_key=None,
+                    fingerprint="fixture-waiting",
+                    operation="run",
+                    args={},
+                    lanes=mutator_lanes,
+                    timeout=None,
+                    verbose=False,
+                    env={},
+                    created_at=conductor.now(),
+                    log_path=jobs / "waiting-mutator.log",
+                )
+                state.jobs[waiting.ticket] = waiting
+                state.queue.append(waiting.ticket)
+                blockers = state._blocked_by_locked(waiting)
+                self_test.assertEqual(blockers[0]["ticket"], job.ticket)
+                self_test.assertEqual(blockers[0]["conflictingLanes"], ["build"])
+                canceled = state.job_cancel(job.ticket, None)
+                self_test.assertTrue(canceled["cancellationIgnored"])
+                self_test.assertIn("non-abortable", canceled["cancellationIgnoredReason"])
+                self_test.assertFalse(job.cancel_requested)
+                self_test.assertEqual(job.phase, "publishingCache")
+                return {"state": "published", "generation": 1}
+
+        self_test = self
+        fake_process = mock.Mock()
+        fake_process.pid = os.getpid()
+        fake_process.wait.return_value = 0
+        with mock.patch.object(state.registry, "prepare", return_value=(["/usr/bin/true"], ["build"], repo, {}, 11.0)), mock.patch.object(
+            state, "_build_cache_manager", return_value=FakeCache()
+        ), mock.patch.object(
+            conductor.BuildCacheManager, "_tree_deadline_seconds", return_value=29.0
+        ), mock.patch.object(state, "_acquire_global_heavy_slot", return_value="lease"), mock.patch.object(
+            state, "_release_global_heavy_slot", side_effect=lambda lease: released.append(lease)
+        ), mock.patch.object(conductor.subprocess, "Popen", return_value=fake_process), mock.patch.object(
+            conductor, "process_table_snapshot", return_value={}
+        ), mock.patch.object(conductor, "process_start_token", return_value="fixture"), mock.patch.object(
+            state,
+            "_write_running_processes_durable",
+            side_effect=lambda: startup_events.append("durable-running-registry"),
+        ), mock.patch.object(conductor.os, "write", side_effect=tracked_write), mock.patch.object(
+            state, "_schedule_locked"
+        ), mock.patch.object(state, "_refresh_output_summary"):
+            state._run_job(job.ticket)
+
+        self.assertEqual(job.state, "completed")
+        self.assertEqual(startup_events, ["durable-running-registry", "wrapper-release"])
+        fake_process.wait.assert_called_once_with(
+            timeout=conductor.BuildCacheManager.retry_job_timeout(11.0, 29.0)
+        )
+        self.assertEqual(job.build_cache["attemptTimeoutSeconds"], 11.0)
+        self.assertEqual(job.build_cache["cleanupTimeoutSeconds"], 29.0)
+        self.assertEqual(
+            job.build_cache["retryEnvelopeTimeoutSeconds"],
+            2 * 11.0 + 29.0 + conductor.BUILD_CACHE_RETRY_OVERHEAD_SECONDS,
+        )
+        self.assertEqual(job.build_cache["publication"]["state"], "published")
+        self.assertEqual(
+            job.result_summary,
+            "completed successfully; cancellation ignored during non-abortable cache publication",
+        )
+        self.assertTrue(job.to_payload()["cancellationIgnored"])
+        self.assertEqual(state.status_payload()["cacheWriteLane"]["activeTicket"], None)
+
+    def test_cache_retry_wrapper_gate_eof_prevents_any_attempt(self) -> None:
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        with mock.patch.dict(
+            os.environ,
+            {"REPOPROMPT_CONDUCTOR_CACHE_WRAPPER_GATE_FD": str(read_fd)},
+        ), mock.patch.object(conductor, "_run_cache_attempt") as attempt, self.assertRaises(conductor.ConductorError):
+            conductor.operation_cache_retry(Path("/tmp/repo"), {})
+
+        attempt.assert_not_called()
+
+    def test_cache_attempt_gate_eof_never_execs_the_real_build(self) -> None:
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        with mock.patch.object(conductor.os, "execvpe") as execvpe:
+            code = conductor.run_cache_attempt_gate(read_fd, json.dumps(["swift", "build"]))
+
+        self.assertEqual(code, 125)
+        execvpe.assert_not_called()
+
+    def test_timed_out_cache_attempt_escalates_and_reaps_its_process_group(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        attempt_record = Path(temporary.name) / "cache-attempt.cache-attempt.json"
+        process = mock.Mock(pid=4242)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["swift", "build"], 7.0),
+            subprocess.TimeoutExpired(["swift", "build"], conductor.TERMINATE_GRACE_SECONDS),
+            -signal.SIGKILL,
+        ]
+        process.poll.return_value = -signal.SIGKILL
+
+        events: list[str] = []
+
+        def publish_record(path: Path, payload: dict) -> None:
+            self.assertEqual(path, attempt_record)
+            self.assertEqual(payload["wrapperStartToken"], "wrapper-start")
+            self.assertEqual(payload["attemptStartToken"], "attempt-start")
+            events.append("record")
+
+        def release_gate(_fd: int, payload: bytes) -> int:
+            self.assertEqual(payload, b"1")
+            events.append("release")
+            return 1
+
+        with mock.patch.object(conductor.subprocess, "Popen", return_value=process) as popen, mock.patch.object(
+            conductor, "process_start_token", side_effect=lambda pid: "attempt-start" if pid == 4242 else "wrapper-start"
+        ), mock.patch.object(conductor.os, "getpgid", return_value=4242), mock.patch.object(
+            conductor, "_atomic_write_json", side_effect=publish_record
+        ), mock.patch.object(conductor, "_durable_unlink") as durable_unlink, mock.patch.object(
+            conductor.os, "write", side_effect=release_gate
+        ), mock.patch.object(conductor.os, "killpg") as killpg:
+            result = conductor._run_cache_attempt(
+                ["swift", "build"],
+                Path("/tmp/repo"),
+                7.0,
+                attempt_record,
+                "cache-attempt",
+            )
+
+        self.assertEqual(result, (124, True))
+        self.assertTrue(popen.call_args.kwargs["start_new_session"])
+        self.assertIn("__cache_attempt_gate", popen.call_args.args[0])
+        self.assertEqual(events, ["record", "release"])
+        durable_unlink.assert_called_once_with(attempt_record)
+        self.assertEqual(
+            process.wait.call_args_list,
+            [
+                mock.call(timeout=7.0),
+                mock.call(timeout=conductor.TERMINATE_GRACE_SECONDS),
+                mock.call(timeout=conductor.KILL_GRACE_SECONDS),
+            ],
+        )
+        self.assertEqual(
+            killpg.call_args_list,
+            [mock.call(4242, signal.SIGTERM), mock.call(4242, signal.SIGKILL)],
+        )
+
+    def test_inconclusive_attempt_reap_preserves_durable_identity_record(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        attempt_record = Path(temporary.name) / "inconclusive.cache-attempt.json"
+        process = mock.Mock(pid=5151)
+        process.wait.side_effect = [
+            subprocess.TimeoutExpired(["swift", "build"], 3.0),
+            subprocess.TimeoutExpired(["swift", "build"], conductor.TERMINATE_GRACE_SECONDS),
+            subprocess.TimeoutExpired(["swift", "build"], conductor.KILL_GRACE_SECONDS),
+        ]
+        process.poll.return_value = None
+
+        original_write = os.write
+
+        def tracked_write(fd: int, payload: bytes) -> int:
+            if payload == b"1":
+                return 1
+            return original_write(fd, payload)
+
+        with mock.patch.object(conductor.subprocess, "Popen", return_value=process), mock.patch.object(
+            conductor, "process_start_token", side_effect=lambda pid: "attempt-start" if pid == 5151 else "wrapper-start"
+        ), mock.patch.object(conductor.os, "getpgid", return_value=5151), mock.patch.object(
+            conductor.os, "write", side_effect=tracked_write
+        ), mock.patch.object(conductor.os, "killpg"):
+            with self.assertRaisesRegex(conductor.ConductorError, "did not exit"):
+                conductor._run_cache_attempt(
+                    ["swift", "build"],
+                    Path("/tmp/repo"),
+                    3.0,
+                    attempt_record,
+                    "inconclusive",
+                )
+
+        payload = json.loads(attempt_record.read_text(encoding="utf-8"))
+        self.assertEqual(payload["attemptPID"], 5151)
+        self.assertEqual(payload["attemptStartToken"], "attempt-start")
+
+    def test_terminal_cache_attempt_timeout_projects_to_job_contract(self) -> None:
+        def make_job(ticket: str) -> conductor.Job:
+            return conductor.Job(
+                ticket=ticket,
+                request_key=None,
+                fingerprint="fixture",
+                operation="build",
+                args={},
+                lanes=["build"],
+                timeout=17.0,
+                verbose=False,
+                env={},
+                created_at=conductor.now(),
+                log_path=Path("/tmp") / f"{ticket}.log",
+                state="failed",
+                exit_code=124,
+            )
+
+        seeded = make_job("seeded-timeout")
+        conductor.DaemonState._apply_cache_retry_outcome_locked(
+            seeded,
+            {
+                "attemptTimeoutSeconds": 17.0,
+                "seededTimedOut": True,
+                "coldRetryAttempted": False,
+            },
+        )
+        self.assertTrue(seeded.to_payload()["timedOut"])
+        self.assertEqual(seeded.error, "seeded cache build attempt timed out after 17.0s")
+
+        cold = make_job("cold-timeout")
+        conductor.DaemonState._apply_cache_retry_outcome_locked(
+            cold,
+            {
+                "attemptTimeoutSeconds": 17.0,
+                "seededTimedOut": False,
+                "coldRetryAttempted": True,
+                "coldTimedOut": True,
+            },
+        )
+        self.assertTrue(cold.to_payload()["timedOut"])
+        self.assertEqual(cold.error, "cold recovery cache build attempt timed out after 17.0s")
+
+    def test_seeded_failure_retries_cold_once_and_records_suspect(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        manager = self.manager(repo, store)
+        context, _ = self.publish_seed(manager)
+        key = context.snapshot.key
+        (repo / ".build" / ".conductor-cache-provenance.json").write_text(
+            json.dumps({"key": key}), encoding="utf-8"
+        )
+        ticket = "seeded-retry"
+        outcome = repo / f"{ticket}.cache-outcome.json"
+        attempt_record = repo / f"{ticket}.cache-attempt.json"
+        with mock.patch.dict(os.environ, {"REPOPROMPT_DEV_BUILD_CACHE_DIR": str(store)}), mock.patch.object(
+            conductor,
+            "_run_cache_attempt",
+            side_effect=[(1, False), (0, False)],
+        ) as run:
+            code = conductor.operation_cache_retry(
+                repo,
+                {
+                    "argv": ["swift", "build"],
+                    "key": key,
+                    "outcomePath": str(outcome),
+                    "attemptTimeout": 17.0,
+                    "cleanupTimeout": 31.0,
+                    "attemptRecordPath": str(attempt_record),
+                    "ticket": ticket,
+                },
+            )
+
+        payload = json.loads(outcome.read_text(encoding="utf-8"))
+        self.assertEqual(code, 0)
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual([call.args[2] for call in run.call_args_list], [17.0, 17.0])
+        self.assertEqual([call.args[3] for call in run.call_args_list], [attempt_record, attempt_record])
+        self.assertEqual([call.args[4] for call in run.call_args_list], [ticket, ticket])
+        self.assertEqual(payload["attemptTimeoutSeconds"], 17.0)
+        self.assertEqual(payload["cleanupTimeoutSeconds"], 31.0)
+        self.assertFalse(payload["seededTimedOut"])
+        self.assertFalse(payload["coldTimedOut"])
+        self.assertTrue(payload["coldRetryAttempted"])
+        self.assertTrue(payload["coldSucceeded"])
+        self.assertEqual(payload["suspectCount"], 1)
+
+    def test_bounded_cleanup_failure_refuses_cold_retry_without_losing_outcome(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        manager = self.manager(repo, store)
+        context, _ = self.publish_seed(manager)
+        key = context.snapshot.key
+        (repo / ".build" / ".conductor-cache-provenance.json").write_text(
+            json.dumps({"key": key}), encoding="utf-8"
+        )
+        ticket = "cleanup-failure"
+        outcome = repo / f"{ticket}.cache-outcome.json"
+        attempt_record = repo / f"{ticket}.cache-attempt.json"
+
+        with mock.patch.object(
+            conductor,
+            "_run_cache_attempt",
+            return_value=(1, False),
+        ) as attempt, mock.patch.object(
+            conductor,
+            "_remove_cache_build_for_retry",
+            return_value=False,
+        ) as remove:
+            code = conductor.operation_cache_retry(
+                repo,
+                {
+                    "argv": ["swift", "build"],
+                    "key": key,
+                    "outcomePath": str(outcome),
+                    "attemptTimeout": 19.0,
+                    "cleanupTimeout": 41.0,
+                    "attemptRecordPath": str(attempt_record),
+                    "ticket": ticket,
+                },
+            )
+
+        payload = json.loads(outcome.read_text(encoding="utf-8"))
+        self.assertEqual(code, 1)
+        attempt.assert_called_once_with(["swift", "build"], repo, 19.0, attempt_record, ticket)
+        remove.assert_called_once_with(repo / ".build", 41.0)
+        self.assertFalse(payload["coldRetryAttempted"])
+        self.assertIn("bounded cleanup allowance", payload["reason"])
+        self.assertTrue((repo / ".build").is_dir())
+
+    def test_successful_cold_recovery_survives_advisory_suspect_bookkeeping_failure(self) -> None:
+        temporary, repo, store = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        self.create_build(repo)
+        manager = self.manager(repo, store)
+        context, _ = self.publish_seed(manager)
+        key = context.snapshot.key
+        (repo / ".build" / ".conductor-cache-provenance.json").write_text(
+            json.dumps({"key": key}), encoding="utf-8"
+        )
+        ticket = "bookkeeping-failure"
+        outcome = repo / f"{ticket}.cache-outcome.json"
+        attempt_record = repo / f"{ticket}.cache-attempt.json"
+
+        with mock.patch.object(
+            conductor,
+            "_run_cache_attempt",
+            side_effect=[(1, False), (0, False)],
+        ), mock.patch.object(
+            conductor.BuildCacheManager,
+            "confirm_seeded_failure",
+            side_effect=OSError("suspect bookkeeping fixture"),
+        ):
+            code = conductor.operation_cache_retry(
+                repo,
+                {
+                    "argv": ["swift", "build"],
+                    "key": key,
+                    "outcomePath": str(outcome),
+                    "attemptTimeout": 23.0,
+                    "attemptRecordPath": str(attempt_record),
+                    "ticket": ticket,
+                },
+            )
+
+        payload = json.loads(outcome.read_text(encoding="utf-8"))
+        self.assertEqual(code, 0)
+        self.assertTrue(payload["coldSucceeded"])
+        self.assertIn("suspect bookkeeping fixture", payload["suspectBookkeepingError"])
+        self.assertEqual(
+            conductor.BuildCacheManager.retry_job_timeout(23.0, conductor.BUILD_CACHE_CLONE_MAX_SECONDS),
+            2 * 23.0
+            + conductor.BUILD_CACHE_CLONE_MAX_SECONDS
+            + conductor.BUILD_CACHE_RETRY_OVERHEAD_SECONDS,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -352,6 +352,337 @@ class ConductorCheckpointThreeTests(LifecycleTestCase):
         self.assertEqual(report["verified"], [101])
         self.assertEqual(report["skipped"], [102])
 
+    def test_stale_daemon_cleanup_terminates_wrapper_and_detached_cache_attempt_group(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        self.write_stale_metadata(state)
+        ticket = "11111111-1111-1111-1111-111111111111"
+        attempt_record = state.paths.jobs_dir / f"{ticket}.cache-attempt.json"
+        state.paths.running_processes_path.write_text(
+            json.dumps(
+                {
+                    "version": 3,
+                    "processes": [
+                        {
+                            "ticket": ticket,
+                            "pid": 101,
+                            "pgid": 101,
+                            "processStart": "wrapper-start",
+                            "cacheAttemptRecord": attempt_record.name,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        conductor._atomic_write_json(
+            attempt_record,
+            {
+                "version": 1,
+                "state": "active",
+                "ticket": ticket,
+                "wrapperPID": 101,
+                "wrapperStartToken": "wrapper-start",
+                "attemptPID": 202,
+                "attemptPGID": 202,
+                "attemptStartToken": "attempt-start",
+            },
+        )
+        snapshot = {
+            101: (1, "wrapper-start"),
+            202: (101, "attempt-start"),
+            # This descendant shares attempt pgid 202; killpg(202) covers both.
+            303: (202, "descendant-start"),
+        }
+
+        def signal_group(pgid: int, _sig: signal.Signals) -> None:
+            if pgid == 101:
+                snapshot.pop(101, None)
+            elif pgid == 202:
+                snapshot.pop(202, None)
+                snapshot.pop(303, None)
+
+        with mock.patch.object(conductor, "process_table_snapshot", side_effect=lambda: dict(snapshot)), mock.patch.object(
+            conductor.os, "getpgrp", return_value=999
+        ), mock.patch.object(
+            conductor.os, "getpgid", side_effect=lambda pid: {101: 101, 202: 202}[pid]
+        ), mock.patch.object(conductor.os, "killpg", side_effect=signal_group) as killpg, mock.patch.object(
+            conductor, "_wait_for_recovery_targets_exit", return_value=[]
+        ):
+            result = conductor.cleanup_stale_files(state.paths)
+
+        self.assertEqual(result.state, "cleaned")
+        self.assertEqual(
+            killpg.call_args_list,
+            [mock.call(101, signal.SIGTERM), mock.call(202, signal.SIGTERM)],
+        )
+        self.assertFalse(attempt_record.exists())
+        self.assertFalse(state.paths.running_processes_path.exists())
+        self.assertFalse(state.paths.pid_path.exists())
+        self.assertFalse(state.paths.daemon_meta_path.exists())
+
+    def assert_attempt_rollover_is_recovered(self, *, initial_record_present: bool) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        self.write_stale_metadata(state)
+        ticket = "44444444-4444-4444-4444-444444444444"
+        attempt_record = state.paths.jobs_dir / f"{ticket}.cache-attempt.json"
+        state.paths.running_processes_path.write_text(
+            json.dumps(
+                {
+                    "version": 3,
+                    "processes": [
+                        {
+                            "ticket": ticket,
+                            "pid": 101,
+                            "pgid": 101,
+                            "processStart": "wrapper-start",
+                            "cacheAttemptRecord": attempt_record.name,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        snapshot = {101: (1, "wrapper-start")}
+        if initial_record_present:
+            conductor._atomic_write_json(
+                attempt_record,
+                {
+                    "version": 1,
+                    "state": "active",
+                    "ticket": ticket,
+                    "wrapperPID": 101,
+                    "wrapperStartToken": "wrapper-start",
+                    "attemptPID": 202,
+                    "attemptPGID": 202,
+                    "attemptStartToken": "attempt-a",
+                },
+            )
+            snapshot[202] = (101, "attempt-a")
+
+        def signal_group(pgid: int, _sig: signal.Signals) -> None:
+            if pgid == 101:
+                # Simulate the cache wrapper committing attempt B immediately
+                # before TERM takes effect. Recovery must re-read after wrapper
+                # exit instead of unlinking the newly replaced sidecar.
+                conductor._atomic_write_json(
+                    attempt_record,
+                    {
+                        "version": 1,
+                        "state": "active",
+                        "ticket": ticket,
+                        "wrapperPID": 101,
+                        "wrapperStartToken": "wrapper-start",
+                        "attemptPID": 404,
+                        "attemptPGID": 404,
+                        "attemptStartToken": "attempt-b",
+                    },
+                )
+                snapshot.pop(101, None)
+                snapshot.pop(202, None)
+                snapshot[404] = (1, "attempt-b")
+            elif pgid == 404:
+                snapshot.pop(404, None)
+
+        with mock.patch.object(conductor, "process_table_snapshot", side_effect=lambda: dict(snapshot)), mock.patch.object(
+            conductor.os, "getpgrp", return_value=999
+        ), mock.patch.object(
+            conductor.os, "getpgid", side_effect=lambda pid: {101: 101, 202: 202, 404: 404}[pid]
+        ), mock.patch.object(conductor.os, "killpg", side_effect=signal_group) as killpg, mock.patch.object(
+            conductor, "_wait_for_recovery_targets_exit", return_value=[]
+        ):
+            result = conductor.cleanup_stale_files(state.paths)
+
+        self.assertEqual(result.state, "cleaned")
+        self.assertEqual(
+            killpg.call_args_list,
+            [mock.call(101, signal.SIGTERM), mock.call(404, signal.SIGTERM)],
+        )
+        self.assertFalse(attempt_record.exists())
+        self.assertFalse(state.paths.running_processes_path.exists())
+
+    def test_stale_cleanup_recovers_attempt_a_to_b_rollover(self) -> None:
+        self.assert_attempt_rollover_is_recovered(initial_record_present=True)
+
+    def test_stale_cleanup_recovers_missing_to_published_attempt_transition(self) -> None:
+        self.assert_attempt_rollover_is_recovered(initial_record_present=False)
+
+    def test_reused_cache_attempt_identity_is_not_signaled(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        ticket = "22222222-2222-2222-2222-222222222222"
+        attempt_record = state.paths.jobs_dir / f"{ticket}.cache-attempt.json"
+        state.paths.running_processes_path.write_text(
+            json.dumps(
+                {
+                    "version": 3,
+                    "processes": [
+                        {
+                            "ticket": ticket,
+                            "pid": 101,
+                            "pgid": 101,
+                            "processStart": "wrapper-start",
+                            "cacheAttemptRecord": attempt_record.name,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        conductor._atomic_write_json(
+            attempt_record,
+            {
+                "version": 1,
+                "state": "active",
+                "ticket": ticket,
+                "wrapperPID": 101,
+                "wrapperStartToken": "wrapper-start",
+                "attemptPID": 202,
+                "attemptPGID": 202,
+                "attemptStartToken": "old-attempt-start",
+            },
+        )
+        snapshot = {101: (1, "wrapper-start"), 202: (1, "reused-attempt-start")}
+
+        with mock.patch.object(conductor, "process_table_snapshot", return_value=snapshot), mock.patch.object(
+            conductor.os, "getpgrp", return_value=999
+        ), mock.patch.object(conductor.os, "getpgid", return_value=101), mock.patch.object(
+            conductor.os, "killpg"
+        ) as killpg:
+            report = conductor.signal_running_process_groups(state.paths, signal.SIGTERM)
+
+        killpg.assert_called_once_with(101, signal.SIGTERM)
+        self.assertEqual(report["verified"], [101])
+        self.assertEqual(report["skipped"], [202])
+        attempt_group = next(group for group in report["groups"] if group["kind"] == "cacheAttempt")
+        self.assertEqual(attempt_group["state"], "stale")
+        self.assertTrue(report["identityComplete"])
+
+    def test_ambiguous_cache_attempt_record_preserves_stale_daemon_evidence(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        self.write_stale_metadata(state)
+        ticket = "33333333-3333-3333-3333-333333333333"
+        attempt_record = state.paths.jobs_dir / f"{ticket}.cache-attempt.json"
+        state.paths.running_processes_path.write_text(
+            json.dumps(
+                {
+                    "version": 3,
+                    "processes": [
+                        {
+                            "ticket": ticket,
+                            "pid": 101,
+                            "pgid": 101,
+                            "processStart": "wrapper-start",
+                            "cacheAttemptRecord": attempt_record.name,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        conductor._atomic_write_json(
+            attempt_record,
+            {
+                "version": 1,
+                "state": "active",
+                "ticket": ticket,
+                "wrapperPID": 101,
+                "wrapperStartToken": "mismatched-wrapper",
+                "attemptPID": 202,
+                "attemptPGID": 202,
+                "attemptStartToken": "attempt-start",
+            },
+        )
+
+        with mock.patch.object(
+            conductor, "process_table_snapshot", return_value={101: (1, "wrapper-start")}
+        ), mock.patch.object(conductor.os, "getpgrp", return_value=999), mock.patch.object(
+            conductor.os, "getpgid", return_value=101
+        ), mock.patch.object(conductor.os, "killpg"):
+            result = conductor.cleanup_stale_files(state.paths)
+
+        self.assertEqual(result.state, "ambiguous")
+        self.assertFalse(result.cleaned)
+        self.assertTrue(attempt_record.exists())
+        self.assertTrue(state.paths.running_processes_path.exists())
+        self.assertTrue(state.paths.pid_path.exists())
+        self.assertTrue(state.paths.daemon_meta_path.exists())
+
+    def test_force_stop_waits_for_nonabortable_cache_publication_and_reports_policy(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        job = self.make_job(state, "publishing", "build", {}, ["build"], job_state="running")
+        job.phase = "publishingCache"
+        state.jobs[job.ticket] = job
+        state.active_lanes["build"] = job.ticket
+        deferred: list[tuple[object, tuple[object, ...]]] = []
+
+        class DeferredThread:
+            def __init__(self, *, target: object, args: tuple[object, ...] = (), **_kwargs: object) -> None:
+                deferred.append((target, args))
+
+            def start(self) -> None:
+                return None
+
+        with mock.patch.object(conductor.threading, "Thread", DeferredThread):
+            payload = state.stop(force=True)
+
+        self.assertFalse(job.cancel_requested)
+        self.assertIn("non-abortable", job.cancellation_ignored_reason or "")
+        self.assertEqual(
+            payload["forceStop"],
+            {
+                "requested": True,
+                "publicationPolicy": "waitForNonAbortableAtomicPublication",
+                "publicationWaitTickets": [job.ticket],
+                "publicationWaitTimeoutSeconds": conductor.BUILD_CACHE_FORCE_STOP_WAIT_SECONDS,
+                "cancellationIgnored": True,
+            },
+        )
+        self.assertEqual(len(deferred), 1)
+        server = mock.Mock()
+        state.server = server
+
+        def complete_publication(*_args: object, **_kwargs: object) -> None:
+            self.assertFalse(server.shutdown.called)
+            job.state = "completed"
+            job.phase = "terminal"
+
+        with mock.patch.object(state.condition, "wait", side_effect=complete_publication) as wait, mock.patch.object(
+            conductor.time, "sleep"
+        ):
+            state._force_shutdown_when_canceled([job.ticket])
+
+        wait.assert_called_once_with(timeout=conductor.PROCESS_TREE_POLL_SECONDS)
+        server.shutdown.assert_called_once_with()
+
+    def test_force_stop_publication_wait_expiry_keeps_daemon_and_publication_intact(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        job = self.make_job(state, "publishing-timeout", "build", {}, ["build"], job_state="running")
+        job.phase = "publishingCache"
+        job.cancellation_ignored_reason = "immutable cache publication is non-abortable"
+        state.jobs[job.ticket] = job
+        state.shutdown_requested = True
+        state.server = mock.Mock()
+
+        with mock.patch.object(conductor, "BUILD_CACHE_FORCE_STOP_WAIT_SECONDS", 0.0), mock.patch.object(
+            state, "_warn_job_locked"
+        ) as warn, mock.patch.object(conductor.time, "sleep"):
+            state._force_shutdown_when_canceled([job.ticket])
+
+        self.assertFalse(state.shutdown_requested)
+        self.assertEqual(job.state, "running")
+        self.assertEqual(job.phase, "publishingCache")
+        state.server.shutdown.assert_not_called()
+        warn.assert_called_once_with(
+            job,
+            "buildCachePublicationStopWaitExpired",
+            "daemon stop --force left non-abortable cache publication running after bounded wait",
+        )
+
     def test_concurrent_terminal_waiters_coalesce_summary_and_both_receive_result(self) -> None:
         tmp, state = self.make_state()
         self.addCleanup(tmp.cleanup)
@@ -1296,7 +1627,10 @@ class ConductorCheckpointThreeTests(LifecycleTestCase):
 
 class LifecycleQueueTests(LifecycleTestCase):
     def test_protocol_version_bump_replaces_older_daemons(self) -> None:
-        self.assertEqual(conductor.PROTOCOL_VERSION, 13)
+        self.assertEqual(conductor.PROTOCOL_VERSION, 16)
+
+    def test_server_listen_backlog_matches_bounded_handler_capacity(self) -> None:
+        self.assertEqual(conductor.ThreadedUnixServer.request_queue_size, conductor.MAX_ACTIVE_REQUEST_HANDLERS)
 
     def test_explicit_wait_timeout_survives_repeated_server_clamps(self) -> None:
         clock_value = [0.0]
@@ -1667,7 +2001,7 @@ class LifecycleQueueTests(LifecycleTestCase):
         self.assertEqual(code, 0)
         self.assertEqual(enqueue_launch.call_args.args[2], {"subcommand": "launch-existing", "appArgs": ["--demo"]})
 
-    def test_app_relaunch_delegates_split_internal_runner_with_live_lane_and_timeout(self) -> None:
+    def test_app_relaunch_delegates_split_internal_runner_with_build_live_lanes_and_timeout(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             registry = conductor.OperationRegistry(Path(tmp))
             argv, lanes, _cwd, _env, timeout = registry.prepare(
@@ -1679,11 +2013,30 @@ class LifecycleQueueTests(LifecycleTestCase):
 
         self.assertIn("__operation_runner", argv)
         self.assertIn("debug_app_build_then_launch", argv[-1])
-        self.assertEqual(lanes, ["liveApp"])
+        self.assertEqual(lanes, ["build", "liveApp"])
         self.assertEqual(timeout, conductor.MEDIUM_TIMEOUT_SECONDS)
         self.assertIn("app_launch_existing", launch_existing_argv[-1])
         self.assertEqual(launch_existing_lanes, ["liveApp"])
         self.assertEqual(conductor.operation_display_name("app", {"subcommand": "relaunch"}), "app relaunch")
+
+    def test_building_live_operations_share_build_lane_without_expanding_nonbuilding_lifecycle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = conductor.OperationRegistry(Path(tmp))
+            mutators = (
+                {"operation": "run", "args": {}},
+                {"operation": "app", "args": {"subcommand": "relaunch"}},
+                {"operation": "smoke", "args": {"launch": True}},
+            )
+            nonmutators = (
+                {"operation": "app", "args": {"subcommand": "stop"}},
+                {"operation": "app", "args": {"subcommand": "launch-existing"}},
+                {"operation": "smoke", "args": {"packagedApp": "/tmp/RepoPrompt CE.app"}},
+            )
+            mutator_lanes = [registry.prepare(request)[1] for request in mutators]
+            nonmutator_lanes = [registry.prepare(request)[1] for request in nonmutators]
+
+        self.assertTrue(all("build" in lanes for lanes in mutator_lanes))
+        self.assertTrue(all("build" not in lanes for lanes in nonmutator_lanes))
 
     def test_guardrails_delegates_aggregator_without_lanes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -323,6 +323,119 @@ class ConductorCheckpointThreeTests(LifecycleTestCase):
         self.assertFalse(state.paths.daemon_meta_path.exists())
         self.assertFalse(state.paths.running_processes_path.exists())
 
+    def test_worker_cleanup_preserves_registry_identity_for_final_stale_evidence_check(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        conductor._atomic_write_json(
+            state.paths.running_processes_path,
+            {"version": 3, "generation": 1, "processes": []},
+        )
+        registry_identity = conductor._path_identity(state.paths.running_processes_path)
+
+        cleanup = conductor.cleanup_running_process_groups(state.paths)
+
+        self.assertTrue(cleanup["safeToForget"])
+        self.assertEqual(conductor._path_identity(state.paths.running_processes_path), registry_identity)
+
+    def test_stale_cleanup_rejects_registry_replacement_during_worker_cleanup(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        self.write_stale_metadata(state)
+        conductor._atomic_write_json(
+            state.paths.running_processes_path,
+            {"version": 3, "generation": 1, "processes": []},
+        )
+
+        def replace_registry(_paths: conductor.Paths) -> dict[str, object]:
+            conductor._atomic_write_json(
+                state.paths.running_processes_path,
+                {"version": 3, "generation": 2, "processes": []},
+            )
+            return {"safeToForget": True}
+
+        with mock.patch.object(conductor, "cleanup_running_process_groups", side_effect=replace_registry):
+            result = conductor.cleanup_stale_files(state.paths)
+
+        self.assertEqual(result.state, "ambiguous")
+        self.assertFalse(result.cleaned)
+        self.assertIn("evidence changed before cleanup", result.reason)
+        self.assertTrue(state.paths.pid_path.exists())
+        self.assertTrue(state.paths.daemon_meta_path.exists())
+        self.assertTrue(state.paths.running_processes_path.exists())
+
+    def test_stale_cleanup_start_lock_cannot_unlink_replacement_registry(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        self.write_stale_metadata(state)
+        conductor._atomic_write_json(
+            state.paths.running_processes_path,
+            {"version": 3, "generation": 1, "processes": []},
+        )
+        ready_path = state.paths.state_dir / "replacement-ready"
+        acquired_path = state.paths.state_dir / "replacement-acquired"
+        child: subprocess.Popen[str] | None = None
+        original_unlink = Path.unlink
+
+        def unlink_with_waiting_replacement(path: Path, *args: object, **kwargs: object) -> None:
+            nonlocal child
+            if path == state.paths.pid_path and child is None:
+                child = subprocess.Popen(
+                    [
+                        sys.executable,
+                        "-c",
+                        textwrap.dedent(
+                            """
+                            import fcntl
+                            import json
+                            import os
+                            import sys
+                            from pathlib import Path
+
+                            lock_path, registry_path, ready_path, acquired_path = map(Path, sys.argv[1:])
+                            ready_path.write_text("ready", encoding="utf-8")
+                            with lock_path.open("a+") as lock_file:
+                                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                                acquired_path.write_text("acquired", encoding="utf-8")
+                                temporary = registry_path.with_suffix(".replacement")
+                                temporary.write_text(
+                                    json.dumps({"version": 3, "generation": 2, "processes": []}),
+                                    encoding="utf-8",
+                                )
+                                os.replace(temporary, registry_path)
+                            """
+                        ),
+                        str(state.paths.lock_path),
+                        str(state.paths.running_processes_path),
+                        str(ready_path),
+                        str(acquired_path),
+                    ],
+                    text=True,
+                )
+                deadline = time.monotonic() + 2.0
+                while not ready_path.exists() and time.monotonic() < deadline:
+                    time.sleep(0.01)
+                self.assertTrue(ready_path.exists(), "replacement process did not reach the start-lock barrier")
+                # With the cleanup transaction holding daemon.start.lock, the
+                # replacement cannot acquire or publish before stale evidence
+                # unlinking finishes. Without that lock this wait observes the
+                # replacement and the following pathname unlink deletes it.
+                deadline = time.monotonic() + 0.2
+                while not acquired_path.exists() and time.monotonic() < deadline:
+                    time.sleep(0.01)
+                self.assertFalse(acquired_path.exists())
+            original_unlink(path, *args, **kwargs)
+
+        with mock.patch.object(Path, "unlink", new=unlink_with_waiting_replacement):
+            result = conductor.cleanup_stale_files(state.paths)
+
+        assert child is not None
+        self.assertEqual(child.wait(timeout=2.0), 0)
+        self.assertEqual(result.state, "cleaned")
+        self.assertFalse(state.paths.pid_path.exists())
+        self.assertFalse(state.paths.daemon_meta_path.exists())
+        replacement = json.loads(state.paths.running_processes_path.read_text(encoding="utf-8"))
+        self.assertEqual(replacement["generation"], 2)
+
     def test_recovery_signals_only_exact_pid_start_and_pgid_anchor(self) -> None:
         tmp, state = self.make_state()
         self.addCleanup(tmp.cleanup)


### PR DESCRIPTION
## Summary

Follow-up to #765.

- add an immutable, content-addressed conductor build cache keyed by toolchain, manifests, build configuration, and build-affecting environment
- seed and publish `.build` trees atomically, excluding unsafe ModuleCache/log/provenance content and degrading cleanly to a cold build on any cache failure
- coordinate every conductor operation that mutates `.build` through the build lane, while releasing machine-wide heavy admission before cache publication so another worktree can make progress
- bound clone, sanitize, measurement, seeded-attempt, cold-retry, cancellation, and publication operations with truthful status and diagnostics
- persist exact PID/start-token/PGID identity for session-isolated cache attempts so daemon-crash recovery can reap wrapper, attempt, and descendants without PID-reuse risk
- make cache status read-only, preserve stable lock-inode authority, add cache hygiene and diagnostics, and include `CC`/`CXX` in cache invalidation

## User impact

Worktrees currently repeat large parts of the Swift dependency build graph even when package inputs and toolchain state are unchanged. This cache reuses a validated immutable seed where safe while preserving cold-build correctness. It also keeps resource use bounded: checkout-local build lanes remain serialized, machine-wide heavy slots protect expensive compilation, and cache publication occurs after the heavy slot is released.

Cache failures never authorize unsafe deletion or lock stealing. A seeded failure retries from a provenance-verified cold tree, and ambiguous process identity preserves evidence rather than signaling or recovering automatically.

## Validation

- `/usr/bin/python3 Scripts/test_conductor_cache.py` — 26 passed
- `python3 Scripts/test_conductor_lifecycle.py` — 152 passed
- `/usr/bin/python3 Scripts/test_conductor_output.py` — 34 passed
- `make conductor-selftest` — passed all constituent suites
- `make guardrails` — passed
- contribution commit and push preflights — passed
- outgoing-range secret scan — passed
- Fable 5 High final review — submit-ready, no blocking findings

Prior isolated debug-build stress of the cache core measured:

- cache clone/seed preparation: 56.7 seconds
- seeded debug build: 22m28s
- cold debug build: 39m09s
- approximately 43% faster in that run

## Scope and tradeoffs

Changed only:

- `Makefile`
- `Scripts/conductor.py`
- `Scripts/test_conductor_cache.py`
- `Scripts/test_conductor_lifecycle.py`

SwiftPM/llbuild state can contain absolute worktree paths, so cross-worktree seeds may still revalidate or rebuild path-bound nodes. This PR intentionally does not introduce a canonical fixed-path build checkout; that can be evaluated separately. Uncoordinated direct `swift` builds also remain outside conductor lane protection, as documented.

The submission commit is directly based on merged #765 at `9a1847e74456cbe9f2014a49549ab0fa66234a43` and is byte-identical for the affected files to the final reviewed implementation.
