### PR TITLE
feat(agent-mode): add pinned Claude Opus 4.8 picker model

### DIFF
--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
@@ -237,6 +237,7 @@ public enum ClaudeCompatibleModelCatalog {
     private static let fable5Raw = "claude-fable-5"
     private static let opus1mRaw = "opus[1m]"
     private static let opus5Raw = "claude-opus-5"
+    private static let opus48Raw = "claude-opus-4-8"
     private static let opus47Raw = "claude-opus-4-7"
     private static let opus46Raw = "claude-opus-4-6"
     private static let opus45Raw = "claude-opus-4-5"
@@ -268,6 +269,12 @@ public enum ClaudeCompatibleModelCatalog {
             rawValue: opus5Raw,
             displayName: "Opus 5",
             description: "Pinned Claude Opus 5 with 1M context for demanding reasoning and long-horizon agentic work. Requires Claude Code 2.1.219 or newer.",
+            supportsXHigh: true
+        ),
+        StaticModel(
+            rawValue: opus48Raw,
+            displayName: "Opus 4.8",
+            description: "Pinned Claude Opus 4.8 with native 1M context. Opus-tier capability for complex reasoning and architecture.",
             supportsXHigh: true
         ),
         StaticModel(

--- a/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
+++ b/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
@@ -171,6 +171,7 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
             "opus[1m]",
             "opus",
             "claude-opus-5",
+            "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-opus-4-5",
@@ -186,6 +187,10 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         let opus5 = try XCTUnwrap(claude.options.first { $0.rawValue == "claude-opus-5" })
         XCTAssertEqual(opus5.displayName, "Opus 5")
         XCTAssertEqual(opus5.supportedEffortLevels, ["low", "medium", "high", "xhigh", "max"])
+        let opus48 = try XCTUnwrap(claude.options.first { $0.rawValue == "claude-opus-4-8" })
+        XCTAssertEqual(opus48.displayName, "Opus 4.8")
+        XCTAssertEqual(opus48.supportedEffortLevels, ["low", "medium", "high", "xhigh", "max"])
+        XCTAssertFalse(opus48.isProviderDefault)
         let sonnet5 = try XCTUnwrap(claude.options.first { $0.rawValue == "claude-sonnet-5" })
         XCTAssertEqual(sonnet5.displayName, "Sonnet 5")
         XCTAssertEqual(sonnet5.supportedEffortLevels, ["low", "medium", "high", "xhigh", "max"])
@@ -201,6 +206,18 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
                 "claude-opus-5:max"
             ]
         )
+        XCTAssertEqual(
+            expandedClaude.options.filter { $0.rawValue.hasPrefix("claude-opus-4-8:") }.map(\.rawValue),
+            [
+                "claude-opus-4-8:low",
+                "claude-opus-4-8:medium",
+                "claude-opus-4-8:high",
+                "claude-opus-4-8:xhigh",
+                "claude-opus-4-8:max"
+            ]
+        )
+        XCTAssertFalse(expandedClaude.options.contains { $0.rawValue == "claude-opus-4-8[1m]" })
+        XCTAssertFalse(expandedClaude.options.contains { $0.rawValue.hasPrefix("claude-opus-4-8[1m]:") })
         XCTAssertTrue(expandedClaude.options.contains { $0.rawValue == "claude-sonnet-5:max" })
         XCTAssertTrue(expandedClaude.options.contains { $0.rawValue == "claude-sonnet-5:xhigh" })
 
@@ -239,6 +256,7 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(ClaudeCompatibleModelNormalizer.normalizedSlotModel("glm-5.2[1m]:xhigh", config: ClaudeCompatibleBackendID.glmZAI.defaultPreset), "sonnet")
         XCTAssertEqual(ClaudeCompatibleHeadlessRuntime.runtimeModelParam("opus:xhigh"), "opus")
         XCTAssertEqual(ClaudeCompatibleHeadlessRuntime.runtimeModelParam("claude-opus-5:max"), "claude-opus-5")
+        XCTAssertEqual(ClaudeCompatibleHeadlessRuntime.runtimeModelParam("claude-opus-4-8:max"), "claude-opus-4-8")
         XCTAssertEqual(ClaudeCompatibleHeadlessRuntime.runtimeModelParam("claude-opus-5:xhigh"), "claude-opus-5")
         XCTAssertEqual(ClaudeCompatibleHeadlessRuntime.runtimeModelParam("claude-sonnet-5:xhigh"), "claude-sonnet-5")
         XCTAssertEqual(ClaudeCompatibleModelNormalizer.normalizedGLMModel("glm-4.5-air", config: ClaudeCompatibleBackendID.glmZAI.defaultPreset), "haiku")

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -85,6 +85,7 @@ enum AgentModel: String, CaseIterable, Codable {
     case claudeSonnet46 = "claude-sonnet-4-6"
     case claudeSonnet45 = "claude-sonnet-4-5"
     case claudeOpus5 = "claude-opus-5"
+    case claudeOpus48 = "claude-opus-4-8"
     case claudeOpus47 = "claude-opus-4-7"
     case claudeOpus46 = "claude-opus-4-6"
     case claudeOpus45 = "claude-opus-4-5"
@@ -157,6 +158,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .claudeSonnet46: "Sonnet 4.6"
         case .claudeSonnet45: "Sonnet 4.5"
         case .claudeOpus5: "Opus 5"
+        case .claudeOpus48: "Opus 4.8"
         case .claudeOpus47: "Opus 4.7"
         case .claudeOpus46: "Opus 4.6"
         case .claudeOpus45: "Opus 4.5"
@@ -223,6 +225,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .claudeSonnet46: "Pinned Claude Sonnet 4.6. Balanced speed and capability for everyday engineering."
         case .claudeSonnet45: "Pinned Claude Sonnet 4.5. Balanced speed and capability for everyday engineering."
         case .claudeOpus5: "Pinned Claude Opus 5 with 1M context for demanding reasoning and long-horizon agentic work. Requires Claude Code 2.1.219 or newer."
+        case .claudeOpus48: "Pinned Claude Opus 4.8 with native 1M context. Opus-tier capability for complex reasoning and architecture."
         case .claudeOpus47: "Pinned Claude Opus 4.7. Opus-tier capability for complex reasoning and architecture."
         case .claudeOpus46: "Pinned Claude Opus 4.6. Opus-tier capability for complex reasoning and architecture."
         case .claudeOpus45: "Pinned Claude Opus 4.5. Opus-tier capability for complex reasoning and architecture."
@@ -289,7 +292,7 @@ enum AgentModel: String, CaseIterable, Codable {
                 .defaultModel,
                 .claudeFable5,
                 .claudeOpus1m,
-                .claudeOpus, .claudeOpus5, .claudeOpus47, .claudeOpus46, .claudeOpus45,
+                .claudeOpus, .claudeOpus5, .claudeOpus48, .claudeOpus47, .claudeOpus46, .claudeOpus45,
                 .claudeSonnet, .claudeSonnet5, .claudeSonnet46, .claudeSonnet45,
                 .claudeHaiku, .claudeHaiku45
             ]
@@ -579,7 +582,7 @@ enum AgentModel: String, CaseIterable, Codable {
     /// Returns `nil` for models where the context window is unknown or unverified.
     var contextWindowTokens: Int? {
         switch self {
-        case .claudeFable5, .claudeSonnet5, .claudeOpus5, .claudeOpus1m, .glm52_1m:
+        case .claudeFable5, .claudeSonnet5, .claudeOpus5, .claudeOpus48, .claudeOpus1m, .glm52_1m:
             1_000_000
         case .claudeSonnet, .claudeOpus, .claudeHaiku,
              .claudeSonnet46, .claudeSonnet45,

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -389,6 +389,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
         AgentModel.claudeOpus.rawValue.lowercased(),
         AgentModel.claudeOpus1m.rawValue.lowercased(),
         AgentModel.claudeOpus5.rawValue.lowercased(),
+        AgentModel.claudeOpus48.rawValue.lowercased(),
         AgentModel.claudeOpus47.rawValue.lowercased(),
         AgentModel.claudeOpus46.rawValue.lowercased(),
         AgentModel.claudeOpus45.rawValue.lowercased()

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
@@ -27,6 +27,7 @@ enum ClaudeCodeAIModelCatalog {
         ModelDefinition(runtimeModelRaw: "opus[1m]", displayName: "Opus Latest (1M)", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "opus", displayName: "Opus Latest", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-opus-5", displayName: "Opus 5", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
+        ModelDefinition(runtimeModelRaw: "claude-opus-4-8", displayName: "Opus 4.8", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-opus-4-7", displayName: "Opus 4.7", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-opus-4-6", displayName: "Opus 4.6", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-opus-4-5-20251101", displayName: "Opus 4.5", supportedEfforts: []),

--- a/Tests/RepoPromptTests/AI/ModelPickerStringOrderingTests.swift
+++ b/Tests/RepoPromptTests/AI/ModelPickerStringOrderingTests.swift
@@ -118,11 +118,12 @@ final class ModelPickerStringOrderingTests: XCTestCase {
         )
 
         let menu = AIModel.claudeCodeMenu(for: models)
-        XCTAssertEqual(Array(menu.groups.prefix(5).map(\.baseModelRaw)), [
+        XCTAssertEqual(Array(menu.groups.prefix(6).map(\.baseModelRaw)), [
             "claude-fable-5",
             "opus[1m]",
             "opus",
             "claude-opus-5",
+            "claude-opus-4-8",
             "claude-opus-4-7"
         ])
         let opus5Group = try XCTUnwrap(menu.groups.first { $0.baseModelRaw == "claude-opus-5" })
@@ -159,6 +160,90 @@ final class ModelPickerStringOrderingTests: XCTestCase {
         let xhighSelection = try ClaudeCodeProvider.resolveCLIModelSelection(for: .claudeCodeModel(specifier: "claude-opus-5:xhigh"))
         XCTAssertEqual(xhighSelection.modelArgument, "claude-opus-5")
         XCTAssertEqual(xhighSelection.effortLevel, .xhigh)
+    }
+
+    func testClaudeCodePickerExposesOpus48AsPinnedOneMillionTokenModel() throws {
+        let baseRaw = "claude-opus-4-8"
+        let effortRaws = [
+            "claude-opus-4-8:low",
+            "claude-opus-4-8:medium",
+            "claude-opus-4-8:high",
+            "claude-opus-4-8:xhigh",
+            "claude-opus-4-8:max"
+        ]
+        let expectedModels = ([baseRaw] + effortRaws).map {
+            AIModel.claudeCodeModel(specifier: $0)
+        }
+
+        let models = AIModel.modelsForProvider(.claudeCode)
+        for model in expectedModels {
+            XCTAssertTrue(models.contains(model), "Missing Claude Code picker model \(model.rawValue)")
+        }
+        XCTAssertFalse(models.contains(.claudeCodeModel(specifier: "claude-opus-4-8[1m]")))
+
+        let menu = AIModel.claudeCodeMenu(for: models)
+        let groupRaws = menu.groups.map(\.baseModelRaw)
+        let opus48Index = try XCTUnwrap(groupRaws.firstIndex(of: baseRaw))
+        XCTAssertGreaterThan(opus48Index, 0)
+        XCTAssertLessThan(opus48Index + 1, groupRaws.count)
+        XCTAssertEqual(groupRaws[opus48Index - 1], "claude-opus-5")
+        XCTAssertEqual(groupRaws[opus48Index + 1], "claude-opus-4-7")
+
+        let opus48Group = menu.groups[opus48Index]
+        XCTAssertEqual(opus48Group.displayName, "Opus 4.8")
+        XCTAssertEqual(opus48Group.options.compactMap(\.model.claudeCodeRuntimeSpecifierRaw), effortRaws)
+        XCTAssertEqual(opus48Group.options.map(\.displayName), ["Low", "Medium", "High", "XHigh", "Max"])
+
+        for (raw, expectedModel) in zip([baseRaw] + effortRaws, expectedModels) {
+            XCTAssertEqual(
+                AIModel.fromModelName("\(ClaudeCodeAIModelCatalog.rawPrefix)\(raw)"),
+                expectedModel
+            )
+        }
+        XCTAssertNil(AIModel.fromModelName("\(ClaudeCodeAIModelCatalog.rawPrefix)claude-opus-4-8:ultra"))
+        XCTAssertNil(AIModel.fromModelName("\(ClaudeCodeAIModelCatalog.rawPrefix)claude-opus-4-8[1m]"))
+
+        let effortLevels: [ClaudeCodeEffortLevel] = [.low, .medium, .high, .xhigh, .max]
+        for (raw, effort) in zip(effortRaws, effortLevels) {
+            let selection = try ClaudeCodeProvider.resolveCLIModelSelection(
+                for: .claudeCodeModel(specifier: raw)
+            )
+            XCTAssertEqual(selection.modelArgument, baseRaw)
+            XCTAssertEqual(selection.effortLevel, effort)
+        }
+
+        let agentModel = try XCTUnwrap(AgentModel(rawValue: baseRaw))
+        XCTAssertEqual(agentModel, .claudeOpus48)
+        XCTAssertEqual(agentModel.displayName, "Opus 4.8")
+        XCTAssertEqual(
+            agentModel.description,
+            "Pinned Claude Opus 4.8 with native 1M context. Opus-tier capability for complex reasoning and architecture."
+        )
+        XCTAssertEqual(agentModel.contextWindowTokens, 1_000_000)
+        XCTAssertTrue(agentModel.isExtendedContext)
+        XCTAssertEqual(AgentModel.resolvedModel(forRaw: "claude-opus-4-8:max", agentKind: .claudeCode), .claudeOpus48)
+
+        let claudeModels = AgentModel.modelsForAgent(.claudeCode)
+        let agentModelIndex = try XCTUnwrap(claudeModels.firstIndex(of: .claudeOpus48))
+        XCTAssertGreaterThan(agentModelIndex, 0)
+        XCTAssertLessThan(agentModelIndex + 1, claudeModels.count)
+        XCTAssertEqual(claudeModels[agentModelIndex - 1], .claudeOpus5)
+        XCTAssertEqual(claudeModels[agentModelIndex + 1], .claudeOpus47)
+
+        let encoded = try JSONEncoder().encode(agentModel)
+        XCTAssertEqual(encoded, Data("\"claude-opus-4-8\"".utf8))
+        XCTAssertEqual(try JSONDecoder().decode(AgentModel.self, from: encoded), .claudeOpus48)
+
+        let availability = AgentModelCatalog.AvailabilityContext(claudeCodeAvailable: true)
+        for raw in [baseRaw] + effortRaws {
+            let normalized = AgentModelCatalog.normalizePersistedSelection(
+                agentRaw: AgentProviderKind.claudeCode.rawValue,
+                modelRaw: raw,
+                availability: availability
+            )
+            XCTAssertEqual(normalized.agent, .claudeCode)
+            XCTAssertEqual(normalized.modelRaw, raw)
+        }
     }
 
     func testClaudeOpusRecommendationCopyTracksStableAlias() {

--- a/Tests/RepoPromptTests/AgentMode/AgentRuntimeSidebarViewModelTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentRuntimeSidebarViewModelTests.swift
@@ -163,6 +163,23 @@ final class AgentRuntimeSidebarViewModelTests: XCTestCase {
         XCTAssertEqual(store.runtimeVM.snapshot.effectiveContextWindowTokens, 1_000_000)
     }
 
+    func testClaudeOpus48BaseAndEncodedSelectionsFallBackToOneMillionTokenContextWindow() {
+        let store = AgentRuntimeMetricsUIStore()
+
+        for selectedModelRaw in ["claude-opus-4-8", "claude-opus-4-8:xhigh"] {
+            store.update(
+                transcriptSnapshot: AgentTranscriptAnalyticsSnapshot(),
+                codexUsage: nil,
+                liveSelectedFileCount: nil,
+                selectedAgent: .claudeCode,
+                selectedModelRaw: selectedModelRaw
+            )
+
+            XCTAssertNil(store.runtimeVM.snapshot.contextWindowTokens)
+            XCTAssertEqual(store.runtimeVM.snapshot.effectiveContextWindowTokens, 1_000_000, selectedModelRaw)
+        }
+    }
+
     func testEncodedClaudeEffortSelectionResolvesContextWindowFallback() {
         let store = AgentRuntimeMetricsUIStore()
         store.update(

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeCompatiblePluginBridgeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeCompatiblePluginBridgeTests.swift
@@ -83,12 +83,13 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         XCTAssertEqual(snapshot.defaultModelRaw, "opus")
         XCTAssertEqual(snapshot.options.first?.rawValue, "default")
         XCTAssertEqual(snapshot.options.first?.isPlaceholderDefault, true)
-        XCTAssertEqual(AgentModel.modelsForAgent(.claudeCode).map(\.rawValue), [
+        let expectedClaudeModelRaws = [
             "default",
             "claude-fable-5",
             "opus[1m]",
             "opus",
             "claude-opus-5",
+            "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-opus-4-5",
@@ -98,12 +99,17 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
             "claude-sonnet-4-5",
             "haiku",
             "claude-haiku-4-5"
-        ])
+        ]
+        XCTAssertEqual(snapshot.options.map(\.rawValue), expectedClaudeModelRaws)
+        XCTAssertEqual(AgentModel.modelsForAgent(.claudeCode).map(\.rawValue), expectedClaudeModelRaws)
         XCTAssertTrue(snapshot.options.contains { $0.rawValue == "claude-fable-5" && $0.supportedEffortLevels.contains("xhigh") })
         XCTAssertTrue(snapshot.options.contains { $0.rawValue == "opus" && $0.supportedEffortLevels.contains("xhigh") })
         let opus5BaseOption = try XCTUnwrap(snapshot.options.first { $0.rawValue == "claude-opus-5" })
         XCTAssertEqual(opus5BaseOption.displayName, "Opus 5")
         XCTAssertEqual(opus5BaseOption.supportedEffortLevels, ["low", "medium", "high", "xhigh", "max"])
+        let opus48BaseOption = try XCTUnwrap(snapshot.options.first { $0.rawValue == "claude-opus-4-8" })
+        XCTAssertEqual(opus48BaseOption.displayName, "Opus 4.8")
+        XCTAssertEqual(opus48BaseOption.supportedEffortLevels, ["low", "medium", "high", "xhigh", "max"])
         let sonnet5BaseOption = try XCTUnwrap(snapshot.options.first { $0.rawValue == "claude-sonnet-5" })
         XCTAssertEqual(sonnet5BaseOption.displayName, "Sonnet 5")
         XCTAssertEqual(sonnet5BaseOption.supportedEffortLevels, ["low", "medium", "high", "xhigh", "max"])
@@ -117,6 +123,7 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         XCTAssertTrue(groupRaws.contains("opus[1m]"))
         XCTAssertTrue(groupRaws.contains("opus"))
         XCTAssertTrue(groupRaws.contains("claude-opus-5"))
+        XCTAssertTrue(groupRaws.contains("claude-opus-4-8"))
         XCTAssertTrue(groupRaws.contains("sonnet"))
         XCTAssertTrue(groupRaws.contains("claude-sonnet-5"))
         let opus5Group = try XCTUnwrap(menu.groups.first { $0.baseModelRaw == "claude-opus-5" })
@@ -128,6 +135,21 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
             "claude-opus-5:xhigh",
             "claude-opus-5:max"
         ])
+        let opus48Group = try XCTUnwrap(menu.groups.first { $0.baseModelRaw == "claude-opus-4-8" })
+        XCTAssertEqual(opus48Group.displayName, "Opus 4.8")
+        XCTAssertEqual(opus48Group.options.map(\.rawValue), [
+            "claude-opus-4-8:low",
+            "claude-opus-4-8:medium",
+            "claude-opus-4-8:high",
+            "claude-opus-4-8:xhigh",
+            "claude-opus-4-8:max"
+        ])
+        let opus5GroupIndex = try XCTUnwrap(menu.groups.firstIndex { $0.baseModelRaw == "claude-opus-5" })
+        let opus48GroupIndex = try XCTUnwrap(menu.groups.firstIndex { $0.baseModelRaw == "claude-opus-4-8" })
+        let opus47GroupIndex = try XCTUnwrap(menu.groups.firstIndex { $0.baseModelRaw == "claude-opus-4-7" })
+        XCTAssertEqual(opus48GroupIndex, opus5GroupIndex + 1)
+        XCTAssertEqual(opus47GroupIndex, opus48GroupIndex + 1)
+
         let sonnet5Group = try XCTUnwrap(menu.groups.first { $0.baseModelRaw == "claude-sonnet-5" })
         XCTAssertEqual(sonnet5Group.displayName, "Sonnet 5")
         XCTAssertEqual(sonnet5Group.options.map(\.rawValue), [
@@ -140,6 +162,18 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-opus-5", for: .claudeCode, availability: availability))
         XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-opus-5:max", for: .claudeCode, availability: availability))
         XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-opus-5:xhigh", for: .claudeCode, availability: availability))
+        for raw in [
+            "claude-opus-4-8",
+            "claude-opus-4-8:low",
+            "claude-opus-4-8:medium",
+            "claude-opus-4-8:high",
+            "claude-opus-4-8:xhigh",
+            "claude-opus-4-8:max"
+        ] {
+            XCTAssertTrue(AgentModelCatalog.isValid(rawModel: raw, for: .claudeCode, availability: availability), raw)
+        }
+        XCTAssertFalse(AgentModelCatalog.isValid(rawModel: "claude-opus-4-8:ultra", for: .claudeCode, availability: availability))
+        XCTAssertFalse(AgentModelCatalog.isValid(rawModel: "claude-opus-4-8[1m]", for: .claudeCode, availability: availability))
         XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-sonnet-5", for: .claudeCode, availability: availability))
         XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-sonnet-5:max", for: .claudeCode, availability: availability))
         XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-sonnet-5:xhigh", for: .claudeCode, availability: availability))
@@ -163,6 +197,30 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
             opus5Discovery.startTargets.first { $0.modelRaw == "claude-opus-5:max" }?.contextWindowTokens,
             1_000_000
         )
+        let opus48Discoveries = discovery.models.filter { $0.id == "claude-opus-4-8" }
+        XCTAssertEqual(opus48Discoveries.count, 1)
+        let opus48Discovery = try XCTUnwrap(opus48Discoveries.first)
+        XCTAssertEqual(opus48Discovery.contextWindowTokens, 1_000_000)
+        XCTAssertTrue(opus48Discovery.hasMultipleTargets)
+        XCTAssertEqual(opus48Discovery.startTargets.map(\.modelRaw), [
+            "claude-opus-4-8:low",
+            "claude-opus-4-8:medium",
+            "claude-opus-4-8:high",
+            "claude-opus-4-8:xhigh",
+            "claude-opus-4-8:max"
+        ])
+        XCTAssertEqual(opus48Discovery.startTargets.map(\.selectionID.rawValue), [
+            "claudeCode:claude-opus-4-8:low",
+            "claudeCode:claude-opus-4-8:medium",
+            "claudeCode:claude-opus-4-8:high",
+            "claudeCode:claude-opus-4-8:xhigh",
+            "claudeCode:claude-opus-4-8:max"
+        ])
+        XCTAssertTrue(opus48Discovery.startTargets.allSatisfy { $0.contextWindowTokens == 1_000_000 })
+        XCTAssertTrue(opus48Discovery.startTargets.allSatisfy { !$0.isDefault })
+        XCTAssertFalse(discovery.models.contains { $0.id == "claude-opus-4-8[1m]" })
+        XCTAssertFalse(discovery.models.flatMap(\.startTargets).contains { $0.modelRaw.contains("claude-opus-4-8[1m]") })
+
         let sonnet5Discovery = try XCTUnwrap(discovery.models.first { $0.id == "claude-sonnet-5" })
         XCTAssertEqual(sonnet5Discovery.contextWindowTokens, 1_000_000)
         XCTAssertTrue(sonnet5Discovery.tags.contains(.balanced))
@@ -546,7 +604,7 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         }
         XCTAssertGreaterThanOrEqual(
             comparedPickerRaws,
-            6,
+            7,
             "AI picker shares too few base raws with the provider catalog; the consistency check lost coverage"
         )
     }


### PR DESCRIPTION
## Summary

Adds Claude Opus 4.8 as a pinned model in the Agent Mode model picker, available through both the Claude-compatible provider plugin and the app's model catalog.

## Changes

- Register `claude-opus-4-8` in the provider plugin and model catalog so it appears as a selectable picker option.
- Update picker ordering tests to cover the new entry's sort position.
- Add plugin bridge and runtime support test coverage for the new model.

Closes #771
