### PR TITLE
Agent Mode: detach Claude coordinator from view model

### DIFF
--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -711,6 +711,23 @@ for path in "${terminal_session_neutral_files[@]}"; do
     grep -n -E 'AgentModeViewModel\.AttachmentTurnDisposition|AgentModeRunService\.CancellationCompletion' "$path"
 done
 
+# Claude runtime coordination must use its closed host capability surface rather
+# than retaining or attaching the concrete AgentModeViewModel. TabSession remains
+# intentionally nested until the separately scoped session-type extraction.
+claude_coordinator_source="Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift"
+if [[ ! -f "$claude_coordinator_source" ]]; then
+  fail "required Claude agent-mode coordinator source missing: $claude_coordinator_source"
+else
+  print_matches \
+    "ClaudeAgentModeCoordinator stores concrete AgentModeViewModel authority" \
+    grep -n -E '(^|[[:space:]])(weak[[:space:]]+)?(var|let)[[:space:]]+[[:alnum:]_]+[[:space:]]*:[[:space:]]*AgentModeViewModel[?]?[[:space:]]*$' \
+      "$claude_coordinator_source"
+  print_matches \
+    "ClaudeAgentModeCoordinator reintroduced attach(viewModel:)" \
+    grep -n -E 'func[[:space:]]+attach\(viewModel:[[:space:]]*AgentModeViewModel[?]?\)' \
+      "$claude_coordinator_source"
+fi
+
 # 7. Removed IDE-era Prompt selected-files panel and Prompt-owned preset bottom bar
 # artifacts must not return. The live compact selected-files surface is
 # SelectedFilesGrid/FilePreviewPopover, and Settings owns its chat preset picker.

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
@@ -18,6 +18,24 @@ final class ClaudeAgentModeCoordinator {
     typealias MCPActiveToolQuery = (_ runID: UUID) -> Bool
     typealias ActiveAgentRunWaitQuery = (_ runID: UUID) -> Bool
 
+    struct HostCapabilities {
+        let setAgentRunActive: @MainActor (_ session: AgentModeViewModel.TabSession, _ isActive: Bool) -> Void
+        let requestUIRefresh: @MainActor (_ session: AgentModeViewModel.TabSession, _ urgent: Bool) -> Void
+        let scheduleSave: @MainActor (_ session: AgentModeViewModel.TabSession) -> Void
+        let stageClaudeResumeRecoveryHandoff: @MainActor (_ session: AgentModeViewModel.TabSession) async -> Void
+        let prependPendingHandoff: @MainActor (_ text: String, _ session: AgentModeViewModel.TabSession) -> String
+
+        static var noOp: Self {
+            Self(
+                setAgentRunActive: { _, _ in },
+                requestUIRefresh: { _, _ in },
+                scheduleSave: { _ in },
+                stageClaudeResumeRecoveryHandoff: { _ in },
+                prependPendingHandoff: { text, _ in text }
+            )
+        }
+    }
+
     private enum SteeringInterruptSafePointResult {
         case ready
         case cancelled
@@ -48,7 +66,8 @@ final class ClaudeAgentModeCoordinator {
     private static let logger = Logger(subsystem: "com.repoprompt.agents", category: "ClaudeSteering")
     private static let flagSettingsLogger = Logger(subsystem: "com.repoprompt.agents", category: "ClaudeFlagSettings")
 
-    private weak var viewModel: AgentModeViewModel?
+    private weak var providerBindingService: AgentModeProviderBindingService?
+    private var hostCapabilities: HostCapabilities = .noOp
     private let windowID: Int
     private let workspacePathProvider: (AgentModeViewModel.TabSession) throws -> String?
     private let claudeControllerFactory: ClaudeControllerFactory
@@ -140,12 +159,16 @@ final class ClaudeAgentModeCoordinator {
         )
         guard scheduleSave else { return true }
         session.isDirty = true
-        viewModel?.scheduleSave(for: session.tabID)
+        hostCapabilities.scheduleSave(session)
         return true
     }
 
-    func attach(viewModel: AgentModeViewModel) {
-        self.viewModel = viewModel
+    func installHostCapabilities(
+        _ hostCapabilities: HostCapabilities,
+        providerBindingService: AgentModeProviderBindingService
+    ) {
+        self.hostCapabilities = hostCapabilities
+        self.providerBindingService = providerBindingService
     }
 
     func stop() {
@@ -181,10 +204,10 @@ final class ClaudeAgentModeCoordinator {
         session.runState = state
         session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
         session.setRunningStatus(nil, source: nil)
-        viewModel?.setAgentRunActive(session.tabID, isActive: false)
-        viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
+        hostCapabilities.setAgentRunActive(session, false)
+        hostCapabilities.requestUIRefresh(session, true)
         if save {
-            viewModel?.scheduleSave(for: session.tabID)
+            hostCapabilities.scheduleSave(session)
         }
     }
 
@@ -428,7 +451,7 @@ final class ClaudeAgentModeCoordinator {
             session.providerSessionID = nil
             session.providerCleanupHandle = nil
             session.isDirty = true
-            viewModel?.scheduleSave(for: session.tabID)
+            hostCapabilities.scheduleSave(session)
         }
         _ = await retireClaudeController(
             detached,
@@ -576,7 +599,7 @@ final class ClaudeAgentModeCoordinator {
                 throw error
             }
 
-            await viewModel?.stageClaudeResumeRecoveryHandoffIfNeeded(for: session)
+            await hostCapabilities.stageClaudeResumeRecoveryHandoff(session)
             guard sessionOwnsClaudeController(controller, for: session) else {
                 await controller.shutdown()
                 throw ControllerLifecycleError.superseded
@@ -599,7 +622,7 @@ final class ClaudeAgentModeCoordinator {
             session.providerSessionID = nil
             session.providerCleanupHandle = nil
             session.isDirty = true
-            viewModel?.scheduleSave(for: session.tabID)
+            hostCapabilities.scheduleSave(session)
 
             let freshRunID = AgentModeProcessRunIdentity.startFreshProcessRun(for: session)
             let retryWorkspacePath = try workspacePathProvider(session)
@@ -810,8 +833,8 @@ final class ClaudeAgentModeCoordinator {
         session.runState = .running
         var handler = toolHandler(for: session)
         handler.resetTurnState(for: session)
-        viewModel?.setAgentRunActive(session.tabID, isActive: true)
-        viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
+        hostCapabilities.setAgentRunActive(session, true)
+        hostCapabilities.requestUIRefresh(session, true)
 
         for _ in 0 ..< 3 {
             await ensureClaudeNativeSession(session: session)
@@ -897,11 +920,7 @@ final class ClaudeAgentModeCoordinator {
             }
 
             do {
-                let outboundText: String = if let viewModel {
-                    viewModel.prependPendingHandoffIfNeeded(text, session: session)
-                } else {
-                    text
-                }
+                let outboundText = hostCapabilities.prependPendingHandoff(text, session)
                 let instructions = agentModeInstructionInjection(for: session)
                 let providerBoundText = providerBoundUserMessage(outboundText, instructions: instructions)
                 let turnID = try await controller.sendUserMessage(providerBoundText)
@@ -987,7 +1006,7 @@ final class ClaudeAgentModeCoordinator {
         session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
         session.setRunningStatus("Thinking…", source: .transport)
         session.runState = .running
-        viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
+        hostCapabilities.requestUIRefresh(session, true)
         Task { [controller] in
             await controller.respondToPermissionRequest(id: requestID, decision: decision)
         }
@@ -1324,7 +1343,7 @@ final class ClaudeAgentModeCoordinator {
     private func effectiveClaudeRuntimePermission(
         for session: AgentModeViewModel.TabSession
     ) -> ClaudeControllerLaunchPolicy {
-        guard let providerBindingService = viewModel?.providerBindingService else {
+        guard let providerBindingService else {
             return ClaudeControllerLaunchPolicy(
                 permissionMode: session.permissionProfile.claudePermissionMode,
                 allowNativeBashTool: session.permissionProfile == .mcpSafeDefaults ? false : nil,
@@ -1377,7 +1396,7 @@ final class ClaudeAgentModeCoordinator {
     }
 
     private func currentClaudeEffortLevel(for session: AgentModeViewModel.TabSession) -> ClaudeCodeEffortLevel {
-        viewModel?.providerBindingService.claudeEffortLevel(
+        providerBindingService?.claudeEffortLevel(
             forModelRaw: session.selectedModelRaw,
             agentKind: session.selectedAgent
         ) ?? ClaudeAgentToolPreferences.effortLevel(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1523,6 +1523,27 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
     private weak var oracleViewModel: OracleViewModel?
 
+    private func makeClaudeCoordinatorHostCapabilities() -> ClaudeAgentModeCoordinator.HostCapabilities {
+        ClaudeAgentModeCoordinator.HostCapabilities(
+            setAgentRunActive: { [weak self] session, isActive in
+                self?.setAgentRunActive(session, isActive: isActive)
+            },
+            requestUIRefresh: { [weak self] session, urgent in
+                guard let self, sessions[session.tabID] === session else { return }
+                requestUIRefresh(tabID: session.tabID, urgent: urgent)
+            },
+            scheduleSave: { [weak self] session in
+                self?.scheduleSave(for: session)
+            },
+            stageClaudeResumeRecoveryHandoff: { [weak self] session in
+                await self?.stageClaudeResumeRecoveryHandoffIfNeeded(for: session)
+            },
+            prependPendingHandoff: { [weak self] text, session in
+                self?.prependPendingHandoffIfNeeded(text, session: session) ?? text
+            }
+        )
+    }
+
     init(
         windowID: Int,
         promptManager: PromptViewModel,
@@ -1681,7 +1702,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             )
         }
         codexCoordinator.attach(viewModel: self)
-        claudeCoordinator.attach(viewModel: self)
+        claudeCoordinator.installHostCapabilities(
+            makeClaudeCoordinatorHostCapabilities(),
+            providerBindingService: providerBindingService
+        )
         runInteractionStateObserver = codexCoordinator
         mcpServer.registerAgentWorktreeBindingsProvider { [weak self] sessionID, tabID in
             guard let self else { return .unavailable }
@@ -1865,7 +1889,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             )
             providerBindingService = AgentModeProviderBindingService()
             codexCoordinator.attach(viewModel: self)
-            claudeCoordinator.attach(viewModel: self)
+            claudeCoordinator.installHostCapabilities(
+                makeClaudeCoordinatorHostCapabilities(),
+                providerBindingService: providerBindingService
+            )
             runInteractionStateObserver = codexCoordinator
             testMCPServer?.registerAgentWorktreeBindingsProvider { [weak self] sessionID, tabID in
                 guard let self else { return .unavailable }

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -437,6 +437,7 @@ extension AgentModeRunServiceLifecycleTests {
             text: "fail deterministically",
             attachments: []
         )
+        withExtendedLifetime(providerBindingService) {}
 
         XCTAssertFalse(didSend)
         XCTAssertEqual(session.runState, .failed)

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -385,6 +385,84 @@ extension AgentModeRunServiceLifecycleTests {
         XCTAssertTrue(recorder.contains("stale-send:shutdown"))
     }
 
+    func testClaudeSendFailureFinalizesThroughCapabilitiesWithoutViewModel() async {
+        let recorder = LifecycleRecorder()
+        let controller = LifecycleFakeNativeController(
+            recorder: recorder,
+            label: "no-vm",
+            failSend: true
+        )
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        session.providerSessionID = "lifecycle-claude-session"
+        var projectedSessions: [AgentModeViewModel.TabSession] = []
+        var projectedStates: [AgentSessionRunState] = []
+        let capabilities = ClaudeAgentModeCoordinator.HostCapabilities(
+            setAgentRunActive: { projectedSession, isActive in
+                projectedSessions.append(projectedSession)
+                projectedStates.append(projectedSession.runState)
+                recorder.record("host:active:\(isActive)")
+            },
+            requestUIRefresh: { projectedSession, urgent in
+                projectedSessions.append(projectedSession)
+                projectedStates.append(projectedSession.runState)
+                recorder.record("host:refresh:\(urgent)")
+            },
+            scheduleSave: { projectedSession in
+                projectedSessions.append(projectedSession)
+                projectedStates.append(projectedSession.runState)
+                recorder.record("host:save")
+            },
+            stageClaudeResumeRecoveryHandoff: { _ in },
+            prependPendingHandoff: { outboundText, projectedSession in
+                projectedSessions.append(projectedSession)
+                projectedStates.append(projectedSession.runState)
+                recorder.record("host:prepend")
+                return outboundText
+            }
+        )
+        let providerBindingService = AgentModeProviderBindingService()
+        let coordinator = ClaudeAgentModeCoordinator(
+            windowID: 1,
+            workspacePathProvider: { _ in "/workspace" },
+            claudeControllerFactory: { _, _, _, _ in controller }
+        )
+        coordinator.installHostCapabilities(
+            capabilities,
+            providerBindingService: providerBindingService
+        )
+
+        let didSend = await coordinator.sendClaudeNativeMessage(
+            session: session,
+            text: "fail deterministically",
+            attachments: []
+        )
+
+        XCTAssertFalse(didSend)
+        XCTAssertEqual(session.runState, .failed)
+        XCTAssertNil(session.runningStatusText)
+        XCTAssertNil(session.runningStatusSource)
+        XCTAssertEqual(session.items.count(where: { $0.kind == .error }), 1)
+        XCTAssertTrue(projectedSessions.allSatisfy { $0 === session })
+        XCTAssertEqual(
+            projectedStates,
+            [.running, .running, .running, .failed, .failed, .failed]
+        )
+        XCTAssertEqual(
+            recorder.events,
+            [
+                "host:active:true",
+                "host:refresh:true",
+                "no-vm:start",
+                "host:prepend",
+                "no-vm:send",
+                "host:active:false",
+                "host:refresh:true",
+                "host:save"
+            ]
+        )
+    }
+
     func testInvalidatedClaudeResumeTransferCannotRestoreClearedSessionID() async {
         let recorder = LifecycleRecorder()
         let sessionRefGate = LifecycleAsyncGate()


### PR DESCRIPTION
## Summary

- remove the concrete `AgentModeViewModel` storage/attach edge from `ClaudeAgentModeCoordinator`
- replace ambient VM authority with a Claude-specific five-operation host capability surface
- inject `AgentModeProviderBindingService` directly while preserving its existing lifetime and fallback behavior
- keep every capability exact-session-bound, including stale/recycled-tab protection for presentation and persistence projections
- add a deterministic coordinator send-failure regression that runs without an `AgentModeViewModel` object
- add a source-layout guardrail preventing concrete VM storage or `attach(viewModel:)` from returning to the Claude coordinator

## Architecture and authority

This is dependency inversion, not a new backend authority:

- `DomainAgentRunSessionStore` remains the durable lifecycle authority
- `AgentRunTerminalCommitBarrier` remains the terminal settlement driver
- the app composition root still implements presentation, persistence, and handoff projections
- `ClaudeAgentModeCoordinator` now receives only the five operations it actually needs instead of an ambient reference to the full view model

`finalizeSession` behavior is intentionally preserved in this PR. Converging that remaining parallel state writer with the terminal barrier requires a separate semantics decision for reconnect/restore failures that have no live attempt ownership.

## Non-goals

- no Codex coordinator changes
- no terminal-settlement ordering or `finalizeSession` behavior changes
- no `TabSession` extraction or hook-signature neutralization
- no new store, god protocol, package, provider rewrite, persistence schema, or wire-format change
- no tab-ID re-resolution

## Validation

- `AgentModeRunServiceLifecycleTests` on the runtime diff — **42/42 passed**, including the new no-VM coordinator regression
- new no-VM regression after review-polish lifetime pin — **passed**
- coordinated `RepoPrompt` product build — **passed**
- formatter/format check — **passed**, 0/1467 remaining
- SwiftLint strict — **passed**
- repository/source-layout/headless guardrails — **passed**
- commit and push contribution preflights with staged/outgoing secret scans — **passed**
- Fable 5 High architecture/code review — **APPROVE**, no blocking findings

After the test-only lifetime pin, the broader 42-test filter encountered one unchanged ACP bootstrap 5-second timeout. The affected test passed independently **1/1** without code changes; the runtime diff had already passed the complete filter **42/42**. No retry, timeout increase, or assertion weakening was introduced.

## Follow-up unlocked

With Claude coordinator host obligations now explicit, the next bounded behavior PR can decide and implement `finalizeSession` convergence with canonical terminal settlement, including a defined contract for ownership-less reconnect/restore failures.
