### PR TITLE
Agent Mode: bind terminal settlement to exact sessions

### DIFF
--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -692,19 +692,19 @@ print_matches \
   "WorkspaceFilesViewModel references removed recursive eager loading seam" \
   grep -n -E 'loadContentsRecursively' Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
 
-# Agent Mode terminal settlement stays independent of the app's concrete tab
-# session type. Concrete binding is allowed only in the app-host adapter.
+# Agent Mode terminal settlement stays free of the app's concrete TabSession
+# type. Other narrow nested vocabulary remains an explicit follow-up boundary.
 terminal_session_neutral_files=(
   "Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift"
   "Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift"
 )
 for path in "${terminal_session_neutral_files[@]}"; do
   if [[ ! -f "$path" ]]; then
-    fail "required session-neutral terminal settlement source missing: $path"
+      fail "required TabSession-neutral terminal settlement source missing: $path"
     continue
   fi
   print_matches \
-    "session-neutral terminal settlement source references AgentModeViewModel.TabSession: $path" \
+      "TabSession-neutral terminal settlement source references AgentModeViewModel.TabSession: $path" \
     grep -n -F 'AgentModeViewModel.TabSession' "$path"
 done
 

--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -692,6 +692,22 @@ print_matches \
   "WorkspaceFilesViewModel references removed recursive eager loading seam" \
   grep -n -E 'loadContentsRecursively' Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
 
+# Agent Mode terminal settlement stays independent of the app's concrete tab
+# session type. Concrete binding is allowed only in the app-host adapter.
+terminal_session_neutral_files=(
+  "Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift"
+  "Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift"
+)
+for path in "${terminal_session_neutral_files[@]}"; do
+  if [[ ! -f "$path" ]]; then
+    fail "required session-neutral terminal settlement source missing: $path"
+    continue
+  fi
+  print_matches \
+    "session-neutral terminal settlement source references AgentModeViewModel.TabSession: $path" \
+    grep -n -F 'AgentModeViewModel.TabSession' "$path"
+done
+
 # 7. Removed IDE-era Prompt selected-files panel and Prompt-owned preset bottom bar
 # artifacts must not return. The live compact selected-files surface is
 # SelectedFilesGrid/FilePreviewPopover, and Settings owns its chat preset picker.

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
@@ -70,9 +70,12 @@ final class AgentModeRunService {
     ) {
         self.dependencies = dependencies
         self.hooks = hooks
-        let terminalCommitBarrier = AgentRunTerminalCommitBarrier(hooks: hooks)
+        let terminalCommitBarrier = AgentRunTerminalCommitBarrier()
         self.terminalCommitBarrier = terminalCommitBarrier
-        dependencies.codexCoordinator.installTerminalCommitBarrier(terminalCommitBarrier)
+        dependencies.codexCoordinator.installTerminalCommitBarrier(
+            terminalCommitBarrier,
+            terminalSessionBinder: { hooks.bindTerminalSession($0) }
+        )
         headlessRunner = HeadlessAgentModeRunner(
             headlessProviderFactory: dependencies.headlessProviderFactory,
             hooks: hooks,
@@ -432,7 +435,7 @@ final class AgentModeRunService {
         let ownership = session.activeRunOwnership ?? session.beginRunAttempt(source: "runService.startupFailure")
         hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: session.runID,
             terminalState: .failed,
@@ -561,13 +564,13 @@ final class AgentModeRunService {
                 session.pendingInstructions.insert(contentsOf: providerTexts, at: 0)
             }
             session.mcpFollowUpRunPending = true
-            hooks.continuation.startFollowUpRun(tabID, first)
+            hooks.continuation.startFollowUpRun(session, first)
             return
         }
         session.pendingInstructions.insert(contentsOf: providerTexts, at: 0)
         session.isDirty = true
         hooks.bindingObservation.updateBindings(session)
-        hooks.persistence.scheduleSave(tabID)
+        hooks.persistence.scheduleSave(session)
     }
 
     /// Claims superseding protection for the currently outstanding Claude turn when
@@ -905,12 +908,12 @@ final class AgentModeRunService {
         {
             await terminalCommitBarrier.awaitTerminalPublication(
                 for: revision.ownership,
-                session: session
+                lifecycle: session.runLifecycle
             )
             if completion == .terminalTeardownCompleted {
                 await terminalCommitBarrier.awaitTerminalTeardown(
                     for: revision.ownership,
-                    session: session
+                    lifecycle: session.runLifecycle
                 )
             }
             return
@@ -979,7 +982,7 @@ final class AgentModeRunService {
         }
 
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: expectedRunID,
             terminalState: .cancelled,
@@ -1035,7 +1038,7 @@ final class AgentModeRunService {
         if completion == .terminalTeardownCompleted {
             await terminalCommitBarrier.awaitTerminalTeardown(
                 for: ownership,
-                session: session
+                lifecycle: session.runLifecycle
             )
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
@@ -14,9 +14,10 @@ import RepoPromptDomainRuntime
 // - Presentation, binding-observation, queued-work recovery, and persistence
 //   hooks are host projections. They must never become backend authority: a
 //   headless host may implement them as no-ops without changing run semantics.
-// - `AgentModeViewModel.TabSession` still appears in these signatures because
-//   the app host is the only adopter today. The grouping is the contract seam;
-//   neutralizing the session parameter is the provider-migration step (PR 3).
+// - `AgentModeViewModel.TabSession` remains at broader app-host orchestration
+//   hooks because the app is the only adopter today. Terminal settlement does
+//   not receive that type: `bindTerminalSession(_:)` partially applies the
+//   exact originating object into a session-neutral capability value.
 
 extension AgentModeRunService {
     /// Token/usage accounting projection for non-Codex turns.
@@ -44,7 +45,7 @@ extension AgentModeRunService {
     ///
     /// Authority: presentation projection.
     struct RunPresentationHooks {
-        let setAgentRunActive: (UUID, Bool) -> Void
+        let setAgentRunActive: (AgentModeViewModel.TabSession, Bool) -> Void
         let requestUIRefresh: (UUID, Bool) -> Void
         let notifyAgentTurnComplete: (AgentModeViewModel.TabSession) -> Void
     }
@@ -73,7 +74,7 @@ extension AgentModeRunService {
     ///
     /// Authority: persistence projection.
     struct RunPersistenceHooks {
-        let scheduleSave: (UUID) -> Void
+        let scheduleSave: (AgentModeViewModel.TabSession) -> Void
     }
 
     /// Transcript projection of provider stream events and terminal finalization.
@@ -143,7 +144,7 @@ extension AgentModeRunService {
     ///
     /// Authority: lifecycle command issuance back into the host.
     struct RunContinuationHooks {
-        let startFollowUpRun: (UUID, String) -> Void
+        let startFollowUpRun: (AgentModeViewModel.TabSession, String) -> Void
         /// Wakes MCP waiters once a steering instruction has actually been delivered to the provider.
         let signalMCPInstructionDelivered: (_ session: AgentModeViewModel.TabSession) async -> Void
     }
@@ -161,5 +162,141 @@ extension AgentModeRunService {
         let interactions: RunInteractionHooks
         let terminalSettlement: TerminalSettlementHooks
         let continuation: RunContinuationHooks
+    }
+}
+
+// MARK: - Exact session partial application for terminal settlement
+
+extension AgentModeRunService.Hooks {
+    /// Binds the terminal settlement surface to the exact originating object.
+    ///
+    /// This is the app-host composition edge: the returned value retains that
+    /// object directly and never re-resolves it through the tab dictionary.
+    @MainActor
+    func bindTerminalSession(
+        _ session: AgentModeViewModel.TabSession
+    ) -> AgentRunTerminalSessionBinding {
+        let tabID = session.tabID
+        return AgentRunTerminalSessionBinding(
+            tabID: tabID,
+            lifecycle: session.runLifecycle,
+            hooks: .init(
+                flushPendingAssistantDelta: {
+                    transcript.flushPendingAssistantDelta(session)
+                },
+                finalizeStreamingItems: {
+                    transcript.finalizeStreamingItems(session)
+                },
+                finalizePendingToolCalls: { terminalState in
+                    transcript.finalizePendingToolCalls(session, terminalState)
+                },
+                finalizeNonCodexTurnUsage: {
+                    usage.finalizeNonCodexTurnUsage(session, nil, nil, nil)
+                },
+                cancelPendingInteractions: { reviewReason in
+                    interactions.cancelPendingQuestion(session)
+                    interactions.cancelPendingApproval(session)
+                    interactions.cancelPendingApplyEditsReview(session, reviewReason)
+                    interactions.cancelPendingWorktreeMergeReview(session, reviewReason)
+                },
+                finalizeAttachments: { reservationID, disposition in
+                    attachments.finalizeAttachmentsForTurn(session, reservationID, disposition)
+                },
+                setAgentRunInactive: {
+                    presentation.setAgentRunActive(session, false)
+                },
+                prepareTerminalPublication: {
+                    terminalSettlement.prepareTerminalPublication(session)
+                },
+                makeTerminalPublicationEnvelope: { ownership, terminalState, expectedRunID, failureReason in
+                    terminalSettlement.makeTerminalPublicationEnvelope(
+                        session,
+                        ownership,
+                        terminalState,
+                        expectedRunID,
+                        failureReason
+                    )
+                },
+                updateBindings: {
+                    bindingObservation.updateBindings(session)
+                },
+                notifyAgentTurnComplete: {
+                    presentation.notifyAgentTurnComplete(session)
+                },
+                scheduleSave: {
+                    persistence.scheduleSave(session)
+                },
+                publishTerminalCommit: { revision, successorKind in
+                    await terminalSettlement.publishTerminalCommit(
+                        session,
+                        revision,
+                        successorKind
+                    )
+                },
+                startFollowUpRun: { instruction in
+                    continuation.startFollowUpRun(session, instruction)
+                }
+            ),
+            validatesOwnership: { ownership, expectedRunID in
+                session.isCurrentRunAttemptForCurrentBinding(
+                    ownership,
+                    expectedRunID: expectedRunID
+                )
+            },
+            providerDrainGeneration: {
+                session.providerTerminalDrainGeneration
+            },
+            terminalTurnID: {
+                session.items.last(where: { $0.kind == .user })?.id
+            },
+            queuedFollowUp: {
+                session.pendingInstructions.first
+            },
+            setFollowUpPending: { pending in
+                session.mcpFollowUpRunPending = pending
+            },
+            removeFirstQueuedFollowUp: {
+                guard !session.pendingInstructions.isEmpty else { return nil }
+                return session.pendingInstructions.removeFirst()
+            },
+            appendError: { errorText in
+                session.appendItem(
+                    AgentChatItem.error(
+                        errorText,
+                        sequenceIndex: session.nextSequenceIndex
+                    )
+                )
+            },
+            finishActiveState: { ownership, terminalState, source in
+                session.agentTask = nil
+                session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
+                session.setRunningStatus(nil, source: nil)
+                session.waitingPrompt = nil
+                session.runState = terminalState
+                _ = session.endRunAttempt(ifCurrent: ownership, source: source)
+            },
+            retainProcessRunIdentity: { runID, terminalTurnID in
+                AgentModeProcessRunIdentity.retainProcessRunID(
+                    runID,
+                    inTranscriptTurnID: terminalTurnID,
+                    for: session
+                )
+            },
+            sourceItemsRevision: {
+                session.sourceItemsRevision
+            },
+            assistantDeltaFlushGeneration: {
+                session.assistantDeltaFlushGeneration
+            },
+            latestFailureText: {
+                AgentTranscriptIO.latestErrorText(
+                    from: session.transcript,
+                    latestTurnOnly: true
+                ) ?? AgentTranscriptIO.latestErrorText(
+                    from: session.transcript,
+                    latestTurnOnly: false
+                )
+            }
+        )
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
@@ -17,7 +17,7 @@ import RepoPromptDomainRuntime
 // - `AgentModeViewModel.TabSession` remains at broader app-host orchestration
 //   hooks because the app is the only adopter today. Terminal settlement does
 //   not receive that type: `bindTerminalSession(_:)` partially applies the
-//   exact originating object into a session-neutral capability value.
+//   exact originating object into a `TabSession`-neutral capability value.
 
 extension AgentModeRunService {
     /// Token/usage accounting projection for non-Codex turns.

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -43,6 +43,9 @@ final class AgentRunTerminalCommitBarrier {
     }
 
     struct Request {
+        // This request is concrete-TabSession-free. The remaining app-owned
+        // AttachmentTurnDisposition and CancellationCompletion vocabulary is a
+        // deliberately deferred contract-hoisting boundary for a later slice.
         let binding: AgentRunTerminalSessionBinding
         let ownership: AgentRunOwnership
         let expectedRunID: UUID?

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -43,7 +43,7 @@ final class AgentRunTerminalCommitBarrier {
     }
 
     struct Request {
-        let session: AgentModeViewModel.TabSession
+        let binding: AgentRunTerminalSessionBinding
         let ownership: AgentRunOwnership
         let expectedRunID: UUID?
         let terminalState: AgentSessionRunState
@@ -63,7 +63,7 @@ final class AgentRunTerminalCommitBarrier {
         let postCommit: () -> Void
 
         init(
-            session: AgentModeViewModel.TabSession,
+            binding: AgentRunTerminalSessionBinding,
             ownership: AgentRunOwnership,
             expectedRunID: UUID?,
             terminalState: AgentSessionRunState,
@@ -82,7 +82,7 @@ final class AgentRunTerminalCommitBarrier {
             prepareProviderState: @escaping () -> (@MainActor () async -> Void)? = { nil },
             postCommit: @escaping () -> Void = {}
         ) {
-            self.session = session
+            self.binding = binding
             self.ownership = ownership
             self.expectedRunID = expectedRunID
             self.terminalState = terminalState
@@ -121,19 +121,17 @@ final class AgentRunTerminalCommitBarrier {
         #endif
     }
 
-    private let hooks: AgentModeRunService.Hooks
     private var terminalTeardownTasks: [AgentRunOwnership: Task<Void, Never>] = [:]
     private var consumedProviderSuccessorIDs: Set<UUID> = []
     private var consumedProviderSuccessorOrder: [UUID] = []
     private let maxConsumedProviderSuccessorTombstones = 512
 
-    init(hooks: AgentModeRunService.Hooks) {
-        self.hooks = hooks
-    }
+    init() {}
 
     @discardableResult
     func commit(_ request: Request) async -> AgentRunTerminalCommitRevision? {
-        let session = request.session
+        let binding = request.binding
+        let lifecycle = binding.lifecycle
         guard request.terminalState == .completed
             || request.terminalState == .cancelled
             || request.terminalState == .failed
@@ -141,34 +139,33 @@ final class AgentRunTerminalCommitBarrier {
             assertionFailure("Terminal commit requires a terminal run state")
             return nil
         }
-        guard !session.terminalCommitInProgress else {
+        guard !lifecycle.terminalCommitInProgress else {
             recordRejection("commit_in_progress", request: request)
             return nil
         }
-        if let existingRevision = session.lastTerminalCommitRevision,
+        if let existingRevision = lifecycle.lastTerminalCommitRevision,
            existingRevision.ownership == request.ownership
         {
             recordRejection("duplicate_commit", request: request)
-            if session.lastTerminalPublicationResult?.isResolved != true {
+            if lifecycle.lastTerminalPublicationResult?.isResolved != true {
                 // Duplicate retry: records a result while no terminal commit is
                 // in progress; the facade operation is intentionally unguarded.
-                let retriedResult = await hooks.terminalSettlement.publishTerminalCommit(
-                    session,
+                let retriedResult = await binding.hooks.publishTerminalCommit(
                     existingRevision,
                     existingRevision.successorKind
                 )
-                session.runLifecycle.recordTerminalPublicationResult(retriedResult)
+                lifecycle.recordTerminalPublicationResult(retriedResult)
             }
             if let followUpInstruction = takeQueuedFollowUpIfReady(
-                session: session,
+                binding: binding,
                 revision: existingRevision,
-                publicationResult: session.lastTerminalPublicationResult
+                publicationResult: lifecycle.lastTerminalPublicationResult
             ) {
-                hooks.continuation.startFollowUpRun(session.tabID, followUpInstruction)
+                binding.hooks.startFollowUpRun(followUpInstruction)
             }
             if let providerSuccessor = request.providerSuccessor,
                providerSuccessor.id == existingRevision.providerSuccessorID,
-               let publicationResult = session.lastTerminalPublicationResult
+               let publicationResult = lifecycle.lastTerminalPublicationResult
             {
                 notifyProviderSuccessor(
                     providerSuccessor,
@@ -182,7 +179,7 @@ final class AgentRunTerminalCommitBarrier {
             recordRejection("stale_ownership", request: request)
             return nil
         }
-        guard session.providerTerminalDrainGeneration == request.providerDrainGeneration else {
+        guard binding.providerDrainGeneration == request.providerDrainGeneration else {
             recordRejection("stale_provider_drain_generation", request: request)
             return nil
         }
@@ -191,27 +188,27 @@ final class AgentRunTerminalCommitBarrier {
             recordRejection("provider_buffers_pending", request: request)
             return nil
         }
-        let terminalTurnID = session.items.last(where: { $0.kind == .user })?.id
+        let terminalTurnID = binding.terminalTurnID
 
-        let acquiredTerminalCommitPhase = session.runLifecycle.beginTerminalCommit()
+        let acquiredTerminalCommitPhase = lifecycle.beginTerminalCommit()
         assert(acquiredTerminalCommitPhase, "Terminal commit phase acquisition must succeed after the in-progress guard")
         recordTerminalBarrierState(true, request: request)
-        hooks.transcript.flushPendingAssistantDelta(session)
+        binding.hooks.flushPendingAssistantDelta()
         guard validatesOwnership(request) else {
-            session.runLifecycle.abortTerminalCommit()
+            lifecycle.abortTerminalCommit()
             recordTerminalBarrierState(false, request: request)
             recordRejection("ownership_changed_during_drain", request: request)
             return nil
         }
 
-        hooks.transcript.finalizeStreamingItems(session)
-        hooks.transcript.finalizePendingToolCalls(session, request.terminalState)
+        binding.hooks.finalizeStreamingItems()
+        binding.hooks.finalizePendingToolCalls(request.terminalState)
         if request.finalizeNonCodexUsage {
-            hooks.usage.finalizeNonCodexTurnUsage(session, nil, nil, nil)
+            binding.hooks.finalizeNonCodexTurnUsage()
         }
 
         let queuedInstruction = request.terminalState == .completed && request.supportsFollowUp
-            ? session.pendingInstructions.first
+            ? binding.queuedFollowUp
             : nil
         let providerSuccessor = request.terminalState == .completed
             ? request.providerSuccessor
@@ -221,11 +218,9 @@ final class AgentRunTerminalCommitBarrier {
             "Generic and provider-specific successors must not drain from the same terminal commit"
         )
         if queuedInstruction != nil || providerSuccessor != nil {
-            session.mcpFollowUpRunPending = true
+            binding.setFollowUpPending(true)
         }
 
-        hooks.interactions.cancelPendingQuestion(session)
-        hooks.interactions.cancelPendingApproval(session)
         let reviewCancellationReason = switch request.terminalState {
         case .completed:
             "Run completed before review decision"
@@ -236,10 +231,8 @@ final class AgentRunTerminalCommitBarrier {
         default:
             "Run finished"
         }
-        hooks.interactions.cancelPendingApplyEditsReview(session, reviewCancellationReason)
-        hooks.interactions.cancelPendingWorktreeMergeReview(session, reviewCancellationReason)
-        hooks.attachments.finalizeAttachmentsForTurn(
-            session,
+        binding.hooks.cancelPendingInteractions(reviewCancellationReason)
+        binding.hooks.finalizeAttachments(
             request.attachmentReservationID,
             request.attachmentDisposition
         )
@@ -247,20 +240,20 @@ final class AgentRunTerminalCommitBarrier {
         if let errorText = request.errorText?.trimmingCharacters(in: .whitespacesAndNewlines),
            !errorText.isEmpty
         {
-            session.appendItem(AgentChatItem.error(errorText, sequenceIndex: session.nextSequenceIndex))
+            binding.appendError(errorText)
         }
 
         guard validatesOwnership(request),
-              session.providerTerminalDrainGeneration == request.providerDrainGeneration,
+              binding.providerDrainGeneration == request.providerDrainGeneration,
               request.providerBuffersAreDrained()
         else {
-            session.runLifecycle.abortTerminalCommit()
+            lifecycle.abortTerminalCommit()
             recordTerminalBarrierState(false, request: request)
             recordRejection("ownership_or_drain_changed_before_commit", request: request)
             return nil
         }
 
-        let attemptTeardown = session.claimRunAttemptTerminalTeardown(
+        let attemptTeardown = lifecycle.claimTerminalTeardown(
             ownership: request.ownership,
             terminalState: request.terminalState
         )
@@ -273,20 +266,15 @@ final class AgentRunTerminalCommitBarrier {
         } else {
             nil
         }
-        session.agentTask = nil
-        session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
-        session.setRunningStatus(nil, source: nil)
-        session.waitingPrompt = nil
-        session.runState = request.terminalState
-        _ = session.endRunAttempt(ifCurrent: request.ownership, source: request.source)
-        hooks.presentation.setAgentRunActive(session.tabID, false)
-        hooks.terminalSettlement.prepareTerminalPublication(session)
+        binding.finishActiveState(
+            ownership: request.ownership,
+            terminalState: request.terminalState,
+            source: request.source
+        )
+        binding.hooks.setAgentRunInactive()
+        binding.hooks.prepareTerminalPublication()
         if let runID = request.expectedRunID, let terminalTurnID {
-            AgentModeProcessRunIdentity.retainProcessRunID(
-                runID,
-                inTranscriptTurnID: terminalTurnID,
-                for: session
-            )
+            binding.retainProcessRunIdentity(runID, terminalTurnID: terminalTurnID)
         }
 
         let successorKind: AgentRunEpochTransitionKind? = if queuedInstruction != nil {
@@ -296,18 +284,17 @@ final class AgentRunTerminalCommitBarrier {
         }
         // Resolved exactly once at settlement; the publication envelope is built
         // before the revision is stored, so the reason is threaded explicitly.
-        let failureReason = resolveTerminalFailureReason(request: request, session: session)
+        let failureReason = resolveTerminalFailureReason(request: request, binding: binding)
         let revision = AgentRunTerminalCommitRevision(
             commitID: UUID(),
             ownership: request.ownership,
             terminalState: request.terminalState,
             failureReason: failureReason,
             expectedRunID: request.expectedRunID,
-            sourceItemsRevision: session.sourceItemsRevision,
-            assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
+            sourceItemsRevision: binding.sourceItemsRevision,
+            assistantDeltaFlushGeneration: binding.assistantDeltaFlushGeneration,
             providerDrainGeneration: request.providerDrainGeneration,
-            mcpPublicationEnvelope: hooks.terminalSettlement.makeTerminalPublicationEnvelope(
-                session,
+            mcpPublicationEnvelope: binding.hooks.makeTerminalPublicationEnvelope(
                 request.ownership,
                 request.terminalState,
                 request.expectedRunID,
@@ -316,26 +303,25 @@ final class AgentRunTerminalCommitBarrier {
             successorKind: successorKind,
             providerSuccessorID: providerSuccessor?.id
         )
-        session.runLifecycle.stageTerminalRevision(revision)
+        lifecycle.stageTerminalRevision(revision)
 
-        hooks.bindingObservation.updateBindings(session)
+        binding.hooks.updateBindings()
         if request.notifyTurnComplete {
-            hooks.presentation.notifyAgentTurnComplete(session)
+            binding.hooks.notifyAgentTurnComplete()
         }
-        hooks.persistence.scheduleSave(session.tabID)
-        let publicationResult = await hooks.terminalSettlement.publishTerminalCommit(
-            session,
+        binding.hooks.scheduleSave()
+        let publicationResult = await binding.hooks.publishTerminalCommit(
             revision,
             successorKind
         )
-        session.runLifecycle.recordTerminalPublicationResult(publicationResult)
+        lifecycle.recordTerminalPublicationResult(publicationResult)
         let followUpInstruction = takeQueuedFollowUpIfReady(
-            session: session,
+            binding: binding,
             revision: revision,
-            publicationResult: session.lastTerminalPublicationResult
+            publicationResult: lifecycle.lastTerminalPublicationResult
         )
         if let providerSuccessor,
-           let publicationResult = session.lastTerminalPublicationResult
+           let publicationResult = lifecycle.lastTerminalPublicationResult
         {
             notifyProviderSuccessor(
                 providerSuccessor,
@@ -346,24 +332,24 @@ final class AgentRunTerminalCommitBarrier {
         let teardownTask = registerTerminalTeardown(
             teardown,
             ownership: request.ownership,
-            tabID: session.tabID
+            tabID: binding.tabID
         )
-        session.runLifecycle.completeTerminalCommit()
+        lifecycle.completeTerminalCommit()
         recordTerminalBarrierState(false, request: request)
         request.postCommit()
 
         if let followUpInstruction {
-            hooks.continuation.startFollowUpRun(session.tabID, followUpInstruction)
+            binding.hooks.startFollowUpRun(followUpInstruction)
         }
         if request.completion == .terminalTeardownCompleted {
             await teardownTask?.value
         }
 
         #if DEBUG
-            AgentModePerfDiagnostics.increment("run.terminal.commit.accepted", tabID: session.tabID)
+            AgentModePerfDiagnostics.increment("run.terminal.commit.accepted", tabID: binding.tabID)
             AgentModePerfDiagnostics.increment(
                 "run.terminal.commit.accepted.\(request.terminalState.rawValue)",
-                tabID: session.tabID
+                tabID: binding.tabID
             )
         #endif
         return revision
@@ -375,7 +361,7 @@ final class AgentRunTerminalCommitBarrier {
     /// settled error text the publication snapshot projects today.
     private func resolveTerminalFailureReason(
         request: Request,
-        session: AgentModeViewModel.TabSession
+        binding: AgentRunTerminalSessionBinding
     ) -> DomainAgentRunSnapshot.FailureReason? {
         switch request.terminalState {
         case .cancelled:
@@ -384,8 +370,7 @@ final class AgentRunTerminalCommitBarrier {
             if let failureReason = request.failureReason {
                 return failureReason
             }
-            let settledFailureText = AgentTranscriptIO.latestErrorText(from: session.transcript, latestTurnOnly: true)
-                ?? AgentTranscriptIO.latestErrorText(from: session.transcript, latestTurnOnly: false)
+            let settledFailureText = binding.latestFailureText
             return DomainAgentRunSnapshot.FailureReason.classify(status: .failed, statusText: settledFailureText)
         default:
             return nil
@@ -416,7 +401,7 @@ final class AgentRunTerminalCommitBarrier {
     }
 
     private func takeQueuedFollowUpIfReady(
-        session: AgentModeViewModel.TabSession,
+        binding: AgentRunTerminalSessionBinding,
         revision: AgentRunTerminalCommitRevision,
         publicationResult: AgentRunTerminalPublicationResult?
     ) -> String? {
@@ -432,25 +417,23 @@ final class AgentRunTerminalCommitBarrier {
         case .rejected:
             return nil
         case .stale:
-            if !session.pendingInstructions.isEmpty {
-                session.pendingInstructions.removeFirst()
-            }
-            session.mcpFollowUpRunPending = false
+            _ = binding.removeFirstQueuedFollowUp()
+            binding.setFollowUpPending(false)
             return nil
         }
-        guard !session.pendingInstructions.isEmpty else {
-            session.mcpFollowUpRunPending = false
+        guard binding.queuedFollowUp != nil else {
+            binding.setFollowUpPending(false)
             return nil
         }
-        return session.pendingInstructions.removeFirst()
+        return binding.removeFirstQueuedFollowUp()
     }
 
     func awaitTerminalPublication(
         for ownership: AgentRunOwnership,
-        session: AgentModeViewModel.TabSession
+        lifecycle: AgentRunAttemptLifecycle
     ) async {
-        while session.terminalCommitInProgress {
-            if let revision = session.lastTerminalCommitRevision,
+        while lifecycle.terminalCommitInProgress {
+            if let revision = lifecycle.lastTerminalCommitRevision,
                revision.ownership != ownership
             {
                 return
@@ -461,10 +444,10 @@ final class AgentRunTerminalCommitBarrier {
 
     func awaitTerminalTeardown(
         for ownership: AgentRunOwnership,
-        session: AgentModeViewModel.TabSession
+        lifecycle: AgentRunAttemptLifecycle
     ) async {
-        await awaitTerminalPublication(for: ownership, session: session)
-        guard session.lastTerminalCommitRevision?.ownership == ownership else { return }
+        await awaitTerminalPublication(for: ownership, lifecycle: lifecycle)
+        guard lifecycle.lastTerminalCommitRevision?.ownership == ownership else { return }
         await terminalTeardownTasks[ownership]?.value
     }
 
@@ -489,7 +472,7 @@ final class AgentRunTerminalCommitBarrier {
     }
 
     private func validatesOwnership(_ request: Request) -> Bool {
-        request.session.isCurrentRunAttemptForCurrentBinding(
+        request.binding.validatesOwnership(
             request.ownership,
             expectedRunID: request.expectedRunID
         )
@@ -497,10 +480,10 @@ final class AgentRunTerminalCommitBarrier {
 
     private func recordRejection(_ reason: String, request: Request) {
         #if DEBUG
-            AgentModePerfDiagnostics.increment("run.terminal.commit.rejected.\(reason)", tabID: request.session.tabID)
+            AgentModePerfDiagnostics.increment("run.terminal.commit.rejected.\(reason)", tabID: request.binding.tabID)
             AgentModePerfDiagnostics.event(
                 "run.terminal.commitRejected",
-                tabID: request.session.tabID,
+                tabID: request.binding.tabID,
                 fields: [
                     "reason": reason,
                     "source": request.source,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift
@@ -1,0 +1,140 @@
+import Foundation
+import RepoPromptDomainRuntime
+
+/// Exact-object-bound capabilities used by the terminal settlement spine.
+///
+/// This value carries no app session type and performs no lookup by `tabID`.
+/// The app host partially applies its concrete session at the run/settlement
+/// edge, while the terminal barrier operates only on this capability surface
+/// and `AgentRunAttemptLifecycle`.
+@MainActor
+struct AgentRunTerminalSessionBinding {
+    struct Hooks {
+        let flushPendingAssistantDelta: @MainActor () -> Void
+        let finalizeStreamingItems: @MainActor () -> Void
+        let finalizePendingToolCalls: @MainActor (AgentSessionRunState) -> Void
+        let finalizeNonCodexTurnUsage: @MainActor () -> Void
+        let cancelPendingInteractions: @MainActor (_ reviewReason: String) -> Void
+        let finalizeAttachments: @MainActor (UUID?, AgentModeViewModel.AttachmentTurnDisposition) -> Void
+        let setAgentRunInactive: @MainActor () -> Void
+        let prepareTerminalPublication: @MainActor () -> Void
+        let makeTerminalPublicationEnvelope: @MainActor (
+            AgentRunOwnership,
+            AgentSessionRunState,
+            UUID?,
+            DomainAgentRunSnapshot.FailureReason?
+        ) -> AgentRunTerminalPublicationEnvelope?
+        let updateBindings: @MainActor () -> Void
+        let notifyAgentTurnComplete: @MainActor () -> Void
+        let scheduleSave: @MainActor () -> Void
+        let publishTerminalCommit: @MainActor (
+            AgentRunTerminalCommitRevision,
+            AgentRunEpochTransitionKind?
+        ) async -> AgentRunTerminalPublicationResult
+        let startFollowUpRun: @MainActor (String) -> Void
+    }
+
+    let tabID: UUID
+    let lifecycle: AgentRunAttemptLifecycle
+    let hooks: Hooks
+
+    private let ownershipValidator: @MainActor (AgentRunOwnership, UUID?) -> Bool
+    private let providerDrainGenerationProvider: @MainActor () -> UInt64
+    private let terminalTurnIDProvider: @MainActor () -> UUID?
+    private let queuedFollowUpProvider: @MainActor () -> String?
+    private let followUpPendingSetter: @MainActor (Bool) -> Void
+    private let firstQueuedFollowUpRemover: @MainActor () -> String?
+    private let errorAppender: @MainActor (String) -> Void
+    private let activeStateFinisher: @MainActor (AgentRunOwnership, AgentSessionRunState, String) -> Void
+    private let processRunIdentityRetainer: @MainActor (UUID, UUID) -> Void
+    private let sourceItemsRevisionProvider: @MainActor () -> Int
+    private let assistantDeltaFlushGenerationProvider: @MainActor () -> UInt64
+    private let latestFailureTextProvider: @MainActor () -> String?
+
+    init(
+        tabID: UUID,
+        lifecycle: AgentRunAttemptLifecycle,
+        hooks: Hooks,
+        validatesOwnership: @escaping @MainActor (AgentRunOwnership, UUID?) -> Bool,
+        providerDrainGeneration: @escaping @MainActor () -> UInt64,
+        terminalTurnID: @escaping @MainActor () -> UUID?,
+        queuedFollowUp: @escaping @MainActor () -> String?,
+        setFollowUpPending: @escaping @MainActor (Bool) -> Void,
+        removeFirstQueuedFollowUp: @escaping @MainActor () -> String?,
+        appendError: @escaping @MainActor (String) -> Void,
+        finishActiveState: @escaping @MainActor (AgentRunOwnership, AgentSessionRunState, String) -> Void,
+        retainProcessRunIdentity: @escaping @MainActor (UUID, UUID) -> Void,
+        sourceItemsRevision: @escaping @MainActor () -> Int,
+        assistantDeltaFlushGeneration: @escaping @MainActor () -> UInt64,
+        latestFailureText: @escaping @MainActor () -> String?
+    ) {
+        self.tabID = tabID
+        self.lifecycle = lifecycle
+        self.hooks = hooks
+        ownershipValidator = validatesOwnership
+        providerDrainGenerationProvider = providerDrainGeneration
+        terminalTurnIDProvider = terminalTurnID
+        queuedFollowUpProvider = queuedFollowUp
+        followUpPendingSetter = setFollowUpPending
+        firstQueuedFollowUpRemover = removeFirstQueuedFollowUp
+        errorAppender = appendError
+        activeStateFinisher = finishActiveState
+        processRunIdentityRetainer = retainProcessRunIdentity
+        sourceItemsRevisionProvider = sourceItemsRevision
+        assistantDeltaFlushGenerationProvider = assistantDeltaFlushGeneration
+        latestFailureTextProvider = latestFailureText
+    }
+
+    func validatesOwnership(_ ownership: AgentRunOwnership, expectedRunID: UUID?) -> Bool {
+        ownershipValidator(ownership, expectedRunID)
+    }
+
+    var providerDrainGeneration: UInt64 {
+        providerDrainGenerationProvider()
+    }
+
+    var terminalTurnID: UUID? {
+        terminalTurnIDProvider()
+    }
+
+    var queuedFollowUp: String? {
+        queuedFollowUpProvider()
+    }
+
+    func setFollowUpPending(_ pending: Bool) {
+        followUpPendingSetter(pending)
+    }
+
+    @discardableResult
+    func removeFirstQueuedFollowUp() -> String? {
+        firstQueuedFollowUpRemover()
+    }
+
+    func appendError(_ text: String) {
+        errorAppender(text)
+    }
+
+    func finishActiveState(
+        ownership: AgentRunOwnership,
+        terminalState: AgentSessionRunState,
+        source: String
+    ) {
+        activeStateFinisher(ownership, terminalState, source)
+    }
+
+    func retainProcessRunIdentity(_ runID: UUID, terminalTurnID: UUID) {
+        processRunIdentityRetainer(runID, terminalTurnID)
+    }
+
+    var sourceItemsRevision: Int {
+        sourceItemsRevisionProvider()
+    }
+
+    var assistantDeltaFlushGeneration: UInt64 {
+        assistantDeltaFlushGenerationProvider()
+    }
+
+    var latestFailureText: String? {
+        latestFailureTextProvider()
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift
@@ -3,10 +3,14 @@ import RepoPromptDomainRuntime
 
 /// Exact-object-bound capabilities used by the terminal settlement spine.
 ///
-/// This value carries no app session type and performs no lookup by `tabID`.
-/// The app host partially applies its concrete session at the run/settlement
-/// edge, while the terminal barrier operates only on this capability surface
-/// and `AgentRunAttemptLifecycle`.
+/// This value carries no concrete `TabSession` and performs no lookup by
+/// `tabID`. The app host partially applies its exact session at the
+/// run/settlement edge, while the terminal barrier operates only on this
+/// capability surface and `AgentRunAttemptLifecycle`.
+///
+/// This slice is intentionally `TabSession`-neutral, not yet independent of all
+/// app-owned nested vocabulary: `AttachmentTurnDisposition` remains a narrow
+/// follow-up boundary rather than being hoisted in this PR.
 @MainActor
 struct AgentRunTerminalSessionBinding {
     struct Hooks {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -249,6 +249,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
 
     private weak var viewModel: AgentModeViewModel?
     private var terminalCommitBarrier: AgentRunTerminalCommitBarrier?
+    private var terminalSessionBinder: (@MainActor (AgentModeViewModel.TabSession) -> AgentRunTerminalSessionBinding)?
     #if DEBUG
         private var testWorkspaceResolutionFailurePublicationGate: (@Sendable () async -> Void)?
     #endif
@@ -421,8 +422,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         self.viewModel = viewModel
     }
 
-    func installTerminalCommitBarrier(_ barrier: AgentRunTerminalCommitBarrier) {
+    func installTerminalCommitBarrier(
+        _ barrier: AgentRunTerminalCommitBarrier,
+        terminalSessionBinder: @escaping @MainActor (AgentModeViewModel.TabSession) -> AgentRunTerminalSessionBinding
+    ) {
         terminalCommitBarrier = barrier
+        self.terminalSessionBinder = terminalSessionBinder
     }
 
     func setActiveAgentRunWaitDrain(_ drain: @escaping ActiveAgentRunWaitDrain) {
@@ -6557,7 +6562,8 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         providerSuccessor: AgentRunTerminalCommitBarrier.ProviderSuccessor? = nil
     ) async {
         guard let ownership = session.activeRunOwnership,
-              let terminalCommitBarrier
+              let terminalCommitBarrier,
+              let terminalSessionBinder
         else {
             return
         }
@@ -6601,7 +6607,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             .deleteFiles
         }
         let request = AgentRunTerminalCommitBarrier.Request(
-            session: session,
+            binding: terminalSessionBinder(session),
             ownership: ownership,
             expectedRunID: expectedRunID,
             terminalState: terminalState,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -107,7 +107,7 @@ final class ACPIntegratedAgentModeRunner {
         let runAttemptID = ownership.attemptID
         session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .preparingRuntime)
         session.runState = .running
-        hooks.presentation.setAgentRunActive(tabID, true)
+        hooks.presentation.setAgentRunActive(session, true)
         setRunningStatus(initialTransportStatusText(for: runRequest.agentKind), source: .transport, session: session, urgent: true)
 
         let freshRunRequest = runRequest
@@ -399,7 +399,7 @@ final class ACPIntegratedAgentModeRunner {
         else { return }
         hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: runID,
             terminalState: .failed,
@@ -430,7 +430,7 @@ final class ACPIntegratedAgentModeRunner {
         else { return }
         hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: runID,
             terminalState: .cancelled,
@@ -506,7 +506,7 @@ final class ACPIntegratedAgentModeRunner {
             )
             _ = syncACPSelectedModelFromRegistryIfNeeded(agentKind: runRequest.agentKind, session: session)
             session.isDirty = true
-            hooks.persistence.scheduleSave(session.tabID)
+            hooks.persistence.scheduleSave(session)
             hooks.bindingObservation.updateBindings(session)
 
             try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
@@ -804,7 +804,7 @@ final class ACPIntegratedAgentModeRunner {
         }
         guard changed else { return }
         session.isDirty = true
-        hooks.persistence.scheduleSave(session.tabID)
+        hooks.persistence.scheduleSave(session)
         hooks.bindingObservation.updateBindings(session)
     }
 
@@ -924,7 +924,7 @@ final class ACPIntegratedAgentModeRunner {
         else { return }
         hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: runID,
             terminalState: .cancelled,
@@ -965,7 +965,7 @@ final class ACPIntegratedAgentModeRunner {
         }
         let supportsSessionResume = terminalState == .completed && controller != nil
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: runID,
             terminalState: terminalState,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
@@ -87,7 +87,7 @@ final class ClaudeIntegratedAgentModeRunner {
         session.pendingSupersedingTurnCompletions = 0
         session.claudeSupersedingProtectedTurnIDs.removeAll()
         session.claudeExpectedTurnIDs.removeAll()
-        hooks.presentation.setAgentRunActive(tabID, true)
+        hooks.presentation.setAgentRunActive(session, true)
         hooks.bindingObservation.updateBindings(session)
 
         session.agentTask = Task { [weak self, weak session] in
@@ -218,7 +218,7 @@ final class ClaudeIntegratedAgentModeRunner {
                         codexRolloutPath: session.codexRolloutPath
                     )
                     session.isDirty = true
-                    hooks.persistence.scheduleSave(session.tabID)
+                    hooks.persistence.scheduleSave(session)
                 }
                 if status.isRepoPromptServerFailed {
                     return ConsumeEventsOutcome(
@@ -265,7 +265,7 @@ final class ClaudeIntegratedAgentModeRunner {
                     if !session.runState.isActive {
                         session.runState = .running
                     }
-                    hooks.presentation.setAgentRunActive(session.tabID, true)
+                    hooks.presentation.setAgentRunActive(session, true)
                     hooks.bindingObservation.updateBindings(session)
                     continue eventLoop
                 }
@@ -293,7 +293,7 @@ final class ClaudeIntegratedAgentModeRunner {
                     let errorItem = AgentChatItem.error(trimmed, sequenceIndex: session.nextSequenceIndex)
                     session.appendItem(errorItem)
                     hooks.bindingObservation.updateBindings(session)
-                    hooks.persistence.scheduleSave(session.tabID)
+                    hooks.persistence.scheduleSave(session)
                 }
             }
         }
@@ -323,7 +323,7 @@ final class ClaudeIntegratedAgentModeRunner {
     ) async {
         hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: runID,
             terminalState: .cancelled,
@@ -347,7 +347,7 @@ final class ClaudeIntegratedAgentModeRunner {
         shouldShutdownSession: Bool = false
     ) async {
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: runID,
             terminalState: terminalState,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
@@ -46,12 +46,12 @@ final class HeadlessAgentModeRunner {
         session.runningStatusText = nil
         session.runningStatusSource = nil
         session.runState = .running
-        hooks.presentation.setAgentRunActive(tabID, true)
+        hooks.presentation.setAgentRunActive(session, true)
         hooks.bindingObservation.updateBindings(session)
 
         guard session.selectedAgent != .codexExec else {
             await terminalCommitBarrier.commit(.init(
-                session: session,
+                binding: hooks.bindTerminalSession(session),
                 ownership: ownership,
                 expectedRunID: runID,
                 terminalState: .failed,
@@ -137,7 +137,7 @@ final class HeadlessAgentModeRunner {
     ) async {
         hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
         await terminalCommitBarrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: runID,
             terminalState: .cancelled,
@@ -194,7 +194,7 @@ final class HeadlessAgentModeRunner {
             }
 
             await terminalCommitBarrier.commit(.init(
-                session: session,
+                binding: hooks.bindTerminalSession(session),
                 ownership: ownership,
                 expectedRunID: runID,
                 terminalState: .completed,
@@ -216,7 +216,7 @@ final class HeadlessAgentModeRunner {
             }
             hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
             await terminalCommitBarrier.commit(.init(
-                session: session,
+                binding: hooks.bindTerminalSession(session),
                 ownership: ownership,
                 expectedRunID: runID,
                 terminalState: .cancelled,
@@ -238,7 +238,7 @@ final class HeadlessAgentModeRunner {
             }
             hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
             await terminalCommitBarrier.commit(.init(
-                session: session,
+                binding: hooks.bindTerminalSession(session),
                 ownership: ownership,
                 expectedRunID: runID,
                 terminalState: .failed,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1221,6 +1221,24 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         syncComposerUIState()
     }
 
+    /// Applies run-activity projection only to the exact supplied session.
+    /// A recycled tab identifier must not let a predecessor update its successor.
+    func setAgentRunActive(_ session: TabSession, isActive: Bool) {
+        let tabID = session.tabID
+        guard sessions[tabID] === session else {
+            if isActive {
+                if session.activeAgentRunStartedAt == nil {
+                    session.activeAgentRunStartedAt = Date()
+                }
+            } else {
+                session.activeAgentRunStartedAt = nil
+                session.deferredActiveAgentRunTimerRollback = nil
+            }
+            return
+        }
+        setAgentRunActive(tabID, isActive: isActive)
+    }
+
     private func publishActiveAgentRunStartedAt(for tabID: UUID, session: TabSession?) {
         let nextStartedAt = session?.activeAgentRunStartedAt
         if tabID == currentTabID, activeAgentRunStartedAt != nextStartedAt {
@@ -2216,8 +2234,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 }
             ),
             presentation: .init(
-                setAgentRunActive: { [weak self] tabID, isActive in
-                    self?.setAgentRunActive(tabID, isActive: isActive)
+                setAgentRunActive: { [weak self] session, isActive in
+                    self?.setAgentRunActive(session, isActive: isActive)
                 },
                 requestUIRefresh: { [weak self] tabID, urgent in
                     self?.requestUIRefresh(tabID: tabID, urgent: urgent)
@@ -2239,8 +2257,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 }
             ),
             persistence: .init(
-                scheduleSave: { [weak self] tabID in
-                    self?.scheduleSave(for: tabID)
+                scheduleSave: { [weak self] session in
+                    self?.scheduleSave(for: session)
                 }
             ),
             transcript: .init(
@@ -2350,9 +2368,15 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 }
             ),
             continuation: .init(
-                startFollowUpRun: { [weak self] tabID, initialMessage in
-                    Task { [weak self] in
-                        await self?.startAgentRun(tabID: tabID, initialMessage: initialMessage)
+                startFollowUpRun: { [weak self] session, initialMessage in
+                    Task { @MainActor [weak self, weak session] in
+                        guard let self, let session else { return }
+                        guard sessions[session.tabID] === session else {
+                            session.mcpFollowUpRunPending = false
+                            handleObservedMCPStateChange(for: session)
+                            return
+                        }
+                        await startAgentRun(tabID: session.tabID, initialMessage: initialMessage)
                     }
                 },
                 signalMCPInstructionDelivered: { [weak self] session in
@@ -11923,6 +11947,13 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             guard !Task.isCancelled else { return }
             await self?.saveSession(for: tabID)
         }
+    }
+
+    /// Schedules persistence only while the supplied object is still the live
+    /// owner of its tab identifier. Stale predecessors must not save successors.
+    func scheduleSave(for session: TabSession) {
+        guard sessions[session.tabID] === session else { return }
+        scheduleSave(for: session.tabID)
     }
 
     func scheduleSaveForCommandOutput(tabID: UUID, minInterval: TimeInterval = 5.0) {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -739,6 +739,13 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             _ = runService
         }
 
+        func test_startFollowUpRun(
+            for session: TabSession,
+            initialMessage: String
+        ) async {
+            await startFollowUpRun(for: session, initialMessage: initialMessage)
+        }
+
         var test_isCursorModelPollingActive: Bool {
             cursorModelsSubscriptionTask != nil
         }
@@ -1198,9 +1205,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         let session = session(for: tabID, createIfNeeded: false)
         if isActive {
             tabsWithActiveAgentRun.insert(tabID)
-            if session?.activeAgentRunStartedAt == nil {
-                session?.activeAgentRunStartedAt = Date()
-            }
+            applyAgentRunActivity(to: session, isActive: true)
             // A new/resumed run clears any stale "completed in background"
             // badge the user hasn't acknowledged yet. The run-state transition
             // observer also handles this on .running, but some provider paths
@@ -1209,8 +1214,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             acknowledgeSidebarRunAttention(tabID: tabID)
         } else {
             tabsWithActiveAgentRun.remove(tabID)
-            session?.activeAgentRunStartedAt = nil
-            session?.deferredActiveAgentRunTimerRollback = nil
+            applyAgentRunActivity(to: session, isActive: false)
             // Intentionally do NOT clear/mark attention here. Provider paths
             // sometimes call setAgentRunActive(false) before session.runState
             // has been mutated to its terminal/waiting value — detection must
@@ -1226,17 +1230,21 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     func setAgentRunActive(_ session: TabSession, isActive: Bool) {
         let tabID = session.tabID
         guard sessions[tabID] === session else {
-            if isActive {
-                if session.activeAgentRunStartedAt == nil {
-                    session.activeAgentRunStartedAt = Date()
-                }
-            } else {
-                session.activeAgentRunStartedAt = nil
-                session.deferredActiveAgentRunTimerRollback = nil
-            }
+            applyAgentRunActivity(to: session, isActive: isActive)
             return
         }
         setAgentRunActive(tabID, isActive: isActive)
+    }
+
+    private func applyAgentRunActivity(to session: TabSession?, isActive: Bool) {
+        if isActive {
+            if session?.activeAgentRunStartedAt == nil {
+                session?.activeAgentRunStartedAt = Date()
+            }
+        } else {
+            session?.activeAgentRunStartedAt = nil
+            session?.deferredActiveAgentRunTimerRollback = nil
+        }
     }
 
     private func publishActiveAgentRunStartedAt(for tabID: UUID, session: TabSession?) {
@@ -2371,12 +2379,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 startFollowUpRun: { [weak self] session, initialMessage in
                     Task { @MainActor [weak self, weak session] in
                         guard let self, let session else { return }
-                        guard sessions[session.tabID] === session else {
-                            session.mcpFollowUpRunPending = false
-                            handleObservedMCPStateChange(for: session)
-                            return
-                        }
-                        await startAgentRun(tabID: session.tabID, initialMessage: initialMessage)
+                        await startFollowUpRun(for: session, initialMessage: initialMessage)
                     }
                 },
                 signalMCPInstructionDelivered: { [weak self] session in
@@ -2392,6 +2395,26 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             hooks: hooks,
             toolTrackingHooks: toolTrackingHooks
         )
+    }
+
+    private func startFollowUpRun(
+        for session: TabSession,
+        initialMessage: String
+    ) async {
+        guard sessions[session.tabID] === session else {
+            session.mcpFollowUpRunPending = false
+            #if DEBUG
+                AgentModePerfDiagnostics.increment("run.followUp.dropped.staleSession", tabID: session.tabID)
+                AgentModePerfDiagnostics.event(
+                    "run.followUp.dropped",
+                    tabID: session.tabID,
+                    fields: ["reason": "staleSession"]
+                )
+            #endif
+            handleObservedMCPStateChange(for: session)
+            return
+        }
+        await startAgentRun(tabID: session.tabID, initialMessage: initialMessage)
     }
 
     /// Build the generic orchestration hooks that provider tool tracking handlers need.

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -22,7 +22,8 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
 
     func testTerminalCommitPreservesRebuiltToolCorrelationIndexes() async throws {
         let recorder = LifecycleRecorder()
-        let barrier = AgentRunTerminalCommitBarrier(hooks: makeHooks(recorder: recorder))
+        let hooks = makeHooks(recorder: recorder)
+        let barrier = AgentRunTerminalCommitBarrier()
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         let invocationID = UUID()
         session.setItemsSilently([
@@ -46,7 +47,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         completed.text = completed.toolResultJSON ?? ""
         session.replaceItem(at: 3, with: completed)
         let revision = await barrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: session.runID,
             terminalState: .completed,
@@ -701,7 +702,8 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
 
     func testTerminalBarrierRejectsStaleOwnership() async {
         let recorder = LifecycleRecorder()
-        let barrier = AgentRunTerminalCommitBarrier(hooks: makeHooks(recorder: recorder))
+        let hooks = makeHooks(recorder: recorder)
+        let barrier = AgentRunTerminalCommitBarrier()
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.installRunID(UUID())
         session.runState = .running
@@ -710,7 +712,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let currentOwnership = session.beginRunAttempt(source: "test.current")
 
         let staleRevision = await barrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: staleOwnership,
             expectedRunID: session.runID,
             terminalState: .completed,
@@ -728,7 +730,8 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
 
     func testNewAttemptResetsProviderDrainGenerationAcrossProviderFamilies() async {
         let recorder = LifecycleRecorder()
-        let barrier = AgentRunTerminalCommitBarrier(hooks: makeHooks(recorder: recorder))
+        let hooks = makeHooks(recorder: recorder)
+        let barrier = AgentRunTerminalCommitBarrier()
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.installRunID(UUID())
         session.runState = .running
@@ -742,7 +745,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let claudeOwnership = session.beginRunAttempt(source: "test.claude")
         XCTAssertEqual(session.providerTerminalDrainGeneration, 0)
         let revision = await barrier.commit(.init(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: claudeOwnership,
             expectedRunID: session.runID,
             terminalState: .completed,
@@ -897,13 +900,13 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                     : .accepted(successorEpoch: nil)
             }
         )
-        let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
+        let barrier = AgentRunTerminalCommitBarrier()
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.installRunID(UUID())
         session.runState = .running
         let ownership = session.beginRunAttempt(source: "test.retryPublication")
         let request = AgentRunTerminalCommitBarrier.Request(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: session.runID,
             terminalState: .completed,
@@ -945,7 +948,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 return nil
             }
         )
-        let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
+        let barrier = AgentRunTerminalCommitBarrier()
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.installRunID(UUID())
         session.runState = .running
@@ -958,7 +961,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             compact: false
         )
         let request = AgentRunTerminalCommitBarrier.Request(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: session.runID,
             terminalState: .failed,
@@ -1027,14 +1030,14 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             },
             startFollowUpRun: { _, text in recorder.record("follow-up:\(text)") }
         )
-        let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
+        let barrier = AgentRunTerminalCommitBarrier()
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.installRunID(UUID())
         session.runState = .running
         session.pendingInstructions = ["continue"]
         let ownership = session.beginRunAttempt(source: "test.followUpPublication")
         let request = AgentRunTerminalCommitBarrier.Request(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: session.runID,
             terminalState: .completed,
@@ -1069,7 +1072,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                     : .accepted(successorEpoch: nil)
             }
         )
-        let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
+        let barrier = AgentRunTerminalCommitBarrier()
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.installRunID(UUID())
         session.runState = .running
@@ -1077,7 +1080,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let ownership = session.beginRunAttempt(source: "test.providerSuccessor")
         let successorID = UUID()
         let request = AgentRunTerminalCommitBarrier.Request(
-            session: session,
+            binding: hooks.bindTerminalSession(session),
             ownership: ownership,
             expectedRunID: session.runID,
             terminalState: .completed,
@@ -1108,6 +1111,163 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         XCTAssertEqual(consumedRevisions.count, 1)
         XCTAssertEqual(session.pendingInstructions, ["unrelated generic instruction"])
         XCTAssertEqual(session.lastTerminalCommitRevision?.providerSuccessorID, successorID)
+    }
+
+    func testTerminalBindingMutatesOnlyExactPredecessorWhenTabIDIsRecycled() async {
+        let recorder = LifecycleRecorder()
+        let recycledTabID = UUID()
+
+        let predecessor = AgentModeViewModel.TabSession(tabID: recycledTabID)
+        predecessor.installRunID(UUID())
+        predecessor.runState = .running
+        predecessor.activeAgentRunStartedAt = Date(timeIntervalSince1970: 1)
+        predecessor.pendingInstructions = ["continue predecessor"]
+        let predecessorOwnership = predecessor.beginRunAttempt(source: "test.predecessor")
+
+        let successor = AgentModeViewModel.TabSession(tabID: recycledTabID)
+        successor.installRunID(UUID())
+        successor.runState = .running
+        let successorStartedAt = Date(timeIntervalSince1970: 2)
+        successor.activeAgentRunStartedAt = successorStartedAt
+        successor.saveRequestGeneration = 41
+        let successorOwnership = successor.beginRunAttempt(source: "test.successor")
+
+        var inactiveSession: AgentModeViewModel.TabSession?
+        var savedSession: AgentModeViewModel.TabSession?
+        var followUpSession: AgentModeViewModel.TabSession?
+        var followUpText: String?
+        let hooks = makeHooks(
+            recorder: recorder,
+            setAgentRunActive: { session, isActive in
+                XCTAssertFalse(isActive)
+                inactiveSession = session
+                session.activeAgentRunStartedAt = nil
+            },
+            scheduleSave: { session in
+                savedSession = session
+                session.saveRequestGeneration &+= 1
+            },
+            startFollowUpRun: { session, text in
+                followUpSession = session
+                followUpText = text
+                session.mcpFollowUpRunPending = false
+            }
+        )
+        let barrier = AgentRunTerminalCommitBarrier()
+
+        let revision = await barrier.commit(.init(
+            binding: hooks.bindTerminalSession(predecessor),
+            ownership: predecessorOwnership,
+            expectedRunID: predecessor.runID,
+            terminalState: .completed,
+            source: "test.predecessor",
+            attachmentDisposition: .deleteFiles,
+            finalizeNonCodexUsage: false,
+            supportsFollowUp: true,
+            notifyTurnComplete: false
+        ))
+
+        XCTAssertNotNil(revision)
+        XCTAssertEqual(predecessor.runState, .completed)
+        XCTAssertNil(predecessor.activeRunOwnership)
+        XCTAssertEqual(predecessor.lastTerminalCommitRevision, revision)
+        XCTAssertTrue(inactiveSession === predecessor)
+        XCTAssertTrue(savedSession === predecessor)
+        XCTAssertTrue(followUpSession === predecessor)
+        XCTAssertEqual(followUpText, "continue predecessor")
+        XCTAssertNil(predecessor.activeAgentRunStartedAt)
+        XCTAssertEqual(predecessor.saveRequestGeneration, 1)
+        XCTAssertTrue(predecessor.pendingInstructions.isEmpty)
+        XCTAssertFalse(predecessor.mcpFollowUpRunPending)
+        XCTAssertEqual(successor.runState, .running)
+        XCTAssertEqual(successor.activeRunOwnership, successorOwnership)
+        XCTAssertNil(successor.lastTerminalCommitRevision)
+        XCTAssertEqual(successor.activeAgentRunStartedAt, successorStartedAt)
+        XCTAssertEqual(successor.saveRequestGeneration, 41)
+    }
+
+    func testSessionNeutralRequestPreservesDuplicateSettlementAndExplicitFailurePrecedence() async throws {
+        let barrier = AgentRunTerminalCommitBarrier()
+        let probe = NeutralTerminalBindingProbe()
+        let runID = UUID()
+        probe.lifecycle.installRunID(runID)
+        let ownership = probe.lifecycle.beginAttempt(
+            context: .init(tabID: probe.tabID, persistentSessionID: nil)
+        )
+        probe.latestFailureText = "Provider request timed out after 60 seconds"
+        let request = AgentRunTerminalCommitBarrier.Request(
+            binding: probe.makeBinding(),
+            ownership: ownership,
+            expectedRunID: runID,
+            terminalState: .failed,
+            source: "test.neutralRequest",
+            failureReason: .processCrash,
+            attachmentDisposition: .deleteFiles,
+            finalizeNonCodexUsage: false,
+            supportsFollowUp: false,
+            notifyTurnComplete: false
+        )
+
+        let firstResult = await barrier.commit(request)
+        let first = try XCTUnwrap(firstResult)
+        XCTAssertEqual(first.failureReason, .processCrash)
+        XCTAssertEqual(probe.runState, .failed)
+        XCTAssertEqual(probe.envelopeFailureReasons, [.processCrash])
+        XCTAssertEqual(probe.publishedFailureReasons, [.processCrash])
+        XCTAssertEqual(probe.lifecycle.lastTerminalPublicationResult, .rejected(reason: "test_transient_rejection"))
+
+        probe.latestFailureText = "A later generic agent error"
+        let duplicateResult = await barrier.commit(request)
+        let duplicate = try XCTUnwrap(duplicateResult)
+
+        XCTAssertEqual(duplicate, first)
+        XCTAssertEqual(duplicate.failureReason, .processCrash)
+        XCTAssertEqual(probe.flushCount, 1)
+        XCTAssertEqual(probe.publicationAttempts, 2)
+        XCTAssertEqual(probe.envelopeFailureReasons, [.processCrash])
+        XCTAssertEqual(probe.publishedFailureReasons, [.processCrash, .processCrash])
+        XCTAssertEqual(probe.lifecycle.lastTerminalPublicationResult, .accepted(successorEpoch: nil))
+    }
+
+    func testTerminalPublicationWaitDependsOnlyOnAttemptLifecycle() async {
+        let barrier = AgentRunTerminalCommitBarrier()
+        let lifecycle = AgentRunAttemptLifecycle()
+        let runID = UUID()
+        let tabID = UUID()
+        lifecycle.installRunID(runID)
+        let ownership = lifecycle.beginAttempt(
+            context: .init(tabID: tabID, persistentSessionID: nil)
+        )
+        XCTAssertTrue(lifecycle.beginTerminalCommit())
+
+        let waiterStarted = expectation(description: "lifecycle waiter started")
+        var waiterReturned = false
+        let waiter = Task { @MainActor in
+            waiterStarted.fulfill()
+            await barrier.awaitTerminalPublication(for: ownership, lifecycle: lifecycle)
+            waiterReturned = true
+        }
+        await fulfillment(of: [waiterStarted])
+        XCTAssertFalse(waiterReturned)
+
+        lifecycle.stageTerminalRevision(.init(
+            commitID: UUID(),
+            ownership: ownership,
+            terminalState: .completed,
+            failureReason: nil,
+            expectedRunID: runID,
+            sourceItemsRevision: 0,
+            assistantDeltaFlushGeneration: 0,
+            providerDrainGeneration: 0,
+            mcpPublicationEnvelope: nil,
+            successorKind: nil,
+            providerSuccessorID: nil
+        ))
+        lifecycle.completeTerminalCommit()
+        await waiter.value
+
+        XCTAssertTrue(waiterReturned)
+        await barrier.awaitTerminalTeardown(for: ownership, lifecycle: lifecycle)
     }
 
     func testConcurrentPublicationOnlyCancellationWaitsForCanonicalPublication() async throws {
@@ -1676,7 +1836,9 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             UUID?,
             AgentRunMCPSnapshot.FailureReason?
         ) -> AgentRunTerminalPublicationEnvelope?)? = nil,
-        startFollowUpRun: ((UUID, String) -> Void)? = nil
+        setAgentRunActive: ((AgentModeViewModel.TabSession, Bool) -> Void)? = nil,
+        scheduleSave: ((AgentModeViewModel.TabSession) -> Void)? = nil,
+        startFollowUpRun: ((AgentModeViewModel.TabSession, String) -> Void)? = nil
     ) -> AgentModeRunService.Hooks {
         let flushPendingAssistantDelta = flushPendingAssistantDelta ?? { _ in
             recorder.record("assistant-flush")
@@ -1699,7 +1861,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 finalizeAttachmentsForTurn: { _, _, disposition in recorder.record("attachments:\(disposition)") }
             ),
             presentation: .init(
-                setAgentRunActive: { _, isActive in recorder.record("run-active:\(isActive)") },
+                setAgentRunActive: setAgentRunActive ?? { _, isActive in recorder.record("run-active:\(isActive)") },
                 requestUIRefresh: { _, _ in },
                 notifyAgentTurnComplete: { _ in }
             ),
@@ -1710,7 +1872,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 restoreDraftText: { _, text, _, _ in recorder.record("draft:\(text)") }
             ),
             persistence: .init(
-                scheduleSave: { _ in recorder.record("save") }
+                scheduleSave: scheduleSave ?? { _ in recorder.record("save") }
             ),
             transcript: .init(
                 handleHeadlessStreamResult: { _, _, _, _ in },
@@ -2148,6 +2310,68 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             }
             cursor = index + 1
         }
+    }
+}
+
+@MainActor
+private final class NeutralTerminalBindingProbe {
+    let tabID = UUID()
+    let lifecycle = AgentRunAttemptLifecycle()
+
+    var runState: AgentSessionRunState = .running
+    var latestFailureText: String?
+    var flushCount = 0
+    var publicationAttempts = 0
+    var envelopeFailureReasons: [AgentRunMCPSnapshot.FailureReason?] = []
+    var publishedFailureReasons: [AgentRunMCPSnapshot.FailureReason?] = []
+
+    func makeBinding() -> AgentRunTerminalSessionBinding {
+        AgentRunTerminalSessionBinding(
+            tabID: tabID,
+            lifecycle: lifecycle,
+            hooks: .init(
+                flushPendingAssistantDelta: { self.flushCount += 1 },
+                finalizeStreamingItems: {},
+                finalizePendingToolCalls: { _ in },
+                finalizeNonCodexTurnUsage: {},
+                cancelPendingInteractions: { _ in },
+                finalizeAttachments: { _, _ in },
+                setAgentRunInactive: {},
+                prepareTerminalPublication: {},
+                makeTerminalPublicationEnvelope: { _, _, _, failureReason in
+                    self.envelopeFailureReasons.append(failureReason)
+                    return nil
+                },
+                updateBindings: {},
+                notifyAgentTurnComplete: {},
+                scheduleSave: {},
+                publishTerminalCommit: { revision, _ in
+                    self.publicationAttempts += 1
+                    self.publishedFailureReasons.append(revision.failureReason)
+                    return self.publicationAttempts == 1
+                        ? .rejected(reason: "test_transient_rejection")
+                        : .accepted(successorEpoch: nil)
+                },
+                startFollowUpRun: { _ in }
+            ),
+            validatesOwnership: { ownership, expectedRunID in
+                self.lifecycle.isCurrentAttempt(ownership, expectedRunID: expectedRunID)
+            },
+            providerDrainGeneration: { 0 },
+            terminalTurnID: { nil },
+            queuedFollowUp: { nil },
+            setFollowUpPending: { _ in },
+            removeFirstQueuedFollowUp: { nil },
+            appendError: { self.latestFailureText = $0 },
+            finishActiveState: { ownership, terminalState, _ in
+                self.runState = terminalState
+                _ = self.lifecycle.endAttempt(ifCurrent: ownership)
+            },
+            retainProcessRunIdentity: { _, _ in },
+            sourceItemsRevision: { 0 },
+            assistantDeltaFlushGeneration: { 0 },
+            latestFailureText: { self.latestFailureText }
+        )
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -2133,6 +2133,46 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTFail("Timed out waiting for condition")
     }
 
+    func testRecycledTabStaleSessionGuardsDoNotMutateOrDispatchSuccessor() async {
+        let viewModel = makeViewModel()
+        let tabID = UUID()
+
+        let predecessor = AgentModeViewModel.TabSession(tabID: tabID)
+        predecessor.activeAgentRunStartedAt = Date(timeIntervalSince1970: 1)
+        predecessor.mcpFollowUpRunPending = true
+        predecessor.saveRequestGeneration = 7
+        viewModel.test_installLiveSession(predecessor)
+
+        let successor = AgentModeViewModel.TabSession(tabID: tabID)
+        let successorStartedAt = Date(timeIntervalSince1970: 2)
+        successor.activeAgentRunStartedAt = successorStartedAt
+        successor.saveRequestGeneration = 41
+        viewModel.test_installLiveSession(successor)
+        viewModel.setAgentRunActive(successor, isActive: true)
+
+        viewModel.setAgentRunActive(predecessor, isActive: false)
+        viewModel.scheduleSave(for: predecessor)
+        await viewModel.test_startFollowUpRun(
+            for: predecessor,
+            initialMessage: "must not reach recycled successor"
+        )
+
+        XCTAssertNil(predecessor.activeAgentRunStartedAt)
+        XCTAssertEqual(predecessor.saveRequestGeneration, 7)
+        XCTAssertNil(predecessor.saveDebounceTask)
+        XCTAssertFalse(predecessor.mcpFollowUpRunPending)
+
+        XCTAssertEqual(successor.activeAgentRunStartedAt, successorStartedAt)
+        XCTAssertTrue(viewModel.isTabRunning(tabID))
+        XCTAssertEqual(successor.saveRequestGeneration, 41)
+        XCTAssertNil(successor.saveDebounceTask)
+        XCTAssertEqual(successor.runState, .idle)
+        XCTAssertNil(successor.runID)
+        XCTAssertNil(successor.activeRunOwnership)
+        XCTAssertNil(successor.agentTask)
+        XCTAssertTrue(successor.items.isEmpty)
+    }
+
     private func makeViewModel() -> AgentModeViewModel {
         let viewModel = AgentModeViewModel(
             codexControllerFactory: { _, _, _, _, _, _ in InactiveRefreshFakeCodexController() }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPRoutingReadinessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPRoutingReadinessTests.swift
@@ -599,7 +599,11 @@ final class CodexMCPRoutingReadinessTests: XCTestCase {
         )
         retainedHosts.append(host)
         let coordinator = host.test_codexCoordinator
-        coordinator.installTerminalCommitBarrier(AgentRunTerminalCommitBarrier(hooks: makeHooks(recorder: recorder)))
+        let hooks = makeHooks(recorder: recorder)
+        coordinator.installTerminalCommitBarrier(
+            AgentRunTerminalCommitBarrier(),
+            terminalSessionBinder: { hooks.bindTerminalSession($0) }
+        )
         return coordinator
     }
 


### PR DESCRIPTION
## Summary

- introduce an exact-object-bound, `TabSession`-neutral terminal session binding for Agent Mode runs
- keep terminal settlement in `AgentRunTerminalCommitBarrier` while removing its direct dependency on `AgentModeViewModel.TabSession` and unbound mutable hooks
- make terminal waits depend only on `AgentRunAttemptLifecycle`
- prevent stale predecessor sessions from mutating a recycled same-tab successor during activity projection, persistence, and follow-up dispatch
- add source-layout enforcement and deterministic regressions for exact-session binding, duplicate settlement/failure precedence, lifecycle-only waits, and stale projection guards

## Authority boundaries

This preserves the existing single authorities:

- `DomainAgentRunSessionStore` remains the durable lifecycle authority
- `AgentRunAttemptLifecycle` remains the transient per-attempt authority
- `AgentRunTerminalCommitBarrier` remains the sole exactly-once terminal settlement driver

The change does **not** add a second session store, re-resolve sessions by tab ID, change persisted schemas or MCP wire contracts, rewrite providers, redesign the UI, or introduce a new package target.

## Validation

Post-merge with current `origin/main`:

- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `make dev-test FILTER=AgentModeRunServiceLifecycleTests` — 41/41 passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` — passed

Feature-head validation (the subsequent main merge only added the unrelated Sonoma async-frame compatibility change from #768):

- `make dev-lint` — passed; SwiftFormat 0/1467 and SwiftLint strict passed
- `make dev-test FILTER=CodexMCPRoutingReadinessTests` — 8/8 passed
- focused real-view-model stale-session guard — 1/1 passed
- source-layout and repository guardrails — passed
- Fable 5 High architecture/code review — **APPROVE**, no blockers

The full local PR-ready root run was not wholly green: four unchanged CodeMap/workspace suites failed amid suite-level authority/timing interference. Each affected suite then passed independently without code changes:

- `WorkspaceCodemapArtifactBindingTests` — 9/9
- `WorkspaceCodemapLiveOverlayTests` — 42/42
- `WorkspaceCodemapLocalGitClassificationTests` — 11/11
- `WorkspacePendingSeededRootTests` — 13/13

## Follow-ups / non-goals

A later boundary PR can hoist remaining app-nested terminal vocabulary such as `AttachmentTurnDisposition` and `CancellationCompletion`. Broader tool tracking, context-usage projection, and session orchestration extraction are intentionally outside this PR.
