### PR TITLE
Bound untrusted Agent Mode tool names before normalization

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
@@ -131,7 +131,12 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
     public var taggedFileAttachments: [AgentTaggedFileAttachment]
 
     /// Tool metadata (for toolCall/toolResult kinds)
-    public var toolName: String?
+    public var toolName: String? {
+        didSet {
+            toolName = AgentToolNamePolicy.accepted(toolName)
+        }
+    }
+
     public var toolInvocationID: UUID?
     public var toolArgsJSON: String? // JSON string of tool arguments
     public var toolResultJSON: String? // Tool execution result JSON (for toolResult kind)
@@ -180,7 +185,7 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
         self.text = text
         self.attachments = attachments
         self.taggedFileAttachments = taggedFileAttachments
-        self.toolName = toolName
+        self.toolName = AgentToolNamePolicy.accepted(toolName)
         self.toolInvocationID = toolInvocationID
         self.toolArgsJSON = toolArgsJSON
         self.toolResultJSON = toolResultJSON
@@ -214,7 +219,7 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
         text = try c.decode(String.self, forKey: .text)
         attachments = try c.decodeIfPresent([AgentImageAttachment].self, forKey: .attachments) ?? []
         taggedFileAttachments = try c.decodeIfPresent([AgentTaggedFileAttachment].self, forKey: .taggedFileAttachments) ?? []
-        toolName = try c.decodeIfPresent(String.self, forKey: .toolName)
+        toolName = try AgentToolNamePolicy.accepted(c.decodeIfPresent(String.self, forKey: .toolName))
         toolInvocationID = try c.decodeIfPresent(UUID.self, forKey: .toolInvocationID)
         toolArgsJSON = try c.decodeIfPresent(String.self, forKey: .toolArgsJSON)
         toolResultJSON = try c.decodeIfPresent(String.self, forKey: .toolResultJSON)
@@ -242,7 +247,15 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
     }
 
     public static func toolCall(name: String, invocationID: UUID? = nil, argsJSON: String?, sequenceIndex: Int = 0) -> AgentChatItem {
-        AgentChatItem(kind: .toolCall, text: "Using tool: \(name)", toolName: name, toolInvocationID: invocationID, toolArgsJSON: argsJSON, sequenceIndex: sequenceIndex)
+        let acceptedName = AgentToolNamePolicy.accepted(name)
+        return AgentChatItem(
+            kind: .toolCall,
+            text: acceptedName.map { "Using tool: \($0)" } ?? "Using tool",
+            toolName: acceptedName,
+            toolInvocationID: invocationID,
+            toolArgsJSON: argsJSON,
+            sequenceIndex: sequenceIndex
+        )
     }
 
     public static func toolResult(name: String, invocationID: UUID? = nil, argsJSON: String? = nil, resultJSON: String, isError: Bool? = nil, sequenceIndex: Int = 0) -> AgentChatItem {
@@ -296,7 +309,12 @@ public struct AgentChatItemPersist: Codable, Identifiable, Sendable, Equatable {
     public var text: String
     public var attachments: [AgentImageAttachment]
     public var taggedFileAttachments: [AgentTaggedFileAttachment]
-    public var toolName: String?
+    public var toolName: String? {
+        didSet {
+            toolName = AgentToolNamePolicy.accepted(toolName)
+        }
+    }
+
     public var toolInvocationID: UUID?
     public var toolArgsJSON: String?
     public var toolResultJSON: String?
@@ -314,7 +332,7 @@ public struct AgentChatItemPersist: Codable, Identifiable, Sendable, Equatable {
         kind = item.kind
         attachments = item.attachments
         taggedFileAttachments = item.taggedFileAttachments
-        toolName = item.toolName
+        toolName = AgentToolNamePolicy.accepted(item.toolName)
         toolInvocationID = item.toolInvocationID
         toolArgsJSON = sanitizeToolResults && (item.kind == .toolCall || item.kind == .toolResult) ? nil : item.toolArgsJSON
         reasoning = item.reasoning
@@ -451,7 +469,7 @@ public struct AgentChatItemPersist: Codable, Identifiable, Sendable, Equatable {
         text = try container.decode(String.self, forKey: .text)
         attachments = try container.decodeIfPresent([AgentImageAttachment].self, forKey: .attachments) ?? []
         taggedFileAttachments = try container.decodeIfPresent([AgentTaggedFileAttachment].self, forKey: .taggedFileAttachments) ?? []
-        toolName = try container.decodeIfPresent(String.self, forKey: .toolName)
+        toolName = try AgentToolNamePolicy.accepted(container.decodeIfPresent(String.self, forKey: .toolName))
         toolInvocationID = try container.decodeIfPresent(UUID.self, forKey: .toolInvocationID)
         toolArgsJSON = try container.decodeIfPresent(String.self, forKey: .toolArgsJSON)
         toolResultJSON = try container.decodeIfPresent(String.self, forKey: .toolResultJSON)

--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentToolNamePolicy.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentToolNamePolicy.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Bounds untrusted provider tool names before any normalization or display work.
+enum AgentToolNamePolicy {
+    /// Tool names are identifiers, not payloads. This keeps all downstream work bounded while
+    /// leaving ample room for namespaced MCP and provider tool names.
+    static let maximumUTF8Length = 512
+
+    static func accepted(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let inspectedLength = raw.utf8.prefix(maximumUTF8Length + 1).count
+        return inspectedLength <= maximumUTF8Length ? raw : nil
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentToolNamePolicy.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentToolNamePolicy.swift
@@ -5,6 +5,7 @@ enum AgentToolNamePolicy {
     /// Tool names are identifiers, not payloads. This keeps all downstream work bounded while
     /// leaving ample room for namespaced MCP and provider tool names.
     static let maximumUTF8Length = 512
+    static let fallbackName = "tool"
 
     static func accepted(_ raw: String?) -> String? {
         guard let raw else { return nil }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -648,6 +648,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     }
 
     private func isRepoPromptTrackerToolName(_ toolName: String) -> Bool {
+        guard let toolName = AgentToolNamePolicy.accepted(toolName) else { return false }
         if AgentToolTrackingSupport.isRepoPromptTool(toolName) {
             return true
         }
@@ -6893,6 +6894,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             )
         case let .toolCall(toolName, invocationID, argsJSON):
             guard session.runState.isActive else { return }
+            let toolName = AgentToolNamePolicy.accepted(toolName) ?? AgentToolNamePolicy.fallbackName
             clearCodexPendingAuthRetryTurn(session)
             sealAssistantBoundary(session)
             noteCodexNativeToolCall(
@@ -6933,6 +6935,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             viewModel?.requestUIRefresh(tabID: session.tabID)
         case let .toolResult(toolName, invocationID, argsJSON, resultJSON, isError):
             guard session.runState.isActive else { return }
+            let toolName = AgentToolNamePolicy.accepted(toolName) ?? AgentToolNamePolicy.fallbackName
             clearCodexPendingAuthRetryTurn(session)
             sealAssistantBoundary(session)
             if AgentToolTrackingSupport.isExplicitRepoPromptTool(toolName) {
@@ -7339,7 +7342,9 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     }
 
     private static func normalizedExternalToolName(_ raw: String?) -> String? {
-        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
+        guard let acceptedName = AgentToolNamePolicy.accepted(raw) else { return nil }
+        let raw = acceptedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return nil }
         let lowered = raw.lowercased()
         if let webCanonical = AgentWebToolCanonicalNames.canonicalToolCardName(lowered) {
             return webCanonical

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ToolTracking/AgentToolTrackingContracts.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ToolTracking/AgentToolTrackingContracts.swift
@@ -121,17 +121,19 @@ struct AgentToolTrackingHooks {
 enum AgentToolTrackingSupport {
     /// Whether the tool name belongs to a RepoPrompt MCP tool (any naming convention).
     static func isRepoPromptTool(_ name: String) -> Bool {
-        MCPIntegrationHelper.isRepoPromptToolName(name)
+        guard let name = AgentToolNamePolicy.accepted(name) else { return false }
+        return MCPIntegrationHelper.isRepoPromptToolName(name)
     }
 
     /// Whether the tool name uses the explicit server-prefixed RepoPrompt naming.
     static func isExplicitRepoPromptTool(_ name: String) -> Bool {
-        MCPIntegrationHelper.isRepoPromptToolNameWithServerPrefix(name)
+        guard let name = AgentToolNamePolicy.accepted(name) else { return false }
+        return MCPIntegrationHelper.isRepoPromptToolNameWithServerPrefix(name)
     }
 
     /// Whether a tool should be hidden from the agent transcript UI.
     static func shouldHideToolFromTranscript(_ name: String?) -> Bool {
-        AgentTranscriptIO.shouldHideToolFromTranscript(name)
+        AgentTranscriptIO.shouldHideToolFromTranscript(AgentToolNamePolicy.accepted(name))
     }
 
     /// Whether a provider tool event should be suppressed in favor of tracker-sourced events.
@@ -154,6 +156,7 @@ enum AgentToolTrackingSupport {
     ) -> Bool {
         guard session.selectedAgent.usesClaudeNativeRuntime else { return false }
         guard invocationID == nil else { return false }
+        guard let toolName = AgentToolNamePolicy.accepted(toolName) else { return false }
         return toolName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "read"
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
@@ -90,7 +90,7 @@ enum AgentWebToolCanonicalNames {
 
     static func isWebSearchName(_ name: String) -> Bool {
         guard let name = AgentToolNamePolicy.accepted(name) else { return false }
-        switch normalizedName(name) {
+        return switch normalizedName(name) {
         case "search", "web_search", "web_search_request", "google_web_search", "search_web", "websearch":
             true
         default:
@@ -100,7 +100,7 @@ enum AgentWebToolCanonicalNames {
 
     static func isWebReadName(_ name: String) -> Bool {
         guard let name = AgentToolNamePolicy.accepted(name) else { return false }
-        switch normalizedName(name) {
+        return switch normalizedName(name) {
         case "webfetch", "web_fetch", "web_read", "read_web", "browser.open", "browser_open", "open_url",
              "read_url", "fetch_url", "web_page", "webpage", "read_web_page":
             true

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
@@ -65,7 +65,9 @@ enum AgentWebToolPayloadKeys {
 
 enum AgentWebToolCanonicalNames {
     static func canonicalWebActionType(_ raw: String?) -> String? {
-        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
+        guard let acceptedName = AgentToolNamePolicy.accepted(raw) else { return nil }
+        let raw = acceptedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return nil }
         switch raw {
         case "search":
             return "search"
@@ -79,7 +81,7 @@ enum AgentWebToolCanonicalNames {
     }
 
     static func canonicalToolCardName(_ raw: String?) -> String? {
-        guard let raw else { return nil }
+        guard let raw = AgentToolNamePolicy.accepted(raw) else { return nil }
         let names = normalizedNameCandidates(raw)
         if names.contains(where: isWebSearchName) { return "search" }
         if names.contains(where: isWebReadName) { return "web_read" }
@@ -87,6 +89,7 @@ enum AgentWebToolCanonicalNames {
     }
 
     static func isWebSearchName(_ name: String) -> Bool {
+        guard let name = AgentToolNamePolicy.accepted(name) else { return false }
         switch normalizedName(name) {
         case "search", "web_search", "web_search_request", "google_web_search", "search_web", "websearch":
             true
@@ -96,6 +99,7 @@ enum AgentWebToolCanonicalNames {
     }
 
     static func isWebReadName(_ name: String) -> Bool {
+        guard let name = AgentToolNamePolicy.accepted(name) else { return false }
         switch normalizedName(name) {
         case "webfetch", "web_fetch", "web_read", "read_web", "browser.open", "browser_open", "open_url",
              "read_url", "fetch_url", "web_page", "webpage", "read_web_page":
@@ -127,6 +131,7 @@ enum AgentWebToolCanonicalNames {
     }
 
     private static func normalizedNameCandidates(_ raw: String) -> [String] {
+        guard let raw = AgentToolNamePolicy.accepted(raw) else { return [] }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
         let stripped = trimmed.replacingOccurrences(of: "mcp__RepoPrompt__", with: "")

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
@@ -3,7 +3,9 @@ import RepoPromptShared
 import SwiftUI
 
 func normalizedToolCardName(_ name: String?) -> String? {
-    guard let raw = name?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
+    guard let acceptedName = AgentToolNamePolicy.accepted(name) else { return nil }
+    let raw = acceptedName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !raw.isEmpty else { return nil }
     let canonical = MCPIntegrationHelper.canonicalRepoPromptToolName(raw) ?? raw
     // External tools can be namespaced (for example, "functions.bash").
     // Route by suffix so tool cards stay consistent.

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -3691,6 +3691,10 @@ final class CodexNativeSessionController {
             parseTokenUsagePayload(from: params)
         }
 
+        static func test_normalizedExternalToolName(_ raw: String?) -> String? {
+            normalizedExternalToolName(raw)
+        }
+
         static func test_parseErrorNotification(from params: [String: Any]) -> ErrorNotification? {
             parseErrorNotification(from: params)
         }
@@ -6509,8 +6513,8 @@ final class CodexNativeSessionController {
     }
 
     private static func normalizedExternalToolName(_ raw: String?) -> String? {
-        guard let raw else { return nil }
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let acceptedName = AgentToolNamePolicy.accepted(raw) else { return nil }
+        let trimmed = acceptedName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         let lowered = trimmed.lowercased()
         let suffix = lowered.split(separator: ".").last.map(String.init) ?? lowered

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
@@ -5,6 +5,16 @@ import XCTest
 final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
     private static let webSearchAliases = ["search", "web_search", "web_search_request", "google_web_search", "search_web"]
 
+    func testExternalToolNameNormalizationRejectsOversizedInputBeforeCanonicalization() {
+        let oversizedName = String(repeating: "x", count: AgentToolNamePolicy.maximumUTF8Length + 1)
+
+        XCTAssertNil(CodexNativeSessionController.test_normalizedExternalToolName(oversizedName))
+        XCTAssertEqual(
+            CodexNativeSessionController.test_normalizedExternalToolName(" functions.exec_command "),
+            "bash"
+        )
+    }
+
     func testRawExecCallIDAndSnapshotItemIDShareOnlyOpaqueProcessHandle() async throws {
         let controller = makeControllerWithThread(turnID: "turn-1")
         await controller.test_handleNotification(

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
@@ -2,6 +2,46 @@
 import XCTest
 
 final class WebSearchToolCardTests: XCTestCase {
+    func testToolNamePolicyBoundsNormalizationByUTF8Length() {
+        let maximum = AgentToolNamePolicy.maximumUTF8Length
+        let exactASCII = String(repeating: "a", count: maximum)
+        let oversizedASCII = exactASCII + "a"
+        XCTAssertEqual(normalizedToolCardName(exactASCII), exactASCII)
+        XCTAssertNil(normalizedToolCardName(oversizedASCII))
+        XCTAssertNil(AgentWebToolCanonicalNames.canonicalToolCardName(oversizedASCII))
+
+        let robot = "🤖"
+        let exactMultibyte = String(repeating: robot, count: maximum / robot.utf8.count)
+        let oversizedMultibyte = exactMultibyte + robot
+        XCTAssertEqual(exactMultibyte.utf8.count, maximum)
+        XCTAssertEqual(normalizedToolCardName(exactMultibyte), exactMultibyte)
+        XCTAssertNil(normalizedToolCardName(oversizedMultibyte))
+    }
+
+    func testToolNamePolicyAppliesToLiveMutationsAndPersistedDecoding() throws {
+        let oversizedName = String(repeating: "x", count: AgentToolNamePolicy.maximumUTF8Length + 1)
+        var item = AgentChatItem.toolCall(name: "search", argsJSON: nil)
+        item.toolName = oversizedName
+        XCTAssertNil(item.toolName)
+
+        let persisted = AgentChatItemPersist(from: AgentChatItem.toolCall(name: "search", argsJSON: nil))
+        let encoded = try JSONEncoder().encode(persisted)
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object["toolName"] = oversizedName
+        let oversizedPersistedData = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(AgentChatItemPersist.self, from: oversizedPersistedData)
+        XCTAssertNil(decoded.toolName)
+        XCTAssertNil(decoded.toItem().toolName)
+    }
+
+    func testOversizedToolNameFallsBackBeforeRenderRouting() {
+        let oversizedName = String(repeating: "search", count: AgentToolNamePolicy.maximumUTF8Length)
+        var item = AgentChatItem(kind: .toolCall, text: "Using tool", toolName: "search")
+        item.toolName = oversizedName
+        XCTAssertNil(item.toolName)
+        XCTAssertNil(ToolCardRouter.callPresentation(for: item))
+    }
+
     func testWebSearchNamesStayDistinctFromFileSearchAndRouteAsKnownResult() {
         for alias in ["search", "web_search", "web_search_request", "google_web_search", "search_web", "websearch"] {
             XCTAssertEqual(normalizedToolCardName(alias), "search", alias)

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
@@ -20,9 +20,20 @@ final class WebSearchToolCardTests: XCTestCase {
 
     func testToolNamePolicyAppliesToLiveMutationsAndPersistedDecoding() throws {
         let oversizedName = String(repeating: "x", count: AgentToolNamePolicy.maximumUTF8Length + 1)
+        let factoryItem = AgentChatItem.toolCall(name: oversizedName, argsJSON: nil)
+        XCTAssertNil(factoryItem.toolName)
+        XCTAssertEqual(factoryItem.text, "Using tool")
+
         var item = AgentChatItem.toolCall(name: "search", argsJSON: nil)
         item.toolName = oversizedName
         XCTAssertNil(item.toolName)
+
+        let encodedItem = try JSONEncoder().encode(AgentChatItem.toolCall(name: "search", argsJSON: nil))
+        var itemObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedItem) as? [String: Any])
+        itemObject["toolName"] = oversizedName
+        let oversizedItemData = try JSONSerialization.data(withJSONObject: itemObject)
+        let decodedItem = try JSONDecoder().decode(AgentChatItem.self, from: oversizedItemData)
+        XCTAssertNil(decodedItem.toolName)
 
         let persisted = AgentChatItemPersist(from: AgentChatItem.toolCall(name: "search", argsJSON: nil))
         let encoded = try JSONEncoder().encode(persisted)


### PR DESCRIPTION
## Summary

- cap provider-supplied Agent Mode tool names at 512 UTF-8 bytes using bounded traversal
- enforce the invariant at live/persisted transcript assignment and decoding
- validate before Codex/tool-tracking classification and before render-path trimming, lowercasing, MCP canonicalization, or replacement work
- preserve oversized Codex events with a bounded generic `tool` fallback rather than processing or persisting the raw identifier
- add exact-boundary ASCII/multibyte, live mutation, factory, Codable persistence, and render-routing regressions

## Sentry evidence and scope

This supersedes #757 and is based on Sentry issue `REPOPROMPT-GT` (`7660086266`), event `63f14861ac764f168be006a31c6002db`.

The production stack corroborates main-thread work through `AgentMessageBubble` -> `normalizedToolCardName` -> `AgentWebToolCanonicalNames.normalizedNameCandidates` -> Foundation replacement. It does **not** include the raw tool name or its length, so this PR does not claim Sentry proved an extremely long input. Instead, it establishes a defensive resource bound at the untrusted-input authority and retains a render-path guard for persisted/legacy state.

The Sentry bot patch in #757 guarded only an inner helper with `raw.count < 500`; that count is itself a full grapheme traversal and occurs after earlier unbounded trimming/lowercasing. This replacement bounds UTF-8 traversal before those transformations.

## Validation

- `make dev-format` — pass
- `make dev-test FILTER=WebSearchToolCardTests` — pass, 14 tests / 0 failures (ticket `bf6ae8f2-9037-4914-8615-67bb89c696e9`)
- `make dev-lint` — pass (final PR-ready lint ticket `d85fdf43-6cff-4fd0-899b-cb7f37ed7cc1`)
- `make dev-swift-build PRODUCT=RepoPrompt` — pass (ticket `8a3667b4-6739-451f-8064-894863f728ca`)
- contribution `commit` and `push` preflights — pass; staged/outgoing secret scans clean
- full `pr-ready` root suite — failed after 54m52s in unrelated existing concurrency/codemap tests (`ACPAgentSessionControllerModeConfigTests.testTransportTerminationDrainsPromptSettlementWaiters`, `AgentSelectedFilesModelCoordinatorTests.testDisplayedCountReadinessUsesCompletedCodemapSnapshotDuringSameIdentityRefresh`, `CodeMapArtifactBuildCoordinatorTests.testExplicitAdmissionOccursAtConfiguredConsecutiveDemandLimit`, and `CodeMapRootManifestStoreTests.testStaleAndInterruptedAccessTouchesFailClosed`). The changed focused suite passed separately; no retries or timeout changes were used.

## Review

A separate read-only critical review found the initial render/model bound did not cover Codex pre-ingestion classification. The final branch incorporates that finding by guarding shared tool-tracking helpers and Codex event entry before any tool-name transformation.
