### PR TITLE
Agent Mode: centralize Claude settlement authority

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
@@ -667,7 +667,8 @@ final class AgentModeRunService {
         guard !session.pendingClaudeSteeringInstructions.isEmpty else { return false }
 
         guard let runID = session.runID,
-              let runAttemptID = session.activeRunAttemptID else { return false }
+              let ownership = session.activeRunOwnership else { return false }
+        let runAttemptID = ownership.attemptID
 
         if let firstQueuedSteeringID = session.pendingClaudeSteeringInstructions.first?.id {
             protectCurrentClaudeTurnForAcceptedSteeringIfNeeded(
@@ -785,24 +786,29 @@ final class AgentModeRunService {
                     session
                 )
                 steeringDebugLog("[AgentRunSteeringWake] Claude flush sending native interrupt id=\(steering.id) tab=\(tabID) runID=\(runID) attempt=\(runAttemptID)")
-                let sent = await dependencies.claudeCoordinator.sendClaudeNativeMessage(
+                let sendOutcome = await dependencies.claudeCoordinator.sendClaudeNativeMessage(
                     session: session,
                     text: augmentedSteeringText,
-                    attachments: []
+                    attachments: [],
+                    intent: .runAttempt(ownership: ownership, runID: runID)
                 )
-                steeringDebugLog("[AgentRunSteeringWake] Claude flush send completed id=\(steering.id) tab=\(tabID) runID=\(runID) attempt=\(runAttemptID) sent=\(sent)")
-                hooks.providerInput.recordPendingHandoffSendOutcome(session, sent)
-                if sent {
+                steeringDebugLog("[AgentRunSteeringWake] Claude flush send completed id=\(steering.id) tab=\(tabID) runID=\(runID) attempt=\(runAttemptID) outcome=\(String(describing: sendOutcome))")
+                switch sendOutcome {
+                case .sent:
+                    hooks.providerInput.recordPendingHandoffSendOutcome(session, true)
                     await hooks.continuation.signalMCPInstructionDelivered(session)
-                }
-                if !sent {
-                    // Re-insert the failed instruction so it's included in the restore
+                case .failed:
+                    hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
+                    // Re-insert the failed instruction so it's included in the restore.
+                    // The coordinator deliberately leaves the live run state and
+                    // ownership untouched; the owner event loop settles later.
                     session.pendingClaudeSteeringInstructions.insert(steering, at: 0)
                     if let dequeuedUserInputTokens {
                         session.pendingNonCodexUserInputTokenQueue.insert(dequeuedUserInputTokens, at: 0)
                     }
-                    // Restore ALL remaining queued drafts (including the one that failed)
                     restoreAllQueuedClaudeSteeringDrafts(tabID: tabID, session: session, strategy: .prependAlways)
+                    return
+                case .superseded:
                     return
                 }
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
@@ -18,8 +18,57 @@ final class ClaudeAgentModeCoordinator {
     typealias MCPActiveToolQuery = (_ runID: UUID) -> Bool
     typealias ActiveAgentRunWaitQuery = (_ runID: UUID) -> Bool
 
+    enum NativeSessionIntent: Equatable {
+        case runAttempt(ownership: AgentRunOwnership, runID: UUID)
+        case reconnect(
+            runID: UUID,
+            providerSessionID: String,
+            currency: AgentModeViewModel.PersistentBindingTransitionToken
+        )
+
+        var runID: UUID {
+            switch self {
+            case let .runAttempt(_, runID), let .reconnect(runID, _, _):
+                runID
+            }
+        }
+
+        var allowsFreshStartRecovery: Bool {
+            if case .runAttempt = self { return true }
+            return false
+        }
+
+        @MainActor
+        func isCurrent(for session: AgentModeViewModel.TabSession) -> Bool {
+            switch self {
+            case let .runAttempt(ownership, runID):
+                session.isCurrentRunAttemptForCurrentBinding(
+                    ownership,
+                    expectedRunID: runID
+                )
+            case let .reconnect(runID, providerSessionID, currency):
+                session.persistentBindingTransitionToken() == currency
+                    && session.activeRunOwnership == nil
+                    && session.runID == runID
+                    && session.providerSessionID == providerSessionID
+            }
+        }
+    }
+
+    enum EnsureSessionOutcome: Equatable {
+        case ready
+        case failed(message: String)
+        case superseded
+    }
+
+    enum NativeSendOutcome: Equatable {
+        case sent
+        case failed(message: String)
+        case superseded
+    }
+
     struct HostCapabilities {
-        let setAgentRunActive: @MainActor (_ session: AgentModeViewModel.TabSession, _ isActive: Bool) -> Void
+        let isSessionCurrent: @MainActor (_ session: AgentModeViewModel.TabSession) -> Bool
         let requestUIRefresh: @MainActor (_ session: AgentModeViewModel.TabSession, _ urgent: Bool) -> Void
         let scheduleSave: @MainActor (_ session: AgentModeViewModel.TabSession) -> Void
         let stageClaudeResumeRecoveryHandoff: @MainActor (_ session: AgentModeViewModel.TabSession) async -> Void
@@ -27,7 +76,7 @@ final class ClaudeAgentModeCoordinator {
 
         static var noOp: Self {
             Self(
-                setAgentRunActive: { _, _ in },
+                isSessionCurrent: { _ in true },
                 requestUIRefresh: { _, _ in },
                 scheduleSave: { _ in },
                 stageClaudeResumeRecoveryHandoff: { _ in },
@@ -196,21 +245,6 @@ final class ClaudeAgentModeCoordinator {
         }
     }
 
-    private func finalizeSession(
-        _ session: AgentModeViewModel.TabSession,
-        state: AgentSessionRunState,
-        save: Bool = false
-    ) {
-        session.runState = state
-        session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
-        session.setRunningStatus(nil, source: nil)
-        hostCapabilities.setAgentRunActive(session, false)
-        hostCapabilities.requestUIRefresh(session, true)
-        if save {
-            hostCapabilities.scheduleSave(session)
-        }
-    }
-
     func events(for session: AgentModeViewModel.TabSession) async -> AsyncStream<NativeAgentRuntimeEvent>? {
         guard let controller = session.claudeController else { return nil }
         // Ensure the stream has a live continuation before returning. This
@@ -279,13 +313,32 @@ final class ClaudeAgentModeCoordinator {
         return handler
     }
 
-    func ensureClaudeNativeSession(
-        session: AgentModeViewModel.TabSession
-    ) async {
-        guard session.selectedAgent.usesClaudeNativeRuntime else { return }
-        await awaitPendingClaudeResumeTransferIfNeeded(for: session)
+    private func intentIsCurrent(
+        _ intent: NativeSessionIntent,
+        for session: AgentModeViewModel.TabSession
+    ) -> Bool {
+        hostCapabilities.isSessionCurrent(session) && intent.isCurrent(for: session)
+    }
 
-        let runID = AgentModeProcessRunIdentity.ensureProcessRunID(for: session)
+    func ensureClaudeNativeSession(
+        session: AgentModeViewModel.TabSession,
+        intent: NativeSessionIntent
+    ) async -> EnsureSessionOutcome {
+        guard session.selectedAgent.usesClaudeNativeRuntime,
+              intentIsCurrent(intent, for: session)
+        else {
+            return .superseded
+        }
+
+        switch intent {
+        case .runAttempt:
+            await awaitPendingClaudeResumeTransferIfNeeded(for: session)
+        case .reconnect:
+            guard !hasPendingResumeTransfer(for: session) else { return .superseded }
+        }
+        guard intentIsCurrent(intent, for: session) else { return .superseded }
+
+        let runID = intent.runID
         let launchModelRaw = session.selectedModelRaw
         let runtimeVariant = session.selectedAgent.claudeRuntimeVariant ?? .standard
         let runtimePermission = effectiveClaudeRuntimePermission(for: session)
@@ -310,25 +363,30 @@ final class ClaudeAgentModeCoordinator {
         if let existingController = session.claudeController,
            runtimeVariantChanged || permissionModeChanged || bashToolChanged || mcpStrictModeChanged
         {
-            guard await !(existingController.hasTurnInFlight) else {
-                return
+            let hasTurnInFlight = await existingController.hasTurnInFlight
+            guard intentIsCurrent(intent, for: session),
+                  sessionOwnsClaudeController(existingController, for: session)
+            else {
+                return .superseded
+            }
+            guard !hasTurnInFlight else { return .ready }
+            if case .reconnect = intent, runtimeVariantChanged {
+                return .failed(message: "Claude reconnect requires a fresh session after the runtime provider changed.")
             }
             await recycleClaudeControllerForLaunchSettingsChange(
                 session: session,
                 existingController: existingController,
                 runtimeVariantChanged: runtimeVariantChanged
             )
+            guard intentIsCurrent(intent, for: session) else { return .superseded }
         }
 
         let runtimeWorkspacePath: String?
         do {
             runtimeWorkspacePath = try workspacePathProvider(session)
         } catch {
-            let message = Self.providerStartupFailureMessage(for: error)
-            let errorItem = AgentChatItem.error(message, sequenceIndex: session.nextSequenceIndex)
-            session.appendItem(errorItem)
-            finalizeSession(session, state: .failed, save: true)
-            return
+            guard intentIsCurrent(intent, for: session) else { return .superseded }
+            return .failed(message: Self.providerStartupFailureMessage(for: error))
         }
 
         if let existingController = session.claudeController,
@@ -339,16 +397,18 @@ final class ClaudeAgentModeCoordinator {
                 from: session,
                 removeToolTracking: true
             ) else {
-                return
+                return .superseded
             }
             _ = await retireClaudeController(
                 detached,
                 for: session,
-                captureProviderSessionID: true
+                captureProviderSessionID: intent.allowsFreshStartRecovery
             )
+            guard intentIsCurrent(intent, for: session) else { return .superseded }
         }
 
         if session.claudeController == nil {
+            guard intentIsCurrent(intent, for: session) else { return .superseded }
             let launchSettings = ControllerLaunchSettings(
                 runtimeVariant: runtimeVariant,
                 workspacePath: runtimeWorkspacePath,
@@ -366,35 +426,37 @@ final class ClaudeAgentModeCoordinator {
             session.claudeController = createdController
             controllerLaunchSettingsByTabID[session.tabID] = launchSettings
             await createdController.ensureEventsStreamReady()
-            guard sessionOwnsClaudeController(createdController, for: session) else {
-                await createdController.shutdown()
-                return
+            guard intentIsCurrent(intent, for: session),
+                  sessionOwnsClaudeController(createdController, for: session)
+            else {
+                if !sessionOwnsClaudeController(createdController, for: session) {
+                    await createdController.shutdown()
+                }
+                return .superseded
             }
         }
 
-        guard let controller = session.claudeController else { return }
+        guard let controller = session.claudeController else { return .superseded }
         do {
             let model = effectiveClaudeModel(selectedModelRaw: launchModelRaw)
             let sessionRef = try await startOrResumeWithFallback(
                 controller: controller,
                 session: session,
-                runID: runID,
+                intent: intent,
                 model: model,
                 runtimeVariant: runtimeVariant,
                 effectivePermissionMode: effectivePermissionMode,
                 effectiveAllowNativeBashTool: effectiveAllowNativeBashTool,
                 effectiveMCPStrictMode: effectiveMCPStrictMode
             )
+            guard intentIsCurrent(intent, for: session) else { return .superseded }
             updateProviderSessionIDIfNeeded(sessionRef.sessionID, for: session)
+            return .ready
         } catch ControllerLifecycleError.superseded {
-            return
+            return .superseded
         } catch {
-            let errorItem = AgentChatItem.error(
-                "Claude native start failed: \(error.localizedDescription)",
-                sequenceIndex: session.nextSequenceIndex
-            )
-            session.appendItem(errorItem)
-            finalizeSession(session, state: .failed, save: true)
+            guard intentIsCurrent(intent, for: session) else { return .superseded }
+            return .failed(message: "Claude native start failed: \(error.localizedDescription)")
         }
     }
 
@@ -566,7 +628,7 @@ final class ClaudeAgentModeCoordinator {
     private func startOrResumeWithFallback(
         controller: any NativeAgentRuntimeControlling,
         session: AgentModeViewModel.TabSession,
-        runID: UUID,
+        intent: NativeSessionIntent,
         model: String?,
         runtimeVariant: ClaudeCodeRuntimeVariant,
         effectivePermissionMode: String,
@@ -583,48 +645,51 @@ final class ClaudeAgentModeCoordinator {
                 effortLevel: effortLevel,
                 systemPromptOverride: systemPromptOverride
             )
-            guard sessionOwnsClaudeController(controller, for: session) else {
-                await controller.shutdown()
+            guard intentIsCurrent(intent, for: session),
+                  sessionOwnsClaudeController(controller, for: session)
+            else {
+                if !sessionOwnsClaudeController(controller, for: session) {
+                    await controller.shutdown()
+                }
                 throw ControllerLifecycleError.superseded
             }
             return sessionRef
         } catch ControllerLifecycleError.superseded {
             throw ControllerLifecycleError.superseded
         } catch {
-            guard sessionOwnsClaudeController(controller, for: session) else {
-                await controller.shutdown()
+            guard intentIsCurrent(intent, for: session),
+                  sessionOwnsClaudeController(controller, for: session)
+            else {
+                if !sessionOwnsClaudeController(controller, for: session) {
+                    await controller.shutdown()
+                }
                 throw ControllerLifecycleError.superseded
             }
-            guard shouldRetryFreshStartWithoutResume(after: error, existingSessionID: existingSessionID) else {
+            guard intent.allowsFreshStartRecovery,
+                  shouldRetryFreshStartWithoutResume(after: error, existingSessionID: existingSessionID)
+            else {
                 throw error
             }
 
             await hostCapabilities.stageClaudeResumeRecoveryHandoff(session)
-            guard sessionOwnsClaudeController(controller, for: session) else {
-                await controller.shutdown()
+            guard intentIsCurrent(intent, for: session),
+                  let detached = detachClaudeController(
+                      controller,
+                      from: session,
+                      removeToolTracking: true
+                  )
+            else {
                 throw ControllerLifecycleError.superseded
             }
-            await controller.shutdown()
-            guard let detached = detachClaudeController(
-                controller,
-                from: session,
-                removeToolTracking: true
-            ) else {
-                throw ControllerLifecycleError.superseded
-            }
+            await detached.controller.shutdown()
             await stopToolTracking(detached, for: session)
-            // Run-scoped retry: if a successor installed its own run identity
-            // while tool tracking stopped, this fresh-start retry is superseded
-            // and must not touch the successor's state.
-            guard session.clearRunID(ifCurrent: runID) else {
+            guard intentIsCurrent(intent, for: session) else {
                 throw ControllerLifecycleError.superseded
             }
-            session.providerSessionID = nil
-            session.providerCleanupHandle = nil
-            session.isDirty = true
-            hostCapabilities.scheduleSave(session)
 
-            let freshRunID = AgentModeProcessRunIdentity.startFreshProcessRun(for: session)
+            // A resume fallback is still the same canonical run attempt. Reuse
+            // its process identity and retain the previous provider identity
+            // until the fresh controller has actually started successfully.
             let retryWorkspacePath = try workspacePathProvider(session)
             let launchSettings = ControllerLaunchSettings(
                 runtimeVariant: runtimeVariant,
@@ -634,7 +699,7 @@ final class ClaudeAgentModeCoordinator {
                 mcpStrictMode: effectiveMCPStrictMode
             )
             let freshController = claudeControllerFactory(
-                freshRunID,
+                intent.runID,
                 session.tabID,
                 windowID,
                 launchSettings
@@ -648,8 +713,12 @@ final class ClaudeAgentModeCoordinator {
                 effortLevel: effortLevel,
                 systemPromptOverride: systemPromptOverride
             )
-            guard sessionOwnsClaudeController(freshController, for: session) else {
-                await freshController.shutdown()
+            guard intentIsCurrent(intent, for: session),
+                  sessionOwnsClaudeController(freshController, for: session)
+            else {
+                if !sessionOwnsClaudeController(freshController, for: session) {
+                    await freshController.shutdown()
+                }
                 throw ControllerLifecycleError.superseded
             }
             return sessionRef
@@ -825,22 +894,26 @@ final class ClaudeAgentModeCoordinator {
     func sendClaudeNativeMessage(
         session: AgentModeViewModel.TabSession,
         text: String,
-        attachments _: [AgentImageAttachment]
-    ) async -> Bool {
-        session.waitingPrompt = nil
-        session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
-        session.setRunningStatus("Thinking…", source: .transport)
-        session.runState = .running
+        attachments _: [AgentImageAttachment],
+        intent: NativeSessionIntent
+    ) async -> NativeSendOutcome {
+        guard intentIsCurrent(intent, for: session) else { return .superseded }
         var handler = toolHandler(for: session)
         handler.resetTurnState(for: session)
-        hostCapabilities.setAgentRunActive(session, true)
-        hostCapabilities.requestUIRefresh(session, true)
 
         for _ in 0 ..< 3 {
-            await ensureClaudeNativeSession(session: session)
-            guard let controller = session.claudeController else {
-                finalizeSession(session, state: .failed)
-                return false
+            switch await ensureClaudeNativeSession(session: session, intent: intent) {
+            case .ready:
+                break
+            case let .failed(message):
+                return recordSendFailure(message, session: session, intent: intent)
+            case .superseded:
+                return .superseded
+            }
+            guard intentIsCurrent(intent, for: session),
+                  let controller = session.claudeController
+            else {
+                return .superseded
             }
 
             if hasEffectiveClaudeControllerLaunchSettingsMismatch(for: session) {
@@ -849,33 +922,45 @@ final class ClaudeAgentModeCoordinator {
                     controller: controller,
                     handler: handler
                 ) else {
-                    if !sessionOwnsClaudeController(controller, for: session) {
-                        continue
+                    guard intentIsCurrent(intent, for: session),
+                          sessionOwnsClaudeController(controller, for: session)
+                    else {
+                        return .superseded
                     }
-                    return false
+                    return recordSendFailure(
+                        "Claude native send failed because the active turn could not be interrupted safely.",
+                        session: session,
+                        intent: intent
+                    )
                 }
-                guard sessionOwnsClaudeController(controller, for: session) else {
-                    continue
+                guard intentIsCurrent(intent, for: session),
+                      sessionOwnsClaudeController(controller, for: session)
+                else {
+                    return .superseded
                 }
                 await recycleClaudeControllerForLaunchSettingsChange(
                     session: session,
                     existingController: controller,
                     runtimeVariantChanged: effectiveClaudeRuntimeVariantChanged(for: session)
                 )
-                if let runID = session.runID {
-                    await ensureClaudeToolTrackingIfNeeded(for: session, runID: runID)
-                    handler = toolHandler(for: session)
-                }
+                guard intentIsCurrent(intent, for: session) else { return .superseded }
+                await ensureClaudeToolTrackingIfNeeded(for: session, runID: intent.runID)
+                handler = toolHandler(for: session)
                 continue
             }
 
             let hasActiveSession = await controller.hasActiveSession
-            guard sessionOwnsClaudeController(controller, for: session) else {
-                continue
+            guard intentIsCurrent(intent, for: session),
+                  sessionOwnsClaudeController(controller, for: session)
+            else {
+                return .superseded
             }
             guard hasActiveSession else {
-                finalizeSession(session, state: .failed)
-                return false
+                return recordSendFailure(
+                    "Claude native send failed because the provider session is not active.",
+                    session: session,
+                    intent: intent
+                )
             }
 
             guard await interruptClaudeTurnIfNeeded(
@@ -883,13 +968,21 @@ final class ClaudeAgentModeCoordinator {
                 controller: controller,
                 handler: handler
             ) else {
-                if !sessionOwnsClaudeController(controller, for: session) {
-                    continue
+                guard intentIsCurrent(intent, for: session),
+                      sessionOwnsClaudeController(controller, for: session)
+                else {
+                    return .superseded
                 }
-                return false
+                return recordSendFailure(
+                    "Claude native send failed because the active turn could not be interrupted safely.",
+                    session: session,
+                    intent: intent
+                )
             }
-            guard sessionOwnsClaudeController(controller, for: session) else {
-                continue
+            guard intentIsCurrent(intent, for: session),
+                  sessionOwnsClaudeController(controller, for: session)
+            else {
+                return .superseded
             }
 
             // Ensure the events stream has a live continuation before sending. If a
@@ -899,8 +992,10 @@ final class ClaudeAgentModeCoordinator {
             // so events that arrive in between must be buffered in a live stream.
             // ensureEventsStreamReady is idempotent — it only recreates if nil.
             await controller.ensureEventsStreamReady()
-            guard sessionOwnsClaudeController(controller, for: session) else {
-                continue
+            guard intentIsCurrent(intent, for: session),
+                  sessionOwnsClaudeController(controller, for: session)
+            else {
+                return .superseded
             }
 
             // This is the final launch-settings validation before dispatch. There is
@@ -912,10 +1007,9 @@ final class ClaudeAgentModeCoordinator {
                     existingController: controller,
                     runtimeVariantChanged: effectiveClaudeRuntimeVariantChanged(for: session)
                 )
-                if let runID = session.runID {
-                    await ensureClaudeToolTrackingIfNeeded(for: session, runID: runID)
-                    handler = toolHandler(for: session)
-                }
+                guard intentIsCurrent(intent, for: session) else { return .superseded }
+                await ensureClaudeToolTrackingIfNeeded(for: session, runID: intent.runID)
+                handler = toolHandler(for: session)
                 continue
             }
 
@@ -924,34 +1018,58 @@ final class ClaudeAgentModeCoordinator {
                 let instructions = agentModeInstructionInjection(for: session)
                 let providerBoundText = providerBoundUserMessage(outboundText, instructions: instructions)
                 let turnID = try await controller.sendUserMessage(providerBoundText)
-                guard sessionOwnsClaudeController(controller, for: session) else {
-                    await controller.shutdown()
-                    return false
+                guard intentIsCurrent(intent, for: session),
+                      sessionOwnsClaudeController(controller, for: session)
+                else {
+                    if !sessionOwnsClaudeController(controller, for: session) {
+                        await controller.shutdown()
+                    }
+                    return .superseded
                 }
                 session.claudeExpectedTurnIDs.insert(turnID)
-                return true
+                return .sent
             } catch {
-                guard sessionOwnsClaudeController(controller, for: session) else {
-                    await controller.shutdown()
-                    return false
+                guard intentIsCurrent(intent, for: session),
+                      sessionOwnsClaudeController(controller, for: session)
+                else {
+                    if !sessionOwnsClaudeController(controller, for: session) {
+                        await controller.shutdown()
+                    }
+                    return .superseded
                 }
-                let errorItem = AgentChatItem.error(
+                return recordSendFailure(
                     "Claude native send failed: \(error.localizedDescription)",
-                    sequenceIndex: session.nextSequenceIndex
+                    session: session,
+                    intent: intent
                 )
-                session.appendItem(errorItem)
-                finalizeSession(session, state: .failed, save: true)
-                return false
             }
         }
 
-        let errorItem = AgentChatItem.error(
+        return recordSendFailure(
             "Claude native send failed because launch settings changed repeatedly before dispatch.",
-            sequenceIndex: session.nextSequenceIndex
+            session: session,
+            intent: intent
         )
-        session.appendItem(errorItem)
-        finalizeSession(session, state: .failed, save: true)
-        return false
+    }
+
+    private func recordSendFailure(
+        _ message: String,
+        session: AgentModeViewModel.TabSession,
+        intent: NativeSessionIntent
+    ) -> NativeSendOutcome {
+        guard intentIsCurrent(intent, for: session) else { return .superseded }
+        if session.items.last?.kind != .error || session.items.last?.text != message {
+            session.appendItem(
+                AgentChatItem.error(
+                    message,
+                    sequenceIndex: session.nextSequenceIndex
+                )
+            )
+        }
+        session.isDirty = true
+        hostCapabilities.requestUIRefresh(session, true)
+        hostCapabilities.scheduleSave(session)
+        return .failed(message: message)
     }
 
     private func interruptClaudeTurnIfNeeded(

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
@@ -320,6 +320,17 @@ final class ClaudeAgentModeCoordinator {
         hostCapabilities.isSessionCurrent(session) && intent.isCurrent(for: session)
     }
 
+    func runAttemptIsCurrent(
+        _ ownership: AgentRunOwnership,
+        runID: UUID,
+        for session: AgentModeViewModel.TabSession
+    ) -> Bool {
+        intentIsCurrent(
+            .runAttempt(ownership: ownership, runID: runID),
+            for: session
+        )
+    }
+
     func ensureClaudeNativeSession(
         session: AgentModeViewModel.TabSession,
         intent: NativeSessionIntent

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
@@ -151,6 +151,7 @@ final class ClaudeIntegratedAgentModeRunner {
                         runID: runID,
                         for: session
                     ) {
+                        self.hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
                         let revision = await self.finalize(
                             session: session,
                             runID: runID,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
@@ -112,17 +112,29 @@ final class ClaudeIntegratedAgentModeRunner {
 
                 let providerName = session.selectedAgent.rawValue
                 await lease.providerInitializationStarted(provider: providerName)
-                let sent = await self.claudeCoordinator.sendClaudeNativeMessage(
+                let sendOutcome = await self.claudeCoordinator.sendClaudeNativeMessage(
                     session: session,
                     text: initialMessageForRun,
-                    attachments: attachments
+                    attachments: attachments,
+                    intent: .runAttempt(ownership: ownership, runID: runID)
                 )
+                let providerInitializationOutcome = switch sendOutcome {
+                case .sent:
+                    "ready"
+                case .failed:
+                    Task.isCancelled ? "cancelled" : "failed"
+                case .superseded:
+                    "superseded"
+                }
                 await lease.providerInitializationCompleted(
                     provider: providerName,
-                    outcome: sent ? "ready" : (Task.isCancelled ? "cancelled" : "failed")
+                    outcome: providerInitializationOutcome
                 )
-                self.hooks.providerInput.recordPendingHandoffSendOutcome(session, sent)
-                guard sent else {
+                switch sendOutcome {
+                case .sent:
+                    self.hooks.providerInput.recordPendingHandoffSendOutcome(session, true)
+                case .failed:
+                    self.hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
                     await self.finalize(
                         session: session,
                         runID: runID,
@@ -132,6 +144,9 @@ final class ClaudeIntegratedAgentModeRunner {
                         errorText: nil,
                         notifyTurnComplete: false
                     )
+                    return
+                case .superseded:
+                    await lease.cancelAndCleanup()
                     return
                 }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
@@ -146,7 +146,26 @@ final class ClaudeIntegratedAgentModeRunner {
                     )
                     return
                 case .superseded:
-                    await lease.cancelAndCleanup()
+                    if self.claudeCoordinator.runAttemptIsCurrent(
+                        ownership,
+                        runID: runID,
+                        for: session
+                    ) {
+                        let revision = await self.finalize(
+                            session: session,
+                            runID: runID,
+                            ownership: ownership,
+                            attachmentReservationID: attachmentReservationID,
+                            terminalState: .cancelled,
+                            errorText: nil,
+                            notifyTurnComplete: false
+                        )
+                        if revision == nil {
+                            await lease.cancelAndCleanup()
+                        }
+                    } else {
+                        await lease.cancelAndCleanup()
+                    }
                     return
                 }
 
@@ -351,6 +370,7 @@ final class ClaudeIntegratedAgentModeRunner {
         ))
     }
 
+    @discardableResult
     private func finalize(
         session: AgentModeViewModel.TabSession,
         runID: UUID,
@@ -360,7 +380,7 @@ final class ClaudeIntegratedAgentModeRunner {
         errorText: String?,
         notifyTurnComplete: Bool,
         shouldShutdownSession: Bool = false
-    ) async {
+    ) async -> AgentRunTerminalCommitRevision? {
         await terminalCommitBarrier.commit(.init(
             binding: hooks.bindTerminalSession(session),
             ownership: ownership,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1525,8 +1525,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
     private func makeClaudeCoordinatorHostCapabilities() -> ClaudeAgentModeCoordinator.HostCapabilities {
         ClaudeAgentModeCoordinator.HostCapabilities(
-            setAgentRunActive: { [weak self] session, isActive in
-                self?.setAgentRunActive(session, isActive: isActive)
+            isSessionCurrent: { [weak self] session in
+                guard let self else { return false }
+                return sessions[session.tabID] === session
             },
             requestUIRefresh: { [weak self] session, urgent in
                 guard let self, sessions[session.tabID] === session else { return }
@@ -3415,7 +3416,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 await codexCoordinator.ensureCodexNativeSession(session: session)
             }
             if session.selectedAgent.usesClaudeNativeRuntime, session.runState.isActive {
-                await claudeCoordinator.ensureClaudeNativeSession(session: session)
+                await reconnectClaudeNativeSessionIfNeeded(session)
             }
         }
     }
@@ -4753,6 +4754,87 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         return true
     }
 
+    private func reconnectClaudeNativeSessionIfNeeded(_ session: TabSession) async {
+        guard session.selectedAgent.usesClaudeNativeRuntime,
+              session.runState.isActive,
+              session.activeRunOwnership == nil
+        else {
+            return
+        }
+
+        let currency = session.persistentBindingTransitionToken()
+        let expectedRunID = session.runID
+        let expectedProviderSessionID = session.providerSessionID
+        guard let expectedRunID,
+              let expectedProviderSessionID,
+              !expectedProviderSessionID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            recoverOwnershiplessClaudeReconnectFailure(
+                session,
+                currency: currency,
+                expectedRunID: expectedRunID,
+                expectedProviderSessionID: expectedProviderSessionID,
+                message: "Claude reconnect failed because the prior runtime identity is unavailable."
+            )
+            return
+        }
+
+        let outcome = await claudeCoordinator.ensureClaudeNativeSession(
+            session: session,
+            intent: .reconnect(
+                runID: expectedRunID,
+                providerSessionID: expectedProviderSessionID,
+                currency: currency
+            )
+        )
+        guard case let .failed(message) = outcome else { return }
+        recoverOwnershiplessClaudeReconnectFailure(
+            session,
+            currency: currency,
+            expectedRunID: expectedRunID,
+            expectedProviderSessionID: expectedProviderSessionID,
+            message: message
+        )
+    }
+
+    private func recoverOwnershiplessClaudeReconnectFailure(
+        _ session: TabSession,
+        currency: PersistentBindingTransitionToken,
+        expectedRunID: UUID?,
+        expectedProviderSessionID: String?,
+        message: String
+    ) {
+        guard persistentBindingTransitionIsCurrent(currency),
+              sessions[session.tabID] === session,
+              session.selectedAgent.usesClaudeNativeRuntime,
+              session.runState.isActive,
+              session.activeRunOwnership == nil,
+              session.runID == expectedRunID,
+              session.providerSessionID == expectedProviderSessionID
+        else {
+            return
+        }
+
+        if session.items.last?.kind != .error || session.items.last?.text != message {
+            session.appendItem(
+                AgentChatItem.error(
+                    message,
+                    sequenceIndex: session.nextSequenceIndex
+                )
+            )
+        }
+        session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
+        session.setRunningStatus(nil, source: nil)
+        session.waitingPrompt = nil
+        session.runState = .idle
+        session.isDirty = true
+        setAgentRunActive(session, isActive: false)
+        updateBindingsFromSession(session)
+        requestUIRefresh(tabID: session.tabID, urgent: true)
+        scheduleSave(for: session)
+        publishMCPStateChange(for: session)
+    }
+
     /// Ensures a session exists for the given tab ID and loads any persisted state.
     /// Used by MCP tool handlers to ensure session is ready before accessing it.
     func ensureSessionReady(tabID: UUID, reconnectActiveProviders: Bool = false) async -> TabSession {
@@ -4772,7 +4854,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             await codexCoordinator.ensureCodexNativeSession(session: session)
         }
         if reconnectActiveProviders, session.selectedAgent.usesClaudeNativeRuntime, session.runState.isActive {
-            await claudeCoordinator.ensureClaudeNativeSession(session: session)
+            await reconnectClaudeNativeSessionIfNeeded(session)
         }
 
         return session

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -225,6 +225,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             let harness = makeHarness(recorder: recorder, claudeController: claudeController)
             let session = AgentModeViewModel.TabSession(tabID: UUID())
             session.selectedAgent = .claudeCode
+            harness.host.test_installLiveSession(session)
 
             let outcome = await harness.service.startRun(
                 tabID: session.tabID,
@@ -244,6 +245,14 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             XCTAssertFalse(recorder.contains("factory:acp-provider"))
             XCTAssertFalse(recorder.contains("factory:headless"))
             await session.agentTask?.value
+            XCTAssertEqual(session.runState, .failed)
+            XCTAssertNil(session.activeRunOwnership)
+            XCTAssertNotNil(session.lastTerminalCommitRevision)
+            XCTAssertEqual(session.items.count(where: { $0.kind == .error }), 1)
+            XCTAssertEqual(recorder.events.count(where: { $0.hasPrefix("commit:") }), 1)
+            XCTAssertEqual(recorder.events.count(where: { $0 == "run-active:false" }), 1)
+            XCTAssertTrue(recorder.contains("attachments:deleteFiles"))
+            XCTAssertTrue(recorder.contains("save"))
         }
 
         do {
@@ -376,7 +385,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 idleWaiter: { _ in recorder.record("idle") },
                 claudeController: claudeController
             )
-            let session = makeRunningClaudeSession(controller: claudeController)
+            let session = makeRunningClaudeSession(controller: claudeController, host: harness.host)
             session.pendingClaudeSteeringInstructions = [makeClaudeSteeringInstruction(session: session, text: "steer successfully")]
 
             let queueStarted = await harness.service.submitQueuedClaudeSteeringIfSupported(session: session)
@@ -402,7 +411,8 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 idleWaiter: { _ in recorder.record("idle") },
                 claudeController: claudeController
             )
-            let session = makeRunningClaudeSession(controller: claudeController)
+            let session = makeRunningClaudeSession(controller: claudeController, host: harness.host)
+            let ownership = session.activeRunOwnership
             session.pendingClaudeSteeringInstructions = [makeClaudeSteeringInstruction(session: session, text: "restore me")]
             session.pendingNonCodexUserInputTokenQueue = [7]
 
@@ -412,8 +422,13 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
 
             XCTAssertTrue(session.pendingClaudeSteeringInstructions.isEmpty)
             XCTAssertEqual(session.pendingNonCodexUserInputTokenQueue, [7])
+            XCTAssertEqual(session.runState, .running)
+            XCTAssertEqual(session.activeRunOwnership, ownership)
+            XCTAssertNil(session.lastTerminalCommitRevision)
+            XCTAssertEqual(session.items.count(where: { $0.kind == .error }), 1)
             XCTAssertTrue(recorder.contains("draft:restore me"))
             XCTAssertFalse(recorder.contains("delivered"))
+            XCTAssertFalse(recorder.contains(prefix: "commit:"))
             assertOrderedEvents(["idle", "claude:interrupt:interrupt", "claude:send", "draft:restore me"], in: recorder)
         }
     }
@@ -783,7 +798,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 recorder.record("commit:\(revision.commitID.uuidString)")
             }
         )
-        let session = makeRunningClaudeSession(controller: controller)
+        let session = makeRunningClaudeSession(controller: controller, host: harness.host)
         session.pendingAssistantDelta = "buffered terminal tail"
 
         await harness.service.cancelRun(
@@ -1956,13 +1971,17 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         )
     }
 
-    func makeRunningClaudeSession(controller: LifecycleFakeNativeController) -> AgentModeViewModel.TabSession {
+    func makeRunningClaudeSession(
+        controller: LifecycleFakeNativeController,
+        host: AgentModeViewModel? = nil
+    ) -> AgentModeViewModel.TabSession {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .claudeCode
         session.runState = .running
         session.installRunID(UUID())
         session.beginRunAttempt(source: "test")
         session.claudeController = controller
+        host?.test_installLiveSession(session)
         return session
     }
 

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -24,7 +24,7 @@ extension AgentModeRunServiceLifecycleTests {
                 return newController
             }
         )
-        let session = makeRunningClaudeSession(controller: oldController)
+        let session = makeRunningClaudeSession(controller: oldController, host: harness.host)
         session.permissionProfile = .mcpSafeDefaults
         setClaudeControllerLaunchSettings(
             for: session,
@@ -81,7 +81,7 @@ extension AgentModeRunServiceLifecycleTests {
                 return newController
             }
         )
-        let session = makeRunningClaudeSession(controller: oldController)
+        let session = makeRunningClaudeSession(controller: oldController, host: harness.host)
         let initialProfile = AgentProviderPermissionProfile.providerOverride(.claude(.fullAccess))
         let initialRuntime = resolvedClaudeLaunchPolicy(
             profile: initialProfile,
@@ -143,7 +143,7 @@ extension AgentModeRunServiceLifecycleTests {
                 return newController
             }
         )
-        let session = makeRunningClaudeSession(controller: oldController)
+        let session = makeRunningClaudeSession(controller: oldController, host: harness.host)
         let runtime = resolvedClaudeLaunchPolicy(
             profile: .mcpSafeDefaults,
             harness: harness
@@ -211,7 +211,7 @@ extension AgentModeRunServiceLifecycleTests {
                 return fallbackController
             }
         )
-        let session = makeRunningClaudeSession(controller: oldController)
+        let session = makeRunningClaudeSession(controller: oldController, host: harness.host)
         session.permissionProfile = .mcpSafeDefaults
         setClaudeControllerLaunchSettings(
             for: session,
@@ -258,7 +258,7 @@ extension AgentModeRunServiceLifecycleTests {
         ], in: recorder)
     }
 
-    func testClaudeWorkspaceRecycleDoesNotClearReplacementAfterCurrentSessionAwait() async {
+    func testClaudeWorkspaceRecycleDoesNotClearReplacementAfterCurrentSessionAwait() async throws {
         let recorder = LifecycleRecorder()
         let currentSessionRefGate = LifecycleAsyncGate()
         let oldController = LifecycleFakeNativeController(
@@ -281,7 +281,7 @@ extension AgentModeRunServiceLifecycleTests {
                 return fallbackController
             }
         )
-        let session = makeRunningClaudeSession(controller: oldController)
+        let session = makeRunningClaudeSession(controller: oldController, host: harness.host)
         let runtime = resolvedClaudeLaunchPolicy(
             profile: .mcpSafeDefaults,
             harness: harness
@@ -299,8 +299,13 @@ extension AgentModeRunServiceLifecycleTests {
             mcpStrictMode: runtime?.mcpStrictMode
         )
 
+        let ownership = try XCTUnwrap(session.activeRunOwnership)
+        let runID = try XCTUnwrap(session.runID)
         let ensureTask = Task {
-            await harness.host.claudeCoordinator.ensureClaudeNativeSession(session: session)
+            await harness.host.claudeCoordinator.ensureClaudeNativeSession(
+                session: session,
+                intent: .runAttempt(ownership: ownership, runID: runID)
+            )
         }
         await currentSessionRefGate.waitUntilArrived()
         session.claudeController = replacementController
@@ -313,7 +318,7 @@ extension AgentModeRunServiceLifecycleTests {
             mcpStrictMode: runtime?.mcpStrictMode
         )
         await currentSessionRefGate.release()
-        await ensureTask.value
+        _ = await ensureTask.value
 
         guard let finalController = session.claudeController else {
             XCTFail("Expected replacement workspace controller to remain installed")
@@ -330,7 +335,7 @@ extension AgentModeRunServiceLifecycleTests {
         ], in: recorder)
     }
 
-    func testClaudeSendCompletionDoesNotFailReplacementController() async {
+    func testClaudeSendCompletionDoesNotFailReplacementController() async throws {
         let recorder = LifecycleRecorder()
         let sendGate = LifecycleAsyncGate()
         let oldController = LifecycleFakeNativeController(
@@ -346,7 +351,7 @@ extension AgentModeRunServiceLifecycleTests {
             recorder: recorder,
             claudeController: oldController
         )
-        let session = makeRunningClaudeSession(controller: oldController)
+        let session = makeRunningClaudeSession(controller: oldController, host: harness.host)
         let runtime = resolvedClaudeLaunchPolicy(
             profile: session.permissionProfile,
             harness: harness
@@ -359,19 +364,29 @@ extension AgentModeRunServiceLifecycleTests {
             mcpStrictMode: runtime?.mcpStrictMode
         )
 
+        let ownership = try XCTUnwrap(session.activeRunOwnership)
+        let runID = try XCTUnwrap(session.runID)
+        let readiness = await harness.host.claudeCoordinator.ensureClaudeNativeSession(
+            session: session,
+            intent: .runAttempt(ownership: ownership, runID: runID)
+        )
+        guard readiness == .ready else {
+            return XCTFail("Expected the exact live session to be ready before the send race, got \(readiness)")
+        }
         let sendTask = Task {
             await harness.host.claudeCoordinator.sendClaudeNativeMessage(
                 session: session,
                 text: "do not fail replacement",
-                attachments: []
+                attachments: [],
+                intent: .runAttempt(ownership: ownership, runID: runID)
             )
         }
         await sendGate.waitUntilArrived()
         session.claudeController = replacementController
         await sendGate.release()
 
-        let didSend = await sendTask.value
-        XCTAssertFalse(didSend)
+        let sendOutcome = await sendTask.value
+        XCTAssertEqual(sendOutcome, .superseded)
         guard let finalController = session.claudeController else {
             XCTFail("Expected replacement controller to remain installed")
             return
@@ -385,7 +400,7 @@ extension AgentModeRunServiceLifecycleTests {
         XCTAssertTrue(recorder.contains("stale-send:shutdown"))
     }
 
-    func testClaudeSendFailureFinalizesThroughCapabilitiesWithoutViewModel() async {
+    func testClaudeSendFailureReportsEvidenceWithoutTerminalizingSession() async {
         let recorder = LifecycleRecorder()
         let controller = LifecycleFakeNativeController(
             recorder: recorder,
@@ -395,14 +410,15 @@ extension AgentModeRunServiceLifecycleTests {
         let session = AgentModeViewModel.TabSession(tabID: UUID())
         session.selectedAgent = .claudeCode
         session.providerSessionID = "lifecycle-claude-session"
+        let runID = UUID()
+        session.installRunID(runID)
+        session.runState = .running
+        session.setRunningStatus("Thinking…", source: .transport)
+        let ownership = session.beginRunAttempt(source: "test.coordinatorFailure")
         var projectedSessions: [AgentModeViewModel.TabSession] = []
         var projectedStates: [AgentSessionRunState] = []
         let capabilities = ClaudeAgentModeCoordinator.HostCapabilities(
-            setAgentRunActive: { projectedSession, isActive in
-                projectedSessions.append(projectedSession)
-                projectedStates.append(projectedSession.runState)
-                recorder.record("host:active:\(isActive)")
-            },
+            isSessionCurrent: { $0 === session },
             requestUIRefresh: { projectedSession, urgent in
                 projectedSessions.append(projectedSession)
                 projectedStates.append(projectedSession.runState)
@@ -432,36 +448,252 @@ extension AgentModeRunServiceLifecycleTests {
             providerBindingService: providerBindingService
         )
 
-        let didSend = await coordinator.sendClaudeNativeMessage(
+        let sendOutcome = await coordinator.sendClaudeNativeMessage(
             session: session,
             text: "fail deterministically",
-            attachments: []
+            attachments: [],
+            intent: .runAttempt(ownership: ownership, runID: runID)
         )
         withExtendedLifetime(providerBindingService) {}
 
-        XCTAssertFalse(didSend)
-        XCTAssertEqual(session.runState, .failed)
-        XCTAssertNil(session.runningStatusText)
-        XCTAssertNil(session.runningStatusSource)
+        guard case let .failed(message) = sendOutcome else {
+            return XCTFail("Expected explicit Claude send failure")
+        }
+        XCTAssertEqual(message, "Claude native send failed: Expected Claude send failure.")
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertEqual(session.activeRunOwnership, ownership)
+        XCTAssertEqual(session.runningStatusText, "Thinking…")
+        XCTAssertEqual(session.runningStatusSource, .transport)
+        XCTAssertNil(session.lastTerminalCommitRevision)
         XCTAssertEqual(session.items.count(where: { $0.kind == .error }), 1)
         XCTAssertTrue(projectedSessions.allSatisfy { $0 === session })
-        XCTAssertEqual(
-            projectedStates,
-            [.running, .running, .running, .failed, .failed, .failed]
-        )
+        XCTAssertEqual(projectedStates, [.running, .running, .running])
         XCTAssertEqual(
             recorder.events,
             [
-                "host:active:true",
-                "host:refresh:true",
                 "no-vm:start",
                 "host:prepend",
                 "no-vm:send",
-                "host:active:false",
                 "host:refresh:true",
                 "host:save"
             ]
         )
+    }
+
+    func testOwnershiplessClaudeReconnectFailureNormalizesIdleWithEvidenceAndRetainsProviderIdentity() async {
+        let recorder = LifecycleRecorder()
+        let controller = LifecycleFakeNativeController(
+            recorder: recorder,
+            label: "reconnect-fail",
+            startOrResumeFailure: NativeAgentRuntimeControllerError.processNotRunning
+        )
+        let harness = makeHarness(recorder: recorder, claudeController: controller)
+        let session = await harness.host.ensureSessionReady(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        session.providerSessionID = "retained-provider-session"
+        let runID = UUID()
+        session.installRunID(runID)
+        session.runState = .running
+        harness.host.setAgentRunActive(session, isActive: true)
+        let saveGenerationBefore = session.saveRequestGeneration
+
+        _ = await harness.host.ensureSessionReady(
+            tabID: session.tabID,
+            reconnectActiveProviders: true
+        )
+
+        XCTAssertEqual(session.runState, .idle)
+        XCTAssertNil(session.activeRunOwnership)
+        XCTAssertEqual(session.runID, runID)
+        XCTAssertEqual(session.providerSessionID, "retained-provider-session")
+        XCTAssertNil(session.activeAgentRunStartedAt)
+        XCTAssertNil(session.lastTerminalCommitRevision)
+        XCTAssertEqual(session.items.count(where: { $0.kind == .error }), 1)
+        XCTAssertTrue(session.items.last?.text.contains("Claude native start failed") == true)
+        XCTAssertTrue(session.isDirty)
+        XCTAssertGreaterThan(session.saveRequestGeneration, saveGenerationBefore)
+        XCTAssertTrue(recorder.contains("reconnect-fail:start-failed"))
+    }
+
+    func testClaudeReconnectRacingLiveOwnershipWritesNothingAndPreservesOwnerCurrency() async {
+        let recorder = LifecycleRecorder()
+        let startGate = LifecycleAsyncGate()
+        let controller = LifecycleFakeNativeController(
+            recorder: recorder,
+            label: "reconnect-owner-race",
+            startOrResumeGate: startGate,
+            startOrResumeFailure: NativeAgentRuntimeControllerError.processNotRunning
+        )
+        let harness = makeHarness(recorder: recorder, claudeController: controller)
+        let session = await harness.host.ensureSessionReady(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        session.providerSessionID = "owner-race-provider-session"
+        let runID = UUID()
+        session.installRunID(runID)
+        session.runState = .running
+        let saveGenerationBefore = session.saveRequestGeneration
+        let sourceRevisionBefore = session.sourceItemsRevision
+
+        let reconnectTask = Task { @MainActor in
+            await harness.host.ensureSessionReady(
+                tabID: session.tabID,
+                reconnectActiveProviders: true
+            )
+        }
+        await startGate.waitUntilArrived()
+        let ownership = session.beginRunAttempt(source: "test.reconnectOwnerRace")
+        await startGate.release()
+        _ = await reconnectTask.value
+
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertEqual(session.activeRunOwnership, ownership)
+        XCTAssertEqual(session.runID, runID)
+        XCTAssertEqual(session.providerSessionID, "owner-race-provider-session")
+        XCTAssertEqual(session.sourceItemsRevision, sourceRevisionBefore)
+        XCTAssertEqual(session.saveRequestGeneration, saveGenerationBefore)
+        XCTAssertTrue(session.items.filter { $0.kind == .error }.isEmpty)
+        XCTAssertTrue(
+            session.isCurrentRunAttemptForCurrentBinding(
+                ownership,
+                expectedRunID: runID
+            )
+        )
+        XCTAssertNil(session.lastTerminalCommitRevision)
+    }
+
+    func testConcurrentOwnershiplessClaudeReconnectFailuresAppendOneError() async {
+        let recorder = LifecycleRecorder()
+        let startGate = LifecycleAsyncGate()
+        let controller = LifecycleFakeNativeController(
+            recorder: recorder,
+            label: "reconnect-concurrent",
+            startOrResumeGate: startGate,
+            startOrResumeFailure: NativeAgentRuntimeControllerError.processNotRunning,
+            repeatsStartOrResumeFailure: true
+        )
+        let harness = makeHarness(recorder: recorder, claudeController: controller)
+        let session = await harness.host.ensureSessionReady(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        session.providerSessionID = "concurrent-provider-session"
+        let runID = UUID()
+        session.installRunID(runID)
+        session.runState = .running
+
+        let first = Task { @MainActor in
+            await harness.host.ensureSessionReady(
+                tabID: session.tabID,
+                reconnectActiveProviders: true
+            )
+        }
+        await startGate.waitUntilArrived()
+        let second = Task { @MainActor in
+            await harness.host.ensureSessionReady(
+                tabID: session.tabID,
+                reconnectActiveProviders: true
+            )
+        }
+        await startGate.waitUntilArrivals(2)
+        await startGate.release()
+        _ = await first.value
+        _ = await second.value
+
+        XCTAssertEqual(session.runState, .idle)
+        XCTAssertEqual(session.runID, runID)
+        XCTAssertEqual(session.providerSessionID, "concurrent-provider-session")
+        XCTAssertEqual(session.items.count(where: { $0.kind == .error }), 1)
+        XCTAssertEqual(
+            recorder.events.count(where: { $0 == "reconnect-concurrent:start-failed" }),
+            2
+        )
+        XCTAssertNil(session.lastTerminalCommitRevision)
+    }
+
+    func testClaudeReconnectFailureWritesNothingAfterTabRecycleOrBindingChange() async {
+        do {
+            let recorder = LifecycleRecorder()
+            let startGate = LifecycleAsyncGate()
+            let controller = LifecycleFakeNativeController(
+                recorder: recorder,
+                label: "reconnect-recycled",
+                startOrResumeGate: startGate,
+                startOrResumeFailure: NativeAgentRuntimeControllerError.processNotRunning
+            )
+            let harness = makeHarness(recorder: recorder, claudeController: controller)
+            let session = await harness.host.ensureSessionReady(tabID: UUID())
+            session.selectedAgent = .claudeCode
+            session.providerSessionID = "recycled-provider-session"
+            let runID = UUID()
+            session.installRunID(runID)
+            session.runState = .running
+            let saveGenerationBefore = session.saveRequestGeneration
+            let sourceRevisionBefore = session.sourceItemsRevision
+
+            let reconnectTask = Task { @MainActor in
+                await harness.host.ensureSessionReady(
+                    tabID: session.tabID,
+                    reconnectActiveProviders: true
+                )
+            }
+            await startGate.waitUntilArrived()
+            let successor = AgentModeViewModel.TabSession(tabID: session.tabID)
+            successor.selectedAgent = .claudeCode
+            successor.providerSessionID = "successor-provider-session"
+            successor.runState = .idle
+            harness.host.test_installLiveSession(successor)
+            await startGate.release()
+            _ = await reconnectTask.value
+
+            XCTAssertEqual(session.runState, .running)
+            XCTAssertEqual(session.runID, runID)
+            XCTAssertEqual(session.providerSessionID, "recycled-provider-session")
+            XCTAssertEqual(session.sourceItemsRevision, sourceRevisionBefore)
+            XCTAssertEqual(session.saveRequestGeneration, saveGenerationBefore)
+            XCTAssertTrue(session.items.filter { $0.kind == .error }.isEmpty)
+            XCTAssertEqual(successor.runState, .idle)
+            XCTAssertEqual(successor.providerSessionID, "successor-provider-session")
+            XCTAssertTrue(successor.items.isEmpty)
+        }
+
+        do {
+            let recorder = LifecycleRecorder()
+            let startGate = LifecycleAsyncGate()
+            let controller = LifecycleFakeNativeController(
+                recorder: recorder,
+                label: "reconnect-rebound",
+                startOrResumeGate: startGate,
+                startOrResumeFailure: NativeAgentRuntimeControllerError.processNotRunning
+            )
+            let harness = makeHarness(recorder: recorder, claudeController: controller)
+            let session = await harness.host.ensureSessionReady(tabID: UUID())
+            session.selectedAgent = .claudeCode
+            session.providerSessionID = "rebound-provider-session"
+            let runID = UUID()
+            session.installRunID(runID)
+            session.runState = .running
+            _ = harness.host.test_installPersistentSessionBinding(sessionID: UUID(), on: session)
+
+            let reconnectTask = Task { @MainActor in
+                await harness.host.ensureSessionReady(
+                    tabID: session.tabID,
+                    reconnectActiveProviders: true
+                )
+            }
+            await startGate.waitUntilArrived()
+            _ = harness.host.test_installPersistentSessionBinding(sessionID: UUID(), on: session)
+            let reboundBinding = session.persistentSessionBindingIdentity
+            let saveGenerationAfterRebind = session.saveRequestGeneration
+            let sourceRevisionAfterRebind = session.sourceItemsRevision
+            await startGate.release()
+            _ = await reconnectTask.value
+
+            XCTAssertEqual(session.runState, .running)
+            XCTAssertEqual(session.runID, runID)
+            XCTAssertEqual(session.providerSessionID, "rebound-provider-session")
+            XCTAssertEqual(session.persistentSessionBindingIdentity, reboundBinding)
+            XCTAssertEqual(session.sourceItemsRevision, sourceRevisionAfterRebind)
+            XCTAssertEqual(session.saveRequestGeneration, saveGenerationAfterRebind)
+            XCTAssertTrue(session.items.filter { $0.kind == .error }.isEmpty)
+        }
     }
 
     func testInvalidatedClaudeResumeTransferCannotRestoreClearedSessionID() async {
@@ -472,7 +704,7 @@ extension AgentModeRunServiceLifecycleTests {
             currentSessionRefGate: sessionRefGate
         )
         let harness = makeHarness(recorder: recorder, claudeController: controller)
-        let session = makeRunningClaudeSession(controller: controller)
+        let session = makeRunningClaudeSession(controller: controller, host: harness.host)
         session.providerSessionID = "session-to-clear"
 
         let detached = harness.host.claudeCoordinator.prepareClaudeCancelSync(session)
@@ -571,17 +803,24 @@ extension AgentModeRunServiceLifecycleTests {
         session.providerSessionID = "existing-session"
         let originalRunID = UUID()
         session.installRunID(originalRunID)
+        session.runState = .running
+        harness.host.test_installLiveSession(session)
         let initialRunState = session.runState
 
+        let ownership = session.beginRunAttempt(source: "test.resumeFallback")
         let ensureTask = Task { @MainActor in
-            await harness.host.claudeCoordinator.ensureClaudeNativeSession(session: session)
+            await harness.host.claudeCoordinator.ensureClaudeNativeSession(
+                session: session,
+                intent: .runAttempt(ownership: ownership, runID: originalRunID)
+            )
         }
         await shutdownGate.waitUntilArrived()
         let successorRunID = UUID()
         session.installRunID(successorRunID)
         await shutdownGate.release()
-        await ensureTask.value
+        let ensureOutcome = await ensureTask.value
 
+        XCTAssertEqual(ensureOutcome, .superseded)
         XCTAssertTrue(recorder.contains("resume-fail:start-failed"))
         XCTAssertEqual(
             session.runID,
@@ -658,17 +897,17 @@ extension AgentModeRunServiceLifecycleTests {
 }
 
 actor LifecycleAsyncGate {
-    private var arrived = false
+    private var arrivalCount = 0
     private var released = false
-    private var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+    private var arrivalWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
 
     func arriveAndWait() async {
-        arrived = true
-        let arrivalWaiters = arrivalWaiters
-        self.arrivalWaiters.removeAll()
-        for waiter in arrivalWaiters {
-            waiter.resume()
+        arrivalCount += 1
+        let readyWaiters = arrivalWaiters.filter { $0.count <= arrivalCount }
+        arrivalWaiters.removeAll { $0.count <= arrivalCount }
+        for waiter in readyWaiters {
+            waiter.continuation.resume()
         }
         guard !released else { return }
         await withCheckedContinuation { continuation in
@@ -677,9 +916,13 @@ actor LifecycleAsyncGate {
     }
 
     func waitUntilArrived() async {
-        guard !arrived else { return }
+        await waitUntilArrivals(1)
+    }
+
+    func waitUntilArrivals(_ count: Int) async {
+        guard arrivalCount < count else { return }
         await withCheckedContinuation { continuation in
-            arrivalWaiters.append(continuation)
+            arrivalWaiters.append((count: count, continuation: continuation))
         }
     }
 
@@ -701,8 +944,10 @@ actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
     private let failSend: Bool
     private let currentSessionRefGate: LifecycleAsyncGate?
     private let eventsStreamReadyGate: LifecycleAsyncGate?
+    private let startOrResumeGate: LifecycleAsyncGate?
     private let sendUserMessageGate: LifecycleAsyncGate?
     private let shutdownGate: LifecycleAsyncGate?
+    private let repeatsStartOrResumeFailure: Bool
     private var pendingStartOrResumeFailure: Error?
     private let sessionRef = NativeAgentRuntimeSessionRef(sessionID: "lifecycle-claude-session")
     private let stream: AsyncStream<NativeAgentRuntimeEvent>
@@ -714,9 +959,11 @@ actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
         failSend: Bool = false,
         currentSessionRefGate: LifecycleAsyncGate? = nil,
         eventsStreamReadyGate: LifecycleAsyncGate? = nil,
+        startOrResumeGate: LifecycleAsyncGate? = nil,
         sendUserMessageGate: LifecycleAsyncGate? = nil,
         shutdownGate: LifecycleAsyncGate? = nil,
-        startOrResumeFailure: Error? = nil
+        startOrResumeFailure: Error? = nil,
+        repeatsStartOrResumeFailure: Bool = false
     ) {
         self.recorder = recorder
         self.label = label
@@ -724,8 +971,10 @@ actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
         self.failSend = failSend
         self.currentSessionRefGate = currentSessionRefGate
         self.eventsStreamReadyGate = eventsStreamReadyGate
+        self.startOrResumeGate = startOrResumeGate
         self.sendUserMessageGate = sendUserMessageGate
         self.shutdownGate = shutdownGate
+        self.repeatsStartOrResumeFailure = repeatsStartOrResumeFailure
         pendingStartOrResumeFailure = startOrResumeFailure
         stream = AsyncStream { _ in }
     }
@@ -757,8 +1006,14 @@ actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
         effortLevel: NativeAgentRuntimeEffortLevel?,
         systemPromptOverride: String?
     ) async throws -> NativeAgentRuntimeSessionRef {
+        if let startOrResumeGate {
+            recorder.record("\(label):start-arrived")
+            await startOrResumeGate.arriveAndWait()
+        }
         if let failure = pendingStartOrResumeFailure {
-            pendingStartOrResumeFailure = nil
+            if !repeatsStartOrResumeFailure {
+                pendingStartOrResumeFailure = nil
+            }
             recorder.record("\(label):start-failed")
             throw failure
         }

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -452,6 +452,7 @@ extension AgentModeRunServiceLifecycleTests {
         XCTAssertEqual(session.lastTerminalCommitRevision?.terminalState, .cancelled)
         XCTAssertEqual(recorder.events.count(where: { $0.hasPrefix("commit:") }), 1)
         XCTAssertEqual(recorder.events.count(where: { $0 == "run-active:false" }), 1)
+        XCTAssertEqual(recorder.events.count(where: { $0 == "handoff:false" }), 1)
         XCTAssertTrue(recorder.contains("attachments:deleteFiles"))
         XCTAssertTrue(recorder.contains("runner-superseded:shutdown"))
         XCTAssertFalse(recorder.contains("runner-replacement:shutdown"))

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -400,6 +400,63 @@ extension AgentModeRunServiceLifecycleTests {
         XCTAssertTrue(recorder.contains("stale-send:shutdown"))
     }
 
+    func testClaudeRunnerSettlesCurrentAttemptWhenControllerReplacementSupersedesSend() async throws {
+        let recorder = LifecycleRecorder()
+        let sendGate = LifecycleAsyncGate()
+        let oldController = LifecycleFakeNativeController(
+            recorder: recorder,
+            label: "runner-superseded",
+            sendUserMessageGate: sendGate
+        )
+        let replacementController = LifecycleFakeNativeController(
+            recorder: recorder,
+            label: "runner-replacement"
+        )
+        let harness = makeHarness(
+            recorder: recorder,
+            claudeController: oldController
+        )
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        session.claudeController = oldController
+        harness.host.test_installLiveSession(session)
+        let runtime = resolvedClaudeLaunchPolicy(
+            profile: session.permissionProfile,
+            harness: harness
+        )
+        setClaudeControllerLaunchSettings(
+            for: session,
+            coordinator: harness.host.claudeCoordinator,
+            permissionMode: runtime?.permissionMode,
+            allowNativeBashTool: runtime?.allowNativeBashTool,
+            mcpStrictMode: runtime?.mcpStrictMode
+        )
+
+        _ = await harness.service.startRun(
+            tabID: session.tabID,
+            session: session,
+            initialUserMessage: "settle superseded send",
+            initialMessageForRun: "settle superseded send",
+            attachments: []
+        )
+        let ownership = try XCTUnwrap(session.activeRunOwnership)
+        await sendGate.waitUntilArrived()
+        let agentTask = try XCTUnwrap(session.agentTask)
+        session.claudeController = replacementController
+        await sendGate.release()
+        await agentTask.value
+
+        XCTAssertEqual(session.runState, .cancelled)
+        XCTAssertNil(session.activeRunOwnership)
+        XCTAssertEqual(session.lastTerminalCommitRevision?.ownership, ownership)
+        XCTAssertEqual(session.lastTerminalCommitRevision?.terminalState, .cancelled)
+        XCTAssertEqual(recorder.events.count(where: { $0.hasPrefix("commit:") }), 1)
+        XCTAssertEqual(recorder.events.count(where: { $0 == "run-active:false" }), 1)
+        XCTAssertTrue(recorder.contains("attachments:deleteFiles"))
+        XCTAssertTrue(recorder.contains("runner-superseded:shutdown"))
+        XCTAssertFalse(recorder.contains("runner-replacement:shutdown"))
+    }
+
     func testClaudeSendFailureReportsEvidenceWithoutTerminalizingSession() async {
         let recorder = LifecycleRecorder()
         let controller = LifecycleFakeNativeController(


### PR DESCRIPTION
## Summary

- replace Claude coordinator terminal mutations with explicit `ready` / `failed` / `superseded` outcomes bound to an immutable run-attempt or reconnect intent
- keep live-attempt settlement in `AgentRunTerminalCommitBarrier`, including exactly-once cleanup, publication, and ownership release on initial send failure
- make queued steering failures restore the draft without stealing terminal authority from the live owner
- normalize failed ownershipless reconnects to an observable idle state only after exact tab, binding, run, and provider currency checks
- reuse the canonical run ID across Claude resume fallback and retain provider identity until a replacement controller starts successfully

## Authority invariants

- `ClaudeAgentModeCoordinator` owns controller lifecycle and failure evidence, not terminal run state
- `AgentRunTerminalCommitBarrier` remains the sole settlement driver for owned live attempts
- ownershipless restoration has no live attempt to settle and may only normalize state through the host after exact currency revalidation
- stale tab, binding, controller, ownership, run, or provider identities produce `superseded` and no state mutation

## Validation

- `make dev-test FILTER=AgentModeRunServiceLifecycleTests` — 46 tests passed
- `make dev-lint` — passed
- `make guardrails` — passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready` — passed
  - full root test suite passed
  - `swift build --product RepoPrompt` passed
- Fable 5 High read-only architecture review — approved with no must-fix findings

The visible debug app was not launched or stopped; no live-app smoke was performed.

## Non-goals / follow-ups

- move the remaining `TabSession`-shaped coordinator contract into domain-owned session APIs
- independently close the pre-existing attachment-reservation cleanup gap on a superseded runner
- separately harden the rare steering-send failure case where a protected completion is consumed during the failing send
- avoid an extra resume attempt against a retained provider session ID after both resume and fallback fail
