### PR TITLE
fix(mcp): add Sonoma async frame compatibility barrier

### DIFF
--- a/Sources/RepoPromptDomainRuntime/Diffing/EditFlowPerf.swift
+++ b/Sources/RepoPromptDomainRuntime/Diffing/EditFlowPerf.swift
@@ -1504,10 +1504,11 @@ package enum EditFlowPerf {
         }
 
         /// Compatibility barrier for https://github.com/repoprompt/repoprompt-ce/issues/301.
-        /// Optimizing nested generic async passthroughs around MCP limiter and TaskLocal scopes can
-        /// abort in `swift_task_dealloc` on macOS 14 release builds. Keep this boundary until the
-        /// upstream Swift ownership miscompile is resolved. This stack is distinct from
-        /// https://github.com/swiftlang/swift/issues/86204; no `Task.sleep` specialization is present.
+        /// The deterministic macOS 14 release crash unwinds through these generic async passthroughs
+        /// around MCP limiter and TaskLocal scopes. Preserve a non-inlined boundary pending Sonoma
+        /// verification and resolution of the underlying compiler/runtime interaction. The reported
+        /// stack is distinct from https://github.com/swiftlang/swift/issues/86204: no `Task.sleep`
+        /// specialization is present.
         @inline(never)
         package static func measure<T>(
             _ name: StaticString,

--- a/Sources/RepoPromptDomainRuntime/Diffing/EditFlowPerf.swift
+++ b/Sources/RepoPromptDomainRuntime/Diffing/EditFlowPerf.swift
@@ -1503,7 +1503,12 @@ package enum EditFlowPerf {
             try operation()
         }
 
-        @inline(__always)
+        /// Compatibility barrier for https://github.com/repoprompt/repoprompt-ce/issues/301.
+        /// Optimizing nested generic async passthroughs around MCP limiter and TaskLocal scopes can
+        /// abort in `swift_task_dealloc` on macOS 14 release builds. Keep this boundary until the
+        /// upstream Swift ownership miscompile is resolved. This stack is distinct from
+        /// https://github.com/swiftlang/swift/issues/86204; no `Task.sleep` specialization is present.
+        @inline(never)
         package static func measure<T>(
             _ name: StaticString,
             operation: () async throws -> T
@@ -1511,7 +1516,8 @@ package enum EditFlowPerf {
             try await operation()
         }
 
-        @inline(__always)
+        // Keep the dimensions overload behind the same issue #301 optimizer barrier.
+        @inline(never)
         package static func measure<T>(
             _ name: StaticString,
             _ dimensions: @autoclosure () -> Dimensions,


### PR DESCRIPTION
## Summary

- keep the release-only async `EditFlowPerf.measure` passthroughs behind an `@inline(never)` boundary
- preserve an explicit async frame around the MCP limiter / task-local unwind path implicated by the deterministic macOS 14 `swift_task_dealloc` abort
- document that this stack is distinct from the `Task.sleep(for:)` specialization tracked by swiftlang/swift#86204

## Rationale

Issue #301 reproduces on Sonoma when any MCP `tools/call` unwinds through nested generic async wrappers, connection admission, and task-local routing. The synchronous passthroughs cannot suspend, so this change limits the optimizer barrier to the two async release stubs and does not alter runtime behavior.

This is an evidence-led compatibility candidate, not proof of the underlying compiler/runtime cause. The source comment deliberately describes the confirmed stack and keeps the exact cause provisional.

## Validation

- `make dev-format` — passed, 0/1466 files changed
- `make dev-lint` — passed
- `./conductor release preflight --async --request-key issue-301-release-preflight` — passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready` — passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` — passed

There is no valuable debug/unit regression for a release optimizer + host Swift concurrency runtime interaction. Decisive verification remains a packaged release build on macOS 14 running `repoprompt-mcp -e 'windows'` and another `tools/call`; the reporter has offered to test a diagnostic build.

Addresses #301.