### PR TITLE
Agent Mode: hoist terminal attachment disposition

### DIFF
--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -693,7 +693,7 @@ print_matches \
   grep -n -E 'loadContentsRecursively' Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
 
 # Agent Mode terminal settlement stays free of the app's concrete TabSession
-# type. Other narrow nested vocabulary remains an explicit follow-up boundary.
+# type and uses provider-neutral domain terminal command vocabulary directly.
 terminal_session_neutral_files=(
   "Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift"
   "Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift"
@@ -706,6 +706,9 @@ for path in "${terminal_session_neutral_files[@]}"; do
   print_matches \
       "TabSession-neutral terminal settlement source references AgentModeViewModel.TabSession: $path" \
     grep -n -F 'AgentModeViewModel.TabSession' "$path"
+  print_matches \
+      "domain-vocabulary terminal settlement source references app-nested terminal command type: $path" \
+    grep -n -E 'AgentModeViewModel\.AttachmentTurnDisposition|AgentModeRunService\.CancellationCompletion' "$path"
 done
 
 # 7. Removed IDE-era Prompt selected-files panel and Prompt-owned preset bottom bar

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunServiceHooks.swift
@@ -38,7 +38,7 @@ extension AgentModeRunService {
         let markAttachmentsConsumed: (AgentModeViewModel.TabSession, UUID?) -> Void
         let stageConsumedAttachmentFilesForDeferredCleanup: ([AgentImageAttachment], AgentModeViewModel.TabSession) -> Void
         let consumeDeferredAttachmentCleanup: (AgentModeViewModel.TabSession, Bool) -> Void
-        let finalizeAttachmentsForTurn: (AgentModeViewModel.TabSession, UUID?, AgentModeViewModel.AttachmentTurnDisposition) -> Void
+        let finalizeAttachmentsForTurn: (AgentModeViewModel.TabSession, UUID?, DomainAgentRunAttachmentTurnDisposition) -> Void
     }
 
     /// UI-only callbacks. Never authoritative for run lifecycle decisions.

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -43,19 +43,19 @@ final class AgentRunTerminalCommitBarrier {
     }
 
     struct Request {
-        // This request is concrete-TabSession-free. The remaining app-owned
-        // AttachmentTurnDisposition and CancellationCompletion vocabulary is a
-        // deliberately deferred contract-hoisting boundary for a later slice.
+        // This request is concrete-TabSession-free. Its domain command values
+        // carry no settlement authority; the exact-object binding applies them
+        // through host-owned capabilities.
         let binding: AgentRunTerminalSessionBinding
         let ownership: AgentRunOwnership
         let expectedRunID: UUID?
         let terminalState: AgentSessionRunState
         let source: String
-        let completion: AgentModeRunService.CancellationCompletion
+        let completion: DomainAgentRunCancellationCompletion
         let errorText: String?
         let failureReason: DomainAgentRunSnapshot.FailureReason?
         let attachmentReservationID: UUID?
-        let attachmentDisposition: AgentModeViewModel.AttachmentTurnDisposition
+        let attachmentDisposition: DomainAgentRunAttachmentTurnDisposition
         let finalizeNonCodexUsage: Bool
         let supportsFollowUp: Bool
         let providerSuccessor: ProviderSuccessor?
@@ -71,11 +71,11 @@ final class AgentRunTerminalCommitBarrier {
             expectedRunID: UUID?,
             terminalState: AgentSessionRunState,
             source: String,
-            completion: AgentModeRunService.CancellationCompletion = .terminalPublished,
+            completion: DomainAgentRunCancellationCompletion = .terminalPublished,
             errorText: String? = nil,
             failureReason: DomainAgentRunSnapshot.FailureReason? = nil,
             attachmentReservationID: UUID? = nil,
-            attachmentDisposition: AgentModeViewModel.AttachmentTurnDisposition,
+            attachmentDisposition: DomainAgentRunAttachmentTurnDisposition,
             finalizeNonCodexUsage: Bool,
             supportsFollowUp: Bool,
             providerSuccessor: ProviderSuccessor? = nil,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalSessionBinding.swift
@@ -6,11 +6,9 @@ import RepoPromptDomainRuntime
 /// This value carries no concrete `TabSession` and performs no lookup by
 /// `tabID`. The app host partially applies its exact session at the
 /// run/settlement edge, while the terminal barrier operates only on this
-/// capability surface and `AgentRunAttemptLifecycle`.
-///
-/// This slice is intentionally `TabSession`-neutral, not yet independent of all
-/// app-owned nested vocabulary: `AttachmentTurnDisposition` remains a narrow
-/// follow-up boundary rather than being hoisted in this PR.
+/// capability surface and `AgentRunAttemptLifecycle`. Attachment finalization
+/// is expressed in provider-neutral domain command vocabulary; the bound app
+/// hook remains the attachment persistence authority that applies it.
 @MainActor
 struct AgentRunTerminalSessionBinding {
     struct Hooks {
@@ -19,7 +17,7 @@ struct AgentRunTerminalSessionBinding {
         let finalizePendingToolCalls: @MainActor (AgentSessionRunState) -> Void
         let finalizeNonCodexTurnUsage: @MainActor () -> Void
         let cancelPendingInteractions: @MainActor (_ reviewReason: String) -> Void
-        let finalizeAttachments: @MainActor (UUID?, AgentModeViewModel.AttachmentTurnDisposition) -> Void
+        let finalizeAttachments: @MainActor (UUID?, DomainAgentRunAttachmentTurnDisposition) -> Void
         let setAgentRunInactive: @MainActor () -> Void
         let prepareTerminalPublication: @MainActor () -> Void
         let makeTerminalPublicationEnvelope: @MainActor (

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RepoPromptDomainRuntime
 
 struct AgentPersistentSessionBindingIdentity: Equatable, Hashable {
     let tabID: UUID
@@ -484,11 +485,9 @@ extension AgentModeViewModel {
         }
     }
 
-    enum AttachmentTurnDisposition: Equatable {
-        case restoreToPending
-        case deleteFiles
-        case keepFiles
-    }
+    /// Compatibility alias for app call sites while terminal settlement uses the
+    /// provider-neutral domain command vocabulary directly.
+    typealias AttachmentTurnDisposition = DomainAgentRunAttachmentTurnDisposition
 
     enum AttachmentTurnState: Equatable {
         case idle

--- a/Sources/RepoPromptDomainRuntime/DomainAgentRunExecutionContracts.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainAgentRunExecutionContracts.swift
@@ -46,6 +46,22 @@ package enum DomainAgentRunCancellationCompletion: Equatable, Hashable {
     case terminalTeardownCompleted
 }
 
+/// What terminal settlement should do with attachment files reserved for a turn.
+///
+/// This is provider-neutral command vocabulary, not attachment lifecycle
+/// authority: the execution host applies the disposition through its attachment
+/// persistence boundary. It carries no files, session state, or presentation
+/// policy, and does not change the canonical run lifecycle authority owned by
+/// `DomainAgentRunSessionStore`.
+package enum DomainAgentRunAttachmentTurnDisposition: Equatable, Hashable, Sendable {
+    /// Return the turn's attachments to the host's pending attachment state.
+    case restoreToPending
+    /// Delete the turn's attachment files during finalization.
+    case deleteFiles
+    /// Preserve the turn's attachment files during finalization.
+    case keepFiles
+}
+
 /// Provider-neutral terminal result of one Agent run execution.
 ///
 /// Exactly one outcome may settle a run. Hosts map an outcome into their

--- a/Tests/RepoPromptDomainRuntimeTests/DomainAgentRunExecutionContractsTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainAgentRunExecutionContractsTests.swift
@@ -19,11 +19,26 @@ final class DomainAgentRunExecutionContractsTests: XCTestCase {
         )
     }
 
+    func testAttachmentTurnDispositionCasesAreDistinctAndExhaustivelyHandled() {
+        let dispositions: [DomainAgentRunAttachmentTurnDisposition] = [
+            .restoreToPending,
+            .deleteFiles,
+            .keepFiles
+        ]
+
+        XCTAssertEqual(Set(dispositions).count, 3)
+        XCTAssertEqual(
+            dispositions.map(attachmentDispositionCaseName),
+            ["restoreToPending", "deleteFiles", "keepFiles"]
+        )
+    }
+
     func testExecutionContractTypesAreSendableValueTypes() {
         // Compile-time Sendable checks: these calls fail to compile if any
         // contract type loses Sendable conformance or value semantics.
         assertSendable(DomainAgentRunCancellationIntent.userStop)
         assertSendable(DomainAgentRunCancellationCompletion.terminalPublished)
+        assertSendable(DomainAgentRunAttachmentTurnDisposition.restoreToPending)
         assertSendable(DomainAgentRunTerminalOutcome.completed(assistantText: "done"))
     }
 
@@ -121,6 +136,16 @@ final class DomainAgentRunExecutionContractsTests: XCTestCase {
 
     private func assertSendable(_ value: some Sendable & Equatable) {
         XCTAssertEqual(value, value)
+    }
+
+    private func attachmentDispositionCaseName(
+        _ disposition: DomainAgentRunAttachmentTurnDisposition
+    ) -> String {
+        switch disposition {
+        case .restoreToPending: "restoreToPending"
+        case .deleteFiles: "deleteFiles"
+        case .keepFiles: "keepFiles"
+        }
     }
 
     private func makeSnapshot(


### PR DESCRIPTION
## Summary

- make `RepoPromptDomainRuntime` the sole owner of terminal attachment-disposition command vocabulary
- keep existing app call sites source-compatible through a narrow `AgentModeViewModel.AttachmentTurnDisposition` typealias
- make the terminal commit barrier and exact-session binding use domain attachment and cancellation contracts directly
- extend the existing terminal-spine guardrail so app-nested command vocabulary cannot re-enter that boundary
- add sendability and exhaustive-case contract coverage

## Why this is the next thin-UI slice

PR #772 removed concrete `TabSession` from the terminal settlement spine but deliberately left attachment disposition as app-nested vocabulary. Cancellation completion was already domain-owned; this PR corrects that historical description and hoists only the remaining command contract.

This is a vocabulary/ownership boundary, not a second attachment authority. `DomainAgentRunSessionStore` remains the canonical durable lifecycle authority, the exact-object session binding remains the settlement adapter, and the existing host attachment hook remains responsible for applying file/draft persistence behavior.

## Non-goals

- no movement of `finalizeAttachmentsForTurn` behavior or `TabSession` attachment state
- no new store, protocol, package, or tab-ID lookup
- no provider, runner, coordinator, persistence, wire-format, or UI behavior changes
- no centralization of existing host policy expressions

## Validation

- `DomainAgentRunExecutionContractsTests` — 6/6 passed
- `AgentModeRunServiceLifecycleTests` — 41/41 passed
- coordinated `RepoPrompt` product build — passed
- coordinated full debug package build during independent review — passed
- `make dev-format` — 0/1467 files changed
- `make dev-lint` — passed, including SwiftLint strict
- repository/source-layout/headless guardrails — passed
- commit and push contribution preflights, including staged/outgoing secret scans — passed
- Fable 5 High architecture/code review — **APPROVE**, no blocking or medium findings

## Rollback

This is a single vocabulary relocation with no persisted representation. A single-commit revert restores the nested enum and prior spellings without data migration.
