### PR TITLE
Enforce one accounting identity per prompt file

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
@@ -1770,8 +1770,10 @@ enum AgentContextExportResolver {
             }
             guard let result else { continue }
             slicePathResults[path] = result
-            if let file = result.file, sliceRangesByFileID[file.id] == nil {
-                sliceRangesByFileID[file.id] = ranges
+            if let file = result.file {
+                var mergedRanges = sliceRangesByFileID[file.id, default: []]
+                mergedRanges.append(contentsOf: ranges)
+                sliceRangesByFileID[file.id] = SliceRangeMath.normalize(mergedRanges)
             }
         }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
@@ -1250,7 +1250,10 @@ enum AgentContextExportResolver {
                 )
             }
         } else if codeMapUsage == .auto || codeMapUsage == .complete {
-            var seenIDs = Set(rowEntries.map(\.entry.id))
+            var seenPhysicalFiles = PromptContextPhysicalFileIdentitySet()
+            for rowEntry in rowEntries {
+                _ = seenPhysicalFiles.insert(rowEntry.entry)
+            }
             let rootsByID = Dictionary(uniqueKeysWithValues: roots.map { ($0.id, $0) })
             for rendered in codemapPresentation.orderedEntries {
                 guard !resolution.selectedFileIDs.contains(rendered.fileID),
@@ -1269,7 +1272,7 @@ enum AgentContextExportResolver {
                     canRemove: codeMapUsage == .auto,
                     removesAutomaticSourceIntent: codeMapUsage == .auto,
                     to: &rowEntries,
-                    seenIDs: &seenIDs
+                    seenPhysicalFiles: &seenPhysicalFiles
                 )
             }
         }
@@ -1708,7 +1711,7 @@ enum AgentContextExportResolver {
         var rows: [RowResolutionEntry] = []
         var missingPaths: [String] = []
         var invalidPaths: [String] = []
-        var seenIDs = Set<ResolvedPromptFileEntryID>()
+        var seenPhysicalFiles = PromptContextPhysicalFileIdentitySet()
         var selectedFileIDs = Set<UUID>()
 
         let selectedRequests = selection.selectedPaths.map {
@@ -1740,7 +1743,7 @@ enum AgentContextExportResolver {
                     rootScope: rootScope,
                     selectedFileIDs: &selectedFileIDs,
                     rows: &rows,
-                    seenIDs: &seenIDs
+                    seenPhysicalFiles: &seenPhysicalFiles
                 ) {
                     continue
                 }
@@ -1758,7 +1761,7 @@ enum AgentContextExportResolver {
                     loadedContent: nil,
                     rootFolderPath: result.location.rootPath
                 )
-                append(entry, canRemove: true, to: &rows, seenIDs: &seenIDs)
+                append(entry, canRemove: true, to: &rows, seenPhysicalFiles: &seenPhysicalFiles)
             } else if let folder = result.folder {
                 let files = await store.files(inRoot: folder.rootID)
                 let prefix = folder.standardizedRelativePath
@@ -1770,7 +1773,7 @@ enum AgentContextExportResolver {
                         loadedContent: nil,
                         rootFolderPath: result.location.rootPath
                     )
-                    append(entry, canRemove: false, to: &rows, seenIDs: &seenIDs)
+                    append(entry, canRemove: false, to: &rows, seenPhysicalFiles: &seenPhysicalFiles)
                 }
             } else {
                 invalidPaths.append(path)
@@ -1817,7 +1820,7 @@ enum AgentContextExportResolver {
                 loadedContent: nil,
                 rootFolderPath: result.location.rootPath
             )
-            append(entry, canRemove: true, to: &rows, seenIDs: &seenIDs)
+            append(entry, canRemove: true, to: &rows, seenPhysicalFiles: &seenPhysicalFiles)
         }
 
         AgentSelectedFilesDiagnostics.durationEvent(
@@ -1958,7 +1961,7 @@ enum AgentContextExportResolver {
         rootScope: WorkspaceLookupRootScope,
         selectedFileIDs: inout Set<UUID>,
         rows: inout [RowResolutionEntry],
-        seenIDs: inout Set<ResolvedPromptFileEntryID>
+        seenPhysicalFiles: inout PromptContextPhysicalFileIdentitySet
     ) async -> Bool {
         let roots = await store.rootRefs(scope: rootScope)
         var handled = false
@@ -1977,7 +1980,7 @@ enum AgentContextExportResolver {
                     loadedContent: nil,
                     rootFolderPath: root.standardizedFullPath
                 )
-                append(entry, canRemove: false, to: &rows, seenIDs: &seenIDs)
+                append(entry, canRemove: false, to: &rows, seenPhysicalFiles: &seenPhysicalFiles)
             }
         }
         return handled
@@ -2033,9 +2036,9 @@ enum AgentContextExportResolver {
         canRemove: Bool,
         removesAutomaticSourceIntent: Bool = false,
         to rows: inout [RowResolutionEntry],
-        seenIDs: inout Set<ResolvedPromptFileEntryID>
+        seenPhysicalFiles: inout PromptContextPhysicalFileIdentitySet
     ) {
-        guard seenIDs.insert(entry.id).inserted else { return }
+        guard seenPhysicalFiles.insert(entry) else { return }
         rows.append(RowResolutionEntry(
             entry: entry,
             canRemove: canRemove,

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
@@ -1771,9 +1771,11 @@ enum AgentContextExportResolver {
             guard let result else { continue }
             slicePathResults[path] = result
             if let file = result.file {
-                var mergedRanges = sliceRangesByFileID[file.id, default: []]
-                mergedRanges.append(contentsOf: ranges)
-                sliceRangesByFileID[file.id] = SliceRangeMath.normalize(mergedRanges)
+                StoredSelectionPathNormalization.mergeSliceRanges(
+                    ranges,
+                    for: file.id,
+                    into: &sliceRangesByFileID
+                )
             }
         }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
@@ -1250,9 +1250,9 @@ enum AgentContextExportResolver {
                 )
             }
         } else if codeMapUsage == .auto || codeMapUsage == .complete {
-            var seenPhysicalFiles = PromptContextPhysicalFileIdentitySet()
+            var seenAccountingIdentities = PromptContextAccountingIdentitySet()
             for rowEntry in rowEntries {
-                _ = seenPhysicalFiles.insert(rowEntry.entry)
+                _ = seenAccountingIdentities.insert(rowEntry.entry)
             }
             let rootsByID = Dictionary(uniqueKeysWithValues: roots.map { ($0.id, $0) })
             for rendered in codemapPresentation.orderedEntries {
@@ -1272,7 +1272,7 @@ enum AgentContextExportResolver {
                     canRemove: codeMapUsage == .auto,
                     removesAutomaticSourceIntent: codeMapUsage == .auto,
                     to: &rowEntries,
-                    seenPhysicalFiles: &seenPhysicalFiles
+                    seenAccountingIdentities: &seenAccountingIdentities
                 )
             }
         }
@@ -1711,7 +1711,7 @@ enum AgentContextExportResolver {
         var rows: [RowResolutionEntry] = []
         var missingPaths: [String] = []
         var invalidPaths: [String] = []
-        var seenPhysicalFiles = PromptContextPhysicalFileIdentitySet()
+        var seenAccountingIdentities = PromptContextAccountingIdentitySet()
         var selectedFileIDs = Set<UUID>()
 
         let selectedRequests = selection.selectedPaths.map {
@@ -1728,61 +1728,17 @@ enum AgentContextExportResolver {
             ]
         )
 
-        for path in selection.selectedPaths {
-            let result = await selectedLookupResult(
-                for: path,
-                batchedResults: selectedLookupResults,
-                store: store,
-                profile: profile,
-                rootScope: rootScope
-            )
-            guard let result else {
-                if await appendDirectoryRows(
-                    for: path,
-                    store: store,
-                    rootScope: rootScope,
-                    selectedFileIDs: &selectedFileIDs,
-                    rows: &rows,
-                    seenPhysicalFiles: &seenPhysicalFiles
-                ) {
-                    continue
-                }
-                missingPaths.append(path)
-                continue
-            }
-
-            if let file = result.file {
-                selectedFileIDs.insert(file.id)
-                let ranges = sliceRanges(for: path, file: file, location: result.location, in: selection.slices)
-                let entry = ResolvedPromptFileEntry(
-                    file: file,
-                    lineRanges: ranges,
-                    mode: (ranges?.isEmpty == false) ? .sliced : .fullFile,
-                    loadedContent: nil,
-                    rootFolderPath: result.location.rootPath
-                )
-                append(entry, canRemove: true, to: &rows, seenPhysicalFiles: &seenPhysicalFiles)
-            } else if let folder = result.folder {
-                let files = await store.files(inRoot: folder.rootID)
-                let prefix = folder.standardizedRelativePath
-                for file in files where prefix.isEmpty || file.standardizedRelativePath == prefix || file.standardizedRelativePath.hasPrefix(prefix + "/") {
-                    selectedFileIDs.insert(file.id)
-                    let entry = ResolvedPromptFileEntry(
-                        file: file,
-                        mode: .fullFile,
-                        loadedContent: nil,
-                        rootFolderPath: result.location.rootPath
-                    )
-                    append(entry, canRemove: false, to: &rows, seenPhysicalFiles: &seenPhysicalFiles)
-                }
-            } else {
-                invalidPaths.append(path)
+        var selectedPathResultsByPath = selectedLookupResults
+        for path in selection.selectedPaths where selectedPathResultsByPath[path] == nil {
+            if let result = await store.lookupPath(path, profile: profile, rootScope: rootScope) {
+                selectedPathResultsByPath[path] = result
             }
         }
+        let directlySelectedFileIDs = Set(selectedPathResultsByPath.values.compactMap { $0.file?.id })
 
-        let orderedSlicePaths = selection.slices.keys.sorted(by: utf8Precedes)
+        let orderedSlicePaths = StoredSelectionPathNormalization.orderedSlicePaths(selection.slices)
         let slicePaths = orderedSlicePaths.filter { path in
-            selection.slices[path]?.isEmpty == false && selectedLookupResults[path] == nil
+            selection.slices[path]?.isEmpty == false && selectedPathResultsByPath[path] == nil
         }
         let sliceLookupRequests = slicePaths.map {
             WorkspacePathLookupRequest(userPath: $0, profile: profile, rootScope: rootScope)
@@ -1801,9 +1757,83 @@ enum AgentContextExportResolver {
                 "resultCount": String(sliceLookupResults.count)
             ]
         )
+        var slicePathResults: [String: WorkspacePathLookupResult] = [:]
+        var sliceRangesByFileID: [UUID: [LineRange]] = [:]
         for path in orderedSlicePaths {
             guard let ranges = selection.slices[path], !ranges.isEmpty else { continue }
-            guard let result = selectedLookupResults[path] ?? sliceLookupResults[path] else {
+            let result: WorkspacePathLookupResult? = if let cached = selectedPathResultsByPath[path]
+                ?? sliceLookupResults[path]
+            {
+                cached
+            } else {
+                await store.lookupPath(path, profile: profile, rootScope: rootScope)
+            }
+            guard let result else { continue }
+            slicePathResults[path] = result
+            if let file = result.file, sliceRangesByFileID[file.id] == nil {
+                sliceRangesByFileID[file.id] = ranges
+            }
+        }
+
+        for path in selection.selectedPaths {
+            let result = selectedPathResultsByPath[path]
+            guard let result else {
+                if await appendDirectoryRows(
+                    for: path,
+                    store: store,
+                    rootScope: rootScope,
+                    directlySelectedFileIDs: directlySelectedFileIDs,
+                    sliceRangesByFileID: sliceRangesByFileID,
+                    selectedFileIDs: &selectedFileIDs,
+                    rows: &rows,
+                    seenAccountingIdentities: &seenAccountingIdentities
+                ) {
+                    continue
+                }
+                missingPaths.append(path)
+                continue
+            }
+
+            if let file = result.file {
+                selectedFileIDs.insert(file.id)
+                let ranges = sliceRangesByFileID[file.id]
+                let entry = ResolvedPromptFileEntry(
+                    file: file,
+                    lineRanges: ranges,
+                    mode: (ranges?.isEmpty == false) ? .sliced : .fullFile,
+                    loadedContent: nil,
+                    rootFolderPath: result.location.rootPath
+                )
+                append(entry, canRemove: true, to: &rows, seenAccountingIdentities: &seenAccountingIdentities)
+            } else if let folder = result.folder {
+                let files = await store.files(inRoot: folder.rootID)
+                let prefix = folder.standardizedRelativePath
+                for file in files where prefix.isEmpty || file.standardizedRelativePath == prefix || file.standardizedRelativePath.hasPrefix(prefix + "/") {
+                    guard !directlySelectedFileIDs.contains(file.id) else { continue }
+                    selectedFileIDs.insert(file.id)
+                    let ranges = sliceRangesByFileID[file.id]
+                    let entry = ResolvedPromptFileEntry(
+                        file: file,
+                        lineRanges: ranges,
+                        mode: (ranges?.isEmpty == false) ? .sliced : .fullFile,
+                        loadedContent: nil,
+                        rootFolderPath: result.location.rootPath
+                    )
+                    append(
+                        entry,
+                        canRemove: ranges?.isEmpty == false,
+                        to: &rows,
+                        seenAccountingIdentities: &seenAccountingIdentities
+                    )
+                }
+            } else {
+                invalidPaths.append(path)
+            }
+        }
+
+        for path in orderedSlicePaths {
+            guard selection.slices[path]?.isEmpty == false else { continue }
+            guard let result = slicePathResults[path] else {
                 missingPaths.append(path)
                 continue
             }
@@ -1811,7 +1841,9 @@ enum AgentContextExportResolver {
                 invalidPaths.append(path)
                 continue
             }
-            guard !selectedFileIDs.contains(file.id) else { continue }
+            guard !selectedFileIDs.contains(file.id),
+                  let ranges = sliceRangesByFileID[file.id]
+            else { continue }
             selectedFileIDs.insert(file.id)
             let entry = ResolvedPromptFileEntry(
                 file: file,
@@ -1820,7 +1852,7 @@ enum AgentContextExportResolver {
                 loadedContent: nil,
                 rootFolderPath: result.location.rootPath
             )
-            append(entry, canRemove: true, to: &rows, seenPhysicalFiles: &seenPhysicalFiles)
+            append(entry, canRemove: true, to: &rows, seenAccountingIdentities: &seenAccountingIdentities)
         }
 
         AgentSelectedFilesDiagnostics.durationEvent(
@@ -1959,9 +1991,11 @@ enum AgentContextExportResolver {
         for path: String,
         store: WorkspaceFileContextStore,
         rootScope: WorkspaceLookupRootScope,
+        directlySelectedFileIDs: Set<UUID>,
+        sliceRangesByFileID: [UUID: [LineRange]],
         selectedFileIDs: inout Set<UUID>,
         rows: inout [RowResolutionEntry],
-        seenPhysicalFiles: inout PromptContextPhysicalFileIdentitySet
+        seenAccountingIdentities: inout PromptContextAccountingIdentitySet
     ) async -> Bool {
         let roots = await store.rootRefs(scope: rootScope)
         var handled = false
@@ -1973,14 +2007,22 @@ enum AgentContextExportResolver {
             handled = true
             let files = await store.files(inRoot: root.id)
             for file in files where relativePrefix.isEmpty || file.standardizedRelativePath.hasPrefix(relativePrefix + "/") {
+                guard !directlySelectedFileIDs.contains(file.id) else { continue }
                 selectedFileIDs.insert(file.id)
+                let ranges = sliceRangesByFileID[file.id]
                 let entry = ResolvedPromptFileEntry(
                     file: file,
-                    mode: .fullFile,
+                    lineRanges: ranges,
+                    mode: (ranges?.isEmpty == false) ? .sliced : .fullFile,
                     loadedContent: nil,
                     rootFolderPath: root.standardizedFullPath
                 )
-                append(entry, canRemove: false, to: &rows, seenPhysicalFiles: &seenPhysicalFiles)
+                append(
+                    entry,
+                    canRemove: ranges?.isEmpty == false,
+                    to: &rows,
+                    seenAccountingIdentities: &seenAccountingIdentities
+                )
             }
         }
         return handled
@@ -1999,46 +2041,14 @@ enum AgentContextExportResolver {
         return StandardizedPath.relative(expanded)
     }
 
-    private static func selectedLookupResult(
-        for path: String,
-        batchedResults: [String: WorkspacePathLookupResult],
-        store: WorkspaceFileContextStore,
-        profile: PathLocateProfile,
-        rootScope: WorkspaceLookupRootScope
-    ) async -> WorkspacePathLookupResult? {
-        if let result = batchedResults[path] { return result }
-        return await store.lookupPath(path, profile: profile, rootScope: rootScope)
-    }
-
-    private static func sliceRanges(
-        for path: String,
-        file: WorkspaceFileRecord,
-        location: WorkspacePathLocation,
-        in slices: [String: [LineRange]]
-    ) -> [LineRange]? {
-        let candidateKeys = [
-            path,
-            StandardizedPath.absolute(path),
-            file.relativePath,
-            file.standardizedRelativePath,
-            file.fullPath,
-            file.standardizedFullPath,
-            location.absolutePath
-        ]
-        for key in candidateKeys {
-            if let ranges = slices[key] { return ranges }
-        }
-        return nil
-    }
-
     private static func append(
         _ entry: ResolvedPromptFileEntry,
         canRemove: Bool,
         removesAutomaticSourceIntent: Bool = false,
         to rows: inout [RowResolutionEntry],
-        seenPhysicalFiles: inout PromptContextPhysicalFileIdentitySet
+        seenAccountingIdentities: inout PromptContextAccountingIdentitySet
     ) {
-        guard seenPhysicalFiles.insert(entry) else { return }
+        guard seenAccountingIdentities.insert(entry) else { return }
         rows.append(RowResolutionEntry(
             entry: entry,
             canRemove: canRemove,

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -214,9 +214,10 @@ actor PromptContextAccountingService {
         filePathDisplay: FilePathDisplay,
         displayPathResolver: ((ResolvedPromptFileEntry) -> String?)? = nil
     ) async -> PromptContextEntryMetricsSnapshot {
-        guard !entries.isEmpty else { return .empty }
+        let uniqueEntries = uniquePhysicalEntries(entries)
+        guard !uniqueEntries.isEmpty else { return .empty }
 
-        let loadedEntries = await entriesLoadingContentIfNeeded(entries, store: store)
+        let loadedEntries = await entriesLoadingContentIfNeeded(uniqueEntries, store: store)
         let snapshots = makePromptFileEntrySnapshots(
             from: loadedEntries,
             codemapPresentation: codemapPresentation,
@@ -238,11 +239,12 @@ actor PromptContextAccountingService {
         resolvedContentEntries: [PromptContextResolvedContentMetricsEntry]
     ) async throws -> PromptContextEntryMetricsSnapshot {
         try checkResolvedContentCancellation()
-        guard !resolvedContentEntries.isEmpty else { return .empty }
+        let uniqueResolvedContentEntries = uniquePhysicalEntries(resolvedContentEntries)
+        guard !uniqueResolvedContentEntries.isEmpty else { return .empty }
 
         var loadedEntries: [ResolvedPromptFileEntry] = []
-        loadedEntries.reserveCapacity(resolvedContentEntries.count)
-        for input in resolvedContentEntries {
+        loadedEntries.reserveCapacity(uniqueResolvedContentEntries.count)
+        for input in uniqueResolvedContentEntries {
             try checkResolvedContentCancellation()
             guard let content = try await resolvedContentReader(input.location, .promptAccounting) else {
                 throw PromptContextResolvedContentAccountingError.contentUnavailable(input.location)
@@ -266,7 +268,7 @@ actor PromptContextAccountingService {
         }
         try checkResolvedContentCancellation()
         let displayPathsByFileID = Dictionary(
-            uniqueKeysWithValues: resolvedContentEntries.map { ($0.fileID, $0.renderedDisplayPath) }
+            uniqueKeysWithValues: uniqueResolvedContentEntries.map { ($0.fileID, $0.renderedDisplayPath) }
         )
         let snapshots = makePromptFileEntrySnapshots(
             from: loadedEntries,
@@ -379,7 +381,7 @@ actor PromptContextAccountingService {
         var entries: [ResolvedPromptFileEntry] = []
         var missingPaths: [String] = []
         var invalidPaths: [String] = []
-        var seenIDs = Set<ResolvedPromptFileEntryID>()
+        var seenPhysicalFiles = PromptContextPhysicalFileIdentitySet()
         var selectedFileIDs = Set<UUID>()
         let orderedSlicePaths = selection.slices.keys.sorted {
             let lhs = StoredSelectionPathNormalization.standardizedPath($0) ?? $0
@@ -798,7 +800,7 @@ actor PromptContextAccountingService {
                     loadedContent: content ?? nil,
                     rootFolderPath: result.location.rootPath
                 )
-                append(entry, to: &entries, seenIDs: &seenIDs)
+                append(entry, to: &entries, seenPhysicalFiles: &seenPhysicalFiles)
                 #if DEBUG
                     PromptTokenRecountDiagnostics.event(
                         "tokenRecount.accounting.resolveEntries.selectedPath.end",
@@ -882,7 +884,7 @@ actor PromptContextAccountingService {
                         loadedContent: content ?? nil,
                         rootFolderPath: result.location.rootPath
                     )
-                    append(entry, to: &entries, seenIDs: &seenIDs)
+                    append(entry, to: &entries, seenPhysicalFiles: &seenPhysicalFiles)
                 }
                 #if DEBUG
                     PromptTokenRecountDiagnostics.event(
@@ -962,7 +964,7 @@ actor PromptContextAccountingService {
                 continue
             }
             let entry = ResolvedPromptFileEntry(file: file, lineRanges: ranges, mode: .sliced, loadedContent: content ?? nil, rootFolderPath: result.location.rootPath)
-            append(entry, to: &entries, seenIDs: &seenIDs)
+            append(entry, to: &entries, seenPhysicalFiles: &seenPhysicalFiles)
         }
 
         #if DEBUG
@@ -1002,7 +1004,7 @@ actor PromptContextAccountingService {
                     loadedContent: nil,
                     rootFolderPath: rootsByID[file.rootID]?.fullPath
                 )
-                append(entry, to: &entries, seenIDs: &seenIDs)
+                append(entry, to: &entries, seenPhysicalFiles: &seenPhysicalFiles)
             }
         }
 
@@ -1184,8 +1186,31 @@ actor PromptContextAccountingService {
         return nil
     }
 
-    private func append(_ entry: ResolvedPromptFileEntry, to entries: inout [ResolvedPromptFileEntry], seenIDs: inout Set<ResolvedPromptFileEntryID>) {
-        guard seenIDs.insert(entry.id).inserted else { return }
+    private nonisolated func uniquePhysicalEntries(
+        _ entries: [ResolvedPromptFileEntry]
+    ) -> [ResolvedPromptFileEntry] {
+        var identities = PromptContextPhysicalFileIdentitySet()
+        return entries.filter { identities.insert($0) }
+    }
+
+    private nonisolated func uniquePhysicalEntries(
+        _ entries: [PromptContextResolvedContentMetricsEntry]
+    ) -> [PromptContextResolvedContentMetricsEntry] {
+        var identities = PromptContextPhysicalFileIdentitySet()
+        return entries.filter { entry in
+            identities.insert(
+                fileID: entry.fileID,
+                standardizedFullPath: StandardizedPath.absolute(entry.location.resolvedFileURL.path)
+            )
+        }
+    }
+
+    private func append(
+        _ entry: ResolvedPromptFileEntry,
+        to entries: inout [ResolvedPromptFileEntry],
+        seenPhysicalFiles: inout PromptContextPhysicalFileIdentitySet
+    ) {
+        guard seenPhysicalFiles.insert(entry) else { return }
         entries.append(entry)
     }
 }

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -508,9 +508,11 @@ actor PromptContextAccountingService {
             guard let result else { continue }
             slicePathResults[path] = result
             if let file = result.file {
-                var mergedRanges = sliceRangesByFileID[file.id, default: []]
-                mergedRanges.append(contentsOf: ranges)
-                sliceRangesByFileID[file.id] = SliceRangeMath.normalize(mergedRanges)
+                StoredSelectionPathNormalization.mergeSliceRanges(
+                    ranges,
+                    for: file.id,
+                    into: &sliceRangesByFileID
+                )
             }
         }
 

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -507,8 +507,10 @@ actor PromptContextAccountingService {
             }
             guard let result else { continue }
             slicePathResults[path] = result
-            if let file = result.file, sliceRangesByFileID[file.id] == nil {
-                sliceRangesByFileID[file.id] = ranges
+            if let file = result.file {
+                var mergedRanges = sliceRangesByFileID[file.id, default: []]
+                mergedRanges.append(contentsOf: ranges)
+                sliceRangesByFileID[file.id] = SliceRangeMath.normalize(mergedRanges)
             }
         }
 

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -381,14 +381,9 @@ actor PromptContextAccountingService {
         var entries: [ResolvedPromptFileEntry] = []
         var missingPaths: [String] = []
         var invalidPaths: [String] = []
-        var seenPhysicalFiles = PromptContextPhysicalFileIdentitySet()
+        var seenAccountingIdentities = PromptContextAccountingIdentitySet()
         var selectedFileIDs = Set<UUID>()
-        let orderedSlicePaths = selection.slices.keys.sorted {
-            let lhs = StoredSelectionPathNormalization.standardizedPath($0) ?? $0
-            let rhs = StoredSelectionPathNormalization.standardizedPath($1) ?? $1
-            if lhs != rhs { return lhs.utf8.lexicographicallyPrecedes(rhs.utf8) }
-            return $0.utf8.lexicographicallyPrecedes($1.utf8)
-        }
+        let orderedSlicePaths = StoredSelectionPathNormalization.orderedSlicePaths(selection.slices)
 
         #if DEBUG
             let selectedPathsStartMS = PromptTokenRecountDiagnostics.start()
@@ -457,6 +452,7 @@ actor PromptContextAccountingService {
             )
         #endif
         var selectedPathResultsByIndex: [Int: WorkspacePathLookupResult] = [:]
+        var selectedPathResultsByPath: [String: WorkspacePathLookupResult] = [:]
         var selectedPathFallbackLookups = 0
         for (selectedPathIndex, path) in selection.selectedPaths.enumerated() {
             guard !Task.isCancelled else {
@@ -464,8 +460,17 @@ actor PromptContextAccountingService {
             }
             if let result = selectedPathLookupResults[path] {
                 selectedPathResultsByIndex[selectedPathIndex] = result
+                selectedPathResultsByPath[path] = result
             } else if let result = await store.lookupPath(path, profile: profile, rootScope: rootScope) {
                 selectedPathResultsByIndex[selectedPathIndex] = result
+                selectedPathResultsByPath[path] = result
+                selectedPathFallbackLookups += 1
+            } else if let result = await store.lookupDiscoverableCatalogPathForExactAbsoluteSearchScope(
+                path,
+                rootScope: rootScope
+            ) {
+                selectedPathResultsByIndex[selectedPathIndex] = result
+                selectedPathResultsByPath[path] = result
                 selectedPathFallbackLookups += 1
             }
         }
@@ -480,6 +485,32 @@ actor PromptContextAccountingService {
                 )
             }
         #endif
+
+        let directlySelectedFileIDs = Set(selectedPathResultsByIndex.values.compactMap { $0.file?.id })
+        let sliceLookupRequests = orderedSlicePaths.compactMap { path -> WorkspacePathLookupRequest? in
+            guard selection.slices[path]?.isEmpty == false, selectedPathResultsByPath[path] == nil else {
+                return nil
+            }
+            return WorkspacePathLookupRequest(userPath: path, profile: profile, rootScope: rootScope)
+        }
+        let sliceLookupResults = await store.lookupPaths(sliceLookupRequests)
+        var slicePathResults: [String: WorkspacePathLookupResult] = [:]
+        var sliceRangesByFileID: [UUID: [LineRange]] = [:]
+        for path in orderedSlicePaths {
+            guard let ranges = selection.slices[path], !ranges.isEmpty else { continue }
+            let result: WorkspacePathLookupResult? = if let cached = selectedPathResultsByPath[path]
+                ?? sliceLookupResults[path]
+            {
+                cached
+            } else {
+                await store.lookupPath(path, profile: profile, rootScope: rootScope)
+            }
+            guard let result else { continue }
+            slicePathResults[path] = result
+            if let file = result.file, sliceRangesByFileID[file.id] == nil {
+                sliceRangesByFileID[file.id] = ranges
+            }
+        }
 
         var operationSourceFileIDs: [UUID] = []
         var seenOperationSourceFileIDs = Set<UUID>()
@@ -501,7 +532,7 @@ actor PromptContextAccountingService {
             }
         }
         for path in orderedSlicePaths {
-            if let file = await store.lookupPath(path, profile: profile, rootScope: rootScope)?.file {
+            if let file = slicePathResults[path]?.file {
                 appendOperationSource(file)
             }
         }
@@ -781,7 +812,7 @@ actor PromptContextAccountingService {
                     selectedPathsDebugState.beginAssembly(index: selectedPathIndex, path: path, resolvedKind: "file")
                 #endif
                 selectedFileIDs.insert(file.id)
-                let ranges = sliceRanges(for: path, file: file, location: result.location, in: selection.slices)
+                let ranges = sliceRangesByFileID[file.id]
                 let useSelectedCodemap = codeMapUsage == .selected && codemapPresentation.renderedEntriesByFileID[file.id] != nil
                 let content = useSelectedCodemap ? nil : selectedFileReadResults[selectedPathIndex]?.content
                 if codeMapUsage == .selected,
@@ -800,7 +831,7 @@ actor PromptContextAccountingService {
                     loadedContent: content ?? nil,
                     rootFolderPath: result.location.rootPath
                 )
-                append(entry, to: &entries, seenPhysicalFiles: &seenPhysicalFiles)
+                append(entry, to: &entries, seenAccountingIdentities: &seenAccountingIdentities)
                 #if DEBUG
                     PromptTokenRecountDiagnostics.event(
                         "tokenRecount.accounting.resolveEntries.selectedPath.end",
@@ -830,7 +861,9 @@ actor PromptContextAccountingService {
                     guard !Task.isCancelled else {
                         return PromptContextEntryResolution(entries: entries, missingPaths: missingPaths, invalidPaths: invalidPaths, codemapPresentation: codemapPresentation)
                     }
+                    guard !directlySelectedFileIDs.contains(file.id) else { continue }
                     selectedFileIDs.insert(file.id)
+                    let ranges = sliceRangesByFileID[file.id]
                     let useSelectedCodemap = codeMapUsage == .selected && codemapPresentation.renderedEntriesByFileID[file.id] != nil
                     let content: String?
                     if useSelectedCodemap {
@@ -880,11 +913,12 @@ actor PromptContextAccountingService {
                     let entry = ResolvedPromptFileEntry(
                         file: file,
                         isCodemap: useSelectedCodemap,
-                        mode: useSelectedCodemap ? .codemap : .fullFile,
+                        lineRanges: useSelectedCodemap ? nil : ranges,
+                        mode: useSelectedCodemap ? .codemap : ((ranges?.isEmpty == false) ? .sliced : .fullFile),
                         loadedContent: content ?? nil,
                         rootFolderPath: result.location.rootPath
                     )
-                    append(entry, to: &entries, seenPhysicalFiles: &seenPhysicalFiles)
+                    append(entry, to: &entries, seenAccountingIdentities: &seenAccountingIdentities)
                 }
                 #if DEBUG
                     PromptTokenRecountDiagnostics.event(
@@ -929,11 +963,11 @@ actor PromptContextAccountingService {
             )
         #endif
         for path in orderedSlicePaths {
-            guard let ranges = selection.slices[path] else { continue }
+            guard selection.slices[path]?.isEmpty == false else { continue }
             guard !Task.isCancelled else {
                 return PromptContextEntryResolution(entries: entries, missingPaths: missingPaths, invalidPaths: invalidPaths, codemapPresentation: codemapPresentation)
             }
-            guard let result = await store.lookupPath(path, profile: profile, rootScope: rootScope) else {
+            guard let result = slicePathResults[path] else {
                 missingPaths.append(path)
                 continue
             }
@@ -941,7 +975,9 @@ actor PromptContextAccountingService {
                 invalidPaths.append(path)
                 continue
             }
-            guard !selectedFileIDs.contains(file.id) else { continue }
+            guard !selectedFileIDs.contains(file.id),
+                  let ranges = sliceRangesByFileID[file.id]
+            else { continue }
             selectedFileIDs.insert(file.id)
             let content: String? = switch contentPolicy {
             case .loadContent:
@@ -964,7 +1000,7 @@ actor PromptContextAccountingService {
                 continue
             }
             let entry = ResolvedPromptFileEntry(file: file, lineRanges: ranges, mode: .sliced, loadedContent: content ?? nil, rootFolderPath: result.location.rootPath)
-            append(entry, to: &entries, seenPhysicalFiles: &seenPhysicalFiles)
+            append(entry, to: &entries, seenAccountingIdentities: &seenAccountingIdentities)
         }
 
         #if DEBUG
@@ -1004,7 +1040,7 @@ actor PromptContextAccountingService {
                     loadedContent: nil,
                     rootFolderPath: rootsByID[file.rootID]?.fullPath
                 )
-                append(entry, to: &entries, seenPhysicalFiles: &seenPhysicalFiles)
+                append(entry, to: &entries, seenAccountingIdentities: &seenAccountingIdentities)
             }
         }
 
@@ -1170,33 +1206,17 @@ actor PromptContextAccountingService {
         return entry.file.fullPath
     }
 
-    private nonisolated func sliceRanges(for path: String, file: WorkspaceFileRecord, location: WorkspacePathLocation, in slices: [String: [LineRange]]) -> [LineRange]? {
-        let candidateKeys = [
-            path,
-            StandardizedPath.absolute(path),
-            file.relativePath,
-            file.standardizedRelativePath,
-            file.fullPath,
-            file.standardizedFullPath,
-            location.absolutePath
-        ]
-        for key in candidateKeys {
-            if let ranges = slices[key] { return ranges }
-        }
-        return nil
-    }
-
     private nonisolated func uniquePhysicalEntries(
         _ entries: [ResolvedPromptFileEntry]
     ) -> [ResolvedPromptFileEntry] {
-        var identities = PromptContextPhysicalFileIdentitySet()
+        var identities = PromptContextAccountingIdentitySet()
         return entries.filter { identities.insert($0) }
     }
 
     private nonisolated func uniquePhysicalEntries(
         _ entries: [PromptContextResolvedContentMetricsEntry]
     ) -> [PromptContextResolvedContentMetricsEntry] {
-        var identities = PromptContextPhysicalFileIdentitySet()
+        var identities = PromptContextAccountingIdentitySet()
         return entries.filter { entry in
             identities.insert(
                 fileID: entry.fileID,
@@ -1208,9 +1228,9 @@ actor PromptContextAccountingService {
     private func append(
         _ entry: ResolvedPromptFileEntry,
         to entries: inout [ResolvedPromptFileEntry],
-        seenPhysicalFiles: inout PromptContextPhysicalFileIdentitySet
+        seenAccountingIdentities: inout PromptContextAccountingIdentitySet
     ) {
-        guard seenPhysicalFiles.insert(entry) else { return }
+        guard seenAccountingIdentities.insert(entry) else { return }
         entries.append(entry)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Utilities/WorkspacePathNormalizations.swift
+++ b/Sources/RepoPrompt/Infrastructure/Utilities/WorkspacePathNormalizations.swift
@@ -30,6 +30,23 @@ enum StoredSelectionPathNormalization {
         }
     }
 
+    static func mergeSliceRanges(
+        _ ranges: [LineRange],
+        for fileID: UUID,
+        into rangesByFileID: inout [UUID: [LineRange]]
+    ) {
+        guard var mergedRanges = rangesByFileID[fileID] else {
+            rangesByFileID[fileID] = ranges
+            return
+        }
+        mergedRanges.append(contentsOf: ranges)
+        let normalizedRanges = SliceRangeMath.normalize(mergedRanges)
+        // Empty line ranges mean full-file content downstream. Preserve the prior
+        // nonempty value if malformed decoded ranges normalize away entirely.
+        guard !normalizedRanges.isEmpty else { return }
+        rangesByFileID[fileID] = normalizedRanges
+    }
+
     static func standardizedSlices(_ slices: [String: [LineRange]]) -> [String: [LineRange]] {
         guard !slices.isEmpty else { return [:] }
 

--- a/Sources/RepoPrompt/Infrastructure/Utilities/WorkspacePathNormalizations.swift
+++ b/Sources/RepoPrompt/Infrastructure/Utilities/WorkspacePathNormalizations.swift
@@ -21,6 +21,15 @@ enum StoredSelectionPathNormalization {
         return result
     }
 
+    static func orderedSlicePaths(_ slices: [String: [LineRange]]) -> [String] {
+        slices.keys.sorted {
+            let lhs = standardizedPath($0) ?? $0
+            let rhs = standardizedPath($1) ?? $1
+            if lhs != rhs { return lhs.utf8.lexicographicallyPrecedes(rhs.utf8) }
+            return $0.utf8.lexicographicallyPrecedes($1.utf8)
+        }
+    }
+
     static func standardizedSlices(_ slices: [String: [LineRange]]) -> [String: [LineRange]] {
         guard !slices.isEmpty else { return [:] }
 

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/PromptContextEntryMetrics.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/PromptContextEntryMetrics.swift
@@ -1,8 +1,10 @@
 import Foundation
+import OSLog
 
-/// Maintains the one-to-one file-ID/path identity required by prompt accounting.
-/// The first accepted entry wins; later collisions on either key are rejected.
-struct PromptContextPhysicalFileIdentitySet {
+/// Tracks prompt-accounting record identity by model UUID and standardized path string.
+/// This is not filesystem inode or symlink identity. The first accepted record wins;
+/// later collisions on either key are rejected so both metric indexes stay coherent.
+struct PromptContextAccountingIdentitySet {
     private var fileIDs = Set<UUID>()
     private var standardizedFullPaths = Set<String>()
 
@@ -35,6 +37,15 @@ struct PromptContextEntryMetric: Equatable {
 }
 
 struct PromptContextEntryMetricsSnapshot: Equatable {
+    #if DEBUG
+        private static let identityLogger = Logger(
+            subsystem: "com.repoprompt.prompt",
+            category: "ContextAccountingIdentity"
+        )
+    #endif
+
+    /// Authoritative total from the rendered selected-file payload. Defensive metric filtering
+    /// never recomputes this denominator when it rejects a conflicting per-file index record.
     let totalSelectedDisplayTokens: Int
     let metricsByFileID: [UUID: PromptContextEntryMetric]
     let metricsByStandardizedFullPath: [String: PromptContextEntryMetric]
@@ -48,13 +59,21 @@ struct PromptContextEntryMetricsSnapshot: Equatable {
     init(totalSelectedDisplayTokens: Int, metrics: [PromptContextEntryMetric]) {
         self.totalSelectedDisplayTokens = totalSelectedDisplayTokens
 
-        var identities = PromptContextPhysicalFileIdentitySet()
+        var identities = PromptContextAccountingIdentitySet()
         var metricsByFileID: [UUID: PromptContextEntryMetric] = [:]
         var metricsByStandardizedFullPath: [String: PromptContextEntryMetric] = [:]
-        for metric in metrics where identities.insert(
-            fileID: metric.fileID,
-            standardizedFullPath: metric.standardizedFullPath
-        ) {
+        for metric in metrics {
+            guard identities.insert(
+                fileID: metric.fileID,
+                standardizedFullPath: metric.standardizedFullPath
+            ) else {
+                #if DEBUG
+                    Self.identityLogger.fault(
+                        "Dropped conflicting per-file metric while preserving authoritative totalSelectedDisplayTokens=\(totalSelectedDisplayTokens, privacy: .public)"
+                    )
+                #endif
+                continue
+            }
             metricsByFileID[metric.fileID] = metric
             metricsByStandardizedFullPath[metric.standardizedFullPath] = metric
         }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/PromptContextEntryMetrics.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/PromptContextEntryMetrics.swift
@@ -1,5 +1,29 @@
 import Foundation
 
+/// Maintains the one-to-one file-ID/path identity required by prompt accounting.
+/// The first accepted entry wins; later collisions on either key are rejected.
+struct PromptContextPhysicalFileIdentitySet {
+    private var fileIDs = Set<UUID>()
+    private var standardizedFullPaths = Set<String>()
+
+    mutating func insert(fileID: UUID, standardizedFullPath: String) -> Bool {
+        guard !fileIDs.contains(fileID),
+              !standardizedFullPaths.contains(standardizedFullPath)
+        else { return false }
+
+        fileIDs.insert(fileID)
+        standardizedFullPaths.insert(standardizedFullPath)
+        return true
+    }
+
+    mutating func insert(_ entry: ResolvedPromptFileEntry) -> Bool {
+        insert(
+            fileID: entry.file.id,
+            standardizedFullPath: entry.file.standardizedFullPath
+        )
+    }
+}
+
 struct PromptContextEntryMetric: Equatable {
     let fileID: UUID
     let standardizedFullPath: String
@@ -23,12 +47,19 @@ struct PromptContextEntryMetricsSnapshot: Equatable {
 
     init(totalSelectedDisplayTokens: Int, metrics: [PromptContextEntryMetric]) {
         self.totalSelectedDisplayTokens = totalSelectedDisplayTokens
-        metricsByFileID = Dictionary(
-            uniqueKeysWithValues: metrics.map { ($0.fileID, $0) }
-        )
-        metricsByStandardizedFullPath = Dictionary(
-            uniqueKeysWithValues: metrics.map { ($0.standardizedFullPath, $0) }
-        )
+
+        var identities = PromptContextPhysicalFileIdentitySet()
+        var metricsByFileID: [UUID: PromptContextEntryMetric] = [:]
+        var metricsByStandardizedFullPath: [String: PromptContextEntryMetric] = [:]
+        for metric in metrics where identities.insert(
+            fileID: metric.fileID,
+            standardizedFullPath: metric.standardizedFullPath
+        ) {
+            metricsByFileID[metric.fileID] = metric
+            metricsByStandardizedFullPath[metric.standardizedFullPath] = metric
+        }
+        self.metricsByFileID = metricsByFileID
+        self.metricsByStandardizedFullPath = metricsByStandardizedFullPath
     }
 
     private init(

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -1740,6 +1740,46 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertEqual(targetRow.metrics.knownValues?.tokenCount, TokenCalculationService.estimateTokens(for: renderedSlice))
     }
 
+    func testRowsMergeSliceRangesForAliasesOfSameFile() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportSliceAliases")
+        let targetURL = root.appendingPathComponent("Target.swift")
+        try write("one\ntwo\nthree\nfour\n", to: targetURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let aliasPath = root.path + "/./Target.swift"
+        let ranges = [
+            LineRange(start: 1, end: 1),
+            LineRange(start: 4, end: 4)
+        ]
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: AgentContextExportSource(
+                tabID: UUID(),
+                promptText: "Review slice aliases",
+                selection: StoredSelection(
+                    slices: [
+                        targetURL.path: [ranges[0]],
+                        aliasPath: [ranges[1]]
+                    ],
+                    codemapAutoEnabled: false
+                ),
+                selectedMetaPromptIDs: [],
+                tabName: "Slice Aliases",
+                activeAgentSessionID: nil,
+                worktreeBindings: []
+            ),
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+
+        XCTAssertEqual(model.rows.count, 1)
+        let row = try XCTUnwrap(model.rows.first)
+        XCTAssertEqual(row.kind, .slices)
+        XCTAssertEqual(row.lineRanges, ranges)
+        XCTAssertTrue(row.canRemove)
+    }
+
     @MainActor
     func testSourceBuilderUsesRequestedInactiveTabInsteadOfActiveSnapshot() {
         let requestedTabID = UUID()

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -1683,8 +1683,8 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertTrue(model.rows.allSatisfy { !$0.canRemove })
     }
 
-    func testRowsAndMetricsUseOnePhysicalIdentityForDirectSliceAndContainingFolder() async throws {
-        let root = try makeTemporaryRoot(name: "AgentExportPhysicalIdentity")
+    func testRowsAndMetricsPreserveExplicitSliceRegardlessOfContainingFolderOrder() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportAccountingIdentity")
         let sources = root.appendingPathComponent("Sources")
         let targetURL = sources.appendingPathComponent("Target.swift")
         let otherURL = sources.appendingPathComponent("Other.swift")
@@ -1696,40 +1696,47 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         let store = WorkspaceFileContextStore()
         _ = try await store.loadRoot(path: root.path)
         let sliceRange = LineRange(start: 2, end: 2)
-        let source = AgentContextExportSource(
-            tabID: UUID(),
-            promptText: "Review physical identity",
-            selection: StoredSelection(
-                selectedPaths: [targetURL.path, sources.path],
-                slices: [targetURL.path: [sliceRange]],
-                codemapAutoEnabled: false
-            ),
-            selectedMetaPromptIDs: [],
-            tabName: "Physical Identity",
-            activeAgentSessionID: nil,
-            worktreeBindings: []
-        )
 
-        let model = try await AgentContextExportResolver.resolveModel(
-            source: source,
-            store: store,
-            filePathDisplay: .relative,
-            codeMapUsage: .none
-        )
+        func resolve(selectedPaths: [String]) async throws -> AgentContextExportModel {
+            try await AgentContextExportResolver.resolveModel(
+                source: AgentContextExportSource(
+                    tabID: UUID(),
+                    promptText: "Review accounting identity",
+                    selection: StoredSelection(
+                        selectedPaths: selectedPaths,
+                        slices: [targetURL.path: [sliceRange]],
+                        codemapAutoEnabled: false
+                    ),
+                    selectedMetaPromptIDs: [],
+                    tabName: "Accounting Identity",
+                    activeAgentSessionID: nil,
+                    worktreeBindings: []
+                ),
+                store: store,
+                filePathDisplay: .relative,
+                codeMapUsage: .none
+            )
+        }
 
-        XCTAssertEqual(model.rows.count, 2)
-        XCTAssertEqual(Set(model.rows.map(\.id.fileID)).count, 2)
-        XCTAssertEqual(Set(model.rows.map(\.physicalPath)).count, 2)
-        let targetRow = try XCTUnwrap(model.rows.first {
+        let directFirst = try await resolve(selectedPaths: [targetURL.path, sources.path])
+        let folderFirst = try await resolve(selectedPaths: [sources.path, targetURL.path])
+
+        XCTAssertEqual(folderFirst.rows, directFirst.rows)
+        XCTAssertEqual(folderFirst.totalSelectedDisplayTokens, directFirst.totalSelectedDisplayTokens)
+        XCTAssertEqual(folderFirst.rows.count, 2)
+        XCTAssertEqual(Set(folderFirst.rows.map(\.id.fileID)).count, 2)
+        XCTAssertEqual(Set(folderFirst.rows.map(\.physicalPath)).count, 2)
+        let targetRow = try XCTUnwrap(folderFirst.rows.first {
             $0.physicalPath == targetURL.standardizedFileURL.path
         })
         XCTAssertEqual(targetRow.kind, .slices)
         XCTAssertEqual(targetRow.lineRanges, [sliceRange])
+        XCTAssertTrue(targetRow.canRemove)
 
         let renderedSlice = SliceAssemblyBuilder.build(from: targetContent, ranges: [sliceRange]).combinedText
         let expectedTotal = TokenCalculationService.estimateTokens(for: renderedSlice)
             + TokenCalculationService.estimateTokens(for: otherContent)
-        XCTAssertEqual(model.totalSelectedDisplayTokens, expectedTotal)
+        XCTAssertEqual(folderFirst.totalSelectedDisplayTokens, expectedTotal)
         XCTAssertEqual(targetRow.metrics.knownValues?.tokenCount, TokenCalculationService.estimateTokens(for: renderedSlice))
     }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -1683,6 +1683,56 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertTrue(model.rows.allSatisfy { !$0.canRemove })
     }
 
+    func testRowsAndMetricsUseOnePhysicalIdentityForDirectSliceAndContainingFolder() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportPhysicalIdentity")
+        let sources = root.appendingPathComponent("Sources")
+        let targetURL = sources.appendingPathComponent("Target.swift")
+        let otherURL = sources.appendingPathComponent("Other.swift")
+        let targetContent = "skip\nselected line\nskip\n"
+        let otherContent = "let other = true\n"
+        try write(targetContent, to: targetURL)
+        try write(otherContent, to: otherURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let sliceRange = LineRange(start: 2, end: 2)
+        let source = AgentContextExportSource(
+            tabID: UUID(),
+            promptText: "Review physical identity",
+            selection: StoredSelection(
+                selectedPaths: [targetURL.path, sources.path],
+                slices: [targetURL.path: [sliceRange]],
+                codemapAutoEnabled: false
+            ),
+            selectedMetaPromptIDs: [],
+            tabName: "Physical Identity",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+
+        XCTAssertEqual(model.rows.count, 2)
+        XCTAssertEqual(Set(model.rows.map(\.id.fileID)).count, 2)
+        XCTAssertEqual(Set(model.rows.map(\.physicalPath)).count, 2)
+        let targetRow = try XCTUnwrap(model.rows.first {
+            $0.physicalPath == targetURL.standardizedFileURL.path
+        })
+        XCTAssertEqual(targetRow.kind, .slices)
+        XCTAssertEqual(targetRow.lineRanges, [sliceRange])
+
+        let renderedSlice = SliceAssemblyBuilder.build(from: targetContent, ranges: [sliceRange]).combinedText
+        let expectedTotal = TokenCalculationService.estimateTokens(for: renderedSlice)
+            + TokenCalculationService.estimateTokens(for: otherContent)
+        XCTAssertEqual(model.totalSelectedDisplayTokens, expectedTotal)
+        XCTAssertEqual(targetRow.metrics.knownValues?.tokenCount, TokenCalculationService.estimateTokens(for: renderedSlice))
+    }
+
     @MainActor
     func testSourceBuilderUsesRequestedInactiveTabInsteadOfActiveSnapshot() {
         let requestedTabID = UUID()

--- a/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
@@ -201,6 +201,53 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         XCTAssertEqual(folderSnapshot.totalSelectedDisplayTokens, expectedTotal)
     }
 
+    func testResolutionMergesSliceRangesForAliasesOfSameFile() async throws {
+        let root = try makeTemporaryRoot(name: "AccountingSliceAliases")
+        let targetURL = root.appendingPathComponent("Target.swift")
+        let content = "one\ntwo\nthree\nfour\n"
+        try write(content, to: targetURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let service = PromptContextAccountingService()
+        let aliasPath = root.path + "/./Target.swift"
+        let ranges = [
+            LineRange(start: 1, end: 1),
+            LineRange(start: 4, end: 4)
+        ]
+
+        let resolution = await service.resolveEntries(
+            selection: StoredSelection(
+                slices: [
+                    targetURL.path: [ranges[0]],
+                    aliasPath: [ranges[1]]
+                ],
+                codemapAutoEnabled: false
+            ),
+            store: store,
+            codeMapUsage: .none
+        )
+
+        XCTAssertEqual(resolution.missingPaths, [])
+        XCTAssertEqual(resolution.invalidPaths, [])
+        XCTAssertEqual(resolution.entries.count, 1)
+        let entry = try XCTUnwrap(resolution.entries.first)
+        XCTAssertEqual(entry.mode, .sliced)
+        XCTAssertEqual(entry.lineRanges, ranges)
+
+        let snapshot = await service.calculateEntryMetricsSnapshot(
+            entries: resolution.entries,
+            store: store,
+            codemapPresentation: .empty,
+            filePathDisplay: .relative
+        )
+        let renderedSlice = SliceAssemblyBuilder.build(from: content, ranges: ranges).combinedText
+        XCTAssertEqual(
+            snapshot.totalSelectedDisplayTokens,
+            TokenCalculationService.estimateTokens(for: renderedSlice)
+        )
+    }
+
     func testEntryMetricsAccountingKeepsFirstSliceForDuplicatePhysicalFile() async throws {
         let root = try makeTemporaryRoot(name: "AccountingPhysicalIdentitySliceFirst")
         let targetURL = root.appendingPathComponent("Target.swift")

--- a/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
@@ -140,6 +140,67 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         XCTAssertEqual(resolution.invalidPaths, [])
     }
 
+    func testResolutionAndAccountingPreserveExplicitSliceRegardlessOfContainingFolderOrder() async throws {
+        let root = try makeTemporaryRoot(name: "AccountingFolderSlicePrecedence")
+        let targetURL = root.appendingPathComponent("Target.swift")
+        let otherURL = root.appendingPathComponent("Other.swift")
+        let targetContent = "skip\nselected line\nskip\n"
+        let otherContent = "let other = true\n"
+        try write(targetContent, to: targetURL)
+        try write(otherContent, to: otherURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let service = PromptContextAccountingService()
+        let sliceRange = LineRange(start: 2, end: 2)
+
+        func resolve(selectedPaths: [String]) async -> PromptContextEntryResolution {
+            await service.resolveEntries(
+                selection: StoredSelection(
+                    selectedPaths: selectedPaths,
+                    slices: [targetURL.path: [sliceRange]],
+                    codemapAutoEnabled: false
+                ),
+                store: store,
+                codeMapUsage: .none
+            )
+        }
+
+        let directFirst = await resolve(selectedPaths: [targetURL.path, root.path])
+        let folderFirst = await resolve(selectedPaths: [root.path, targetURL.path])
+
+        XCTAssertEqual(folderFirst.missingPaths, [])
+        XCTAssertEqual(folderFirst.invalidPaths, [])
+        XCTAssertEqual(folderFirst.entries.count, 2)
+        let directEntriesByID = Dictionary(uniqueKeysWithValues: directFirst.entries.map { ($0.file.id, $0) })
+        let folderEntriesByID = Dictionary(uniqueKeysWithValues: folderFirst.entries.map { ($0.file.id, $0) })
+        XCTAssertEqual(folderEntriesByID, directEntriesByID)
+        let targetEntry = try XCTUnwrap(folderFirst.entries.first {
+            $0.file.standardizedFullPath == targetURL.standardizedFileURL.path
+        })
+        XCTAssertEqual(targetEntry.mode, .sliced)
+        XCTAssertEqual(targetEntry.lineRanges, [sliceRange])
+
+        let directSnapshot = await service.calculateEntryMetricsSnapshot(
+            entries: directFirst.entries,
+            store: store,
+            codemapPresentation: .empty,
+            filePathDisplay: .relative
+        )
+        let folderSnapshot = await service.calculateEntryMetricsSnapshot(
+            entries: folderFirst.entries,
+            store: store,
+            codemapPresentation: .empty,
+            filePathDisplay: .relative
+        )
+        XCTAssertEqual(folderSnapshot, directSnapshot)
+
+        let renderedSlice = SliceAssemblyBuilder.build(from: targetContent, ranges: [sliceRange]).combinedText
+        let expectedTotal = TokenCalculationService.estimateTokens(for: renderedSlice)
+            + TokenCalculationService.estimateTokens(for: otherContent)
+        XCTAssertEqual(folderSnapshot.totalSelectedDisplayTokens, expectedTotal)
+    }
+
     func testEntryMetricsAccountingKeepsFirstSliceForDuplicatePhysicalFile() async throws {
         let root = try makeTemporaryRoot(name: "AccountingPhysicalIdentitySliceFirst")
         let targetURL = root.appendingPathComponent("Target.swift")
@@ -582,6 +643,7 @@ final class PromptContextAccountingServiceTests: XCTestCase {
             metrics: [first, duplicateID, duplicatePath]
         )
 
+        XCTAssertEqual(snapshot.totalSelectedDisplayTokens, 10)
         XCTAssertEqual(snapshot.metricsByFileID, [firstID: first])
         XCTAssertEqual(snapshot.metricsByStandardizedFullPath, [firstPath: first])
         XCTAssertNil(snapshot.metric(forFileID: otherID))

--- a/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
@@ -140,6 +140,90 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         XCTAssertEqual(resolution.invalidPaths, [])
     }
 
+    func testEntryMetricsAccountingKeepsFirstSliceForDuplicatePhysicalFile() async throws {
+        let root = try makeTemporaryRoot(name: "AccountingPhysicalIdentitySliceFirst")
+        let targetURL = root.appendingPathComponent("Target.swift")
+        let content = "skip\nselected line\nskip\n"
+        try write(content, to: targetURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let lookup = await store.lookupPath(targetURL.path)
+        let file = try XCTUnwrap(lookup?.file)
+        let sliceRange = LineRange(start: 2, end: 2)
+        let sliceEntry = ResolvedPromptFileEntry(
+            file: file,
+            lineRanges: [sliceRange],
+            mode: .sliced,
+            loadedContent: content,
+            rootFolderPath: root.path
+        )
+        let fullEntry = ResolvedPromptFileEntry(
+            file: file,
+            mode: .fullFile,
+            loadedContent: content,
+            rootFolderPath: root.path
+        )
+
+        let snapshot = await PromptContextAccountingService().calculateEntryMetricsSnapshot(
+            entries: [sliceEntry, fullEntry],
+            store: store,
+            codemapPresentation: .empty,
+            filePathDisplay: .relative
+        )
+
+        let renderedSlice = SliceAssemblyBuilder.build(from: content, ranges: [sliceRange]).combinedText
+        let expectedTokens = TokenCalculationService.estimateTokens(for: renderedSlice)
+        let metric = try XCTUnwrap(snapshot.metric(forFileID: file.id))
+        XCTAssertEqual(snapshot.metricsByFileID.count, 1)
+        XCTAssertEqual(snapshot.metricsByStandardizedFullPath.count, 1)
+        XCTAssertEqual(snapshot.totalSelectedDisplayTokens, expectedTokens)
+        XCTAssertEqual(metric.renderMode, .slice)
+        XCTAssertEqual(metric.displayTokenCount, expectedTokens)
+        XCTAssertEqual(metric.includedLineCount, 1)
+    }
+
+    func testEntryMetricsAccountingKeepsFirstFullFileForDuplicatePhysicalFile() async throws {
+        let root = try makeTemporaryRoot(name: "AccountingPhysicalIdentityFullFirst")
+        let targetURL = root.appendingPathComponent("Target.swift")
+        let content = "skip\nselected line\nskip\n"
+        try write(content, to: targetURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let lookup = await store.lookupPath(targetURL.path)
+        let file = try XCTUnwrap(lookup?.file)
+        let fullEntry = ResolvedPromptFileEntry(
+            file: file,
+            mode: .fullFile,
+            loadedContent: content,
+            rootFolderPath: root.path
+        )
+        let sliceEntry = ResolvedPromptFileEntry(
+            file: file,
+            lineRanges: [LineRange(start: 2, end: 2)],
+            mode: .sliced,
+            loadedContent: content,
+            rootFolderPath: root.path
+        )
+
+        let snapshot = await PromptContextAccountingService().calculateEntryMetricsSnapshot(
+            entries: [fullEntry, sliceEntry],
+            store: store,
+            codemapPresentation: .empty,
+            filePathDisplay: .relative
+        )
+
+        let expectedTokens = TokenCalculationService.estimateTokens(for: content)
+        let metric = try XCTUnwrap(snapshot.metric(forFileID: file.id))
+        XCTAssertEqual(snapshot.metricsByFileID.count, 1)
+        XCTAssertEqual(snapshot.metricsByStandardizedFullPath.count, 1)
+        XCTAssertEqual(snapshot.totalSelectedDisplayTokens, expectedTokens)
+        XCTAssertEqual(metric.renderMode, .full)
+        XCTAssertEqual(metric.displayTokenCount, expectedTokens)
+        XCTAssertEqual(metric.includedLineCount, 3)
+    }
+
     func testSelectedCodemapUsageDoesNotLoadContentWhenCodemapExists() async throws {
         let root = try makeTemporaryRoot(name: "AccountingSelectedCodemap")
         let fileURL = root.appendingPathComponent("A.swift")
@@ -411,6 +495,97 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         XCTAssertEqual(sliceMetric.displayTokenCount, expectedSliceTokens)
         XCTAssertEqual(sliceMetric.displayPercentage, Double(expectedSliceTokens) / Double(expectedTotal))
         XCTAssertEqual(sliceMetric.includedLineCount, 2)
+    }
+
+    func testResolvedContentMetricsDeduplicatePhysicalFileBeforeReadingAndAccounting() async throws {
+        let root = try makeTemporaryRoot(name: "ResolvedAccountingPhysicalIdentity")
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let fileID = UUID()
+        let rootID = UUID()
+        let content = "skip\nselected line\nskip\n"
+        let location = ResolvedFileContentLocation(
+            resolvedRootURL: root,
+            resolvedFileURL: root.appendingPathComponent("Target.swift"),
+            relativePath: "Target.swift"
+        )
+        let sliceRange = LineRange(start: 2, end: 2)
+        let recorder = ResolvedAccountingReaderRecorder(contents: ["Target.swift": content])
+        let service = PromptContextAccountingService(resolvedContentReader: { location, workloadClass in
+            await recorder.read(location: location, workloadClass: workloadClass)
+        })
+
+        let snapshot = try await service.calculateEntryMetricsSnapshot(resolvedContentEntries: [
+            PromptContextResolvedContentMetricsEntry(
+                fileID: fileID,
+                rootID: rootID,
+                location: location,
+                renderedDisplayPath: "Logical/First.swift",
+                lineRanges: [sliceRange]
+            ),
+            PromptContextResolvedContentMetricsEntry(
+                fileID: fileID,
+                rootID: rootID,
+                location: location,
+                renderedDisplayPath: "Logical/Later.swift",
+                lineRanges: nil
+            )
+        ])
+
+        let inputs = await recorder.recordedInputs()
+        XCTAssertEqual(inputs.map(\.location.relativePath), ["Target.swift"])
+        let metric = try XCTUnwrap(snapshot.metric(forFileID: fileID))
+        let renderedSlice = SliceAssemblyBuilder.build(from: content, ranges: [sliceRange]).combinedText
+        let expectedTokens = TokenCalculationService.estimateTokens(for: renderedSlice)
+        XCTAssertEqual(snapshot.metricsByFileID.count, 1)
+        XCTAssertEqual(snapshot.metricsByStandardizedFullPath.count, 1)
+        XCTAssertEqual(snapshot.totalSelectedDisplayTokens, expectedTokens)
+        XCTAssertEqual(metric.renderedDisplayPath, "Logical/First.swift")
+        XCTAssertEqual(metric.renderMode, .slice)
+        XCTAssertEqual(metric.displayTokenCount, expectedTokens)
+    }
+
+    func testEntryMetricsSnapshotKeepsIndexesCoherentForIdentityConflicts() {
+        let firstID = UUID()
+        let otherID = UUID()
+        let firstPath = "/tmp/First.swift"
+        let first = PromptContextEntryMetric(
+            fileID: firstID,
+            standardizedFullPath: firstPath,
+            renderedDisplayPath: "First.swift",
+            renderMode: .full,
+            displayTokenCount: 10,
+            displayPercentage: 0.5,
+            includedLineCount: 1
+        )
+        let duplicateID = PromptContextEntryMetric(
+            fileID: firstID,
+            standardizedFullPath: "/tmp/DuplicateID.swift",
+            renderedDisplayPath: "DuplicateID.swift",
+            renderMode: .slice,
+            displayTokenCount: 20,
+            displayPercentage: 1,
+            includedLineCount: 2
+        )
+        let duplicatePath = PromptContextEntryMetric(
+            fileID: otherID,
+            standardizedFullPath: firstPath,
+            renderedDisplayPath: "DuplicatePath.swift",
+            renderMode: .codemap,
+            displayTokenCount: 30,
+            displayPercentage: 1,
+            includedLineCount: 3
+        )
+
+        let snapshot = PromptContextEntryMetricsSnapshot(
+            totalSelectedDisplayTokens: 10,
+            metrics: [first, duplicateID, duplicatePath]
+        )
+
+        XCTAssertEqual(snapshot.metricsByFileID, [firstID: first])
+        XCTAssertEqual(snapshot.metricsByStandardizedFullPath, [firstPath: first])
+        XCTAssertNil(snapshot.metric(forFileID: otherID))
+        XCTAssertNil(snapshot.metric(forStandardizedFullPath: duplicateID.standardizedFullPath))
     }
 
     func testResolvedContentReadFailureThrowsWithoutPartialSnapshot() async throws {


### PR DESCRIPTION
## Summary

This replaces #751 with a root-cause fix for [REPOPROMPT-GJ](https://repoprompt.sentry.io/issues/7658736307/).

- enforce one logical accounting entry per file UUID and standardized path before file reads and token accounting
- make explicit slices deterministically override containing folder selections, independent of selection order
- use one shared ordering policy for slice resolution in prompt accounting and Agent context export
- construct metrics indexes defensively and atomically, logging conflicting drops in DEBUG while preserving the authoritative total

## Why replace the Sentry patch

The Sentry event strongly confirms the duplicate-UUID trap in `PromptContextEntryMetricsSnapshot.init`, but it does not prove the bot's proposed upstream cause.

The original patch changed both indexes to first-wins dictionaries. That avoids the immediate trap while leaving the underlying accounting inconsistency intact: prompt resolution could admit multiple composite entries for one file, totals could count each entry, and downstream results/indexes still collapse by file UUID or path.

This change aligns resolution identity with the downstream accounting contract instead of silently choosing one duplicate after accounting has already diverged. It also makes full/folder/slice precedence explicit and covered in both input orders.

## Validation

- `PromptContextAccountingServiceTests`: 24 tests, 0 failures
- `AgentContextExportResolverTests`: 56 tests, 0 failures
- strict Swift lint: passed
- mandatory push safety preflight: passed
- PR-ready safety, secret scan, guardrails, and lint phases: passed
- PR-ready full root suite reached tests and reported one unrelated existing transport assertion: `DirectHeadlessStdioTransportTests.testParentProcessChangeAndReadFailureHaveExplicitProvenance` expected `stdinRead(errno: 9)` but received `stdinRead(errno: 21)`. No changed prompt-accounting or export test failed; the PR-ready script stopped at that root-suite failure before later product-build lanes.
