### PR TITLE
Support configurable Oracle groups of up to five

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModelsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModelsSettingsViewModel.swift
@@ -368,8 +368,8 @@ final class AgentModelsSettingsViewModel: ObservableObject {
         ModelDestination(
             id: "agentModels.additionalOracle.\(index)",
             getter: { [weak self] in
-                guard let self, self.additionalOracleModelRaws.indices.contains(index) else { return "" }
-                return self.additionalOracleModelRaws[index]
+                guard let self, additionalOracleModelRaws.indices.contains(index) else { return "" }
+                return additionalOracleModelRaws[index]
             },
             applier: { [weak self] rawValue in
                 self?.setAdditionalOracleModel(raw: rawValue, at: index)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModelsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModelsSettingsViewModel.swift
@@ -180,6 +180,10 @@ final class AgentModelsSettingsViewModel: ObservableObject {
         displayName(forChatModelRaw: profileSnapshot.planningModelRaw, fallback: "Select an Oracle model")
     }
 
+    var currentSecondaryOracleModelName: String {
+        displayName(forChatModelRaw: profileSnapshot.secondaryOracleModelRaw, fallback: "Disabled")
+    }
+
     var currentBuiltinChatModelName: String {
         let raw = profileSnapshot.syncChatModelWithOracle
             ? profileSnapshot.planningModelRaw
@@ -309,6 +313,19 @@ final class AgentModelsSettingsViewModel: ObservableObject {
         )
     }
 
+    var secondaryOracleModelDestination: ModelDestination {
+        ModelDestination(
+            id: "agentModels.secondaryOracle",
+            allowsEmptySelection: true,
+            getter: { [weak self] in
+                self?.profileSnapshot.secondaryOracleModelRaw ?? ""
+            },
+            applier: { [weak self] rawValue in
+                self?.setSecondaryOracleModel(raw: rawValue)
+            }
+        )
+    }
+
     /// Destination for the Built-in Chat model. Writes `preferredComposeModel`
     /// and, when the sync toggle is on, mirrors to `planningModel` in the
     /// selected global/workspace Agent Models profile.
@@ -335,6 +352,18 @@ final class AgentModelsSettingsViewModel: ObservableObject {
             } else {
                 profile.preferredComposeModelRaw = raw
             }
+        }
+    }
+
+    func setSecondaryOracleModel(raw: String) {
+        let canonicalRaw: String?
+        do {
+            canonicalRaw = try OraclePairModelSelectionPolicy.canonicalSecondaryRaw(raw)
+        } catch {
+            return
+        }
+        updateSelectedProfile(reason: "agent_models.secondary_oracle_model") { profile in
+            profile.secondaryOracleModelRaw = canonicalRaw
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModelsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModelsSettingsViewModel.swift
@@ -180,8 +180,46 @@ final class AgentModelsSettingsViewModel: ObservableObject {
         displayName(forChatModelRaw: profileSnapshot.planningModelRaw, fallback: "Select an Oracle model")
     }
 
+    var additionalOracleModelRaws: [String] {
+        profileSnapshot.additionalOracleModelRaws
+    }
+
+    var maximumOracleCount: Int {
+        OraclePairModelSelectionPolicy.maximumOracleCount
+    }
+
+    var totalOracleCount: Int {
+        additionalOracleModelRaws.count + 1
+    }
+
+    var canAddAdditionalOracle: Bool {
+        guard additionalOracleModelRaws.count < OraclePairModelSelectionPolicy.maximumAdditionalOracleCount else {
+            return false
+        }
+        do {
+            return try OraclePairModelSelectionPolicy.canonicalSecondaryRaw(profileSnapshot.planningModelRaw) != nil
+        } catch {
+            return false
+        }
+    }
+
+    var addOracleHelpText: String {
+        if additionalOracleModelRaws.count >= OraclePairModelSelectionPolicy.maximumAdditionalOracleCount {
+            return "Maximum of \(maximumOracleCount) Oracles configured"
+        }
+        if !canAddAdditionalOracle {
+            return "Select the primary Oracle model first"
+        }
+        return "Add another Oracle using the primary model"
+    }
+
     var currentSecondaryOracleModelName: String {
-        displayName(forChatModelRaw: profileSnapshot.secondaryOracleModelRaw, fallback: "Disabled")
+        additionalOracleModelName(at: 0, fallback: "Disabled")
+    }
+
+    func additionalOracleModelName(at index: Int, fallback: String = "Select an Oracle model") -> String {
+        guard additionalOracleModelRaws.indices.contains(index) else { return fallback }
+        return displayName(forChatModelRaw: additionalOracleModelRaws[index], fallback: fallback)
     }
 
     var currentBuiltinChatModelName: String {
@@ -326,6 +364,19 @@ final class AgentModelsSettingsViewModel: ObservableObject {
         )
     }
 
+    func additionalOracleModelDestination(at index: Int) -> ModelDestination {
+        ModelDestination(
+            id: "agentModels.additionalOracle.\(index)",
+            getter: { [weak self] in
+                guard let self, self.additionalOracleModelRaws.indices.contains(index) else { return "" }
+                return self.additionalOracleModelRaws[index]
+            },
+            applier: { [weak self] rawValue in
+                self?.setAdditionalOracleModel(raw: rawValue, at: index)
+            }
+        )
+    }
+
     /// Destination for the Built-in Chat model. Writes `preferredComposeModel`
     /// and, when the sync toggle is on, mirrors to `planningModel` in the
     /// selected global/workspace Agent Models profile.
@@ -364,6 +415,50 @@ final class AgentModelsSettingsViewModel: ObservableObject {
         }
         updateSelectedProfile(reason: "agent_models.secondary_oracle_model") { profile in
             profile.secondaryOracleModelRaw = canonicalRaw
+        }
+    }
+
+    func addAdditionalOracle() {
+        guard additionalOracleModelRaws.count < OraclePairModelSelectionPolicy.maximumAdditionalOracleCount else {
+            return
+        }
+        let primaryRaw: String
+        do {
+            guard let canonicalRaw = try OraclePairModelSelectionPolicy.canonicalSecondaryRaw(
+                profileSnapshot.planningModelRaw
+            ) else { return }
+            primaryRaw = canonicalRaw
+        } catch {
+            return
+        }
+        updateSelectedProfile(reason: "agent_models.additional_oracle.add") { profile in
+            guard profile.additionalOracleModelRaws.count
+                < OraclePairModelSelectionPolicy.maximumAdditionalOracleCount
+            else { return }
+            profile.additionalOracleModelRaws.append(primaryRaw)
+        }
+    }
+
+    func removeAdditionalOracle(at index: Int) {
+        guard additionalOracleModelRaws.indices.contains(index) else { return }
+        updateSelectedProfile(reason: "agent_models.additional_oracle.remove") { profile in
+            guard profile.additionalOracleModelRaws.indices.contains(index) else { return }
+            profile.additionalOracleModelRaws.remove(at: index)
+        }
+    }
+
+    func setAdditionalOracleModel(raw: String, at index: Int) {
+        guard additionalOracleModelRaws.indices.contains(index) else { return }
+        let canonicalRaw: String
+        do {
+            guard let resolvedRaw = try OraclePairModelSelectionPolicy.canonicalSecondaryRaw(raw) else { return }
+            canonicalRaw = resolvedRaw
+        } catch {
+            return
+        }
+        updateSelectedProfile(reason: "agent_models.additional_oracle.model") { profile in
+            guard profile.additionalOracleModelRaws.indices.contains(index) else { return }
+            profile.additionalOracleModelRaws[index] = canonicalRaw
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
@@ -23,20 +23,45 @@ enum AgentOraclePillPresentation: Equatable {
     var label: String {
         switch self {
         case .legacySingle: "Oracle"
-        case .pairedLane(.primary): "Primary Oracle"
-        case .pairedLane(.secondary): "Secondary Oracle"
+        case let .pairedLane(lane):
+            lane == .primary ? "Primary Oracle" : "Oracle \(lane.ordinal)"
+        }
+    }
+
+    var compactLabel: String {
+        switch self {
+        case .legacySingle: "Oracle"
+        case .pairedLane(.primary): "Oracle 1"
+        case let .pairedLane(lane): "O\(lane.ordinal)"
         }
     }
 }
 
 enum AgentOraclePillLogic {
     static func presentations(
+        additionalModelRaws: [String],
+        groupSessionLanes: Set<OracleLane> = []
+    ) -> [AgentOraclePillPresentation] {
+        let configuredAdditional = (try? OraclePairModelSelectionPolicy.canonicalAdditionalRaws(
+            additionalModelRaws
+        )) ?? []
+        guard !configuredAdditional.isEmpty || !groupSessionLanes.isEmpty else {
+            return [.legacySingle]
+        }
+        let configuredLanes = Set(OracleLane.allCases.prefix(configuredAdditional.count + 1))
+        return configuredLanes.union(groupSessionLanes).sorted { $0.ordinal < $1.ordinal }.map {
+            .pairedLane($0)
+        }
+    }
+
+    static func presentations(
         secondaryModelRaw: String?,
         hasSecondarySession: Bool = false
     ) -> [AgentOraclePillPresentation] {
-        let secondaryConfigured = (try? OraclePairModelSelectionPolicy.canonicalSecondaryRaw(secondaryModelRaw)) != nil
-        guard secondaryConfigured || hasSecondarySession else { return [.legacySingle] }
-        return [.pairedLane(.primary), .pairedLane(.secondary)]
+        presentations(
+            additionalModelRaws: secondaryModelRaw.map { [$0] } ?? [],
+            groupSessionLanes: hasSecondarySession ? [.primary, .secondary] : []
+        )
     }
 
     static func resolvedLane(for session: ChatSession) -> OracleLane? {
@@ -228,8 +253,9 @@ enum AgentOraclePillLogic {
     }
 }
 
-/// Pill that appears when there are oracle chat sessions for the current tab.
-/// More prominent when streaming. Clicking opens a wide popover with chat transcript.
+/// Primary stays visible as a stable Agent Mode affordance. Additional lane pills
+/// appear when they have a live or historical session for the current tab.
+/// Active pills open a wide popover with the chat transcript.
 struct AgentOraclePill: View {
     @ObservedObject var oracleViewModel: OracleViewModel
     let windowID: Int
@@ -312,12 +338,16 @@ struct AgentOraclePill: View {
         latestTabSession != nil
     }
 
+    private var shouldRender: Bool {
+        hasAnySessions || lane.isPrimary
+    }
+
     var body: some View {
         #if DEBUG
             let _ = AgentModePerfDiagnostics.increment("ui.body.statusPills.oracle")
         #endif
         Group {
-            if hasAnySessions {
+            if shouldRender {
                 let cornerRadius = AgentPillMetrics.cornerRadius()
                 Button {
                     openPopover(chatID: nil)
@@ -332,7 +362,7 @@ struct AgentOraclePill: View {
                                 .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
                                 .foregroundStyle(.secondary)
                         }
-                        Text(presentation.label)
+                        Text(presentation.compactLabel)
                             .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: isStreaming ? .semibold : .medium))
                             .foregroundStyle(isStreaming ? .primary : .secondary)
                     }
@@ -347,8 +377,11 @@ struct AgentOraclePill: View {
                     .shadow(color: isStreaming ? Color.purple.opacity(0.15) : .clear, radius: 4, y: 1)
                 }
                 .buttonStyle(.plain)
+                .disabled(!hasAnySessions)
                 .hoverTooltip(
-                    isStreaming
+                    !hasAnySessions
+                        ? "Oracle is ready — its latest chat will appear here"
+                        : isStreaming
                         ? "\(presentation.label) is thinking — click to view the live chat"
                         : "Open the latest \(presentation.label) chat for this tab",
                     .top
@@ -371,7 +404,7 @@ struct AgentOraclePill: View {
                 )
                 return
             }
-            guard presentation != .pairedLane(.secondary),
+            guard presentation.lane == .primary,
                   let route = AgentOracleLatestPopoverRoute(notificationUserInfo: note.userInfo),
                   route.windowID == windowID,
                   route.tabID == currentTabID,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
@@ -210,10 +210,7 @@ enum AgentOraclePillLogic {
         {
             return currentSessionID
         }
-        return latestSession(
-            in: sameWorkspaceEligibleSessions,
-            streamingSessionIDs: streamingSessionIDs
-        )?.id
+        return latestSession(in: sameWorkspaceEligibleSessions, streamingSessionIDs: streamingSessionIDs)?.id
     }
 
     static func session(matchingChatID raw: String, in sessions: [ChatSession]) -> ChatSession? {
@@ -341,14 +338,11 @@ struct AgentOraclePill: View {
                     }
                     .padding(.horizontal, AgentPillMetrics.horizontalPadding())
                     .frame(height: AgentPillMetrics.height())
-                    .background(.ultraThinMaterial)
+                    .background(isStreaming ? AnyShapeStyle(.ultraThinMaterial) : AnyShapeStyle(.ultraThinMaterial))
                     .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                     .overlay(
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .stroke(
-                                isStreaming ? Color.purple.opacity(0.4) : Color.secondary.opacity(0.15),
-                                lineWidth: isStreaming ? 1 : 0.5
-                            )
+                            .stroke(isStreaming ? Color.purple.opacity(0.4) : Color.secondary.opacity(0.15), lineWidth: isStreaming ? 1 : 0.5)
                     )
                     .shadow(color: isStreaming ? Color.purple.opacity(0.15) : .clear, radius: 4, y: 1)
                 }
@@ -508,13 +502,14 @@ struct AgentOraclePill: View {
         workspaceID: UUID? = nil,
         presentation: AgentOraclePopoverPresentation = .standard
     ) {
+        guard let tabID = currentTabID else { return }
         openRequestGeneration &+= 1
         let generation = openRequestGeneration
 
         guard let chatID else {
-            guard let latestTabSession else { return }
+            guard let target = latestTabSession else { return }
             present(
-                sessionID: latestTabSession.id,
+                sessionID: target.id,
                 isExplicit: false,
                 actionPolicy: .standard,
                 generation: generation
@@ -522,7 +517,6 @@ struct AgentOraclePill: View {
             return
         }
 
-        guard let tabID = currentTabID else { return }
         presentedPopover = nil
         guard let workspaceID,
               let request = AgentOraclePillLogic.explicitOpenRequest(

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
@@ -2,7 +2,55 @@ import SwiftUI
 
 // MARK: - Oracle Pill
 
+enum AgentOraclePillPresentation: Equatable {
+    case legacySingle
+    case pairedLane(OracleLane)
+
+    var id: String {
+        switch self {
+        case .legacySingle: "legacy"
+        case let .pairedLane(lane): lane.rawValue
+        }
+    }
+
+    var lane: OracleLane {
+        switch self {
+        case .legacySingle: .primary
+        case let .pairedLane(lane): lane
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .legacySingle: "Oracle"
+        case .pairedLane(.primary): "Primary Oracle"
+        case .pairedLane(.secondary): "Secondary Oracle"
+        }
+    }
+}
+
 enum AgentOraclePillLogic {
+    static func presentations(
+        secondaryModelRaw: String?,
+        hasSecondarySession: Bool = false
+    ) -> [AgentOraclePillPresentation] {
+        let secondaryConfigured = (try? OraclePairModelSelectionPolicy.canonicalSecondaryRaw(secondaryModelRaw)) != nil
+        guard secondaryConfigured || hasSecondarySession else { return [.legacySingle] }
+        return [.pairedLane(.primary), .pairedLane(.secondary)]
+    }
+
+    static func resolvedLane(for session: ChatSession) -> OracleLane? {
+        switch (session.oraclePairID, session.oracleLane) {
+        case (nil, nil): .primary
+        case let (.some, lane?): lane
+        default: nil
+        }
+    }
+
+    static func sessions(_ sessions: [ChatSession], resolvedTo lane: OracleLane) -> [ChatSession] {
+        sessions.filter { resolvedLane(for: $0) == lane }
+    }
+
     struct ExplicitOpenRequest: Equatable {
         let generation: UInt64
         let workspaceID: UUID
@@ -45,13 +93,15 @@ enum AgentOraclePillLogic {
         for request: ExplicitOpenRequest,
         currentGeneration: UInt64,
         currentWorkspaceID: UUID?,
-        currentTabID: UUID?
+        currentTabID: UUID?,
+        expectedLane: OracleLane = .primary
     ) -> Bool {
         guard request.generation == currentGeneration,
               request.workspaceID == currentWorkspaceID,
               request.tabID == currentTabID,
               session.workspaceID == request.workspaceID,
-              session.composeTabID == request.tabID else { return false }
+              session.composeTabID == request.tabID,
+              resolvedLane(for: session) == expectedLane else { return false }
         return Self.session(matchingChatID: request.chatID, in: [session]) != nil
     }
 
@@ -160,7 +210,10 @@ enum AgentOraclePillLogic {
         {
             return currentSessionID
         }
-        return latestSession(in: sameWorkspaceEligibleSessions, streamingSessionIDs: streamingSessionIDs)?.id
+        return latestSession(
+            in: sameWorkspaceEligibleSessions,
+            streamingSessionIDs: streamingSessionIDs
+        )?.id
     }
 
     static func session(matchingChatID raw: String, in sessions: [ChatSession]) -> ChatSession? {
@@ -186,6 +239,7 @@ struct AgentOraclePill: View {
     let currentTabID: UUID?
     let activeAgentSessionID: UUID?
     let activeRunID: UUID?
+    let presentation: AgentOraclePillPresentation
 
     private struct PopoverPresentation: Identifiable {
         /// Identifies the open request; bump the generation whenever the session or policy changes
@@ -203,10 +257,21 @@ struct AgentOraclePill: View {
         fontScale.preset
     }
 
-    private var eligibleTabSessions: [ChatSession] {
+    private var lane: OracleLane {
+        presentation.lane
+    }
+
+    private var sameTabLaneSessions: [ChatSession] {
         guard let tabID = currentTabID else { return [] }
-        return AgentOraclePillLogic.eligibleSessions(
-            sessions: oracleViewModel.sessions(forTabID: tabID),
+        return AgentOraclePillLogic.sessions(
+            oracleViewModel.sessions(forTabID: tabID),
+            resolvedTo: lane
+        )
+    }
+
+    private var eligibleTabSessions: [ChatSession] {
+        AgentOraclePillLogic.eligibleSessions(
+            sessions: sameTabLaneSessions,
             streamingSessionIDs: oracleViewModel.streamingSessions,
             liveMessageCount: { oracleViewModel.liveMessageCount(for: $0) },
             activeAgentSessionID: activeAgentSessionID,
@@ -228,7 +293,9 @@ struct AgentOraclePill: View {
 
     private func presentedSession(for presentation: PopoverPresentation) -> ChatSession? {
         guard let tabID = currentTabID else { return nil }
-        return oracleViewModel.sessions(forTabID: tabID).first { $0.id == presentation.sessionID }
+        return oracleViewModel.sessions(forTabID: tabID).first {
+            $0.id == presentation.sessionID && AgentOraclePillLogic.resolvedLane(for: $0) == lane
+        }
     }
 
     private func isPresentedSessionStreaming(_ presentation: PopoverPresentation) -> Bool {
@@ -236,9 +303,10 @@ struct AgentOraclePill: View {
     }
 
     private func popoverSubtitle(_ presentation: PopoverPresentation) -> String {
-        guard let session = presentedSession(for: presentation) else { return "Latest tab chat" }
+        let latestLabel = self.presentation == .legacySingle ? "Latest tab chat" : "Latest \(lane.rawValue) chat"
+        guard let session = presentedSession(for: presentation) else { return latestLabel }
         if session.id == latestTabSession?.id {
-            return "Latest tab chat"
+            return latestLabel
         }
         return session.name
     }
@@ -267,22 +335,30 @@ struct AgentOraclePill: View {
                                 .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
                                 .foregroundStyle(.secondary)
                         }
-                        Text("Oracle")
+                        Text(presentation.label)
                             .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: isStreaming ? .semibold : .medium))
                             .foregroundStyle(isStreaming ? .primary : .secondary)
                     }
                     .padding(.horizontal, AgentPillMetrics.horizontalPadding())
                     .frame(height: AgentPillMetrics.height())
-                    .background(isStreaming ? AnyShapeStyle(.ultraThinMaterial) : AnyShapeStyle(.ultraThinMaterial))
+                    .background(.ultraThinMaterial)
                     .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                     .overlay(
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .stroke(isStreaming ? Color.purple.opacity(0.4) : Color.secondary.opacity(0.15), lineWidth: isStreaming ? 1 : 0.5)
+                            .stroke(
+                                isStreaming ? Color.purple.opacity(0.4) : Color.secondary.opacity(0.15),
+                                lineWidth: isStreaming ? 1 : 0.5
+                            )
                     )
                     .shadow(color: isStreaming ? Color.purple.opacity(0.15) : .clear, radius: 4, y: 1)
                 }
                 .buttonStyle(.plain)
-                .hoverTooltip(isStreaming ? "Oracle is thinking — click to view the live chat" : "Open the latest Oracle chat for this tab", .top)
+                .hoverTooltip(
+                    isStreaming
+                        ? "\(presentation.label) is thinking — click to view the live chat"
+                        : "Open the latest \(presentation.label) chat for this tab",
+                    .top
+                )
                 .animation(.easeInOut(duration: 0.2), value: isStreaming)
             } else {
                 Color.clear.frame(width: 0, height: 0)
@@ -301,7 +377,8 @@ struct AgentOraclePill: View {
                 )
                 return
             }
-            guard let route = AgentOracleLatestPopoverRoute(notificationUserInfo: note.userInfo),
+            guard presentation != .pairedLane(.secondary),
+                  let route = AgentOracleLatestPopoverRoute(notificationUserInfo: note.userInfo),
                   route.windowID == windowID,
                   route.tabID == currentTabID,
                   route.workspaceID == oracleViewModel.workspaceManager.activeWorkspaceID
@@ -343,7 +420,7 @@ struct AgentOraclePill: View {
         let transcriptMaxHeight = fontPreset.scaledClamped(600, max: 780)
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
-                Text("Oracle")
+                Text(self.presentation.label)
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 13, weight: .semibold))
                 if isPresentedSessionStreaming(presentation) {
                     ProgressView()
@@ -375,7 +452,7 @@ struct AgentOraclePill: View {
 
     private func reconcilePresentedSession() {
         guard let presentation = presentedPopover else { return }
-        let sameTabSessions = currentTabID.map { oracleViewModel.sessions(forTabID: $0) } ?? []
+        let sameTabSessions = sameTabLaneSessions
         let resolvedID = AgentOraclePillLogic.reconciledPresentedSessionID(
             currentSessionID: presentation.sessionID,
             isExplicit: presentation.isExplicit,
@@ -431,14 +508,13 @@ struct AgentOraclePill: View {
         workspaceID: UUID? = nil,
         presentation: AgentOraclePopoverPresentation = .standard
     ) {
-        guard let tabID = currentTabID else { return }
         openRequestGeneration &+= 1
         let generation = openRequestGeneration
 
         guard let chatID else {
-            guard let target = latestTabSession else { return }
+            guard let latestTabSession else { return }
             present(
-                sessionID: target.id,
+                sessionID: latestTabSession.id,
                 isExplicit: false,
                 actionPolicy: .standard,
                 generation: generation
@@ -446,6 +522,7 @@ struct AgentOraclePill: View {
             return
         }
 
+        guard let tabID = currentTabID else { return }
         presentedPopover = nil
         guard let workspaceID,
               let request = AgentOraclePillLogic.explicitOpenRequest(
@@ -467,7 +544,8 @@ struct AgentOraclePill: View {
                     for: request,
                     currentGeneration: openRequestGeneration,
                     currentWorkspaceID: oracleViewModel.workspaceManager.activeWorkspaceID,
-                    currentTabID: currentTabID
+                    currentTabID: currentTabID,
+                    expectedLane: lane
                 )
             else { return }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentStatusPillsRow.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentStatusPillsRow.swift
@@ -15,22 +15,20 @@ struct AgentStatusPillsRow: View {
     }
 
     private var oraclePresentations: [AgentOraclePillPresentation] {
-        let hasSecondarySession = snapshot.currentTabID.map { tabID in
-            let secondarySessions = AgentOraclePillLogic.sessions(
-                oracleViewModel.sessions(forTabID: tabID),
-                resolvedTo: .secondary
-            )
-            return !AgentOraclePillLogic.eligibleSessions(
-                sessions: secondarySessions,
+        let groupSessionLanes: Set<OracleLane> = snapshot.currentTabID.map { tabID in
+            let groupedSessions = oracleViewModel.sessions(forTabID: tabID).filter { $0.oraclePairID != nil }
+            let eligible = AgentOraclePillLogic.eligibleSessions(
+                sessions: groupedSessions,
                 streamingSessionIDs: oracleViewModel.streamingSessions,
                 liveMessageCount: { oracleViewModel.liveMessageCount(for: $0) },
                 activeAgentSessionID: snapshot.activeAgentSessionID,
                 activeRunID: snapshot.activeRunID
-            ).isEmpty
-        } ?? false
+            )
+            return Set(eligible.compactMap(\.oracleLane))
+        } ?? []
         return AgentOraclePillLogic.presentations(
-            secondaryModelRaw: promptManager.secondaryOracleModelRaw,
-            hasSecondarySession: hasSecondarySession
+            additionalModelRaws: promptManager.additionalOracleModelRaws,
+            groupSessionLanes: groupSessionLanes
         )
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentStatusPillsRow.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentStatusPillsRow.swift
@@ -14,6 +14,26 @@ struct AgentStatusPillsRow: View {
         statusPillsUI.snapshot
     }
 
+    private var oraclePresentations: [AgentOraclePillPresentation] {
+        let hasSecondarySession = snapshot.currentTabID.map { tabID in
+            let secondarySessions = AgentOraclePillLogic.sessions(
+                oracleViewModel.sessions(forTabID: tabID),
+                resolvedTo: .secondary
+            )
+            return !AgentOraclePillLogic.eligibleSessions(
+                sessions: secondarySessions,
+                streamingSessionIDs: oracleViewModel.streamingSessions,
+                liveMessageCount: { oracleViewModel.liveMessageCount(for: $0) },
+                activeAgentSessionID: snapshot.activeAgentSessionID,
+                activeRunID: snapshot.activeRunID
+            ).isEmpty
+        } ?? false
+        return AgentOraclePillLogic.presentations(
+            secondaryModelRaw: promptManager.secondaryOracleModelRaw,
+            hasSecondarySession: hasSecondarySession
+        )
+    }
+
     var body: some View {
         #if DEBUG
             let _ = AgentModePerfDiagnostics.increment("ui.body.statusPillsRow")
@@ -65,13 +85,16 @@ struct AgentStatusPillsRow: View {
             Spacer(minLength: 0)
 
             HStack(spacing: 6) {
-                AgentOraclePill(
-                    oracleViewModel: oracleViewModel,
-                    windowID: windowID,
-                    currentTabID: snapshot.currentTabID,
-                    activeAgentSessionID: snapshot.activeAgentSessionID,
-                    activeRunID: snapshot.activeRunID
-                )
+                ForEach(oraclePresentations, id: \.id) { presentation in
+                    AgentOraclePill(
+                        oracleViewModel: oracleViewModel,
+                        windowID: windowID,
+                        currentTabID: snapshot.currentTabID,
+                        activeAgentSessionID: snapshot.activeAgentSessionID,
+                        activeRunID: snapshot.activeRunID,
+                        presentation: presentation
+                    )
+                }
 
                 AgentContextPill(
                     promptManager: promptManager,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
@@ -475,6 +475,10 @@ private struct ContextBuilderCompletedSummaryView: View {
         contextBuilderFollowUpChatID(for: dto)
     }
 
+    private var oracleLanes: [ContextBuilderOracleLaneSummary] {
+        contextBuilderOracleLaneSummaries(for: dto)
+    }
+
     private var detailParts: [String] {
         var parts: [String] = []
         if let fileCount = dto?.fileCount {
@@ -496,10 +500,10 @@ private struct ContextBuilderCompletedSummaryView: View {
         return selection
     }
 
-    private func openOraclePreview() {
+    private func openOraclePreview(chatID: String?) {
         guard let userInfo = contextBuilderOraclePopoverUserInfo(
             openContext: oracleOpenContext,
-            chatID: followUpChatID
+            chatID: chatID
         ) else { return }
         NotificationCenter.default.post(name: .showAgentOraclePopover, object: nil, userInfo: userInfo)
     }
@@ -523,19 +527,37 @@ private struct ContextBuilderCompletedSummaryView: View {
                     .lineLimit(3)
             }
 
-            if let followUpChatID, !followUpChatID.isEmpty {
-                Text("Oracle chat: \(followUpChatID)")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.secondary)
-            }
+            if oracleLanes.isEmpty {
+                if let followUpChatID, !followUpChatID.isEmpty {
+                    Text("Oracle chat: \(followUpChatID)")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
 
-            Button("Open Oracle", action: openOraclePreview)
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .disabled(contextBuilderOraclePopoverUserInfo(
-                    openContext: oracleOpenContext,
-                    chatID: followUpChatID
-                ) == nil)
+                Button("Open Oracle") { openOraclePreview(chatID: followUpChatID) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(contextBuilderOraclePopoverUserInfo(
+                        openContext: oracleOpenContext,
+                        chatID: followUpChatID
+                    ) == nil)
+            } else {
+                ForEach(oracleLanes, id: \.lane) { lane in
+                    HStack(spacing: 6) {
+                        Text(lane.label)
+                            .font(.system(size: 10, weight: .semibold))
+                        StatusBadge(text: lane.statusLabel, status: lane.cardStatus)
+                        Spacer()
+                        Button("Open") { openOraclePreview(chatID: lane.chatID) }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .disabled(contextBuilderOraclePopoverUserInfo(
+                                openContext: oracleOpenContext,
+                                chatID: lane.chatID
+                            ) == nil)
+                    }
+                }
+            }
         }
     }
 }
@@ -544,6 +566,49 @@ private enum ContextBuilderCardPhase {
     case running
     case generatingPlan
     case completed
+}
+
+struct ContextBuilderOracleLaneSummary: Equatable {
+    let lane: OracleLane
+    let status: String
+    let chatID: String?
+
+    var label: String {
+        lane == .primary ? "Primary Oracle" : "Secondary Oracle"
+    }
+
+    var statusLabel: String {
+        status.replacingOccurrences(of: "_", with: " ").capitalized
+    }
+
+    var cardStatus: ToolCardStatus {
+        switch status.lowercased() {
+        case "completed": .success
+        case "failed": .failure
+        default: .neutral
+        }
+    }
+}
+
+func contextBuilderOracleLaneSummaries(
+    for dto: ToolResultDTOs.ContextBuilderDTO?
+) -> [ContextBuilderOracleLaneSummary] {
+    guard let dto,
+          let branch = ContextBuilderFollowUpBranch.select(responseType: dto.responseType)
+    else { return [] }
+    let followUp = switch branch {
+    case .review: dto.review
+    case .plan: dto.plan
+    }
+    guard let results = followUp?.oracleResults else { return [] }
+    return [OracleLane.primary, .secondary].compactMap { lane in
+        guard let result = results[lane.rawValue] else { return nil }
+        return ContextBuilderOracleLaneSummary(
+            lane: lane,
+            status: nonEmptyContextBuilderValue(result.status) ?? "unknown",
+            chatID: nonEmptyContextBuilderValue(result.chatID)
+        )
+    }
 }
 
 func contextBuilderOraclePopoverUserInfo(

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
@@ -574,7 +574,7 @@ struct ContextBuilderOracleLaneSummary: Equatable {
     let chatID: String?
 
     var label: String {
-        lane == .primary ? "Primary Oracle" : "Secondary Oracle"
+        lane == .primary ? "Primary Oracle" : "Oracle \(lane.ordinal)"
     }
 
     var statusLabel: String {
@@ -601,7 +601,7 @@ func contextBuilderOracleLaneSummaries(
     case .plan: dto.plan
     }
     guard let results = followUp?.oracleResults else { return [] }
-    return [OracleLane.primary, .secondary].compactMap { lane in
+    return OracleLane.allCases.compactMap { lane in
         guard let result = results[lane.rawValue] else { return nil }
         return ContextBuilderOracleLaneSummary(
             lane: lane,

--- a/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
@@ -48,6 +48,208 @@ enum ChatSessionLookupResult {
     case ambiguous
 }
 
+private enum ChatSessionFile {
+    static func filename(for id: UUID) -> String {
+        "ChatSession-\(id.uuidString).json"
+    }
+
+    static func sessionID(from filename: String) -> UUID? {
+        guard filename.hasPrefix("ChatSession-"), filename.hasSuffix(".json") else { return nil }
+        return UUID(uuidString: String(filename.dropFirst(12).dropLast(5)))
+    }
+}
+
+/// Current-format crash recovery for installing exactly one Oracle pair.
+private enum OraclePairWriteTransaction {
+    private struct Manifest: Codable {
+        struct Entry: Codable {
+            let sessionID: UUID
+            let originallyExisted: Bool
+        }
+
+        let entries: [Entry]
+    }
+
+    private static let prefix = ".oracle-pair-save-"
+    private static let quarantinePrefix = ".oracle-pair-quarantine-"
+    private static let manifestName = "manifest.json"
+    private static let temporaryManifestName = "manifest.tmp"
+    private static let commitName = "committed"
+
+    static func save(_ replacements: [(id: UUID, data: Data)], in folder: URL) throws {
+        guard replacements.count == 2, Set(replacements.map(\.id)).count == 2 else {
+            throw ChatDataError.invalidFilename("An Oracle pair save requires exactly two distinct sessions.")
+        }
+        try recover(in: folder)
+
+        let replacements = replacements.sorted { $0.id.uuidString < $1.id.uuidString }
+        let entries = try replacements.map { replacement -> Manifest.Entry in
+            let destination = folder.appendingPathComponent(ChatSessionFile.filename(for: replacement.id))
+            let existed = FileManager.default.fileExists(atPath: destination.path)
+            if existed { try requireRegular(destination) }
+            return .init(sessionID: replacement.id, originallyExisted: existed)
+        }
+        let transaction = folder.appendingPathComponent("\(prefix)\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: transaction, withIntermediateDirectories: false)
+
+        do {
+            for replacement in replacements {
+                try write(
+                    replacement.data,
+                    to: transaction.appendingPathComponent("replacement-\(ChatSessionFile.filename(for: replacement.id))")
+                )
+            }
+            let temporaryManifest = transaction.appendingPathComponent(temporaryManifestName)
+            try write(JSONEncoder().encode(Manifest(entries: entries)), to: temporaryManifest)
+            try FileManager.default.moveItem(
+                at: temporaryManifest,
+                to: transaction.appendingPathComponent(manifestName)
+            )
+            for entry in entries {
+                let filename = ChatSessionFile.filename(for: entry.sessionID)
+                let destination = folder.appendingPathComponent(filename)
+                if entry.originallyExisted {
+                    try FileManager.default.moveItem(
+                        at: destination,
+                        to: transaction.appendingPathComponent("original-\(filename)")
+                    )
+                }
+                try FileManager.default.moveItem(
+                    at: transaction.appendingPathComponent("replacement-\(filename)"),
+                    to: destination
+                )
+            }
+            try write(Data(), to: transaction.appendingPathComponent(commitName))
+            try? FileManager.default.removeItem(at: transaction)
+        } catch {
+            do {
+                try recover(transaction, in: folder)
+            } catch {
+                throw saveError("Oracle pair save and recovery both failed.", underlying: error)
+            }
+            throw error
+        }
+    }
+
+    static func recover(in folder: URL) throws {
+        for transaction in try FileManager.default.contentsOfDirectory(
+            at: folder,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: []
+        ) where transaction.lastPathComponent.hasPrefix(prefix) {
+            let suffix = String(transaction.lastPathComponent.dropFirst(prefix.count))
+            let values = try? transaction.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            guard UUID(uuidString: suffix) != nil,
+                  values?.isDirectory == true,
+                  values?.isSymbolicLink != true
+            else {
+                quarantine(transaction, in: folder)
+                continue
+            }
+            do {
+                try recover(transaction, in: folder)
+            } catch ChatDataError.invalidFilename {
+                quarantine(transaction, in: folder)
+            } catch is DecodingError {
+                quarantine(transaction, in: folder)
+            }
+        }
+    }
+
+    private static func quarantine(_ transaction: URL, in folder: URL) {
+        let destination = folder.appendingPathComponent("\(quarantinePrefix)\(UUID().uuidString)")
+        do {
+            try FileManager.default.moveItem(at: transaction, to: destination)
+            print("Quarantined malformed Oracle pair transaction \(transaction.lastPathComponent).")
+        } catch {
+            print("Could not quarantine malformed Oracle pair transaction \(transaction.lastPathComponent): \(error)")
+        }
+    }
+
+    private static func recover(_ transaction: URL, in folder: URL) throws {
+        let manifestURL = transaction.appendingPathComponent(manifestName)
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            _ = try validatedArtifacts(in: transaction, entries: [])
+            try FileManager.default.removeItem(at: transaction)
+            return
+        }
+
+        let manifest = try JSONDecoder().decode(Manifest.self, from: readRegular(manifestURL))
+        guard manifest.entries.count == 2,
+              Set(manifest.entries.map(\.sessionID)).count == 2
+        else { throw ChatDataError.invalidFilename(transaction.lastPathComponent) }
+        _ = try validatedArtifacts(in: transaction, entries: manifest.entries)
+
+        if !FileManager.default.fileExists(atPath: transaction.appendingPathComponent(commitName).path) {
+            for entry in manifest.entries {
+                let filename = ChatSessionFile.filename(for: entry.sessionID)
+                let destination = folder.appendingPathComponent(filename)
+                let original = transaction.appendingPathComponent("original-\(filename)")
+                if entry.originallyExisted, FileManager.default.fileExists(atPath: original.path) {
+                    if FileManager.default.fileExists(atPath: destination.path) {
+                        try FileManager.default.removeItem(at: destination)
+                    }
+                    try FileManager.default.moveItem(at: original, to: destination)
+                } else if !entry.originallyExisted, FileManager.default.fileExists(atPath: destination.path) {
+                    try FileManager.default.removeItem(at: destination)
+                }
+            }
+        }
+        try FileManager.default.removeItem(at: transaction)
+    }
+
+    private static func validatedArtifacts(
+        in transaction: URL,
+        entries: [Manifest.Entry]
+    ) throws -> [String] {
+        let allowedSessionArtifacts = Set(entries.flatMap { entry in
+            let filename = ChatSessionFile.filename(for: entry.sessionID)
+            return ["original-\(filename)", "replacement-\(filename)"]
+        })
+        return try FileManager.default.contentsOfDirectory(
+            at: transaction,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: []
+        ).map { url in
+            let name = url.lastPathComponent
+            let stagingReplacement = name.hasPrefix("replacement-") &&
+                ChatSessionFile.sessionID(from: String(name.dropFirst("replacement-".count))) != nil
+            guard name == manifestName || name == temporaryManifestName || name == commitName ||
+                allowedSessionArtifacts.contains(name) || (entries.isEmpty && stagingReplacement)
+            else { throw ChatDataError.invalidFilename(name) }
+            try requireRegular(url)
+            return name
+        }
+    }
+
+    fileprivate static func requireRegular(_ url: URL) throws {
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+        guard values.isRegularFile == true, values.isSymbolicLink != true else {
+            throw ChatDataError.invalidFilename(url.lastPathComponent)
+        }
+    }
+
+    private static func readRegular(_ url: URL) throws -> Data {
+        try requireRegular(url)
+        return try Data(contentsOf: url, options: .mappedIfSafe)
+    }
+
+    private static func write(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: .withoutOverwriting)
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.synchronize()
+    }
+
+    private static func saveError(_ message: String, underlying: Error) -> ChatDataError {
+        .saveFailed(NSError(
+            domain: "ChatDataService",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: message, NSUnderlyingErrorKey: underlying]
+        ))
+    }
+}
+
 /// Chat history limit options
 public enum ChatHistoryLimit: Int, CaseIterable {
     case fifty = 50
@@ -73,14 +275,10 @@ public enum ChatHistoryLimit: Int, CaseIterable {
 /// An actor that reads/writes ChatSessions from each workspace's "Chats" folder.
 /// (Refactored to remove Task.detached usage but keep method signatures & behavior identical.)
 actor ChatDataService {
-    /// The JSON decoder we'll use
     private let decoder = JSONDecoder()
-
-    init() {
-        // Customize encoder/decoder if desired (dates, etc.)
-    }
-
     private static let fileSaveQueue = DispatchQueue(label: "com.repoprompt.chatDataServiceFileSaveQueue")
+    private var pairMutationPending = false
+    private var pairMutationWaiters: [CheckedContinuation<Void, Never>] = []
 
     // MARK: - Lightweight decode helpers
 
@@ -94,6 +292,9 @@ actor ChatDataService {
         let composeTabID: UUID?
         let agentModeSessionID: UUID?
         let agentModeRunID: UUID?
+        let oraclePairID: UUID?
+        let oracleLane: OracleLane?
+        let oracleHistoryDiverged: Bool?
         let name: String
         let savedAt: Date
         let shortID: String?
@@ -114,37 +315,75 @@ actor ChatDataService {
 
     // MARK: - Public API
 
-    /// Save a ChatSession for a given workspace, returning the file URL on success.
-    /// Performs file I/O inline (still off the main thread due to actor isolation).
+    /// Save a legacy single session using the established serial atomic-write path.
     func saveChatSession(
         _ session: ChatSession,
         for workspace: WorkspaceModel
     ) async throws -> URL {
-        // 1) Get "Chats" folder
-        let chatsFolder = try ensureChatsFolder(for: workspace)
+        guard session.oraclePairID == nil, session.oracleLane == nil else {
+            throw ChatDataError.saveFailed(NSError(
+                domain: "ChatDataService",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Paired Oracle sessions must be saved together."]
+            ))
+        }
+        return try await withExclusivePairMutation {
+            let chatsFolder = try ensureChatsFolder(for: workspace)
+            let fileURL = chatsFolder.appendingPathComponent(ChatSessionFile.filename(for: session.id))
+            var sessionToSave = session
+            sessionToSave.fileURL = fileURL
+            sessionToSave.savedAt = Date()
+            let sessionCopy = sessionToSave
 
-        // 2) Build file URL
-        let filename = "ChatSession-\(session.id.uuidString).json"
-        let fileURL = chatsFolder.appendingPathComponent(filename)
-
-        // 3) Update session with file path & timestamp and capture it as a constant copy
-        var sessionToSave = session
-        sessionToSave.fileURL = fileURL
-        sessionToSave.savedAt = Date()
-        let sessionCopy = sessionToSave // constant copy to capture in the closure
-
-        // 4) Encode & write using a fresh encoder inside the shared static queue
-        return try await withCheckedThrowingContinuation { continuation in
-            Self.fileSaveQueue.async {
-                do {
-                    let freshEncoder = JSONEncoder() // Use a fresh encoder
-                    let data = try freshEncoder.encode(sessionCopy)
-                    try data.write(to: fileURL, options: .atomic)
-                    continuation.resume(returning: fileURL)
-                } catch {
-                    continuation.resume(throwing: error)
+            return try await withCheckedThrowingContinuation { continuation in
+                Self.fileSaveQueue.async {
+                    do {
+                        let data = try JSONEncoder().encode(sessionCopy)
+                        try data.write(to: fileURL, options: .atomic)
+                        continuation.resume(returning: fileURL)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
                 }
             }
+        }
+    }
+
+    private func encodedOracleSessions(
+        _ sessions: [ChatSession],
+        chatsFolder: URL,
+        workspaceID: UUID
+    ) throws -> [(id: UUID, fileURL: URL, data: Data)] {
+        guard sessions.count == 2,
+              Set(sessions.map(\.id)).count == 2,
+              let pairID = sessions.first?.oraclePairID,
+              sessions.allSatisfy({ $0.oraclePairID == pairID && $0.workspaceID == workspaceID }),
+              Set(sessions.compactMap(\.oracleLane)) == Set(OracleLane.allCases)
+        else {
+            throw ChatDataError.invalidFilename("An Oracle pair save requires one Primary and one Secondary session in the target workspace.")
+        }
+        return try sessions.sorted { ($0.oracleLane == .primary ? 0 : 1) < ($1.oracleLane == .primary ? 0 : 1) }.map { session in
+            let fileURL = chatsFolder.appendingPathComponent(ChatSessionFile.filename(for: session.id))
+            var copy = session
+            copy.fileURL = fileURL
+            return try (session.id, fileURL, JSONEncoder().encode(copy))
+        }
+    }
+
+    /// Saves exactly one Primary/Secondary Oracle pair without exposing a half-written generation.
+    func saveOraclePairSessions(
+        _ sessions: [ChatSession],
+        for workspace: WorkspaceModel
+    ) async throws -> [UUID: URL] {
+        try await withExclusivePairMutation {
+            let chatsFolder = try ensureChatsFolder(for: workspace)
+            let prepared = try encodedOracleSessions(
+                sessions,
+                chatsFolder: chatsFolder,
+                workspaceID: workspace.id
+            )
+            try OraclePairWriteTransaction.save(prepared.map { ($0.id, $0.data) }, in: chatsFolder)
+            return Dictionary(uniqueKeysWithValues: prepared.map { ($0.id, $0.fileURL) })
         }
     }
 
@@ -153,7 +392,7 @@ actor ChatDataService {
         from fileURL: URL
     ) async throws -> ChatSession {
         let filename = fileURL.lastPathComponent
-        guard filename.hasPrefix("ChatSession-"), filename.hasSuffix(".json") else {
+        guard let expectedID = ChatSessionFile.sessionID(from: filename) else {
             throw ChatDataError.invalidFilename(filename)
         }
 
@@ -161,6 +400,7 @@ actor ChatDataService {
             // Use memory-mapped reads to reduce peak memory pressure for large sessions
             let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
             var session = try decoder.decode(ChatSession.self, from: data)
+            guard session.id == expectedID else { throw ChatDataError.invalidFilename(filename) }
             session.fileURL = fileURL
             return session
         } catch {
@@ -214,7 +454,6 @@ actor ChatDataService {
                 case let .success(index, _), let .failure(index, _, _):
                     outcomes[index] = outcome
                 }
-
                 if nextIndexToSchedule < files.count {
                     schedule(nextIndexToSchedule)
                     nextIndexToSchedule += 1
@@ -246,7 +485,7 @@ actor ChatDataService {
 
     private nonisolated static func loadChatSessionStubFromDisk(from fileURL: URL) throws -> ChatSession {
         let filename = fileURL.lastPathComponent
-        guard filename.hasPrefix("ChatSession-"), filename.hasSuffix(".json") else {
+        guard let expectedID = ChatSessionFile.sessionID(from: filename) else {
             throw ChatDataError.invalidFilename(filename)
         }
 
@@ -254,6 +493,7 @@ actor ChatDataService {
             // Use memory-mapped reads to reduce peak memory pressure when listing many sessions
             let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
             let header = try JSONDecoder().decode(ChatSessionHeader.self, from: data)
+            guard header.id == expectedID else { throw ChatDataError.invalidFilename(filename) }
             let count = header.messageCount ?? header.messages?.count ?? 0
 
             let shortID = header.shortID ?? ChatSession.makeShortID(name: header.name, uuid: header.id)
@@ -264,6 +504,9 @@ actor ChatDataService {
                 composeTabID: header.composeTabID,
                 agentModeSessionID: header.agentModeSessionID,
                 agentModeRunID: header.agentModeRunID,
+                oraclePairID: header.oraclePairID,
+                oracleLane: header.oracleLane,
+                oracleHistoryDiverged: header.oracleHistoryDiverged ?? false,
                 name: header.name,
                 savedAt: header.savedAt,
                 fileURL: fileURL,
@@ -280,39 +523,99 @@ actor ChatDataService {
         }
     }
 
-    /// Returns a list of "ChatSession-xxx.json" files in the workspace’s Chats folder, sorted by mod date desc.
-    func listChatSessions(for workspace: WorkspaceModel) async throws -> [URL] {
-        let chatsFolder = try ensureChatsFolder(for: workspace)
+    private func modificationDate(for fileURL: URL) -> Date {
+        (try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+    }
 
-        let contents = try FileManager.default.contentsOfDirectory(
+    private struct HistoryFile {
+        let url: URL
+        let id: UUID
+        let pairID: UUID?
+        let lane: OracleLane?
+        let modified: Date
+    }
+
+    private func chatFiles(in chatsFolder: URL) throws -> [URL] {
+        try FileManager.default.contentsOfDirectory(
             at: chatsFolder,
-            includingPropertiesForKeys: [.contentModificationDateKey],
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey, .isSymbolicLinkKey],
             options: [.skipsHiddenFiles]
-        )
-        let jsonFiles = contents.filter {
-            $0.pathExtension.lowercased() == "json" &&
-                $0.lastPathComponent.hasPrefix("ChatSession-")
+        ).filter { url in
+            guard ChatSessionFile.sessionID(from: url.lastPathComponent) != nil,
+                  let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            else { return false }
+            return values.isRegularFile == true && values.isSymbolicLink != true
         }
+    }
 
-        let sortedFiles = jsonFiles.sorted { lhs, rhs in
-            let lhsDate = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
-            let rhsDate = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
-            return lhsDate > rhsDate
+    /// Returns newest-first chat files. Readable pairs are retained or deleted together;
+    /// unreadable exact chat files still consume one bounded-retention slot.
+    func listChatSessions(
+        for workspace: WorkspaceModel,
+        protectedSessionIDs: Set<UUID> = [],
+        applyRetention: Bool = true
+    ) async throws -> [URL] {
+        let chatsFolder = try ensureChatsFolder(for: workspace)
+        let files = try chatFiles(in: chatsFolder).compactMap { url -> HistoryFile? in
+            guard let id = ChatSessionFile.sessionID(from: url.lastPathComponent) else { return nil }
+            let modified = modificationDate(for: url)
+            let stub = try? Self.loadChatSessionStubFromDisk(from: url)
+            return HistoryFile(
+                url: url,
+                id: id,
+                pairID: stub?.oraclePairID,
+                lane: stub?.oracleLane,
+                modified: modified
+            )
         }
-
-        // Apply chat history limit based on user setting
-        let limit = chatHistoryLimit
-        if limit != .unlimited, sortedFiles.count > limit.rawValue {
-            let filesToDelete = sortedFiles.dropFirst(limit.rawValue)
-            for url in filesToDelete {
-                // Best-effort delete; ignore individual failures
-                try? FileManager.default.removeItem(at: url)
+        let groups = Dictionary(grouping: files) { file in
+            file.pairID.map { "pair:\($0.uuidString)" } ?? "session:\(file.id.uuidString)"
+        }.values.map { group in
+            group.sorted {
+                let left = $0.lane == .primary ? 0 : $0.lane == .secondary ? 1 : 2
+                let right = $1.lane == .primary ? 0 : $1.lane == .secondary ? 1 : 2
+                return left == right ? $0.id.uuidString < $1.id.uuidString : left < right
             }
-            return Array(sortedFiles.prefix(limit.rawValue))
+        }.sorted {
+            ($0.map(\.modified).max() ?? .distantPast) > ($1.map(\.modified).max() ?? .distantPast)
         }
 
-        // If unlimited or under limit, return all files
-        return sortedFiles
+        guard applyRetention, !pairMutationPending else { return groups.flatMap { $0.map(\.url) } }
+        let limit = chatHistoryLimit == .unlimited ? Int.max : chatHistoryLimit.rawValue
+        var kept: [[HistoryFile]] = []
+        var dropped: [[HistoryFile]] = []
+        var used = 0
+        var retentionFull = false
+        for group in groups {
+            if group.contains(where: { protectedSessionIDs.contains($0.id) }) {
+                kept.append(group)
+                used += group.count
+            } else if !retentionFull, used + group.count <= limit {
+                kept.append(group)
+                used += group.count
+            } else {
+                dropped.append(group)
+                retentionFull = true
+            }
+        }
+        for group in dropped {
+            try? deleteSessionFiles(Set(group.map(\.id)), in: chatsFolder)
+        }
+        return kept.flatMap { $0.map(\.url) }
+    }
+
+    /// Reads persisted pair metadata without applying retention.
+    func oraclePairSessionStubs(
+        for workspace: WorkspaceModel,
+        pairID: UUID
+    ) async throws -> [ChatSession] {
+        let chatsFolder = try ensureChatsFolder(for: workspace)
+        return try chatFiles(in: chatsFolder).compactMap { url in
+            guard let stub = try? Self.loadChatSessionStubFromDisk(from: url), stub.oraclePairID == pairID else {
+                return nil
+            }
+            return stub
+        }
     }
 
     /// Get metadata for recent chat sessions without loading full content
@@ -321,7 +624,7 @@ actor ChatDataService {
         limit: Int = 10,
         composeTabID: UUID? = nil
     ) async throws -> [ChatSessionMeta] {
-        let files = try await listChatSessions(for: workspace)
+        let files = try await listChatSessions(for: workspace, applyRetention: false)
         let clampedLimit = max(limit, 0)
         guard clampedLimit > 0 else { return [] }
 
@@ -382,7 +685,7 @@ actor ChatDataService {
         guard !trimmedID.isEmpty else { return .notFound }
 
         let targetUUID = UUID(uuidString: trimmedID)
-        let files = try await listChatSessions(for: workspace)
+        let files = try await listChatSessions(for: workspace, applyRetention: false)
         var matchingFileURL: URL?
 
         for fileURL in files {
@@ -413,7 +716,7 @@ actor ChatDataService {
         for workspace: WorkspaceModel,
         composeTabID: UUID? = nil
     ) async throws -> ChatSession? {
-        let files = try await listChatSessions(for: workspace)
+        let files = try await listChatSessions(for: workspace, applyRetention: false)
 
         for fileURL in files {
             do {
@@ -430,9 +733,80 @@ actor ChatDataService {
         return nil
     }
 
-    /// Delete a particular chat session file.
+    /// Delete a particular legacy chat session file.
     func deleteChatSessionFile(_ fileURL: URL) async throws {
         try FileManager.default.removeItem(at: fileURL)
+    }
+
+    /// Deletes the known durable members of one Oracle pair as a unit.
+    func deleteOraclePairSessionFiles(
+        _ sessionIDs: Set<UUID>,
+        for workspace: WorkspaceModel
+    ) async throws {
+        try await withExclusivePairMutation {
+            let chatsFolder = try ensureChatsFolder(for: workspace)
+            try deleteSessionFiles(sessionIDs, in: chatsFolder)
+        }
+    }
+
+    /// Deletes all canonical chat files after the caller has cancelled workspace sends.
+    func deleteAllChatSessionFiles(for workspace: WorkspaceModel) async throws {
+        try await withExclusivePairMutation {
+            let chatsFolder = try ensureChatsFolder(for: workspace)
+            for fileURL in try chatFiles(in: chatsFolder) {
+                try FileManager.default.removeItem(at: fileURL)
+            }
+        }
+    }
+
+    private func withExclusivePairMutation<T>(_ operation: () async throws -> T) async throws -> T {
+        if pairMutationPending {
+            await withCheckedContinuation { continuation in
+                pairMutationWaiters.append(continuation)
+            }
+        } else {
+            pairMutationPending = true
+        }
+        defer {
+            if pairMutationWaiters.isEmpty {
+                pairMutationPending = false
+            } else {
+                pairMutationWaiters.removeFirst().resume()
+            }
+        }
+        await withCheckedContinuation { continuation in
+            Self.fileSaveQueue.async { continuation.resume() }
+        }
+        return try await operation()
+    }
+
+    private func deleteSessionFiles(_ sessionIDs: Set<UUID>, in chatsFolder: URL) throws {
+        guard !sessionIDs.isEmpty, sessionIDs.count <= 2 else {
+            throw ChatDataError.invalidFilename("Oracle pair deletion requires one or two session IDs.")
+        }
+        let saved = try sessionIDs.sorted(by: { $0.uuidString < $1.uuidString }).compactMap { id -> (URL, Data, Date?)? in
+            let url = chatsFolder.appendingPathComponent(ChatSessionFile.filename(for: id))
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            try OraclePairWriteTransaction.requireRegular(url)
+            return try (
+                url,
+                Data(contentsOf: url, options: .mappedIfSafe),
+                url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+            )
+        }
+        do {
+            for (url, _, _) in saved {
+                try FileManager.default.removeItem(at: url)
+            }
+        } catch {
+            for (url, data, date) in saved where !FileManager.default.fileExists(atPath: url.path) {
+                try? data.write(to: url, options: .atomic)
+                if let date {
+                    try? FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+                }
+            }
+            throw error
+        }
     }
 
     // MARK: - Folder Helpers
@@ -446,6 +820,7 @@ actor ChatDataService {
         if !FileManager.default.fileExists(atPath: chatsFolder.path) {
             try FileManager.default.createDirectory(at: chatsFolder, withIntermediateDirectories: true)
         }
+        try OraclePairWriteTransaction.recover(in: chatsFolder)
         return chatsFolder
     }
 

--- a/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
@@ -716,11 +716,14 @@ actor ChatDataService {
         requireCompleteGroup: Bool = true
     ) async throws -> [ChatSession] {
         let chatsFolder = try ensureChatsFolder(for: workspace)
-        let stubs = try chatFiles(in: chatsFolder).compactMap { url in
-            guard let stub = try? Self.loadChatSessionStubFromDisk(from: url), stub.oraclePairID == pairID else {
-                return nil
-            }
-            return stub
+        let fileURLs = try chatFiles(in: chatsFolder)
+        var stubs: [ChatSession] = []
+        stubs.reserveCapacity(fileURLs.count)
+        for fileURL in fileURLs {
+            guard let stub: ChatSession = try? Self.loadChatSessionStubFromDisk(from: fileURL),
+                  stub.oraclePairID == pairID
+            else { continue }
+            stubs.append(stub)
         }
         guard !stubs.isEmpty else { return [] }
         _ = try OracleGroupPersistencePolicy.validate(
@@ -728,8 +731,10 @@ actor ChatDataService {
             workspaceID: workspace.id,
             requireCompleteGroup: requireCompleteGroup
         )
-        return stubs.sorted {
-            ($0.oracleLane?.ordinal ?? .max) < ($1.oracleLane?.ordinal ?? .max)
+        return stubs.sorted { lhs, rhs in
+            let lhsOrdinal: Int = lhs.oracleLane?.ordinal ?? Int.max
+            let rhsOrdinal: Int = rhs.oracleLane?.ordinal ?? Int.max
+            return lhsOrdinal < rhsOrdinal
         }
     }
 

--- a/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
@@ -275,7 +275,13 @@ public enum ChatHistoryLimit: Int, CaseIterable {
 /// An actor that reads/writes ChatSessions from each workspace's "Chats" folder.
 /// (Refactored to remove Task.detached usage but keep method signatures & behavior identical.)
 actor ChatDataService {
+    /// The JSON decoder we'll use
     private let decoder = JSONDecoder()
+
+    init() {
+        // Customize encoder/decoder if desired (dates, etc.)
+    }
+
     private static let fileSaveQueue = DispatchQueue(label: "com.repoprompt.chatDataServiceFileSaveQueue")
     private var pairMutationPending = false
     private var pairMutationWaiters: [CheckedContinuation<Void, Never>] = []
@@ -454,6 +460,7 @@ actor ChatDataService {
                 case let .success(index, _), let .failure(index, _, _):
                     outcomes[index] = outcome
                 }
+
                 if nextIndexToSchedule < files.count {
                     schedule(nextIndexToSchedule)
                     nextIndexToSchedule += 1

--- a/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
@@ -59,7 +59,74 @@ private enum ChatSessionFile {
     }
 }
 
-/// Current-format crash recovery for installing exactly one Oracle pair.
+private enum OracleGroupPersistencePolicy {
+    static let validSizeRange = 2 ... OracleLane.allCases.count
+
+    static func orderedLanes(count: Int) throws -> [OracleLane] {
+        guard validSizeRange.contains(count) else {
+            throw ChatDataError.invalidFilename("An Oracle group requires between two and five sessions.")
+        }
+        return try OracleLane.orderedPrefix(count: count)
+    }
+
+    static func effectiveGroupSize(for session: ChatSession) -> Int? {
+        if let groupSize = session.oracleGroupSize {
+            return groupSize
+        }
+        // Compatibility for histories written by the original two-lane draft.
+        guard session.oraclePairID != nil,
+              session.oracleLane == .primary || session.oracleLane == .secondary
+        else { return nil }
+        return 2
+    }
+
+    @discardableResult
+    static func validate(
+        _ sessions: [ChatSession],
+        workspaceID: UUID? = nil,
+        requireCompleteGroup: Bool
+    ) throws -> Int {
+        guard !sessions.isEmpty,
+              sessions.count <= validSizeRange.upperBound,
+              Set(sessions.map(\.id)).count == sessions.count,
+              let groupID = sessions.first?.oraclePairID,
+              sessions.allSatisfy({ $0.oraclePairID == groupID })
+        else {
+            throw ChatDataError.invalidFilename("Oracle group sessions must have distinct identities and one shared group ID.")
+        }
+        if let workspaceID, !sessions.allSatisfy({ $0.workspaceID == workspaceID }) {
+            throw ChatDataError.invalidFilename("Oracle group sessions must belong to the target workspace.")
+        }
+
+        let groupSizes = sessions.compactMap { effectiveGroupSize(for: $0) }
+        guard groupSizes.count == sessions.count,
+              let groupSize = groupSizes.first,
+              validSizeRange.contains(groupSize),
+              groupSizes.allSatisfy({ $0 == groupSize }),
+              sessions.count <= groupSize
+        else {
+            throw ChatDataError.invalidFilename("Oracle group sessions must declare the same valid group size.")
+        }
+        if requireCompleteGroup, sessions.count != groupSize {
+            throw ChatDataError.invalidFilename(
+                "Oracle group is incomplete: expected \(groupSize) sessions, found \(sessions.count)."
+            )
+        }
+
+        let expectedLanes = try orderedLanes(count: groupSize)
+        let lanes = sessions.compactMap(\.oracleLane)
+        guard lanes.count == sessions.count,
+              Set(lanes).count == sessions.count,
+              Set(lanes).isSubset(of: Set(expectedLanes)),
+              !requireCompleteGroup || Set(lanes) == Set(expectedLanes)
+        else {
+            throw ChatDataError.invalidFilename("Oracle group sessions must use distinct contiguous lanes starting at Primary.")
+        }
+        return groupSize
+    }
+}
+
+/// Current-format crash recovery for atomically installing one Oracle group.
 private enum OraclePairWriteTransaction {
     private struct Manifest: Codable {
         struct Entry: Codable {
@@ -77,8 +144,10 @@ private enum OraclePairWriteTransaction {
     private static let commitName = "committed"
 
     static func save(_ replacements: [(id: UUID, data: Data)], in folder: URL) throws {
-        guard replacements.count == 2, Set(replacements.map(\.id)).count == 2 else {
-            throw ChatDataError.invalidFilename("An Oracle pair save requires exactly two distinct sessions.")
+        guard OracleGroupPersistencePolicy.validSizeRange.contains(replacements.count),
+              Set(replacements.map(\.id)).count == replacements.count
+        else {
+            throw ChatDataError.invalidFilename("An Oracle group save requires between two and five distinct sessions.")
         }
         try recover(in: folder)
 
@@ -125,7 +194,7 @@ private enum OraclePairWriteTransaction {
             do {
                 try recover(transaction, in: folder)
             } catch {
-                throw saveError("Oracle pair save and recovery both failed.", underlying: error)
+                throw saveError("Oracle group save and recovery both failed.", underlying: error)
             }
             throw error
         }
@@ -175,8 +244,8 @@ private enum OraclePairWriteTransaction {
         }
 
         let manifest = try JSONDecoder().decode(Manifest.self, from: readRegular(manifestURL))
-        guard manifest.entries.count == 2,
-              Set(manifest.entries.map(\.sessionID)).count == 2
+        guard OracleGroupPersistencePolicy.validSizeRange.contains(manifest.entries.count),
+              Set(manifest.entries.map(\.sessionID)).count == manifest.entries.count
         else { throw ChatDataError.invalidFilename(transaction.lastPathComponent) }
         _ = try validatedArtifacts(in: transaction, entries: manifest.entries)
 
@@ -300,6 +369,7 @@ actor ChatDataService {
         let agentModeRunID: UUID?
         let oraclePairID: UUID?
         let oracleLane: OracleLane?
+        let oracleGroupSize: Int?
         let oracleHistoryDiverged: Bool?
         let name: String
         let savedAt: Date
@@ -326,11 +396,14 @@ actor ChatDataService {
         _ session: ChatSession,
         for workspace: WorkspaceModel
     ) async throws -> URL {
-        guard session.oraclePairID == nil, session.oracleLane == nil else {
+        guard session.oraclePairID == nil,
+              session.oracleLane == nil,
+              session.oracleGroupSize == nil
+        else {
             throw ChatDataError.saveFailed(NSError(
                 domain: "ChatDataService",
                 code: 3,
-                userInfo: [NSLocalizedDescriptionKey: "Paired Oracle sessions must be saved together."]
+                userInfo: [NSLocalizedDescriptionKey: "Grouped Oracle sessions must be saved together."]
             ))
         }
         return try await withExclusivePairMutation {
@@ -360,23 +433,23 @@ actor ChatDataService {
         chatsFolder: URL,
         workspaceID: UUID
     ) throws -> [(id: UUID, fileURL: URL, data: Data)] {
-        guard sessions.count == 2,
-              Set(sessions.map(\.id)).count == 2,
-              let pairID = sessions.first?.oraclePairID,
-              sessions.allSatisfy({ $0.oraclePairID == pairID && $0.workspaceID == workspaceID }),
-              Set(sessions.compactMap(\.oracleLane)) == Set(OracleLane.allCases)
-        else {
-            throw ChatDataError.invalidFilename("An Oracle pair save requires one Primary and one Secondary session in the target workspace.")
-        }
-        return try sessions.sorted { ($0.oracleLane == .primary ? 0 : 1) < ($1.oracleLane == .primary ? 0 : 1) }.map { session in
+        let groupSize = try OracleGroupPersistencePolicy.validate(
+            sessions,
+            workspaceID: workspaceID,
+            requireCompleteGroup: true
+        )
+        return try sessions.sorted {
+            ($0.oracleLane?.ordinal ?? .max) < ($1.oracleLane?.ordinal ?? .max)
+        }.map { session in
             let fileURL = chatsFolder.appendingPathComponent(ChatSessionFile.filename(for: session.id))
             var copy = session
             copy.fileURL = fileURL
+            copy.oracleGroupSize = groupSize
             return try (session.id, fileURL, JSONEncoder().encode(copy))
         }
     }
 
-    /// Saves exactly one Primary/Secondary Oracle pair without exposing a half-written generation.
+    /// Saves one complete two-to-five-member Oracle group without exposing a partial generation.
     func saveOraclePairSessions(
         _ sessions: [ChatSession],
         for workspace: WorkspaceModel
@@ -513,6 +586,7 @@ actor ChatDataService {
                 agentModeRunID: header.agentModeRunID,
                 oraclePairID: header.oraclePairID,
                 oracleLane: header.oracleLane,
+                oracleGroupSize: header.oracleGroupSize,
                 oracleHistoryDiverged: header.oracleHistoryDiverged ?? false,
                 name: header.name,
                 savedAt: header.savedAt,
@@ -539,7 +613,20 @@ actor ChatDataService {
         let id: UUID
         let pairID: UUID?
         let lane: OracleLane?
+        let groupSize: Int?
+        let metadataReadable: Bool
         let modified: Date
+    }
+
+    private func retentionCost(for group: [HistoryFile]) -> Int {
+        let declaredSizes = Set(group.compactMap(\.groupSize))
+        guard declaredSizes.count == 1,
+              let declaredSize = declaredSizes.first,
+              OracleGroupPersistencePolicy.validSizeRange.contains(declaredSize)
+        else { return group.count }
+        // An incomplete durable group still consumes its declared number of slots. This
+        // prevents a missing file from making the group appear to be a smaller valid one.
+        return max(group.count, declaredSize)
     }
 
     private func chatFiles(in chatsFolder: URL) throws -> [URL] {
@@ -555,8 +642,9 @@ actor ChatDataService {
         }
     }
 
-    /// Returns newest-first chat files. Readable pairs are retained or deleted together;
-    /// unreadable exact chat files still consume one bounded-retention slot.
+    /// Returns newest-first chat files. Oracle groups are retained or deleted together.
+    /// If any canonical chat file is unreadable, retention fails closed because that file
+    /// may be a group member whose durable membership can no longer be recovered.
     func listChatSessions(
         for workspace: WorkspaceModel,
         protectedSessionIDs: Set<UUID> = [],
@@ -572,6 +660,8 @@ actor ChatDataService {
                 id: id,
                 pairID: stub?.oraclePairID,
                 lane: stub?.oracleLane,
+                groupSize: stub?.oracleGroupSize,
+                metadataReadable: stub != nil,
                 modified: modified
             )
         }
@@ -579,27 +669,31 @@ actor ChatDataService {
             file.pairID.map { "pair:\($0.uuidString)" } ?? "session:\(file.id.uuidString)"
         }.values.map { group in
             group.sorted {
-                let left = $0.lane == .primary ? 0 : $0.lane == .secondary ? 1 : 2
-                let right = $1.lane == .primary ? 0 : $1.lane == .secondary ? 1 : 2
+                let left = $0.lane?.ordinal ?? .max
+                let right = $1.lane?.ordinal ?? .max
                 return left == right ? $0.id.uuidString < $1.id.uuidString : left < right
             }
         }.sorted {
             ($0.map(\.modified).max() ?? .distantPast) > ($1.map(\.modified).max() ?? .distantPast)
         }
 
-        guard applyRetention, !pairMutationPending else { return groups.flatMap { $0.map(\.url) } }
+        guard applyRetention,
+              !pairMutationPending,
+              files.allSatisfy(\.metadataReadable)
+        else { return groups.flatMap { $0.map(\.url) } }
         let limit = chatHistoryLimit == .unlimited ? Int.max : chatHistoryLimit.rawValue
         var kept: [[HistoryFile]] = []
         var dropped: [[HistoryFile]] = []
         var used = 0
         var retentionFull = false
         for group in groups {
+            let cost = retentionCost(for: group)
             if group.contains(where: { protectedSessionIDs.contains($0.id) }) {
                 kept.append(group)
-                used += group.count
-            } else if !retentionFull, used + group.count <= limit {
+                used += cost
+            } else if !retentionFull, used + cost <= limit {
                 kept.append(group)
-                used += group.count
+                used += cost
             } else {
                 dropped.append(group)
                 retentionFull = true
@@ -611,17 +705,31 @@ actor ChatDataService {
         return kept.flatMap { $0.map(\.url) }
     }
 
-    /// Reads persisted pair metadata without applying retention.
+    /// Reads persisted Oracle group metadata without applying retention.
+    ///
+    /// Complete validation is the default so a missing file cannot be mistaken for a
+    /// smaller valid group. Cleanup callers may opt into an incomplete read to discover
+    /// and delete the durable members that remain.
     func oraclePairSessionStubs(
         for workspace: WorkspaceModel,
-        pairID: UUID
+        pairID: UUID,
+        requireCompleteGroup: Bool = true
     ) async throws -> [ChatSession] {
         let chatsFolder = try ensureChatsFolder(for: workspace)
-        return try chatFiles(in: chatsFolder).compactMap { url in
+        let stubs = try chatFiles(in: chatsFolder).compactMap { url in
             guard let stub = try? Self.loadChatSessionStubFromDisk(from: url), stub.oraclePairID == pairID else {
                 return nil
             }
             return stub
+        }
+        guard !stubs.isEmpty else { return [] }
+        _ = try OracleGroupPersistencePolicy.validate(
+            stubs,
+            workspaceID: workspace.id,
+            requireCompleteGroup: requireCompleteGroup
+        )
+        return stubs.sorted {
+            ($0.oracleLane?.ordinal ?? .max) < ($1.oracleLane?.ordinal ?? .max)
         }
     }
 
@@ -745,14 +853,19 @@ actor ChatDataService {
         try FileManager.default.removeItem(at: fileURL)
     }
 
-    /// Deletes the known durable members of one Oracle pair as a unit.
+    /// Deletes the known durable members of one Oracle group as a unit.
     func deleteOraclePairSessionFiles(
         _ sessionIDs: Set<UUID>,
         for workspace: WorkspaceModel
     ) async throws {
         try await withExclusivePairMutation {
             let chatsFolder = try ensureChatsFolder(for: workspace)
-            try deleteSessionFiles(sessionIDs, in: chatsFolder)
+            let expandedSessionIDs = try oracleGroupSessionIDsForDeletion(
+                seededBy: sessionIDs,
+                in: chatsFolder,
+                workspaceID: workspace.id
+            )
+            try deleteSessionFiles(expandedSessionIDs, in: chatsFolder)
         }
     }
 
@@ -787,9 +900,56 @@ actor ChatDataService {
         return try await operation()
     }
 
+    private func oracleGroupSessionIDsForDeletion(
+        seededBy sessionIDs: Set<UUID>,
+        in chatsFolder: URL,
+        workspaceID: UUID
+    ) throws -> Set<UUID> {
+        guard !sessionIDs.isEmpty, sessionIDs.count <= OracleGroupPersistencePolicy.validSizeRange.upperBound else {
+            throw ChatDataError.invalidFilename("Oracle group deletion requires between one and five session IDs.")
+        }
+        let files = try chatFiles(in: chatsFolder)
+        let readableStubs = files.compactMap { url in
+            try? Self.loadChatSessionStubFromDisk(from: url)
+        }
+        let readableSessionIDs = Set(readableStubs.map(\.id))
+        let unreadableSessionIDs = Set(files.compactMap { url in
+            ChatSessionFile.sessionID(from: url.lastPathComponent)
+        }).subtracting(readableSessionIDs)
+        guard sessionIDs.isDisjoint(with: unreadableSessionIDs) else {
+            throw ChatDataError.invalidFilename(
+                "Oracle group deletion cannot classify an unreadable seeded chat session."
+            )
+        }
+        let seededStubs = readableStubs.filter { sessionIDs.contains($0.id) }
+        let groupIDs = Set(seededStubs.compactMap(\.oraclePairID))
+        guard groupIDs.count <= 1 else {
+            throw ChatDataError.invalidFilename("Oracle group deletion cannot span multiple groups.")
+        }
+        guard let groupID = groupIDs.first else { return sessionIDs }
+        guard seededStubs.allSatisfy({ $0.oraclePairID == groupID }) else {
+            throw ChatDataError.invalidFilename(
+                "Oracle group deletion cannot include ungrouped chat sessions."
+            )
+        }
+        guard unreadableSessionIDs.isEmpty else {
+            throw ChatDataError.invalidFilename(
+                "Oracle group deletion cannot prove complete membership while a chat file is unreadable."
+            )
+        }
+
+        let members = readableStubs.filter { $0.oraclePairID == groupID }
+        _ = try OracleGroupPersistencePolicy.validate(
+            members,
+            workspaceID: workspaceID,
+            requireCompleteGroup: false
+        )
+        return sessionIDs.union(members.map(\.id))
+    }
+
     private func deleteSessionFiles(_ sessionIDs: Set<UUID>, in chatsFolder: URL) throws {
-        guard !sessionIDs.isEmpty, sessionIDs.count <= 2 else {
-            throw ChatDataError.invalidFilename("Oracle pair deletion requires one or two session IDs.")
+        guard !sessionIDs.isEmpty, sessionIDs.count <= OracleGroupPersistencePolicy.validSizeRange.upperBound else {
+            throw ChatDataError.invalidFilename("Oracle group deletion requires between one and five session IDs.")
         }
         let saved = try sessionIDs.sorted(by: { $0.uuidString < $1.uuidString }).compactMap { id -> (URL, Data, Date?)? in
             let url = chatsFolder.appendingPathComponent(ChatSessionFile.filename(for: id))

--- a/Sources/RepoPrompt/Features/Chat/Services/ChatSession.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/ChatSession.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+enum OracleLane: String, Codable, CaseIterable, Hashable {
+    case primary
+    case secondary
+}
+
 enum ChatSessionError: Error {
     case emptySession
     case invalidFilename(String)
@@ -26,6 +31,9 @@ struct ChatSession: Codable, Identifiable {
     var composeTabID: UUID?
     var agentModeSessionID: UUID?
     var agentModeRunID: UUID?
+    var oraclePairID: UUID?
+    var oracleLane: OracleLane?
+    var oracleHistoryDiverged: Bool
     var name: String
     var savedAt: Date
     var fileURL: URL?
@@ -58,6 +66,9 @@ struct ChatSession: Codable, Identifiable {
         composeTabID: UUID? = nil,
         agentModeSessionID: UUID? = nil,
         agentModeRunID: UUID? = nil,
+        oraclePairID: UUID? = nil,
+        oracleLane: OracleLane? = nil,
+        oracleHistoryDiverged: Bool = false,
         name: String = "Untitled",
         savedAt: Date = Date(),
         fileURL: URL? = nil,
@@ -75,6 +86,9 @@ struct ChatSession: Codable, Identifiable {
         self.composeTabID = composeTabID
         self.agentModeSessionID = agentModeSessionID
         self.agentModeRunID = agentModeRunID
+        self.oraclePairID = oraclePairID
+        self.oracleLane = oracleLane
+        self.oracleHistoryDiverged = oracleHistoryDiverged
         self.name = name
         self.savedAt = savedAt
         self.fileURL = fileURL
@@ -93,6 +107,9 @@ struct ChatSession: Codable, Identifiable {
         case composeTabID
         case agentModeSessionID
         case agentModeRunID
+        case oraclePairID
+        case oracleLane
+        case oracleHistoryDiverged
         case name
         case savedAt
         case fileURL
@@ -113,6 +130,9 @@ struct ChatSession: Codable, Identifiable {
         composeTabID = try container.decodeIfPresent(UUID.self, forKey: .composeTabID)
         agentModeSessionID = try container.decodeIfPresent(UUID.self, forKey: .agentModeSessionID)
         agentModeRunID = try container.decodeIfPresent(UUID.self, forKey: .agentModeRunID)
+        oraclePairID = try container.decodeIfPresent(UUID.self, forKey: .oraclePairID)
+        oracleLane = try container.decodeIfPresent(OracleLane.self, forKey: .oracleLane)
+        oracleHistoryDiverged = try container.decodeIfPresent(Bool.self, forKey: .oracleHistoryDiverged) ?? false
         name = try container.decode(String.self, forKey: .name)
         savedAt = try container.decode(Date.self, forKey: .savedAt)
         fileURL = try container.decodeIfPresent(URL.self, forKey: .fileURL)

--- a/Sources/RepoPrompt/Features/Chat/Services/ChatSession.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/ChatSession.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum OracleLane: String, Codable, CaseIterable, Hashable, Sendable {
+enum OracleLane: String, Codable, CaseIterable, Hashable {
     case primary
     case secondary
     case oracle3 = "oracle_3"
@@ -49,7 +49,7 @@ enum OracleLane: String, Codable, CaseIterable, Hashable, Sendable {
     }
 }
 
-enum OracleLaneValidationError: LocalizedError, Equatable, Sendable {
+enum OracleLaneValidationError: LocalizedError, Equatable {
     case invalidCount(Int)
     case invalidPrefix(expected: [OracleLane], actual: [OracleLane])
 

--- a/Sources/RepoPrompt/Features/Chat/Services/ChatSession.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/ChatSession.swift
@@ -1,8 +1,66 @@
 import Foundation
 
-enum OracleLane: String, Codable, CaseIterable, Hashable {
+enum OracleLane: String, Codable, CaseIterable, Hashable, Sendable {
     case primary
     case secondary
+    case oracle3 = "oracle_3"
+    case oracle4 = "oracle_4"
+    case oracle5 = "oracle_5"
+
+    /// Stable one-based position used by persistence, transport, and UI ordering.
+    var ordinal: Int {
+        switch self {
+        case .primary: 1
+        case .secondary: 2
+        case .oracle3: 3
+        case .oracle4: 4
+        case .oracle5: 5
+        }
+    }
+
+    var isPrimary: Bool {
+        self == .primary
+    }
+
+    var displayLabel: String {
+        switch self {
+        case .primary: "Primary Oracle"
+        case .secondary: "Secondary Oracle"
+        case .oracle3: "Oracle 3"
+        case .oracle4: "Oracle 4"
+        case .oracle5: "Oracle 5"
+        }
+    }
+
+    /// Returns the only valid ordered lane prefix for a configured Oracle count.
+    static func orderedPrefix(count: Int) throws -> [OracleLane] {
+        guard (1 ... allCases.count).contains(count) else {
+            throw OracleLaneValidationError.invalidCount(count)
+        }
+        return Array(allCases.prefix(count))
+    }
+
+    /// Ensures lanes are unique, contiguous, and ordered from Primary.
+    static func validateOrderedPrefix(_ lanes: [OracleLane]) throws {
+        let expected = try orderedPrefix(count: lanes.count)
+        guard lanes == expected else {
+            throw OracleLaneValidationError.invalidPrefix(expected: expected, actual: lanes)
+        }
+    }
+}
+
+enum OracleLaneValidationError: LocalizedError, Equatable, Sendable {
+    case invalidCount(Int)
+    case invalidPrefix(expected: [OracleLane], actual: [OracleLane])
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidCount(count):
+            "Oracle lane count must be between 1 and \(OracleLane.allCases.count); received \(count)."
+        case let .invalidPrefix(expected, actual):
+            "Oracle lanes must be the ordered prefix [\(expected.map(\.rawValue).joined(separator: ", "))]; received [\(actual.map(\.rawValue).joined(separator: ", "))]."
+        }
+    }
 }
 
 enum ChatSessionError: Error {
@@ -33,6 +91,9 @@ struct ChatSession: Codable, Identifiable {
     var agentModeRunID: UUID?
     var oraclePairID: UUID?
     var oracleLane: OracleLane?
+    /// Expected member count for the logical Oracle group containing this session.
+    /// Legacy Primary/Secondary pairs decode as a two-member group.
+    var oracleGroupSize: Int?
     var oracleHistoryDiverged: Bool
     var name: String
     var savedAt: Date
@@ -68,6 +129,7 @@ struct ChatSession: Codable, Identifiable {
         agentModeRunID: UUID? = nil,
         oraclePairID: UUID? = nil,
         oracleLane: OracleLane? = nil,
+        oracleGroupSize: Int? = nil,
         oracleHistoryDiverged: Bool = false,
         name: String = "Untitled",
         savedAt: Date = Date(),
@@ -88,6 +150,10 @@ struct ChatSession: Codable, Identifiable {
         self.agentModeRunID = agentModeRunID
         self.oraclePairID = oraclePairID
         self.oracleLane = oracleLane
+        self.oracleGroupSize = oracleGroupSize ?? Self.inferredLegacyOracleGroupSize(
+            pairID: oraclePairID,
+            lane: oracleLane
+        )
         self.oracleHistoryDiverged = oracleHistoryDiverged
         self.name = name
         self.savedAt = savedAt
@@ -109,6 +175,7 @@ struct ChatSession: Codable, Identifiable {
         case agentModeRunID
         case oraclePairID
         case oracleLane
+        case oracleGroupSize
         case oracleHistoryDiverged
         case name
         case savedAt
@@ -132,6 +199,8 @@ struct ChatSession: Codable, Identifiable {
         agentModeRunID = try container.decodeIfPresent(UUID.self, forKey: .agentModeRunID)
         oraclePairID = try container.decodeIfPresent(UUID.self, forKey: .oraclePairID)
         oracleLane = try container.decodeIfPresent(OracleLane.self, forKey: .oracleLane)
+        oracleGroupSize = try container.decodeIfPresent(Int.self, forKey: .oracleGroupSize)
+            ?? Self.inferredLegacyOracleGroupSize(pairID: oraclePairID, lane: oracleLane)
         oracleHistoryDiverged = try container.decodeIfPresent(Bool.self, forKey: .oracleHistoryDiverged) ?? false
         name = try container.decode(String.self, forKey: .name)
         savedAt = try container.decode(Date.self, forKey: .savedAt)
@@ -163,9 +232,21 @@ struct ChatSession: Codable, Identifiable {
             )
         return collapsed.isEmpty ? "Untitled Chat" : collapsed
     }
+
+    private static func inferredLegacyOracleGroupSize(pairID: UUID?, lane: OracleLane?) -> Int? {
+        guard pairID != nil, lane == .primary || lane == .secondary else { return nil }
+        return 2
+    }
 }
 
 extension ChatSession {
+    /// Generic terminology for new multi-Oracle code while preserving the durable
+    /// `oraclePairID` key and all existing pair call sites.
+    var oracleGroupID: UUID? {
+        get { oraclePairID }
+        set { oraclePairID = newValue }
+    }
+
     /// Message count for UI and sorting when `messages` may be unloaded.
     var effectiveMessageCount: Int {
         messageCount ?? messages.count

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -41,20 +41,26 @@ extension OracleViewModel {
 
     struct OracleSendLiveCallbacks {
         var modelsResolved: (@MainActor @Sendable (AIModel, AIModel?) -> Void)?
+        var groupModelsResolved: (@MainActor @Sendable ([OracleLane: AIModel]) -> Void)?
         var pairSessionsResolved: (@MainActor @Sendable (UUID, UUID) async throws -> Void)?
+        var groupSessionsResolved: (@MainActor @Sendable ([OracleLane: UUID]) async throws -> Void)?
         var primarySessionResolved: (@MainActor @Sendable (UUID) async throws -> Void)?
         var primaryProgress: (@MainActor @Sendable (String, String?) -> Void)?
         var laneLifecycle: (@MainActor @Sendable (OracleLane, OracleMessageLifecycleActivityEvent) -> Void)?
 
         init(
             modelsResolved: (@MainActor @Sendable (AIModel, AIModel?) -> Void)? = nil,
+            groupModelsResolved: (@MainActor @Sendable ([OracleLane: AIModel]) -> Void)? = nil,
             pairSessionsResolved: (@MainActor @Sendable (UUID, UUID) async throws -> Void)? = nil,
+            groupSessionsResolved: (@MainActor @Sendable ([OracleLane: UUID]) async throws -> Void)? = nil,
             primarySessionResolved: (@MainActor @Sendable (UUID) async throws -> Void)? = nil,
             primaryProgress: (@MainActor @Sendable (String, String?) -> Void)? = nil,
             laneLifecycle: (@MainActor @Sendable (OracleLane, OracleMessageLifecycleActivityEvent) -> Void)? = nil
         ) {
             self.modelsResolved = modelsResolved
+            self.groupModelsResolved = groupModelsResolved
             self.pairSessionsResolved = pairSessionsResolved
+            self.groupSessionsResolved = groupSessionsResolved
             self.primarySessionResolved = primarySessionResolved
             self.primaryProgress = primaryProgress
             self.laneLifecycle = laneLifecycle
@@ -1014,7 +1020,7 @@ extension OracleViewModel {
             }
             guard allowPairedSessions || existing.oraclePairID == nil else {
                 throw ChatToolError.invalidParams(
-                    "Paired Oracle histories cannot be continued while Secondary Oracle is disabled. Start a new chat."
+                    "Grouped Oracle histories cannot be continued while only one Oracle is configured. Start a new chat."
                 )
             }
 
@@ -1126,10 +1132,16 @@ extension OracleViewModel {
         return new.id
     }
 
-    private struct OraclePairSessionResolution {
-        let pairID: UUID
-        let primary: ChatSession
-        let secondary: ChatSession
+    private struct OracleGroupSessionResolution {
+        let groupID: UUID
+        let members: [OracleLane: ChatSession]
+
+        var primary: ChatSession {
+            guard let primary = members[.primary] else {
+                preconditionFailure("A validated Oracle group must contain Primary")
+            }
+            return primary
+        }
     }
 
     private func validateRemovedOracleSendArguments(_ args: [String: Value]) throws {
@@ -1151,10 +1163,10 @@ extension OracleViewModel {
 
     @MainActor
     func resolveOracleSecondaryModel(workspaceID: UUID?) throws -> AIModel? {
-        try resolveOracleSecondaryModel(
+        try resolveAdditionalOracleModels(
             workspaceID: workspaceID,
             effectiveProfile: GlobalSettingsStore.shared.effectiveAgentModelsProfile(workspaceID:)
-        )
+        ).first
     }
 
     @MainActor
@@ -1162,8 +1174,24 @@ extension OracleViewModel {
         workspaceID: UUID?,
         effectiveProfile: (UUID?) -> AgentModelsSettingsProfile
     ) throws -> AIModel? {
-        try OraclePairModelSelectionPolicy.resolveSecondary(
-            raw: effectiveProfile(workspaceID).secondaryOracleModelRaw
+        try resolveAdditionalOracleModels(workspaceID: workspaceID, effectiveProfile: effectiveProfile).first
+    }
+
+    @MainActor
+    func resolveAdditionalOracleModels(workspaceID: UUID?) throws -> [AIModel] {
+        try resolveAdditionalOracleModels(
+            workspaceID: workspaceID,
+            effectiveProfile: GlobalSettingsStore.shared.effectiveAgentModelsProfile(workspaceID:)
+        )
+    }
+
+    @MainActor
+    func resolveAdditionalOracleModels(
+        workspaceID: UUID?,
+        effectiveProfile: (UUID?) -> AgentModelsSettingsProfile
+    ) throws -> [AIModel] {
+        try OraclePairModelSelectionPolicy.resolveAdditional(
+            raws: effectiveProfile(workspaceID).additionalOracleModelRaws
         )
     }
 
@@ -1201,9 +1229,10 @@ extension OracleViewModel {
     }
 
     @MainActor
-    private func resolveOraclePairSource(
+    private func resolveOracleGroupSource(
         requestedChatID: String?,
         forceNew: Bool,
+        expectedLanes: [OracleLane],
         workspaceID: UUID,
         tabID: UUID,
         agentModeSessionID: UUID?,
@@ -1225,17 +1254,41 @@ extension OracleViewModel {
             ) else {
                 throw ChatToolError.invalidParams("The requested Oracle chat belongs to a different workspace, tab, Agent session, or run.")
             }
+            if source.oraclePairID != nil {
+                // Explicit inactive-tab resolution intentionally loads only the requested
+                // member. Validate that member's durable cardinality here; the complete
+                // in-memory or persisted group is validated and loaded by preparation.
+                guard source.oracleGroupSize == expectedLanes.count,
+                      source.oracleLane.map { expectedLanes.contains($0) } == true
+                else {
+                    throw ChatToolError(
+                        code: .conflict,
+                        message: "This Oracle history was created with a different number of Oracles. Start a new chat with new_chat=true.",
+                        details: nil
+                    )
+                }
+            }
             return source
         }
 
-        let candidates = sessions.filter {
-            Self.sessionMatchesExactOracleRoute(
-                $0,
-                workspaceID: workspaceID,
-                tabID: tabID,
-                agentModeSessionID: agentModeSessionID,
-                agentModeRunID: agentModeRunID
-            ) && $0.oraclePairID != nil && $0.oracleLane == .primary
+        var membersByGroup: [UUID: [ChatSession]] = [:]
+        for session in sessions where Self.sessionMatchesExactOracleRoute(
+            session,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            agentModeSessionID: agentModeSessionID,
+            agentModeRunID: agentModeRunID
+        ) {
+            guard let groupID = session.oraclePairID else { continue }
+            membersByGroup[groupID, default: []].append(session)
+        }
+        let expectedLaneSet = Set(expectedLanes)
+        let candidates = membersByGroup.values.compactMap { members -> ChatSession? in
+            guard members.count == expectedLanes.count,
+                  Set(members.compactMap(\.oracleLane)) == expectedLaneSet,
+                  members.allSatisfy({ $0.oracleGroupSize == expectedLanes.count })
+            else { return nil }
+            return members.first(where: { $0.oracleLane == .primary })
         }.sorted { $0.savedAt > $1.savedAt }
         if let activeID = workspaceManager.activeChatSessionID(forTabID: tabID),
            let active = candidates.first(where: { $0.id == activeID })
@@ -1251,19 +1304,31 @@ extension OracleViewModel {
     }
 
     @MainActor
-    private func loadPersistedOraclePair(
-        pairID: UUID,
+    private func loadPersistedOracleGroup(
+        groupID: UUID,
+        expectedLanes: [OracleLane]? = nil,
         workspaceID: UUID,
         tabID: UUID,
         agentModeSessionID: UUID?,
         agentModeRunID: UUID?
-    ) async throws -> (primary: ChatSession, secondary: ChatSession, inserted: Set<UUID>) {
+    ) async throws -> (members: [OracleLane: ChatSession], inserted: Set<UUID>) {
         guard let workspace = workspaceManager.workspaces.first(where: { $0.id == workspaceID }) else {
-            throw ChatToolError.invalidParams("The Oracle pair workspace is unavailable.")
+            throw ChatToolError.invalidParams("The Oracle group workspace is unavailable.")
         }
-        let stubs = try await chatData.oraclePairSessionStubs(for: workspace, pairID: pairID)
-        guard stubs.count == 2, Set(stubs.map(\.id)).count == 2 else {
-            throw ChatToolError(code: .conflict, message: "Oracle pair \(pairID.uuidString) is incomplete; start a new Oracle chat instead of continuing it.", details: nil)
+        let stubs = try await chatData.oraclePairSessionStubs(for: workspace, pairID: groupID)
+        guard let groupSize = stubs.first?.oracleGroupSize,
+              (2 ... OracleLane.allCases.count).contains(groupSize),
+              stubs.count == groupSize,
+              Set(stubs.map(\.id)).count == groupSize,
+              stubs.allSatisfy({ $0.oracleGroupSize == groupSize })
+        else {
+            throw ChatToolError(code: .conflict, message: "Oracle group \(groupID.uuidString) is incomplete; start a new Oracle chat instead of continuing it.", details: nil)
+        }
+        let persistedLanes = Array(OracleLane.allCases.prefix(groupSize))
+        guard Set(stubs.compactMap(\.oracleLane)) == Set(persistedLanes),
+              expectedLanes == nil || expectedLanes == persistedLanes
+        else {
+            throw ChatToolError(code: .conflict, message: "Oracle group \(groupID.uuidString) has incompatible lane metadata; start a new Oracle chat instead of continuing it.", details: nil)
         }
 
         var loaded: [ChatSession] = []
@@ -1276,9 +1341,10 @@ extension OracleViewModel {
             }
             loaded.append(full)
         }
-        guard loaded.count == 2,
+        guard loaded.count == groupSize,
               loaded.allSatisfy({ member in
-                  member.oraclePairID == pairID &&
+                  member.oraclePairID == groupID &&
+                      member.oracleGroupSize == groupSize &&
                       Self.sessionMatchesExactOracleRoute(
                           member,
                           workspaceID: workspaceID,
@@ -1287,10 +1353,9 @@ extension OracleViewModel {
                           agentModeRunID: agentModeRunID
                       ) && !isSessionStreaming(member.id)
               }),
-              let primary = loaded.first(where: { $0.oracleLane == .primary }),
-              let secondary = loaded.first(where: { $0.oracleLane == .secondary })
+              Set(loaded.compactMap(\.oracleLane)) == Set(persistedLanes)
         else {
-            throw ChatToolError(code: .conflict, message: "Oracle pair metadata is unavailable, corrupt, or already streaming.", details: nil)
+            throw ChatToolError(code: .conflict, message: "Oracle group metadata is unavailable, corrupt, or already streaming.", details: nil)
         }
 
         var inserted = Set<UUID>()
@@ -1305,7 +1370,12 @@ extension OracleViewModel {
         for member in loaded {
             await reloadSessionFromMemory(member)
         }
-        return (primary, secondary, inserted)
+        return (
+            Dictionary(uniqueKeysWithValues: loaded.compactMap { member in
+                member.oracleLane.map { ($0, member) }
+            }),
+            inserted
+        )
     }
 
     @MainActor
@@ -1327,26 +1397,25 @@ extension OracleViewModel {
 
         do {
             try await oracleSendClaims.withClaim([claim]) {
-                let pair = try await self.loadPersistedOraclePair(
-                    pairID: pairID,
+                let group = try await self.loadPersistedOracleGroup(
+                    groupID: pairID,
                     workspaceID: workspaceID,
                     tabID: tabID,
                     agentModeSessionID: target.agentModeSessionID,
                     agentModeRunID: target.agentModeRunID
                 )
-                guard pair.primary.id == sessionID || pair.secondary.id == sessionID,
+                guard group.members.values.contains(where: { $0.id == sessionID }),
                       let index = self.sessions.firstIndex(where: { $0.id == sessionID })
                 else {
-                    throw ChatToolError.internalError("Failed to resolve the renamed Oracle pair member.")
+                    throw ChatToolError.internalError("Failed to resolve the renamed Oracle group member.")
                 }
 
                 let originalName = self.sessions[index].name
                 self.sessions[index].name = newName
                 do {
-                    _ = try await self.persistOraclePairHistories(
-                        pairID: pairID,
-                        primarySessionID: pair.primary.id,
-                        secondarySessionID: pair.secondary.id
+                    _ = try await self.persistOracleGroupHistories(
+                        groupID: pairID,
+                        sessionIDsByLane: group.members.mapValues(\.id)
                     )
                 } catch let error as ChatToolError where error.details?["durable_commit"] == "true" {
                     throw error
@@ -1357,8 +1426,8 @@ extension OracleViewModel {
                     {
                         self.sessions[currentIndex].name = originalName
                     }
-                    if !pair.inserted.isEmpty {
-                        self.removeOraclePairSessionState(pair.inserted)
+                    if !group.inserted.isEmpty {
+                        self.removeOraclePairSessionState(group.inserted)
                     }
                     throw error
                 }
@@ -1366,7 +1435,7 @@ extension OracleViewModel {
         } catch OracleSendClaimError.conflict {
             throw ChatToolError(
                 code: .conflict,
-                message: "This Oracle pair is busy and could not be renamed.",
+                message: "This Oracle group is busy and could not be renamed.",
                 details: nil
             )
         }
@@ -1380,12 +1449,33 @@ extension OracleViewModel {
         agentModeSessionID: UUID?,
         agentModeRunID: UUID?
     ) async throws -> (primary: ChatSession, secondary: ChatSession)? {
-        let members = sessions.filter { $0.oraclePairID == pairID }
+        guard let members = try await resolveInMemoryOracleGroupMembers(
+            groupID: pairID,
+            expectedLanes: [.primary, .secondary],
+            workspaceID: workspaceID,
+            tabID: tabID,
+            agentModeSessionID: agentModeSessionID,
+            agentModeRunID: agentModeRunID
+        ), let primary = members[.primary], let secondary = members[.secondary]
+        else { return nil }
+        return (primary, secondary)
+    }
+
+    @MainActor
+    private func resolveInMemoryOracleGroupMembers(
+        groupID: UUID,
+        expectedLanes: [OracleLane],
+        workspaceID: UUID,
+        tabID: UUID,
+        agentModeSessionID: UUID?,
+        agentModeRunID: UUID?
+    ) async throws -> [OracleLane: ChatSession]? {
+        let members = sessions.filter { $0.oraclePairID == groupID }
         guard !members.isEmpty else { return nil }
-        guard members.count <= 2 else {
+        guard members.count <= OracleLane.allCases.count else {
             throw ChatToolError(
                 code: .conflict,
-                message: "Oracle pair \(pairID.uuidString) has duplicate members.",
+                message: "Oracle group \(groupID.uuidString) has too many members.",
                 details: nil
             )
         }
@@ -1393,35 +1483,32 @@ extension OracleViewModel {
         guard !laneGroups.values.contains(where: { $0.count > 1 }) else {
             throw ChatToolError(
                 code: .conflict,
-                message: "Oracle pair \(pairID.uuidString) has duplicate lanes.",
+                message: "Oracle group \(groupID.uuidString) has duplicate lanes.",
                 details: nil
             )
         }
-        guard members.count == 2,
-              let primary = members.first(where: { $0.oracleLane == .primary }),
-              let secondary = members.first(where: { $0.oracleLane == .secondary }),
-              Self.sessionMatchesExactOracleRoute(
-                  primary,
-                  workspaceID: workspaceID,
-                  tabID: tabID,
-                  agentModeSessionID: agentModeSessionID,
-                  agentModeRunID: agentModeRunID
-              ),
-              Self.sessionMatchesExactOracleRoute(
-                  secondary,
-                  workspaceID: workspaceID,
-                  tabID: tabID,
-                  agentModeSessionID: agentModeSessionID,
-                  agentModeRunID: agentModeRunID
-              ),
-              !isSessionStreaming(primary.id),
-              !isSessionStreaming(secondary.id),
-              let loadedPrimary = await ensureSessionLoadedForBackground(primary),
-              let loadedSecondary = await ensureSessionLoadedForBackground(secondary)
-        else {
-            return nil
+        guard members.count == expectedLanes.count,
+              Set(members.compactMap(\.oracleLane)) == Set(expectedLanes),
+              members.allSatisfy({ member in
+                  member.oracleGroupSize == expectedLanes.count &&
+                      Self.sessionMatchesExactOracleRoute(
+                          member,
+                          workspaceID: workspaceID,
+                          tabID: tabID,
+                          agentModeSessionID: agentModeSessionID,
+                          agentModeRunID: agentModeRunID
+                      ) && !isSessionStreaming(member.id)
+              })
+        else { return nil }
+
+        var loaded: [OracleLane: ChatSession] = [:]
+        for lane in expectedLanes {
+            guard let member = members.first(where: { $0.oracleLane == lane }),
+                  let full = await ensureSessionLoadedForBackground(member)
+            else { return nil }
+            loaded[lane] = full
         }
-        return (loadedPrimary, loadedSecondary)
+        return loaded
     }
 
     private struct OraclePairPreparationRollbackState {
@@ -1471,6 +1558,7 @@ extension OracleViewModel {
             if current.agentModeSessionID == assigned.agentModeSessionID { current.agentModeSessionID = original.agentModeSessionID }
             if current.agentModeRunID == assigned.agentModeRunID { current.agentModeRunID = original.agentModeRunID }
             if current.oraclePairID == assigned.oraclePairID { current.oraclePairID = original.oraclePairID }
+            if current.oracleGroupSize == assigned.oracleGroupSize { current.oracleGroupSize = original.oracleGroupSize }
             if current.oracleLane == assigned.oracleLane { current.oracleLane = original.oracleLane }
             if current.oracleHistoryDiverged == assigned.oracleHistoryDiverged {
                 current.oracleHistoryDiverged = original.oracleHistoryDiverged
@@ -1496,32 +1584,36 @@ extension OracleViewModel {
     }
 
     @MainActor
-    private func resolveOrCreateOraclePairSessions(
+    private func resolveOrCreateOracleGroupSessions(
         requestedChatID: String?,
         forceNew: Bool,
         desiredName: String?,
+        expectedLanes: [OracleLane],
         workspaceID: UUID,
         tabID: UUID,
         activatePrimaryInUI: Bool,
         agentModeSessionID: UUID?,
         agentModeRunID: UUID?,
-        sessionsResolved: (@MainActor @Sendable (UUID, UUID) async throws -> Void)?
-    ) async throws -> OraclePairSessionResolution {
-        guard Set(sessions.map(\.id)).count == sessions.count,
+        sessionsResolved: (@MainActor @Sendable ([OracleLane: UUID]) async throws -> Void)?
+    ) async throws -> OracleGroupSessionResolution {
+        guard (2 ... OracleLane.allCases.count).contains(expectedLanes.count),
+              expectedLanes == Array(OracleLane.allCases.prefix(expectedLanes.count)),
+              Set(sessions.map(\.id)).count == sessions.count,
               workspaceManager.workspaces.contains(where: { $0.id == workspaceID })
         else {
-            throw ChatToolError(code: .conflict, message: "Oracle pair session identities are invalid.", details: nil)
+            throw ChatToolError(code: .conflict, message: "Oracle group session identities are invalid.", details: nil)
         }
         let initialSessionIDs = Set(sessions.map(\.id))
-        let source = try await resolveOraclePairSource(
+        let source = try await resolveOracleGroupSource(
             requestedChatID: requestedChatID,
             forceNew: forceNew,
+            expectedLanes: expectedLanes,
             workspaceID: workspaceID,
             tabID: tabID,
             agentModeSessionID: agentModeSessionID,
             agentModeRunID: agentModeRunID
         )
-        let pairID = source?.oraclePairID ?? UUID()
+        let groupID = source?.oraclePairID ?? UUID()
         var rollback = OraclePairPreparationRollbackState(
             workspaceID: workspaceID,
             tabID: tabID,
@@ -1531,47 +1623,47 @@ extension OracleViewModel {
         rollback.insertedSessionIDs = Set(sessions.map(\.id)).subtracting(initialSessionIDs)
 
         do {
-            var primary: ChatSession?
-            var secondary: ChatSession?
+            var members: [OracleLane: ChatSession] = [:]
             if source?.oraclePairID != nil {
-                if let pair = try await resolveInMemoryOraclePairMembers(
-                    pairID: pairID,
+                if let inMemory = try await resolveInMemoryOracleGroupMembers(
+                    groupID: groupID,
+                    expectedLanes: expectedLanes,
                     workspaceID: workspaceID,
                     tabID: tabID,
                     agentModeSessionID: agentModeSessionID,
                     agentModeRunID: agentModeRunID
                 ) {
-                    primary = pair.primary
-                    secondary = pair.secondary
+                    members = inMemory
                 } else {
-                    let pair = try await loadPersistedOraclePair(
-                        pairID: pairID,
+                    let persisted = try await loadPersistedOracleGroup(
+                        groupID: groupID,
+                        expectedLanes: expectedLanes,
                         workspaceID: workspaceID,
                         tabID: tabID,
                         agentModeSessionID: agentModeSessionID,
                         agentModeRunID: agentModeRunID
                     )
-                    primary = pair.primary
-                    secondary = pair.secondary
-                    rollback.insertedSessionIDs.formUnion(pair.inserted)
+                    members = persisted.members
+                    rollback.insertedSessionIDs.formUnion(persisted.inserted)
                 }
             } else if let source {
-                guard source.oracleLane != .secondary,
+                guard source.oracleLane == nil,
                       !isSessionStreaming(source.id),
                       let loaded = await ensureSessionLoadedForBackground(source)
                 else {
                     throw ChatToolError(code: .conflict, message: "The Oracle session is unavailable or already streaming.", details: nil)
                 }
-                primary = loaded
+                members[.primary] = loaded
             }
 
-            for member in [primary, secondary].compactMap(\.self) {
+            for member in members.values {
                 rollback.originalSessions[member.id] = member
             }
-            let primaryName = desiredName ?? primary?.name ?? "Oracle"
-            if primary == nil {
-                primary = try await createSession(
-                    named: primaryName,
+            let primaryName = desiredName ?? members[.primary]?.name ?? "Oracle"
+            for lane in expectedLanes where members[lane] == nil {
+                let name = lane == .primary ? primaryName : "\(primaryName) — Oracle \(lane.ordinal)"
+                let created = try await createSession(
+                    named: name,
                     workspaceID: workspaceID,
                     tabID: tabID,
                     activateInUI: false,
@@ -1580,69 +1672,64 @@ extension OracleViewModel {
                     agentModeRunID: agentModeRunID,
                     reuseBlankSession: false
                 )
-                rollback.createdSessionIDs.insert(primary!.id)
+                members[lane] = created
+                rollback.createdSessionIDs.insert(created.id)
             }
-            if secondary == nil {
-                secondary = try await createSession(
-                    named: "\(primaryName) — Secondary",
-                    workspaceID: workspaceID,
-                    tabID: tabID,
-                    activateInUI: false,
-                    setActiveForTab: false,
-                    agentModeSessionID: agentModeSessionID,
-                    agentModeRunID: agentModeRunID,
-                    reuseBlankSession: false
-                )
-                rollback.createdSessionIDs.insert(secondary!.id)
-            }
-            guard var primary, var secondary, primary.id != secondary.id else {
-                throw ChatToolError(code: .conflict, message: "Failed to create a distinct Oracle pair.", details: nil)
+            guard members.count == expectedLanes.count,
+                  Set(members.values.map(\.id)).count == expectedLanes.count,
+                  let primary = members[.primary]
+            else {
+                throw ChatToolError(code: .conflict, message: "Failed to create a distinct Oracle group.", details: nil)
             }
             rollback.insertedSessionIDs.formUnion(rollback.createdSessionIDs)
 
-            let diverged = primary.oracleHistoryDiverged || secondary.oracleHistoryDiverged ||
-                Self.oracleHistoriesDiverged(
-                    primary: primary.messages.filter(\.isUser).map(\.rawText),
-                    secondary: secondary.messages.filter(\.isUser).map(\.rawText)
-                )
+            let primaryHistory = primary.messages.filter(\.isUser).map(\.rawText)
+            let diverged = members.values.contains(where: \.oracleHistoryDiverged) || expectedLanes.dropFirst().contains { lane in
+                members[lane]?.messages.filter(\.isUser).map(\.rawText) != primaryHistory
+            }
             let savedAt = Date()
             func prepare(_ session: inout ChatSession, lane: OracleLane) {
                 session.workspaceID = workspaceID
                 session.composeTabID = tabID
                 session.agentModeSessionID = agentModeSessionID
                 session.agentModeRunID = agentModeRunID
-                session.oraclePairID = pairID
+                session.oraclePairID = groupID
+                session.oracleGroupSize = expectedLanes.count
                 session.oracleLane = lane
                 session.oracleHistoryDiverged = diverged
                 session.savedAt = savedAt
             }
-            prepare(&primary, lane: .primary)
-            prepare(&secondary, lane: .secondary)
-            guard let primaryIndex = sessions.firstIndex(where: { $0.id == primary.id }),
-                  let secondaryIndex = sessions.firstIndex(where: { $0.id == secondary.id })
-            else {
-                throw ChatToolError(code: .conflict, message: "Oracle pair preparation changed before lane dispatch.", details: nil)
+            for lane in expectedLanes {
+                guard var member = members[lane],
+                      let index = sessions.firstIndex(where: { $0.id == member.id })
+                else {
+                    throw ChatToolError(code: .conflict, message: "Oracle group preparation changed before lane dispatch.", details: nil)
+                }
+                prepare(&member, lane: lane)
+                sessions[index] = member
+                members[lane] = member
+                rollback.assignedSessions[member.id] = member
             }
-            sessions[primaryIndex] = primary
-            sessions[secondaryIndex] = secondary
-            rollback.assignedSessions = [primary.id: primary, secondary.id: secondary]
-            try await sessionsResolved?(primary.id, secondary.id)
+            try await sessionsResolved?(members.mapValues(\.id))
 
             if activatePrimaryInUI {
+                guard let preparedPrimary = members[.primary] else {
+                    throw ChatToolError.internalError("Oracle group lost its Primary session during activation.")
+                }
                 await activateResolvedChatSession(
-                    primary,
+                    preparedPrimary,
                     resolvedTabID: tabID,
                     activateInUI: true,
                     setActiveForTab: true
                 )
             }
-            return OraclePairSessionResolution(pairID: pairID, primary: primary, secondary: secondary)
+            return OracleGroupSessionResolution(groupID: groupID, members: members)
         } catch {
             let preparationError = error
             let rollbackFailures = await rollbackOraclePairPreparation(rollback)
             guard rollbackFailures.isEmpty else {
                 throw ChatToolError.internalError(
-                    "Oracle pair preparation failed (\(preparationError.localizedDescription)); rollback also failed: \(rollbackFailures.joined(separator: "; "))"
+                    "Oracle group preparation failed (\(preparationError.localizedDescription)); rollback also failed: \(rollbackFailures.joined(separator: "; "))"
                 )
             }
             throw preparationError
@@ -1678,11 +1765,13 @@ extension OracleViewModel {
                 liveCallbacks: liveCallbacks
             ).toMCPObject()
         } catch let failure as OracleSendFailure {
+            let payload = ToolOutputFormatter.rawJSONString(.object(failure.result.toMCPObject()))
             throw ChatToolError(
                 code: .internalError,
                 message: failure.message,
                 details: [
-                    "oracle_pair_payload": ToolOutputFormatter.rawJSONString(.object(failure.result.toMCPObject()))
+                    "oracle_group_payload": payload,
+                    "oracle_pair_payload": payload
                 ]
             )
         }
@@ -1695,6 +1784,7 @@ extension OracleViewModel {
         promptVM: PromptViewModel,
         tabContext: OracleSendTabContext? = nil,
         primaryModelSelection: ModelSelectionResult? = nil,
+        additionalModelOverrides: [AIModel]? = nil,
         secondaryModelOverride: AIModel? = nil,
         liveCallbacks: OracleSendLiveCallbacks = OracleSendLiveCallbacks()
     ) async throws -> OracleSendResult {
@@ -1704,11 +1794,21 @@ extension OracleViewModel {
             agentSessionID: tabContext?.agentModeSessionID,
             agentRunID: tabContext?.agentModeRunID
         )
-        let secondaryModel = try secondaryModelOverride ?? resolveOracleSecondaryModel(workspaceID: workspaceID)
+        let additionalModels: [AIModel]
+        if let additionalModelOverrides {
+            additionalModels = additionalModelOverrides
+        } else if let secondaryModelOverride {
+            additionalModels = [secondaryModelOverride]
+        } else {
+            additionalModels = try resolveAdditionalOracleModels(workspaceID: workspaceID)
+        }
+        guard additionalModels.count <= OracleLane.allCases.count - 1 else {
+            throw ChatToolError.invalidParams("Oracle supports at most five concurrent models.")
+        }
 
         let operation: @MainActor () async throws -> OracleSendResult = {
             try self.validateRemovedOracleSendArguments(args)
-            guard let secondaryModel else {
+            guard !additionalModels.isEmpty else {
                 if let primaryModelSelection {
                     liveCallbacks.modelsResolved?(primaryModelSelection.model, nil)
                 }
@@ -1729,33 +1829,33 @@ extension OracleViewModel {
                   let tabID = route.contextID,
                   self.workspaceManager.bindingCandidate(forContextID: tabID)?.workspaceID == workspaceID
             else {
-                throw ChatToolError.invalidParams("Paired Oracle requires an exact workspace and tab route.")
+                throw ChatToolError.invalidParams("Multiple Oracles require an exact workspace and tab route.")
             }
-            let pair = try await self.tool_pairedChatSend(
+            let group = try await self.tool_groupedChatSend(
                 args: args,
                 promptVM: promptVM,
                 tabContext: tabContext,
                 mode: mode,
                 message: message,
-                secondaryModel: secondaryModel,
+                additionalModels: additionalModels,
                 workspaceID: workspaceID,
                 tabID: tabID,
                 primaryModelSelectionOverride: primaryModelSelection,
                 liveCallbacks: liveCallbacks
             )
-            let result = OracleSendResult(payload: .paired(pair), route: route)
-            // Fail closed whenever Primary fails (including incomplete). Secondary-only
-            // failure stays a returned partial_failure so callers can keep Primary text.
-            if case let .failure(failure) = pair.result.primary {
+            let result = OracleSendResult(payload: .paired(group), route: route)
+            // Fail closed whenever Primary fails (including incomplete). Additional-lane
+            // failures stay a returned partial_failure so callers can keep Primary text.
+            if case let .failure(failure) = group.result.primary {
                 throw OracleSendFailure(
                     result: result,
-                    message: pair.failureSummary ?? failure.message
+                    message: group.failureSummary ?? failure.message
                 )
             }
             return result
         }
 
-        guard secondaryModel != nil, let workspaceID else { return try await operation() }
+        guard !additionalModels.isEmpty, let workspaceID else { return try await operation() }
         let claim = OracleSendClaimKey.oracleSend(
             workspaceID: workspaceID,
             tabID: route.contextID,
@@ -1774,13 +1874,13 @@ extension OracleViewModel {
     }
 
     @MainActor
-    private func tool_pairedChatSend(
+    private func tool_groupedChatSend(
         args: [String: Value],
         promptVM: PromptViewModel,
         tabContext: OracleSendTabContext?,
         mode: String,
         message: String,
-        secondaryModel: AIModel,
+        additionalModels: [AIModel],
         workspaceID: UUID,
         tabID: UUID,
         primaryModelSelectionOverride: ModelSelectionResult?,
@@ -1796,7 +1896,16 @@ extension OracleViewModel {
                 promptVM: promptVM
             )
         }
-        liveCallbacks.modelsResolved?(primarySelection.model, secondaryModel)
+        let lanes = Array(OracleLane.allCases.prefix(additionalModels.count + 1))
+        var modelsByLane: [OracleLane: AIModel] = [.primary: primarySelection.model]
+        for (lane, model) in zip(lanes.dropFirst(), additionalModels) {
+            modelsByLane[lane] = model
+        }
+        if let groupModelsResolved = liveCallbacks.groupModelsResolved {
+            groupModelsResolved(modelsByLane)
+        } else {
+            liveCallbacks.modelsResolved?(primarySelection.model, additionalModels.first)
+        }
         let shouldActivatePrimary: Bool = if tabContext?.activationPolicy == .background {
             false
         } else if let tabContext {
@@ -1805,81 +1914,82 @@ extension OracleViewModel {
         } else {
             true
         }
-        let pair = try await resolveOrCreateOraclePairSessions(
+        let group = try await resolveOrCreateOracleGroupSessions(
             requestedChatID: args["chat_id"]?.stringValue,
             forceNew: args["new_chat"]?.boolValue ?? false,
             desiredName: args["chat_name"]?.stringValue,
+            expectedLanes: lanes,
             workspaceID: workspaceID,
             tabID: tabID,
             activatePrimaryInUI: shouldActivatePrimary,
             agentModeSessionID: tabContext?.agentModeSessionID,
             agentModeRunID: tabContext?.agentModeRunID,
-            sessionsResolved: { primary, secondary in
-                try await liveCallbacks.pairSessionsResolved?(primary, secondary)
+            sessionsResolved: { sessionIDsByLane in
+                if let groupSessionsResolved = liveCallbacks.groupSessionsResolved {
+                    try await groupSessionsResolved(sessionIDsByLane)
+                } else if let primary = sessionIDsByLane[.primary], let secondary = sessionIDsByLane[.secondary] {
+                    try await liveCallbacks.pairSessionsResolved?(primary, secondary)
+                }
             }
         )
-        pinSession(pair.primary.id)
-        pinSession(pair.secondary.id)
-        defer {
-            unpinSession(pair.secondary.id)
-            unpinSession(pair.primary.id)
+        for member in group.members.values {
+            pinSession(member.id)
         }
-        var primaryArgs = args
-        primaryArgs["chat_id"] = .string(pair.primary.shortID)
-        primaryArgs["new_chat"] = .bool(false)
-        primaryArgs.removeValue(forKey: "chat_name")
-        var secondaryArgs = args
-        secondaryArgs["chat_id"] = .string(pair.secondary.shortID)
-        secondaryArgs["new_chat"] = .bool(false)
-        secondaryArgs.removeValue(forKey: "chat_name")
-        let secondarySelection = ModelSelectionResult(
-            model: secondaryModel,
-            mcpControlInfo: "Secondary Oracle (\(secondaryModel.displayName))",
-            isAutoSelected: false,
-            chatPresetID: primarySelection.chatPresetID
-        )
+        defer {
+            for member in group.members.values {
+                unpinSession(member.id)
+            }
+        }
+        var selectionsByLane: [OracleLane: ModelSelectionResult] = [.primary: primarySelection]
+        for lane in lanes.dropFirst() {
+            guard let model = modelsByLane[lane] else {
+                throw ChatToolError.internalError("Oracle group lost a configured model before dispatch.")
+            }
+            selectionsByLane[lane] = ModelSelectionResult(
+                model: model,
+                mcpControlInfo: "Oracle \(lane.ordinal) (\(model.displayName))",
+                isAutoSelected: false,
+                chatPresetID: primarySelection.chatPresetID
+            )
+        }
+        var operationsByLane: [OracleLane: OraclePairCoordinator.Operation<ChatSendReply>] = [:]
+        for lane in lanes {
+            guard let member = group.members[lane], let selection = selectionsByLane[lane] else {
+                throw ChatToolError.internalError("Oracle group lost a prepared lane before dispatch.")
+            }
+            var laneArgs = args
+            laneArgs["chat_id"] = .string(member.shortID)
+            laneArgs["new_chat"] = .bool(false)
+            laneArgs.removeValue(forKey: "chat_name")
+            let sendArgs = laneArgs
+            let onProgress = lane == .primary ? liveCallbacks.primaryProgress : nil
+            operationsByLane[lane] = {
+                let result = try await self.tool_singleChatSendClaimed(
+                    args: sendArgs,
+                    promptVM: promptVM,
+                    tabContext: tabContext,
+                    modelSelectionOverride: selection,
+                    resolvedMessageOverride: message,
+                    activateInUI: false,
+                    lane: lane,
+                    laneLifecycle: liveCallbacks.laneLifecycle,
+                    onProgress: onProgress
+                )
+                _ = try OraclePairCoordinator.validatedResponse(result.response, lane: lane)
+                return result
+            }
+        }
         let execution: OraclePairCoordinator.Result<ChatSendReply>
         do {
-            execution = try await OraclePairCoordinator.run(
-                primary: {
-                    let result = try await self.tool_singleChatSendClaimed(
-                        args: primaryArgs,
-                        promptVM: promptVM,
-                        tabContext: tabContext,
-                        modelSelectionOverride: primarySelection,
-                        resolvedMessageOverride: message,
-                        activateInUI: false,
-                        lane: .primary,
-                        laneLifecycle: liveCallbacks.laneLifecycle,
-                        onProgress: liveCallbacks.primaryProgress
-                    )
-                    _ = try OraclePairCoordinator.validatedResponse(result.response, lane: .primary)
-                    return result
-                },
-                secondary: {
-                    let result = try await self.tool_singleChatSendClaimed(
-                        args: secondaryArgs,
-                        promptVM: promptVM,
-                        tabContext: tabContext,
-                        modelSelectionOverride: secondarySelection,
-                        resolvedMessageOverride: message,
-                        activateInUI: false,
-                        lane: .secondary,
-                        laneLifecycle: liveCallbacks.laneLifecycle
-                    )
-                    _ = try OraclePairCoordinator.validatedResponse(result.response, lane: .secondary)
-                    return result
-                }
-            )
+            execution = try await OraclePairCoordinator.run(operationsByLane: operationsByLane)
         } catch is CancellationError {
             do {
-                _ = try await persistOraclePairHistories(
-                    pairID: pair.pairID,
-                    primarySessionID: pair.primary.id,
-                    secondarySessionID: pair.secondary.id
+                _ = try await persistOracleGroupHistories(
+                    groupID: group.groupID,
+                    sessionIDsByLane: group.members.mapValues(\.id)
                 )
             } catch {
-                let message = "Cancelled Oracle pair history persistence failed: \(error.localizedDescription)"
+                let message = "Cancelled Oracle group history persistence failed: \(error.localizedDescription)"
                 print(message)
             }
             throw CancellationError()
@@ -1888,29 +1998,27 @@ extension OracleViewModel {
         let historyDiverged: Bool
         var historyPersistenceError: String?
         do {
-            historyDiverged = try await persistOraclePairHistories(
-                pairID: pair.pairID,
-                primarySessionID: pair.primary.id,
-                secondarySessionID: pair.secondary.id
+            historyDiverged = try await persistOracleGroupHistories(
+                groupID: group.groupID,
+                sessionIDsByLane: group.members.mapValues(\.id)
             )
         } catch {
             historyPersistenceError = error.localizedDescription
-            historyDiverged = Self.oracleHistoriesDiverged(
-                primary: oracleUserHistory(in: pair.primary.id) ?? [],
-                secondary: oracleUserHistory(in: pair.secondary.id) ?? []
-            )
-            for index in sessions.indices where sessions[index].oraclePairID == pair.pairID {
+            let primaryHistory = oracleUserHistory(in: group.primary.id) ?? []
+            historyDiverged = lanes.dropFirst().contains { lane in
+                guard let sessionID = group.members[lane]?.id else { return true }
+                return oracleUserHistory(in: sessionID) != primaryHistory
+            }
+            for index in sessions.indices where sessions[index].oraclePairID == group.groupID {
                 sessions[index].oracleHistoryDiverged = historyDiverged
             }
         }
-        return OraclePairSendReply(
-            pairID: pair.pairID,
+        return try OraclePairSendReply(
+            groupID: group.groupID,
             mode: mode,
-            primarySessionID: pair.primary.id,
-            primaryChatID: pair.primary.shortID,
-            secondaryChatID: pair.secondary.shortID,
-            primaryModel: primarySelection.model,
-            secondaryModel: secondaryModel,
+            sessionIDsByLane: group.members.mapValues(\.id),
+            chatIDsByLane: group.members.mapValues(\.shortID),
+            modelsByLane: modelsByLane,
             result: execution,
             historyDiverged: historyDiverged,
             historyPersistenceError: historyPersistenceError

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -1746,11 +1746,11 @@ extension OracleViewModel {
             let result = OracleSendResult(payload: .paired(pair), route: route)
             // Fail closed whenever Primary fails (including incomplete). Secondary-only
             // failure stays a returned partial_failure so callers can keep Primary text.
-            if case .failure = pair.result.primary, let failureSummary = pair.failureSummary {
-                throw OracleSendFailure(result: result, message: failureSummary)
-            }
-            if pair.status == .failed, let failureSummary = pair.failureSummary {
-                throw OracleSendFailure(result: result, message: failureSummary)
+            if case let .failure(failure) = pair.result.primary {
+                throw OracleSendFailure(
+                    result: result,
+                    message: pair.failureSummary ?? failure.message
+                )
             }
             return result
         }
@@ -1906,6 +1906,7 @@ extension OracleViewModel {
         return OraclePairSendReply(
             pairID: pair.pairID,
             mode: mode,
+            primarySessionID: pair.primary.id,
             primaryChatID: pair.primary.shortID,
             secondaryChatID: pair.secondary.shortID,
             primaryModel: primarySelection.model,

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -1794,13 +1794,12 @@ extension OracleViewModel {
             agentSessionID: tabContext?.agentModeSessionID,
             agentRunID: tabContext?.agentModeRunID
         )
-        let additionalModels: [AIModel]
-        if let additionalModelOverrides {
-            additionalModels = additionalModelOverrides
+        let additionalModels: [AIModel] = if let additionalModelOverrides {
+            additionalModelOverrides
         } else if let secondaryModelOverride {
-            additionalModels = [secondaryModelOverride]
+            [secondaryModelOverride]
         } else {
-            additionalModels = try resolveAdditionalOracleModels(workspaceID: workspaceID)
+            try resolveAdditionalOracleModels(workspaceID: workspaceID)
         }
         guard additionalModels.count <= OracleLane.allCases.count - 1 else {
             throw ChatToolError.invalidParams("Oracle supports at most five concurrent models.")

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -1259,7 +1259,8 @@ extension OracleViewModel {
                 // member. Validate that member's durable cardinality here; the complete
                 // in-memory or persisted group is validated and loaded by preparation.
                 guard source.oracleGroupSize == expectedLanes.count,
-                      source.oracleLane.map { expectedLanes.contains($0) } == true
+                      let sourceLane = source.oracleLane,
+                      expectedLanes.contains(sourceLane)
                 else {
                     throw ChatToolError(
                         code: .conflict,

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -25,11 +25,40 @@ extension OracleViewModel {
     // MARK: - Model Selection
 
     /// Encapsulates the result of model selection
-    private struct ModelSelectionResult {
+    struct ModelSelectionResult {
         let model: AIModel
         let mcpControlInfo: String?
         let isAutoSelected: Bool
         let chatPresetID: UUID? // The chat preset to use for this mode (always resolved now)
+    }
+
+    enum OracleSendActivationPolicy: Equatable {
+        case legacyAutomatic
+        case background
+
+        static let publicMCP: Self = .legacyAutomatic
+    }
+
+    struct OracleSendLiveCallbacks {
+        var modelsResolved: (@MainActor @Sendable (AIModel, AIModel?) -> Void)?
+        var pairSessionsResolved: (@MainActor @Sendable (UUID, UUID) async throws -> Void)?
+        var primarySessionResolved: (@MainActor @Sendable (UUID) async throws -> Void)?
+        var primaryProgress: (@MainActor @Sendable (String, String?) -> Void)?
+        var laneLifecycle: (@MainActor @Sendable (OracleLane, OracleMessageLifecycleActivityEvent) -> Void)?
+
+        init(
+            modelsResolved: (@MainActor @Sendable (AIModel, AIModel?) -> Void)? = nil,
+            pairSessionsResolved: (@MainActor @Sendable (UUID, UUID) async throws -> Void)? = nil,
+            primarySessionResolved: (@MainActor @Sendable (UUID) async throws -> Void)? = nil,
+            primaryProgress: (@MainActor @Sendable (String, String?) -> Void)? = nil,
+            laneLifecycle: (@MainActor @Sendable (OracleLane, OracleMessageLifecycleActivityEvent) -> Void)? = nil
+        ) {
+            self.modelsResolved = modelsResolved
+            self.pairSessionsResolved = pairSessionsResolved
+            self.primarySessionResolved = primarySessionResolved
+            self.primaryProgress = primaryProgress
+            self.laneLifecycle = laneLifecycle
+        }
     }
 
     enum OracleSendPackagingProvenance: Equatable {
@@ -49,6 +78,7 @@ extension OracleViewModel {
         let selection: StoredSelection
         let lookupContext: WorkspaceLookupContext?
         let reviewGitContext: FrozenPromptGitReviewContext
+        let prebuiltAIMessage: AIMessage?
         let provenance: OracleSendPackagingProvenance
 
         init(
@@ -61,6 +91,7 @@ extension OracleViewModel {
             selection: StoredSelection,
             lookupContext: WorkspaceLookupContext?,
             reviewGitContext: FrozenPromptGitReviewContext,
+            prebuiltAIMessage: AIMessage? = nil,
             provenance: OracleSendPackagingProvenance
         ) {
             self.sourceTabID = sourceTabID
@@ -72,6 +103,7 @@ extension OracleViewModel {
             self.selection = selection
             self.lookupContext = lookupContext
             self.reviewGitContext = reviewGitContext
+            self.prebuiltAIMessage = prebuiltAIMessage
             self.provenance = provenance
         }
 
@@ -131,6 +163,8 @@ extension OracleViewModel {
         let origin: OracleSendOrigin
         let agentModeSessionID: UUID?
         let agentModeRunID: UUID?
+        let activationPolicy: OracleSendActivationPolicy
+        let completionPolicy: OracleResponseCompletionPolicy
         let packaging: OracleSendPackagingContext
 
         init(
@@ -139,6 +173,8 @@ extension OracleViewModel {
             origin: OracleSendOrigin = .compatibility,
             agentModeSessionID: UUID? = nil,
             agentModeRunID: UUID? = nil,
+            activationPolicy: OracleSendActivationPolicy = .legacyAutomatic,
+            completionPolicy: OracleResponseCompletionPolicy = .interactive,
             packaging: OracleSendPackagingContext
         ) {
             self.tabID = tabID
@@ -146,6 +182,8 @@ extension OracleViewModel {
             self.origin = origin
             self.agentModeSessionID = agentModeSessionID
             self.agentModeRunID = agentModeRunID
+            self.activationPolicy = activationPolicy
+            self.completionPolicy = completionPolicy
             self.packaging = packaging
         }
     }
@@ -384,10 +422,10 @@ extension OracleViewModel {
         modelParam: String? = nil,
         workspaceID: UUID? = nil,
         planningModelRawOverride: String? = nil
-    ) async throws -> (model: AIModel, chatPresetID: UUID?, mcpControlInfo: String?) {
+    ) async throws -> ModelSelectionResult {
         let presetsManager = ModelPresetsManager.shared
         let allPresets = presetsManager.allPresets()
-        let selection = try await selectModel(
+        return try await selectModel(
             modelParam: modelParam,
             mode: mode,
             allPresets: allPresets,
@@ -396,7 +434,6 @@ extension OracleViewModel {
                 GlobalSettingsStore.shared.effectiveAgentModelsProfile(workspaceID: $0).planningModelRaw
             }
         )
-        return (selection.model, selection.chatPresetID, selection.mcpControlInfo)
     }
 
     /// Finds a built-in chat preset for the given mode
@@ -737,20 +774,24 @@ extension OracleViewModel {
     @MainActor
     func createSession(
         named name: String?,
+        workspaceID: UUID? = nil,
         tabID: UUID? = nil,
         activateInUI: Bool = true,
         setActiveForTab: Bool = true,
         agentModeSessionID: UUID? = nil,
-        agentModeRunID: UUID? = nil
+        agentModeRunID: UUID? = nil,
+        reuseBlankSession: Bool = true
     ) async throws -> ChatSession {
         let safeName = ChatSession.validatedName(name ?? "")
         let createdID = await startNewChatSession(
             name: safeName,
+            workspaceID: workspaceID,
             tabID: tabID,
             agentModeSessionID: agentModeSessionID,
             agentModeRunID: agentModeRunID,
             activateInUI: activateInUI,
-            setActiveForTab: setActiveForTab
+            setActiveForTab: setActiveForTab,
+            reuseBlankSession: reuseBlankSession
         )
 
         guard let id = createdID ?? currentSessionID,
@@ -904,14 +945,16 @@ extension OracleViewModel {
     private func activateResolvedChatSession(
         _ session: ChatSession,
         resolvedTabID: UUID?,
-        activateInUI: Bool
+        activateInUI: Bool,
+        setActiveForTab: Bool
     ) async {
         if activateInUI {
-            await switchToSession(session.id)
+            await switchToSession(session.id, setActiveForTab: setActiveForTab)
             return
         }
 
         _ = await ensureSessionLoadedForBackground(session)
+        guard setActiveForTab else { return }
         let targetTabID = await resolveBackgroundTabID(
             for: session,
             fallbackTabID: resolvedTabID
@@ -929,19 +972,23 @@ extension OracleViewModel {
         _ idString: String?,
         desiredName: String? = nil,
         forceNew: Bool = false,
+        workspaceID: UUID? = nil,
         tabID: UUID? = nil,
         activateInUI: Bool = true,
+        setActiveForTab: Bool = true,
         agentModeSessionID: UUID? = nil,
-        agentModeRunID: UUID? = nil
+        agentModeRunID: UUID? = nil,
+        allowPairedSessions: Bool = true
     ) async throws -> UUID {
         let resolvedTabID = tabID ?? promptViewModel.activeComposeTabID
 
         if forceNew {
             let new = try await createSession(
                 named: desiredName,
+                workspaceID: workspaceID,
                 tabID: resolvedTabID,
                 activateInUI: activateInUI,
-                setActiveForTab: true,
+                setActiveForTab: setActiveForTab,
                 agentModeSessionID: agentModeSessionID,
                 agentModeRunID: agentModeRunID
             )
@@ -965,6 +1012,11 @@ extension OracleViewModel {
             ) else {
                 throw ChatToolError.invalidParams("Chat with ID '\(idString)' belongs to a different Agent Mode owner")
             }
+            guard allowPairedSessions || existing.oraclePairID == nil else {
+                throw ChatToolError.invalidParams(
+                    "Paired Oracle histories cannot be continued while Secondary Oracle is disabled. Start a new chat."
+                )
+            }
 
             await applyOracleOwnerIfNeeded(
                 sessionID: existing.id,
@@ -972,7 +1024,12 @@ extension OracleViewModel {
                 agentModeSessionID: agentModeSessionID,
                 agentModeRunID: agentModeRunID
             )
-            await activateResolvedChatSession(existing, resolvedTabID: resolvedTabID, activateInUI: activateInUI)
+            await activateResolvedChatSession(
+                existing,
+                resolvedTabID: resolvedTabID,
+                activateInUI: activateInUI,
+                setActiveForTab: setActiveForTab
+            )
 
             if let newName = desiredName,
                !newName.isEmpty,
@@ -984,7 +1041,8 @@ extension OracleViewModel {
         }
 
         func eligible(_ session: ChatSession, allowUnownedLegacy: Bool = true) -> Bool {
-            Self.sessionBelongsToResolvedTab(session, tabID: resolvedTabID) &&
+            (allowPairedSessions || session.oraclePairID == nil) &&
+                Self.sessionBelongsToResolvedTab(session, tabID: resolvedTabID) &&
                 Self.sessionMatchesOracleOwner(
                     session,
                     agentModeSessionID: agentModeSessionID,
@@ -1041,7 +1099,12 @@ extension OracleViewModel {
                 agentModeSessionID: agentModeSessionID,
                 agentModeRunID: agentModeRunID
             )
-            await activateResolvedChatSession(candidate, resolvedTabID: resolvedTabID, activateInUI: activateInUI)
+            await activateResolvedChatSession(
+                candidate,
+                resolvedTabID: resolvedTabID,
+                activateInUI: activateInUI,
+                setActiveForTab: setActiveForTab
+            )
             if let newName = desiredName,
                !newName.isEmpty,
                newName != candidate.name
@@ -1053,118 +1116,880 @@ extension OracleViewModel {
 
         let new = try await createSession(
             named: desiredName ?? "New Chat",
+            workspaceID: workspaceID,
             tabID: resolvedTabID,
             activateInUI: activateInUI,
-            setActiveForTab: true,
+            setActiveForTab: setActiveForTab,
             agentModeSessionID: agentModeSessionID,
             agentModeRunID: agentModeRunID
         )
         return new.id
     }
 
-    /// Full implementation of the shared oracle send backend.
-    @MainActor
-    func tool_chatSend(
-        args: [String: Value],
-        promptVM: PromptViewModel,
-        tabContext: OracleSendTabContext? = nil
-    ) async throws
-        -> [String: Value]
-    {
-        // ────────── 1. Validate & extract parameters ──────────
+    private struct OraclePairSessionResolution {
+        let pairID: UUID
+        let primary: ChatSession
+        let secondary: ChatSession
+    }
+
+    private func validateRemovedOracleSendArguments(_ args: [String: Value]) throws {
         let removedArgs = ["selected_paths", "git_scope", "git_base"].filter { args[$0] != nil }
         if !removedArgs.isEmpty {
             throw ChatToolError.invalidParams(
                 "ask_oracle no longer accepts \(removedArgs.joined(separator: ", ")). Use manage_selection for selection and git tools for git context."
             )
         }
+    }
 
-        let useTabPrompt = args["use_tab_prompt"]?.boolValue ?? false
-        let rawMessage = args["message"]?.stringValue ?? ""
-
-        // Resolve message: either from tab prompt or explicit message parameter
-        let message: String
-        if useTabPrompt {
-            let base = tabContext?.packaging.promptText ?? promptVM.promptText
-            message = base.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !message.isEmpty else {
-                throw ChatToolError.invalidParams("Active tab prompt is empty (use_tab_prompt=true)")
-            }
-        } else {
-            message = rawMessage
-            guard !message.isEmpty else {
-                throw ChatToolError.invalidParams("message cannot be empty")
-            }
-        }
-
+    private func validatedOracleSendMode(_ args: [String: Value]) throws -> String {
         let mode = args["mode"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? "chat"
         guard ["chat", "plan", "review"].contains(mode) else {
             throw ChatToolError.invalidParams("Invalid mode: \(mode). Valid modes: chat, plan, review")
         }
+        return mode
+    }
+
+    @MainActor
+    func resolveOracleSecondaryModel(workspaceID: UUID?) throws -> AIModel? {
+        try resolveOracleSecondaryModel(
+            workspaceID: workspaceID,
+            effectiveProfile: GlobalSettingsStore.shared.effectiveAgentModelsProfile(workspaceID:)
+        )
+    }
+
+    @MainActor
+    func resolveOracleSecondaryModel(
+        workspaceID: UUID?,
+        effectiveProfile: (UUID?) -> AgentModelsSettingsProfile
+    ) throws -> AIModel? {
+        try OraclePairModelSelectionPolicy.resolveSecondary(
+            raw: effectiveProfile(workspaceID).secondaryOracleModelRaw
+        )
+    }
+
+    @MainActor
+    private func resolvedOracleMessage(
+        args: [String: Value],
+        promptVM: PromptViewModel,
+        tabContext: OracleSendTabContext?
+    ) throws -> String {
+        if args["use_tab_prompt"]?.boolValue ?? false {
+            let message = (tabContext?.packaging.promptText ?? promptVM.promptText)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !message.isEmpty else {
+                throw ChatToolError.invalidParams("Active tab prompt is empty (use_tab_prompt=true)")
+            }
+            return message
+        }
+        guard let message = args["message"]?.stringValue, !message.isEmpty else {
+            throw ChatToolError.invalidParams("message cannot be empty")
+        }
+        return message
+    }
+
+    private nonisolated static func sessionMatchesExactOracleRoute(
+        _ session: ChatSession,
+        workspaceID: UUID,
+        tabID: UUID,
+        agentModeSessionID: UUID?,
+        agentModeRunID: UUID?
+    ) -> Bool {
+        session.workspaceID == workspaceID &&
+            session.composeTabID == tabID &&
+            session.agentModeSessionID == agentModeSessionID &&
+            session.agentModeRunID == agentModeRunID
+    }
+
+    @MainActor
+    private func resolveOraclePairSource(
+        requestedChatID: String?,
+        forceNew: Bool,
+        workspaceID: UUID,
+        tabID: UUID,
+        agentModeSessionID: UUID?,
+        agentModeRunID: UUID?
+    ) async throws -> ChatSession? {
+        guard !forceNew else { return nil }
+        if let requestedChatID = requestedChatID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !requestedChatID.isEmpty
+        {
+            guard let source = try await resolveSessionForExplicitContinuation(id: requestedChatID, tabID: tabID) else {
+                throw ChatToolError.notFound("Chat with ID '\(requestedChatID)' not found")
+            }
+            guard Self.sessionMatchesExactOracleRoute(
+                source,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                agentModeSessionID: agentModeSessionID,
+                agentModeRunID: agentModeRunID
+            ) else {
+                throw ChatToolError.invalidParams("The requested Oracle chat belongs to a different workspace, tab, Agent session, or run.")
+            }
+            return source
+        }
+
+        let candidates = sessions.filter {
+            Self.sessionMatchesExactOracleRoute(
+                $0,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                agentModeSessionID: agentModeSessionID,
+                agentModeRunID: agentModeRunID
+            ) && $0.oraclePairID != nil && $0.oracleLane == .primary
+        }.sorted { $0.savedAt > $1.savedAt }
+        if let activeID = workspaceManager.activeChatSessionID(forTabID: tabID),
+           let active = candidates.first(where: { $0.id == activeID })
+        {
+            return active
+        }
+        if let currentSessionID,
+           let current = candidates.first(where: { $0.id == currentSessionID })
+        {
+            return current
+        }
+        return candidates.first
+    }
+
+    @MainActor
+    private func loadPersistedOraclePair(
+        pairID: UUID,
+        workspaceID: UUID,
+        tabID: UUID,
+        agentModeSessionID: UUID?,
+        agentModeRunID: UUID?
+    ) async throws -> (primary: ChatSession, secondary: ChatSession, inserted: Set<UUID>) {
+        guard let workspace = workspaceManager.workspaces.first(where: { $0.id == workspaceID }) else {
+            throw ChatToolError.invalidParams("The Oracle pair workspace is unavailable.")
+        }
+        let stubs = try await chatData.oraclePairSessionStubs(for: workspace, pairID: pairID)
+        guard stubs.count == 2, Set(stubs.map(\.id)).count == 2 else {
+            throw ChatToolError(code: .conflict, message: "Oracle pair \(pairID.uuidString) is incomplete; start a new Oracle chat instead of continuing it.", details: nil)
+        }
+
+        var loaded: [ChatSession] = []
+        for stub in stubs {
+            let member = sessions.first(where: { $0.id == stub.id }) ?? stub
+            let full: ChatSession = if member.isListStub, let fileURL = member.fileURL {
+                try await chatData.loadChatSession(from: fileURL)
+            } else {
+                member
+            }
+            loaded.append(full)
+        }
+        guard loaded.count == 2,
+              loaded.allSatisfy({ member in
+                  member.oraclePairID == pairID &&
+                      Self.sessionMatchesExactOracleRoute(
+                          member,
+                          workspaceID: workspaceID,
+                          tabID: tabID,
+                          agentModeSessionID: agentModeSessionID,
+                          agentModeRunID: agentModeRunID
+                      ) && !isSessionStreaming(member.id)
+              }),
+              let primary = loaded.first(where: { $0.oracleLane == .primary }),
+              let secondary = loaded.first(where: { $0.oracleLane == .secondary })
+        else {
+            throw ChatToolError(code: .conflict, message: "Oracle pair metadata is unavailable, corrupt, or already streaming.", details: nil)
+        }
+
+        var inserted = Set<UUID>()
+        for member in loaded {
+            if let index = sessions.firstIndex(where: { $0.id == member.id }) {
+                sessions[index] = member
+            } else {
+                sessions.append(member)
+                inserted.insert(member.id)
+            }
+        }
+        for member in loaded {
+            await reloadSessionFromMemory(member)
+        }
+        return (primary, secondary, inserted)
+    }
+
+    @MainActor
+    func persistOraclePairRename(sessionID: UUID, newName: String) async throws {
+        guard let target = sessions.first(where: { $0.id == sessionID }),
+              let pairID = target.oraclePairID,
+              target.oracleLane != nil,
+              let workspaceID = target.workspaceID,
+              let tabID = target.composeTabID
+        else {
+            throw ChatToolError.internalError("Failed to resolve the Oracle pair for renaming.")
+        }
+        let claim = OracleSendClaimKey.oracleSend(
+            workspaceID: workspaceID,
+            tabID: tabID,
+            agentModeSessionID: target.agentModeSessionID,
+            agentModeRunID: target.agentModeRunID
+        )
+
+        do {
+            try await oracleSendClaims.withClaim([claim]) {
+                let pair = try await self.loadPersistedOraclePair(
+                    pairID: pairID,
+                    workspaceID: workspaceID,
+                    tabID: tabID,
+                    agentModeSessionID: target.agentModeSessionID,
+                    agentModeRunID: target.agentModeRunID
+                )
+                guard pair.primary.id == sessionID || pair.secondary.id == sessionID,
+                      let index = self.sessions.firstIndex(where: { $0.id == sessionID })
+                else {
+                    throw ChatToolError.internalError("Failed to resolve the renamed Oracle pair member.")
+                }
+
+                let originalName = self.sessions[index].name
+                self.sessions[index].name = newName
+                do {
+                    _ = try await self.persistOraclePairHistories(
+                        pairID: pairID,
+                        primarySessionID: pair.primary.id,
+                        secondarySessionID: pair.secondary.id
+                    )
+                } catch let error as ChatToolError where error.details?["durable_commit"] == "true" {
+                    throw error
+                } catch {
+                    if let currentIndex = self.sessions.firstIndex(where: { $0.id == sessionID }),
+                       self.sessions[currentIndex].oraclePairID == pairID,
+                       self.sessions[currentIndex].name == newName
+                    {
+                        self.sessions[currentIndex].name = originalName
+                    }
+                    if !pair.inserted.isEmpty {
+                        self.removeOraclePairSessionState(pair.inserted)
+                    }
+                    throw error
+                }
+            }
+        } catch OracleSendClaimError.conflict {
+            throw ChatToolError(
+                code: .conflict,
+                message: "This Oracle pair is busy and could not be renamed.",
+                details: nil
+            )
+        }
+    }
+
+    @MainActor
+    func resolveInMemoryOraclePairMembers(
+        pairID: UUID,
+        workspaceID: UUID,
+        tabID: UUID,
+        agentModeSessionID: UUID?,
+        agentModeRunID: UUID?
+    ) async throws -> (primary: ChatSession, secondary: ChatSession)? {
+        let members = sessions.filter { $0.oraclePairID == pairID }
+        guard !members.isEmpty else { return nil }
+        guard members.count <= 2 else {
+            throw ChatToolError(
+                code: .conflict,
+                message: "Oracle pair \(pairID.uuidString) has duplicate members.",
+                details: nil
+            )
+        }
+        let laneGroups = Dictionary(grouping: members.compactMap(\.oracleLane), by: { $0 })
+        guard !laneGroups.values.contains(where: { $0.count > 1 }) else {
+            throw ChatToolError(
+                code: .conflict,
+                message: "Oracle pair \(pairID.uuidString) has duplicate lanes.",
+                details: nil
+            )
+        }
+        guard members.count == 2,
+              let primary = members.first(where: { $0.oracleLane == .primary }),
+              let secondary = members.first(where: { $0.oracleLane == .secondary }),
+              Self.sessionMatchesExactOracleRoute(
+                  primary,
+                  workspaceID: workspaceID,
+                  tabID: tabID,
+                  agentModeSessionID: agentModeSessionID,
+                  agentModeRunID: agentModeRunID
+              ),
+              Self.sessionMatchesExactOracleRoute(
+                  secondary,
+                  workspaceID: workspaceID,
+                  tabID: tabID,
+                  agentModeSessionID: agentModeSessionID,
+                  agentModeRunID: agentModeRunID
+              ),
+              !isSessionStreaming(primary.id),
+              !isSessionStreaming(secondary.id),
+              let loadedPrimary = await ensureSessionLoadedForBackground(primary),
+              let loadedSecondary = await ensureSessionLoadedForBackground(secondary)
+        else {
+            return nil
+        }
+        return (loadedPrimary, loadedSecondary)
+    }
+
+    private struct OraclePairPreparationRollbackState {
+        let workspaceID: UUID
+        let tabID: UUID
+        let priorCurrentSessionID: UUID?
+        let priorTabActiveSessionID: UUID?
+        var originalSessions: [UUID: ChatSession] = [:]
+        var createdSessionIDs: Set<UUID> = []
+        var insertedSessionIDs: Set<UUID> = []
+        var assignedSessions: [UUID: ChatSession] = [:]
+    }
+
+    @MainActor
+    private func rollbackOraclePairPreparation(
+        _ state: OraclePairPreparationRollbackState
+    ) async -> [String] {
+        var failures: [String] = []
+        let operationSessionIDs = state.createdSessionIDs.union(state.originalSessions.keys)
+
+        for sessionID in operationSessionIDs where isSessionStreaming(sessionID) {
+            await cancelAIResponse(in: sessionID, skipPartialParseAndSave: true)
+        }
+
+        if !state.createdSessionIDs.isEmpty {
+            if let workspace = workspaceManager.workspaces.first(where: { $0.id == state.workspaceID }) {
+                do {
+                    try await chatData.deleteOraclePairSessionFiles(
+                        state.createdSessionIDs,
+                        for: workspace
+                    )
+                } catch {
+                    failures.append("created sessions: \(error.localizedDescription)")
+                }
+            } else {
+                failures.append("created sessions: workspace is unavailable")
+            }
+        }
+
+        for (sessionID, original) in state.originalSessions {
+            guard let index = sessions.firstIndex(where: { $0.id == sessionID }),
+                  let assigned = state.assignedSessions[sessionID]
+            else { continue }
+            var current = sessions[index]
+            if current.workspaceID == assigned.workspaceID { current.workspaceID = original.workspaceID }
+            if current.composeTabID == assigned.composeTabID { current.composeTabID = original.composeTabID }
+            if current.agentModeSessionID == assigned.agentModeSessionID { current.agentModeSessionID = original.agentModeSessionID }
+            if current.agentModeRunID == assigned.agentModeRunID { current.agentModeRunID = original.agentModeRunID }
+            if current.oraclePairID == assigned.oraclePairID { current.oraclePairID = original.oraclePairID }
+            if current.oracleLane == assigned.oracleLane { current.oracleLane = original.oracleLane }
+            if current.oracleHistoryDiverged == assigned.oracleHistoryDiverged {
+                current.oracleHistoryDiverged = original.oracleHistoryDiverged
+            }
+            if current.fileURL == assigned.fileURL { current.fileURL = original.fileURL }
+            if current.savedAt == assigned.savedAt { current.savedAt = original.savedAt }
+            sessions[index] = current
+        }
+
+        let insertedSessionIDs = state.createdSessionIDs.union(state.insertedSessionIDs)
+        if !insertedSessionIDs.isEmpty {
+            removeOraclePairSessionState(insertedSessionIDs)
+        }
+        if let activeID = workspaceManager.activeChatSessionID(forTabID: state.tabID),
+           state.createdSessionIDs.contains(activeID)
+        {
+            workspaceManager.setActiveChatSessionID(state.priorTabActiveSessionID, forTabID: state.tabID)
+        }
+        if let currentSessionID, state.createdSessionIDs.contains(currentSessionID) {
+            self.currentSessionID = state.priorCurrentSessionID
+        }
+        return failures
+    }
+
+    @MainActor
+    private func resolveOrCreateOraclePairSessions(
+        requestedChatID: String?,
+        forceNew: Bool,
+        desiredName: String?,
+        workspaceID: UUID,
+        tabID: UUID,
+        activatePrimaryInUI: Bool,
+        agentModeSessionID: UUID?,
+        agentModeRunID: UUID?,
+        sessionsResolved: (@MainActor @Sendable (UUID, UUID) async throws -> Void)?
+    ) async throws -> OraclePairSessionResolution {
+        guard Set(sessions.map(\.id)).count == sessions.count,
+              workspaceManager.workspaces.contains(where: { $0.id == workspaceID })
+        else {
+            throw ChatToolError(code: .conflict, message: "Oracle pair session identities are invalid.", details: nil)
+        }
+        let initialSessionIDs = Set(sessions.map(\.id))
+        let source = try await resolveOraclePairSource(
+            requestedChatID: requestedChatID,
+            forceNew: forceNew,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            agentModeSessionID: agentModeSessionID,
+            agentModeRunID: agentModeRunID
+        )
+        let pairID = source?.oraclePairID ?? UUID()
+        var rollback = OraclePairPreparationRollbackState(
+            workspaceID: workspaceID,
+            tabID: tabID,
+            priorCurrentSessionID: currentSessionID,
+            priorTabActiveSessionID: workspaceManager.activeChatSessionID(forTabID: tabID)
+        )
+        rollback.insertedSessionIDs = Set(sessions.map(\.id)).subtracting(initialSessionIDs)
+
+        do {
+            var primary: ChatSession?
+            var secondary: ChatSession?
+            if source?.oraclePairID != nil {
+                if let pair = try await resolveInMemoryOraclePairMembers(
+                    pairID: pairID,
+                    workspaceID: workspaceID,
+                    tabID: tabID,
+                    agentModeSessionID: agentModeSessionID,
+                    agentModeRunID: agentModeRunID
+                ) {
+                    primary = pair.primary
+                    secondary = pair.secondary
+                } else {
+                    let pair = try await loadPersistedOraclePair(
+                        pairID: pairID,
+                        workspaceID: workspaceID,
+                        tabID: tabID,
+                        agentModeSessionID: agentModeSessionID,
+                        agentModeRunID: agentModeRunID
+                    )
+                    primary = pair.primary
+                    secondary = pair.secondary
+                    rollback.insertedSessionIDs.formUnion(pair.inserted)
+                }
+            } else if let source {
+                guard source.oracleLane != .secondary,
+                      !isSessionStreaming(source.id),
+                      let loaded = await ensureSessionLoadedForBackground(source)
+                else {
+                    throw ChatToolError(code: .conflict, message: "The Oracle session is unavailable or already streaming.", details: nil)
+                }
+                primary = loaded
+            }
+
+            for member in [primary, secondary].compactMap(\.self) {
+                rollback.originalSessions[member.id] = member
+            }
+            let primaryName = desiredName ?? primary?.name ?? "Oracle"
+            if primary == nil {
+                primary = try await createSession(
+                    named: primaryName,
+                    workspaceID: workspaceID,
+                    tabID: tabID,
+                    activateInUI: false,
+                    setActiveForTab: false,
+                    agentModeSessionID: agentModeSessionID,
+                    agentModeRunID: agentModeRunID,
+                    reuseBlankSession: false
+                )
+                rollback.createdSessionIDs.insert(primary!.id)
+            }
+            if secondary == nil {
+                secondary = try await createSession(
+                    named: "\(primaryName) — Secondary",
+                    workspaceID: workspaceID,
+                    tabID: tabID,
+                    activateInUI: false,
+                    setActiveForTab: false,
+                    agentModeSessionID: agentModeSessionID,
+                    agentModeRunID: agentModeRunID,
+                    reuseBlankSession: false
+                )
+                rollback.createdSessionIDs.insert(secondary!.id)
+            }
+            guard var primary, var secondary, primary.id != secondary.id else {
+                throw ChatToolError(code: .conflict, message: "Failed to create a distinct Oracle pair.", details: nil)
+            }
+            rollback.insertedSessionIDs.formUnion(rollback.createdSessionIDs)
+
+            let diverged = primary.oracleHistoryDiverged || secondary.oracleHistoryDiverged ||
+                Self.oracleHistoriesDiverged(
+                    primary: primary.messages.filter(\.isUser).map(\.rawText),
+                    secondary: secondary.messages.filter(\.isUser).map(\.rawText)
+                )
+            let savedAt = Date()
+            func prepare(_ session: inout ChatSession, lane: OracleLane) {
+                session.workspaceID = workspaceID
+                session.composeTabID = tabID
+                session.agentModeSessionID = agentModeSessionID
+                session.agentModeRunID = agentModeRunID
+                session.oraclePairID = pairID
+                session.oracleLane = lane
+                session.oracleHistoryDiverged = diverged
+                session.savedAt = savedAt
+            }
+            prepare(&primary, lane: .primary)
+            prepare(&secondary, lane: .secondary)
+            guard let primaryIndex = sessions.firstIndex(where: { $0.id == primary.id }),
+                  let secondaryIndex = sessions.firstIndex(where: { $0.id == secondary.id })
+            else {
+                throw ChatToolError(code: .conflict, message: "Oracle pair preparation changed before lane dispatch.", details: nil)
+            }
+            sessions[primaryIndex] = primary
+            sessions[secondaryIndex] = secondary
+            rollback.assignedSessions = [primary.id: primary, secondary.id: secondary]
+            try await sessionsResolved?(primary.id, secondary.id)
+
+            if activatePrimaryInUI {
+                await activateResolvedChatSession(
+                    primary,
+                    resolvedTabID: tabID,
+                    activateInUI: true,
+                    setActiveForTab: true
+                )
+            }
+            return OraclePairSessionResolution(pairID: pairID, primary: primary, secondary: secondary)
+        } catch {
+            let preparationError = error
+            let rollbackFailures = await rollbackOraclePairPreparation(rollback)
+            guard rollbackFailures.isEmpty else {
+                throw ChatToolError.internalError(
+                    "Oracle pair preparation failed (\(preparationError.localizedDescription)); rollback also failed: \(rollbackFailures.joined(separator: "; "))"
+                )
+            }
+            throw preparationError
+        }
+    }
+
+    nonisolated static func oracleHistoriesDiverged(
+        primary: [String],
+        secondary: [String]
+    ) -> Bool {
+        primary != secondary
+    }
+
+    @MainActor
+    func recordLaneEffectiveModel(sessionID: UUID, model: AIModel) {
+        guard let index = sessions.firstIndex(where: { $0.id == sessionID }) else { return }
+        sessions[index].preferredAIModel = model.rawValue
+    }
+
+    /// MCP transport boundary for Oracle sends.
+    @MainActor
+    func tool_chatSend(
+        args: [String: Value],
+        promptVM: PromptViewModel,
+        tabContext: OracleSendTabContext? = nil,
+        liveCallbacks: OracleSendLiveCallbacks = OracleSendLiveCallbacks()
+    ) async throws -> [String: Value] {
+        do {
+            return try await sendOracle(
+                args: args,
+                promptVM: promptVM,
+                tabContext: tabContext,
+                liveCallbacks: liveCallbacks
+            ).toMCPObject()
+        } catch let failure as OracleSendFailure {
+            throw ChatToolError(
+                code: .internalError,
+                message: failure.message,
+                details: [
+                    "oracle_pair_payload": ToolOutputFormatter.rawJSONString(.object(failure.result.toMCPObject()))
+                ]
+            )
+        }
+    }
+
+    /// Typed Oracle runtime entry point for in-app callers.
+    @MainActor
+    func sendOracle(
+        args: [String: Value],
+        promptVM: PromptViewModel,
+        tabContext: OracleSendTabContext? = nil,
+        primaryModelSelection: ModelSelectionResult? = nil,
+        secondaryModelOverride: AIModel? = nil,
+        liveCallbacks: OracleSendLiveCallbacks = OracleSendLiveCallbacks()
+    ) async throws -> OracleSendResult {
+        let workspaceID = tabContext?.workspaceID ?? workspaceManager.activeWorkspace?.id
+        let route = OracleSendRoute(
+            contextID: tabContext?.tabID ?? promptVM.activeComposeTabID,
+            agentSessionID: tabContext?.agentModeSessionID,
+            agentRunID: tabContext?.agentModeRunID
+        )
+        let secondaryModel = try secondaryModelOverride ?? resolveOracleSecondaryModel(workspaceID: workspaceID)
+
+        let operation: @MainActor () async throws -> OracleSendResult = {
+            try self.validateRemovedOracleSendArguments(args)
+            guard let secondaryModel else {
+                if let primaryModelSelection {
+                    liveCallbacks.modelsResolved?(primaryModelSelection.model, nil)
+                }
+                let reply = try await self.tool_singleChatSendClaimed(
+                    args: args,
+                    promptVM: promptVM,
+                    tabContext: tabContext,
+                    modelSelectionOverride: primaryModelSelection,
+                    sessionResolved: liveCallbacks.primarySessionResolved,
+                    onProgress: liveCallbacks.primaryProgress
+                )
+                return OracleSendResult(payload: .single(reply), route: route)
+            }
+
+            let message = try self.resolvedOracleMessage(args: args, promptVM: promptVM, tabContext: tabContext)
+            let mode = try self.validatedOracleSendMode(args)
+            guard let workspaceID,
+                  let tabID = route.contextID,
+                  self.workspaceManager.bindingCandidate(forContextID: tabID)?.workspaceID == workspaceID
+            else {
+                throw ChatToolError.invalidParams("Paired Oracle requires an exact workspace and tab route.")
+            }
+            let pair = try await self.tool_pairedChatSend(
+                args: args,
+                promptVM: promptVM,
+                tabContext: tabContext,
+                mode: mode,
+                message: message,
+                secondaryModel: secondaryModel,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                primaryModelSelectionOverride: primaryModelSelection,
+                liveCallbacks: liveCallbacks
+            )
+            let result = OracleSendResult(payload: .paired(pair), route: route)
+            if pair.status == .failed, let failureSummary = pair.failureSummary {
+                throw OracleSendFailure(result: result, message: failureSummary)
+            }
+            return result
+        }
+
+        guard secondaryModel != nil, let workspaceID else { return try await operation() }
+        let claim = OracleSendClaimKey.oracleSend(
+            workspaceID: workspaceID,
+            tabID: route.contextID,
+            agentModeSessionID: route.agentSessionID,
+            agentModeRunID: route.agentRunID
+        )
+        do {
+            return try await oracleSendClaims.withClaim([claim], operation: operation)
+        } catch OracleSendClaimError.conflict {
+            throw ChatToolError(
+                code: .conflict,
+                message: "This Oracle route already has an in-flight request.",
+                details: nil
+            )
+        }
+    }
+
+    @MainActor
+    private func tool_pairedChatSend(
+        args: [String: Value],
+        promptVM: PromptViewModel,
+        tabContext: OracleSendTabContext?,
+        mode: String,
+        message: String,
+        secondaryModel: AIModel,
+        workspaceID: UUID,
+        tabID: UUID,
+        primaryModelSelectionOverride: ModelSelectionResult?,
+        liveCallbacks: OracleSendLiveCallbacks
+    ) async throws -> OraclePairSendReply {
+        let primarySelection = if let primaryModelSelectionOverride {
+            primaryModelSelectionOverride
+        } else {
+            try await selectModel(
+                modelParam: args["model"]?.stringValue,
+                mode: mode,
+                allPresets: ModelPresetsManager.shared.allPresets(),
+                promptVM: promptVM
+            )
+        }
+        liveCallbacks.modelsResolved?(primarySelection.model, secondaryModel)
+        let shouldActivatePrimary: Bool = if tabContext?.activationPolicy == .background {
+            false
+        } else if let tabContext {
+            promptVM.activeComposeTabID == tabContext.tabID &&
+                !isSessionStreaming(workspaceManager.activeChatSessionID(forTabID: tabContext.tabID))
+        } else {
+            true
+        }
+        let pair = try await resolveOrCreateOraclePairSessions(
+            requestedChatID: args["chat_id"]?.stringValue,
+            forceNew: args["new_chat"]?.boolValue ?? false,
+            desiredName: args["chat_name"]?.stringValue,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            activatePrimaryInUI: shouldActivatePrimary,
+            agentModeSessionID: tabContext?.agentModeSessionID,
+            agentModeRunID: tabContext?.agentModeRunID,
+            sessionsResolved: { primary, secondary in
+                try await liveCallbacks.pairSessionsResolved?(primary, secondary)
+            }
+        )
+        pinSession(pair.primary.id)
+        pinSession(pair.secondary.id)
+        defer {
+            unpinSession(pair.secondary.id)
+            unpinSession(pair.primary.id)
+        }
+        var primaryArgs = args
+        primaryArgs["chat_id"] = .string(pair.primary.shortID)
+        primaryArgs["new_chat"] = .bool(false)
+        primaryArgs.removeValue(forKey: "chat_name")
+        var secondaryArgs = args
+        secondaryArgs["chat_id"] = .string(pair.secondary.shortID)
+        secondaryArgs["new_chat"] = .bool(false)
+        secondaryArgs.removeValue(forKey: "chat_name")
+        let secondarySelection = ModelSelectionResult(
+            model: secondaryModel,
+            mcpControlInfo: "Secondary Oracle (\(secondaryModel.displayName))",
+            isAutoSelected: false,
+            chatPresetID: primarySelection.chatPresetID
+        )
+        let execution: OraclePairCoordinator.Result<ChatSendReply>
+        do {
+            execution = try await OraclePairCoordinator.run(
+                primary: {
+                    let result = try await self.tool_singleChatSendClaimed(
+                        args: primaryArgs,
+                        promptVM: promptVM,
+                        tabContext: tabContext,
+                        modelSelectionOverride: primarySelection,
+                        resolvedMessageOverride: message,
+                        activateInUI: false,
+                        lane: .primary,
+                        laneLifecycle: liveCallbacks.laneLifecycle,
+                        onProgress: liveCallbacks.primaryProgress
+                    )
+                    _ = try OraclePairCoordinator.validatedResponse(result.response, lane: .primary)
+                    return result
+                },
+                secondary: {
+                    let result = try await self.tool_singleChatSendClaimed(
+                        args: secondaryArgs,
+                        promptVM: promptVM,
+                        tabContext: tabContext,
+                        modelSelectionOverride: secondarySelection,
+                        resolvedMessageOverride: message,
+                        activateInUI: false,
+                        lane: .secondary,
+                        laneLifecycle: liveCallbacks.laneLifecycle
+                    )
+                    _ = try OraclePairCoordinator.validatedResponse(result.response, lane: .secondary)
+                    return result
+                }
+            )
+        } catch is CancellationError {
+            do {
+                _ = try await persistOraclePairHistories(
+                    pairID: pair.pairID,
+                    primarySessionID: pair.primary.id,
+                    secondarySessionID: pair.secondary.id
+                )
+            } catch {
+                let message = "Cancelled Oracle pair history persistence failed: \(error.localizedDescription)"
+                print(message)
+            }
+            throw CancellationError()
+        }
+
+        let historyDiverged: Bool
+        var historyPersistenceError: String?
+        do {
+            historyDiverged = try await persistOraclePairHistories(
+                pairID: pair.pairID,
+                primarySessionID: pair.primary.id,
+                secondarySessionID: pair.secondary.id
+            )
+        } catch {
+            historyPersistenceError = error.localizedDescription
+            historyDiverged = Self.oracleHistoriesDiverged(
+                primary: oracleUserHistory(in: pair.primary.id) ?? [],
+                secondary: oracleUserHistory(in: pair.secondary.id) ?? []
+            )
+            for index in sessions.indices where sessions[index].oraclePairID == pair.pairID {
+                sessions[index].oracleHistoryDiverged = historyDiverged
+            }
+        }
+        return OraclePairSendReply(
+            pairID: pair.pairID,
+            mode: mode,
+            primaryChatID: pair.primary.shortID,
+            secondaryChatID: pair.secondary.shortID,
+            primaryModel: primarySelection.model,
+            secondaryModel: secondaryModel,
+            result: execution,
+            historyDiverged: historyDiverged,
+            historyPersistenceError: historyPersistenceError
+        )
+    }
+
+    @MainActor
+    private func tool_singleChatSendClaimed(
+        args: [String: Value],
+        promptVM: PromptViewModel,
+        tabContext: OracleSendTabContext? = nil,
+        modelSelectionOverride: ModelSelectionResult? = nil,
+        resolvedMessageOverride: String? = nil,
+        activateInUI: Bool? = nil,
+        lane: OracleLane? = nil,
+        laneLifecycle: (@MainActor @Sendable (OracleLane, OracleMessageLifecycleActivityEvent) -> Void)? = nil,
+        sessionResolved: (@MainActor @Sendable (UUID) async throws -> Void)? = nil,
+        onProgress: (@MainActor @Sendable (String, String?) -> Void)? = nil
+    ) async throws -> ChatSendReply {
+        // ────────── 1. Validate & extract parameters ──────────
+        let message = try resolvedMessageOverride ??
+            resolvedOracleMessage(args: args, promptVM: promptVM, tabContext: tabContext)
+        let mode = try validatedOracleSendMode(args)
         let chatName = args["chat_name"]?.stringValue
         let chatIdIn = args["chat_id"]?.stringValue
         let newChat = args["new_chat"]?.boolValue ?? false
-        let modelParam = args["model"]?.stringValue
-        // Deprecated compatibility parameter: Oracle replies are text-only and no longer emit diffs.
         _ = args["include_diffs"]?.boolValue
         let selectionOverride = tabContext?.packaging.selection
         let lookupContextOverride = tabContext?.packaging.lookupContext
         let reviewGitContextOverride = tabContext?.packaging.reviewGitContext
+        let prebuiltAIMessage = tabContext?.packaging.prebuiltAIMessage
 
-        // ────────── 2. Handle model selection ──────────
-        let presetsManager = ModelPresetsManager.shared
-        let allPresets = presetsManager.allPresets()
-
-        let modelSelection = try await selectModel(
-            modelParam: modelParam,
-            mode: mode,
-            allPresets: allPresets,
-            promptVM: promptVM
-        )
-
+        let modelSelection = if let modelSelectionOverride {
+            modelSelectionOverride
+        } else {
+            try await selectModel(
+                modelParam: args["model"]?.stringValue,
+                mode: mode,
+                allPresets: ModelPresetsManager.shared.allPresets(),
+                promptVM: promptVM
+            )
+        }
         let selectedModel = modelSelection.model
         let mcpControlledModel = modelSelection.mcpControlInfo
         let overrideModelName = selectedModel.displayName
         let overrideChatPresetName: String? = {
             if let presetID = modelSelection.chatPresetID,
-               let chatPreset = ChatPresetManager.shared.preset(with: presetID)
-            {
-                return chatPreset.name
-            }
-            // Fallback: map the requested mode to a built-in chat preset so the orange chip matches the active mode
-            if let builtIn = findBuiltInPreset(for: mode) {
-                return builtIn.name
-            }
-            return nil
+               let chatPreset = ChatPresetManager.shared.preset(with: presetID) { return chatPreset.name }
+            return findBuiltInPreset(for: mode)?.name
         }()
 
-        // ────────── 3. Resolve chat session ──────────
         let tabID = tabContext?.tabID ?? promptVM.activeComposeTabID
         let shouldActivate: Bool
-        if let tabContext {
-            let isFocusedTab = (promptVM.activeComposeTabID == tabContext.tabID)
+        if tabContext?.activationPolicy == .background {
+            shouldActivate = false
+        } else if let activateInUI {
+            shouldActivate = activateInUI
+        } else if let tabContext {
             let activeSessionID = workspaceManager.activeChatSessionID(forTabID: tabContext.tabID)
                 ?? currentSessionID.flatMap { currentID in
                     sessions.first(where: { $0.id == currentID && $0.composeTabID == tabContext.tabID })?.id
                 }
-            let isUserStreaming = isSessionStreaming(activeSessionID)
-            shouldActivate = isFocusedTab && !isUserStreaming
+            shouldActivate = promptVM.activeComposeTabID == tabContext.tabID &&
+                !isSessionStreaming(activeSessionID)
         } else {
             shouldActivate = true
         }
+        let allowPairedSessions = lane != nil
+        let shouldSetActiveForTab = tabContext?.activationPolicy == .background ? false : !allowPairedSessions
         let chatID = try await locateOrCreateChat(
             chatIdIn,
             desiredName: chatName,
             forceNew: newChat,
+            workspaceID: tabContext?.workspaceID,
             tabID: tabID,
             activateInUI: shouldActivate,
+            setActiveForTab: shouldSetActiveForTab,
             agentModeSessionID: tabContext?.agentModeSessionID,
-            agentModeRunID: tabContext?.agentModeRunID
+            agentModeRunID: tabContext?.agentModeRunID,
+            allowPairedSessions: allowPairedSessions
         )
+        try await sessionResolved?(chatID)
         pinSession(chatID)
         defer { unpinSession(chatID) }
 
-        // Set MCP control info for the MCP-triggered session only
         if let mcpControlledModel {
             setMCPSessionUIState(
                 MCPSessionUIState(
@@ -1178,11 +2003,7 @@ extension OracleViewModel {
             clearMCPSessionUIState(for: chatID)
         }
 
-        // ────────── 4. Determine mode ──────────
         let effectiveMode = PromptViewModel.PlanActMode(rawValue: mode.capitalized) ?? .chat
-
-        // ────────── 5. Send user message & wait for completion ──────────
-        // Pass the selected model, chat preset, and mode to sendMessage without affecting global state.
         let send = {
             await self.sendMessage(
                 message,
@@ -1194,47 +2015,80 @@ extension OracleViewModel {
                 gitBaseOverride: nil,
                 selectionOverride: selectionOverride,
                 lookupContextOverride: lookupContextOverride,
-                reviewGitContextOverride: reviewGitContextOverride
+                reviewGitContextOverride: reviewGitContextOverride,
+                overrideAIMessage: prebuiltAIMessage,
+                completionPolicy: tabContext?.completionPolicy ?? .interactive,
+                onProgress: onProgress
             )
         }
-        let queryId: UUID?
+        let dispatchedMessageID: UUID?
         #if DEBUG
             let trace = OracleReviewPackagingDiagnostics.makeTraceContext(
                 tabContext: tabContext,
                 observer: oracleReviewPackagingTraceObserverForTesting
             )
-            queryId = await OracleReviewPackagingDiagnostics.withTrace(trace, operation: send)
+            dispatchedMessageID = await OracleReviewPackagingDiagnostics.withTrace(trace, operation: send)
         #else
-            queryId = await send()
+            dispatchedMessageID = await send()
         #endif
-        guard let queryId else {
+        guard let queryID = dispatchedMessageID else {
+            if let lane {
+                throw OracleLaneFailure(message: "Oracle \(lane.rawValue) lane did not start.")
+            }
             throw OracleContextBuilderCompletionError.missingExactQuery
         }
-        let response = try await waitForContextBuilderCompletion(queryId)
 
-        // ────────── 6. Build typed reply ──────────
-        let replyObj = ChatSendReply(
+        let response: String
+        if let lane {
+            let lifecycleObserverID = laneLifecycle.map { callback in
+                addMessageLifecycleActivityObserver(for: queryID) { event in
+                    callback(lane, event)
+                }
+            }
+            defer {
+                if let lifecycleObserverID {
+                    removeMessageLifecycleActivityObserver(for: queryID, observerID: lifecycleObserverID)
+                }
+            }
+            do {
+                switch try await waitForMessageFinalisationOutcome(queryID) {
+                case .completed:
+                    recordLaneEffectiveModel(sessionID: chatID, model: selectedModel)
+                case let .providerTerminatedIncomplete(reason, partialResponse):
+                    let error = OracleContextBuilderCompletionError.providerTerminatedIncomplete(reason: reason)
+                    throw OracleLaneFailure(message: error.localizedDescription, partialResponse: partialResponse)
+                case let .streamEndedWithoutProviderCompletion(partialResponse):
+                    let error = OracleContextBuilderCompletionError.streamEndedWithoutProviderCompletion
+                    throw OracleLaneFailure(message: error.localizedDescription, partialResponse: partialResponse)
+                case let .interactiveWatchdog(partialResponse):
+                    let error = OracleContextBuilderCompletionError.interactiveWatchdogFinalization
+                    throw OracleLaneFailure(message: error.localizedDescription, partialResponse: partialResponse)
+                case let .failed(message, partialResponse):
+                    throw OracleLaneFailure(message: message, partialResponse: partialResponse)
+                case let .cancelled(message, partialResponse):
+                    if Task.isCancelled { throw CancellationError() }
+                    throw OracleLaneFailure(
+                        message: message,
+                        partialResponse: partialResponse,
+                        code: .cancelled
+                    )
+                }
+            } catch is CancellationError {
+                await cancelAIResponse(in: chatID, skipPartialParseAndSave: false)
+                throw CancellationError()
+            }
+            response = try await waitForContextBuilderCompletion(queryID)
+        } else {
+            response = try await waitForContextBuilderCompletion(queryID)
+        }
+
+        return ChatSendReply(
             chatId: chatID,
             shortId: sessions.first(where: { $0.id == chatID })?.shortID ?? "",
             mode: mode,
             response: response,
             errors: nil
         )
-
-        // Serialise to MCP Value → dictionary
-        guard case var .object(dict) = replyObj.toMCPValue() else {
-            throw ChatToolError.internalError("failed to encode reply")
-        }
-        if let tabID {
-            dict["context_id"] = .string(tabID.uuidString)
-        }
-        if let agentModeSessionID = tabContext?.agentModeSessionID {
-            dict["agent_session_id"] = .string(agentModeSessionID.uuidString)
-        }
-        if let agentModeRunID = tabContext?.agentModeRunID {
-            dict["agent_run_id"] = .string(agentModeRunID.uuidString)
-        }
-        return dict
     }
 
     /// Legacy entry point kept for compatibility with `MCPServerViewModel`.
@@ -1280,6 +2134,11 @@ extension OracleViewModel {
         ]
         if let resolvedTabID = tabID ?? resolvedSession.composeTabID {
             result["context_id"] = .string(resolvedTabID.uuidString)
+        }
+        if let pairID = resolvedSession.oraclePairID {
+            result["oracle_pair_id"] = .string(pairID.uuidString)
+            result["oracle_lane"] = .string(resolvedSession.oracleLane?.rawValue ?? "unknown")
+            result["oracle_history_diverged"] = .bool(resolvedSession.oracleHistoryDiverged)
         }
 
         return result

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -1744,6 +1744,11 @@ extension OracleViewModel {
                 liveCallbacks: liveCallbacks
             )
             let result = OracleSendResult(payload: .paired(pair), route: route)
+            // Fail closed whenever Primary fails (including incomplete). Secondary-only
+            // failure stays a returned partial_failure so callers can keep Primary text.
+            if case .failure = pair.result.primary, let failureSummary = pair.failureSummary {
+                throw OracleSendFailure(result: result, message: failureSummary)
+            }
             if pair.status == .failed, let failureSummary = pair.failureSummary {
                 throw OracleSendFailure(result: result, message: failureSummary)
             }

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -312,13 +312,13 @@ enum OracleResponseCompletionPolicy: Equatable {
     case contextBuilderStrict
 }
 
-enum OracleMessageFinalizationOutcome: Equatable {
-    case providerCompleted
-    case providerTerminatedIncomplete(reason: String)
-    case streamEndedWithoutProviderCompletion
-    case interactiveWatchdog
-    case cancelled
-    case failed(message: String)
+enum ChatSendTerminalOutcome: Equatable {
+    case completed
+    case providerTerminatedIncomplete(reason: String, partialResponse: String?)
+    case streamEndedWithoutProviderCompletion(partialResponse: String?)
+    case interactiveWatchdog(partialResponse: String?)
+    case failed(message: String, partialResponse: String?)
+    case cancelled(message: String, partialResponse: String?)
 }
 
 enum OracleContextBuilderCompletionError: LocalizedError, Equatable {
@@ -350,70 +350,170 @@ enum OracleContextBuilderCompletionError: LocalizedError, Equatable {
     }
 }
 
+struct OraclePairRoute: Hashable {
+    let workspaceID: UUID
+    let tabID: UUID
+    let agentModeSessionID: UUID?
+    let agentModeRunID: UUID?
+}
+
+enum OracleSendClaimKey: Hashable {
+    case route(OraclePairRoute)
+    case workspace(UUID)
+
+    static func oracleSend(
+        workspaceID: UUID,
+        tabID: UUID?,
+        agentModeSessionID: UUID?,
+        agentModeRunID: UUID?
+    ) -> Self {
+        guard let tabID else { return .workspace(workspaceID) }
+        return .route(OraclePairRoute(
+            workspaceID: workspaceID,
+            tabID: tabID,
+            agentModeSessionID: agentModeSessionID,
+            agentModeRunID: agentModeRunID
+        ))
+    }
+}
+
+enum OracleSendClaimError: Error, Equatable {
+    case conflict
+}
+
+@MainActor
+final class OracleSendClaimRegistry {
+    private var claimedKeys: Set<OracleSendClaimKey> = []
+
+    func withClaim<Result>(
+        _ keys: Set<OracleSendClaimKey>,
+        operation: @MainActor () async throws -> Result
+    ) async throws -> Result {
+        guard !keys.contains(where: conflicts(with:)) else { throw OracleSendClaimError.conflict }
+        claimedKeys.formUnion(keys)
+        defer { claimedKeys.subtract(keys) }
+        return try await operation()
+    }
+
+    private func conflicts(with requested: OracleSendClaimKey) -> Bool {
+        claimedKeys.contains { existing in
+            switch (requested, existing) {
+            case let (.route(requestedRoute), .route(existingRoute)):
+                requestedRoute == existingRoute
+            case let (.route(route), .workspace(workspaceID)),
+                 let (.workspace(workspaceID), .route(route)):
+                route.workspaceID == workspaceID
+            case let (.workspace(requestedID), .workspace(existingID)):
+                requestedID == existingID
+            }
+        }
+    }
+}
+
 actor MessageFinalisationHub {
     private struct WaiterKey: Hashable {
         let messageID: UUID
         let waiterID: UUID
     }
 
-    private var waiters: [UUID: [UUID: CheckedContinuation<Void, Never>]] = [:]
+    private var waiters: [UUID: [UUID: CheckedContinuation<ChatSendTerminalOutcome?, Never>]] = [:]
     private var cancelledWaiters: Set<WaiterKey> = []
-    private var completedOutcomes: [UUID: OracleMessageFinalizationOutcome] = [:]
+    private var terminalOutcomes: [UUID: ChatSendTerminalOutcome] = [:]
 
     func register(
         _ id: UUID,
         waiterID: UUID,
-        cont: CheckedContinuation<Void, Never>
+        cont: CheckedContinuation<ChatSendTerminalOutcome?, Never>
     ) {
         let key = WaiterKey(messageID: id, waiterID: waiterID)
-        if completedOutcomes[id] != nil || cancelledWaiters.remove(key) != nil {
-            cont.resume()
+        if let outcome = terminalOutcomes[id] {
+            cont.resume(returning: outcome)
+            return
+        }
+        if cancelledWaiters.remove(key) != nil {
+            cont.resume(returning: nil)
             return
         }
         waiters[id, default: [:]][waiterID] = cont
     }
 
-    func fulfil(_ id: UUID, outcome: OracleMessageFinalizationOutcome) {
-        if completedOutcomes[id] == nil {
-            completedOutcomes[id] = outcome
-        }
+    func fulfil(_ id: UUID, outcome: ChatSendTerminalOutcome = .completed) {
+        guard terminalOutcomes[id] == nil else { return }
+        terminalOutcomes[id] = outcome
         cancelledWaiters = Set(cancelledWaiters.filter { $0.messageID != id })
         guard let list = waiters.removeValue(forKey: id) else { return }
         for continuation in list.values {
-            continuation.resume()
+            continuation.resume(returning: outcome)
         }
     }
 
     /// Cancels only the requesting task's waiter. Message completion remains authoritative
     /// for every other current or future waiter.
     func cancel(_ id: UUID, waiterID: UUID) {
-        guard completedOutcomes[id] == nil else { return }
+        guard terminalOutcomes[id] == nil else { return }
         if let continuation = waiters[id]?.removeValue(forKey: waiterID) {
             if waiters[id]?.isEmpty == true {
                 waiters.removeValue(forKey: id)
             }
-            continuation.resume()
+            continuation.resume(returning: nil)
         } else {
             cancelledWaiters.insert(WaiterKey(messageID: id, waiterID: waiterID))
         }
     }
 
     func isCompleted(_ id: UUID) -> Bool {
-        completedOutcomes[id] != nil
+        terminalOutcomes[id] != nil
     }
 
-    func outcome(for id: UUID) -> OracleMessageFinalizationOutcome? {
-        completedOutcomes[id]
+    func outcome(for id: UUID) -> ChatSendTerminalOutcome? {
+        terminalOutcomes[id]
+    }
+
+    func discard(_ id: UUID) {
+        terminalOutcomes.removeValue(forKey: id)
+    }
+
+    func discardAll() {
+        terminalOutcomes.removeAll(keepingCapacity: false)
+        let allWaiters = waiters.values.flatMap(\.values)
+        waiters.removeAll(keepingCapacity: false)
+        cancelledWaiters.removeAll(keepingCapacity: false)
+        for continuation in allWaiters {
+            continuation.resume(returning: nil)
+        }
+    }
+
+    nonisolated func waitForOutcome(
+        _ id: UUID,
+        timeout: Duration = .seconds(4 * 60 * 60)
+    ) async throws -> ChatSendTerminalOutcome? {
+        if let outcome = await outcome(for: id) { return outcome }
+        return try await withThrowingTaskGroup(of: ChatSendTerminalOutcome?.self) { group in
+            group.addTask {
+                let waiterID = UUID()
+                let outcome = await withTaskCancellationHandler {
+                    await withCheckedContinuation { continuation in
+                        Task { await self.register(id, waiterID: waiterID, cont: continuation) }
+                    }
+                } onCancel: {
+                    Task { await self.cancel(id, waiterID: waiterID) }
+                }
+                try Task.checkCancellation()
+                return outcome
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(for: timeout)
+                return nil
+            }
+            let result = try await group.next() ?? nil
+            group.cancelAll()
+            return result
+        }
     }
 
     /// Clean up any orphaned waiters (safety mechanism)
     func cleanup() {
-        let allWaiters = waiters.values.flatMap(\.values)
-        waiters.removeAll()
-        cancelledWaiters.removeAll()
-        for continuation in allWaiters {
-            continuation.resume()
-        }
+        discardAll()
     }
 }
 
@@ -452,6 +552,11 @@ class OracleViewModel: ObservableObject {
     @Published private(set) var streamingSessions: Set<UUID> = []
     @Published private(set) var messageStoreRevision: Int = 0
     @Published private(set) var currentQueryId: UUID?
+    let oracleSendClaims = OracleSendClaimRegistry()
+
+    #if DEBUG
+        var oraclePairDidCommitTestHook: (@MainActor () async -> Void)?
+    #endif
 
     /// Per-session stream state
     private var runStateBySession: [UUID: SessionRunState] = [:]
@@ -956,6 +1061,17 @@ class OracleViewModel: ObservableObject {
         (pinnedSessionRefCounts[sessionID] ?? 0) > 0
     }
 
+    @MainActor
+    private var historyRetentionProtectedSessionIDs: Set<UUID> {
+        let activeTabSessionIDs = workspaceManager.activeWorkspace?.composeTabs.compactMap {
+            workspaceManager.activeChatSessionID(forTabID: $0.id)
+        } ?? []
+        return Set(pinnedSessionRefCounts.keys)
+            .union(streamingSessions)
+            .union(currentSessionID.map { [$0] } ?? [])
+            .union(activeTabSessionIDs)
+    }
+
     #if DEBUG
         @MainActor
         func isSessionPinnedForTesting(_ sessionID: UUID) -> Bool {
@@ -1007,7 +1123,6 @@ class OracleViewModel: ObservableObject {
 
     @MainActor
     private func purgeMessageCaches(for messageId: UUID) {
-        // Message-scoped cleanup only; does not cancel live streams or touch session-level state.
         sessionIDByMessageId.removeValue(forKey: messageId)
         streamIDsByQueryId.removeValue(forKey: messageId)
         cancelFinalizationWatchdog(for: messageId)
@@ -1016,7 +1131,7 @@ class OracleViewModel: ObservableObject {
     }
 
     @MainActor
-    private func clearAllSessionStorage() {
+    private func clearAllSessionStorage() async {
         sessionSwitchGeneration += 1
         messageStore.removeAll(keepingCapacity: false)
         messageStoreRevision &+= 1
@@ -1030,6 +1145,7 @@ class OracleViewModel: ObservableObject {
         sessionSwitchInProgressID = nil
         currentQueryId = nil
         recomputeWorkspaceBusyAndFontFreeze()
+        await finalisationHub.discardAll()
     }
 
     @MainActor
@@ -1409,7 +1525,9 @@ class OracleViewModel: ObservableObject {
                 aiResponseId: queryId,
                 sessionID: sessionID,
                 partialBuffer: content,
-                outcome: .interactiveWatchdog
+                terminalOutcome: .interactiveWatchdog(
+                    partialResponse: content.isEmpty ? nil : content
+                )
             )
         }
     }
@@ -1575,49 +1693,50 @@ class OracleViewModel: ObservableObject {
                 aiResponseId: queryId,
                 sessionID: sessionID,
                 partialBuffer: content,
-                outcome: .interactiveWatchdog
+                terminalOutcome: .interactiveWatchdog(
+                    partialResponse: content.isEmpty ? nil : content
+                )
             )
         }
     }
 
     // MARK: - Message Finalisation
 
-    nonisolated func waitForContextBuilderCompletion(_ id: UUID) async throws -> String {
-        if await finalisationHub.outcome(for: id) == nil {
-            let hasExactMessage = await MainActor.run {
-                guard let sessionID = self.sessionIDByMessageId[id],
-                      let messages = self.messageStore[sessionID]
-                else {
-                    return false
-                }
-                return messages.contains(where: { $0.id == id && !$0.isUser })
-            }
-            guard hasExactMessage else {
-                throw OracleContextBuilderCompletionError.missingExactQuery
-            }
+    nonisolated func waitForMessageFinalisationOutcome(_ id: UUID) async throws -> ChatSendTerminalOutcome {
+        guard let outcome = try await finalisationHub.waitForOutcome(id) else {
+            await cancelFinalisationAfterTimeout(messageID: id)
+            throw ChatToolError.internalError(
+                "Oracle message \(id.uuidString) did not finalize within 4 hours."
+            )
+        }
+        return outcome
+    }
 
-            let waiterID = UUID()
-            await withTaskCancellationHandler {
-                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                    Task {
-                        await finalisationHub.register(
-                            id,
-                            waiterID: waiterID,
-                            cont: cont
-                        )
-                    }
-                }
-            } onCancel: {
-                Task { await finalisationHub.cancel(id, waiterID: waiterID) }
+    @MainActor
+    private func cancelFinalisationAfterTimeout(messageID: UUID) async {
+        guard let sessionID = sessionIDByMessageId[messageID] else { return }
+        await cancelAIResponse(in: sessionID, skipPartialParseAndSave: false)
+    }
+
+    nonisolated func waitForContextBuilderCompletion(_ id: UUID) async throws -> String {
+        let hasExactMessage = await MainActor.run {
+            guard let sessionID = self.sessionIDByMessageId[id],
+                  let messages = self.messageStore[sessionID]
+            else {
+                return false
             }
-            try Task.checkCancellation()
+            return messages.contains(where: { $0.id == id && !$0.isUser })
+        }
+        guard hasExactMessage else {
+            throw OracleContextBuilderCompletionError.missingExactQuery
         }
 
-        guard let outcome = await finalisationHub.outcome(for: id) else {
+        guard let outcome = try await finalisationHub.waitForOutcome(id) else {
+            await cancelFinalisationAfterTimeout(messageID: id)
             throw OracleContextBuilderCompletionError.missingFinalizationOutcome
         }
         switch outcome {
-        case .providerCompleted:
+        case .completed:
             let content = await MainActor.run { () -> String? in
                 guard let sessionID = self.sessionIDByMessageId[id],
                       let message = self.messageStore[sessionID]?.first(where: { $0.id == id && !$0.isUser }),
@@ -1634,7 +1753,7 @@ class OracleViewModel: ObservableObject {
                 throw OracleContextBuilderCompletionError.emptyProcessedContent
             }
             return content
-        case let .providerTerminatedIncomplete(reason):
+        case let .providerTerminatedIncomplete(reason, _):
             throw OracleContextBuilderCompletionError.providerTerminatedIncomplete(reason: reason)
         case .streamEndedWithoutProviderCompletion:
             throw OracleContextBuilderCompletionError.streamEndedWithoutProviderCompletion
@@ -1642,7 +1761,7 @@ class OracleViewModel: ObservableObject {
             throw OracleContextBuilderCompletionError.interactiveWatchdogFinalization
         case .cancelled:
             throw CancellationError()
-        case let .failed(message):
+        case let .failed(message, _):
             throw OracleContextBuilderCompletionError.providerStreamFailed(message: message)
         }
     }
@@ -1652,32 +1771,17 @@ class OracleViewModel: ObservableObject {
             guard let sessionID = self.sessionIDByMessageId[id],
                   let messages = self.messageStore[sessionID],
                   let message = messages.first(where: { $0.id == id })
-            else {
-                return nil
-            }
+            else { return nil }
             return message.isFinalized
         }
-        if messageState == nil {
-            return
-        }
-        if messageState == true {
-            return
-        }
+        guard messageState == false else { return }
         let hubCompleted = await finalisationHub.isCompleted(id)
-        if hubCompleted {
-            return
-        }
+        guard !hubCompleted else { return }
 
         let waiterID = UUID()
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                Task {
-                    await finalisationHub.register(
-                        id,
-                        waiterID: waiterID,
-                        cont: cont
-                    )
-                }
+        _ = await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                Task { await finalisationHub.register(id, waiterID: waiterID, cont: continuation) }
             }
         } onCancel: {
             Task { await finalisationHub.cancel(id, waiterID: waiterID) }
@@ -1697,33 +1801,55 @@ class OracleViewModel: ObservableObject {
         }
     }
 
-    /// Deletes the given session from disk and memory, mimicking the old logic.
-    /// 1) If it has a file URL, we remove the file from disk via `chatData`.
-    /// 2) Animate removal from `sessions`.
-    /// 3) If this was the current session, switch to another or create a new one.
+    /// Deletes one logical chat. Paired Oracle sessions are one lifecycle unit:
+    /// every known member is cancelled, deleted, and removed from memory together.
     @MainActor
-    func deleteSession(_ session: ChatSession) async {
+    @discardableResult
+    func deleteSession(_ session: ChatSession) async -> Bool {
+        guard session.oraclePairID != nil else {
+            return await deleteLegacySession(session)
+        }
+        guard let workspaceID = session.workspaceID,
+              let workspace = workspaceManager.workspaces.first(where: { $0.id == workspaceID })
+        else {
+            return await deleteLegacySession(session)
+        }
+        let claim = OracleSendClaimKey.oracleSend(
+            workspaceID: workspaceID,
+            tabID: session.composeTabID,
+            agentModeSessionID: session.agentModeSessionID,
+            agentModeRunID: session.agentModeRunID
+        )
+        do {
+            return try await oracleSendClaims.withClaim([claim]) {
+                await self.deleteClaimedSession(session, workspace: workspace)
+            }
+        } catch OracleSendClaimError.conflict {
+            return false
+        } catch {
+            print("Error claiming logical chat session deletion: \(error)")
+            return false
+        }
+    }
+
+    @MainActor
+    private func deleteLegacySession(_ session: ChatSession) async -> Bool {
         sessionSwitchGeneration += 1
         if isSessionStreaming(session.id) {
             await cancelAIResponse(in: session.id, skipPartialParseAndSave: true)
         }
-        clearMCPSessionUIState(for: session.id)
-        // 1) Attempt to delete file from disk (if it exists).
         if let fileURL = session.fileURL {
             do {
-                // Ensure we do it on background or in an actor
                 try await chatData.deleteChatSessionFile(fileURL)
             } catch {
-                print("Error deleting chat session file: \(error)")
+                print("Error deleting legacy chat session file: \(error)")
             }
         }
 
-        // 2) Remove from in-memory list with animation on the main actor
+        let deletedCurrentSession = currentSessionID == session.id
         withAnimation {
-            guard let idx = sessions.firstIndex(where: { $0.id == session.id }) else { return }
+            sessions.removeAll { $0.id == session.id }
             purgeSessionStorage(session.id)
-            sessions.remove(at: idx)
-
             if let tabID = session.composeTabID,
                workspaceManager.activeChatSessionID(forTabID: tabID) == session.id
             {
@@ -1733,48 +1859,113 @@ class OracleViewModel: ObservableObject {
                     .first
                 workspaceManager.setActiveChatSessionID(replacement?.id, forTabID: tabID)
             }
+        }
+        if deletedCurrentSession {
+            await ensureActiveSessionForCurrentTab(createIfMissing: true)
+        }
+        return true
+    }
 
-            // If the deleted session was active, pick a new session or create one
-            if session.id == currentSessionID {
-                Task { [weak self] in
-                    await self?.ensureActiveSessionForCurrentTab(createIfMissing: true)
-                }
+    @MainActor
+    func deleteClaimedSession(_ session: ChatSession, workspace: WorkspaceModel) async -> Bool {
+        sessionSwitchGeneration += 1
+        guard let pairID = session.oraclePairID else {
+            return await deleteLegacySession(session)
+        }
+        let persistedMembers: [ChatSession]
+        do {
+            persistedMembers = try await chatData.oraclePairSessionStubs(for: workspace, pairID: pairID)
+        } catch {
+            print("Error resolving Oracle pair for deletion: \(error)")
+            return false
+        }
+        let memberIDs = Set([session.id]).union(persistedMembers.map(\.id)).union(
+            sessions.lazy.filter { $0.oraclePairID == pairID }.map(\.id)
+        )
+        guard memberIDs.count <= 2 else {
+            print("Refusing to delete malformed Oracle pair \(pairID).")
+            return false
+        }
+        let inMemoryMembers = sessions.filter { memberIDs.contains($0.id) }
+        for member in inMemoryMembers where isSessionStreaming(member.id) {
+            await cancelAIResponse(in: member.id, skipPartialParseAndSave: true)
+        }
+
+        do {
+            try await chatData.deleteOraclePairSessionFiles(memberIDs, for: workspace)
+        } catch {
+            print("Error deleting logical chat session: \(error)")
+            return false
+        }
+
+        let affectedTabIDs = Set(inMemoryMembers.compactMap(\.composeTabID))
+        let deletedCurrentSession = currentSessionID.map(memberIDs.contains) ?? false
+        withAnimation {
+            sessions.removeAll { memberIDs.contains($0.id) }
+            for memberID in memberIDs {
+                purgeSessionStorage(memberID)
+            }
+            for tabID in affectedTabIDs {
+                guard let activeSessionID = workspaceManager.activeChatSessionID(forTabID: tabID),
+                      memberIDs.contains(activeSessionID)
+                else { continue }
+                let replacement = sessions
+                    .filter { $0.composeTabID == tabID }
+                    .sorted { lhs, rhs in
+                        if lhs.savedAt != rhs.savedAt { return lhs.savedAt > rhs.savedAt }
+                        let leftLane = lhs.oracleLane == .primary ? 0 : lhs.oracleLane == .secondary ? 1 : 2
+                        let rightLane = rhs.oracleLane == .primary ? 0 : rhs.oracleLane == .secondary ? 1 : 2
+                        if leftLane != rightLane { return leftLane < rightLane }
+                        return lhs.id.uuidString < rhs.id.uuidString
+                    }
+                    .first
+                workspaceManager.setActiveChatSessionID(replacement?.id, forTabID: tabID)
             }
         }
+        if deletedCurrentSession {
+            await ensureActiveSessionForCurrentTab(createIfMissing: true)
+        }
+        return true
     }
 
     // MARK: - Clearing All Chats
 
     @MainActor
     func clearAllChats() async {
-        await cancelAllActiveSessionStreams()
-        // 1) Identify the currently active workspace
         guard let activeWS = workspaceManager.activeWorkspace else {
             print("No active workspace found; nothing to clear.")
             return
         }
-
-        // 2) Delete chat JSON files only for this workspace
         do {
-            let files = try await chatData.listChatSessions(for: activeWS)
-            for file in files {
-                try await chatData.deleteChatSessionFile(file)
+            try await oracleSendClaims.withClaim([.workspace(activeWS.id)]) {
+                await self.clearClaimedChats(in: activeWS)
             }
+        } catch OracleSendClaimError.conflict {
+            print("Cannot clear chats while an Oracle request is active in this workspace.")
         } catch {
-            print("Error clearing chats for workspace \(activeWS.name): \(error)")
+            print("Error claiming workspace chat deletion: \(error)")
+        }
+    }
+
+    @MainActor
+    private func clearClaimedChats(in workspace: WorkspaceModel) async {
+        await cancelAllActiveSessionStreams()
+        do {
+            try await chatData.deleteAllChatSessionFiles(for: workspace)
+        } catch {
+            print("Error clearing chats for workspace \(workspace.name): \(error)")
+            return
         }
 
-        // 3) Remove from memory all sessions belonging to the active workspace
-        sessions.removeAll()
-        dropMessagesSafely()
+        let removedIDs = Set(sessions.lazy.filter { $0.workspaceID == workspace.id }.map(\.id))
+        sessions.removeAll { removedIDs.contains($0.id) }
+        for sessionID in removedIDs {
+            purgeSessionStorage(sessionID)
+        }
         cleanupShadowHolders()
-        clearAllSessionStorage()
         currentSessionID = nil
-
-        if let workspace = workspaceManager.activeWorkspace {
-            for tab in workspace.composeTabs {
-                workspaceManager.setActiveChatSessionID(nil, forTabID: tab.id)
-            }
+        for tab in workspace.composeTabs {
+            workspaceManager.setActiveChatSessionID(nil, forTabID: tab.id)
         }
 
         await startNewChatSession()
@@ -1916,7 +2107,7 @@ class OracleViewModel: ObservableObject {
             sessions.removeAll()
             dropMessagesSafely()
             cleanupShadowHolders()
-            clearAllSessionStorage()
+            await clearAllSessionStorage()
             currentSessionID = nil
             #if DEBUG
                 WorkspaceRestorePerfLog.event(
@@ -1947,7 +2138,7 @@ class OracleViewModel: ObservableObject {
         sessions.removeAll()
         dropMessagesSafely()
         cleanupShadowHolders()
-        clearAllSessionStorage()
+        await clearAllSessionStorage()
         currentSessionID = nil
         #if DEBUG
             WorkspaceRestorePerfLog.event(
@@ -1965,7 +2156,10 @@ class OracleViewModel: ObservableObject {
             let listSessionsStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
         #endif
         do {
-            let files = try await chatData.listChatSessions(for: workspace)
+            let files = try await chatData.listChatSessions(
+                for: workspace,
+                protectedSessionIDs: historyRetentionProtectedSessionIDs
+            )
             #if DEBUG
                 listedFiles = files
             #endif
@@ -2109,16 +2303,18 @@ class OracleViewModel: ObservableObject {
     @discardableResult
     func startNewChatSession(
         name: String = "New Chat",
+        workspaceID: UUID? = nil,
         tabID: UUID? = nil,
         agentModeSessionID: UUID? = nil,
         agentModeRunID: UUID? = nil,
         activateInUI: Bool = true,
-        setActiveForTab: Bool = true
+        setActiveForTab: Bool = true,
+        reuseBlankSession: Bool = true
     ) async -> UUID? {
         let resolvedTabID = tabID ?? promptViewModel.activeComposeTabID
 
         // If there's already a blank session with that name, just switch to it
-        if let existingIndex = sessions.firstIndex(where: {
+        if reuseBlankSession, let existingIndex = sessions.firstIndex(where: {
             $0.name == name &&
                 $0.effectiveMessageCount == 0 &&
                 $0.composeTabID == resolvedTabID &&
@@ -2168,7 +2364,7 @@ class OracleViewModel: ObservableObject {
         let selectedChatPresetId = promptViewModel.selectedChatPresetID
 
         let newSession = ChatSession(
-            workspaceID: workspaceManager.activeWorkspace?.id,
+            workspaceID: workspaceID ?? workspaceManager.activeWorkspace?.id,
             composeTabID: resolvedTabID,
             agentModeSessionID: agentModeSessionID,
             agentModeRunID: agentModeRunID,
@@ -2596,7 +2792,7 @@ class OracleViewModel: ObservableObject {
     }
 
     @MainActor
-    private func reloadSessionFromMemory(_ session: ChatSession) async {
+    func reloadSessionFromMemory(_ session: ChatSession) async {
         let shouldAffectDisplayed = (session.id == currentSessionID)
         if shouldAffectDisplayed {
             // Clear existing messages first but maintain ephemeral state
@@ -2690,6 +2886,9 @@ class OracleViewModel: ObservableObject {
                 sessionToSave.composeTabID = session.composeTabID
                 sessionToSave.agentModeSessionID = session.agentModeSessionID
                 sessionToSave.agentModeRunID = session.agentModeRunID
+                sessionToSave.oraclePairID = session.oraclePairID
+                sessionToSave.oracleLane = session.oracleLane
+                sessionToSave.oracleHistoryDiverged = session.oracleHistoryDiverged
                 sessionToSave.selectedFilePaths = session.selectedFilePaths
                 sessionToSave.selectedPromptIDs = session.selectedPromptIDs
                 sessionToSave.preferredAIModel = session.preferredAIModel
@@ -2722,13 +2921,18 @@ class OracleViewModel: ObservableObject {
     }
 
     @MainActor
-    func autosaveChatHistory(for sessionID: UUID, force: Bool = false) {
+    @discardableResult
+    func autosaveChatHistory(
+        for sessionID: UUID,
+        force: Bool = false
+    ) -> Task<Void, Never>? {
         // ------------------------------------------------------------------
         // 0️⃣  Preconditions
         // ------------------------------------------------------------------
-        guard let session = sessions.first(where: { $0.id == sessionID }) else { return }
+        guard let session = sessions.first(where: { $0.id == sessionID }) else { return nil }
+        guard session.oraclePairID == nil, session.oracleLane == nil else { return nil }
         guard let liveMessages = messageStore[sessionID] ?? (sessionID == currentSessionID ? messages : nil) else {
-            return
+            return nil
         }
 
         // ------------------------------------------------------------------
@@ -2801,7 +3005,7 @@ class OracleViewModel: ObservableObject {
 
         if !force && !shouldSkipChangeCheck && nothingChanged {
             oracleViewModelDebugLog("autosaveChatHistory -> skipped (no meaningful changes)")
-            return
+            return nil
         }
 
         // ------------------------------------------------------------------
@@ -2844,7 +3048,7 @@ class OracleViewModel: ObservableObject {
         // ------------------------------------------------------------------
         // 7️⃣  Persist to disk
         // ------------------------------------------------------------------
-        Task {
+        return Task {
             do {
                 let fileURL = try await autosaveSession(sessionCopy)
                 await MainActor.run {
@@ -2979,8 +3183,13 @@ class OracleViewModel: ObservableObject {
             print("Warning: Ignoring overrideAIMessage without overrideMode.")
             return nil
         }
+        let wrappedUserMessage = """
+        <user_instructions>
+        \(newUserMessage)
+        </user_instructions>
+        """
         guard let lastUserMessage = overrideAIMessage.conversationMessages.last(where: { $0.role == .user })?.content,
-              lastUserMessage == newUserMessage
+              lastUserMessage == newUserMessage || lastUserMessage == wrappedUserMessage
         else {
             print("Warning: Ignoring overrideAIMessage because its final user message does not match the current send input.")
             return nil
@@ -2988,7 +3197,147 @@ class OracleViewModel: ObservableObject {
         return overrideAIMessage
     }
 
+    #if DEBUG
+        func acceptsOverrideAIMessageForTesting(_ message: AIMessage, userMessage: String) -> Bool {
+            validatedOverrideAIMessage(
+                message,
+                newUserMessage: userMessage,
+                selectionOverride: StoredSelection(),
+                overrideMode: .review
+            ) != nil
+        }
+    #endif
+
     // MARK: - Main Send/Receive Flow
+
+    nonisolated static func storedOracleMessages(
+        _ messages: [AIChatMessage],
+        preserving existing: [StoredMessage]
+    ) throws -> [StoredMessage] {
+        let duplicate = [messages.map(\.id), existing.map(\.id)].lazy.compactMap { ids in
+            Dictionary(grouping: ids, by: { $0 }).first(where: { $0.value.count > 1 })?.key
+        }.first
+        if let duplicate {
+            throw ChatToolError(
+                code: .conflict,
+                message: "Duplicate Oracle message identity.",
+                details: ["duplicate_id": duplicate.uuidString]
+            )
+        }
+        let existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        let createdAt = Date()
+        return messages.map { message in
+            StoredMessage(
+                id: message.id,
+                isUser: message.isUser,
+                rawText: message.content,
+                timestamp: existingByID[message.id]?.timestamp ?? createdAt,
+                sequenceIndex: message.sequenceIndex,
+                allowedFilePaths: message.allowedFilePaths.isEmpty ? nil : message.allowedFilePaths,
+                promptTokens: message.promptTokens,
+                completionTokens: message.completionTokens,
+                cost: message.cost,
+                modelName: message.modelName
+            )
+        }
+    }
+
+    @MainActor
+    func persistOraclePairHistories(
+        pairID: UUID,
+        primarySessionID: UUID,
+        secondarySessionID: UUID
+    ) async throws -> Bool {
+        guard primarySessionID != secondarySessionID,
+              let primaryIndex = sessions.firstIndex(where: { $0.id == primarySessionID }),
+              let secondaryIndex = sessions.firstIndex(where: { $0.id == secondarySessionID }),
+              sessions[primaryIndex].oraclePairID == pairID,
+              sessions[primaryIndex].oracleLane == .primary,
+              sessions[secondaryIndex].oraclePairID == pairID,
+              sessions[secondaryIndex].oracleLane == .secondary,
+              let workspaceID = sessions[primaryIndex].workspaceID,
+              sessions[secondaryIndex].workspaceID == workspaceID,
+              let workspace = workspaceManager.workspaces.first(where: { $0.id == workspaceID }),
+              let primaryMessages = messageStore[primarySessionID],
+              let secondaryMessages = messageStore[secondarySessionID]
+        else {
+            throw ChatToolError.internalError("Failed to persist a complete Oracle pair history.")
+        }
+
+        let projectionWorkspaceLoadGeneration = workspaceChatSessionLoadGeneration
+        let projectionActiveWorkspaceID = workspaceManager.activeWorkspace?.id
+        let diverged = Self.oracleHistoriesDiverged(
+            primary: primaryMessages.filter(\.isUser).map(\.content),
+            secondary: secondaryMessages.filter(\.isUser).map(\.content)
+        )
+        let savedAt = Date()
+        var primary = sessions[primaryIndex]
+        var secondary = sessions[secondaryIndex]
+        primary.messages = try Self.storedOracleMessages(primaryMessages, preserving: primary.messages)
+        secondary.messages = try Self.storedOracleMessages(secondaryMessages, preserving: secondary.messages)
+        primary.savedAt = savedAt
+        secondary.savedAt = savedAt
+        primary.oracleHistoryDiverged = diverged
+        secondary.oracleHistoryDiverged = diverged
+
+        let fileURLs = try await chatData.saveOraclePairSessions([primary, secondary], for: workspace)
+        primary.fileURL = fileURLs[primarySessionID]
+        secondary.fileURL = fileURLs[secondarySessionID]
+
+        #if DEBUG
+            await oraclePairDidCommitTestHook?()
+        #endif
+
+        guard projectionWorkspaceLoadGeneration == workspaceChatSessionLoadGeneration,
+              projectionActiveWorkspaceID == workspaceManager.activeWorkspace?.id
+        else {
+            throw ChatToolError(
+                code: .conflict,
+                message: "Oracle pair histories were committed, but the workspace changed before projection; durable state was not projected into the new workspace.",
+                details: ["durable_commit": "true"]
+            )
+        }
+
+        let projectionRouteIsCurrent = sessions.contains {
+            $0.id == primarySessionID &&
+                $0.oraclePairID == pairID &&
+                $0.oracleLane == .primary &&
+                $0.workspaceID == workspaceID
+        } && sessions.contains {
+            $0.id == secondarySessionID &&
+                $0.oraclePairID == pairID &&
+                $0.oracleLane == .secondary &&
+                $0.workspaceID == workspaceID
+        }
+        for member in [primary, secondary] {
+            if let index = sessions.firstIndex(where: { $0.id == member.id }) {
+                sessions[index] = member
+            } else {
+                sessions.append(member)
+            }
+        }
+        if !projectionRouteIsCurrent {
+            throw ChatToolError(
+                code: .conflict,
+                message: "Oracle pair histories were committed, but in-memory state changed during projection; durable state was restored.",
+                details: ["durable_commit": "true"]
+            )
+        }
+        return diverged
+    }
+
+    @MainActor
+    func removeOraclePairSessionState(_ sessionIDs: Set<UUID>) {
+        sessions.removeAll { sessionIDs.contains($0.id) }
+        for sessionID in sessionIDs {
+            purgeSessionStorage(sessionID)
+        }
+    }
+
+    @MainActor
+    func oracleUserHistory(in sessionID: UUID) -> [String]? {
+        messageStore[sessionID]?.filter(\.isUser).map(\.content)
+    }
 
     @MainActor
     @discardableResult
@@ -3008,7 +3357,6 @@ class OracleViewModel: ObservableObject {
         onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
     ) async -> UUID? {
         guard !newUserMessage.isEmpty else { return nil }
-        _ = true
 
         let targetSessionID: UUID
         if let sessionID {
@@ -3031,18 +3379,15 @@ class OracleViewModel: ObservableObject {
 
         ensureSessionStorage(targetSessionID)
 
-        // Create the user message
-        let userId = UUID()
+        let userID = UUID()
         let userMessage = AIChatMessage(
-            id: userId,
+            id: userID,
             content: newUserMessage,
             isUser: true,
             sequenceIndex: nextSequenceIndex(for: targetSessionID)
         )
-        withSessionMessages(targetSessionID) { msgs in
-            msgs.append(userMessage)
-        }
-        registerMessage(userId, sessionID: targetSessionID)
+        withSessionMessages(targetSessionID) { $0.append(userMessage) }
+        registerMessage(userID, sessionID: targetSessionID)
 
         let conversation = buildConversationEntries(for: targetSessionID)
 
@@ -3056,6 +3401,7 @@ class OracleViewModel: ObservableObject {
         if !promptViewModel.isModelAvailable(model) {
             // Show error in chat instead of silently falling back
             let errorMessage = AIChatMessage(
+                id: UUID(),
                 content: "Error: The model '\(model.displayName)' is not available. Please check that the \(model.providerType.displayName) API key is configured in Settings.",
                 isUser: false,
                 isFinalized: true
@@ -3067,7 +3413,7 @@ class OracleViewModel: ObservableObject {
             autosaveChatHistory(for: targetSessionID)
             await finalisationHub.fulfil(
                 errorMessage.id,
-                outcome: .failed(message: errorMessage.content)
+                outcome: .failed(message: errorMessage.content, partialResponse: nil)
             )
             return errorMessage.id
         }
@@ -3268,7 +3614,7 @@ class OracleViewModel: ObservableObject {
                                 aiResponseId: aiResponseId,
                                 sessionID: targetSessionID,
                                 partialBuffer: partialBuffer,
-                                outcome: .providerCompleted
+                                terminalOutcome: .completed
                             )
                             await self.cleanupOracleProviderConversation(providerCleanupHandle, model: model)
                         }
@@ -3289,17 +3635,22 @@ class OracleViewModel: ObservableObject {
                             self.updateLatestTokenCounts()
                         }
                     }
-                    let outcome: OracleMessageFinalizationOutcome = if let incompleteProviderReason {
-                        .providerTerminatedIncomplete(reason: incompleteProviderReason)
+                    let terminalOutcome: ChatSendTerminalOutcome = if let incompleteProviderReason {
+                        .providerTerminatedIncomplete(
+                            reason: incompleteProviderReason,
+                            partialResponse: partialBuffer.isEmpty ? nil : partialBuffer
+                        )
                     } else {
-                        .streamEndedWithoutProviderCompletion
+                        .streamEndedWithoutProviderCompletion(
+                            partialResponse: partialBuffer.isEmpty ? nil : partialBuffer
+                        )
                     }
                     Task {
                         await self.finalizeAIResponse(
                             aiResponseId: aiResponseId,
                             sessionID: targetSessionID,
                             partialBuffer: partialBuffer,
-                            outcome: outcome
+                            terminalOutcome: terminalOutcome
                         )
                         await self.cleanupOracleProviderConversation(providerCleanupHandle, model: model)
                     }
@@ -3312,7 +3663,7 @@ class OracleViewModel: ObservableObject {
                     self.clearSessionStreaming(targetSessionID)
                 }
                 Task {
-                    await handleSendMessageError(error, aiResponseId: aiResponseId, sessionID: targetSessionID)
+                    await self.handleSendMessageError(error, aiResponseId: aiResponseId, sessionID: targetSessionID)
                     await self.cleanupOracleProviderConversation(providerCleanupHandle, model: model)
                 }
             }
@@ -3337,7 +3688,7 @@ class OracleViewModel: ObservableObject {
         aiResponseId: UUID,
         sessionID: UUID,
         partialBuffer: String,
-        outcome: OracleMessageFinalizationOutcome
+        terminalOutcome: ChatSendTerminalOutcome
     ) async {
         // Single-flight finalisation: provider stop, watchdogs, and cancellation can
         // all race to finalize the same message.
@@ -3363,7 +3714,7 @@ class OracleViewModel: ObservableObject {
             messageStore[sessionID]?.first(where: { $0.id == aiResponseId })?
                 .content ?? partialBuffer
         }
-        if case let .providerTerminatedIncomplete(reason) = outcome {
+        if case let .providerTerminatedIncomplete(reason, _) = terminalOutcome {
             let error = OracleContextBuilderCompletionError.providerTerminatedIncomplete(reason: reason)
             let incompleteContent = finalContent + "\n\n--\nError:\n\(error.localizedDescription)"
             finalContent = incompleteContent
@@ -3403,16 +3754,17 @@ class OracleViewModel: ObservableObject {
         // When finalizing after a delegate‑edit retry, force autosave so XML results persist
         // even if the assistant message text hasn't changed (avoids "no meaningful changes" skip).
         let shouldForceAutosave = (activeRetryTask != nil)
-        autosaveChatHistory(for: sessionID, force: shouldForceAutosave)
+        let autosaveTask = autosaveChatHistory(for: sessionID, force: shouldForceAutosave)
+        await autosaveTask?.value
 
         // 5️⃣ Notify observers and any waiters that this message is finalised
         emitMessageLifecycleActivity(.finalizationCompleted, for: aiResponseId)
-        await concludeFinalisation(aiResponseId, outcome: outcome)
+        await concludeFinalisation(aiResponseId, outcome: terminalOutcome)
     }
 
     private func concludeFinalisation(
         _ id: UUID,
-        outcome: OracleMessageFinalizationOutcome
+        outcome: ChatSendTerminalOutcome
     ) async {
         completionPolicies.removeValue(forKey: id)
         await finalisationHub.fulfil(id, outcome: outcome)
@@ -3435,27 +3787,36 @@ class OracleViewModel: ObservableObject {
             print("AI response was cancelled.")
             guard let index = messageStore[sessionID]?.firstIndex(where: { $0.id == aiResponseId }) else {
                 clearSessionStreaming(sessionID)
-                await concludeFinalisation(aiResponseId, outcome: .cancelled)
+                await concludeFinalisation(
+                    aiResponseId,
+                    outcome: .cancelled(message: "Request was cancelled.", partialResponse: nil)
+                )
                 return
             }
 
             if messageStore[sessionID]?[index].isFinalized == true {
                 clearSessionStreaming(sessionID)
-                await concludeFinalisation(aiResponseId, outcome: .cancelled)
+                await concludeFinalisation(
+                    aiResponseId,
+                    outcome: .cancelled(message: "Request was cancelled.", partialResponse: nil)
+                )
                 return
             }
 
             let finalContent = messageStore[sessionID]?[index].content ?? ""
             if finalContent.isEmpty {
-                await concludeFinalisation(aiResponseId, outcome: .cancelled)
                 withSessionMessages(sessionID) { msgs in
                     if let idx = msgs.firstIndex(where: { $0.id == aiResponseId }) {
                         msgs.remove(at: idx)
                     }
                 }
-                purgeMessageCaches(for: aiResponseId)
-                clearSessionStreaming(sessionID)
                 autosaveChatHistory(for: sessionID)
+                clearSessionStreaming(sessionID)
+                await concludeFinalisation(
+                    aiResponseId,
+                    outcome: .cancelled(message: "Request was cancelled.", partialResponse: nil)
+                )
+                purgeMessageCaches(for: aiResponseId)
                 return
             }
 
@@ -3464,7 +3825,10 @@ class OracleViewModel: ObservableObject {
                     aiResponseId: aiResponseId,
                     sessionID: sessionID,
                     partialBuffer: finalContent,
-                    outcome: .cancelled
+                    terminalOutcome: .cancelled(
+                        message: "Request was cancelled.",
+                        partialResponse: finalContent.isEmpty ? nil : finalContent
+                    )
                 )
             }
             return
@@ -3475,6 +3839,10 @@ class OracleViewModel: ObservableObject {
         // Pass token count to error message handler for non-cancellation errors
         let tokenCount = promptViewModel.totalTokenCount
         let errorMessage = userFriendlyErrorMessage(for: error, tokenCount: tokenCount)
+        let partialContent = messageStore[sessionID]?
+            .first(where: { $0.id == aiResponseId })?
+            .content
+        let partialResponse = partialContent.flatMap { $0.isEmpty ? nil : $0 }
         if messageStore[sessionID]?.contains(where: { $0.id == aiResponseId }) == true {
             let appendedErrorBlock = "\n\n--\nError:\n\(errorMessage)"
             withSessionMessages(sessionID) { msgs in
@@ -3500,7 +3868,7 @@ class OracleViewModel: ObservableObject {
         clearSessionStreaming(sessionID)
         await concludeFinalisation(
             aiResponseId,
-            outcome: .failed(message: errorMessage)
+            outcome: .failed(message: errorMessage, partialResponse: partialResponse)
         )
     }
 
@@ -3680,26 +4048,35 @@ class OracleViewModel: ObservableObject {
 
         guard !skipPartialParseAndSave, let queryId = qid else {
             if let qid {
-                await concludeFinalisation(qid, outcome: .cancelled)
+                await concludeFinalisation(
+                    qid,
+                    outcome: .cancelled(message: "Request was cancelled.", partialResponse: nil)
+                )
             }
             return
         }
 
         guard let idx = messageStore[sessionID]?.firstIndex(where: { $0.id == queryId && !$0.isUser }) else {
-            await concludeFinalisation(queryId, outcome: .cancelled)
+            await concludeFinalisation(
+                queryId,
+                outcome: .cancelled(message: "Request was cancelled.", partialResponse: nil)
+            )
             return
         }
 
         let finalContent = messageStore[sessionID]?[idx].content.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if finalContent.isEmpty {
-            await concludeFinalisation(queryId, outcome: .cancelled)
             withSessionMessages(sessionID) { msgs in
                 if let index = msgs.firstIndex(where: { $0.id == queryId && !$0.isUser }) {
                     msgs.remove(at: index)
                 }
             }
-            purgeMessageCaches(for: queryId)
             autosaveChatHistory(for: sessionID)
+            await concludeFinalisation(
+                queryId,
+                outcome: .cancelled(message: "Request was cancelled.", partialResponse: nil)
+            )
+            purgeMessageCaches(for: queryId)
             return
         }
 
@@ -3712,7 +4089,13 @@ class OracleViewModel: ObservableObject {
         autosaveChatHistory(for: sessionID)
 
         // Notify any waiters that this message is finalised (cancelled)
-        await concludeFinalisation(queryId, outcome: .cancelled)
+        await concludeFinalisation(
+            queryId,
+            outcome: .cancelled(
+                message: "Request was cancelled.",
+                partialResponse: finalContent.isEmpty ? nil : finalContent
+            )
+        )
     }
 
     @MainActor
@@ -3825,6 +4208,18 @@ class OracleViewModel: ObservableObject {
         }
         guard let index = sessions.firstIndex(where: { $0.id == id }) else {
             print("Session \(id) not found for renaming.")
+            return
+        }
+
+        if sessions[index].oraclePairID != nil || sessions[index].oracleLane != nil {
+            Task { [weak self] in
+                guard let self else { return }
+                do {
+                    try await persistOraclePairRename(sessionID: id, newName: newName)
+                } catch {
+                    print("Error saving renamed Oracle pair: \(error)")
+                }
+            }
             return
         }
 

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -1808,7 +1808,7 @@ class OracleViewModel: ObservableObject {
         }
     }
 
-    /// Deletes one logical chat. Paired Oracle sessions are one lifecycle unit:
+    /// Deletes one logical chat. Grouped Oracle sessions are one lifecycle unit:
     /// every known member is cancelled, deleted, and removed from memory together.
     @MainActor
     @discardableResult
@@ -1819,7 +1819,11 @@ class OracleViewModel: ObservableObject {
         guard let workspaceID = session.workspaceID,
               let workspace = workspaceManager.workspaces.first(where: { $0.id == workspaceID })
         else {
-            return await deleteLegacySession(session)
+            // Group membership is a lifecycle invariant. Without the owning workspace we
+            // cannot discover or atomically delete the other lanes, so fail closed instead
+            // of silently deleting only the selected member through the legacy path.
+            print("Refusing to delete grouped Oracle session without its owning workspace.")
+            return false
         }
         let claim = OracleSendClaimKey.oracleSend(
             workspaceID: workspaceID,
@@ -1876,21 +1880,41 @@ class OracleViewModel: ObservableObject {
     @MainActor
     func deleteClaimedSession(_ session: ChatSession, workspace: WorkspaceModel) async -> Bool {
         sessionSwitchGeneration += 1
-        guard let pairID = session.oraclePairID else {
+        guard let groupID = session.oraclePairID else {
             return await deleteLegacySession(session)
         }
         let persistedMembers: [ChatSession]
         do {
-            persistedMembers = try await chatData.oraclePairSessionStubs(for: workspace, pairID: pairID)
+            persistedMembers = try await chatData.oraclePairSessionStubs(
+                for: workspace,
+                pairID: groupID,
+                requireCompleteGroup: false
+            )
         } catch {
-            print("Error resolving Oracle pair for deletion: \(error)")
+            print("Error resolving Oracle group for deletion: \(error)")
             return false
         }
         let memberIDs = Set([session.id]).union(persistedMembers.map(\.id)).union(
-            sessions.lazy.filter { $0.oraclePairID == pairID }.map(\.id)
+            sessions.lazy.filter { $0.oraclePairID == groupID }.map(\.id)
         )
-        guard memberIDs.count <= 2 else {
-            print("Refusing to delete malformed Oracle pair \(pairID).")
+        let knownMembersByID = Dictionary(
+            ([session] + persistedMembers + sessions.filter { $0.oraclePairID == groupID }).map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        let knownMembers = Array(knownMembersByID.values)
+        let declaredSizes = Set(knownMembers.compactMap(\.oracleGroupSize))
+        guard knownMembers.compactMap(\.oracleGroupSize).count == knownMembers.count,
+              declaredSizes.count == 1,
+              let groupSize = declaredSizes.first,
+              (2 ... OracleLane.allCases.count).contains(groupSize),
+              let expectedLanes = try? OracleLane.orderedPrefix(count: groupSize),
+              memberIDs.count <= groupSize,
+              knownMembers.allSatisfy({ $0.workspaceID == workspace.id && $0.oraclePairID == groupID }),
+              knownMembers.compactMap(\.oracleLane).count == knownMembers.count,
+              Set(knownMembers.compactMap(\.oracleLane)).count == knownMembers.count,
+              Set(knownMembers.compactMap(\.oracleLane)).isSubset(of: Set(expectedLanes))
+        else {
+            print("Refusing to delete malformed Oracle group \(groupID).")
             return false
         }
         let inMemoryMembers = sessions.filter { memberIDs.contains($0.id) }
@@ -1920,8 +1944,8 @@ class OracleViewModel: ObservableObject {
                     .filter { $0.composeTabID == tabID }
                     .sorted { lhs, rhs in
                         if lhs.savedAt != rhs.savedAt { return lhs.savedAt > rhs.savedAt }
-                        let leftLane = lhs.oracleLane == .primary ? 0 : lhs.oracleLane == .secondary ? 1 : 2
-                        let rightLane = rhs.oracleLane == .primary ? 0 : rhs.oracleLane == .secondary ? 1 : 2
+                        let leftLane = lhs.oracleLane?.ordinal ?? .max
+                        let rightLane = rhs.oracleLane?.ordinal ?? .max
                         if leftLane != rightLane { return leftLane < rightLane }
                         return lhs.id.uuidString < rhs.id.uuidString
                     }
@@ -2902,6 +2926,7 @@ class OracleViewModel: ObservableObject {
                 sessionToSave.agentModeRunID = session.agentModeRunID
                 sessionToSave.oraclePairID = session.oraclePairID
                 sessionToSave.oracleLane = session.oracleLane
+                sessionToSave.oracleGroupSize = session.oracleGroupSize
                 sessionToSave.oracleHistoryDiverged = session.oracleHistoryDiverged
                 sessionToSave.selectedFilePaths = session.selectedFilePaths
                 sessionToSave.selectedPromptIDs = session.selectedPromptIDs
@@ -2944,7 +2969,10 @@ class OracleViewModel: ObservableObject {
         // 0️⃣  Preconditions
         // ------------------------------------------------------------------
         guard let session = sessions.first(where: { $0.id == sessionID }) else { return nil }
-        guard session.oraclePairID == nil, session.oracleLane == nil else { return nil }
+        guard session.oraclePairID == nil,
+              session.oracleLane == nil,
+              session.oracleGroupSize == nil
+        else { return nil }
         guard let liveMessages = messageStore[sessionID] ?? (sessionID == currentSessionID ? messages : nil) else {
             return nil
         }
@@ -3257,46 +3285,68 @@ class OracleViewModel: ObservableObject {
     }
 
     @MainActor
-    func persistOraclePairHistories(
-        pairID: UUID,
-        primarySessionID: UUID,
-        secondarySessionID: UUID
+    func persistOracleGroupHistories(
+        groupID: UUID,
+        sessionIDsByLane: [OracleLane: UUID]
     ) async throws -> Bool {
-        guard primarySessionID != secondarySessionID,
-              let primaryIndex = sessions.firstIndex(where: { $0.id == primarySessionID }),
-              let secondaryIndex = sessions.firstIndex(where: { $0.id == secondarySessionID }),
-              sessions[primaryIndex].oraclePairID == pairID,
-              sessions[primaryIndex].oracleLane == .primary,
-              sessions[secondaryIndex].oraclePairID == pairID,
-              sessions[secondaryIndex].oracleLane == .secondary,
-              let workspaceID = sessions[primaryIndex].workspaceID,
-              sessions[secondaryIndex].workspaceID == workspaceID,
-              let workspace = workspaceManager.workspaces.first(where: { $0.id == workspaceID }),
-              let primaryMessages = messageStore[primarySessionID],
-              let secondaryMessages = messageStore[secondarySessionID]
+        let groupSize = sessionIDsByLane.count
+        guard (2 ... OracleLane.allCases.count).contains(groupSize),
+              Set(sessionIDsByLane.values).count == groupSize,
+              let orderedLanes = try? OracleLane.orderedPrefix(count: groupSize),
+              Set(sessionIDsByLane.keys) == Set(orderedLanes)
         else {
-            throw ChatToolError.internalError("Failed to persist a complete Oracle pair history.")
+            throw ChatToolError.internalError("Failed to persist a complete Oracle group history.")
+        }
+
+        var members: [ChatSession] = []
+        var liveMessagesByLane: [OracleLane: [AIChatMessage]] = [:]
+        for lane in orderedLanes {
+            guard let sessionID = sessionIDsByLane[lane],
+                  let member = sessions.first(where: { $0.id == sessionID }),
+                  member.oraclePairID == groupID,
+                  member.oracleLane == lane,
+                  member.oracleGroupSize == groupSize,
+                  let liveMessages = messageStore[sessionID]
+            else {
+                throw ChatToolError.internalError("Failed to persist a complete Oracle group history.")
+            }
+            members.append(member)
+            liveMessagesByLane[lane] = liveMessages
+        }
+        guard let workspaceID = members.first?.workspaceID,
+              members.allSatisfy({ $0.workspaceID == workspaceID }),
+              let workspace = workspaceManager.workspaces.first(where: { $0.id == workspaceID }),
+              let primaryMessages = liveMessagesByLane[.primary]
+        else {
+            throw ChatToolError.internalError("Failed to persist a complete Oracle group history.")
         }
 
         let projectionWorkspaceLoadGeneration = workspaceChatSessionLoadGeneration
         let projectionActiveWorkspaceID = workspaceManager.activeWorkspace?.id
-        let diverged = Self.oracleHistoriesDiverged(
-            primary: primaryMessages.filter(\.isUser).map(\.content),
-            secondary: secondaryMessages.filter(\.isUser).map(\.content)
-        )
+        let primaryUserHistory = primaryMessages.filter(\.isUser).map(\.content)
+        let diverged = orderedLanes.dropFirst().contains { lane in
+            guard let laneMessages = liveMessagesByLane[lane] else { return true }
+            return laneMessages.filter(\.isUser).map(\.content) != primaryUserHistory
+        }
         let savedAt = Date()
-        var primary = sessions[primaryIndex]
-        var secondary = sessions[secondaryIndex]
-        primary.messages = try Self.storedOracleMessages(primaryMessages, preserving: primary.messages)
-        secondary.messages = try Self.storedOracleMessages(secondaryMessages, preserving: secondary.messages)
-        primary.savedAt = savedAt
-        secondary.savedAt = savedAt
-        primary.oracleHistoryDiverged = diverged
-        secondary.oracleHistoryDiverged = diverged
+        for index in members.indices {
+            let lane = orderedLanes[index]
+            guard let liveMessages = liveMessagesByLane[lane] else {
+                throw ChatToolError.internalError("Failed to persist a complete Oracle group history.")
+            }
+            members[index].messages = try Self.storedOracleMessages(
+                liveMessages,
+                preserving: members[index].messages
+            )
+            members[index].savedAt = savedAt
+            members[index].oracleGroupSize = groupSize
+            members[index].oracleHistoryDiverged = diverged
+        }
 
-        let fileURLs = try await chatData.saveOraclePairSessions([primary, secondary], for: workspace)
-        primary.fileURL = fileURLs[primarySessionID]
-        secondary.fileURL = fileURLs[secondarySessionID]
+        let fileURLs = try await chatData.saveOraclePairSessions(members, for: workspace)
+        for index in members.indices {
+            members[index].fileURL = fileURLs[members[index].id]
+        }
 
         #if DEBUG
             await oraclePairDidCommitTestHook?()
@@ -3307,23 +3357,22 @@ class OracleViewModel: ObservableObject {
         else {
             throw ChatToolError(
                 code: .conflict,
-                message: "Oracle pair histories were committed, but the workspace changed before projection; durable state was not projected into the new workspace.",
+                message: "Oracle group histories were committed, but the workspace changed before projection; durable state was not projected into the new workspace.",
                 details: ["durable_commit": "true"]
             )
         }
 
-        let projectionRouteIsCurrent = sessions.contains {
-            $0.id == primarySessionID &&
-                $0.oraclePairID == pairID &&
-                $0.oracleLane == .primary &&
-                $0.workspaceID == workspaceID
-        } && sessions.contains {
-            $0.id == secondarySessionID &&
-                $0.oraclePairID == pairID &&
-                $0.oracleLane == .secondary &&
-                $0.workspaceID == workspaceID
+        let projectionRouteIsCurrent = orderedLanes.allSatisfy { lane in
+            guard let sessionID = sessionIDsByLane[lane] else { return false }
+            return sessions.contains {
+                $0.id == sessionID &&
+                    $0.oraclePairID == groupID &&
+                    $0.oracleLane == lane &&
+                    $0.oracleGroupSize == groupSize &&
+                    $0.workspaceID == workspaceID
+            }
         }
-        for member in [primary, secondary] {
+        for member in members {
             if let index = sessions.firstIndex(where: { $0.id == member.id }) {
                 sessions[index] = member
             } else {
@@ -3333,11 +3382,27 @@ class OracleViewModel: ObservableObject {
         if !projectionRouteIsCurrent {
             throw ChatToolError(
                 code: .conflict,
-                message: "Oracle pair histories were committed, but in-memory state changed during projection; durable state was restored.",
+                message: "Oracle group histories were committed, but in-memory state changed during projection; durable state was restored.",
                 details: ["durable_commit": "true"]
             )
         }
         return diverged
+    }
+
+    /// Compatibility wrapper for two-lane callers while group runtime migration lands.
+    @MainActor
+    func persistOraclePairHistories(
+        pairID: UUID,
+        primarySessionID: UUID,
+        secondarySessionID: UUID
+    ) async throws -> Bool {
+        try await persistOracleGroupHistories(
+            groupID: pairID,
+            sessionIDsByLane: [
+                .primary: primarySessionID,
+                .secondary: secondarySessionID
+            ]
+        )
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -1125,6 +1125,7 @@ class OracleViewModel: ObservableObject {
 
     @MainActor
     private func purgeMessageCaches(for messageId: UUID) {
+        // Message-scoped cleanup only; does not cancel live streams or touch session-level state.
         sessionIDByMessageId.removeValue(forKey: messageId)
         streamIDsByQueryId.removeValue(forKey: messageId)
         cancelFinalizationWatchdog(for: messageId)
@@ -3370,6 +3371,7 @@ class OracleViewModel: ObservableObject {
         onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
     ) async -> UUID? {
         guard !newUserMessage.isEmpty else { return nil }
+        _ = true
 
         let targetSessionID: UUID
         if let sessionID {
@@ -3392,15 +3394,18 @@ class OracleViewModel: ObservableObject {
 
         ensureSessionStorage(targetSessionID)
 
-        let userID = UUID()
+        // Create the user message
+        let userId = UUID()
         let userMessage = AIChatMessage(
-            id: userID,
+            id: userId,
             content: newUserMessage,
             isUser: true,
             sequenceIndex: nextSequenceIndex(for: targetSessionID)
         )
-        withSessionMessages(targetSessionID) { $0.append(userMessage) }
-        registerMessage(userID, sessionID: targetSessionID)
+        withSessionMessages(targetSessionID) { msgs in
+            msgs.append(userMessage)
+        }
+        registerMessage(userId, sessionID: targetSessionID)
 
         let conversation = buildConversationEntries(for: targetSessionID)
 
@@ -3414,7 +3419,6 @@ class OracleViewModel: ObservableObject {
         if !promptViewModel.isModelAvailable(model) {
             // Show error in chat instead of silently falling back
             let errorMessage = AIChatMessage(
-                id: UUID(),
                 content: "Error: The model '\(model.displayName)' is not available. Please check that the \(model.providerType.displayName) API key is configured in Settings.",
                 isUser: false,
                 isFinalized: true

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -1317,9 +1317,9 @@ class OracleViewModel: ObservableObject {
             // Keep a single awaitable restore task. Workspace switch only yields once after
             // notifying listeners, so tests and MCP callers must be able to wait until chat
             // sessions finish reloading (sessions.removeAll + stub load + ensureActive).
-            self.workspaceChatRestoreTask = Task { @MainActor [weak self] in
+            workspaceChatRestoreTask = Task { @MainActor [weak self] in
                 guard let self else { return }
-                await self.handleWorkspaceSwitched(to: newWS)
+                await handleWorkspaceSwitched(to: newWS)
             }
         }
 

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -614,6 +614,8 @@ class OracleViewModel: ObservableObject {
     private var sessionSwitchGeneration: Int = 0
     private var workspaceChatSessionLoadGeneration: UInt64 = 0
     private let workspaceSwitchChatStubLoadConcurrency = 4
+    /// Tracks the latest workspace-switch chat restore so callers can await settlement.
+    private var workspaceChatRestoreTask: Task<Void, Never>?
 
     /// Session management
     @Published var sessions: [ChatSession] = [] {
@@ -1312,8 +1314,12 @@ class OracleViewModel: ObservableObject {
         // New code using multi-listener approach:
         self.workspaceManager.addWorkspaceDidSwitchListener(label: "chat") { [weak self] newWS in
             guard let self else { return }
-            Task { [weak self] in
-                await self?.handleWorkspaceSwitched(to: newWS)
+            // Keep a single awaitable restore task. Workspace switch only yields once after
+            // notifying listeners, so tests and MCP callers must be able to wait until chat
+            // sessions finish reloading (sessions.removeAll + stub load + ensureActive).
+            self.workspaceChatRestoreTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                await self.handleWorkspaceSwitched(to: newWS)
             }
         }
 
@@ -1977,6 +1983,13 @@ class OracleViewModel: ObservableObject {
         guard !isSwitchingTabsForSession else { return }
         guard tabID != nil else { return }
         _ = await ensureActiveSessionForCurrentTab(createIfMissing: true)
+    }
+
+    /// Waits for the most recent workspace-switch chat restore to finish.
+    /// Call after `WorkspaceManager.switchWorkspace` before asserting Oracle session state.
+    @MainActor
+    func awaitWorkspaceChatSessionsRestored() async {
+        await workspaceChatRestoreTask?.value
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Combine
+import enum MCP.Value
 import SwiftUI
 
 // AgentLogEntry and AgentLogEntryType are defined in Models/Agent/AgentLogModels.swift
@@ -97,6 +98,19 @@ enum ContextBuilderFollowUpType: String, CaseIterable, Codable {
         case .review: "Review"
         case .question: "Answer"
         }
+    }
+}
+
+struct ContextBuilderSupersededFollowUpDrain {
+    let task: Task<Void, Never>
+    let completion: AsyncStream<Void>
+}
+
+private struct ContextBuilderSupersededFollowUpDrainTimeout: LocalizedError {
+    let timeout: TimeInterval
+
+    var errorDescription: String? {
+        "Previous Oracle follow-up did not stop within \(timeout.formatted(.number.precision(.fractionLength(1))))s; no replacement was started."
     }
 }
 
@@ -309,11 +323,16 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         // MARK: - Background Plan Generation (per-tab tracking)
 
-        /// Task handle for this tab's background plan generation
+        /// Task handle for this tab's background plan generation.
         var backgroundPlanTask: Task<Void, Never>?
+        /// Retained cancellation/join work that must finish before a replacement starts.
+        var supersededFollowUpDrain: ContextBuilderSupersededFollowUpDrain?
+        /// Monotonic owner for runtime callbacks and completion publication.
+        var backgroundPlanGeneration: UInt64 = 0
 
-        /// Live Oracle chat session used by MCP follow-up streaming.
-        var followUpOracleSessionID: UUID?
+        /// The two live Oracle lanes used by follow-up streaming.
+        var followUpPrimarySessionID: UUID?
+        var followUpSecondarySessionID: UUID?
 
         /// Per-tab auto-generate plan setting (loaded from tab config)
         var autoGeneratePlan: Bool = false
@@ -395,7 +414,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             mcpControlToken = nil
             mcpWorkspaceID = nil
             mcpPlanningModelRaw = nil
-            followUpOracleSessionID = nil
+            supersededFollowUpDrain = nil
+            backgroundPlanGeneration = 0
+            followUpPrimarySessionID = nil
+            followUpSecondarySessionID = nil
             pendingAskUser = nil
             askUserContinuation = nil
             pendingAskUserRunID = nil
@@ -442,7 +464,14 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 _ mode: HeadlessMode,
                 _ prompt: String,
                 _ selection: StoredSelection
-            ) async throws -> ChatSendReply
+            ) async throws -> OracleSendResult
+            typealias ToolChatSend = @MainActor @Sendable (
+                _ args: [String: Value],
+                _ promptVM: PromptViewModel,
+                _ tabContext: OracleViewModel.OracleSendTabContext,
+                _ primaryModelSelection: OracleViewModel.ModelSelectionResult,
+                _ liveCallbacks: OracleViewModel.OracleSendLiveCallbacks
+            ) async throws -> OracleSendResult
 
             let beforeProcessingProviderEvent: ((_ result: AIStreamResult, _ runID: UUID) async -> Void)?
             let providerEventDisposition: ((_ result: AIStreamResult, _ runID: UUID, _ accepted: Bool) -> Void)?
@@ -460,6 +489,9 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 _ runID: UUID,
                 _ snapshot: MCPServerViewModel.ContextBuilderCommittedTabSnapshot
             ) async -> Void)?
+            let cancelFollowUpOracleSession: (@MainActor @Sendable (UUID) async -> Void)?
+            let toolChatSend: ToolChatSend?
+            let supersededDrainTimeout: TimeInterval?
 
             init(
                 beforeProcessingProviderEvent: ((_ result: AIStreamResult, _ runID: UUID) async -> Void)?,
@@ -475,7 +507,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 afterCommittedTabSnapshotCaptured: (@MainActor @Sendable (
                     _ runID: UUID,
                     _ snapshot: MCPServerViewModel.ContextBuilderCommittedTabSnapshot
-                ) async -> Void)? = nil
+                ) async -> Void)? = nil,
+                cancelFollowUpOracleSession: (@MainActor @Sendable (UUID) async -> Void)? = nil,
+                toolChatSend: ToolChatSend? = nil,
+                supersededDrainTimeout: TimeInterval? = nil
             ) {
                 self.beforeProcessingProviderEvent = beforeProcessingProviderEvent
                 self.providerEventDisposition = providerEventDisposition
@@ -486,6 +521,9 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 self.validateContextBuilderProviders = validateContextBuilderProviders
                 self.committedTabSnapshotCaptured = committedTabSnapshotCaptured
                 self.afterCommittedTabSnapshotCaptured = afterCommittedTabSnapshotCaptured
+                self.cancelFollowUpOracleSession = cancelFollowUpOracleSession
+                self.toolChatSend = toolChatSend
+                self.supersededDrainTimeout = supersededDrainTimeout
             }
         }
 
@@ -1502,16 +1540,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         for session in sessions.values where !session.isMCPControlledRun {
             cancelPendingQuestion(for: session)
-            session.backgroundPlanTask?.cancel()
-            session.backgroundPlanTask = nil
-            if let oracleVM = oracleViewModel,
-               let followUpSessionID = session.followUpOracleSessionID
-            {
-                Task { @MainActor in
-                    await oracleVM.cancelStreaming(in: followUpSessionID)
-                }
-            }
-            session.followUpOracleSessionID = nil
+            _ = supersedeBackgroundPlanGeneration(for: session, using: oracleViewModel)
         }
         sessions = sessions.filter(\.value.isMCPControlledRun)
         lastProcessedTabID = nil
@@ -1561,16 +1590,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             // 1. Cancel any pending clarifying question
             cancelPendingQuestion(for: session)
 
-            // 2. Cancel background plan generation for this tab
-            if session.isBackgroundPlanGenerating {
+            // 2. Cancel background plan generation for this tab.
+            if session.isBackgroundPlanGenerating || session.backgroundPlanTask != nil || session.supersededFollowUpDrain != nil {
                 debugLog("handleComposeTabsWillClose: cancelling background plan for tab \(tabID)")
-                session.backgroundPlanTask?.cancel()
-                session.backgroundPlanTask = nil
+                _ = supersedeBackgroundPlanGeneration(for: session, using: oracleViewModel)
                 session.isBackgroundPlanGenerating = false
-                if let followUpSessionID = session.followUpOracleSessionID {
-                    await oracleViewModel?.cancelStreaming(in: followUpSessionID)
-                }
-                session.followUpOracleSessionID = nil
             }
 
             // 3. Logically cancel every registered run for the tab without waiting for teardown.
@@ -3072,13 +3096,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             guard let session = sessions[tabID] else { continue }
 
             if session.isBackgroundPlanGenerating {
-                session.backgroundPlanTask?.cancel()
-                session.backgroundPlanTask = nil
+                _ = supersedeBackgroundPlanGeneration(for: session, using: oracleViewModel)
                 session.isBackgroundPlanGenerating = false
-                if let followUpSessionID = session.followUpOracleSessionID {
-                    await oracleViewModel?.cancelStreaming(in: followUpSessionID)
-                }
-                session.followUpOracleSessionID = nil
                 updateRuntimeBindings(from: session)
             }
 
@@ -4217,9 +4236,211 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     func chatNameForTab(_ tabID: UUID) -> String {
         let tabName = workspaceManager?.composeTab(with: tabID)?.name
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let workspaceName = workspaceManager?.activeWorkspace?.name ?? "Workspace"
+        let routedWorkspaceID = workspaceManager?.bindingCandidate(forContextID: tabID)?.workspaceID
+        let workspaceName = workspaceManager?.workspaces.first(where: { $0.id == routedWorkspaceID })?.name ?? "Workspace"
         let defaultName = "Plan – \(workspaceName)"
         return (tabName?.isEmpty == false) ? tabName! : defaultName
+    }
+
+    @MainActor
+    private func takeFollowUpOracleSessionIDs(from session: TabSession) -> [UUID] {
+        let ids = [session.followUpPrimarySessionID, session.followUpSecondarySessionID]
+            .compactMap(\.self)
+            .reduce(into: [UUID]()) { result, id in
+                if !result.contains(id) { result.append(id) }
+            }
+        session.followUpPrimarySessionID = nil
+        session.followUpSecondarySessionID = nil
+        return ids
+    }
+
+    @MainActor
+    private func cancelFollowUpOracleSessions(
+        _ sessionIDs: [UUID],
+        using oracleViewModel: OracleViewModel?
+    ) async {
+        for sessionID in sessionIDs {
+            #if DEBUG
+                if let cancel = runTestHooks?.cancelFollowUpOracleSession {
+                    await cancel(sessionID)
+                    continue
+                }
+            #endif
+            await oracleViewModel?.cancelStreaming(in: sessionID)
+        }
+    }
+
+    @MainActor
+    private func scheduleSupersededFollowUpDrain(
+        for session: TabSession,
+        supersededTask: Task<Void, Never>?,
+        sessionIDs: [UUID],
+        using oracleViewModel: OracleViewModel?
+    ) -> ContextBuilderSupersededFollowUpDrain? {
+        let previous = session.supersededFollowUpDrain
+        guard supersededTask != nil || !sessionIDs.isEmpty else { return previous }
+
+        let tabID = session.tabID
+        let generation = session.backgroundPlanGeneration
+        let (completion, continuation) = AsyncStream<Void>.makeStream()
+        let task = Task { @MainActor [weak self, weak session, oracleViewModel] in
+            defer { continuation.finish() }
+            _ = await previous?.task.value
+            if let self {
+                await cancelFollowUpOracleSessions(sessionIDs, using: oracleViewModel)
+            } else {
+                for sessionID in sessionIDs {
+                    await oracleViewModel?.cancelStreaming(in: sessionID)
+                }
+            }
+            _ = await supersededTask?.value
+            if let self, let session,
+               sessions[tabID] === session,
+               session.backgroundPlanGeneration == generation
+            {
+                session.supersededFollowUpDrain = nil
+            }
+        }
+        let drain = ContextBuilderSupersededFollowUpDrain(task: task, completion: completion)
+        session.supersededFollowUpDrain = drain
+        return drain
+    }
+
+    @MainActor
+    private func awaitSupersededFollowUpDrain(
+        _ drain: ContextBuilderSupersededFollowUpDrain?
+    ) async throws {
+        guard let drain else { return }
+        let timeout: TimeInterval = {
+            #if DEBUG
+                if let override = runTestHooks?.supersededDrainTimeout { return override }
+            #endif
+            return 30
+        }()
+        let finished = try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await _ in drain.completion {}
+                try Task.checkCancellation()
+                return true
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(timeout))
+                return false
+            }
+            let first = try await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        guard finished else {
+            throw ContextBuilderSupersededFollowUpDrainTimeout(timeout: timeout)
+        }
+    }
+
+    @MainActor
+    private func supersedeBackgroundPlanGeneration(
+        for session: TabSession,
+        using oracleViewModel: OracleViewModel?
+    ) -> ContextBuilderSupersededFollowUpDrain? {
+        session.backgroundPlanGeneration &+= 1
+        let sessionIDs = takeFollowUpOracleSessionIDs(from: session)
+        let supersededTask = session.backgroundPlanTask
+        session.backgroundPlanTask = nil
+        supersededTask?.cancel()
+        return scheduleSupersededFollowUpDrain(
+            for: session,
+            supersededTask: supersededTask,
+            sessionIDs: sessionIDs,
+            using: oracleViewModel
+        )
+    }
+
+    @MainActor
+    private func beginBackgroundPlanGeneration(
+        for session: TabSession,
+        using oracleViewModel: OracleViewModel?
+    ) -> (generation: UInt64, drain: ContextBuilderSupersededFollowUpDrain?) {
+        let drain = supersedeBackgroundPlanGeneration(for: session, using: oracleViewModel)
+        session.generatedAnswerRoute = nil
+        session.isBackgroundPlanGenerating = true
+        session.backgroundPlanError = nil
+        session.backgroundPlanResponseText = nil
+        session.backgroundPlanReasoningText = nil
+        clearPendingBackgroundPlanUIRefresh(for: session.tabID)
+        applyPlanPreview(to: session)
+        updateRuntimeBindings(from: session)
+        return (session.backgroundPlanGeneration, drain)
+    }
+
+    @MainActor
+    private func publishFollowUpOracleSessions(
+        primary: UUID,
+        secondary: UUID?,
+        workspaceID: UUID,
+        oracleViewModel: OracleViewModel,
+        session: TabSession,
+        generation: UInt64
+    ) throws {
+        guard session.backgroundPlanGeneration == generation else { throw CancellationError() }
+        session.followUpPrimarySessionID = primary
+        session.followUpSecondarySessionID = secondary
+        let primaryChatID = oracleViewModel.sessions.first(where: { $0.id == primary })?.shortID
+            ?? primary.uuidString
+        session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
+            workspaceID: workspaceID,
+            tabID: session.tabID,
+            chatID: primaryChatID
+        )
+        updateRuntimeBindings(from: session)
+    }
+
+    @MainActor
+    private func publishPrimaryProgress(
+        text: String,
+        reasoning: String?,
+        session: TabSession,
+        generation: UInt64
+    ) {
+        guard session.backgroundPlanGeneration == generation,
+              session.isBackgroundPlanGenerating else { return }
+        session.backgroundPlanResponseText = text
+        session.backgroundPlanReasoningText = reasoning
+        applyPlanPreview(to: session)
+        requestBackgroundPlanUIRefresh(for: session.tabID)
+    }
+
+    @MainActor
+    private func publishFollowUpCompletion(
+        _ reply: ChatSendReply,
+        workspaceID: UUID,
+        session: TabSession,
+        generation: UInt64
+    ) throws {
+        guard session.backgroundPlanGeneration == generation else { throw CancellationError() }
+        session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
+            workspaceID: workspaceID,
+            tabID: session.tabID,
+            chatID: reply.shortId
+        )
+        session.backgroundPlanResponseText = reply.response
+        session.backgroundPlanError = nil
+        session.isBackgroundPlanGenerating = false
+        session.followUpPrimarySessionID = nil
+        session.followUpSecondarySessionID = nil
+        clearPendingBackgroundPlanUIRefresh(for: session.tabID)
+        applyPlanPreview(to: session)
+        updateRuntimeBindings(from: session)
+    }
+
+    @MainActor
+    private func resetBackgroundPlanPresentation(for session: TabSession) {
+        session.isBackgroundPlanGenerating = false
+        session.backgroundPlanError = nil
+        session.backgroundPlanResponseText = nil
+        session.backgroundPlanReasoningText = nil
+        session.generatedAnswerRoute = nil
+        clearPendingBackgroundPlanUIRefresh(for: session.tabID)
+        applyPlanPreview(to: session)
+        updateRuntimeBindings(from: session)
     }
 
     /// Called when a tab's discovery run completes successfully.
@@ -4288,63 +4509,45 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         chatName: String = "Plan",
         mode: HeadlessMode = .plan
     ) {
-        // Session must exist - caller ensures tab is valid
         let session = session(for: tabID)
-        guard let originWorkspaceID = workspaceID(containing: tabID) else {
+        guard let workspaceID = workspaceID(containing: tabID) else {
             session.backgroundPlanError = ContextBuilderGenerationError.missingWorkspace.errorDescription
             updateRuntimeBindings(from: session)
             return
         }
-
-        // Cancel any existing background plan task for THIS tab only
-        session.backgroundPlanTask?.cancel()
-
-        session.generatedAnswerRoute = nil
-        session.isBackgroundPlanGenerating = true
-        session.backgroundPlanError = nil
-        session.backgroundPlanResponseText = nil
-        session.backgroundPlanReasoningText = nil
-        clearPendingBackgroundPlanUIRefresh(for: tabID)
-        applyPlanPreview(to: session)
-        updateRuntimeBindings(from: session)
+        let continuationChatID = session.generatedAnswerRoute.flatMap { route in
+            route.workspaceID == workspaceID && route.tabID == tabID ? route.chatID : nil
+        }
+        let start = beginBackgroundPlanGeneration(for: session, using: oracleViewModel)
 
         session.backgroundPlanTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            guard let session = sessions[tabID] else { return }
-
             do {
-                let reply = try await generatePlanFromDiscovery(
+                try await awaitSupersededFollowUpDrain(start.drain)
+                try Task.checkCancellation()
+                guard let session = sessions[tabID],
+                      session.backgroundPlanGeneration == start.generation else { return }
+                _ = try await generatePlanFromDiscovery(
                     tabID: tabID,
-                    originWorkspaceID: originWorkspaceID,
+                    originWorkspaceID: workspaceID,
                     oracleViewModel: oracleViewModel,
                     chatName: chatName,
-                    mode: mode
+                    mode: mode,
+                    continuationChatID: continuationChatID,
+                    generation: start.generation
                 )
-                // generatedAnswerRoute is set inside generatePlanFromDiscovery
-                session.isBackgroundPlanGenerating = false
-                if let response = reply.response, !response.isEmpty {
-                    session.backgroundPlanResponseText = response
-                }
-                clearPendingBackgroundPlanUIRefresh(for: tabID)
-                applyPlanPreview(to: session)
-                updateRuntimeBindings(from: session)
             } catch {
-                // Treat both outer Task cancellation and stream CancellationError as "user cancelled".
-                if Task.isCancelled || (error is CancellationError) {
-                    session.backgroundPlanResponseText = nil
-                    session.backgroundPlanReasoningText = nil
-                    session.backgroundPlanError = nil
-                } else {
-                    session.backgroundPlanError = error.asFriendlyString()
-                }
+                guard let session = sessions[tabID],
+                      session.backgroundPlanGeneration == start.generation else { return }
                 session.isBackgroundPlanGenerating = false
+                session.backgroundPlanError = error is CancellationError ? nil : error.asFriendlyString()
                 clearPendingBackgroundPlanUIRefresh(for: tabID)
                 applyPlanPreview(to: session)
                 updateRuntimeBindings(from: session)
             }
-
-            // Clear task reference when this run ends for any reason
-            session.backgroundPlanTask = nil
+            if let session = sessions[tabID], session.backgroundPlanGeneration == start.generation {
+                session.backgroundPlanTask = nil
+            }
         }
     }
 
@@ -4354,30 +4557,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     func cancelBackgroundPlanGeneration(forTabID tabID: UUID? = nil) {
         let targetTabID = tabID ?? currentTabID
         guard let targetTabID, let session = sessions[targetTabID] else { return }
-
-        // 1) Cancel the underlying follow-up stream in OracleViewModel
-        if let oracleVM = oracleViewModel {
-            if let followUpSessionID = session.followUpOracleSessionID {
-                Task { @MainActor in
-                    await oracleVM.cancelStreaming(in: followUpSessionID)
-                }
-            }
-        }
-
-        // 2) Cancel the wrapper task (so outer await stack unwinds)
-        session.backgroundPlanTask?.cancel()
-        session.backgroundPlanTask = nil
-
-        // 3) Reset UI state on the tab
-        session.isBackgroundPlanGenerating = false
-        session.backgroundPlanError = nil
-        session.backgroundPlanResponseText = nil
-        session.backgroundPlanReasoningText = nil
-        session.generatedAnswerRoute = nil
-        session.followUpOracleSessionID = nil
-        clearPendingBackgroundPlanUIRefresh(for: targetTabID)
-        applyPlanPreview(to: session)
-        updateRuntimeBindings(from: session)
+        _ = supersedeBackgroundPlanGeneration(for: session, using: oracleViewModel)
+        resetBackgroundPlanPresentation(for: session)
     }
 
     /// Clear background plan state for a specific tab (e.g., when starting a new discovery run).
@@ -4485,241 +4666,247 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     // MARK: - MCP Plan/Question Generation
 
-    private func promptMode(for mode: HeadlessMode) -> PromptViewModel.PlanActMode {
-        switch mode {
-        case .plan:
-            .plan
-        case .review:
-            .review
-        case .chat:
-            .chat
-        }
-    }
-
-    private func waitForFollowUpFinalization(
-        in oracleViewModel: OracleViewModel,
-        queryID: UUID,
-        sessionID: UUID,
-        progressReporter: ContextBuilderMCPProgressReporter?,
-        activityReporter: ContextBuilderMCPActivityReporter?
-    ) async throws -> String {
-        let (activityEvents, activityContinuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream(
-            bufferingPolicy: .bufferingNewest(32)
-        )
-        let observerID = oracleViewModel.addMessageLifecycleActivityObserver(for: queryID) { event in
-            activityContinuation.yield(event)
-        }
-        defer {
-            oracleViewModel.removeMessageLifecycleActivityObserver(for: queryID, observerID: observerID)
-            activityContinuation.finish()
-        }
-
-        return try await ContextBuilderFollowUpFinalizationMonitor.wait(
-            activityEvents: activityEvents,
-            waitForFinalization: {
-                try await oracleViewModel.waitForContextBuilderCompletion(queryID)
-            },
-            cancelStreaming: {
-                await oracleViewModel.cancelStreaming(in: sessionID)
-            },
-            reportPhase: { phase in
-                await progressReporter?(phase)
-            },
-            reportActivity: { phase, message in
-                await activityReporter?(phase, message)
-            }
-        )
-    }
-
-    /// Unified follow-up generator that always streams in a real chat session.
-    /// Used by both MCP-triggered follow-ups and UI auto-generate follow-ups.
+    /// Streams ordinary follow-ups through the single-or-paired Oracle runtime without activating chat UI.
     @MainActor
     private func runFollowUpOracleStream(
         for tabID: UUID,
-        originWorkspaceID: UUID,
+        workspaceID: UUID,
         oracleViewModel: OracleViewModel,
         mode: HeadlessMode,
         prompt: String,
         selection: StoredSelection,
         lookupContext: WorkspaceLookupContext? = nil,
         reviewGitContext: FrozenPromptGitReviewContext,
-        finalReviewAuthorization: ContextBuilderFinalReviewAuthorization? = nil,
         agentModeSessionID: UUID? = nil,
         agentModeRunID: UUID? = nil,
         chatName: String,
-        model: AIModel,
-        chatPresetID: UUID?,
-        mcpSessionUIState: OracleViewModel.MCPSessionUIState? = nil,
-        gitScopeOverride: GitInclusion? = nil,
+        primaryModelSelection: OracleViewModel.ModelSelectionResult,
+        secondaryModelOverride: AIModel? = nil,
+        prebuiltAIMessage: AIMessage? = nil,
+        continuationChatID: String? = nil,
         onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil,
         progressReporter: ContextBuilderMCPProgressReporter? = nil,
-        activityReporter: ContextBuilderMCPActivityReporter? = nil
-    ) async throws -> ChatSendReply {
+        activityReporter: ContextBuilderMCPActivityReporter? = nil,
+        generation: UInt64
+    ) async throws -> OracleSendResult {
         let session = session(for: tabID)
+        guard session.backgroundPlanGeneration == generation,
+              session.isBackgroundPlanGenerating else { throw CancellationError() }
 
-        // Set initial UI state
-        session.generatedAnswerRoute = nil
-        session.isBackgroundPlanGenerating = true
-        session.backgroundPlanError = nil
-        session.backgroundPlanResponseText = nil
-        session.backgroundPlanReasoningText = nil
-        session.followUpOracleSessionID = nil
-        updateRuntimeBindings(from: session)
-
-        let modeName = mode.mcpModeName
-        let promptMode = promptMode(for: mode)
-
-        let isFocusedTab = (promptManager.activeComposeTabID == tabID)
-        let activeSessionID = oracleViewModel.workspaceManager.activeChatSessionID(forTabID: tabID) ?? oracleViewModel.currentSessionID
-        let isUserStreaming = oracleViewModel.isSessionStreaming(activeSessionID)
-        let shouldActivate = isFocusedTab && !isUserStreaming
-
-        var createdSessionID: UUID?
-        do {
-            try Task.checkCancellation()
-            guard session.isBackgroundPlanGenerating else {
-                throw CancellationError()
+        var pinnedSessionIDs: Set<UUID> = []
+        defer {
+            for sessionID in pinnedSessionIDs {
+                oracleViewModel.unpinSession(sessionID)
             }
+        }
 
-            await progressReporter?(.payloadPackaging)
-            let aiMessage = try await promptManager.buildHeadlessAIMessage(
-                from: HeadlessContextSnapshot(
-                    tabID: tabID,
-                    promptText: prompt,
-                    selection: selection,
-                    lookupContext: lookupContext,
-                    reviewGitContext: reviewGitContext,
-                    finalReviewAuthorization: finalReviewAuthorization
-                ),
-                model: model,
-                mode: mode,
-                gitScopeOverride: mode == .review ? gitScopeOverride : nil
-            )
-
-            try Task.checkCancellation()
-            guard session.isBackgroundPlanGenerating else {
-                throw CancellationError()
+        func pin(_ sessionID: UUID) {
+            if pinnedSessionIDs.insert(sessionID).inserted {
+                oracleViewModel.pinSession(sessionID)
             }
+        }
 
+        var isPaired = false
+        var terminalLanes: Set<OracleLane> = []
+        var laneActivityTail: Task<Void, Never>?
+        let reportStreamingPhases: @MainActor @Sendable () async -> Void = {
             await progressReporter?(.sessionCreationAndPersist)
-            let createdSession = try await oracleViewModel.createSession(
-                named: chatName,
-                tabID: tabID,
-                activateInUI: shouldActivate,
-                setActiveForTab: true,
-                agentModeSessionID: agentModeSessionID,
-                agentModeRunID: agentModeRunID
-            )
-            createdSessionID = createdSession.id
-            oracleViewModel.pinSession(createdSession.id)
-            defer { oracleViewModel.unpinSession(createdSession.id) }
-            session.followUpOracleSessionID = createdSession.id
-            session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
-                workspaceID: originWorkspaceID,
-                tabID: tabID,
-                chatID: createdSession.shortID
-            )
-            updateRuntimeBindings(from: session)
-
-            try Task.checkCancellation()
-            guard session.isBackgroundPlanGenerating else {
-                throw CancellationError()
-            }
-
-            if let mcpSessionUIState {
-                oracleViewModel.setMCPSessionUIState(mcpSessionUIState, for: createdSession.id)
-            } else {
-                oracleViewModel.clearMCPSessionUIState(for: createdSession.id)
-            }
-
-            try Task.checkCancellation()
-            guard session.isBackgroundPlanGenerating else {
-                throw CancellationError()
-            }
-
             await progressReporter?(.messageSend)
-            guard let queryId = await oracleViewModel.sendMessage(
-                prompt,
-                sessionID: createdSession.id,
-                overrideModel: model,
-                overrideChatPresetID: chatPresetID,
-                overrideMode: promptMode,
-                gitInclusionOverride: mode == .review ? gitScopeOverride : nil,
-                selectionOverride: selection,
-                lookupContextOverride: lookupContext,
-                overrideAIMessage: aiMessage,
-                completionPolicy: .contextBuilderStrict,
-                onProgress: { [weak self] text, reasoning in
-                    guard let self,
-                          let session = sessions[tabID],
-                          session.isBackgroundPlanGenerating else { return }
-                    session.backgroundPlanResponseText = text
-                    session.backgroundPlanReasoningText = reasoning
-                    applyPlanPreview(to: session)
-                    requestBackgroundPlanUIRefresh(for: tabID)
-                    onProgress?(text, reasoning)
-                }
-            ) else {
-                throw ChatToolError.internalError("Failed to start follow-up stream")
-            }
-
-            guard session.isBackgroundPlanGenerating else {
-                throw CancellationError()
-            }
             await progressReporter?(.activeQueryAcquisition)
             await progressReporter?(.streaming)
-            let responseText = try await waitForFollowUpFinalization(
-                in: oracleViewModel,
-                queryID: queryId,
-                sessionID: createdSession.id,
-                progressReporter: progressReporter,
-                activityReporter: activityReporter
-            )
-            guard session.isBackgroundPlanGenerating else {
-                throw CancellationError()
+        }
+        let reportLaneLifecycle: @MainActor @Sendable (
+            OracleLane,
+            OracleMessageLifecycleActivityEvent
+        ) -> Void = { lane, event in
+            guard isPaired else { return }
+            let label = lane == .primary ? "Primary Oracle" : "Secondary Oracle"
+            let phase: ContextBuilderMCPProgressPhase
+            let message: String
+            switch event.kind {
+            case .streamActivity:
+                guard !terminalLanes.contains(lane) else { return }
+                phase = .streaming
+                message = "Still in \(label) response streaming"
+            case .finalizationCompleted:
+                guard terminalLanes.insert(lane).inserted else { return }
+                phase = .messageFinalization
+                message = "\(label) message finalization completed"
+            case .streamFailed:
+                guard terminalLanes.insert(lane).inserted else { return }
+                phase = .streaming
+                message = "\(label) stream failed"
+            case .streamCancelled:
+                guard terminalLanes.insert(lane).inserted else { return }
+                phase = .streaming
+                message = "\(label) stream cancelled"
+            case .streamInactivityWatchdogFired:
+                guard terminalLanes.insert(lane).inserted else { return }
+                phase = .streaming
+                message = "\(label) stream inactivity watchdog fired"
+            default:
+                return
             }
-
-            let reply = ChatSendReply(
-                chatId: createdSession.id,
-                shortId: createdSession.shortID,
-                mode: modeName,
-                response: responseText,
-                errors: nil
-            )
-
-            session.isBackgroundPlanGenerating = false
-            session.followUpOracleSessionID = nil
-            session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
-                workspaceID: originWorkspaceID,
-                tabID: tabID,
-                chatID: reply.shortId
-            )
-            if let response = reply.response, !response.isEmpty {
-                session.backgroundPlanResponseText = response
+            let previous = laneActivityTail
+            laneActivityTail = Task { @MainActor in
+                await previous?.value
+                await activityReporter?(.report(phase: phase, message: message))
             }
-            clearPendingBackgroundPlanUIRefresh(for: tabID)
-            applyPlanPreview(to: session)
-            updateRuntimeBindings(from: session)
-            workspaceManager?.setActiveChatSessionID(reply.chatId, forTabID: tabID)
+        }
+        let callbacks = OracleViewModel.OracleSendLiveCallbacks(
+            modelsResolved: { [weak self] primary, secondary in
+                guard let self,
+                      let session = sessions[tabID],
+                      session.backgroundPlanGeneration == generation
+                else { return }
+                session.mcpPlanModel = if let secondary {
+                    "\(primary.displayName) + \(secondary.displayName)"
+                } else {
+                    primary.displayName
+                }
+                updateRuntimeBindings(from: session)
+            },
+            pairSessionsResolved: { [weak self] primary, secondary in
+                guard let self, let session = sessions[tabID] else { throw CancellationError() }
+                isPaired = true
+                pin(primary)
+                pin(secondary)
+                try publishFollowUpOracleSessions(
+                    primary: primary,
+                    secondary: secondary,
+                    workspaceID: workspaceID,
+                    oracleViewModel: oracleViewModel,
+                    session: session,
+                    generation: generation
+                )
+                await activityReporter?(.suppressHeartbeat(phase: .streaming))
+                await reportStreamingPhases()
+            },
+            primarySessionResolved: { [weak self] primary in
+                guard let self, let session = sessions[tabID] else { throw CancellationError() }
+                pin(primary)
+                try publishFollowUpOracleSessions(
+                    primary: primary,
+                    secondary: nil,
+                    workspaceID: workspaceID,
+                    oracleViewModel: oracleViewModel,
+                    session: session,
+                    generation: generation
+                )
+                await reportStreamingPhases()
+                await activityReporter?(.report(
+                    phase: .streaming,
+                    message: "Oracle response streaming"
+                ))
+            },
+            primaryProgress: { [weak self] text, reasoning in
+                guard let self, let session = sessions[tabID] else { return }
+                publishPrimaryProgress(text: text, reasoning: reasoning, session: session, generation: generation)
+                onProgress?(text, reasoning)
+            },
+            laneLifecycle: reportLaneLifecycle
+        )
+        let packaging = OracleViewModel.OracleSendPackagingContext(
+            sourceTabID: tabID,
+            sourceWorkspaceID: workspaceID,
+            sourceSelectionRevision: 0,
+            sourceAgentSessionID: agentModeSessionID,
+            sourceAgentRunID: agentModeRunID,
+            promptText: prompt,
+            selection: selection,
+            lookupContext: lookupContext,
+            reviewGitContext: reviewGitContext,
+            prebuiltAIMessage: prebuiltAIMessage,
+            provenance: .direct
+        )
+        let tabContext = OracleViewModel.OracleSendTabContext(
+            tabID: tabID,
+            workspaceID: workspaceID,
+            origin: .compatibility,
+            agentModeSessionID: agentModeSessionID,
+            agentModeRunID: agentModeRunID,
+            activationPolicy: .background,
+            completionPolicy: .contextBuilderStrict,
+            packaging: packaging
+        )
+        var args: [String: Value] = [
+            "message": .string(prompt),
+            "mode": .string(mode.mcpModeName),
+            "chat_name": .string(chatName)
+        ]
+        if let continuationChatID {
+            args["chat_id"] = .string(continuationChatID)
+            args["new_chat"] = .bool(false)
+        } else {
+            args["new_chat"] = .bool(true)
+        }
 
-            return reply
+        func dispatch(_ args: [String: Value]) async throws -> OracleSendResult {
+            #if DEBUG
+                if let send = runTestHooks?.toolChatSend {
+                    return try await send(args, promptManager, tabContext, primaryModelSelection, callbacks)
+                }
+            #endif
+            return try await oracleViewModel.sendOracle(
+                args: args,
+                promptVM: promptManager,
+                tabContext: tabContext,
+                primaryModelSelection: primaryModelSelection,
+                secondaryModelOverride: secondaryModelOverride,
+                liveCallbacks: callbacks
+            )
+        }
+
+        do {
+            let result: OracleSendResult
+            do {
+                result = try await dispatch(args)
+            } catch let error as ChatToolError where continuationChatID != nil &&
+                session.followUpPrimarySessionID == nil &&
+                session.backgroundPlanGeneration == generation &&
+                [.notFound, .invalidParams, .conflict].contains(error.code)
+            {
+                session.generatedAnswerRoute = nil
+                var freshArgs = args
+                freshArgs.removeValue(forKey: "chat_id")
+                freshArgs["new_chat"] = .bool(true)
+                result = try await dispatch(freshArgs)
+            }
+            guard let primarySessionID = session.followUpPrimarySessionID else {
+                throw ChatToolError.internalError("Oracle runtime did not publish a Primary session")
+            }
+            let reply: ChatSendReply = switch result.payload {
+            case let .single(reply): reply
+            case let .paired(pair): pair.primaryReply(fallbackSessionID: primarySessionID)
+            }
+            await laneActivityTail?.value
+            await progressReporter?(.messageFinalization)
+            if !isPaired {
+                await activityReporter?(.report(
+                    phase: .messageFinalization,
+                    message: "Oracle message finalization completed"
+                ))
+            }
+            try publishFollowUpCompletion(reply, workspaceID: workspaceID, session: session, generation: generation)
+            return result
         } catch {
-            if let createdSessionID {
-                await oracleViewModel.cancelStreaming(in: createdSessionID)
-            }
-
+            await laneActivityTail?.value
+            guard session.backgroundPlanGeneration == generation else { throw error }
+            let sessionIDs = takeFollowUpOracleSessionIDs(from: session)
+            _ = scheduleSupersededFollowUpDrain(
+                for: session,
+                supersededTask: nil,
+                sessionIDs: sessionIDs,
+                using: oracleViewModel
+            )
+            session.isBackgroundPlanGenerating = false
+            session.backgroundPlanError = error is CancellationError ? nil : error.asFriendlyString()
+            session.backgroundPlanResponseText = nil
+            session.backgroundPlanReasoningText = nil
             if error is CancellationError {
-                session.backgroundPlanResponseText = nil
-                session.backgroundPlanReasoningText = nil
                 session.generatedAnswerRoute = nil
                 session.backgroundPlanError = nil
-            } else {
-                session.backgroundPlanResponseText = nil
-                session.backgroundPlanReasoningText = nil
-                session.backgroundPlanError = error.asFriendlyString()
             }
-            session.isBackgroundPlanGenerating = false
-            session.followUpOracleSessionID = nil
             clearPendingBackgroundPlanUIRefresh(for: tabID)
             applyPlanPreview(to: session)
             updateRuntimeBindings(from: session)
@@ -4728,16 +4915,6 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     }
 
     /// Run plan or question generation for MCP context_builder.
-    /// This method encapsulates all UI state management for MCP-triggered plan/question generation,
-    /// including cancellation wiring, progress updates, and cleanup.
-    ///
-    /// - Parameters:
-    ///   - tabID: The tab to generate for
-    ///   - oracleViewModel: The OracleViewModel to use for follow-up generation
-    ///   - mode: `.plan`, `.chat` (question), or `.review`
-    ///   - prompt: The effective prompt text (already computed by caller)
-    ///   - selection: The file selection (already computed by caller)
-    /// - Returns: The chat reply with chat_id for follow-up
     @MainActor
     func runMCPPlanOrQuestion(
         for identity: WorkspaceSelectionIdentity,
@@ -4753,124 +4930,223 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         gitScopeOverride: GitInclusion? = nil,
         progressReporter: ContextBuilderMCPProgressReporter? = nil,
         activityReporter: ContextBuilderMCPActivityReporter? = nil
-    ) async throws -> ChatSendReply {
-        let tabID = identity.tabID
+    ) async throws -> OracleSendResult {
         #if DEBUG
             if let runner = runTestHooks?.runMCPFollowUp {
                 return try await runner(mode, prompt, selection)
             }
         #endif
 
-        guard let originWorkspaceID = workspaceID(containing: tabID) else {
-            throw ContextBuilderGenerationError.missingWorkspace
+        let state = session(for: identity.tabID)
+        let continuationChatID = state.generatedAnswerRoute.flatMap { route in
+            route.workspaceID == identity.workspaceID && route.tabID == identity.tabID ? route.chatID : nil
         }
+        let start = beginBackgroundPlanGeneration(for: state, using: oracleViewModel)
+        let operation = Task { @MainActor [weak self] in
+            guard let self else { throw CancellationError() }
+            return try await performMCPPlanOrQuestion(
+                identity: identity,
+                oracleViewModel: oracleViewModel,
+                agentModeSessionID: agentModeSessionID,
+                agentModeRunID: agentModeRunID,
+                mode: mode,
+                prompt: prompt,
+                selection: selection,
+                lookupContext: lookupContext,
+                reviewGitContext: reviewGitContext,
+                finalReviewAuthorization: finalReviewAuthorization,
+                gitScopeOverride: gitScopeOverride,
+                progressReporter: progressReporter,
+                activityReporter: activityReporter,
+                continuationChatID: continuationChatID,
+                generation: start.generation,
+                drain: start.drain
+            )
+        }
+        let wrapper = Task {
+            await withTaskCancellationHandler {
+                _ = await operation.result
+            } onCancel: {
+                operation.cancel()
+            }
+        }
+        state.backgroundPlanTask = wrapper
 
-        let modeName = mode.mcpModeName
+        do {
+            let reply = try await withTaskCancellationHandler {
+                try await operation.value
+            } onCancel: {
+                operation.cancel()
+                wrapper.cancel()
+            }
+            if state.backgroundPlanGeneration == start.generation {
+                state.backgroundPlanTask = nil
+            }
+            return reply
+        } catch {
+            guard state.backgroundPlanGeneration == start.generation else { throw error }
+            state.backgroundPlanTask = nil
+            state.isBackgroundPlanGenerating = false
+            state.backgroundPlanError = error is CancellationError ? nil : error.asFriendlyString()
+            updateRuntimeBindings(from: state)
+            throw error
+        }
+    }
+
+    @MainActor
+    private func performMCPPlanOrQuestion(
+        identity: WorkspaceSelectionIdentity,
+        oracleViewModel: OracleViewModel,
+        agentModeSessionID: UUID?,
+        agentModeRunID: UUID?,
+        mode: HeadlessMode,
+        prompt: String,
+        selection: StoredSelection,
+        lookupContext: WorkspaceLookupContext?,
+        reviewGitContext: FrozenPromptGitReviewContext,
+        finalReviewAuthorization: ContextBuilderFinalReviewAuthorization?,
+        gitScopeOverride: GitInclusion?,
+        progressReporter: ContextBuilderMCPProgressReporter?,
+        activityReporter: ContextBuilderMCPActivityReporter?,
+        continuationChatID: String?,
+        generation: UInt64,
+        drain: ContextBuilderSupersededFollowUpDrain?
+    ) async throws -> OracleSendResult {
+        let state = session(for: identity.tabID)
+        try await awaitSupersededFollowUpDrain(drain)
+        try Task.checkCancellation()
+        guard state.backgroundPlanGeneration == generation else { throw CancellationError() }
+
         await progressReporter?(.modelResolution)
-        let modelSelection: (
-            model: AIModel,
-            chatPresetID: UUID?,
-            mcpControlInfo: String?
-        )
+        let modelSelection: OracleViewModel.ModelSelectionResult
         #if DEBUG
             if let resolver = runTestHooks?.resolveMCPFollowUpModel {
-                modelSelection = try await resolver(modeName)
+                let selection = try await resolver(mode.mcpModeName)
+                modelSelection = .init(
+                    model: selection.model,
+                    mcpControlInfo: selection.mcpControlInfo,
+                    isAutoSelected: false,
+                    chatPresetID: selection.chatPresetID
+                )
             } else {
                 modelSelection = try await oracleViewModel.resolveMCPFollowUpModel(
-                    mode: modeName,
+                    mode: mode.mcpModeName,
                     workspaceID: identity.workspaceID,
-                    planningModelRawOverride: sessions[tabID]?.mcpPlanningModelRaw
+                    planningModelRawOverride: state.mcpPlanningModelRaw
                 )
             }
         #else
             modelSelection = try await oracleViewModel.resolveMCPFollowUpModel(
-                mode: modeName,
+                mode: mode.mcpModeName,
                 workspaceID: identity.workspaceID,
-                planningModelRawOverride: sessions[tabID]?.mcpPlanningModelRaw
+                planningModelRawOverride: state.mcpPlanningModelRaw
             )
         #endif
-        let mcpSessionUIState: OracleViewModel.MCPSessionUIState? = {
-            guard let mcpModelInfo = modelSelection.mcpControlInfo else { return nil }
-            let overrideChatPresetName = modelSelection.chatPresetID
-                .flatMap { ChatPresetManager.shared.preset(with: $0)?.name }
-            return OracleViewModel.MCPSessionUIState(
-                modelInfo: mcpModelInfo,
-                overrideModelName: modelSelection.model.displayName,
-                overrideChatPresetName: overrideChatPresetName
-            )
-        }()
+        try Task.checkCancellation()
+        guard state.backgroundPlanGeneration == generation else { throw CancellationError() }
+        await progressReporter?(.payloadPackaging)
 
-        if workspaceManager?.activeWorkspaceID != identity.workspaceID {
-            let session = session(for: tabID)
-            session.generatedAnswerRoute = nil
-            session.isBackgroundPlanGenerating = true
-            session.backgroundPlanError = nil
-            session.backgroundPlanResponseText = nil
-            session.backgroundPlanReasoningText = nil
-            updateRuntimeBindings(from: session)
-            do {
-                let reply = try await oracleViewModel.runHeadless(
-                    prompt: prompt,
-                    modelParam: nil,
-                    chatName: chatNameForTab(tabID),
-                    tabID: tabID,
-                    selection: selection,
-                    mode: mode,
-                    gitScopeOverride: gitScopeOverride,
-                    reviewGitContext: reviewGitContext,
+        let requiresHeadlessPackaging = finalReviewAuthorization != nil || gitScopeOverride != nil
+        let targetsInactiveWorkspace = workspaceManager?.activeWorkspaceID != identity.workspaceID
+        if requiresHeadlessPackaging || targetsInactiveWorkspace {
+            let secondaryModel = try oracleViewModel.resolveOracleSecondaryModel(workspaceID: identity.workspaceID)
+            try Task.checkCancellation()
+            guard state.backgroundPlanGeneration == generation else { throw CancellationError() }
+
+            if let secondaryModel {
+                let aiMessage: AIMessage? = if requiresHeadlessPackaging {
+                    try await promptManager.buildHeadlessAIMessage(
+                        from: HeadlessContextSnapshot(
+                            workspaceID: identity.workspaceID,
+                            tabID: identity.tabID,
+                            promptText: prompt,
+                            selection: selection,
+                            lookupContext: lookupContext,
+                            reviewGitContext: reviewGitContext,
+                            finalReviewAuthorization: finalReviewAuthorization
+                        ),
+                        model: modelSelection.model,
+                        mode: mode,
+                        gitScopeOverride: gitScopeOverride
+                    )
+                } else {
+                    nil
+                }
+                try Task.checkCancellation()
+                guard state.backgroundPlanGeneration == generation else { throw CancellationError() }
+                return try await runFollowUpOracleStream(
+                    for: identity.tabID,
                     workspaceID: identity.workspaceID,
+                    oracleViewModel: oracleViewModel,
+                    mode: mode,
+                    prompt: prompt,
+                    selection: selection,
                     lookupContext: lookupContext,
-                    resolvedModel: modelSelection.model,
-                    finalReviewAuthorization: finalReviewAuthorization,
+                    reviewGitContext: reviewGitContext,
                     agentModeSessionID: agentModeSessionID,
                     agentModeRunID: agentModeRunID,
-                    completionPolicy: .contextBuilderStrict,
-                    onProgress: { [weak self] text, reasoning in
-                        guard let self, let session = sessions[tabID], session.isBackgroundPlanGenerating else { return }
-                        session.backgroundPlanResponseText = text
-                        session.backgroundPlanReasoningText = reasoning
-                    }
+                    chatName: chatNameForTab(identity.tabID),
+                    primaryModelSelection: modelSelection,
+                    secondaryModelOverride: secondaryModel,
+                    prebuiltAIMessage: aiMessage,
+                    continuationChatID: nil,
+                    progressReporter: progressReporter,
+                    activityReporter: activityReporter,
+                    generation: generation
                 )
-                session.isBackgroundPlanGenerating = false
-                session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
-                    workspaceID: identity.workspaceID,
-                    tabID: tabID,
-                    chatID: reply.shortId
-                )
-                session.backgroundPlanResponseText = reply.response
-                workspaceManager?.setActiveChatSessionID(reply.chatId, for: identity)
-                updateRuntimeBindings(from: session)
-                return reply
-            } catch {
-                session.isBackgroundPlanGenerating = false
-                session.backgroundPlanError = error is CancellationError ? nil : error.asFriendlyString()
-                session.backgroundPlanResponseText = nil
-                session.backgroundPlanReasoningText = nil
-                session.generatedAnswerRoute = nil
-                updateRuntimeBindings(from: session)
-                throw error
             }
+
+            state.mcpPlanModel = modelSelection.model.displayName
+            updateRuntimeBindings(from: state)
+            let reply = try await oracleViewModel.runHeadless(
+                prompt: prompt,
+                modelParam: nil,
+                chatName: chatNameForTab(identity.tabID),
+                tabID: identity.tabID,
+                selection: selection,
+                mode: mode,
+                gitScopeOverride: gitScopeOverride,
+                reviewGitContext: reviewGitContext,
+                workspaceID: identity.workspaceID,
+                lookupContext: lookupContext,
+                resolvedModel: modelSelection.model,
+                finalReviewAuthorization: finalReviewAuthorization,
+                agentModeSessionID: agentModeSessionID,
+                agentModeRunID: agentModeRunID,
+                completionPolicy: .contextBuilderStrict,
+                onProgress: { [weak self] text, reasoning in
+                    guard let self, let session = sessions[identity.tabID] else { return }
+                    publishPrimaryProgress(text: text, reasoning: reasoning, session: session, generation: generation)
+                }
+            )
+            try publishFollowUpCompletion(reply, workspaceID: identity.workspaceID, session: state, generation: generation)
+            return OracleSendResult(
+                payload: .single(reply),
+                route: .init(
+                    contextID: identity.tabID,
+                    agentSessionID: agentModeSessionID,
+                    agentRunID: agentModeRunID
+                )
+            )
         }
 
         return try await runFollowUpOracleStream(
-            for: tabID,
-            originWorkspaceID: originWorkspaceID,
+            for: identity.tabID,
+            workspaceID: identity.workspaceID,
             oracleViewModel: oracleViewModel,
             mode: mode,
             prompt: prompt,
             selection: selection,
             lookupContext: lookupContext,
             reviewGitContext: reviewGitContext,
-            finalReviewAuthorization: finalReviewAuthorization,
             agentModeSessionID: agentModeSessionID,
             agentModeRunID: agentModeRunID,
-            chatName: chatNameForTab(tabID),
-            model: modelSelection.model,
-            chatPresetID: modelSelection.chatPresetID,
-            mcpSessionUIState: mcpSessionUIState,
-            gitScopeOverride: gitScopeOverride,
+            chatName: chatNameForTab(identity.tabID),
+            primaryModelSelection: modelSelection,
+            continuationChatID: continuationChatID,
             progressReporter: progressReporter,
-            activityReporter: activityReporter
+            activityReporter: activityReporter,
+            generation: generation
         )
     }
 
@@ -4890,7 +5166,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             gitScopeOverride: GitInclusion? = nil,
             progressReporter: ContextBuilderMCPProgressReporter? = nil,
             activityReporter: ContextBuilderMCPActivityReporter? = nil
-        ) async throws -> ChatSendReply {
+        ) async throws -> OracleSendResult {
             guard let workspaceID = workspaceManager?.activeWorkspaceID else {
                 throw ContextBuilderWorkspaceContextError.missingWorkspace
             }
@@ -4966,6 +5242,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         oracleViewModel: OracleViewModel,
         chatName: String? = nil,
         mode: HeadlessMode = .plan,
+        continuationChatID: String? = nil,
+        generation: UInt64,
         onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
     ) async throws -> ChatSendReply {
         // Get the tab's current state after Context Builder completed
@@ -4995,19 +5273,32 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             ? await promptManager.freezePromptGitReviewContext(tabID: tabID, base: "HEAD")
             : .automaticOnly()
 
-        return try await runFollowUpOracleStream(
+        let result = try await runFollowUpOracleStream(
             for: tabID,
-            originWorkspaceID: originWorkspaceID,
+            workspaceID: originWorkspaceID,
             oracleViewModel: oracleViewModel,
             mode: mode,
             prompt: prompt,
             selection: selection,
             reviewGitContext: reviewGitContext,
             chatName: chatName ?? defaultChatName,
-            model: promptManager.preferredAIModel,
-            chatPresetID: nil,
-            onProgress: onProgress
+            primaryModelSelection: OracleViewModel.ModelSelectionResult(
+                model: promptManager.preferredAIModel,
+                mcpControlInfo: nil,
+                isAutoSelected: false,
+                chatPresetID: nil
+            ),
+            continuationChatID: continuationChatID,
+            onProgress: onProgress,
+            generation: generation
         )
+        return switch result.payload {
+        case let .single(reply): reply
+        case let .paired(pair):
+            pair.primaryReply(fallbackSessionID: oracleViewModel.sessions.first(where: {
+                $0.shortID == pair.primaryChatID
+            })?.id)
+        }
     }
 
     // MARK: - Clarifying Questions

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -330,7 +330,9 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         /// Monotonic owner for runtime callbacks and completion publication.
         var backgroundPlanGeneration: UInt64 = 0
 
-        /// The two live Oracle lanes used by follow-up streaming.
+        /// Live Oracle lanes used by follow-up streaming. The first two fields
+        /// remain as compatibility projections for existing state/tests.
+        var followUpOracleSessionIDsByLane: [OracleLane: UUID] = [:]
         var followUpPrimarySessionID: UUID?
         var followUpSecondarySessionID: UUID?
 
@@ -416,6 +418,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             mcpPlanningModelRaw = nil
             supersededFollowUpDrain = nil
             backgroundPlanGeneration = 0
+            followUpOracleSessionIDsByLane = [:]
             followUpPrimarySessionID = nil
             followUpSecondarySessionID = nil
             pendingAskUser = nil
@@ -4244,11 +4247,14 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     @MainActor
     private func takeFollowUpOracleSessionIDs(from session: TabSession) -> [UUID] {
-        let ids = [session.followUpPrimarySessionID, session.followUpSecondarySessionID]
-            .compactMap(\.self)
-            .reduce(into: [UUID]()) { result, id in
+        let candidateIDs = session.followUpOracleSessionIDsByLane
+            .sorted { $0.key.ordinal < $1.key.ordinal }
+            .map(\.value) +
+            [session.followUpPrimarySessionID, session.followUpSecondarySessionID].compactMap(\.self)
+        let ids = candidateIDs.reduce(into: [UUID]()) { result, id in
                 if !result.contains(id) { result.append(id) }
             }
+        session.followUpOracleSessionIDsByLane = [:]
         session.followUpPrimarySessionID = nil
         session.followUpSecondarySessionID = nil
         return ids
@@ -4373,16 +4379,18 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     @MainActor
     private func publishFollowUpOracleSessions(
-        primary: UUID,
-        secondary: UUID?,
+        sessionIDsByLane: [OracleLane: UUID],
         workspaceID: UUID,
         oracleViewModel: OracleViewModel,
         session: TabSession,
         generation: UInt64
     ) throws {
-        guard session.backgroundPlanGeneration == generation else { throw CancellationError() }
+        guard session.backgroundPlanGeneration == generation,
+              let primary = sessionIDsByLane[.primary]
+        else { throw CancellationError() }
+        session.followUpOracleSessionIDsByLane = sessionIDsByLane
         session.followUpPrimarySessionID = primary
-        session.followUpSecondarySessionID = secondary
+        session.followUpSecondarySessionID = sessionIDsByLane[.secondary]
         let primaryChatID = oracleViewModel.sessions.first(where: { $0.id == primary })?.shortID
             ?? primary.uuidString
         session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
@@ -4424,6 +4432,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         session.backgroundPlanResponseText = reply.response
         session.backgroundPlanError = nil
         session.isBackgroundPlanGenerating = false
+        session.followUpOracleSessionIDsByLane = [:]
         session.followUpPrimarySessionID = nil
         session.followUpSecondarySessionID = nil
         clearPendingBackgroundPlanUIRefresh(for: session.tabID)
@@ -4666,7 +4675,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     // MARK: - MCP Plan/Question Generation
 
-    /// Streams ordinary follow-ups through the single-or-paired Oracle runtime without activating chat UI.
+    /// Streams ordinary follow-ups through the single-or-grouped Oracle runtime without activating chat UI.
     @MainActor
     private func runFollowUpOracleStream(
         for tabID: UUID,
@@ -4681,6 +4690,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         agentModeRunID: UUID? = nil,
         chatName: String,
         primaryModelSelection: OracleViewModel.ModelSelectionResult,
+        additionalModelOverrides: [AIModel]? = nil,
         secondaryModelOverride: AIModel? = nil,
         prebuiltAIMessage: AIMessage? = nil,
         continuationChatID: String? = nil,
@@ -4706,7 +4716,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             }
         }
 
-        var isPaired = false
+        var isGrouped = false
         var terminalLanes: Set<OracleLane> = []
         var laneActivityTail: Task<Void, Never>?
         let reportStreamingPhases: @MainActor @Sendable () async -> Void = {
@@ -4719,8 +4729,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             OracleLane,
             OracleMessageLifecycleActivityEvent
         ) -> Void = { lane, event in
-            guard isPaired else { return }
-            let label = lane == .primary ? "Primary Oracle" : "Secondary Oracle"
+            guard isGrouped else { return }
+            let label = lane == .primary ? "Primary Oracle" : "Oracle \(lane.ordinal)"
             let phase: ContextBuilderMCPProgressPhase
             let message: String
             switch event.kind {
@@ -4753,6 +4763,22 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 await activityReporter?(.report(phase: phase, message: message))
             }
         }
+        let publishGroupSessions: @MainActor @Sendable ([OracleLane: UUID]) async throws -> Void = { [weak self] sessionIDsByLane in
+            guard let self, let session = sessions[tabID] else { throw CancellationError() }
+            isGrouped = true
+            for sessionID in sessionIDsByLane.values {
+                pin(sessionID)
+            }
+            try publishFollowUpOracleSessions(
+                sessionIDsByLane: sessionIDsByLane,
+                workspaceID: workspaceID,
+                oracleViewModel: oracleViewModel,
+                session: session,
+                generation: generation
+            )
+            await activityReporter?(.suppressHeartbeat(phase: .streaming))
+            await reportStreamingPhases()
+        }
         let callbacks = OracleViewModel.OracleSendLiveCallbacks(
             modelsResolved: { [weak self] primary, secondary in
                 guard let self,
@@ -4766,28 +4792,26 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 }
                 updateRuntimeBindings(from: session)
             },
-            pairSessionsResolved: { [weak self] primary, secondary in
-                guard let self, let session = sessions[tabID] else { throw CancellationError() }
-                isPaired = true
-                pin(primary)
-                pin(secondary)
-                try publishFollowUpOracleSessions(
-                    primary: primary,
-                    secondary: secondary,
-                    workspaceID: workspaceID,
-                    oracleViewModel: oracleViewModel,
-                    session: session,
-                    generation: generation
-                )
-                await activityReporter?(.suppressHeartbeat(phase: .streaming))
-                await reportStreamingPhases()
+            groupModelsResolved: { [weak self] modelsByLane in
+                guard let self,
+                      let session = sessions[tabID],
+                      session.backgroundPlanGeneration == generation
+                else { return }
+                session.mcpPlanModel = modelsByLane
+                    .sorted { $0.key.ordinal < $1.key.ordinal }
+                    .map { $0.value.displayName }
+                    .joined(separator: " + ")
+                updateRuntimeBindings(from: session)
             },
+            pairSessionsResolved: { primary, secondary in
+                try await publishGroupSessions([.primary: primary, .secondary: secondary])
+            },
+            groupSessionsResolved: publishGroupSessions,
             primarySessionResolved: { [weak self] primary in
                 guard let self, let session = sessions[tabID] else { throw CancellationError() }
                 pin(primary)
                 try publishFollowUpOracleSessions(
-                    primary: primary,
-                    secondary: nil,
+                    sessionIDsByLane: [.primary: primary],
                     workspaceID: workspaceID,
                     oracleViewModel: oracleViewModel,
                     session: session,
@@ -4852,6 +4876,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 promptVM: promptManager,
                 tabContext: tabContext,
                 primaryModelSelection: primaryModelSelection,
+                additionalModelOverrides: additionalModelOverrides,
                 secondaryModelOverride: secondaryModelOverride,
                 liveCallbacks: callbacks
             )
@@ -4881,7 +4906,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             }
             await laneActivityTail?.value
             await progressReporter?(.messageFinalization)
-            if !isPaired {
+            if !isGrouped {
                 await activityReporter?(.report(
                     phase: .messageFinalization,
                     message: "Oracle message finalization completed"
@@ -5049,11 +5074,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         let requiresHeadlessPackaging = finalReviewAuthorization != nil || gitScopeOverride != nil
         let targetsInactiveWorkspace = workspaceManager?.activeWorkspaceID != identity.workspaceID
         if requiresHeadlessPackaging || targetsInactiveWorkspace {
-            let secondaryModel = try oracleViewModel.resolveOracleSecondaryModel(workspaceID: identity.workspaceID)
+            let additionalModels = try oracleViewModel.resolveAdditionalOracleModels(workspaceID: identity.workspaceID)
             try Task.checkCancellation()
             guard state.backgroundPlanGeneration == generation else { throw CancellationError() }
 
-            if let secondaryModel {
+            if !additionalModels.isEmpty {
                 let aiMessage: AIMessage? = if requiresHeadlessPackaging {
                     try await promptManager.buildHeadlessAIMessage(
                         from: HeadlessContextSnapshot(
@@ -5087,7 +5112,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     agentModeRunID: agentModeRunID,
                     chatName: chatNameForTab(identity.tabID),
                     primaryModelSelection: modelSelection,
-                    secondaryModelOverride: secondaryModel,
+                    additionalModelOverrides: additionalModels,
                     prebuiltAIMessage: aiMessage,
                     continuationChatID: nil,
                     progressReporter: progressReporter,

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -4252,8 +4252,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             .map(\.value) +
             [session.followUpPrimarySessionID, session.followUpSecondarySessionID].compactMap(\.self)
         let ids = candidateIDs.reduce(into: [UUID]()) { result, id in
-                if !result.contains(id) { result.append(id) }
-            }
+            if !result.contains(id) { result.append(id) }
+        }
         session.followUpOracleSessionIDsByLane = [:]
         session.followUpPrimarySessionID = nil
         session.followUpSecondarySessionID = nil
@@ -4799,7 +4799,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 else { return }
                 session.mcpPlanModel = modelsByLane
                     .sorted { $0.key.ordinal < $1.key.ordinal }
-                    .map { $0.value.displayName }
+                    .map(\.value.displayName)
                     .joined(separator: " + ")
                 updateRuntimeBindings(from: session)
             },

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -4872,12 +4872,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 freshArgs["new_chat"] = .bool(true)
                 result = try await dispatch(freshArgs)
             }
-            guard let primarySessionID = session.followUpPrimarySessionID else {
+            guard session.followUpPrimarySessionID != nil else {
                 throw ChatToolError.internalError("Oracle runtime did not publish a Primary session")
             }
             let reply: ChatSendReply = switch result.payload {
             case let .single(reply): reply
-            case let .paired(pair): pair.primaryReply(fallbackSessionID: primarySessionID)
+            case let .paired(pair): pair.primaryReply()
             }
             await laneActivityTail?.value
             await progressReporter?(.messageFinalization)
@@ -5294,10 +5294,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         )
         return switch result.payload {
         case let .single(reply): reply
-        case let .paired(pair):
-            pair.primaryReply(fallbackSessionID: oracleViewModel.sessions.first(where: {
-                $0.shortID == pair.primaryChatID
-            })?.id)
+        case let .paired(pair): pair.primaryReply()
         }
     }
 

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -4730,7 +4730,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             OracleMessageLifecycleActivityEvent
         ) -> Void = { lane, event in
             guard isGrouped else { return }
-            let label = lane == .primary ? "Primary Oracle" : "Oracle \(lane.ordinal)"
+            let label = lane.displayLabel
             let phase: ContextBuilderMCPProgressPhase
             let message: String
             switch event.kind {

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
@@ -282,15 +282,15 @@ final class ContextBuilderRunRecord {
             switch item {
             case let .firstEvent(type):
                 await reportProgress(.providerStreamActive)
-                await activityReporter?(
-                    .providerStreamActive,
-                    "First discovery provider event received: \(type)"
-                )
+                await activityReporter?(.report(
+                    phase: .providerStreamActive,
+                    message: "First discovery provider event received: \(type)"
+                ))
             case let .firstRepoPromptTool(name):
-                await activityReporter?(
-                    .providerStreamActive,
-                    "First nested RepoPrompt MCP tool request observed: \(name)"
-                )
+                await activityReporter?(.report(
+                    phase: .providerStreamActive,
+                    message: "First nested RepoPrompt MCP tool request observed: \(name)"
+                ))
             }
         }
     }

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -329,6 +329,7 @@ class PromptViewModel: ObservableObject {
     private var sessionPreferredModelOverrideRaw: String?
     @Published private var _contextBuilderModel: String = "" // workspace-scoped (synced from ChatGlobalSettings)
     @Published private var _planningModel: String = ""
+    @Published private(set) var secondaryOracleModelRaw: String?
 
     /// Returns the chosen planning model as an `AIModel` (falls back to preferredAIModel).
     var planningModel: AIModel {
@@ -883,6 +884,7 @@ class PromptViewModel: ObservableObject {
             currentRaw: _planningModel,
             persistedRaw: profile.planningModelRaw
         )
+        secondaryOracleModelRaw = profile.secondaryOracleModelRaw
         if sessionPreferredModelOverrideRaw == nil {
             _preferredModel = Self.modelRawAfterSettingsSync(
                 currentRaw: _preferredModel,

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -329,6 +329,7 @@ class PromptViewModel: ObservableObject {
     private var sessionPreferredModelOverrideRaw: String?
     @Published private var _contextBuilderModel: String = "" // workspace-scoped (synced from ChatGlobalSettings)
     @Published private var _planningModel: String = ""
+    @Published private(set) var additionalOracleModelRaws: [String] = []
     @Published private(set) var secondaryOracleModelRaw: String?
 
     /// Returns the chosen planning model as an `AIModel` (falls back to preferredAIModel).
@@ -884,7 +885,8 @@ class PromptViewModel: ObservableObject {
             currentRaw: _planningModel,
             persistedRaw: profile.planningModelRaw
         )
-        secondaryOracleModelRaw = profile.secondaryOracleModelRaw
+        additionalOracleModelRaws = profile.additionalOracleModelRaws
+        secondaryOracleModelRaw = additionalOracleModelRaws.first
         if sessionPreferredModelOverrideRaw == nil {
             _preferredModel = Self.modelRawAfterSettingsSync(
                 currentRaw: _preferredModel,

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
@@ -5,7 +5,8 @@ import Foundation
 ///
 /// Schema v1 contains copy settings, chat settings, and cross-workspace global
 /// defaults. Schema v2 adds optional scalar preference groups. Schema v4 adds
-/// workspace-scoped Agent Models profiles. Scalar fields stay optional so missing
+/// workspace-scoped Agent Models profiles. Schema v5 adds Secondary Oracle model
+/// selection. Scalar fields stay optional so missing
 /// JSON fields fall back through the typed GlobalSettingsStore accessors without
 /// losing current default behavior.
 struct GlobalSettingsDocument: Codable {
@@ -14,7 +15,8 @@ struct GlobalSettingsDocument: Codable {
     /// version from `currentSchemaVersion`.
     static let baselineSchemaVersion = 2
     static let workspaceAgentModelsSchemaVersion = 4
-    static let currentSchemaVersion = 4
+    static let secondaryOracleSchemaVersion = 5
+    static let currentSchemaVersion = 5
     /// Lineage marker for settings files written by this open-source CE schema family.
     ///
     /// CE inherited numeric schema versions from classic/internal builds, so version numbers
@@ -77,6 +79,17 @@ struct GlobalSettingsDocument: Codable {
         var requiredVersion = Self.baselineSchemaVersion
         if let agentModelsSettingsByWorkspaceID, !agentModelsSettingsByWorkspaceID.isEmpty {
             requiredVersion = max(requiredVersion, Self.workspaceAgentModelsSchemaVersion)
+        }
+        let hasGlobalSecondary = scalarPreferences?.modelSelection?.secondaryOracleModel?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+        let hasWorkspaceSecondary = agentModelsSettingsByWorkspaceID?.values.contains {
+            $0.profile?.secondaryOracleModelRaw?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty == false
+        } == true
+        if hasGlobalSecondary || hasWorkspaceSecondary {
+            requiredVersion = max(requiredVersion, Self.secondaryOracleSchemaVersion)
         }
         return requiredVersion
     }
@@ -170,6 +183,7 @@ enum ContextBuilderSettingsWriteIntent {
 
 struct AgentModelsSettingsProfile: Codable, Equatable {
     var planningModelRaw: String?
+    var secondaryOracleModelRaw: String?
     var preferredComposeModelRaw: String?
     var syncChatModelWithOracle: Bool
     var contextBuilderAgentRaw: String?
@@ -179,6 +193,7 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
 
     init(
         planningModelRaw: String? = nil,
+        secondaryOracleModelRaw: String? = nil,
         preferredComposeModelRaw: String? = nil,
         syncChatModelWithOracle: Bool = false,
         contextBuilderAgentRaw: String? = nil,
@@ -187,6 +202,7 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
         restrictMCPAgentDiscoveryToRoleLabels: Bool = false
     ) {
         self.planningModelRaw = Self.normalizedChatModelRaw(planningModelRaw)
+        self.secondaryOracleModelRaw = Self.normalizedChatModelRaw(secondaryOracleModelRaw)
         self.preferredComposeModelRaw = Self.normalizedChatModelRaw(preferredComposeModelRaw)
         self.syncChatModelWithOracle = syncChatModelWithOracle
         self.contextBuilderAgentRaw = Self.normalizedAgentRaw(contextBuilderAgentRaw)
@@ -197,6 +213,7 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
 
     private enum CodingKeys: String, CodingKey {
         case planningModelRaw
+        case secondaryOracleModelRaw
         case preferredComposeModelRaw
         case syncChatModelWithOracle
         case contextBuilderAgentRaw
@@ -209,6 +226,7 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         try self.init(
             planningModelRaw: container.decodeIfPresent(String.self, forKey: .planningModelRaw),
+            secondaryOracleModelRaw: container.decodeIfPresent(String.self, forKey: .secondaryOracleModelRaw),
             preferredComposeModelRaw: container.decodeIfPresent(String.self, forKey: .preferredComposeModelRaw),
             syncChatModelWithOracle: container.decodeIfPresent(Bool.self, forKey: .syncChatModelWithOracle) ?? false,
             contextBuilderAgentRaw: container.decodeIfPresent(String.self, forKey: .contextBuilderAgentRaw),
@@ -453,15 +471,18 @@ struct GlobalScalarPreferences: Codable, Equatable {
     struct ModelSelectionSettings: Codable, Equatable {
         var preferredComposeModel: String?
         var planningModel: String?
+        var secondaryOracleModel: String?
         var syncChatModelWithOracle: Bool?
 
         init(
             preferredComposeModel: String? = nil,
             planningModel: String? = nil,
+            secondaryOracleModel: String? = nil,
             syncChatModelWithOracle: Bool? = nil
         ) {
             self.preferredComposeModel = preferredComposeModel
             self.planningModel = planningModel
+            self.secondaryOracleModel = secondaryOracleModel
             self.syncChatModelWithOracle = syncChatModelWithOracle
         }
     }

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
@@ -6,7 +6,8 @@ import Foundation
 /// Schema v1 contains copy settings, chat settings, and cross-workspace global
 /// defaults. Schema v2 adds optional scalar preference groups. Schema v4 adds
 /// workspace-scoped Agent Models profiles. Schema v5 adds Secondary Oracle model
-/// selection. Scalar fields stay optional so missing
+/// selection. Schema v6 generalizes that setting to an ordered collection of up
+/// to four additional Oracle models. Scalar fields stay optional so missing
 /// JSON fields fall back through the typed GlobalSettingsStore accessors without
 /// losing current default behavior.
 struct GlobalSettingsDocument: Codable {
@@ -16,7 +17,8 @@ struct GlobalSettingsDocument: Codable {
     static let baselineSchemaVersion = 2
     static let workspaceAgentModelsSchemaVersion = 4
     static let secondaryOracleSchemaVersion = 5
-    static let currentSchemaVersion = 5
+    static let additionalOraclesSchemaVersion = 6
+    static let currentSchemaVersion = 6
     /// Lineage marker for settings files written by this open-source CE schema family.
     ///
     /// CE inherited numeric schema versions from classic/internal builds, so version numbers
@@ -90,6 +92,14 @@ struct GlobalSettingsDocument: Codable {
         } == true
         if hasGlobalSecondary || hasWorkspaceSecondary {
             requiredVersion = max(requiredVersion, Self.secondaryOracleSchemaVersion)
+        }
+        let hasGlobalAdditionalOracles = scalarPreferences?.modelSelection?.additionalOracleModels?
+            .contains { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty } == true
+        let hasWorkspaceAdditionalOracles = agentModelsSettingsByWorkspaceID?.values.contains {
+            $0.profile?.additionalOracleModelRaws.isEmpty == false
+        } == true
+        if hasGlobalAdditionalOracles || hasWorkspaceAdditionalOracles {
+            requiredVersion = max(requiredVersion, Self.additionalOraclesSchemaVersion)
         }
         return requiredVersion
     }
@@ -182,8 +192,27 @@ enum ContextBuilderSettingsWriteIntent {
 }
 
 struct AgentModelsSettingsProfile: Codable, Equatable {
+    static let maximumAdditionalOracleModels = 4
+
     var planningModelRaw: String?
-    var secondaryOracleModelRaw: String?
+    var additionalOracleModelRaws: [String]
+    /// Compatibility projection for the original dual-Oracle setting and runtime.
+    /// The legacy Secondary Oracle is always the first ordered additional Oracle.
+    var secondaryOracleModelRaw: String? {
+        get { additionalOracleModelRaws.first }
+        set {
+            if let normalized = Self.normalizedChatModelRaw(newValue) {
+                if additionalOracleModelRaws.isEmpty {
+                    additionalOracleModelRaws.append(normalized)
+                } else {
+                    additionalOracleModelRaws[0] = normalized
+                }
+            } else if !additionalOracleModelRaws.isEmpty {
+                additionalOracleModelRaws.removeFirst()
+            }
+        }
+    }
+
     var preferredComposeModelRaw: String?
     var syncChatModelWithOracle: Bool
     var contextBuilderAgentRaw: String?
@@ -194,6 +223,7 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
     init(
         planningModelRaw: String? = nil,
         secondaryOracleModelRaw: String? = nil,
+        additionalOracleModelRaws: [String]? = nil,
         preferredComposeModelRaw: String? = nil,
         syncChatModelWithOracle: Bool = false,
         contextBuilderAgentRaw: String? = nil,
@@ -202,7 +232,9 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
         restrictMCPAgentDiscoveryToRoleLabels: Bool = false
     ) {
         self.planningModelRaw = Self.normalizedChatModelRaw(planningModelRaw)
-        self.secondaryOracleModelRaw = Self.normalizedChatModelRaw(secondaryOracleModelRaw)
+        self.additionalOracleModelRaws = Self.normalizedAdditionalOracleModelRaws(
+            additionalOracleModelRaws ?? secondaryOracleModelRaw.map { [$0] } ?? []
+        )
         self.preferredComposeModelRaw = Self.normalizedChatModelRaw(preferredComposeModelRaw)
         self.syncChatModelWithOracle = syncChatModelWithOracle
         self.contextBuilderAgentRaw = Self.normalizedAgentRaw(contextBuilderAgentRaw)
@@ -214,6 +246,7 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case planningModelRaw
         case secondaryOracleModelRaw
+        case additionalOracleModelRaws
         case preferredComposeModelRaw
         case syncChatModelWithOracle
         case contextBuilderAgentRaw
@@ -227,12 +260,31 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
         try self.init(
             planningModelRaw: container.decodeIfPresent(String.self, forKey: .planningModelRaw),
             secondaryOracleModelRaw: container.decodeIfPresent(String.self, forKey: .secondaryOracleModelRaw),
+            additionalOracleModelRaws: container.decodeIfPresent([String].self, forKey: .additionalOracleModelRaws),
             preferredComposeModelRaw: container.decodeIfPresent(String.self, forKey: .preferredComposeModelRaw),
             syncChatModelWithOracle: container.decodeIfPresent(Bool.self, forKey: .syncChatModelWithOracle) ?? false,
             contextBuilderAgentRaw: container.decodeIfPresent(String.self, forKey: .contextBuilderAgentRaw),
             contextBuilderModelsByAgent: container.decodeIfPresent([String: String].self, forKey: .contextBuilderModelsByAgent),
             mcpAgentRoleOverrides: container.decodeIfPresent([String: String].self, forKey: .mcpAgentRoleOverrides),
             restrictMCPAgentDiscoveryToRoleLabels: container.decodeIfPresent(Bool.self, forKey: .restrictMCPAgentDiscoveryToRoleLabels) ?? false
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(planningModelRaw, forKey: .planningModelRaw)
+        try container.encodeIfPresent(secondaryOracleModelRaw, forKey: .secondaryOracleModelRaw)
+        if !additionalOracleModelRaws.isEmpty {
+            try container.encode(additionalOracleModelRaws, forKey: .additionalOracleModelRaws)
+        }
+        try container.encodeIfPresent(preferredComposeModelRaw, forKey: .preferredComposeModelRaw)
+        try container.encode(syncChatModelWithOracle, forKey: .syncChatModelWithOracle)
+        try container.encodeIfPresent(contextBuilderAgentRaw, forKey: .contextBuilderAgentRaw)
+        try container.encodeIfPresent(contextBuilderModelsByAgent, forKey: .contextBuilderModelsByAgent)
+        try container.encodeIfPresent(mcpAgentRoleOverrides, forKey: .mcpAgentRoleOverrides)
+        try container.encode(
+            restrictMCPAgentDiscoveryToRoleLabels,
+            forKey: .restrictMCPAgentDiscoveryToRoleLabels
         )
     }
 
@@ -253,6 +305,10 @@ struct AgentModelsSettingsProfile: Codable, Equatable {
 
     private static func normalizedChatModelRaw(_ raw: String?) -> String? {
         trimmedNonEmpty(raw)
+    }
+
+    private static func normalizedAdditionalOracleModelRaws(_ raws: [String]) -> [String] {
+        Array(raws.compactMap(normalizedChatModelRaw).prefix(maximumAdditionalOracleModels))
     }
 
     private static func normalizedAgentRaw(_ raw: String?) -> String? {
@@ -472,18 +528,60 @@ struct GlobalScalarPreferences: Codable, Equatable {
         var preferredComposeModel: String?
         var planningModel: String?
         var secondaryOracleModel: String?
+        var additionalOracleModels: [String]?
         var syncChatModelWithOracle: Bool?
 
         init(
             preferredComposeModel: String? = nil,
             planningModel: String? = nil,
             secondaryOracleModel: String? = nil,
+            additionalOracleModels: [String]? = nil,
             syncChatModelWithOracle: Bool? = nil
         ) {
             self.preferredComposeModel = preferredComposeModel
             self.planningModel = planningModel
             self.secondaryOracleModel = secondaryOracleModel
+            self.additionalOracleModels = Self.normalizedAdditionalOracleModels(additionalOracleModels)
             self.syncChatModelWithOracle = syncChatModelWithOracle
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case preferredComposeModel
+            case planningModel
+            case secondaryOracleModel
+            case additionalOracleModels
+            case syncChatModelWithOracle
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            try self.init(
+                preferredComposeModel: container.decodeIfPresent(String.self, forKey: .preferredComposeModel),
+                planningModel: container.decodeIfPresent(String.self, forKey: .planningModel),
+                secondaryOracleModel: container.decodeIfPresent(String.self, forKey: .secondaryOracleModel),
+                additionalOracleModels: container.decodeIfPresent([String].self, forKey: .additionalOracleModels),
+                syncChatModelWithOracle: container.decodeIfPresent(Bool.self, forKey: .syncChatModelWithOracle)
+            )
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(preferredComposeModel, forKey: .preferredComposeModel)
+            try container.encodeIfPresent(planningModel, forKey: .planningModel)
+            try container.encodeIfPresent(secondaryOracleModel, forKey: .secondaryOracleModel)
+            try container.encodeIfPresent(additionalOracleModels, forKey: .additionalOracleModels)
+            try container.encodeIfPresent(syncChatModelWithOracle, forKey: .syncChatModelWithOracle)
+        }
+
+        private static func normalizedAdditionalOracleModels(_ raws: [String]?) -> [String]? {
+            guard let raws else { return nil }
+            return Array(
+                raws.compactMap { raw in
+                    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return trimmed.isEmpty ? nil : trimmed
+                }
+                .prefix(AgentModelsSettingsProfile.maximumAdditionalOracleModels)
+            )
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -483,6 +483,7 @@ class GlobalSettingsStore: ObservableObject {
     func globalAgentModelsProfile() -> AgentModelsSettingsProfile {
         AgentModelsSettingsProfile(
             planningModelRaw: scalarPreferences.modelSelection?.planningModel,
+            secondaryOracleModelRaw: scalarPreferences.modelSelection?.secondaryOracleModel,
             preferredComposeModelRaw: scalarPreferences.modelSelection?.preferredComposeModel,
             syncChatModelWithOracle: resolvedSyncChatModelWithOracleFromCurrentPreferences(),
             contextBuilderAgentRaw: globalDefaults.discoverAgentRaw,
@@ -500,6 +501,7 @@ class GlobalSettingsStore: ObservableObject {
         let normalized = normalizedAgentModelsProfile(profile)
         var modelSelection = scalarPreferences.modelSelection ?? GlobalScalarPreferences.ModelSelectionSettings()
         modelSelection.planningModel = normalized.planningModelRaw
+        modelSelection.secondaryOracleModel = normalized.secondaryOracleModelRaw
         modelSelection.preferredComposeModel = normalized.preferredComposeModelRaw
         modelSelection.syncChatModelWithOracle = normalized.syncChatModelWithOracle
         scalarPreferences.modelSelection = modelSelection
@@ -625,9 +627,14 @@ class GlobalSettingsStore: ObservableObject {
         var globalChanged = false
         var modelSelection = scalarPreferences.modelSelection ?? GlobalScalarPreferences.ModelSelectionSettings()
         let planning = normalized(modelSelection.planningModel)
+        let secondaryOracle = normalized(modelSelection.secondaryOracleModel)
         let compose = normalized(modelSelection.preferredComposeModel)
-        if planning != modelSelection.planningModel || compose != modelSelection.preferredComposeModel {
+        if planning != modelSelection.planningModel ||
+            secondaryOracle != modelSelection.secondaryOracleModel ||
+            compose != modelSelection.preferredComposeModel
+        {
             modelSelection.planningModel = planning
+            modelSelection.secondaryOracleModel = secondaryOracle
             modelSelection.preferredComposeModel = compose
             scalarPreferences.modelSelection = modelSelection
             globalChanged = true
@@ -650,6 +657,7 @@ class GlobalSettingsStore: ObservableObject {
             guard var settings = agentModelsSettingsByWorkspaceID[workspaceID], var profile = settings.profile else { continue }
             let old = profile
             profile.planningModelRaw = normalized(profile.planningModelRaw)
+            profile.secondaryOracleModelRaw = normalized(profile.secondaryOracleModelRaw)
             profile.preferredComposeModelRaw = normalized(profile.preferredComposeModelRaw)
             if let models = profile.contextBuilderModelsByAgent {
                 profile.contextBuilderModelsByAgent = models.mapValues { AIModel.rawValueWithoutOpenAIServiceTier($0) }
@@ -1020,6 +1028,38 @@ class GlobalSettingsStore: ObservableObject {
 
     func planningModelRaw() -> String? {
         scalarPreferences.modelSelection?.planningModel
+    }
+
+    func secondaryOracleModelRaw() -> String? {
+        scalarPreferences.modelSelection?.secondaryOracleModel
+    }
+
+    func setSecondaryOracleModelRaw(
+        _ raw: String?,
+        commit: Bool = true,
+        reason: String? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        function: StaticString = #function
+    ) {
+        let oldAgentModelsProfile = globalAgentModelsProfile()
+        let oldValue = scalarPreferences.modelSelection?.secondaryOracleModel
+        updateModelSelectionScalar(commit: commit) { settings in
+            settings.secondaryOracleModel = Self.trimmedNonEmptyModelRaw(raw)
+        }
+        recordSettingsWriteDiagnostic(
+            key: "secondaryOracleModelRaw",
+            oldValue: oldValue,
+            newValue: raw,
+            commit: commit,
+            reason: reason,
+            fileID: fileID,
+            line: line,
+            function: function
+        )
+        if globalAgentModelsProfile() != oldAgentModelsProfile {
+            postAgentModelsSettingsDidChange(scope: .global)
+        }
     }
 
     func setPlanningModelRaw(
@@ -2107,6 +2147,7 @@ class GlobalSettingsStore: ObservableObject {
     private func normalizedAgentModelsProfile(_ profile: AgentModelsSettingsProfile) -> AgentModelsSettingsProfile {
         var normalized = AgentModelsSettingsProfile(
             planningModelRaw: profile.planningModelRaw,
+            secondaryOracleModelRaw: profile.secondaryOracleModelRaw,
             preferredComposeModelRaw: profile.preferredComposeModelRaw,
             syncChatModelWithOracle: profile.syncChatModelWithOracle,
             contextBuilderAgentRaw: profile.contextBuilderAgentRaw,
@@ -2168,6 +2209,7 @@ class GlobalSettingsStore: ObservableObject {
         let contextBuilderModelRaw = profile.contextBuilderAgentRaw.flatMap { profile.contextBuilderModelsByAgent?[$0] }
         return [
             "planning=\(profile.planningModelRaw ?? "nil")",
+            "secondaryOracle=\(profile.secondaryOracleModelRaw ?? "nil")",
             "compose=\(profile.preferredComposeModelRaw ?? "nil")",
             "sync=\(profile.syncChatModelWithOracle)",
             "contextBuilder=\(profile.contextBuilderAgentRaw ?? "nil"):\(contextBuilderModelRaw ?? "nil")",

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -481,10 +481,14 @@ class GlobalSettingsStore: ObservableObject {
     // MARK: - Scoped Agent Models Settings
 
     func globalAgentModelsProfile() -> AgentModelsSettingsProfile {
-        AgentModelsSettingsProfile(
-            planningModelRaw: scalarPreferences.modelSelection?.planningModel,
-            secondaryOracleModelRaw: scalarPreferences.modelSelection?.secondaryOracleModel,
-            preferredComposeModelRaw: scalarPreferences.modelSelection?.preferredComposeModel,
+        let modelSelection = scalarPreferences.modelSelection
+        return AgentModelsSettingsProfile(
+            planningModelRaw: modelSelection?.planningModel,
+            additionalOracleModelRaws: Self.normalizedAdditionalOracleModelRaws(
+                modelSelection?.additionalOracleModels,
+                legacySecondary: modelSelection?.secondaryOracleModel
+            ),
+            preferredComposeModelRaw: modelSelection?.preferredComposeModel,
             syncChatModelWithOracle: resolvedSyncChatModelWithOracleFromCurrentPreferences(),
             contextBuilderAgentRaw: globalDefaults.discoverAgentRaw,
             contextBuilderModelsByAgent: globalDefaults.discoverModelsByAgent,
@@ -501,6 +505,9 @@ class GlobalSettingsStore: ObservableObject {
         let normalized = normalizedAgentModelsProfile(profile)
         var modelSelection = scalarPreferences.modelSelection ?? GlobalScalarPreferences.ModelSelectionSettings()
         modelSelection.planningModel = normalized.planningModelRaw
+        modelSelection.additionalOracleModels = normalized.additionalOracleModelRaws.isEmpty
+            ? nil
+            : normalized.additionalOracleModelRaws
         modelSelection.secondaryOracleModel = normalized.secondaryOracleModelRaw
         modelSelection.preferredComposeModel = normalized.preferredComposeModelRaw
         modelSelection.syncChatModelWithOracle = normalized.syncChatModelWithOracle
@@ -628,13 +635,16 @@ class GlobalSettingsStore: ObservableObject {
         var modelSelection = scalarPreferences.modelSelection ?? GlobalScalarPreferences.ModelSelectionSettings()
         let planning = normalized(modelSelection.planningModel)
         let secondaryOracle = normalized(modelSelection.secondaryOracleModel)
+        let additionalOracles = modelSelection.additionalOracleModels?.compactMap(normalized)
         let compose = normalized(modelSelection.preferredComposeModel)
         if planning != modelSelection.planningModel ||
             secondaryOracle != modelSelection.secondaryOracleModel ||
+            additionalOracles != modelSelection.additionalOracleModels ||
             compose != modelSelection.preferredComposeModel
         {
             modelSelection.planningModel = planning
             modelSelection.secondaryOracleModel = secondaryOracle
+            modelSelection.additionalOracleModels = additionalOracles?.isEmpty == true ? nil : additionalOracles
             modelSelection.preferredComposeModel = compose
             scalarPreferences.modelSelection = modelSelection
             globalChanged = true
@@ -657,7 +667,7 @@ class GlobalSettingsStore: ObservableObject {
             guard var settings = agentModelsSettingsByWorkspaceID[workspaceID], var profile = settings.profile else { continue }
             let old = profile
             profile.planningModelRaw = normalized(profile.planningModelRaw)
-            profile.secondaryOracleModelRaw = normalized(profile.secondaryOracleModelRaw)
+            profile.additionalOracleModelRaws = profile.additionalOracleModelRaws.compactMap(normalized)
             profile.preferredComposeModelRaw = normalized(profile.preferredComposeModelRaw)
             if let models = profile.contextBuilderModelsByAgent {
                 profile.contextBuilderModelsByAgent = models.mapValues { AIModel.rawValueWithoutOpenAIServiceTier($0) }
@@ -1031,7 +1041,41 @@ class GlobalSettingsStore: ObservableObject {
     }
 
     func secondaryOracleModelRaw() -> String? {
-        scalarPreferences.modelSelection?.secondaryOracleModel
+        globalAgentModelsProfile().secondaryOracleModelRaw
+    }
+
+    func additionalOracleModelRaws() -> [String] {
+        globalAgentModelsProfile().additionalOracleModelRaws
+    }
+
+    func setAdditionalOracleModelRaws(
+        _ raws: [String],
+        commit: Bool = true,
+        reason: String? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line,
+        function: StaticString = #function
+    ) {
+        let oldAgentModelsProfile = globalAgentModelsProfile()
+        let oldValue = oldAgentModelsProfile.additionalOracleModelRaws
+        let normalized = Self.normalizedAdditionalOracleModelRaws(raws, legacySecondary: nil)
+        updateModelSelectionScalar(commit: commit) { settings in
+            settings.additionalOracleModels = normalized.isEmpty ? nil : normalized
+            settings.secondaryOracleModel = normalized.first
+        }
+        recordSettingsWriteDiagnostic(
+            key: "additionalOracleModelRaws",
+            oldValue: oldValue.joined(separator: ","),
+            newValue: normalized.joined(separator: ","),
+            commit: commit,
+            reason: reason,
+            fileID: fileID,
+            line: line,
+            function: function
+        )
+        if globalAgentModelsProfile() != oldAgentModelsProfile {
+            postAgentModelsSettingsDidChange(scope: .global)
+        }
     }
 
     func setSecondaryOracleModelRaw(
@@ -1043,9 +1087,27 @@ class GlobalSettingsStore: ObservableObject {
         function: StaticString = #function
     ) {
         let oldAgentModelsProfile = globalAgentModelsProfile()
-        let oldValue = scalarPreferences.modelSelection?.secondaryOracleModel
+        let oldValue = oldAgentModelsProfile.secondaryOracleModelRaw
         updateModelSelectionScalar(commit: commit) { settings in
-            settings.secondaryOracleModel = Self.trimmedNonEmptyModelRaw(raw)
+            guard settings.additionalOracleModels != nil else {
+                settings.secondaryOracleModel = Self.trimmedNonEmptyModelRaw(raw)
+                return
+            }
+            var additionalOracles = Self.normalizedAdditionalOracleModelRaws(
+                settings.additionalOracleModels,
+                legacySecondary: settings.secondaryOracleModel
+            )
+            if let normalizedRaw = Self.trimmedNonEmptyModelRaw(raw) {
+                if additionalOracles.isEmpty {
+                    additionalOracles.append(normalizedRaw)
+                } else {
+                    additionalOracles[0] = normalizedRaw
+                }
+            } else if !additionalOracles.isEmpty {
+                additionalOracles.removeFirst()
+            }
+            settings.additionalOracleModels = additionalOracles.isEmpty ? nil : additionalOracles
+            settings.secondaryOracleModel = additionalOracles.first
         }
         recordSettingsWriteDiagnostic(
             key: "secondaryOracleModelRaw",
@@ -2147,7 +2209,7 @@ class GlobalSettingsStore: ObservableObject {
     private func normalizedAgentModelsProfile(_ profile: AgentModelsSettingsProfile) -> AgentModelsSettingsProfile {
         var normalized = AgentModelsSettingsProfile(
             planningModelRaw: profile.planningModelRaw,
-            secondaryOracleModelRaw: profile.secondaryOracleModelRaw,
+            additionalOracleModelRaws: profile.additionalOracleModelRaws,
             preferredComposeModelRaw: profile.preferredComposeModelRaw,
             syncChatModelWithOracle: profile.syncChatModelWithOracle,
             contextBuilderAgentRaw: profile.contextBuilderAgentRaw,
@@ -2210,6 +2272,7 @@ class GlobalSettingsStore: ObservableObject {
         return [
             "planning=\(profile.planningModelRaw ?? "nil")",
             "secondaryOracle=\(profile.secondaryOracleModelRaw ?? "nil")",
+            "additionalOracles=\(profile.additionalOracleModelRaws.joined(separator: ","))",
             "compose=\(profile.preferredComposeModelRaw ?? "nil")",
             "sync=\(profile.syncChatModelWithOracle)",
             "contextBuilder=\(profile.contextBuilderAgentRaw ?? "nil"):\(contextBuilderModelRaw ?? "nil")",
@@ -2543,6 +2606,17 @@ class GlobalSettingsStore: ObservableObject {
             return nil
         }
         return trimmed
+    }
+
+    private static func normalizedAdditionalOracleModelRaws(
+        _ raws: [String]?,
+        legacySecondary: String?
+    ) -> [String] {
+        let source = raws ?? legacySecondary.map { [$0] } ?? []
+        return Array(
+            source.compactMap(trimmedNonEmptyModelRaw)
+                .prefix(AgentModelsSettingsProfile.maximumAdditionalOracleModels)
+        )
     }
 
     private func syncSiblingReason(from reason: String?) -> String? {

--- a/Sources/RepoPrompt/Features/Settings/Views/AIModelDropDown.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AIModelDropDown.swift
@@ -124,8 +124,19 @@ struct AIModelDropdown: View {
 
     private func aiModelMenuItems() -> [StableMenuItem] {
         let allModels = menuModelSnapshot ?? promptViewModel.availableModels
+        var items: [StableMenuItem] = []
+        if destination.allowsEmptySelection {
+            items.append(.action(
+                "Disabled",
+                isSelected: destination.currentRawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ) {
+                destination.apply("")
+            })
+            items.append(.separator)
+        }
         guard !allModels.isEmpty else {
-            return [.action("Configure API Settings", handleConfigureAction)]
+            items.append(.action("Configure API Settings", handleConfigureAction))
+            return items
         }
 
         let groupedModels = Dictionary(grouping: allModels, by: { $0.providerType })
@@ -133,7 +144,7 @@ struct AIModelDropdown: View {
             AIProviderType.displayName(for: $0) < AIProviderType.displayName(for: $1)
         }
 
-        return sortedProviders.flatMap { provider -> [StableMenuItem] in
+        items.append(contentsOf: sortedProviders.flatMap { provider -> [StableMenuItem] in
             let models = AIModel.sortedForPicker(groupedModels[provider] ?? [])
             if provider == .claudeCode {
                 return aiModelClaudeCodeTopLevelMenuItems(for: models)
@@ -156,7 +167,8 @@ struct AIModelDropdown: View {
                 models.map(aiModelMenuItem)
             }
             return [.submenu(AIProviderType.displayName(for: provider), items: providerItems)]
-        }
+        })
+        return items
     }
 
     private func aiModelClaudeCodeTopLevelMenuItems(for models: [AIModel]) -> [StableMenuItem] {
@@ -318,6 +330,7 @@ struct AIModelDropdown: View {
         Self.displayName(
             forRawValue: destination.currentRawValue,
             destinationID: destination.id,
+            allowsEmptySelection: destination.allowsEmptySelection,
             availableModels: promptViewModel.availableModels,
             customOpenRouterModels: promptViewModel.apiSettingsViewModel?.customOpenRouterModels ?? [],
             compatibleClaudeBackendDisplayName: { model in
@@ -331,12 +344,17 @@ struct AIModelDropdown: View {
     static func displayName(
         forRawValue currentModel: String,
         destinationID: String,
+        allowsEmptySelection: Bool = false,
         availableModels: [AIModel],
         customOpenRouterModels: [String],
         compatibleClaudeBackendDisplayName: (AIModel) -> String? = { _ in nil }
     ) -> String {
+        let trimmedRawValue = currentModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        if allowsEmptySelection, trimmedRawValue.isEmpty {
+            return "Disabled"
+        }
         if availableModels.isEmpty {
-            return "No models available"
+            return allowsEmptySelection ? trimmedRawValue : "No models available"
         }
 
         // Check custom OpenRouter models
@@ -355,8 +373,10 @@ struct AIModelDropdown: View {
         }
 
         if destinationID == "planningModel" {
-            let trimmedRawValue = currentModel.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmedRawValue.isEmpty ? "Select an Oracle model" : "Invalid Oracle model"
+        }
+        if allowsEmptySelection {
+            return trimmedRawValue
         }
 
         // Fallback to first available for non-Oracle destinations.

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModelsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModelsSettingsView.swift
@@ -350,64 +350,113 @@ struct AgentModelsSettingsView: View {
 
     private var oracleSection: some View {
         settingsCard {
-            sectionHeader(title: "Primary Oracle Model", subtitle: "The compatibility/default response used by ask_oracle, oracle_send, plan/review, and Context Builder analysis.")
+            sectionHeader(
+                title: "Oracle Models",
+                subtitle: "Oracle 1 is permanent and remains the compatibility/default response. "
+                    + "Add up to four independent additional Oracles; responses are not automatically synthesized."
+            )
 
-            HStack(alignment: .center, spacing: 12) {
-                AIModelDropdown(
-                    promptViewModel: promptVM,
-                    showSettingsPopover: $showSettingsPopover,
-                    windowID: windowID,
-                    useBorderlessStyle: false,
-                    isInGeneralSettings: true,
-                    destination: viewModel.oracleModelDestination
-                )
-
-                Spacer(minLength: 0)
-
-                if viewModel.showsRecommendationActions,
-                   let recommendedName = viewModel.recommendedOracleModelName,
-                   !viewModel.isOracleRecommendationSatisfied
-                {
-                    Text("Recommended: \(recommendedName)")
-                        .font(.caption)
-                        .foregroundColor(.orange)
-
-                    Button("Apply") {
-                        viewModel.applyOracleRecommendation()
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Oracle 1")
+                            .font(.callout.weight(.semibold))
+                        Text("Primary · permanent")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+
+                    Spacer(minLength: 0)
+
+                    AIModelDropdown(
+                        promptViewModel: promptVM,
+                        showSettingsPopover: $showSettingsPopover,
+                        windowID: windowID,
+                        useBorderlessStyle: false,
+                        isInGeneralSettings: true,
+                        destination: viewModel.oracleModelDestination
+                    )
+
+                    if viewModel.showsRecommendationActions,
+                       let recommendedName = viewModel.recommendedOracleModelName,
+                       !viewModel.isOracleRecommendationSatisfied
+                    {
+                        Text("Recommended: \(recommendedName)")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+
+                        Button("Apply") {
+                            viewModel.applyOracleRecommendation()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                }
+
+                HStack(spacing: 6) {
+                    Image(systemName: "cpu")
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                    Text("Using: \(viewModel.currentOracleModelName)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
             }
 
-            HStack(spacing: 6) {
-                Image(systemName: "cpu")
+            ForEach(Array(viewModel.additionalOracleModelRaws.indices), id: \.self) { index in
+                Divider()
+
+                HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Oracle \(index + 2)")
+                            .font(.callout.weight(.semibold))
+                        Text("Using: \(viewModel.additionalOracleModelName(at: index))")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    AIModelDropdown(
+                        promptViewModel: promptVM,
+                        showSettingsPopover: $showSettingsPopover,
+                        windowID: windowID,
+                        useBorderlessStyle: false,
+                        isInGeneralSettings: true,
+                        destination: viewModel.additionalOracleModelDestination(at: index)
+                    )
+
+                    Button {
+                        viewModel.removeAdditionalOracle(at: index)
+                    } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .buttonStyle(.borderless)
                     .foregroundColor(.secondary)
-                    .font(.caption)
-                Text("Using: \(viewModel.currentOracleModelName)")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    .hoverTooltip("Remove Oracle \(index + 2)")
+                    .accessibilityLabel("Remove Oracle \(index + 2)")
+                }
             }
 
             Divider()
 
-            sectionHeader(
-                title: "Secondary Oracle Model",
-                subtitle: "Optional independent second opinion. Both responses are returned without automatic synthesis."
-            )
+            HStack(spacing: 8) {
+                Button {
+                    viewModel.addAdditionalOracle()
+                } label: {
+                    Label("Add Oracle", systemImage: "plus")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(!viewModel.canAddAdditionalOracle)
+                .hoverTooltip(viewModel.addOracleHelpText)
 
-            AIModelDropdown(
-                promptViewModel: promptVM,
-                showSettingsPopover: $showSettingsPopover,
-                windowID: windowID,
-                useBorderlessStyle: false,
-                isInGeneralSettings: true,
-                destination: viewModel.secondaryOracleModelDestination
-            )
+                Spacer(minLength: 0)
 
-            Text("Using: \(viewModel.currentSecondaryOracleModelName)")
-                .font(.caption)
-                .foregroundColor(.secondary)
+                Text("\(viewModel.totalOracleCount) of \(viewModel.maximumOracleCount) configured")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModelsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModelsSettingsView.swift
@@ -350,7 +350,7 @@ struct AgentModelsSettingsView: View {
 
     private var oracleSection: some View {
         settingsCard {
-            sectionHeader(title: "Oracle Model", subtitle: "Used by ask_oracle, oracle_send, plan/review, and Context Builder analysis.")
+            sectionHeader(title: "Primary Oracle Model", subtitle: "The compatibility/default response used by ask_oracle, oracle_send, plan/review, and Context Builder analysis.")
 
             HStack(alignment: .center, spacing: 12) {
                 AIModelDropdown(
@@ -388,6 +388,26 @@ struct AgentModelsSettingsView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
+
+            Divider()
+
+            sectionHeader(
+                title: "Secondary Oracle Model",
+                subtitle: "Optional independent second opinion. Both responses are returned without automatic synthesis."
+            )
+
+            AIModelDropdown(
+                promptViewModel: promptVM,
+                showSettingsPopover: $showSettingsPopover,
+                windowID: windowID,
+                useBorderlessStyle: false,
+                isInGeneralSettings: true,
+                destination: viewModel.secondaryOracleModelDestination
+            )
+
+            Text("Using: \(viewModel.currentSecondaryOracleModelName)")
+                .font(.caption)
+                .foregroundColor(.secondary)
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/AgentOracleAuthoritativeChatIDPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AgentOracleAuthoritativeChatIDPolicy.swift
@@ -12,6 +12,15 @@ enum AgentOracleAuthoritativeChatIDPolicy {
     }
 
     static func extract(fromRootObject object: [String: Any]) -> String? {
+        // Dual-Oracle payloads nest per-lane chat_id under oracle_results. Prefer the
+        // authoritative root/primary id and do not fail closed on those nested keys.
+        if object["oracle_pair_id"] != nil || object["oracle_results"] != nil {
+            if let primary = (object["primary_chat_id"] as? String) ?? (object["chat_id"] as? String) {
+                let trimmed = primary.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }
+            return nil
+        }
         guard !object.keys.contains("chatID"),
               !containsChatID(in: object, excludingAuthoritativeRoot: true),
               let chatID = object["chat_id"] as? String

--- a/Sources/RepoPrompt/Infrastructure/AI/AgentOracleAuthoritativeChatIDPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AgentOracleAuthoritativeChatIDPolicy.swift
@@ -12,9 +12,9 @@ enum AgentOracleAuthoritativeChatIDPolicy {
     }
 
     static func extract(fromRootObject object: [String: Any]) -> String? {
-        // Dual-Oracle payloads nest per-lane chat_id under oracle_results. Prefer the
+        // Multi-Oracle payloads nest per-lane chat_id under oracle_results. Prefer the
         // authoritative root/primary id and do not fail closed on those nested keys.
-        if object["oracle_pair_id"] != nil || object["oracle_results"] != nil {
+        if object["oracle_group_id"] != nil || object["oracle_pair_id"] != nil || object["oracle_results"] != nil {
             if let primary = (object["primary_chat_id"] as? String) ?? (object["chat_id"] as? String) {
                 let trimmed = primary.trimmingCharacters(in: .whitespacesAndNewlines)
                 return trimmed.isEmpty ? nil : trimmed

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
@@ -178,13 +178,14 @@ final class AppSettingsMCPService: Service {
 
         let definition = try AppSettingsMCPRegistry.definition(forKey: key)
         let normalizedValue = try definition.validate(rawValue)
+        let validatedValue = try Self.validatedSecondaryOracleValue(key: definition.key, value: normalizedValue)
 
         let result = try await MainActor.run { () throws -> (oldValue: Value, newValue: Value, changed: Bool, applied: Bool, persistenceBlockReason: GlobalSettingsPersistenceBlockReason?) in
             let oldValue = definition.read(store)
-            let changed = !Self.valuesEqual(oldValue, normalizedValue)
+            let changed = !Self.valuesEqual(oldValue, validatedValue)
             if changed {
-                try definition.write(store, normalizedValue)
-                definition.afterWrite?(store, normalizedValue, notificationCenter)
+                try definition.write(store, validatedValue)
+                definition.afterWrite?(store, validatedValue, notificationCenter)
             }
             let newValue = definition.read(store)
             definition.afterSet?(store, newValue, changed, notificationCenter)
@@ -206,6 +207,18 @@ final class AppSettingsMCPService: Service {
             response["persistence_warning"] = .string(Self.persistenceBlockWarning(reason))
         }
         return .object(response)
+    }
+
+    private static func validatedSecondaryOracleValue(key: String, value: Value) throws -> Value {
+        guard key == "models.secondary_oracle_model", let raw = value.stringValue else { return value }
+        do {
+            guard let canonicalRaw = try OraclePairModelSelectionPolicy.canonicalSecondaryRaw(raw) else {
+                return .null
+            }
+            return .string(canonicalRaw)
+        } catch let error as ChatToolError {
+            throw MCPError.invalidParams(error.message)
+        }
     }
 
     private func options(_ args: [String: Value]) async throws -> Value {
@@ -702,6 +715,21 @@ private enum AppSettingsMCPRegistry {
                 honorSync: true
             ) },
             afterWrite: postRecommendationsDidApply,
+            candidateProvider: aiModelRawCandidates
+        ),
+        optionalModelRawSetting(
+            key: "models.secondary_oracle_model",
+            group: "models",
+            label: "Secondary Oracle Model",
+            description: "Optional independent Secondary Oracle model. Null disables the second lane.",
+            read: { stringOrNull($0.secondaryOracleModelRaw()) },
+            write: { store, value in
+                try store.setSecondaryOracleModelRaw(
+                    optionalString(from: value),
+                    reason: "app_settings.models.secondary_oracle_model"
+                )
+            },
+            afterWrite: nil,
             candidateProvider: aiModelRawCandidates
         ),
         boolSetting(

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
@@ -52,6 +52,7 @@ final class AppSettingsMCPService: Service {
                 - `{"op":"get","keys":["ui.appearance_mode","ui.show_tooltips"]}`
                 - `{"op":"get","group":"file_system"}`
                 - `{"op":"set","key":"models.planning_model","value":null}`
+                - `{"op":"set","key":"models.additional_oracle_models","value":["gpt-5.4-pro","claude-sonnet-4-5-20250929"]}`
                 - `{"op":"set","key":"file_system.global_ignore_defaults","value":"**/node_modules/\\n"}`
                 - `{"op":"options","key":"models.planning_model","agent":"codexExec"}`
 
@@ -63,7 +64,7 @@ final class AppSettingsMCPService: Service {
                         "group": .string(description: "Settings group.", enum: ["ui", "prompt_packaging", "models", "context_builder", "mcp", "code_maps", "file_system", "agent_mode"]),
                         "key": .string(description: "Allowlisted setting key (required for set/options)."),
                         "keys": .array(description: "Multiple keys (get only).", items: .string()),
-                        "value": .anyOf([.boolean(), .integer(), .number(), .string(), .null]),
+                        "value": .anyOf([.boolean(), .integer(), .number(), .string(), .array(items: .string()), .null]),
                         "agent": .string(description: "Filter options by CLI backend."),
                         "limit": .integer(description: "Maximum options returned (1–200)."),
                         "detailed": .boolean(description: "Include descriptions and model metadata.")
@@ -178,7 +179,7 @@ final class AppSettingsMCPService: Service {
 
         let definition = try AppSettingsMCPRegistry.definition(forKey: key)
         let normalizedValue = try definition.validate(rawValue)
-        let validatedValue = try Self.validatedSecondaryOracleValue(key: definition.key, value: normalizedValue)
+        let validatedValue = try Self.validatedOracleModelValue(key: definition.key, value: normalizedValue)
 
         let result = try await MainActor.run { () throws -> (oldValue: Value, newValue: Value, changed: Bool, applied: Bool, persistenceBlockReason: GlobalSettingsPersistenceBlockReason?) in
             let oldValue = definition.read(store)
@@ -209,13 +210,23 @@ final class AppSettingsMCPService: Service {
         return .object(response)
     }
 
-    private static func validatedSecondaryOracleValue(key: String, value: Value) throws -> Value {
-        guard key == "models.secondary_oracle_model", let raw = value.stringValue else { return value }
+    private static func validatedOracleModelValue(key: String, value: Value) throws -> Value {
         do {
-            guard let canonicalRaw = try OraclePairModelSelectionPolicy.canonicalSecondaryRaw(raw) else {
-                return .null
+            switch key {
+            case "models.secondary_oracle_model":
+                guard let raw = value.stringValue else { return value }
+                guard let canonicalRaw = try OraclePairModelSelectionPolicy.canonicalSecondaryRaw(raw) else {
+                    return .null
+                }
+                return .string(canonicalRaw)
+            case "models.additional_oracle_models":
+                guard let values = value.arrayValue else { return value }
+                let raws = values.compactMap(\.stringValue)
+                let canonical = try OraclePairModelSelectionPolicy.canonicalAdditionalRaws(raws)
+                return .array(canonical.map(Value.string))
+            default:
+                return value
             }
-            return .string(canonicalRaw)
         } catch let error as ChatToolError {
             throw MCPError.invalidParams(error.message)
         }
@@ -433,6 +444,7 @@ private enum AppSettingValueType: String {
     case boolean
     case string
     case optionalString = "string|null"
+    case stringArray = "string[]"
     case number
 }
 
@@ -721,12 +733,40 @@ private enum AppSettingsMCPRegistry {
             key: "models.secondary_oracle_model",
             group: "models",
             label: "Secondary Oracle Model",
-            description: "Optional independent Secondary Oracle model. Null disables the second lane.",
+            description: "Compatibility alias for the first additional Oracle model. Null removes that lane and shifts later additional Oracles forward.",
             read: { stringOrNull($0.secondaryOracleModelRaw()) },
             write: { store, value in
                 try store.setSecondaryOracleModelRaw(
                     optionalString(from: value),
                     reason: "app_settings.models.secondary_oracle_model"
+                )
+            },
+            afterWrite: nil,
+            candidateProvider: aiModelRawCandidates
+        ),
+        AppSettingDefinition(
+            key: "models.additional_oracle_models",
+            group: "models",
+            valueType: .stringArray,
+            label: "Additional Oracle Models",
+            description: "Ordered independent Oracle model raw identifiers after the permanent Primary Oracle (zero to four).",
+            allowedValues: nil,
+            read: { .array($0.additionalOracleModelRaws().map(Value.string)) },
+            validate: { value in
+                guard let values = value.arrayValue,
+                      values.count <= OraclePairModelSelectionPolicy.maximumAdditionalOracleCount,
+                      values.allSatisfy({ $0.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false })
+                else {
+                    throw MCPError.invalidParams(
+                        "Setting 'models.additional_oracle_models' requires an array of zero to four non-empty model ID strings."
+                    )
+                }
+                return .array(values)
+            },
+            write: { store, value in
+                store.setAdditionalOracleModelRaws(
+                    value.arrayValue?.compactMap(\.stringValue) ?? [],
+                    reason: "app_settings.models.additional_oracle_models"
                 )
             },
             afterWrite: nil,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
@@ -7,6 +7,19 @@ enum OraclePairSendStatus: String {
     case failed
 }
 
+typealias OracleGroupSendStatus = OraclePairSendStatus
+
+enum OracleGroupReplyValidationError: LocalizedError, Equatable {
+    case laneMetadataMismatch(expected: [OracleLane])
+
+    var errorDescription: String? {
+        switch self {
+        case let .laneMetadataMismatch(expected):
+            "Oracle group metadata must contain exactly the lanes [\(expected.map(\.rawValue).joined(separator: ", "))]."
+        }
+    }
+}
+
 struct OracleSendRoute: Equatable {
     let contextID: UUID?
     let agentSessionID: UUID?
@@ -60,32 +73,103 @@ struct OraclePairSendReply {
     let pairID: UUID
     let mode: String
     let primarySessionID: UUID
-    let primaryChatID: String
-    let secondaryChatID: String
-    let primaryModel: AIModel
-    let secondaryModel: AIModel
+    let sessionIDsByLane: [OracleLane: UUID]
+    let chatIDsByLane: [OracleLane: String]
+    let modelsByLane: [OracleLane: AIModel]
     let result: OraclePairCoordinator.Result<ChatSendReply>
     let historyDiverged: Bool
     let historyPersistenceError: String?
 
-    var status: OraclePairSendStatus {
-        switch (result.primary, result.secondary) {
-        case (.success, .success):
-            historyPersistenceError == nil ? .completed : .partialFailure
-        case (.failure, .failure):
-            .failed
-        default:
-            .partialFailure
+    var groupID: UUID { pairID }
+    var oracleCount: Int { result.orderedResults.count }
+    var orderedLanes: [OracleLane] { result.orderedLanes }
+    var primaryChatID: String { requiredChatID(for: .primary) }
+    var secondaryChatID: String { requiredChatID(for: .secondary) }
+    var primaryModel: AIModel { requiredModel(for: .primary) }
+    var secondaryModel: AIModel { requiredModel(for: .secondary) }
+
+    /// Compatibility initializer for the original two-lane runtime.
+    init(
+        pairID: UUID,
+        mode: String,
+        primarySessionID: UUID,
+        primaryChatID: String,
+        secondaryChatID: String,
+        primaryModel: AIModel,
+        secondaryModel: AIModel,
+        result: OraclePairCoordinator.Result<ChatSendReply>,
+        historyDiverged: Bool,
+        historyPersistenceError: String?
+    ) {
+        self.pairID = pairID
+        self.mode = mode
+        self.primarySessionID = primarySessionID
+        var resolvedSessionIDs: [OracleLane: UUID] = [.primary: primarySessionID]
+        if let secondarySessionID = Self.sessionID(for: .secondary, in: result) {
+            resolvedSessionIDs[.secondary] = secondarySessionID
         }
+        sessionIDsByLane = resolvedSessionIDs
+        chatIDsByLane = [.primary: primaryChatID, .secondary: secondaryChatID]
+        modelsByLane = [.primary: primaryModel, .secondary: secondaryModel]
+        self.result = result
+        self.historyDiverged = historyDiverged
+        self.historyPersistenceError = historyPersistenceError
+    }
+
+    /// Generic ordered group initializer. All metadata maps must cover the same
+    /// complete 2...5 lane prefix represented by `result`.
+    init(
+        groupID: UUID,
+        mode: String,
+        sessionIDsByLane: [OracleLane: UUID],
+        chatIDsByLane: [OracleLane: String],
+        modelsByLane: [OracleLane: AIModel],
+        result: OraclePairCoordinator.Result<ChatSendReply>,
+        historyDiverged: Bool,
+        historyPersistenceError: String?
+    ) throws {
+        let lanes = result.orderedLanes
+        guard (2 ... OracleLane.allCases.count).contains(lanes.count) else {
+            throw OracleLaneValidationError.invalidCount(lanes.count)
+        }
+        try OracleLane.validateOrderedPrefix(lanes)
+        let expected = Set(lanes)
+        guard Set(sessionIDsByLane.keys) == expected,
+              Set(chatIDsByLane.keys) == expected,
+              Set(modelsByLane.keys) == expected,
+              let primarySessionID = sessionIDsByLane[.primary]
+        else {
+            throw OracleGroupReplyValidationError.laneMetadataMismatch(expected: lanes)
+        }
+
+        pairID = groupID
+        self.mode = mode
+        self.primarySessionID = primarySessionID
+        self.sessionIDsByLane = sessionIDsByLane
+        self.chatIDsByLane = chatIDsByLane
+        self.modelsByLane = modelsByLane
+        self.result = result
+        self.historyDiverged = historyDiverged
+        self.historyPersistenceError = historyPersistenceError
+    }
+
+    var status: OraclePairSendStatus {
+        let successCount = result.orderedResults.reduce(into: 0) { count, laneResult in
+            if case .success = laneResult.execution { count += 1 }
+        }
+        if successCount == result.orderedResults.count {
+            return historyPersistenceError == nil ? .completed : .partialFailure
+        }
+        return successCount == 0 ? .failed : .partialFailure
     }
 
     var failureSummary: String? {
-        var warnings = [
-            laneFailureSummary(.primary, result.primary),
-            laneFailureSummary(.secondary, result.secondary)
-        ].compactMap(\.self)
+        var warnings = result.orderedResults.compactMap { laneResult in
+            laneFailureSummary(laneResult.lane, laneResult.execution)
+        }
         if let historyPersistenceError {
-            warnings.append("Oracle pair history persistence failed: \(historyPersistenceError)")
+            let noun = oracleCount == 2 ? "pair" : "group"
+            warnings.append("Oracle \(noun) history persistence failed: \(historyPersistenceError)")
         }
         return warnings.isEmpty ? nil : warnings.joined(separator: "\n")
     }
@@ -128,11 +212,18 @@ struct OraclePairSendReply {
             }
         }
         object["status"] = .string(status.rawValue)
+        object["oracle_group_id"] = .string(groupID.uuidString)
+        object["oracle_count"] = .int(oracleCount)
+        object["oracle_chat_ids"] = .object(Dictionary(uniqueKeysWithValues: orderedLanes.map { lane in
+            (lane.rawValue, .string(requiredChatID(for: lane)))
+        }))
+        object["oracle_result_order"] = .array(orderedLanes.map { .string($0.rawValue) })
         object["oracle_pair_id"] = .string(pairID.uuidString)
         object["primary_chat_id"] = .string(primaryChatID)
         object["secondary_chat_id"] = .string(secondaryChatID)
         object["oracle_history_diverged"] = .bool(historyDiverged)
         if let historyPersistenceError {
+            object["oracle_group_history_persistence_error"] = .string(historyPersistenceError)
             object["oracle_pair_history_persistence_error"] = .string(historyPersistenceError)
         }
         // Surface Secondary-only / history failures at the top level so single-lane
@@ -140,20 +231,19 @@ struct OraclePairSendReply {
         if status != .completed, let failureSummary, object["errors"] == nil {
             object["errors"] = .array([.string(failureSummary)])
         }
-        object["oracle_results"] = .object([
-            "primary": laneValue(
-                lane: .primary,
-                execution: result.primary,
-                chatID: primaryChatID,
-                model: primaryModel
-            ),
-            "secondary": laneValue(
-                lane: .secondary,
-                execution: result.secondary,
-                chatID: secondaryChatID,
-                model: secondaryModel
+        let orderedValues = result.orderedResults.map { laneResult in
+            laneValue(
+                lane: laneResult.lane,
+                execution: laneResult.execution,
+                chatID: requiredChatID(for: laneResult.lane),
+                model: requiredModel(for: laneResult.lane)
             )
-        ])
+        }
+        object["oracle_results"] = .object(Dictionary(uniqueKeysWithValues: zip(
+            orderedLanes.map(\.rawValue),
+            orderedValues
+        )))
+        object["oracle_group_results"] = .array(orderedValues)
         return object
     }
 
@@ -162,8 +252,7 @@ struct OraclePairSendReply {
         _ execution: OraclePairCoordinator.LaneExecution<ChatSendReply>
     ) -> String? {
         guard case let .failure(failure) = execution else { return nil }
-        let label = lane == .primary ? "Primary" : "Secondary"
-        return "\(label) Oracle failed: \(failure.message)"
+        return "\(lane.displayLabel) failed: \(failure.message)"
     }
 
     private func laneValue(
@@ -188,13 +277,44 @@ struct OraclePairSendReply {
             }
         }
         object["oracle_lane"] = .string(lane.rawValue)
+        object["oracle_ordinal"] = .int(lane.ordinal)
+        object["oracle_label"] = .string(lane.displayLabel)
+        object["oracle_group_id"] = .string(groupID.uuidString)
+        object["oracle_count"] = .int(oracleCount)
         object["oracle_pair_id"] = .string(pairID.uuidString)
         object["chat_id"] = .string(chatID)
         object["model_raw_id"] = .string(model.rawValue)
         object["model_display_name"] = .string(model.displayName)
         return .object(object)
     }
+
+    private static func sessionID(
+        for lane: OracleLane,
+        in result: OraclePairCoordinator.Result<ChatSendReply>
+    ) -> UUID? {
+        guard let execution = result[lane] else { return nil }
+        switch execution {
+        case let .success(reply): reply.chatId
+        case .failure: nil
+        }
+    }
+
+    private func requiredChatID(for lane: OracleLane) -> String {
+        guard let chatID = chatIDsByLane[lane] else {
+            preconditionFailure("Validated Oracle group is missing \(lane.rawValue) chat identity")
+        }
+        return chatID
+    }
+
+    private func requiredModel(for lane: OracleLane) -> AIModel {
+        guard let model = modelsByLane[lane] else {
+            preconditionFailure("Validated Oracle group is missing \(lane.rawValue) model identity")
+        }
+        return model
+    }
 }
+
+typealias OracleGroupSendReply = OraclePairSendReply
 
 struct ChatSendReply: Codable {
     let chatId: UUID

--- a/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
@@ -1,6 +1,190 @@
 import Foundation
 import MCP // for Value
 
+enum OraclePairSendStatus: String {
+    case completed
+    case partialFailure = "partial_failure"
+    case failed
+}
+
+struct OracleSendRoute: Equatable {
+    let contextID: UUID?
+    let agentSessionID: UUID?
+    let agentRunID: UUID?
+}
+
+struct OracleSendResult {
+    enum Payload {
+        case single(ChatSendReply)
+        case paired(OraclePairSendReply)
+    }
+
+    let payload: Payload
+    let route: OracleSendRoute
+
+    func primaryReply(fallbackSessionID: UUID? = nil) -> ChatSendReply {
+        switch payload {
+        case let .single(reply): reply
+        case let .paired(pair): pair.primaryReply(fallbackSessionID: fallbackSessionID)
+        }
+    }
+
+    func toMCPObject() -> [String: Value] {
+        var object: [String: Value] = switch payload {
+        case let .single(reply): reply.toMCPObject()
+        case let .paired(reply): reply.toMCPObject()
+        }
+        if let contextID = route.contextID {
+            object["context_id"] = .string(contextID.uuidString)
+        }
+        if let agentSessionID = route.agentSessionID {
+            object["agent_session_id"] = .string(agentSessionID.uuidString)
+        }
+        if let agentRunID = route.agentRunID {
+            object["agent_run_id"] = .string(agentRunID.uuidString)
+        }
+        return object
+    }
+}
+
+struct OracleSendFailure: LocalizedError {
+    let result: OracleSendResult
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
+}
+
+struct OraclePairSendReply {
+    let pairID: UUID
+    let mode: String
+    let primaryChatID: String
+    let secondaryChatID: String
+    let primaryModel: AIModel
+    let secondaryModel: AIModel
+    let result: OraclePairCoordinator.Result<ChatSendReply>
+    let historyDiverged: Bool
+    let historyPersistenceError: String?
+
+    var status: OraclePairSendStatus {
+        switch (result.primary, result.secondary) {
+        case (.success, .success):
+            historyPersistenceError == nil ? .completed : .partialFailure
+        case (.failure, .failure):
+            .failed
+        default:
+            .partialFailure
+        }
+    }
+
+    var failureSummary: String? {
+        var warnings = [
+            laneFailureSummary(.primary, result.primary),
+            laneFailureSummary(.secondary, result.secondary)
+        ].compactMap(\.self)
+        if let historyPersistenceError {
+            warnings.append("Oracle pair history persistence failed: \(historyPersistenceError)")
+        }
+        return warnings.isEmpty ? nil : warnings.joined(separator: "\n")
+    }
+
+    func primaryReply(fallbackSessionID: UUID? = nil) -> ChatSendReply {
+        switch result.primary {
+        case let .success(primary):
+            ChatSendReply(
+                chatId: primary.chatId,
+                shortId: primaryChatID,
+                mode: mode,
+                response: primary.response,
+                errors: failureSummary.map { [$0] }
+            )
+        case let .failure(failure):
+            ChatSendReply(
+                chatId: fallbackSessionID ?? UUID(uuidString: primaryChatID) ?? UUID(),
+                shortId: primaryChatID,
+                mode: mode,
+                response: failure.partialResponse,
+                errors: failureSummary.map { [$0] }
+            )
+        }
+    }
+
+    func toMCPObject() -> [String: Value] {
+        var object: [String: Value] = switch result.primary {
+        case let .success(primary):
+            primary.toMCPObject()
+        case let .failure(failure):
+            [
+                "chat_id": .string(primaryChatID),
+                "mode": .string(mode),
+                "errors": .array([.string(failure.message)])
+            ]
+        }
+        object["status"] = .string(status.rawValue)
+        object["oracle_pair_id"] = .string(pairID.uuidString)
+        object["primary_chat_id"] = .string(primaryChatID)
+        object["secondary_chat_id"] = .string(secondaryChatID)
+        object["oracle_history_diverged"] = .bool(historyDiverged)
+        if let historyPersistenceError {
+            object["oracle_pair_history_persistence_error"] = .string(historyPersistenceError)
+        }
+        object["oracle_results"] = .object([
+            "primary": laneValue(
+                lane: .primary,
+                execution: result.primary,
+                chatID: primaryChatID,
+                model: primaryModel
+            ),
+            "secondary": laneValue(
+                lane: .secondary,
+                execution: result.secondary,
+                chatID: secondaryChatID,
+                model: secondaryModel
+            )
+        ])
+        return object
+    }
+
+    private func laneFailureSummary(
+        _ lane: OracleLane,
+        _ execution: OraclePairCoordinator.LaneExecution<ChatSendReply>
+    ) -> String? {
+        guard case let .failure(failure) = execution else { return nil }
+        let label = lane == .primary ? "Primary" : "Secondary"
+        return "\(label) Oracle failed: \(failure.message)"
+    }
+
+    private func laneValue(
+        lane: OracleLane,
+        execution: OraclePairCoordinator.LaneExecution<ChatSendReply>,
+        chatID: String,
+        model: AIModel
+    ) -> Value {
+        var object: [String: Value]
+        switch execution {
+        case let .success(reply):
+            object = reply.toMCPObject()
+            object["status"] = .string("completed")
+        case let .failure(failure):
+            object = [
+                "status": .string("failed"),
+                "error": .string(failure.message),
+                "error_code": .string(failure.code.rawValue)
+            ]
+            if let partialResponse = failure.partialResponse {
+                object["partial_response"] = .string(partialResponse)
+            }
+        }
+        object["oracle_lane"] = .string(lane.rawValue)
+        object["oracle_pair_id"] = .string(pairID.uuidString)
+        object["chat_id"] = .string(chatID)
+        object["model_raw_id"] = .string(model.rawValue)
+        object["model_display_name"] = .string(model.displayName)
+        return .object(object)
+    }
+}
+
 struct ChatSendReply: Codable {
     let chatId: UUID
     let shortId: String
@@ -8,14 +192,17 @@ struct ChatSendReply: Codable {
     let response: String?
     let errors: [String]?
 
-    func toMCPValue() -> Value {
-        var obj: [String: Value] = [
+    func toMCPObject() -> [String: Value] {
+        var object: [String: Value] = [
             "chat_id": .string(shortId), // Only expose short ID
             "mode": .string(mode)
         ]
-        if let r = response { obj["response"] = .string(r) }
-        if let e = errors { obj["errors"] = .array(e.map { .string($0) }) }
+        if let response { object["response"] = .string(response) }
+        if let errors { object["errors"] = .array(errors.map { .string($0) }) }
+        return object
+    }
 
-        return .object(obj)
+    func toMCPValue() -> Value {
+        .object(toMCPObject())
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
@@ -314,8 +314,10 @@ struct OraclePairSendReply {
     ) -> UUID? {
         guard let execution = result[lane] else { return nil }
         switch execution {
-        case let .success(reply): reply.chatId
-        case .failure: nil
+        case let .success(reply):
+            return reply.chatId
+        case .failure:
+            return nil
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
@@ -22,10 +22,10 @@ struct OracleSendResult {
     let payload: Payload
     let route: OracleSendRoute
 
-    func primaryReply(fallbackSessionID: UUID? = nil) -> ChatSendReply {
+    func primaryReply() -> ChatSendReply {
         switch payload {
         case let .single(reply): reply
-        case let .paired(pair): pair.primaryReply(fallbackSessionID: fallbackSessionID)
+        case let .paired(pair): pair.primaryReply()
         }
     }
 
@@ -59,6 +59,7 @@ struct OracleSendFailure: LocalizedError {
 struct OraclePairSendReply {
     let pairID: UUID
     let mode: String
+    let primarySessionID: UUID
     let primaryChatID: String
     let secondaryChatID: String
     let primaryModel: AIModel
@@ -89,7 +90,7 @@ struct OraclePairSendReply {
         return warnings.isEmpty ? nil : warnings.joined(separator: "\n")
     }
 
-    func primaryReply(fallbackSessionID: UUID? = nil) -> ChatSendReply {
+    func primaryReply() -> ChatSendReply {
         switch result.primary {
         case let .success(primary):
             ChatSendReply(
@@ -101,8 +102,7 @@ struct OraclePairSendReply {
             )
         case let .failure(failure):
             ChatSendReply(
-                // Prefer the resolved Primary session id; shortId alone is not a UUID.
-                chatId: fallbackSessionID ?? UUID(uuidString: primaryChatID) ?? UUID(),
+                chatId: primarySessionID,
                 shortId: primaryChatID,
                 mode: mode,
                 response: failure.partialResponse,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
@@ -80,13 +80,33 @@ struct OraclePairSendReply {
     let historyDiverged: Bool
     let historyPersistenceError: String?
 
-    var groupID: UUID { pairID }
-    var oracleCount: Int { result.orderedResults.count }
-    var orderedLanes: [OracleLane] { result.orderedLanes }
-    var primaryChatID: String { requiredChatID(for: .primary) }
-    var secondaryChatID: String { requiredChatID(for: .secondary) }
-    var primaryModel: AIModel { requiredModel(for: .primary) }
-    var secondaryModel: AIModel { requiredModel(for: .secondary) }
+    var groupID: UUID {
+        pairID
+    }
+
+    var oracleCount: Int {
+        result.orderedResults.count
+    }
+
+    var orderedLanes: [OracleLane] {
+        result.orderedLanes
+    }
+
+    var primaryChatID: String {
+        requiredChatID(for: .primary)
+    }
+
+    var secondaryChatID: String {
+        requiredChatID(for: .secondary)
+    }
+
+    var primaryModel: AIModel {
+        requiredModel(for: .primary)
+    }
+
+    var secondaryModel: AIModel {
+        requiredModel(for: .secondary)
+    }
 
     /// Compatibility initializer for the original two-lane runtime.
     init(

--- a/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ChatSendReply.swift
@@ -101,6 +101,7 @@ struct OraclePairSendReply {
             )
         case let .failure(failure):
             ChatSendReply(
+                // Prefer the resolved Primary session id; shortId alone is not a UUID.
                 chatId: fallbackSessionID ?? UUID(uuidString: primaryChatID) ?? UUID(),
                 shortId: primaryChatID,
                 mode: mode,
@@ -111,15 +112,20 @@ struct OraclePairSendReply {
     }
 
     func toMCPObject() -> [String: Value] {
-        var object: [String: Value] = switch result.primary {
+        var object: [String: Value]
+        switch result.primary {
         case let .success(primary):
-            primary.toMCPObject()
+            object = primary.toMCPObject()
         case let .failure(failure):
-            [
+            object = [
                 "chat_id": .string(primaryChatID),
                 "mode": .string(mode),
-                "errors": .array([.string(failure.message)])
+                "errors": .array([.string(failureSummary ?? failure.message)])
             ]
+            if let partialResponse = failure.partialResponse {
+                object["partial_response"] = .string(partialResponse)
+                object["response"] = .string(partialResponse)
+            }
         }
         object["status"] = .string(status.rawValue)
         object["oracle_pair_id"] = .string(pairID.uuidString)
@@ -128,6 +134,11 @@ struct OraclePairSendReply {
         object["oracle_history_diverged"] = .bool(historyDiverged)
         if let historyPersistenceError {
             object["oracle_pair_history_persistence_error"] = .string(historyPersistenceError)
+        }
+        // Surface Secondary-only / history failures at the top level so single-lane
+        // MCP consumers do not treat partial_failure as a clean success.
+        if status != .completed, let failureSummary, object["errors"] == nil {
+            object["errors"] = .array([.string(failureSummary)])
         }
         object["oracle_results"] = .object([
             "primary": laneValue(

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -61,7 +61,9 @@ struct MCPOracleToolService {
 
     static func structuredOracleSendMCPError(_ error: ChatToolError) -> MCPError? {
         // MCPError.serverError has no structured data field, so this boundary uses one exact versioned envelope.
-        guard let payload = error.details?["oracle_pair_payload"] else { return nil }
+        guard let payload = error.details?["oracle_group_payload"] ?? error.details?["oracle_pair_payload"] else {
+            return nil
+        }
         return .serverError(
             code: -32000,
             message: "\(error.message)\n\(OraclePairFailureTransportEnvelope.encode(payload: payload))"
@@ -79,7 +81,15 @@ struct MCPOracleToolService {
                 ?? value["error"]?.stringValue.map { "Failed: \($0)" }
                 ?? "(No response)"
         }
-        return "# Primary Oracle\n\n\(text(for: "primary"))\n\n# Secondary Oracle\n\n\(text(for: "secondary"))"
+        let requestedOrder = result["oracle_result_order"]?.arrayValue?.compactMap(\.stringValue) ?? []
+        let orderedKeys = requestedOrder.isEmpty
+            ? OracleLane.allCases.map(\.rawValue).filter { lanes[$0] != nil }
+            : requestedOrder.filter { lanes[$0] != nil }
+        guard !orderedKeys.isEmpty else { return result["response"]?.stringValue }
+        return orderedKeys.map { key in
+            let label = OracleLane(rawValue: key)?.displayLabel ?? key
+            return "# \(label)\n\n\(text(for: key))"
+        }.joined(separator: "\n\n")
     }
 
     private func performOracleSend(

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -1,6 +1,23 @@
 import Foundation
 import MCP
 
+enum OraclePairFailureTransportEnvelope {
+    private static let prefix = "[[RPCE_ORACLE_PAIR_FAILURE_V1:"
+    private static let suffix = "]]"
+
+    static func encode(payload: String) -> String {
+        prefix + Data(payload.utf8).base64EncodedString() + suffix
+    }
+
+    static func decodePayload(in text: String) -> String? {
+        guard let prefixRange = text.range(of: prefix),
+              let suffixRange = text.range(of: suffix, range: prefixRange.upperBound ..< text.endIndex),
+              let data = Data(base64Encoded: String(text[prefixRange.upperBound ..< suffixRange.lowerBound]))
+        else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
 @MainActor
 struct MCPOracleToolService {
     typealias RequestMetadata = MCPServerViewModel.RequestMetadata
@@ -41,6 +58,50 @@ struct MCPOracleToolService {
     let withHeartbeat: (_ connectionID: UUID?, _ tool: String, _ stage: String, _ message: String, _ operation: @escaping ChatSendOperation) async throws -> [String: Value]
     let sendChat: SendChat
     let exportOracleResponse: ExportOracleResponse
+
+    static func structuredOracleSendMCPError(_ error: ChatToolError) -> MCPError? {
+        // MCPError.serverError has no structured data field, so this boundary uses one exact versioned envelope.
+        guard let payload = error.details?["oracle_pair_payload"] else { return nil }
+        return .serverError(
+            code: -32000,
+            message: "\(error.message)\n\(OraclePairFailureTransportEnvelope.encode(payload: payload))"
+        )
+    }
+
+    private static func oracleExportResponse(from result: [String: Value]) -> String? {
+        guard let lanes = result["oracle_results"]?.objectValue else {
+            return result["response"]?.stringValue
+        }
+        func text(for lane: String) -> String {
+            guard let value = lanes[lane]?.objectValue else { return "(No response)" }
+            return value["response"]?.stringValue
+                ?? value["partial_response"]?.stringValue
+                ?? value["error"]?.stringValue.map { "Failed: \($0)" }
+                ?? "(No response)"
+        }
+        return "# Primary Oracle\n\n\(text(for: "primary"))\n\n# Secondary Oracle\n\n\(text(for: "secondary"))"
+    }
+
+    private func performOracleSend(
+        args: [String: Value],
+        tabContext: OracleViewModel.OracleSendTabContext?,
+        connectionID: UUID?,
+        toolName: String
+    ) async throws -> [String: Value] {
+        do {
+            return try await withHeartbeat(
+                connectionID,
+                toolName,
+                "waiting",
+                "Waiting for Oracle response..."
+            ) {
+                try await sendChat(args, promptVM, tabContext)
+            }
+        } catch let error as ChatToolError {
+            if let mapped = Self.structuredOracleSendMCPError(error) { throw mapped }
+            throw error
+        }
+    }
 
     func executeOracleUtils(args: [String: Value]) async throws -> Value {
         let op = (args["op"]?.stringValue ?? "")
@@ -211,6 +272,7 @@ struct MCPOracleToolService {
                 origin: .askOracle,
                 agentModeSessionID: owner.agentSessionID,
                 agentModeRunID: owner.runID,
+                activationPolicy: .publicMCP,
                 packaging: packaging
             )
         }
@@ -237,15 +299,12 @@ struct MCPOracleToolService {
 
         await sendStageProgress(connectionID, askOracleToolName, "starting", "Starting Oracle...")
 
-        let capturedChatArgs = chatArgs
-        var result = try await withHeartbeat(
-            connectionID,
-            askOracleToolName,
-            "waiting",
-            "Waiting for Oracle response..."
-        ) {
-            try await sendChat(capturedChatArgs, promptVM, tabContext)
-        }
+        var result = try await performOracleSend(
+            args: chatArgs,
+            tabContext: tabContext,
+            connectionID: connectionID,
+            toolName: askOracleToolName
+        )
 
         if exportResponse {
             let export = try await exportOracleResponse(OracleExportRequest(
@@ -253,7 +312,7 @@ struct MCPOracleToolService {
                 mode: modeRaw,
                 message: message,
                 chatID: result["chat_id"]?.stringValue ?? normalizedChatID,
-                response: result["response"]?.stringValue,
+                response: Self.oracleExportResponse(from: result),
                 destination: exportDestination
             ))
             result["oracle_export_path"] = .string(export.path)
@@ -337,16 +396,12 @@ struct MCPOracleToolService {
         var chatArgs = args
         chatArgs.removeValue(forKey: "export_response")
 
-        let capturedTabContext = tabContext
-        let capturedChatArgs = chatArgs
-        var result = try await withHeartbeat(
-            connectionID,
-            oracleSendToolName,
-            "waiting",
-            "Waiting for Oracle response..."
-        ) {
-            try await sendChat(capturedChatArgs, promptVM, capturedTabContext)
-        }
+        var result = try await performOracleSend(
+            args: chatArgs,
+            tabContext: tabContext,
+            connectionID: connectionID,
+            toolName: oracleSendToolName
+        )
 
         if exportResponse {
             let normalizedChatID = args["chat_id"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -355,7 +410,7 @@ struct MCPOracleToolService {
                 mode: modeRaw,
                 message: message,
                 chatID: result["chat_id"]?.stringValue ?? ((normalizedChatID?.isEmpty == false) ? normalizedChatID : nil),
-                response: result["response"]?.stringValue,
+                response: Self.oracleExportResponse(from: result),
                 destination: exportDestination
             ))
             result["oracle_export_path"] = .string(export.path)
@@ -637,6 +692,7 @@ struct MCPOracleToolService {
             origin: origin,
             agentModeSessionID: owner.agentSessionID,
             agentModeRunID: owner.runID,
+            activationPolicy: .publicMCP,
             packaging: packaging
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-enum OracleLaneFailureCode: String, Equatable, Sendable {
+enum OracleLaneFailureCode: String, Equatable {
     case emptyResponse = "empty_response"
     case executionFailed = "execution_failed"
     case cancelled
 }
 
-struct OracleLaneFailure: LocalizedError, Equatable, Sendable {
+struct OracleLaneFailure: LocalizedError, Equatable {
     let message: String
     let partialResponse: String?
     let code: OracleLaneFailureCode
@@ -27,12 +27,12 @@ struct OracleLaneFailure: LocalizedError, Equatable, Sendable {
 }
 
 enum OraclePairCoordinator {
-    enum LaneExecution<Success: Sendable>: Sendable {
+    enum LaneExecution<Success: Sendable> {
         case success(Success)
         case failure(OracleLaneFailure)
     }
 
-    struct LaneOperation<Success: Sendable>: Sendable {
+    struct LaneOperation<Success: Sendable> {
         let lane: OracleLane
         let operation: Operation<Success>
 
@@ -42,12 +42,12 @@ enum OraclePairCoordinator {
         }
     }
 
-    struct LaneResult<Success: Sendable>: Sendable {
+    struct LaneResult<Success: Sendable> {
         let lane: OracleLane
         let execution: LaneExecution<Success>
     }
 
-    struct Result<Success: Sendable>: Sendable {
+    struct Result<Success: Sendable> {
         let orderedResults: [LaneResult<Success>]
 
         init(primary: LaneExecution<Success>, secondary: LaneExecution<Success>) {

--- a/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+enum OracleLaneFailureCode: String, Equatable {
+    case emptyResponse = "empty_response"
+    case executionFailed = "execution_failed"
+    case cancelled
+}
+
+struct OracleLaneFailure: LocalizedError, Equatable {
+    let message: String
+    let partialResponse: String?
+    let code: OracleLaneFailureCode
+
+    init(
+        message: String,
+        partialResponse: String? = nil,
+        code: OracleLaneFailureCode = .executionFailed
+    ) {
+        self.message = message
+        self.partialResponse = partialResponse
+        self.code = code
+    }
+
+    var errorDescription: String? {
+        message
+    }
+}
+
+enum OraclePairCoordinator {
+    enum LaneExecution<Success: Sendable> {
+        case success(Success)
+        case failure(OracleLaneFailure)
+    }
+
+    struct Result<Success: Sendable> {
+        let primary: LaneExecution<Success>
+        let secondary: LaneExecution<Success>
+    }
+
+    typealias Operation<Success: Sendable> = @MainActor @Sendable () async throws -> Success
+
+    static func validatedResponse(_ response: String?, lane: OracleLane) throws -> String {
+        guard let response, !response.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw OracleLaneFailure(
+                message: "Oracle \(lane.rawValue) lane returned an empty response.",
+                partialResponse: response,
+                code: .emptyResponse
+            )
+        }
+        return response
+    }
+
+    @MainActor
+    static func run<Success: Sendable>(
+        primary: @escaping Operation<Success>,
+        secondary: @escaping Operation<Success>
+    ) async throws -> Result<Success> {
+        try await withThrowingTaskGroup(
+            of: (OracleLane, LaneExecution<Success>).self,
+            returning: Result<Success>.self
+        ) { group in
+            group.addTask { try await (.primary, execute(primary)) }
+            group.addTask { try await (.secondary, execute(secondary)) }
+
+            var primaryResult: LaneExecution<Success>?
+            var secondaryResult: LaneExecution<Success>?
+            do {
+                for try await (lane, result) in group {
+                    switch lane {
+                    case .primary: primaryResult = result
+                    case .secondary: secondaryResult = result
+                    }
+                }
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+
+            guard let primaryResult, let secondaryResult else { throw CancellationError() }
+            return Result(primary: primaryResult, secondary: secondaryResult)
+        }
+    }
+
+    @MainActor
+    private static func execute<Success: Sendable>(
+        _ operation: @escaping Operation<Success>
+    ) async throws -> LaneExecution<Success> {
+        do {
+            return try await .success(operation())
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let failure as OracleLaneFailure {
+            return .failure(failure)
+        } catch {
+            return .failure(OracleLaneFailure(message: error.localizedDescription))
+        }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-enum OracleLaneFailureCode: String, Equatable {
+enum OracleLaneFailureCode: String, Equatable, Sendable {
     case emptyResponse = "empty_response"
     case executionFailed = "execution_failed"
     case cancelled
 }
 
-struct OracleLaneFailure: LocalizedError, Equatable {
+struct OracleLaneFailure: LocalizedError, Equatable, Sendable {
     let message: String
     let partialResponse: String?
     let code: OracleLaneFailureCode
@@ -27,14 +27,75 @@ struct OracleLaneFailure: LocalizedError, Equatable {
 }
 
 enum OraclePairCoordinator {
-    enum LaneExecution<Success: Sendable> {
+    enum LaneExecution<Success: Sendable>: Sendable {
         case success(Success)
         case failure(OracleLaneFailure)
     }
 
-    struct Result<Success: Sendable> {
-        let primary: LaneExecution<Success>
-        let secondary: LaneExecution<Success>
+    struct LaneOperation<Success: Sendable>: Sendable {
+        let lane: OracleLane
+        let operation: Operation<Success>
+
+        init(lane: OracleLane, operation: @escaping Operation<Success>) {
+            self.lane = lane
+            self.operation = operation
+        }
+    }
+
+    struct LaneResult<Success: Sendable>: Sendable {
+        let lane: OracleLane
+        let execution: LaneExecution<Success>
+    }
+
+    struct Result<Success: Sendable>: Sendable {
+        let orderedResults: [LaneResult<Success>]
+
+        init(primary: LaneExecution<Success>, secondary: LaneExecution<Success>) {
+            orderedResults = [
+                LaneResult(lane: .primary, execution: primary),
+                LaneResult(lane: .secondary, execution: secondary)
+            ]
+        }
+
+        init(executionsByLane: [OracleLane: LaneExecution<Success>]) throws {
+            let lanes = executionsByLane.keys.sorted { $0.ordinal < $1.ordinal }
+            guard (2 ... OracleLane.allCases.count).contains(lanes.count) else {
+                throw OracleLaneValidationError.invalidCount(lanes.count)
+            }
+            try OracleLane.validateOrderedPrefix(lanes)
+            orderedResults = executionsByLane.sorted { lhs, rhs in
+                lhs.key.ordinal < rhs.key.ordinal
+            }.map { lane, execution in
+                LaneResult(lane: lane, execution: execution)
+            }
+        }
+
+        var orderedLanes: [OracleLane] {
+            orderedResults.map(\.lane)
+        }
+
+        var executionsByLane: [OracleLane: LaneExecution<Success>] {
+            Dictionary(uniqueKeysWithValues: orderedResults.map { ($0.lane, $0.execution) })
+        }
+
+        subscript(lane: OracleLane) -> LaneExecution<Success>? {
+            orderedResults.first(where: { $0.lane == lane })?.execution
+        }
+
+        var primary: LaneExecution<Success> {
+            requiredExecution(for: .primary)
+        }
+
+        var secondary: LaneExecution<Success> {
+            requiredExecution(for: .secondary)
+        }
+
+        private func requiredExecution(for lane: OracleLane) -> LaneExecution<Success> {
+            guard let execution = self[lane] else {
+                preconditionFailure("Validated Oracle result is missing the \(lane.rawValue) lane")
+            }
+            return execution
+        }
     }
 
     typealias Operation<Success: Sendable> = @MainActor @Sendable () async throws -> Success
@@ -55,29 +116,61 @@ enum OraclePairCoordinator {
         primary: @escaping Operation<Success>,
         secondary: @escaping Operation<Success>
     ) async throws -> Result<Success> {
-        try await withThrowingTaskGroup(
-            of: (OracleLane, LaneExecution<Success>).self,
+        try await run(operations: [
+            LaneOperation(lane: .primary, operation: primary),
+            LaneOperation(lane: .secondary, operation: secondary)
+        ])
+    }
+
+    /// Runs a complete 2...5 Oracle lane prefix concurrently and returns results
+    /// in lane order, independent of task completion order.
+    @MainActor
+    static func run<Success: Sendable>(
+        operationsByLane: [OracleLane: Operation<Success>]
+    ) async throws -> Result<Success> {
+        let operations = operationsByLane
+            .map { LaneOperation(lane: $0.key, operation: $0.value) }
+            .sorted { $0.lane.ordinal < $1.lane.ordinal }
+        return try await run(operations: operations)
+    }
+
+    /// Array form used when the caller already owns a stable configured order.
+    @MainActor
+    static func run<Success: Sendable>(
+        operations: [LaneOperation<Success>]
+    ) async throws -> Result<Success> {
+        let lanes = operations.map(\.lane)
+        guard (2 ... OracleLane.allCases.count).contains(lanes.count) else {
+            throw OracleLaneValidationError.invalidCount(lanes.count)
+        }
+        try OracleLane.validateOrderedPrefix(lanes)
+
+        return try await withThrowingTaskGroup(
+            of: LaneResult<Success>.self,
             returning: Result<Success>.self
         ) { group in
-            group.addTask { try await (.primary, execute(primary)) }
-            group.addTask { try await (.secondary, execute(secondary)) }
+            for laneOperation in operations {
+                group.addTask {
+                    let execution = try await execute(laneOperation.operation)
+                    return LaneResult(
+                        lane: laneOperation.lane,
+                        execution: execution
+                    )
+                }
+            }
 
-            var primaryResult: LaneExecution<Success>?
-            var secondaryResult: LaneExecution<Success>?
+            var executionsByLane: [OracleLane: LaneExecution<Success>] = [:]
             do {
-                for try await (lane, result) in group {
-                    switch lane {
-                    case .primary: primaryResult = result
-                    case .secondary: secondaryResult = result
-                    }
+                for try await laneResult in group {
+                    executionsByLane[laneResult.lane] = laneResult.execution
                 }
             } catch {
                 group.cancelAll()
                 throw error
             }
 
-            guard let primaryResult, let secondaryResult else { throw CancellationError() }
-            return Result(primary: primaryResult, secondary: secondaryResult)
+            guard executionsByLane.count == operations.count else { throw CancellationError() }
+            return try Result(executionsByLane: executionsByLane)
         }
     }
 
@@ -96,3 +189,7 @@ enum OraclePairCoordinator {
         }
     }
 }
+
+/// Preferred generic name for new callers. The compatibility name remains the
+/// concrete declaration so the dual-Oracle runtime can migrate incrementally.
+typealias OracleGroupCoordinator = OraclePairCoordinator

--- a/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
@@ -86,7 +86,7 @@ enum OraclePairCoordinator {
         _ operation: @escaping Operation<Success>
     ) async throws -> LaneExecution<Success> {
         do {
-            return .success(try await operation())
+            return try await .success(operation())
         } catch is CancellationError {
             throw CancellationError()
         } catch let failure as OracleLaneFailure {

--- a/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OraclePairCoordinator.swift
@@ -86,7 +86,7 @@ enum OraclePairCoordinator {
         _ operation: @escaping Operation<Success>
     ) async throws -> LaneExecution<Success> {
         do {
-            return try await .success(operation())
+            return .success(try await operation())
         } catch is CancellationError {
             throw CancellationError()
         } catch let failure as OracleLaneFailure {

--- a/Sources/RepoPrompt/Infrastructure/MCP/OraclePairModelSelectionPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OraclePairModelSelectionPolicy.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum OraclePairModelSelectionPolicy {
+    static func canonicalSecondaryRaw(_ raw: String?) throws -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        guard let model = AIModel.fromModelName(trimmed) else {
+            throw ChatToolError.invalidParams(
+                "Secondary Oracle Model '\(trimmed)' is not a recognized Oracle model ID."
+            )
+        }
+        return model.rawValue
+    }
+
+    static func resolveSecondary(raw: String?) throws -> AIModel? {
+        guard let canonicalRaw = try canonicalSecondaryRaw(raw) else { return nil }
+        return AIModel.fromModelName(canonicalRaw)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/OraclePairModelSelectionPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OraclePairModelSelectionPolicy.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 enum OraclePairModelSelectionPolicy {
+    static let maximumOracleCount = 5
+    static let maximumAdditionalOracleCount = maximumOracleCount - 1
+
     static func canonicalSecondaryRaw(_ raw: String?) throws -> String? {
         let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !trimmed.isEmpty else { return nil }
@@ -15,5 +18,27 @@ enum OraclePairModelSelectionPolicy {
     static func resolveSecondary(raw: String?) throws -> AIModel? {
         guard let canonicalRaw = try canonicalSecondaryRaw(raw) else { return nil }
         return AIModel.fromModelName(canonicalRaw)
+    }
+
+    static func canonicalAdditionalRaws(_ raws: [String]) throws -> [String] {
+        guard raws.count <= maximumAdditionalOracleCount else {
+            throw ChatToolError.invalidParams(
+                "At most \(maximumOracleCount) Oracle models can be configured."
+            )
+        }
+        return try raws.enumerated().compactMap { index, raw in
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            guard let model = AIModel.fromModelName(trimmed) else {
+                throw ChatToolError.invalidParams(
+                    "Oracle \(index + 2) Model '\(trimmed)' is not a recognized Oracle model ID."
+                )
+            }
+            return model.rawValue
+        }
+    }
+
+    static func resolveAdditional(raws: [String]) throws -> [AIModel] {
+        try canonicalAdditionalRaws(raws).compactMap(AIModel.fromModelName)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
@@ -1081,6 +1081,36 @@ enum ToolResultDTOs {
 
     // MARK: - Chat Send
 
+    struct OracleLaneDTO: Codable, Equatable {
+        let status: String?
+        let chatID: String?
+        let mode: String?
+        let response: String?
+        let partialResponse: String?
+        let error: String?
+        let errorCode: String?
+        let errors: [String]?
+        let oracleLane: String?
+        let oraclePairID: String?
+        let modelRawID: String?
+        let modelDisplayName: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case status
+            case chatID = "chat_id"
+            case mode
+            case response
+            case partialResponse = "partial_response"
+            case error
+            case errorCode = "error_code"
+            case errors
+            case oracleLane = "oracle_lane"
+            case oraclePairID = "oracle_pair_id"
+            case modelRawID = "model_raw_id"
+            case modelDisplayName = "model_display_name"
+        }
+    }
+
     struct ChatSendDTO: Codable, Equatable {
         struct Diff: Codable, Equatable {
             let path: String
@@ -1089,47 +1119,128 @@ enum ToolResultDTOs {
 
         let chatID: String?
         let mode: String?
+        let status: String?
         let response: String?
         let diffs: [Diff]?
         let errors: [String]?
+        let oracleResults: [String: OracleLaneDTO]?
+        let oraclePairID: String?
+        let primaryChatID: String?
+        let secondaryChatID: String?
+        let oracleHistoryDiverged: Bool?
+        let oraclePairHistoryPersistenceError: String?
+        let contextID: String?
+        let agentSessionID: String?
+        let agentRunID: String?
 
         private enum CodingKeys: String, CodingKey {
             case chatID = "chat_id"
             case mode
+            case status
             case response
             case diffs
             case patches
             case errors
+            case oracleResults = "oracle_results"
+            case oraclePairID = "oracle_pair_id"
+            case primaryChatID = "primary_chat_id"
+            case secondaryChatID = "secondary_chat_id"
+            case oracleHistoryDiverged = "oracle_history_diverged"
+            case oraclePairHistoryPersistenceError = "oracle_pair_history_persistence_error"
+            case contextID = "context_id"
+            case agentSessionID = "agent_session_id"
+            case agentRunID = "agent_run_id"
+            case error
         }
 
-        init(chatID: String?, mode: String?, response: String?, diffs: [Diff]?, errors: [String]?) {
+        init(
+            chatID: String?,
+            mode: String?,
+            response: String?,
+            diffs: [Diff]?,
+            errors: [String]?,
+            oracleResults: [String: OracleLaneDTO]? = nil,
+            status: String? = nil,
+            oraclePairID: String? = nil,
+            primaryChatID: String? = nil,
+            secondaryChatID: String? = nil,
+            oracleHistoryDiverged: Bool? = nil,
+            oraclePairHistoryPersistenceError: String? = nil,
+            contextID: String? = nil,
+            agentSessionID: String? = nil,
+            agentRunID: String? = nil
+        ) {
             self.chatID = chatID
             self.mode = mode
+            self.status = status
             self.response = response
             self.diffs = diffs
             self.errors = errors
+            self.oracleResults = oracleResults
+            self.oraclePairID = oraclePairID
+            self.primaryChatID = primaryChatID
+            self.secondaryChatID = secondaryChatID
+            self.oracleHistoryDiverged = oracleHistoryDiverged
+            self.oraclePairHistoryPersistenceError = oraclePairHistoryPersistenceError
+            self.contextID = contextID
+            self.agentSessionID = agentSessionID
+            self.agentRunID = agentRunID
         }
 
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            chatID = try container.decodeIfPresent(String.self, forKey: .chatID)
-            mode = try container.decodeIfPresent(String.self, forKey: .mode)
-            response = try container.decodeIfPresent(String.self, forKey: .response)
-            if let decodedDiffs = try container.decodeIfPresent([Diff].self, forKey: .diffs) {
-                diffs = decodedDiffs
+            let embedded: Self? = if let rawError = try? container.decode(String.self, forKey: .error),
+                                     let raw = OraclePairFailureTransportEnvelope.decodePayload(in: rawError)
+            {
+                try? JSONDecoder().decode(Self.self, from: Data(raw.utf8))
             } else {
-                diffs = try container.decodeIfPresent([Diff].self, forKey: .patches)
+                nil
             }
-            errors = try container.decodeIfPresent([String].self, forKey: .errors)
+
+            chatID = try container.decodeIfPresent(String.self, forKey: .chatID) ?? embedded?.chatID
+            mode = try container.decodeIfPresent(String.self, forKey: .mode) ?? embedded?.mode
+            status = try container.decodeIfPresent(String.self, forKey: .status) ?? embedded?.status
+            response = try container.decodeIfPresent(String.self, forKey: .response) ?? embedded?.response
+            diffs = try container.decodeIfPresent([Diff].self, forKey: .diffs)
+                ?? container.decodeIfPresent([Diff].self, forKey: .patches)
+                ?? embedded?.diffs
+            errors = try container.decodeIfPresent([String].self, forKey: .errors) ?? embedded?.errors
+            oracleResults = try container.decodeIfPresent([String: OracleLaneDTO].self, forKey: .oracleResults)
+                ?? embedded?.oracleResults
+            oraclePairID = try container.decodeIfPresent(String.self, forKey: .oraclePairID) ?? embedded?.oraclePairID
+            primaryChatID = try container.decodeIfPresent(String.self, forKey: .primaryChatID) ?? embedded?.primaryChatID
+            secondaryChatID = try container.decodeIfPresent(String.self, forKey: .secondaryChatID) ?? embedded?.secondaryChatID
+            oracleHistoryDiverged = try container.decodeIfPresent(Bool.self, forKey: .oracleHistoryDiverged)
+                ?? embedded?.oracleHistoryDiverged
+            oraclePairHistoryPersistenceError = try container.decodeIfPresent(
+                String.self,
+                forKey: .oraclePairHistoryPersistenceError
+            ) ?? embedded?.oraclePairHistoryPersistenceError
+            contextID = try container.decodeIfPresent(String.self, forKey: .contextID) ?? embedded?.contextID
+            agentSessionID = try container.decodeIfPresent(String.self, forKey: .agentSessionID) ?? embedded?.agentSessionID
+            agentRunID = try container.decodeIfPresent(String.self, forKey: .agentRunID) ?? embedded?.agentRunID
         }
 
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encodeIfPresent(chatID, forKey: .chatID)
             try container.encodeIfPresent(mode, forKey: .mode)
+            try container.encodeIfPresent(status, forKey: .status)
             try container.encodeIfPresent(response, forKey: .response)
             try container.encodeIfPresent(diffs, forKey: .diffs)
             try container.encodeIfPresent(errors, forKey: .errors)
+            try container.encodeIfPresent(oracleResults, forKey: .oracleResults)
+            try container.encodeIfPresent(oraclePairID, forKey: .oraclePairID)
+            try container.encodeIfPresent(primaryChatID, forKey: .primaryChatID)
+            try container.encodeIfPresent(secondaryChatID, forKey: .secondaryChatID)
+            try container.encodeIfPresent(oracleHistoryDiverged, forKey: .oracleHistoryDiverged)
+            try container.encodeIfPresent(
+                oraclePairHistoryPersistenceError,
+                forKey: .oraclePairHistoryPersistenceError
+            )
+            try container.encodeIfPresent(contextID, forKey: .contextID)
+            try container.encodeIfPresent(agentSessionID, forKey: .agentSessionID)
+            try container.encodeIfPresent(agentRunID, forKey: .agentRunID)
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
@@ -1091,6 +1091,10 @@ enum ToolResultDTOs {
         let errorCode: String?
         let errors: [String]?
         let oracleLane: String?
+        let oracleOrdinal: Int?
+        let oracleLabel: String?
+        let oracleGroupID: String?
+        let oracleCount: Int?
         let oraclePairID: String?
         let modelRawID: String?
         let modelDisplayName: String?
@@ -1105,6 +1109,10 @@ enum ToolResultDTOs {
             case errorCode = "error_code"
             case errors
             case oracleLane = "oracle_lane"
+            case oracleOrdinal = "oracle_ordinal"
+            case oracleLabel = "oracle_label"
+            case oracleGroupID = "oracle_group_id"
+            case oracleCount = "oracle_count"
             case oraclePairID = "oracle_pair_id"
             case modelRawID = "model_raw_id"
             case modelDisplayName = "model_display_name"
@@ -1124,10 +1132,16 @@ enum ToolResultDTOs {
         let diffs: [Diff]?
         let errors: [String]?
         let oracleResults: [String: OracleLaneDTO]?
+        let oracleGroupResults: [OracleLaneDTO]?
+        let oracleResultOrder: [String]?
+        let oracleGroupID: String?
+        let oracleCount: Int?
+        let oracleChatIDs: [String: String]?
         let oraclePairID: String?
         let primaryChatID: String?
         let secondaryChatID: String?
         let oracleHistoryDiverged: Bool?
+        let oracleGroupHistoryPersistenceError: String?
         let oraclePairHistoryPersistenceError: String?
         let contextID: String?
         let agentSessionID: String?
@@ -1142,10 +1156,16 @@ enum ToolResultDTOs {
             case patches
             case errors
             case oracleResults = "oracle_results"
+            case oracleGroupResults = "oracle_group_results"
+            case oracleResultOrder = "oracle_result_order"
+            case oracleGroupID = "oracle_group_id"
+            case oracleCount = "oracle_count"
+            case oracleChatIDs = "oracle_chat_ids"
             case oraclePairID = "oracle_pair_id"
             case primaryChatID = "primary_chat_id"
             case secondaryChatID = "secondary_chat_id"
             case oracleHistoryDiverged = "oracle_history_diverged"
+            case oracleGroupHistoryPersistenceError = "oracle_group_history_persistence_error"
             case oraclePairHistoryPersistenceError = "oracle_pair_history_persistence_error"
             case contextID = "context_id"
             case agentSessionID = "agent_session_id"
@@ -1160,11 +1180,17 @@ enum ToolResultDTOs {
             diffs: [Diff]?,
             errors: [String]?,
             oracleResults: [String: OracleLaneDTO]? = nil,
+            oracleGroupResults: [OracleLaneDTO]? = nil,
+            oracleResultOrder: [String]? = nil,
+            oracleGroupID: String? = nil,
+            oracleCount: Int? = nil,
+            oracleChatIDs: [String: String]? = nil,
             status: String? = nil,
             oraclePairID: String? = nil,
             primaryChatID: String? = nil,
             secondaryChatID: String? = nil,
             oracleHistoryDiverged: Bool? = nil,
+            oracleGroupHistoryPersistenceError: String? = nil,
             oraclePairHistoryPersistenceError: String? = nil,
             contextID: String? = nil,
             agentSessionID: String? = nil,
@@ -1177,10 +1203,16 @@ enum ToolResultDTOs {
             self.diffs = diffs
             self.errors = errors
             self.oracleResults = oracleResults
+            self.oracleGroupResults = oracleGroupResults
+            self.oracleResultOrder = oracleResultOrder
+            self.oracleGroupID = oracleGroupID
+            self.oracleCount = oracleCount
+            self.oracleChatIDs = oracleChatIDs
             self.oraclePairID = oraclePairID
             self.primaryChatID = primaryChatID
             self.secondaryChatID = secondaryChatID
             self.oracleHistoryDiverged = oracleHistoryDiverged
+            self.oracleGroupHistoryPersistenceError = oracleGroupHistoryPersistenceError
             self.oraclePairHistoryPersistenceError = oraclePairHistoryPersistenceError
             self.contextID = contextID
             self.agentSessionID = agentSessionID
@@ -1207,11 +1239,23 @@ enum ToolResultDTOs {
             errors = try container.decodeIfPresent([String].self, forKey: .errors) ?? embedded?.errors
             oracleResults = try container.decodeIfPresent([String: OracleLaneDTO].self, forKey: .oracleResults)
                 ?? embedded?.oracleResults
+            oracleGroupResults = try container.decodeIfPresent([OracleLaneDTO].self, forKey: .oracleGroupResults)
+                ?? embedded?.oracleGroupResults
+            oracleResultOrder = try container.decodeIfPresent([String].self, forKey: .oracleResultOrder)
+                ?? embedded?.oracleResultOrder
+            oracleGroupID = try container.decodeIfPresent(String.self, forKey: .oracleGroupID) ?? embedded?.oracleGroupID
+            oracleCount = try container.decodeIfPresent(Int.self, forKey: .oracleCount) ?? embedded?.oracleCount
+            oracleChatIDs = try container.decodeIfPresent([String: String].self, forKey: .oracleChatIDs)
+                ?? embedded?.oracleChatIDs
             oraclePairID = try container.decodeIfPresent(String.self, forKey: .oraclePairID) ?? embedded?.oraclePairID
             primaryChatID = try container.decodeIfPresent(String.self, forKey: .primaryChatID) ?? embedded?.primaryChatID
             secondaryChatID = try container.decodeIfPresent(String.self, forKey: .secondaryChatID) ?? embedded?.secondaryChatID
             oracleHistoryDiverged = try container.decodeIfPresent(Bool.self, forKey: .oracleHistoryDiverged)
                 ?? embedded?.oracleHistoryDiverged
+            oracleGroupHistoryPersistenceError = try container.decodeIfPresent(
+                String.self,
+                forKey: .oracleGroupHistoryPersistenceError
+            ) ?? embedded?.oracleGroupHistoryPersistenceError
             oraclePairHistoryPersistenceError = try container.decodeIfPresent(
                 String.self,
                 forKey: .oraclePairHistoryPersistenceError
@@ -1230,10 +1274,19 @@ enum ToolResultDTOs {
             try container.encodeIfPresent(diffs, forKey: .diffs)
             try container.encodeIfPresent(errors, forKey: .errors)
             try container.encodeIfPresent(oracleResults, forKey: .oracleResults)
+            try container.encodeIfPresent(oracleGroupResults, forKey: .oracleGroupResults)
+            try container.encodeIfPresent(oracleResultOrder, forKey: .oracleResultOrder)
+            try container.encodeIfPresent(oracleGroupID, forKey: .oracleGroupID)
+            try container.encodeIfPresent(oracleCount, forKey: .oracleCount)
+            try container.encodeIfPresent(oracleChatIDs, forKey: .oracleChatIDs)
             try container.encodeIfPresent(oraclePairID, forKey: .oraclePairID)
             try container.encodeIfPresent(primaryChatID, forKey: .primaryChatID)
             try container.encodeIfPresent(secondaryChatID, forKey: .secondaryChatID)
             try container.encodeIfPresent(oracleHistoryDiverged, forKey: .oracleHistoryDiverged)
+            try container.encodeIfPresent(
+                oracleGroupHistoryPersistenceError,
+                forKey: .oracleGroupHistoryPersistenceError
+            )
             try container.encodeIfPresent(
                 oraclePairHistoryPersistenceError,
                 forKey: .oraclePairHistoryPersistenceError

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAppPhysicalCapabilityAdapters.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAppPhysicalCapabilityAdapters.swift
@@ -118,7 +118,7 @@ enum MCPAppPhysicalCapabilityAdapters {
         _ finalReviewAuthorization: ContextBuilderFinalReviewAuthorization?,
         _ progressReporter: ContextBuilderMCPProgressReporter?,
         _ activityReporter: ContextBuilderMCPActivityReporter?
-    ) async throws -> ChatSendReply
+    ) async throws -> OracleSendResult
     typealias CaptureRequestMetadata = @MainActor @Sendable () async -> MCPServerViewModel.RequestMetadata
     typealias ResolveImplicitContextBuilderGitTarget = @MainActor @Sendable (
         _ metadata: MCPServerViewModel.RequestMetadata

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderProgressTimeline.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderProgressTimeline.swift
@@ -159,9 +159,13 @@ typealias ContextBuilderMCPProgressReporter = @MainActor @Sendable (
     _ phase: ContextBuilderMCPProgressPhase
 ) async -> Void
 
+enum ContextBuilderMCPActivity {
+    case report(phase: ContextBuilderMCPProgressPhase, message: String)
+    case suppressHeartbeat(phase: ContextBuilderMCPProgressPhase)
+}
+
 typealias ContextBuilderMCPActivityReporter = @MainActor @Sendable (
-    _ phase: ContextBuilderMCPProgressPhase,
-    _ message: String
+    _ activity: ContextBuilderMCPActivity
 ) async -> Void
 
 struct ContextBuilderMCPProgressEvent: Equatable {
@@ -194,6 +198,8 @@ actor ContextBuilderMCPProgressTimeline {
     private var currentPhase: ContextBuilderMCPProgressPhase?
     private var currentPhaseStartedAt: TimeInterval?
     private var phaseGeneration = 0
+    private var heartbeatSuppressedGeneration: Int?
+    private var pendingHeartbeatSuppressionPhase: ContextBuilderMCPProgressPhase?
     private var didReportSoftBound = false
     private var softBoundTask: Task<Void, Never>?
     private var pendingEvents: [ContextBuilderMCPProgressEvent] = []
@@ -224,6 +230,10 @@ actor ContextBuilderMCPProgressTimeline {
         let generation = phaseGeneration
         currentPhase = phase
         currentPhaseStartedAt = now
+        if pendingHeartbeatSuppressionPhase == phase {
+            heartbeatSuppressedGeneration = generation
+            pendingHeartbeatSuppressionPhase = nil
+        }
         didReportSoftBound = false
         let started = event(
             kind: .started,
@@ -283,15 +293,24 @@ actor ContextBuilderMCPProgressTimeline {
         }
     }
 
+    func suppressHeartbeat(for phase: ContextBuilderMCPProgressPhase) {
+        if currentPhase == phase {
+            heartbeatSuppressedGeneration = phaseGeneration
+        } else {
+            pendingHeartbeatSuppressionPhase = phase
+        }
+    }
+
     func heartbeat(
         fallbackStage: String,
         fallbackMessage: String
-    ) -> (stage: String, message: String) {
+    ) -> (stage: String, message: String)? {
         guard let phase = currentPhase,
               let phaseStartedAt = currentPhaseStartedAt
         else {
             return (fallbackStage, fallbackMessage)
         }
+        guard heartbeatSuppressedGeneration != phaseGeneration else { return nil }
 
         let now = clock()
         return (

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift
@@ -39,8 +39,8 @@ private struct ContextBuilderToolResult: Codable {
     let selection: String
 
     let responseType: String?
-    let plan: ChatSendReply?
-    let review: ChatSendReply?
+    let plan: Value?
+    let review: Value?
     let followUpHint: String?
     let oracleExportPath: String?
     let oracleExportInstruction: String?
@@ -100,10 +100,10 @@ private struct ContextBuilderToolResult: Codable {
             obj["response_type"] = .string(responseType)
         }
         if let plan {
-            obj["plan"] = plan.toMCPValue()
+            obj["plan"] = plan
         }
         if let review {
-            obj["review"] = review.toMCPValue()
+            obj["review"] = review
         }
         if let hint = followUpHint {
             obj["follow_up_hint"] = .string(hint)
@@ -261,6 +261,17 @@ enum ContextBuilderTypedPromptResolver {
 @MainActor
 final class MCPContextBuilderToolProvider: MCPAppToolProviding {
     let group: MCPAppToolGroup = .contextBuilder
+
+    nonisolated static func followUpValue(
+        for result: OracleSendResult
+    ) -> (value: Value, primary: ChatSendReply) {
+        switch result.payload {
+        case let .single(reply):
+            (.object(reply.toMCPObject()), reply)
+        case let .paired(pair):
+            (.object(pair.toMCPObject()), pair.primaryReply())
+        }
+    }
 
     private let runtime: MCPAppToolBinder
     private typealias Dependencies = (
@@ -509,8 +520,13 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
             let progressReporter: ContextBuilderMCPProgressReporter = { phase in
                 await progressTimeline.transition(to: phase)
             }
-            let activityReporter: ContextBuilderMCPActivityReporter = { phase, message in
-                await progressTimeline.reportActivity(phase: phase, message: message)
+            let activityReporter: ContextBuilderMCPActivityReporter = { activity in
+                switch activity {
+                case let .report(phase, message):
+                    await progressTimeline.reportActivity(phase: phase, message: message)
+                case let .suppressHeartbeat(phase):
+                    await progressTimeline.suppressHeartbeat(for: phase)
+                }
             }
 
             func runContextBuilderAndPlan() async throws -> ContextBuilderToolResult {
@@ -674,8 +690,9 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
                 let selectionReply = renderedSelection.reply
                 let formattedSelection = renderedSelection.formatted
 
-                var planReply: ChatSendReply? = nil
-                var reviewReply: ChatSendReply? = nil
+                var planValue: Value? = nil
+                var reviewValue: Value? = nil
+                var followUpPrimaryReply: ChatSendReply? = nil
                 var followUpHint: String? = nil
                 var oracleExportFile: OracleExportFile? = nil
 
@@ -791,7 +808,7 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
                         "Generating \(modeLabel)..."
                     )
 
-                    let reply = try await withTimelinePhaseCompletion(progressTimeline) {
+                    let result = try await withTimelinePhaseCompletion(progressTimeline) {
                         try await withHeartbeat(
                             connectionID: connectionID,
                             tool: MCPWindowToolName.contextBuilder,
@@ -816,12 +833,14 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
                         }
                     }
 
+                    let followUp = Self.followUpValue(for: result)
+                    followUpPrimaryReply = followUp.primary
                     if mode == .review {
-                        reviewReply = reply
+                        reviewValue = followUp.value
                     } else {
-                        planReply = reply
+                        planValue = followUp.value
                     }
-                    followUpHint = "Continue this \(modeLabel) conversation with ask_oracle(chat_id: \"\(reply.shortId)\", new_chat: false)"
+                    followUpHint = "Continue this \(modeLabel) conversation with ask_oracle(chat_id: \"\(followUp.primary.shortId)\", new_chat: false)"
                 }
 
                 await dependencies.execution.sendStageProgress(
@@ -860,8 +879,8 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
                         planningModel: planModelName,
                         selection: formattedSelection,
                         responseType: responseType?.rawValue,
-                        plan: planReply,
-                        review: reviewReply,
+                        plan: planValue,
+                        review: reviewValue,
                         followUpHint: followUpHint,
                         oracleExportPath: oracleExportPath,
                         oracleExportInstruction: oracleExportInstruction
@@ -869,7 +888,7 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
                 }
 
                 if exportResponse,
-                   planReply != nil || reviewReply != nil
+                   planValue != nil || reviewValue != nil
                 {
                     let resultForExport = makeResult(oracleExportPath: nil)
                     let markdown = ToolOutputFormatter.formatDiscoverContext(value: resultForExport.toMCPValue())
@@ -882,8 +901,8 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
                             }
                         }
                         .joined(separator: "\n")
-                    let exportMode = responseType?.rawValue ?? planReply?.mode ?? reviewReply?.mode ?? "response"
-                    let chatID = planReply?.shortId ?? reviewReply?.shortId
+                    let exportMode = responseType?.rawValue ?? followUpPrimaryReply?.mode ?? "response"
+                    let chatID = followUpPrimaryReply?.shortId
                     guard let capturedOracleExportDestination else {
                         throw MCPError.internalError("Missing captured Oracle export destination for context_builder export.")
                     }
@@ -992,7 +1011,7 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
                 while !Task.isCancelled {
                     try await Task.sleep(for: interval)
                     try Task.checkCancellation()
-                    let heartbeat: (stage: String, message: String) = if let timeline {
+                    let heartbeat: (stage: String, message: String)? = if let timeline {
                         await timeline.heartbeat(
                             fallbackStage: stage,
                             fallbackMessage: message
@@ -1000,13 +1019,15 @@ final class MCPContextBuilderToolProvider: MCPAppToolProviding {
                     } else {
                         (stage, message)
                     }
-                    await ServerNetworkManager.shared.sendProgress(
-                        for: connectionID,
-                        tool: tool,
-                        kind: .heartbeat,
-                        stage: heartbeat.stage,
-                        message: heartbeat.message
-                    )
+                    if let heartbeat {
+                        await ServerNetworkManager.shared.sendProgress(
+                            for: connectionID,
+                            tool: tool,
+                            kind: .heartbeat,
+                            stage: heartbeat.stage,
+                            message: heartbeat.message
+                        )
+                    }
                 }
             } catch {
                 // Cancellation is the expected completion path.

--- a/Sources/RepoPrompt/Infrastructure/UI/Components/ModelDestination.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/ModelDestination.swift
@@ -8,11 +8,18 @@ import SwiftUI
 @MainActor
 struct ModelDestination: Identifiable {
     let id: String
+    let allowsEmptySelection: Bool
     private let getter: @MainActor () -> String
     private let applier: @MainActor (String) -> Void
 
-    init(id: String, getter: @escaping @MainActor () -> String, applier: @escaping @MainActor (String) -> Void) {
+    init(
+        id: String,
+        allowsEmptySelection: Bool = false,
+        getter: @escaping @MainActor () -> String,
+        applier: @escaping @MainActor (String) -> Void
+    ) {
         self.id = id
+        self.allowsEmptySelection = allowsEmptySelection
         self.getter = getter
         self.applier = applier
     }

--- a/Tests/RepoPromptTests/AI/AIModelPreferenceRegressionTests.swift
+++ b/Tests/RepoPromptTests/AI/AIModelPreferenceRegressionTests.swift
@@ -36,6 +36,26 @@ final class AIModelPreferenceRegressionTests: XCTestCase {
         )
 
         XCTAssertEqual(displayName, availableModels[0].displayName)
+        XCTAssertEqual(
+            AIModelDropdown.displayName(
+                forRawValue: "   ",
+                destinationID: "secondaryOracle",
+                allowsEmptySelection: true,
+                availableModels: availableModels,
+                customOpenRouterModels: []
+            ),
+            "Disabled"
+        )
+        XCTAssertEqual(
+            AIModelDropdown.displayName(
+                forRawValue: "  custom-secondary-model  ",
+                destinationID: "secondaryOracle",
+                allowsEmptySelection: true,
+                availableModels: [],
+                customOpenRouterModels: []
+            ),
+            "custom-secondary-model"
+        )
     }
 
     @MainActor

--- a/Tests/RepoPromptTests/AgentMode/AgentOraclePillLogicTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentOraclePillLogicTests.swift
@@ -44,6 +44,28 @@ final class AgentOraclePillLogicTests: XCTestCase {
         )
     }
 
+    func testPresentationsScaleToFiveConfiguredOraclesInStableOrder() {
+        let model = AIModel.claude4Sonnet.rawValue
+        XCTAssertEqual(
+            AgentOraclePillLogic.presentations(
+                additionalModelRaws: Array(repeating: model, count: 4)
+            ),
+            OracleLane.allCases.map { .pairedLane($0) }
+        )
+        XCTAssertEqual(AgentOraclePillPresentation.pairedLane(.primary).label, "Primary Oracle")
+        XCTAssertEqual(AgentOraclePillPresentation.pairedLane(.oracle5).label, "Oracle 5")
+    }
+
+    func testHistoricalGroupLanesRemainVisibleAfterConfigurationRemoval() {
+        XCTAssertEqual(
+            AgentOraclePillLogic.presentations(
+                additionalModelRaws: [],
+                groupSessionLanes: Set(OracleLane.allCases)
+            ),
+            OracleLane.allCases.map { .pairedLane($0) }
+        )
+    }
+
     func testLaneResolutionPreservesLegacyPrimaryAndRejectsMalformedMetadata() {
         XCTAssertEqual(AgentOraclePillLogic.resolvedLane(for: makeSession()), .primary)
         XCTAssertEqual(AgentOraclePillLogic.resolvedLane(for: makeSession(pairID: UUID(), lane: .primary)), .primary)

--- a/Tests/RepoPromptTests/AgentMode/AgentOraclePillLogicTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentOraclePillLogicTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class AgentOraclePillLogicTests: XCTestCase {
+    private func makeSession(
+        savedAt: Date = Date(),
+        messageCount: Int? = nil,
+        workspaceID: UUID? = nil,
+        tabID: UUID? = nil,
+        pairID: UUID? = nil,
+        lane: OracleLane? = nil,
+        shortID: String? = nil
+    ) -> ChatSession {
+        ChatSession(
+            workspaceID: workspaceID,
+            composeTabID: tabID,
+            oraclePairID: pairID,
+            oracleLane: lane,
+            name: "Oracle",
+            savedAt: savedAt,
+            messageCount: messageCount,
+            shortID: shortID
+        )
+    }
+
+    func testPresentationsUseConfigurationOrExistingSecondaryLane() {
+        for raw in [String?.none, "", " \n\t "] {
+            XCTAssertEqual(AgentOraclePillLogic.presentations(secondaryModelRaw: raw), [.legacySingle])
+        }
+        XCTAssertEqual(
+            AgentOraclePillLogic.presentations(secondaryModelRaw: "not-a-model"),
+            [.legacySingle]
+        )
+        let paired: [AgentOraclePillPresentation] = [.pairedLane(.primary), .pairedLane(.secondary)]
+        XCTAssertEqual(
+            AgentOraclePillLogic.presentations(secondaryModelRaw: AIModel.claude4Sonnet.rawValue),
+            paired
+        )
+        XCTAssertEqual(
+            AgentOraclePillLogic.presentations(secondaryModelRaw: nil, hasSecondarySession: true),
+            paired
+        )
+    }
+
+    func testLaneResolutionPreservesLegacyPrimaryAndRejectsMalformedMetadata() {
+        XCTAssertEqual(AgentOraclePillLogic.resolvedLane(for: makeSession()), .primary)
+        XCTAssertEqual(AgentOraclePillLogic.resolvedLane(for: makeSession(pairID: UUID(), lane: .primary)), .primary)
+        XCTAssertEqual(AgentOraclePillLogic.resolvedLane(for: makeSession(pairID: UUID(), lane: .secondary)), .secondary)
+        XCTAssertNil(AgentOraclePillLogic.resolvedLane(for: makeSession(pairID: UUID())))
+        XCTAssertNil(AgentOraclePillLogic.resolvedLane(for: makeSession(lane: .primary)))
+        XCTAssertNil(AgentOraclePillLogic.resolvedLane(for: makeSession(lane: .secondary)))
+    }
+
+    func testLaneFilteringKeepsPrimaryAndSecondaryIndependent() {
+        let legacy = makeSession(messageCount: 1)
+        let primary = makeSession(messageCount: 1, pairID: UUID(), lane: .primary)
+        let secondary = makeSession(messageCount: 1, pairID: UUID(), lane: .secondary)
+
+        let primarySessions = AgentOraclePillLogic.sessions(
+            [secondary, primary, legacy],
+            resolvedTo: .primary
+        )
+        let secondarySessions = AgentOraclePillLogic.sessions(
+            [legacy, primary, secondary],
+            resolvedTo: .secondary
+        )
+
+        XCTAssertEqual(Set(primarySessions.map(\.id)), Set([legacy.id, primary.id]))
+        XCTAssertEqual(secondarySessions.map(\.id), [secondary.id])
+    }
+
+    func testLaneWithoutEligibleSessionHasNoPillTarget() {
+        let legacy = makeSession(messageCount: 1)
+        let secondarySessions = AgentOraclePillLogic.sessions([legacy], resolvedTo: .secondary)
+
+        XCTAssertTrue(secondarySessions.isEmpty)
+        XCTAssertNil(AgentOraclePillLogic.latestSession(
+            in: secondarySessions,
+            streamingSessionIDs: []
+        ))
+    }
+
+    func testExactOpenRequiresMatchingLaneAndRoute() throws {
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let secondary = makeSession(
+            workspaceID: workspaceID,
+            tabID: tabID,
+            pairID: UUID(),
+            lane: .secondary,
+            shortID: "secondary-oracle"
+        )
+        let request = try XCTUnwrap(AgentOraclePillLogic.explicitOpenRequest(
+            chatID: secondary.shortID,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            generation: 3
+        ))
+
+        XCTAssertTrue(AgentOraclePillLogic.shouldPresent(
+            session: secondary,
+            for: request,
+            currentGeneration: 3,
+            currentWorkspaceID: workspaceID,
+            currentTabID: tabID,
+            expectedLane: .secondary
+        ))
+        XCTAssertFalse(AgentOraclePillLogic.shouldPresent(
+            session: secondary,
+            for: request,
+            currentGeneration: 3,
+            currentWorkspaceID: workspaceID,
+            currentTabID: tabID,
+            expectedLane: .primary
+        ))
+    }
+
+    func testStreamingFirstSelectionRemainsLaneLocal() {
+        let now = Date()
+        let primaryStreaming = makeSession(savedAt: now.addingTimeInterval(-10), pairID: UUID(), lane: .primary)
+        let primaryNewer = makeSession(savedAt: now, pairID: UUID(), lane: .primary)
+        let secondaryStreaming = makeSession(savedAt: now.addingTimeInterval(10), pairID: UUID(), lane: .secondary)
+        let streaming: Set<UUID> = [primaryStreaming.id, secondaryStreaming.id]
+
+        let primarySessions = AgentOraclePillLogic.sessions(
+            [secondaryStreaming, primaryNewer, primaryStreaming],
+            resolvedTo: .primary
+        )
+        let secondarySessions = AgentOraclePillLogic.sessions(
+            [primaryStreaming, primaryNewer, secondaryStreaming],
+            resolvedTo: .secondary
+        )
+        XCTAssertEqual(
+            AgentOraclePillLogic.latestSession(
+                in: primarySessions,
+                streamingSessionIDs: streaming
+            )?.id,
+            primaryStreaming.id
+        )
+        XCTAssertEqual(
+            AgentOraclePillLogic.latestSession(
+                in: secondarySessions,
+                streamingSessionIDs: streaming
+            )?.id,
+            secondaryStreaming.id
+        )
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/ContextBuilderOracleResultTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/ContextBuilderOracleResultTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class ContextBuilderOracleResultTests: XCTestCase {
+    func testDecodesPairedOracleResults() throws {
+        let dto = try decode(#"""
+        {
+          "response_type": "plan",
+          "plan": {
+            "chat_id": "primary-chat",
+            "status": "partial_failure",
+            "oracle_results": {
+              "primary": {
+                "status": "completed",
+                "chat_id": "primary-chat",
+                "response": "Primary response",
+                "model_display_name": "Primary Model"
+              },
+              "secondary": {
+                "status": "failed",
+                "chat_id": "secondary-chat",
+                "partial_response": "Secondary partial",
+                "error": "Secondary failed",
+                "model_display_name": "Secondary Model"
+              }
+            }
+          }
+        }
+        """#)
+
+        XCTAssertEqual(dto.plan?.status, "partial_failure")
+        XCTAssertEqual(dto.plan?.oracleResults?["primary"]?.response, "Primary response")
+        XCTAssertEqual(dto.plan?.oracleResults?["secondary"]?.partialResponse, "Secondary partial")
+        XCTAssertEqual(dto.plan?.oracleResults?["secondary"]?.error, "Secondary failed")
+    }
+
+    func testLaneProjectionIsStablePrimaryThenSecondary() throws {
+        let dto = try decode(#"""
+        {
+          "response_type": "review",
+          "review": {
+            "oracle_results": {
+              "secondary": {
+                "status": "failed",
+                "chat_id": " secondary-chat ",
+                "error": " Secondary failed ",
+                "model_display_name": "Secondary Model"
+              },
+              "primary": {
+                "status": "completed",
+                "chat_id": "primary-chat",
+                "model_display_name": "Primary Model"
+              }
+            }
+          }
+        }
+        """#)
+
+        let lanes = contextBuilderOracleLaneSummaries(for: dto)
+        XCTAssertEqual(lanes.map(\.lane), [.primary, .secondary])
+        XCTAssertEqual(lanes.map(\.chatID), ["primary-chat", "secondary-chat"])
+        XCTAssertEqual(lanes.map(\.status), ["completed", "failed"])
+        XCTAssertEqual(lanes.map(\.cardStatus), [.success, .failure])
+    }
+
+    func testLanePopoverRoutesOnlyTheExactLaneChat() throws {
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let userInfo = try XCTUnwrap(contextBuilderOraclePopoverUserInfo(
+            openContext: AgentOracleOpenContext(
+                windowID: 7,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                chatID: "ambient-chat"
+            ),
+            chatID: " secondary-chat "
+        ))
+        let route = try XCTUnwrap(AgentOraclePopoverRoute(notificationUserInfo: userInfo))
+
+        XCTAssertEqual(route.workspaceID, workspaceID)
+        XCTAssertEqual(route.tabID, tabID)
+        XCTAssertEqual(route.chatID, "secondary-chat")
+        XCTAssertNil(contextBuilderOraclePopoverUserInfo(
+            openContext: AgentOracleOpenContext(
+                windowID: 7,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                chatID: "ambient-chat"
+            ),
+            chatID: "  "
+        ))
+    }
+
+    func testFollowUpValuePreservesPairedEnvelopeAndLegacyPrimaryProjection() throws {
+        let primaryID = UUID()
+        let pairID = UUID()
+        let result = OracleSendResult(
+            payload: .paired(.init(
+                pairID: pairID,
+                mode: "plan",
+                primaryChatID: "primary-chat",
+                secondaryChatID: "secondary-chat",
+                primaryModel: .gpt54Pro,
+                secondaryModel: .claude4Sonnet,
+                result: .init(
+                    primary: .success(ChatSendReply(
+                        chatId: primaryID,
+                        shortId: "primary-chat",
+                        mode: "plan",
+                        response: "Primary response",
+                        errors: nil
+                    )),
+                    secondary: .failure(.init(message: "Secondary failed", partialResponse: "Secondary partial"))
+                ),
+                historyDiverged: true,
+                historyPersistenceError: nil
+            )),
+            route: .init(contextID: UUID(), agentSessionID: UUID(), agentRunID: UUID())
+        )
+
+        let followUp = MCPContextBuilderToolProvider.followUpValue(for: result)
+        XCTAssertEqual(followUp.primary.chatId, primaryID)
+        XCTAssertEqual(followUp.primary.errors, ["Secondary Oracle failed: Secondary failed"])
+        let json = ToolOutputFormatter.rawJSONString(.object([
+            "response_type": .string("plan"),
+            "plan": followUp.value
+        ]))
+        let dto = try decode(json)
+        XCTAssertEqual(dto.plan?.status, "partial_failure")
+        XCTAssertEqual(dto.plan?.oraclePairID, pairID.uuidString)
+        XCTAssertEqual(dto.plan?.oracleResults?["primary"]?.response, "Primary response")
+        XCTAssertEqual(dto.plan?.oracleResults?["secondary"]?.partialResponse, "Secondary partial")
+    }
+
+    func testFollowUpValueLeavesSingleEnvelopeLegacyFlat() {
+        let reply = ChatSendReply(
+            chatId: UUID(),
+            shortId: "single-chat",
+            mode: "plan",
+            response: "Single response",
+            errors: nil
+        )
+        let result = OracleSendResult(
+            payload: .single(reply),
+            route: .init(contextID: UUID(), agentSessionID: UUID(), agentRunID: UUID())
+        )
+
+        let followUp = MCPContextBuilderToolProvider.followUpValue(for: result)
+        XCTAssertEqual(followUp.primary.shortId, "single-chat")
+        XCTAssertEqual(followUp.value.objectValue?["chat_id"]?.stringValue, "single-chat")
+        XCTAssertNil(followUp.value.objectValue?["status"])
+        XCTAssertNil(followUp.value.objectValue?["oracle_results"])
+        XCTAssertNil(followUp.value.objectValue?["context_id"])
+    }
+
+    func testLegacySingleFollowUpRoutingIsUnchanged() throws {
+        let plan = try decode(#"{"response_type":"plan","plan":{"chat_id":"plan-chat"}}"#)
+        let question = try decode(#"{"response_type":"question","plan":{"chat_id":"question-chat"}}"#)
+        let review = try decode(#"{"response_type":"review","review":{"chat_id":"review-chat"}}"#)
+
+        XCTAssertTrue(contextBuilderOracleLaneSummaries(for: plan).isEmpty)
+        XCTAssertEqual(contextBuilderFollowUpChatID(for: plan), "plan-chat")
+        XCTAssertEqual(contextBuilderFollowUpChatID(for: question), "question-chat")
+        XCTAssertEqual(contextBuilderFollowUpChatID(for: review), "review-chat")
+    }
+
+    private func decode(_ json: String) throws -> ToolResultDTOs.ContextBuilderDTO {
+        try JSONDecoder().decode(ToolResultDTOs.ContextBuilderDTO.self, from: Data(json.utf8))
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/ContextBuilderOracleResultTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/ContextBuilderOracleResultTests.swift
@@ -99,6 +99,7 @@ final class ContextBuilderOracleResultTests: XCTestCase {
             payload: .paired(.init(
                 pairID: pairID,
                 mode: "plan",
+                primarySessionID: primaryID,
                 primaryChatID: "primary-chat",
                 secondaryChatID: "secondary-chat",
                 primaryModel: .gpt54Pro,

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/OracleOperationToolCardRoutingTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/OracleOperationToolCardRoutingTests.swift
@@ -502,7 +502,17 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
     func testAuthoritativeChatIDPolicyPreservesFailClosedRootRulesAcrossEntryPoints() {
         let acceptedPayloads: [([String: Any], String)] = [
             (["chat_id": "  exact-chat  "], "exact-chat"),
-            (["chat_id": "exact-with-unrelated-data", "diffs": [["path": 42]]], "exact-with-unrelated-data")
+            (["chat_id": "exact-with-unrelated-data", "diffs": [["path": 42]]], "exact-with-unrelated-data"),
+            // Dual-Oracle nests lane chat_ids; root/primary remains authoritative.
+            ([
+                "chat_id": "primary-short",
+                "primary_chat_id": "primary-short",
+                "oracle_pair_id": "pair-1",
+                "oracle_results": [
+                    "primary": ["chat_id": "primary-short"],
+                    "secondary": ["chat_id": "secondary-short"]
+                ]
+            ], "primary-short")
         ]
         for (payload, expected) in acceptedPayloads {
             XCTAssertEqual(

--- a/Tests/RepoPromptTests/Chat/OracleMessageFinalisationHubTests.swift
+++ b/Tests/RepoPromptTests/Chat/OracleMessageFinalisationHubTests.swift
@@ -45,7 +45,7 @@ final class OracleMessageFinalisationHubTests: XCTestCase {
         let futureResumedBeforeFulfilment = await futureSignal.isMarked()
         XCTAssertFalse(futureResumedBeforeFulfilment)
 
-        await hub.fulfil(messageID, outcome: .providerCompleted)
+        await hub.fulfil(messageID, outcome: .completed)
         await retainedWaiter.value
         await futureWaiter.value
 
@@ -87,21 +87,97 @@ final class OracleMessageFinalisationHubTests: XCTestCase {
         XCTAssertFalse(retainedResumedBeforeFulfilment)
         XCTAssertFalse(completedBeforeFulfilment)
 
-        await hub.fulfil(messageID, outcome: .providerCompleted)
+        await hub.fulfil(messageID, outcome: .completed)
         await retainedWaiter.value
         let retainedResumedAfterFulfilment = await retainedSignal.isMarked()
         XCTAssertTrue(retainedResumedAfterFulfilment)
     }
 
-    func testFirstTerminalOutcomeRemainsAuthoritative() async {
+    func testConcurrentWaitersReceiveTheSameTerminalOutcome() async throws {
+        let hub = MessageFinalisationHub()
+        let messageID = UUID()
+        let expected = ChatSendTerminalOutcome.failed(
+            message: "provider failed",
+            partialResponse: "partial"
+        )
+
+        async let first = hub.waitForOutcome(messageID, timeout: .seconds(1))
+        async let second = hub.waitForOutcome(messageID, timeout: .seconds(1))
+        await Task.yield()
+        await hub.fulfil(messageID, outcome: expected)
+
+        let outcomes = try await [first, second]
+        XCTAssertEqual(outcomes, [expected, expected])
+    }
+
+    func testTimeoutDoesNotPoisonLaterGenuineOutcome() async throws {
         let hub = MessageFinalisationHub()
         let messageID = UUID()
 
-        await hub.fulfil(messageID, outcome: .streamEndedWithoutProviderCompletion)
-        await hub.fulfil(messageID, outcome: .providerCompleted)
+        let timedOut = try await hub.waitForOutcome(messageID, timeout: .zero)
+        XCTAssertNil(timedOut)
+        let completedAfterTimeout = await hub.isCompleted(messageID)
+        XCTAssertFalse(completedAfterTimeout)
 
+        await hub.fulfil(messageID, outcome: .completed)
+        let later = try await hub.waitForOutcome(messageID, timeout: .seconds(1))
+        XCTAssertEqual(later, .completed)
+    }
+
+    func testDiscardAllClearsOutcomesAndResumesRegisteredWaiters() async {
+        let hub = MessageFinalisationHub()
+        let completedMessageID = UUID()
+        let pendingMessageID = UUID()
+        let pendingWaiterID = UUID()
+        let registered = expectation(description: "waiter registered")
+
+        await hub.fulfil(completedMessageID, outcome: .completed)
+        let pending = Task {
+            await withCheckedContinuation { continuation in
+                Task {
+                    await hub.register(
+                        pendingMessageID,
+                        waiterID: pendingWaiterID,
+                        cont: continuation
+                    )
+                    registered.fulfill()
+                }
+            }
+        }
+        await fulfillment(of: [registered])
+
+        await hub.discardAll()
+
+        let pendingOutcome = await pending.value
+        let completedOutcome = await hub.outcome(for: completedMessageID)
+        XCTAssertNil(pendingOutcome)
+        XCTAssertNil(completedOutcome)
+    }
+
+    func testTerminalOutcomeIsFirstWriterWinsAndDiscardAllowsRetry() async throws {
+        let hub = MessageFinalisationHub()
+        let messageID = UUID()
+
+        await hub.fulfil(
+            messageID,
+            outcome: .failed(message: "provider failed", partialResponse: "partial")
+        )
+        await hub.fulfil(messageID, outcome: .completed)
         let outcome = await hub.outcome(for: messageID)
-        XCTAssertEqual(outcome, .streamEndedWithoutProviderCompletion)
+        XCTAssertEqual(
+            outcome,
+            .failed(message: "provider failed", partialResponse: "partial")
+        )
+
+        await hub.discard(messageID)
+        let completedAfterDiscard = await hub.isCompleted(messageID)
+        let outcomeAfterDiscard = try await hub.waitForOutcome(messageID, timeout: .zero)
+        XCTAssertFalse(completedAfterDiscard)
+        XCTAssertNil(outcomeAfterDiscard)
+
+        await hub.fulfil(messageID, outcome: .completed)
+        let retryOutcome = try await hub.waitForOutcome(messageID, timeout: .seconds(1))
+        XCTAssertEqual(retryOutcome, .completed)
     }
 
     private func makeWaiter(
@@ -111,7 +187,7 @@ final class OracleMessageFinalisationHubTests: XCTestCase {
         signal: OracleFinalisationWaiterSignal
     ) -> Task<Void, Never> {
         Task {
-            await withCheckedContinuation { continuation in
+            _ = await withCheckedContinuation { continuation in
                 Task {
                     await hub.register(
                         messageID,

--- a/Tests/RepoPromptTests/Chat/OraclePairPreparationTests.swift
+++ b/Tests/RepoPromptTests/Chat/OraclePairPreparationTests.swift
@@ -911,14 +911,13 @@ final class OraclePairPreparationTests: XCTestCase {
         ownerSessionID: UUID? = nil,
         ownerRunID: UUID? = nil
     ) -> ChatSession {
-        let name: String
-        switch lane {
+        let name = switch lane {
         case .primary:
-            name = "Primary"
+            "Primary"
         case .secondary:
-            name = "Secondary"
+            "Secondary"
         case .oracle3, .oracle4, .oracle5:
-            name = "Oracle \(lane.ordinal)"
+            "Oracle \(lane.ordinal)"
         }
         return ChatSession(
             workspaceID: fixture.workspace.id,

--- a/Tests/RepoPromptTests/Chat/OraclePairPreparationTests.swift
+++ b/Tests/RepoPromptTests/Chat/OraclePairPreparationTests.swift
@@ -123,6 +123,282 @@ final class OraclePairPreparationTests: XCTestCase {
         )
     }
 
+    func testFiveLaneHistoryPersistenceIsAtomicAndDivergesFromAnyNonPrimaryHistory() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let groupID = UUID()
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        var members = lanes.map { lane in
+            makeSession(
+                fixture: fixture,
+                pairID: groupID,
+                lane: lane,
+                groupSize: lanes.count
+            )
+        }
+        for index in members.indices {
+            members[index].messages = [
+                StoredMessage(
+                    isUser: true,
+                    rawText: lanes[index] == .oracle4 ? "different user turn" : "shared user turn",
+                    sequenceIndex: 0
+                )
+            ]
+        }
+        fixture.oracleViewModel.sessions = members
+        for member in members {
+            let loaded = await fixture.oracleViewModel.ensureSessionMessagesLoaded(member.id)
+            XCTAssertTrue(loaded)
+        }
+
+        let diverged = try await fixture.oracleViewModel.persistOracleGroupHistories(
+            groupID: groupID,
+            sessionIDsByLane: Dictionary(uniqueKeysWithValues: zip(lanes, members.map(\.id)))
+        )
+
+        XCTAssertTrue(diverged)
+        let stubs = try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: groupID
+        )
+        XCTAssertEqual(stubs.compactMap(\.oracleLane), lanes)
+        XCTAssertTrue(stubs.allSatisfy { $0.oracleGroupSize == 5 && $0.oracleHistoryDiverged })
+        for stub in stubs {
+            let persisted = try await fixture.oracleViewModel.chatData.loadChatSession(
+                from: XCTUnwrap(stub.fileURL)
+            )
+            XCTAssertEqual(persisted.messages.count, 1)
+            XCTAssertTrue(persisted.oracleHistoryDiverged)
+        }
+    }
+
+    func testFiveLaneRenamePersistsTheWholeGroup() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let groupID = UUID()
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        let members = lanes.map { lane in
+            makeSession(
+                fixture: fixture,
+                pairID: groupID,
+                lane: lane,
+                groupSize: lanes.count
+            )
+        }
+        fixture.oracleViewModel.sessions = members
+        _ = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            members,
+            for: fixture.workspace
+        )
+        let renamed = try XCTUnwrap(members.first(where: { $0.oracleLane == .oracle4 }))
+
+        try await fixture.oracleViewModel.persistOraclePairRename(
+            sessionID: renamed.id,
+            newName: "Renamed Oracle 4"
+        )
+
+        let stubs = try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: groupID
+        )
+        XCTAssertEqual(stubs.compactMap(\.oracleLane), lanes)
+        for stub in stubs {
+            let persisted = try await fixture.oracleViewModel.chatData.loadChatSession(
+                from: XCTUnwrap(stub.fileURL)
+            )
+            let original = try XCTUnwrap(members.first(where: { $0.id == persisted.id }))
+            let expectedName = persisted.id == renamed.id ? "Renamed Oracle 4" : original.name
+            XCTAssertEqual(persisted.name, expectedName)
+        }
+    }
+
+    func testDeletingOneFiveLaneMemberDeletesTheWholeGroup() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let groupID = UUID()
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        let members = lanes.map { lane in
+            makeSession(
+                fixture: fixture,
+                pairID: groupID,
+                lane: lane,
+                groupSize: lanes.count
+            )
+        }
+        fixture.oracleViewModel.sessions = members
+        let fileURLs = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            members,
+            for: fixture.workspace
+        )
+
+        let deleted = await fixture.oracleViewModel.deleteClaimedSession(
+            members[2],
+            workspace: fixture.workspace
+        )
+
+        XCTAssertTrue(deleted)
+        XCTAssertFalse(fixture.oracleViewModel.sessions.contains { $0.oraclePairID == groupID })
+        XCTAssertTrue(fileURLs.values.allSatisfy { !FileManager.default.fileExists(atPath: $0.path) })
+    }
+
+    func testExplicitContinuationLoadsTheCompletePersistedFiveLaneGroupFromOneColdMember() async throws {
+        let fixture = try await makeFixture(sendPromptOverride: { _, model in
+            (UUID(), completedOracleStream("\(model.rawValue) continued"))
+        })
+        defer { fixture.cleanup() }
+        let groupID = UUID()
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        let members = lanes.map { lane in
+            makeSession(
+                fixture: fixture,
+                pairID: groupID,
+                lane: lane,
+                groupSize: lanes.count
+            )
+        }
+        _ = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            members,
+            for: fixture.workspace
+        )
+        let focusedTabID = UUID()
+        var workspace = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspace)
+        workspace.composeTabs.append(ComposeTabState(id: focusedTabID))
+        workspace.activeComposeTabID = focusedTabID
+        if let index = fixture.composition.workspaceManager.workspaces.firstIndex(where: { $0.id == workspace.id }) {
+            fixture.composition.workspaceManager.workspaces[index] = workspace
+        }
+        fixture.composition.workspaceManager.activeWorkspace = workspace
+        fixture.composition.promptManager.loadComposeTabsFromWorkspace(workspace)
+        let focused = ChatSession(
+            workspaceID: fixture.workspace.id,
+            composeTabID: focusedTabID,
+            name: "Focused unrelated chat"
+        )
+        fixture.oracleViewModel.sessions = [focused]
+        fixture.oracleViewModel.currentSessionID = focused.id
+        fixture.composition.workspaceManager.setActiveChatSessionID(focused.id, forTabID: focusedTabID)
+        fixture.composition.workspaceManager.setActiveChatSessionID(nil, forTabID: fixture.tabID)
+
+        let prompt = "Continue the persisted Oracle group."
+        let packaging = OracleViewModel.OracleSendPackagingContext(
+            sourceTabID: fixture.tabID,
+            sourceWorkspaceID: fixture.workspace.id,
+            sourceSelectionRevision: 0,
+            sourceAgentSessionID: nil,
+            sourceAgentRunID: nil,
+            promptText: prompt,
+            selection: StoredSelection(),
+            lookupContext: nil,
+            reviewGitContext: .automaticOnly(),
+            provenance: .direct
+        )
+        let context = OracleViewModel.OracleSendTabContext(
+            tabID: fixture.tabID,
+            workspaceID: fixture.workspace.id,
+            activationPolicy: .background,
+            completionPolicy: .contextBuilderStrict,
+            packaging: packaging
+        )
+        let primarySelection = OracleViewModel.ModelSelectionResult(
+            model: .gpt54Pro,
+            mcpControlInfo: nil,
+            isAutoSelected: false,
+            chatPresetID: nil
+        )
+        let additionalModels: [AIModel] = [
+            .claude4Sonnet,
+            .gpt54Pro,
+            .claude4Sonnet,
+            .gpt54Pro
+        ]
+
+        let result = try await fixture.oracleViewModel.sendOracle(
+            args: [
+                "message": .string(prompt),
+                "chat_id": .string(members[4].shortID),
+                "new_chat": .bool(false)
+            ],
+            promptVM: fixture.oracleViewModel.promptViewModel,
+            tabContext: context,
+            primaryModelSelection: primarySelection,
+            additionalModelOverrides: additionalModels
+        )
+
+        guard case let .paired(group) = result.payload else {
+            return XCTFail("Expected the persisted Oracle group to continue")
+        }
+        XCTAssertEqual(group.groupID, groupID)
+        XCTAssertEqual(group.oracleCount, lanes.count)
+        XCTAssertEqual(
+            group.sessionIDsByLane,
+            Dictionary(uniqueKeysWithValues: zip(lanes, members.map(\.id)))
+        )
+        XCTAssertEqual(
+            Set(fixture.oracleViewModel.sessions.filter { $0.oraclePairID == groupID }.map(\.id)),
+            Set(members.map(\.id))
+        )
+        XCTAssertEqual(fixture.oracleViewModel.currentSessionID, focused.id)
+        XCTAssertEqual(
+            fixture.composition.workspaceManager.activeChatSessionID(forTabID: focusedTabID),
+            focused.id
+        )
+        XCTAssertNil(fixture.composition.workspaceManager.activeChatSessionID(forTabID: fixture.tabID))
+    }
+
+    func testGroupedDeletionFailsClosedWhenOwningWorkspaceIsUnavailable() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let pairID = UUID()
+        var primary = makeSession(fixture: fixture, pairID: pairID, lane: .primary)
+        var secondary = makeSession(fixture: fixture, pairID: pairID, lane: .secondary)
+        let fileURLs = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            [primary, secondary],
+            for: fixture.workspace
+        )
+        primary.fileURL = fileURLs[primary.id]
+        secondary.fileURL = fileURLs[secondary.id]
+        primary.workspaceID = UUID()
+        fixture.oracleViewModel.sessions = [primary, secondary]
+
+        let deleted = await fixture.oracleViewModel.deleteSession(primary)
+
+        XCTAssertFalse(deleted)
+        XCTAssertEqual(Set(fixture.oracleViewModel.sessions.map(\.id)), Set([primary.id, secondary.id]))
+        XCTAssertTrue(fileURLs.values.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
+    }
+
+    func testGroupedDeletionRejectsMixedGroupedAndLegacySeedsWithoutDeletingEither() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let pairID = UUID()
+        let primary = makeSession(fixture: fixture, pairID: pairID, lane: .primary)
+        let secondary = makeSession(fixture: fixture, pairID: pairID, lane: .secondary)
+        let groupURLs = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            [primary, secondary],
+            for: fixture.workspace
+        )
+        let legacy = ChatSession(
+            workspaceID: fixture.workspace.id,
+            composeTabID: fixture.tabID,
+            name: "Unrelated legacy chat"
+        )
+        let legacyURL = try await fixture.oracleViewModel.chatData.saveChatSession(
+            legacy,
+            for: fixture.workspace
+        )
+
+        do {
+            try await fixture.oracleViewModel.chatData.deleteOraclePairSessionFiles(
+                [primary.id, legacy.id],
+                for: fixture.workspace
+            )
+            XCTFail("Expected mixed grouped and legacy deletion seeds to be rejected")
+        } catch is ChatDataError {}
+
+        XCTAssertTrue(groupURLs.values.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyURL.path))
+    }
+
     func testPairedRenamePersistsBothMembersOrLeavesTheVisibleNameUnchanged() async throws {
         let fixture = try await makeFixture()
         defer { fixture.cleanup() }
@@ -470,12 +746,70 @@ final class OraclePairPreparationTests: XCTestCase {
             for: fixture.workspace,
             pairID: pair.pairID
         )
-        XCTAssertEqual(Set(stubs.compactMap(\.oracleLane)), Set(OracleLane.allCases))
+        XCTAssertEqual(Set(stubs.compactMap(\.oracleLane)), Set([.primary, .secondary]))
         XCTAssertEqual(stubs.count, 2)
         let snapshots = await recorder.snapshot()
         XCTAssertEqual(Set(snapshots.map(\.modelRaw)), Set([primaryModel.rawValue, secondaryModel.rawValue]))
         XCTAssertTrue(snapshots.allSatisfy { $0.prompt?.contains(prompt) == true })
         XCTAssertTrue(snapshots.allSatisfy { $0.fileBlocks.joined(separator: "\n").contains(sentinel) })
+    }
+
+    func testFiveOracleContextBuilderRuntimeDispatchesAndPersistsEveryLane() async throws {
+        let recorder = OracleRuntimeMessageRecorder()
+        let fixture = try await makeFixture(sendPromptOverride: { message, model in
+            await recorder.record(
+                modelRaw: model.rawValue,
+                prompt: message.conversationMessages.last?.content,
+                fileBlocks: message.fileBlocks
+            )
+            return (UUID(), completedOracleStream("\(model.rawValue) response"))
+        })
+        defer { fixture.cleanup() }
+        let primaryModel = AIModel.customProvider(name: "Primary", provider: "custom", model: "oracle-primary")
+        let additionalModels = (2 ... 5).map { ordinal in
+            AIModel.customProvider(
+                name: "Oracle \(ordinal)",
+                provider: "custom",
+                model: "oracle-\(ordinal)"
+            )
+        }
+        let settings = GlobalSettingsStore.shared
+        let priorAdditionalModels = settings.additionalOracleModelRaws()
+        settings.setAdditionalOracleModelRaws(additionalModels.map(\.rawValue), commit: false)
+        defer { settings.setAdditionalOracleModelRaws(priorAdditionalModels, commit: false) }
+        installFollowUpModel(primaryModel, in: fixture)
+        defer { fixture.composition.contextBuilderAgentViewModel.installRunTestHooks(nil) }
+
+        let prompt = "Plan with five independent Oracles."
+        let result = try await fixture.composition.contextBuilderAgentViewModel.runMCPPlanOrQuestion(
+            for: fixture.tabID,
+            oracleViewModel: fixture.oracleViewModel,
+            mode: .plan,
+            prompt: prompt,
+            selection: StoredSelection(),
+            reviewGitContext: .automaticOnly()
+        )
+
+        guard case let .paired(group) = result.payload else {
+            return XCTFail("Expected grouped Oracle result")
+        }
+        XCTAssertEqual(group.status, .completed)
+        XCTAssertEqual(group.oracleCount, 5)
+        XCTAssertEqual(group.orderedLanes, OracleLane.allCases)
+        let stubs = try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: group.groupID
+        )
+        XCTAssertEqual(stubs.compactMap(\.oracleLane), OracleLane.allCases)
+        XCTAssertTrue(stubs.allSatisfy { $0.oracleGroupSize == 5 })
+
+        let snapshots = await recorder.snapshot()
+        XCTAssertEqual(snapshots.count, 5)
+        XCTAssertEqual(
+            Set(snapshots.map(\.modelRaw)),
+            Set([primaryModel.rawValue] + additionalModels.map(\.rawValue))
+        )
+        XCTAssertTrue(snapshots.allSatisfy { $0.prompt?.contains(prompt) == true })
     }
 
     func testPairedContextBuilderRuntimePersistsPartialSecondaryFailure() async throws {
@@ -573,17 +907,28 @@ final class OraclePairPreparationTests: XCTestCase {
         fixture: Fixture,
         pairID: UUID,
         lane: OracleLane,
+        groupSize: Int = 2,
         ownerSessionID: UUID? = nil,
         ownerRunID: UUID? = nil
     ) -> ChatSession {
-        ChatSession(
+        let name: String
+        switch lane {
+        case .primary:
+            name = "Primary"
+        case .secondary:
+            name = "Secondary"
+        case .oracle3, .oracle4, .oracle5:
+            name = "Oracle \(lane.ordinal)"
+        }
+        return ChatSession(
             workspaceID: fixture.workspace.id,
             composeTabID: fixture.tabID,
             agentModeSessionID: ownerSessionID,
             agentModeRunID: ownerRunID,
             oraclePairID: pairID,
             oracleLane: lane,
-            name: lane == .primary ? "Primary" : "Secondary"
+            oracleGroupSize: groupSize,
+            name: name
         )
     }
 

--- a/Tests/RepoPromptTests/Chat/OraclePairPreparationTests.swift
+++ b/Tests/RepoPromptTests/Chat/OraclePairPreparationTests.swift
@@ -1,0 +1,702 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class OraclePairPreparationTests: XCTestCase {
+    func testInMemoryPairResolutionPreservesExactRouteAndRejectsDuplicates() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let pairID = UUID()
+        let ownerSessionID = UUID()
+        let ownerRunID = UUID()
+        let primary = makeSession(
+            fixture: fixture,
+            pairID: pairID,
+            lane: .primary,
+            ownerSessionID: ownerSessionID,
+            ownerRunID: ownerRunID
+        )
+        let secondary = makeSession(
+            fixture: fixture,
+            pairID: pairID,
+            lane: .secondary,
+            ownerSessionID: ownerSessionID,
+            ownerRunID: ownerRunID
+        )
+        fixture.oracleViewModel.sessions = [primary, secondary]
+
+        let resolved = try await fixture.oracleViewModel.resolveInMemoryOraclePairMembers(
+            pairID: pairID,
+            workspaceID: fixture.workspace.id,
+            tabID: fixture.tabID,
+            agentModeSessionID: ownerSessionID,
+            agentModeRunID: ownerRunID
+        )
+        XCTAssertEqual(resolved?.primary.id, primary.id)
+        XCTAssertEqual(resolved?.secondary.id, secondary.id)
+        let durableStubs = try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: pairID
+        )
+        XCTAssertTrue(durableStubs.isEmpty)
+
+        let routeMismatch = try await fixture.oracleViewModel.resolveInMemoryOraclePairMembers(
+            pairID: pairID,
+            workspaceID: fixture.workspace.id,
+            tabID: UUID(),
+            agentModeSessionID: ownerSessionID,
+            agentModeRunID: ownerRunID
+        )
+        XCTAssertNil(routeMismatch)
+
+        fixture.oracleViewModel.sessions = [primary]
+        let incomplete = try await fixture.oracleViewModel.resolveInMemoryOraclePairMembers(
+            pairID: pairID,
+            workspaceID: fixture.workspace.id,
+            tabID: fixture.tabID,
+            agentModeSessionID: ownerSessionID,
+            agentModeRunID: ownerRunID
+        )
+        XCTAssertNil(incomplete)
+
+        let duplicatePrimary = makeSession(
+            fixture: fixture,
+            pairID: pairID,
+            lane: .primary,
+            ownerSessionID: ownerSessionID,
+            ownerRunID: ownerRunID
+        )
+        fixture.oracleViewModel.sessions = [primary, duplicatePrimary]
+        do {
+            _ = try await fixture.oracleViewModel.resolveInMemoryOraclePairMembers(
+                pairID: pairID,
+                workspaceID: fixture.workspace.id,
+                tabID: fixture.tabID,
+                agentModeSessionID: ownerSessionID,
+                agentModeRunID: ownerRunID
+            )
+            XCTFail("Expected duplicate lane conflict")
+        } catch let error as ChatToolError {
+            XCTAssertEqual(error.code, .conflict)
+            XCTAssertTrue(error.message.contains("duplicate lanes"))
+        }
+    }
+
+    func testLaneEffectiveModelsPersistWithFinalPairGeneration() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let pairID = UUID()
+        let primary = makeSession(fixture: fixture, pairID: pairID, lane: .primary)
+        let secondary = makeSession(fixture: fixture, pairID: pairID, lane: .secondary)
+        fixture.oracleViewModel.sessions = [primary, secondary]
+        let primaryLoaded = await fixture.oracleViewModel.ensureSessionMessagesLoaded(primary.id)
+        let secondaryLoaded = await fixture.oracleViewModel.ensureSessionMessagesLoaded(secondary.id)
+        XCTAssertTrue(primaryLoaded)
+        XCTAssertTrue(secondaryLoaded)
+
+        fixture.oracleViewModel.recordLaneEffectiveModel(sessionID: primary.id, model: .gpt54Pro)
+        fixture.oracleViewModel.recordLaneEffectiveModel(sessionID: secondary.id, model: .claude4Sonnet)
+        _ = try await fixture.oracleViewModel.persistOraclePairHistories(
+            pairID: pairID,
+            primarySessionID: primary.id,
+            secondarySessionID: secondary.id
+        )
+
+        let stubs = try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: pairID
+        )
+        XCTAssertEqual(stubs.count, 2)
+        var persisted: [ChatSession] = []
+        for stub in stubs {
+            let fileURL = try XCTUnwrap(stub.fileURL)
+            try await persisted.append(fixture.oracleViewModel.chatData.loadChatSession(from: fileURL))
+        }
+        XCTAssertEqual(
+            persisted.first(where: { $0.oracleLane == .primary })?.preferredAIModel,
+            AIModel.gpt54Pro.rawValue
+        )
+        XCTAssertEqual(
+            persisted.first(where: { $0.oracleLane == .secondary })?.preferredAIModel,
+            AIModel.claude4Sonnet.rawValue
+        )
+    }
+
+    func testPairedRenamePersistsBothMembersOrLeavesTheVisibleNameUnchanged() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let pairID = UUID()
+        let primary = makeSession(fixture: fixture, pairID: pairID, lane: .primary)
+        let secondary = makeSession(fixture: fixture, pairID: pairID, lane: .secondary)
+        fixture.oracleViewModel.sessions = [primary, secondary]
+        let fileURLs = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            [primary, secondary],
+            for: fixture.workspace
+        )
+
+        try await fixture.oracleViewModel.persistOraclePairRename(
+            sessionID: primary.id,
+            newName: "Renamed Primary"
+        )
+
+        var persisted: [ChatSession] = []
+        for stub in try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: pairID
+        ) {
+            try await persisted.append(fixture.oracleViewModel.chatData.loadChatSession(
+                from: XCTUnwrap(stub.fileURL)
+            ))
+        }
+        XCTAssertEqual(persisted.count, 2)
+        XCTAssertEqual(persisted.first(where: { $0.id == primary.id })?.name, "Renamed Primary")
+        XCTAssertEqual(persisted.first(where: { $0.id == secondary.id })?.name, secondary.name)
+        XCTAssertEqual(
+            fixture.oracleViewModel.sessions.first(where: { $0.id == primary.id })?.name,
+            "Renamed Primary"
+        )
+
+        try FileManager.default.removeItem(at: XCTUnwrap(fileURLs[secondary.id]))
+        do {
+            try await fixture.oracleViewModel.persistOraclePairRename(
+                sessionID: primary.id,
+                newName: "Must Not Stick"
+            )
+            XCTFail("Expected incomplete pair rename to fail")
+        } catch let error as ChatToolError {
+            XCTAssertEqual(error.code, .conflict)
+        }
+        XCTAssertEqual(
+            fixture.oracleViewModel.sessions.first(where: { $0.id == primary.id })?.name,
+            "Renamed Primary"
+        )
+        let remainingPrimary = try await fixture.oracleViewModel.chatData.loadChatSession(
+            from: XCTUnwrap(fileURLs[primary.id])
+        )
+        XCTAssertEqual(remainingPrimary.name, "Renamed Primary")
+    }
+
+    func testPairedRenameProjectsCommittedNameAfterStaleReloadInterleaving() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let pairID = UUID()
+        let primary = makeSession(fixture: fixture, pairID: pairID, lane: .primary)
+        let secondary = makeSession(fixture: fixture, pairID: pairID, lane: .secondary)
+        fixture.oracleViewModel.sessions = [primary, secondary]
+        let fileURLs = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            [primary, secondary],
+            for: fixture.workspace
+        )
+        var stalePrimary = primary
+        stalePrimary.fileURL = try XCTUnwrap(fileURLs[primary.id])
+        fixture.oracleViewModel.oraclePairDidCommitTestHook = {
+            guard let index = fixture.oracleViewModel.sessions.firstIndex(where: { $0.id == primary.id }) else {
+                return XCTFail("Expected the Primary session during stale reload projection")
+            }
+            fixture.oracleViewModel.sessions[index] = stalePrimary
+            await fixture.oracleViewModel.reloadSessionFromMemory(stalePrimary)
+        }
+        defer { fixture.oracleViewModel.oraclePairDidCommitTestHook = nil }
+
+        try await fixture.oracleViewModel.persistOraclePairRename(
+            sessionID: primary.id,
+            newName: "Committed Rename"
+        )
+
+        let persistedPrimary = try await fixture.oracleViewModel.chatData.loadChatSession(
+            from: XCTUnwrap(fileURLs[primary.id])
+        )
+        XCTAssertEqual(persistedPrimary.name, "Committed Rename")
+        XCTAssertEqual(
+            fixture.oracleViewModel.sessions.first(where: { $0.id == primary.id })?.name,
+            "Committed Rename"
+        )
+    }
+
+    func testPairedRenameDoesNotRollbackAfterDurableProjectionConflict() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let pairID = UUID()
+        let primary = makeSession(fixture: fixture, pairID: pairID, lane: .primary)
+        let secondary = makeSession(fixture: fixture, pairID: pairID, lane: .secondary)
+        fixture.oracleViewModel.sessions = [primary, secondary]
+        let fileURLs = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            [primary, secondary],
+            for: fixture.workspace
+        )
+        fixture.oracleViewModel.oraclePairDidCommitTestHook = {
+            fixture.oracleViewModel.sessions.removeAll { $0.id == secondary.id }
+        }
+        defer { fixture.oracleViewModel.oraclePairDidCommitTestHook = nil }
+
+        do {
+            try await fixture.oracleViewModel.persistOraclePairRename(
+                sessionID: primary.id,
+                newName: "Durably Committed"
+            )
+            XCTFail("Expected a post-durable projection conflict")
+        } catch let error as ChatToolError {
+            XCTAssertEqual(error.code, .conflict)
+            XCTAssertEqual(error.details?["durable_commit"], "true")
+        }
+
+        XCTAssertEqual(fixture.oracleViewModel.sessions.count, 2)
+        XCTAssertEqual(
+            fixture.oracleViewModel.sessions.first(where: { $0.id == primary.id })?.name,
+            "Durably Committed"
+        )
+        XCTAssertEqual(
+            fixture.oracleViewModel.sessions.first(where: { $0.id == secondary.id })?.name,
+            secondary.name
+        )
+        let persistedPrimary = try await fixture.oracleViewModel.chatData.loadChatSession(
+            from: XCTUnwrap(fileURLs[primary.id])
+        )
+        let persistedSecondary = try await fixture.oracleViewModel.chatData.loadChatSession(
+            from: XCTUnwrap(fileURLs[secondary.id])
+        )
+        XCTAssertEqual(persistedPrimary.name, "Durably Committed")
+        XCTAssertEqual(persistedSecondary.name, secondary.name)
+    }
+
+    func testPairedRenameDoesNotProjectIntoWorkspaceActivatedAfterDurableCommit() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let pairID = UUID()
+        let primary = makeSession(fixture: fixture, pairID: pairID, lane: .primary)
+        let secondary = makeSession(fixture: fixture, pairID: pairID, lane: .secondary)
+        fixture.oracleViewModel.sessions = [primary, secondary]
+        let fileURLs = try await fixture.oracleViewModel.chatData.saveOraclePairSessions(
+            [primary, secondary],
+            for: fixture.workspace
+        )
+
+        let ambientRoot = fixture.storageRoot.appendingPathComponent("AmbientWorkspace", isDirectory: true)
+        try FileManager.default.createDirectory(at: ambientRoot, withIntermediateDirectories: true)
+        let ambient = fixture.composition.workspaceManager.createWorkspace(
+            name: "Ambient pair projection workspace",
+            repoPaths: [ambientRoot.path],
+            ephemeral: true
+        )
+        fixture.oracleViewModel.oraclePairDidCommitTestHook = {
+            await fixture.composition.workspaceManager.switchWorkspace(
+                to: ambient,
+                saveState: false,
+                reason: #function
+            )
+            await fixture.oracleViewModel.loadSessionsFromWorkspace()
+        }
+        defer { fixture.oracleViewModel.oraclePairDidCommitTestHook = nil }
+
+        do {
+            try await fixture.oracleViewModel.persistOraclePairRename(
+                sessionID: primary.id,
+                newName: "Committed Before Workspace Switch"
+            )
+            XCTFail("Expected a post-commit workspace projection conflict")
+        } catch let error as ChatToolError {
+            XCTAssertEqual(error.code, .conflict)
+            XCTAssertEqual(error.details?["durable_commit"], "true")
+        }
+
+        XCTAssertEqual(fixture.composition.workspaceManager.activeWorkspaceID, ambient.id)
+        XCTAssertFalse(fixture.oracleViewModel.sessions.contains { $0.id == primary.id || $0.id == secondary.id })
+        XCTAssertTrue(fixture.oracleViewModel.sessions.allSatisfy { $0.workspaceID == ambient.id })
+
+        let persistedPrimary = try await fixture.oracleViewModel.chatData.loadChatSession(
+            from: XCTUnwrap(fileURLs[primary.id])
+        )
+        XCTAssertEqual(persistedPrimary.name, "Committed Before Workspace Switch")
+    }
+
+    func testDisabledSecondaryDoesNotAcquireThePairedRouteClaim() async throws {
+        let fixture = try await makeFixture()
+        defer { fixture.cleanup() }
+        let settings = GlobalSettingsStore.shared
+        let priorSecondary = settings.secondaryOracleModelRaw()
+        settings.setSecondaryOracleModelRaw(nil, commit: false)
+        defer { settings.setSecondaryOracleModelRaw(priorSecondary, commit: false) }
+
+        let claimStarted = expectation(description: "legacy claim holder started")
+        let claim = OracleSendClaimKey.oracleSend(
+            workspaceID: fixture.workspace.id,
+            tabID: fixture.tabID,
+            agentModeSessionID: nil,
+            agentModeRunID: nil
+        )
+        let holder = Task { @MainActor in
+            try await fixture.oracleViewModel.oracleSendClaims.withClaim([claim]) {
+                claimStarted.fulfill()
+                try await Task.sleep(for: .seconds(30))
+            }
+        }
+        defer { holder.cancel() }
+        await fulfillment(of: [claimStarted])
+
+        do {
+            _ = try await fixture.oracleViewModel.sendOracle(
+                args: ["message": .string("")],
+                promptVM: fixture.oracleViewModel.promptViewModel
+            )
+            XCTFail("Expected empty-message validation")
+        } catch let error as ChatToolError {
+            XCTAssertEqual(error.message, "message cannot be empty")
+        }
+        holder.cancel()
+        do { _ = try await holder.value } catch is CancellationError {}
+    }
+
+    func testDisabledSecondaryPreservesLegacyTabBindingWhenTargetTabIsNotFocused() async throws {
+        let model = AIModel.customProvider(name: "Primary", provider: "custom", model: "oracle-primary")
+        let fixture = try await makeFixture(sendPromptOverride: { _, _ in
+            (UUID(), completedOracleStream("single response"))
+        })
+        defer { fixture.cleanup() }
+        let settings = GlobalSettingsStore.shared
+        let priorSecondary = settings.secondaryOracleModelRaw()
+        settings.setSecondaryOracleModelRaw(nil, commit: false)
+        defer { settings.setSecondaryOracleModelRaw(priorSecondary, commit: false) }
+
+        let focusedTabID = UUID()
+        var workspace = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspace)
+        workspace.composeTabs.append(ComposeTabState(id: focusedTabID))
+        workspace.activeComposeTabID = focusedTabID
+        if let index = fixture.composition.workspaceManager.workspaces.firstIndex(where: { $0.id == workspace.id }) {
+            fixture.composition.workspaceManager.workspaces[index] = workspace
+        }
+        fixture.composition.workspaceManager.activeWorkspace = workspace
+        fixture.composition.promptManager.loadComposeTabsFromWorkspace(workspace)
+
+        let focused = ChatSession(
+            workspaceID: fixture.workspace.id,
+            composeTabID: focusedTabID,
+            name: "Focused chat"
+        )
+        let target = ChatSession(
+            workspaceID: fixture.workspace.id,
+            composeTabID: fixture.tabID,
+            name: "Background target"
+        )
+        fixture.oracleViewModel.sessions = [focused, target]
+        fixture.oracleViewModel.currentSessionID = focused.id
+        fixture.composition.workspaceManager.setActiveChatSessionID(focused.id, forTabID: focusedTabID)
+
+        let packaging = OracleViewModel.OracleSendPackagingContext(
+            sourceTabID: fixture.tabID,
+            sourceWorkspaceID: fixture.workspace.id,
+            sourceSelectionRevision: 0,
+            sourceAgentSessionID: nil,
+            sourceAgentRunID: nil,
+            promptText: "Continue in the target chat.",
+            selection: StoredSelection(),
+            lookupContext: nil,
+            reviewGitContext: .automaticOnly(),
+            provenance: .direct
+        )
+        let context = OracleViewModel.OracleSendTabContext(
+            tabID: fixture.tabID,
+            workspaceID: fixture.workspace.id,
+            packaging: packaging
+        )
+        let selection = OracleViewModel.ModelSelectionResult(
+            model: model,
+            mcpControlInfo: nil,
+            isAutoSelected: false,
+            chatPresetID: nil
+        )
+
+        let result = try await fixture.oracleViewModel.sendOracle(
+            args: [
+                "message": .string("Continue in the target chat."),
+                "chat_id": .string(target.shortID)
+            ],
+            promptVM: fixture.oracleViewModel.promptViewModel,
+            tabContext: context,
+            primaryModelSelection: selection
+        )
+
+        guard case .single = result.payload else { return XCTFail("Expected the legacy single-Oracle path") }
+        XCTAssertEqual(
+            fixture.composition.workspaceManager.activeChatSessionID(forTabID: fixture.tabID),
+            target.id
+        )
+        XCTAssertEqual(fixture.oracleViewModel.currentSessionID, focused.id)
+    }
+
+    func testPairedContextBuilderRuntimePackagesAndPersistsBothSuccessfulLanes() async throws {
+        let recorder = OracleRuntimeMessageRecorder()
+        let fixture = try await makeFixture(sendPromptOverride: { message, model in
+            await recorder.record(
+                modelRaw: model.rawValue,
+                prompt: message.conversationMessages.last?.content,
+                fileBlocks: message.fileBlocks
+            )
+            return (UUID(), completedOracleStream("\(model.rawValue) response"))
+        })
+        defer { fixture.cleanup() }
+        let primaryModel = AIModel.customProvider(name: "Primary", provider: "custom", model: "oracle-primary")
+        let secondaryModel = AIModel.customProvider(name: "Secondary", provider: "custom", model: "oracle-secondary")
+        let priorSecondary = GlobalSettingsStore.shared.secondaryOracleModelRaw()
+        GlobalSettingsStore.shared.setSecondaryOracleModelRaw(secondaryModel.rawValue, commit: false)
+        defer { GlobalSettingsStore.shared.setSecondaryOracleModelRaw(priorSecondary, commit: false) }
+        installFollowUpModel(primaryModel, in: fixture)
+        defer { fixture.composition.contextBuilderAgentViewModel.installRunTestHooks(nil) }
+
+        let sentinel = "dual-oracle-packaging-sentinel"
+        let selectedFile = fixture.storageRoot.appendingPathComponent("Selected.swift")
+        try Data("// \(sentinel)".utf8).write(to: selectedFile)
+        let fileSystemSettings = GlobalSettingsStore.shared.fileSystemSettingsSnapshot()
+        _ = try await fixture.composition.workspaceFileContextStore.loadRoot(
+            path: fixture.storageRoot.path,
+            respectRepoIgnore: fileSystemSettings.respectRepoIgnore,
+            respectCursorignore: fileSystemSettings.respectCursorignore,
+            skipSymlinks: fileSystemSettings.skipSymlinks,
+            enableHierarchicalIgnores: fileSystemSettings.enableHierarchicalIgnores
+        )
+        let prompt = "Plan the dual Oracle runtime."
+        let result = try await fixture.composition.contextBuilderAgentViewModel.runMCPPlanOrQuestion(
+            for: fixture.tabID,
+            oracleViewModel: fixture.oracleViewModel,
+            mode: .plan,
+            prompt: prompt,
+            selection: StoredSelection(selectedPaths: [selectedFile.path]),
+            reviewGitContext: .automaticOnly()
+        )
+
+        guard case let .paired(pair) = result.payload else { return XCTFail("Expected paired Oracle result") }
+        XCTAssertEqual(pair.status, .completed)
+        let stubs = try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: pair.pairID
+        )
+        XCTAssertEqual(Set(stubs.compactMap(\.oracleLane)), Set(OracleLane.allCases))
+        XCTAssertEqual(stubs.count, 2)
+        let snapshots = await recorder.snapshot()
+        XCTAssertEqual(Set(snapshots.map(\.modelRaw)), Set([primaryModel.rawValue, secondaryModel.rawValue]))
+        XCTAssertTrue(snapshots.allSatisfy { $0.prompt?.contains(prompt) == true })
+        XCTAssertTrue(snapshots.allSatisfy { $0.fileBlocks.joined(separator: "\n").contains(sentinel) })
+    }
+
+    func testPairedContextBuilderRuntimePersistsPartialSecondaryFailure() async throws {
+        let primaryModel = AIModel.customProvider(name: "Primary", provider: "custom", model: "oracle-primary")
+        let secondaryModel = AIModel.customProvider(name: "Secondary", provider: "custom", model: "oracle-secondary")
+        let fixture = try await makeFixture(sendPromptOverride: { _, model in
+            if model.rawValue == secondaryModel.rawValue { throw OracleRuntimeTestError.secondaryFailed }
+            return (UUID(), completedOracleStream("primary response"))
+        })
+        defer { fixture.cleanup() }
+        let priorSecondary = GlobalSettingsStore.shared.secondaryOracleModelRaw()
+        GlobalSettingsStore.shared.setSecondaryOracleModelRaw(secondaryModel.rawValue, commit: false)
+        defer { GlobalSettingsStore.shared.setSecondaryOracleModelRaw(priorSecondary, commit: false) }
+        installFollowUpModel(primaryModel, in: fixture)
+        defer { fixture.composition.contextBuilderAgentViewModel.installRunTestHooks(nil) }
+
+        let result = try await fixture.composition.contextBuilderAgentViewModel.runMCPPlanOrQuestion(
+            for: fixture.tabID,
+            oracleViewModel: fixture.oracleViewModel,
+            mode: .plan,
+            prompt: "Exercise partial failure.",
+            selection: StoredSelection(),
+            reviewGitContext: .automaticOnly()
+        )
+
+        guard case let .paired(pair) = result.payload else { return XCTFail("Expected paired Oracle result") }
+        XCTAssertEqual(pair.status, .partialFailure)
+        guard case .success = pair.result.primary, case .failure = pair.result.secondary else {
+            return XCTFail("Expected Primary success and Secondary failure")
+        }
+        let persisted = try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: pair.pairID
+        )
+        XCTAssertEqual(persisted.count, 2)
+    }
+
+    func testPairedContextBuilderRuntimeCancellationFinalizesAndPersistsBothLanes() async throws {
+        let gate = OracleRuntimeStreamGate()
+        let fixture = try await makeFixture(sendPromptOverride: { _, _ in
+            await (UUID(), gate.makeStream())
+        })
+        defer { fixture.cleanup() }
+        let primaryModel = AIModel.customProvider(name: "Primary", provider: "custom", model: "oracle-primary")
+        let secondaryModel = AIModel.customProvider(name: "Secondary", provider: "custom", model: "oracle-secondary")
+        let priorSecondary = GlobalSettingsStore.shared.secondaryOracleModelRaw()
+        GlobalSettingsStore.shared.setSecondaryOracleModelRaw(secondaryModel.rawValue, commit: false)
+        defer { GlobalSettingsStore.shared.setSecondaryOracleModelRaw(priorSecondary, commit: false) }
+        installFollowUpModel(primaryModel, in: fixture)
+        defer { fixture.composition.contextBuilderAgentViewModel.installRunTestHooks(nil) }
+
+        let operation = Task { @MainActor in
+            try await fixture.composition.contextBuilderAgentViewModel.runMCPPlanOrQuestion(
+                for: fixture.tabID,
+                oracleViewModel: fixture.oracleViewModel,
+                mode: .plan,
+                prompt: "Cancel both lanes.",
+                selection: StoredSelection(),
+                reviewGitContext: .automaticOnly()
+            )
+        }
+        await gate.waitUntilRegistered(2)
+        operation.cancel()
+        await gate.finishWithCancellation()
+        do {
+            _ = try await operation.value
+            XCTFail("Expected paired runtime cancellation")
+        } catch is CancellationError {}
+
+        XCTAssertTrue(fixture.oracleViewModel.streamingSessions.isEmpty)
+        let pairIDs = Set(fixture.oracleViewModel.sessions.compactMap(\.oraclePairID))
+        XCTAssertEqual(pairIDs.count, 1)
+        let pairID = try XCTUnwrap(pairIDs.first)
+        let persisted = try await fixture.oracleViewModel.chatData.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: pairID
+        )
+        XCTAssertEqual(persisted.count, 2)
+    }
+
+    private func installFollowUpModel(_ model: AIModel, in fixture: Fixture) {
+        fixture.composition.contextBuilderAgentViewModel.installRunTestHooks(
+            ContextBuilderAgentViewModel.RunTestHooks(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: model, chatPresetID: nil, mcpControlInfo: nil)
+                }
+            )
+        )
+    }
+
+    private func makeSession(
+        fixture: Fixture,
+        pairID: UUID,
+        lane: OracleLane,
+        ownerSessionID: UUID? = nil,
+        ownerRunID: UUID? = nil
+    ) -> ChatSession {
+        ChatSession(
+            workspaceID: fixture.workspace.id,
+            composeTabID: fixture.tabID,
+            agentModeSessionID: ownerSessionID,
+            agentModeRunID: ownerRunID,
+            oraclePairID: pairID,
+            oracleLane: lane,
+            name: lane == .primary ? "Primary" : "Secondary"
+        )
+    }
+
+    private func makeFixture(
+        sendPromptOverride: AIQueriesService.SendPromptOverride? = nil
+    ) async throws -> Fixture {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        defer { GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false) }
+        let composition = WindowStateCompositionFactory.make(
+            windowID: -937,
+            deferredInitialAgentSystemWorkspaceRefresh: true,
+            sharedMCPService: MCPService(),
+            aiQueriesServiceFactory: { keyManager in
+                AIQueriesService(keyManager: keyManager, sendPromptOverride: sendPromptOverride)
+            }
+        )
+        await composition.workspaceManager.awaitInitialized()
+
+        let storageRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OraclePairPreparationTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: storageRoot, withIntermediateDirectories: true)
+        var workspace = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
+        let tabID = UUID()
+        workspace.customStoragePath = storageRoot
+        workspace.composeTabs = [ComposeTabState(id: tabID)]
+        workspace.activeComposeTabID = tabID
+        if let index = composition.workspaceManager.workspaces.firstIndex(where: { $0.id == workspace.id }) {
+            composition.workspaceManager.workspaces[index] = workspace
+        }
+        composition.workspaceManager.activeWorkspace = workspace
+        composition.promptManager.loadComposeTabsFromWorkspace(workspace)
+        await composition.oracleViewModel.loadSessionsFromWorkspace()
+        composition.oracleViewModel.sessions = []
+        return Fixture(
+            composition: composition,
+            workspace: workspace,
+            tabID: tabID,
+            storageRoot: storageRoot
+        )
+    }
+}
+
+private enum OracleRuntimeTestError: Error {
+    case secondaryFailed
+}
+
+private struct OracleRuntimeMessageSnapshot {
+    let modelRaw: String
+    let prompt: String?
+    let fileBlocks: [String]
+}
+
+private actor OracleRuntimeMessageRecorder {
+    private var snapshots: [OracleRuntimeMessageSnapshot] = []
+
+    func record(modelRaw: String, prompt: String?, fileBlocks: [String]) {
+        snapshots.append(.init(modelRaw: modelRaw, prompt: prompt, fileBlocks: fileBlocks))
+    }
+
+    func snapshot() -> [OracleRuntimeMessageSnapshot] {
+        snapshots
+    }
+}
+
+private actor OracleRuntimeStreamGate {
+    private var continuations: [AsyncThrowingStream<ChatStreamOutput, Error>.Continuation] = []
+
+    func makeStream() -> AsyncThrowingStream<ChatStreamOutput, Error> {
+        AsyncThrowingStream { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func waitUntilRegistered(_ count: Int) async {
+        while continuations.count < count {
+            await Task.yield()
+        }
+    }
+
+    func finishWithCancellation() {
+        for continuation in continuations {
+            continuation.finish(throwing: CancellationError())
+        }
+        continuations.removeAll()
+    }
+}
+
+private func completedOracleStream(_ text: String) -> AsyncThrowingStream<ChatStreamOutput, Error> {
+    AsyncThrowingStream { continuation in
+        continuation.yield(ChatStreamOutput(
+            text: text,
+            reasoning: nil,
+            tokens: ChatTokenInfo(),
+            terminalOutcome: .completed
+        ))
+        continuation.finish()
+    }
+}
+
+@MainActor
+private struct Fixture {
+    let composition: WindowStateComposition
+    let workspace: WorkspaceModel
+    let tabID: UUID
+    let storageRoot: URL
+
+    var oracleViewModel: OracleViewModel {
+        composition.oracleViewModel
+    }
+
+    func cleanup() {
+        oracleViewModel.sessions = []
+        try? FileManager.default.removeItem(at: storageRoot)
+    }
+}

--- a/Tests/RepoPromptTests/ChatHistoryJSONOnlyTests.swift
+++ b/Tests/RepoPromptTests/ChatHistoryJSONOnlyTests.swift
@@ -67,6 +67,427 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
         XCTAssertFalse(encodedString.contains("delegateResults"), encodedString)
     }
 
+    func testPairSaveReplacesBothMembers() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Pair Save")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let pairID = UUID()
+        var primary = pairSession(.primary, pairID: pairID, workspace: fixture.workspace, name: "Original Primary")
+        var secondary = pairSession(.secondary, pairID: pairID, workspace: fixture.workspace, name: "Original Secondary")
+        let urls = try await service.saveOraclePairSessions([primary, secondary], for: fixture.workspace)
+
+        primary.name = "Updated Primary"
+        secondary.name = "Updated Secondary"
+        _ = try await service.saveOraclePairSessions([primary, secondary], for: fixture.workspace)
+
+        let updatedPrimary = try await service.loadChatSession(from: XCTUnwrap(urls[primary.id]))
+        let updatedSecondary = try await service.loadChatSession(from: XCTUnwrap(urls[secondary.id]))
+        XCTAssertEqual(updatedPrimary.name, "Updated Primary")
+        XCTAssertEqual(updatedSecondary.name, "Updated Secondary")
+    }
+
+    func testConcurrentPairAndLegacySavesQueueWithoutLosingHistory() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Concurrent Saves")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let pairs = (0 ..< 8).map { index in
+            let pairID = UUID()
+            return OracleLane.allCases.map {
+                pairSession($0, pairID: pairID, workspace: fixture.workspace, name: "Pair \(index) \($0.rawValue)")
+            }
+        }
+        let singles = (0 ..< 8).map {
+            ChatSession(workspaceID: fixture.workspace.id, name: "Single \($0)")
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for pair in pairs {
+                group.addTask {
+                    _ = try await service.saveOraclePairSessions(pair, for: fixture.workspace)
+                }
+            }
+            for single in singles {
+                group.addTask {
+                    _ = try await service.saveChatSession(single, for: fixture.workspace)
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let files = try await service.listChatSessions(for: fixture.workspace, applyRetention: false)
+        let expectedIDs = Set(pairs.flatMap(\.self).map(\.id) + singles.map(\.id))
+        let savedIDs = Set(files.compactMap { UUID(uuidString: String($0.deletingPathExtension().lastPathComponent.dropFirst("ChatSession-".count))) })
+        XCTAssertEqual(savedIDs, expectedIDs)
+    }
+
+    func testPairedSessionCannotUseLegacySingleSave() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Pair Single Save Guard")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let pair = pairSession(.primary, pairID: UUID(), workspace: fixture.workspace, name: "Primary")
+
+        do {
+            _ = try await service.saveChatSession(pair, for: fixture.workspace)
+            XCTFail("Expected a paired session to require the pair save path")
+        } catch is ChatDataError {}
+    }
+
+    func testCurrentPairTransactionRecoversInterruptedAndCommittedInstalls() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Pair Recovery")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let pairID = UUID()
+        var primary = pairSession(.primary, pairID: pairID, workspace: fixture.workspace, name: "Primary")
+        var secondary = pairSession(.secondary, pairID: pairID, workspace: fixture.workspace, name: "Secondary")
+        let urls = try await service.saveOraclePairSessions(
+            [primary, secondary],
+            for: fixture.workspace
+        )
+        let pairURLs = try [XCTUnwrap(urls[primary.id]), XCTUnwrap(urls[secondary.id])]
+        let chatsFolder = pairURLs[0].deletingLastPathComponent()
+
+        let uncommitted = try makeCurrentPairTransaction(files: pairURLs, in: chatsFolder)
+        primary.name = "Interrupted Primary"
+        try FileManager.default.removeItem(at: pairURLs[0])
+        try FileManager.default.removeItem(at: pairURLs[1])
+        try JSONEncoder().encode(primary).write(to: pairURLs[0], options: .atomic)
+
+        _ = try await service.listChatSessions(for: fixture.workspace)
+        let restoredPrimary = try await service.loadChatSession(from: pairURLs[0])
+        let restoredSecondary = try await service.loadChatSession(from: pairURLs[1])
+        XCTAssertEqual(restoredPrimary.name, "Primary")
+        XCTAssertEqual(restoredSecondary.name, "Secondary")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: uncommitted.path))
+
+        let committed = try makeCurrentPairTransaction(files: pairURLs, in: chatsFolder)
+        primary.name = "Committed Primary"
+        secondary.name = "Committed Secondary"
+        try JSONEncoder().encode(primary).write(to: pairURLs[0], options: .atomic)
+        try JSONEncoder().encode(secondary).write(to: pairURLs[1], options: .atomic)
+        try Data().write(to: committed.appendingPathComponent("committed"))
+
+        _ = try await service.listChatSessions(for: fixture.workspace)
+        let committedPrimary = try await service.loadChatSession(from: pairURLs[0])
+        let committedSecondary = try await service.loadChatSession(from: pairURLs[1])
+        XCTAssertEqual(committedPrimary.name, "Committed Primary")
+        XCTAssertEqual(committedSecondary.name, "Committed Secondary")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: committed.path))
+    }
+
+    func testMalformedPairTransactionDebrisIsQuarantinedWithoutBlockingSaves() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Malformed Pair Debris")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let existing = ChatSession(workspaceID: fixture.workspace.id, name: "Existing")
+        _ = try await service.saveChatSession(existing, for: fixture.workspace)
+        let chatsFolder = fixture.root.appendingPathComponent("Chats", isDirectory: true)
+
+        let stray = chatsFolder.appendingPathComponent(".oracle-pair-save-\(UUID().uuidString) conflicted copy")
+        try Data("debris".utf8).write(to: stray)
+        let malformed = chatsFolder.appendingPathComponent(".oracle-pair-save-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: malformed, withIntermediateDirectories: false)
+        try Data("not json".utf8).write(to: malformed.appendingPathComponent("manifest.json"))
+
+        let newSession = ChatSession(workspaceID: fixture.workspace.id, name: "After debris")
+        let newURL = try await service.saveChatSession(newSession, for: fixture.workspace)
+        let files = try await service.listChatSessions(for: fixture.workspace, applyRetention: false)
+        let folderEntries = try FileManager.default.contentsOfDirectory(atPath: chatsFolder.path)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: newURL.path))
+        XCTAssertEqual(files.count, 2)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stray.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: malformed.path))
+        XCTAssertEqual(folderEntries.count(where: { $0.hasPrefix(".oracle-pair-quarantine-") }), 2)
+    }
+
+    func testReadOnlyHistoryQueriesDoNotApplyRetention() async throws {
+        let previousLimit = UserDefaults.standard.object(forKey: "chatHistoryLimit")
+        UserDefaults.standard.set(ChatHistoryLimit.fifty.rawValue, forKey: "chatHistoryLimit")
+        defer {
+            if let previousLimit {
+                UserDefaults.standard.set(previousLimit, forKey: "chatHistoryLimit")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "chatHistoryLimit")
+            }
+        }
+
+        let fixture = try makeTemporaryWorkspace(named: "Read Only History")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        var sessions: [ChatSession] = []
+        for index in 0 ..< 51 {
+            let session = ChatSession(workspaceID: fixture.workspace.id, name: "Session \(index)")
+            sessions.append(session)
+            _ = try await service.saveChatSession(session, for: fixture.workspace)
+        }
+
+        _ = try await service.recentSessions(for: fixture.workspace, limit: 1)
+        _ = try await service.findSessionResult(for: fixture.workspace, id: sessions[0].id.uuidString)
+        _ = try await service.mostRecentSession(for: fixture.workspace)
+
+        let chatsFolder = fixture.root.appendingPathComponent("Chats", isDirectory: true)
+        let fileCount = try FileManager.default.contentsOfDirectory(atPath: chatsFolder.path)
+            .count(where: { $0.hasPrefix("ChatSession-") && $0.hasSuffix(".json") })
+
+        XCTAssertEqual(fileCount, 51)
+    }
+
+    func testRetentionKeepsPairsWholeAndHandlesCorruptFiles() async throws {
+        let previousLimit = UserDefaults.standard.object(forKey: "chatHistoryLimit")
+        UserDefaults.standard.set(ChatHistoryLimit.fifty.rawValue, forKey: "chatHistoryLimit")
+        defer {
+            if let previousLimit {
+                UserDefaults.standard.set(previousLimit, forKey: "chatHistoryLimit")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "chatHistoryLimit")
+            }
+        }
+
+        let fixture = try makeTemporaryWorkspace(named: "Pair Retention")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let chatsFolder = fixture.root.appendingPathComponent("Chats", isDirectory: true)
+        try FileManager.default.createDirectory(at: chatsFolder, withIntermediateDirectories: false)
+        let now = Date()
+        let pairID = UUID()
+        let pair = OracleLane.allCases.map {
+            pairSession($0, pairID: pairID, workspace: fixture.workspace, name: $0.rawValue)
+        }
+        let sessions = pair + (0 ..< 49).map {
+            ChatSession(workspaceID: fixture.workspace.id, name: "Single \($0)")
+        }
+        for (index, session) in sessions.enumerated() {
+            let fileURL = chatsFolder.appendingPathComponent("ChatSession-\(session.id.uuidString).json")
+            try JSONEncoder().encode(session).write(to: fileURL)
+            try FileManager.default.setAttributes(
+                [.modificationDate: now.addingTimeInterval(TimeInterval(-index))],
+                ofItemAtPath: fileURL.path
+            )
+        }
+        let corruptID = UUID()
+        let corruptURL = chatsFolder.appendingPathComponent("ChatSession-\(corruptID.uuidString).json")
+        try Data("not json".utf8).write(to: corruptURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-10000)],
+            ofItemAtPath: corruptURL.path
+        )
+
+        let service = ChatDataService()
+        let retained = try await service.listChatSessions(for: fixture.workspace)
+        XCTAssertEqual(retained.count, 50)
+        XCTAssertTrue(pair.allSatisfy { session in
+            retained.contains { $0.lastPathComponent == "ChatSession-\(session.id.uuidString).json" }
+        })
+        XCTAssertFalse(FileManager.default.fileExists(atPath: corruptURL.path))
+
+        try Data("still corrupt".utf8).write(to: corruptURL)
+        let protected = try await service.listChatSessions(
+            for: fixture.workspace,
+            protectedSessionIDs: [corruptID]
+        )
+        XCTAssertTrue(protected.contains { $0.lastPathComponent == corruptURL.lastPathComponent })
+    }
+
+    func testRetentionDoesNotKeepOlderUnprotectedSingleAfterNewerPairOverflows() async throws {
+        let previousLimit = UserDefaults.standard.object(forKey: "chatHistoryLimit")
+        UserDefaults.standard.set(ChatHistoryLimit.fifty.rawValue, forKey: "chatHistoryLimit")
+        defer {
+            if let previousLimit {
+                UserDefaults.standard.set(previousLimit, forKey: "chatHistoryLimit")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "chatHistoryLimit")
+            }
+        }
+
+        let fixture = try makeTemporaryWorkspace(named: "Pair Retention Ordering")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let chatsFolder = fixture.root.appendingPathComponent("Chats", isDirectory: true)
+        try FileManager.default.createDirectory(at: chatsFolder, withIntermediateDirectories: false)
+        let now = Date()
+        let newerSingles = (0 ..< 49).map {
+            ChatSession(workspaceID: fixture.workspace.id, name: "Newer \($0)")
+        }
+        let pairID = UUID()
+        let pair = OracleLane.allCases.map {
+            pairSession($0, pairID: pairID, workspace: fixture.workspace, name: $0.rawValue)
+        }
+        let olderSingle = ChatSession(workspaceID: fixture.workspace.id, name: "Older unprotected")
+        let protectedOldest = ChatSession(workspaceID: fixture.workspace.id, name: "Oldest protected")
+        let orderedSessions = newerSingles + pair + [olderSingle, protectedOldest]
+        for (index, session) in orderedSessions.enumerated() {
+            let url = chatsFolder.appendingPathComponent("ChatSession-\(session.id.uuidString).json")
+            try JSONEncoder().encode(session).write(to: url)
+            try FileManager.default.setAttributes(
+                [.modificationDate: now.addingTimeInterval(TimeInterval(-index * 10))],
+                ofItemAtPath: url.path
+            )
+        }
+
+        let service = ChatDataService()
+        let retained = try await service.listChatSessions(
+            for: fixture.workspace,
+            protectedSessionIDs: [protectedOldest.id]
+        )
+        let retainedNames = Set(retained.map(\.lastPathComponent))
+
+        XCTAssertEqual(retained.count, 50)
+        XCTAssertTrue(retainedNames.contains("ChatSession-\(protectedOldest.id.uuidString).json"))
+        XCTAssertFalse(retainedNames.contains("ChatSession-\(olderSingle.id.uuidString).json"))
+        XCTAssertTrue(pair.allSatisfy { session in
+            !FileManager.default.fileExists(
+                atPath: chatsFolder.appendingPathComponent("ChatSession-\(session.id.uuidString).json").path
+            )
+        })
+    }
+
+    func testProtectingOnePairMemberRetainsBothMembers() async throws {
+        let previousLimit = UserDefaults.standard.object(forKey: "chatHistoryLimit")
+        UserDefaults.standard.set(ChatHistoryLimit.fifty.rawValue, forKey: "chatHistoryLimit")
+        defer {
+            if let previousLimit {
+                UserDefaults.standard.set(previousLimit, forKey: "chatHistoryLimit")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "chatHistoryLimit")
+            }
+        }
+
+        let fixture = try makeTemporaryWorkspace(named: "Protected Pair Retention")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let pairID = UUID()
+        let pair = OracleLane.allCases.map {
+            pairSession($0, pairID: pairID, workspace: fixture.workspace, name: $0.rawValue)
+        }
+        let urls = try await service.saveOraclePairSessions(pair, for: fixture.workspace)
+        for url in urls.values {
+            try FileManager.default.setAttributes([.modificationDate: Date.distantPast], ofItemAtPath: url.path)
+        }
+        for index in 0 ..< 49 {
+            _ = try await service.saveChatSession(
+                ChatSession(workspaceID: fixture.workspace.id, name: "Single \(index)"),
+                for: fixture.workspace
+            )
+        }
+
+        let retained = try await service.listChatSessions(
+            for: fixture.workspace,
+            protectedSessionIDs: [pair[0].id]
+        )
+
+        XCTAssertEqual(retained.count, 51)
+        let retainedNames = Set(retained.map(\.lastPathComponent))
+        XCTAssertTrue(pair.allSatisfy { session in
+            guard let url = urls[session.id] else { return false }
+            return retainedNames.contains(url.lastPathComponent)
+        })
+    }
+
+    func testRetentionIgnoresNonRegularPathsAndDeletedIDCanBeSavedAgain() async throws {
+        let previousLimit = UserDefaults.standard.object(forKey: "chatHistoryLimit")
+        UserDefaults.standard.set(ChatHistoryLimit.fifty.rawValue, forKey: "chatHistoryLimit")
+        defer {
+            if let previousLimit {
+                UserDefaults.standard.set(previousLimit, forKey: "chatHistoryLimit")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "chatHistoryLimit")
+            }
+        }
+
+        let fixture = try makeTemporaryWorkspace(named: "Retention Best Effort")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let chatsFolder = fixture.root.appendingPathComponent("Chats", isDirectory: true)
+        try FileManager.default.createDirectory(at: chatsFolder, withIntermediateDirectories: false)
+        let now = Date()
+        for index in 0 ..< 50 {
+            let session = ChatSession(workspaceID: fixture.workspace.id, name: "Kept \(index)")
+            let url = chatsFolder.appendingPathComponent("ChatSession-\(session.id.uuidString).json")
+            try JSONEncoder().encode(session).write(to: url)
+            try FileManager.default.setAttributes(
+                [.modificationDate: now.addingTimeInterval(TimeInterval(-index))],
+                ofItemAtPath: url.path
+            )
+        }
+
+        let failed = ChatSession(workspaceID: fixture.workspace.id, name: "Failed retention delete")
+        let failedURL = chatsFolder.appendingPathComponent("ChatSession-\(failed.id.uuidString).json")
+        try FileManager.default.createDirectory(at: failedURL, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-1000)],
+            ofItemAtPath: failedURL.path
+        )
+
+        let deleted = ChatSession(workspaceID: fixture.workspace.id, name: "Successful retention delete")
+        let deletedURL = chatsFolder.appendingPathComponent("ChatSession-\(deleted.id.uuidString).json")
+        try JSONEncoder().encode(deleted).write(to: deletedURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-2000)],
+            ofItemAtPath: deletedURL.path
+        )
+
+        let service = ChatDataService()
+        let retained = try await service.listChatSessions(for: fixture.workspace)
+        XCTAssertEqual(retained.count, 50)
+        XCTAssertFalse(retained.contains { $0.lastPathComponent == failedURL.lastPathComponent })
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failedURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: deletedURL.path))
+
+        try FileManager.default.removeItem(at: failedURL)
+        let savedURL = try await service.saveChatSession(failed, for: fixture.workspace)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: savedURL.path))
+    }
+
+    func testDeletedLegacySessionIDCanBeSavedAgain() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Legacy Resave")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let session = ChatSession(workspaceID: fixture.workspace.id, name: "Legacy")
+        let firstURL = try await service.saveChatSession(session, for: fixture.workspace)
+        try await service.deleteChatSessionFile(firstURL)
+
+        let secondURL = try await service.saveChatSession(session, for: fixture.workspace)
+        XCTAssertEqual(secondURL, firstURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: secondURL.path))
+    }
+
+    func testUnmergedLegacyJournalIsIgnored() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Legacy Journal")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        _ = try await service.saveChatSession(
+            ChatSession(workspaceID: fixture.workspace.id, name: "Existing"),
+            for: fixture.workspace
+        )
+        let chatsFolder = fixture.root.appendingPathComponent("Chats", isDirectory: true)
+        let transaction = chatsFolder.appendingPathComponent(".chat-transaction-future", isDirectory: true)
+        try FileManager.default.createDirectory(at: transaction, withIntermediateDirectories: false)
+        try JSONSerialization.data(withJSONObject: ["version": 2, "entries": []])
+            .write(to: transaction.appendingPathComponent("manifest.json"))
+
+        let saved = try await service.saveChatSession(
+            ChatSession(workspaceID: fixture.workspace.id, name: "After legacy journal"),
+            for: fixture.workspace
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: saved.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: transaction.path))
+    }
+
+    func testPairDeletionUsesCanonicalWorkspaceFiles() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Pair Delete")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let pairID = UUID()
+        let primary = pairSession(.primary, pairID: pairID, workspace: fixture.workspace, name: "Primary")
+        let secondary = pairSession(.secondary, pairID: pairID, workspace: fixture.workspace, name: "Secondary")
+        let urls = try await service.saveOraclePairSessions([primary, secondary], for: fixture.workspace)
+        let primaryURL = try XCTUnwrap(urls[primary.id])
+        let secondaryURL = try XCTUnwrap(urls[secondary.id])
+
+        try await service.deleteOraclePairSessionFiles([primary.id, secondary.id], for: fixture.workspace)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: primaryURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: secondaryURL.path))
+    }
+
     func testLegacyChatSessionEditPayloadsAreIgnoredOnDecodeAndOmittedOnEncode() throws {
         let sessionID = UUID()
         let messageID = UUID()
@@ -100,5 +521,53 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
         let encodedString = String(data: encoded, encoding: .utf8) ?? ""
         XCTAssertFalse(encodedString.contains("changedFilesByMessage"), encodedString)
         XCTAssertFalse(encodedString.contains("delegateEditItemsByMessage"), encodedString)
+    }
+
+    private func pairSession(
+        _ lane: OracleLane,
+        pairID: UUID,
+        workspace: WorkspaceModel,
+        name: String
+    ) -> ChatSession {
+        ChatSession(
+            workspaceID: workspace.id,
+            oraclePairID: pairID,
+            oracleLane: lane,
+            name: name
+        )
+    }
+
+    private func makeCurrentPairTransaction(files: [URL], in chatsFolder: URL) throws -> URL {
+        let transaction = chatsFolder.appendingPathComponent(".oracle-pair-save-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: transaction, withIntermediateDirectories: false)
+        for fileURL in files {
+            try Data(contentsOf: fileURL).write(
+                to: transaction.appendingPathComponent("original-\(fileURL.lastPathComponent)")
+            )
+        }
+        let entries = try files.map { fileURL -> [String: Any] in
+            let rawID = fileURL.deletingPathExtension().lastPathComponent.dropFirst("ChatSession-".count)
+            return try [
+                "sessionID": XCTUnwrap(UUID(uuidString: String(rawID))).uuidString,
+                "originallyExisted": true
+            ]
+        }
+        try JSONSerialization.data(withJSONObject: ["entries": entries])
+            .write(to: transaction.appendingPathComponent("manifest.json"))
+        return transaction
+    }
+
+    private func makeTemporaryWorkspace(named name: String) throws -> (root: URL, workspace: WorkspaceModel) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ChatHistoryJSONOnlyTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return (
+            root,
+            WorkspaceModel(
+                name: name,
+                repoPaths: [root.path],
+                customStoragePath: root
+            )
+        )
     }
 }

--- a/Tests/RepoPromptTests/ChatHistoryJSONOnlyTests.swift
+++ b/Tests/RepoPromptTests/ChatHistoryJSONOnlyTests.swift
@@ -86,14 +86,156 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
         XCTAssertEqual(updatedSecondary.name, "Updated Secondary")
     }
 
+    func testOracleGroupSaveAcceptsEverySupportedSizeInLaneOrder() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Oracle Group Sizes")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+
+        for groupSize in 2 ... 5 {
+            let groupID = UUID()
+            let lanes = try OracleLane.orderedPrefix(count: groupSize)
+            var members = lanes.map { lane in
+                pairSession(
+                    lane,
+                    pairID: groupID,
+                    groupSize: groupSize,
+                    workspace: fixture.workspace,
+                    name: "Group \(groupSize) \(lane.rawValue)"
+                )
+            }
+            let urls = try await service.saveOraclePairSessions(members, for: fixture.workspace)
+            let stubs = try await service.oraclePairSessionStubs(for: fixture.workspace, pairID: groupID)
+
+            XCTAssertEqual(stubs.compactMap(\.oracleLane), lanes)
+            XCTAssertTrue(stubs.allSatisfy { $0.oracleGroupSize == groupSize })
+            XCTAssertEqual(urls.count, groupSize)
+
+            if groupSize == 5 {
+                for index in members.indices {
+                    members[index].name = "Updated \(lanes[index].rawValue)"
+                }
+                _ = try await service.saveOraclePairSessions(members, for: fixture.workspace)
+                for member in members {
+                    let loaded = try await service.loadChatSession(from: XCTUnwrap(urls[member.id]))
+                    XCTAssertEqual(loaded.name, member.name)
+                    XCTAssertEqual(loaded.oracleGroupSize, 5)
+                }
+            }
+        }
+    }
+
+    func testOracleGroupSaveRejectsMismatchedMetadataAndNoncontiguousLanes() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Oracle Group Validation")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let groupID = UUID()
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        var mismatchedSize = lanes.map { lane in
+            pairSession(
+                lane,
+                pairID: groupID,
+                groupSize: 5,
+                workspace: fixture.workspace,
+                name: lane.rawValue
+            )
+        }
+        mismatchedSize[mismatchedSize.count - 1].oracleGroupSize = 4
+
+        do {
+            _ = try await service.saveOraclePairSessions(mismatchedSize, for: fixture.workspace)
+            XCTFail("Expected mismatched group size to fail")
+        } catch is ChatDataError {}
+
+        let noncontiguousGroupID = UUID()
+        let noncontiguous = [OracleLane.primary, .secondary, .oracle4].map { lane in
+            pairSession(
+                lane,
+                pairID: noncontiguousGroupID,
+                groupSize: 3,
+                workspace: fixture.workspace,
+                name: lane.rawValue
+            )
+        }
+        do {
+            _ = try await service.saveOraclePairSessions(noncontiguous, for: fixture.workspace)
+            XCTFail("Expected noncontiguous lanes to fail")
+        } catch is ChatDataError {}
+
+        let validThreeLaneGroupID = UUID()
+        let validThreeLaneGroup = try OracleLane.orderedPrefix(count: 3).map { lane in
+            pairSession(
+                lane,
+                pairID: validThreeLaneGroupID,
+                groupSize: 3,
+                workspace: fixture.workspace,
+                name: lane.rawValue
+            )
+        }
+        var mismatchedGroupID = validThreeLaneGroup
+        mismatchedGroupID[2].oraclePairID = UUID()
+        do {
+            _ = try await service.saveOraclePairSessions(mismatchedGroupID, for: fixture.workspace)
+            XCTFail("Expected mismatched group IDs to fail")
+        } catch is ChatDataError {}
+
+        var mismatchedWorkspace = validThreeLaneGroup
+        mismatchedWorkspace[2].workspaceID = UUID()
+        do {
+            _ = try await service.saveOraclePairSessions(mismatchedWorkspace, for: fixture.workspace)
+            XCTFail("Expected mismatched workspaces to fail")
+        } catch is ChatDataError {}
+    }
+
+    func testMissingGroupFileCannotMasqueradeAsSmallerGroupAndCleanupDeletesRemainder() async throws {
+        let fixture = try makeTemporaryWorkspace(named: "Incomplete Oracle Group")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let service = ChatDataService()
+        let groupID = UUID()
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        let members = lanes.map { lane in
+            pairSession(
+                lane,
+                pairID: groupID,
+                groupSize: 5,
+                workspace: fixture.workspace,
+                name: lane.rawValue
+            )
+        }
+        let urls = try await service.saveOraclePairSessions(members, for: fixture.workspace)
+        try FileManager.default.removeItem(at: XCTUnwrap(urls[members[4].id]))
+
+        do {
+            _ = try await service.oraclePairSessionStubs(for: fixture.workspace, pairID: groupID)
+            XCTFail("Expected an incomplete five-member group to fail validation")
+        } catch is ChatDataError {}
+
+        let remaining = try await service.oraclePairSessionStubs(
+            for: fixture.workspace,
+            pairID: groupID,
+            requireCompleteGroup: false
+        )
+        XCTAssertEqual(remaining.count, 4)
+        XCTAssertTrue(remaining.allSatisfy { $0.oracleGroupSize == 5 })
+
+        try await service.deleteOraclePairSessionFiles([members[0].id], for: fixture.workspace)
+        XCTAssertTrue(urls.values.allSatisfy { !FileManager.default.fileExists(atPath: $0.path) })
+    }
+
     func testConcurrentPairAndLegacySavesQueueWithoutLosingHistory() async throws {
         let fixture = try makeTemporaryWorkspace(named: "Concurrent Saves")
         defer { try? FileManager.default.removeItem(at: fixture.root) }
         let service = ChatDataService()
+        let lanes = try OracleLane.orderedPrefix(count: 5)
         let pairs = (0 ..< 8).map { index in
             let pairID = UUID()
-            return OracleLane.allCases.map {
-                pairSession($0, pairID: pairID, workspace: fixture.workspace, name: "Pair \(index) \($0.rawValue)")
+            return lanes.map {
+                pairSession(
+                    $0,
+                    pairID: pairID,
+                    groupSize: lanes.count,
+                    workspace: fixture.workspace,
+                    name: "Pair \(index) \($0.rawValue)"
+                )
             }
         }
         let singles = (0 ..< 8).map {
@@ -232,7 +374,7 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
         XCTAssertEqual(fileCount, 51)
     }
 
-    func testRetentionKeepsPairsWholeAndHandlesCorruptFiles() async throws {
+    func testRetentionAndGroupDeletionFailClosedForUnreadableChatFiles() async throws {
         let previousLimit = UserDefaults.standard.object(forKey: "chatHistoryLimit")
         UserDefaults.standard.set(ChatHistoryLimit.fifty.rawValue, forKey: "chatHistoryLimit")
         defer {
@@ -249,8 +391,9 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
         try FileManager.default.createDirectory(at: chatsFolder, withIntermediateDirectories: false)
         let now = Date()
         let pairID = UUID()
-        let pair = OracleLane.allCases.map {
-            pairSession($0, pairID: pairID, workspace: fixture.workspace, name: $0.rawValue)
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        let pair = lanes.map {
+            pairSession($0, pairID: pairID, groupSize: lanes.count, workspace: fixture.workspace, name: $0.rawValue)
         }
         let sessions = pair + (0 ..< 49).map {
             ChatSession(workspaceID: fixture.workspace.id, name: "Single \($0)")
@@ -273,11 +416,21 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
 
         let service = ChatDataService()
         let retained = try await service.listChatSessions(for: fixture.workspace)
-        XCTAssertEqual(retained.count, 50)
+        XCTAssertEqual(retained.count, sessions.count + 1)
         XCTAssertTrue(pair.allSatisfy { session in
             retained.contains { $0.lastPathComponent == "ChatSession-\(session.id.uuidString).json" }
         })
-        XCTAssertFalse(FileManager.default.fileExists(atPath: corruptURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: corruptURL.path))
+
+        do {
+            try await service.deleteOraclePairSessionFiles([pair[0].id], for: fixture.workspace)
+            XCTFail("Expected grouped deletion to fail closed while a chat file is unreadable")
+        } catch is ChatDataError {}
+        XCTAssertTrue(pair.allSatisfy { session in
+            FileManager.default.fileExists(
+                atPath: chatsFolder.appendingPathComponent("ChatSession-\(session.id.uuidString).json").path
+            )
+        })
 
         try Data("still corrupt".utf8).write(to: corruptURL)
         let protected = try await service.listChatSessions(
@@ -307,8 +460,9 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
             ChatSession(workspaceID: fixture.workspace.id, name: "Newer \($0)")
         }
         let pairID = UUID()
-        let pair = OracleLane.allCases.map {
-            pairSession($0, pairID: pairID, workspace: fixture.workspace, name: $0.rawValue)
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        let pair = lanes.map {
+            pairSession($0, pairID: pairID, groupSize: lanes.count, workspace: fixture.workspace, name: $0.rawValue)
         }
         let olderSingle = ChatSession(workspaceID: fixture.workspace.id, name: "Older unprotected")
         let protectedOldest = ChatSession(workspaceID: fixture.workspace.id, name: "Oldest protected")
@@ -354,8 +508,9 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: fixture.root) }
         let service = ChatDataService()
         let pairID = UUID()
-        let pair = OracleLane.allCases.map {
-            pairSession($0, pairID: pairID, workspace: fixture.workspace, name: $0.rawValue)
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        let pair = lanes.map {
+            pairSession($0, pairID: pairID, groupSize: lanes.count, workspace: fixture.workspace, name: $0.rawValue)
         }
         let urls = try await service.saveOraclePairSessions(pair, for: fixture.workspace)
         for url in urls.values {
@@ -373,7 +528,7 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
             protectedSessionIDs: [pair[0].id]
         )
 
-        XCTAssertEqual(retained.count, 51)
+        XCTAssertEqual(retained.count, 54)
         let retainedNames = Set(retained.map(\.lastPathComponent))
         XCTAssertTrue(pair.allSatisfy { session in
             guard let url = urls[session.id] else { return false }
@@ -526,6 +681,7 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
     private func pairSession(
         _ lane: OracleLane,
         pairID: UUID,
+        groupSize: Int = 2,
         workspace: WorkspaceModel,
         name: String
     ) -> ChatSession {
@@ -533,6 +689,7 @@ final class ChatHistoryJSONOnlyTests: XCTestCase {
             workspaceID: workspace.id,
             oraclePairID: pairID,
             oracleLane: lane,
+            oracleGroupSize: groupSize,
             name: name
         )
     }

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderDualOracleStateTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderDualOracleStateTests.swift
@@ -748,6 +748,10 @@ final class ContextBuilderDualOracleStateTests: XCTestCase {
             ephemeral: true
         )
         await composition.workspaceManager.switchWorkspace(to: workspace, saveState: false, reason: #function)
+        // Chat restore runs in a listener Task that switchWorkspace does not await.
+        // Settle it before dual-Oracle assertions about current/active chat IDs.
+        await composition.oracleViewModel.awaitWorkspaceChatSessionsRestored()
+        _ = await composition.oracleViewModel.ensureActiveSessionForCurrentTab(createIfMissing: true)
         let active = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
         let tabID = try XCTUnwrap(active.activeComposeTabID ?? active.composeTabs.first?.id)
         return Fixture(composition: composition, tabID: tabID, root: root)

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderDualOracleStateTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderDualOracleStateTests.swift
@@ -1,0 +1,940 @@
+import enum MCP.Value
+@testable import RepoPromptApp
+import XCTest
+
+final class ContextBuilderDualOracleStateTests: XCTestCase {
+    @MainActor
+    func testAuthorizedReviewUsesPairedRuntimeWithExactPayloadAndResolvedModelNames() async throws {
+        #if DEBUG
+            let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(AIModel.claude4Sonnet.rawValue, commit: false)
+            defer { settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+
+            let fixture = try await makeFixture(windowID: -929)
+            defer { fixture.cleanup() }
+            let viewModel = fixture.composition.contextBuilderAgentViewModel
+            let oracleViewModel = fixture.composition.oracleViewModel
+            let workspaceID = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspaceID)
+            let primaryID = UUID()
+            let secondaryID = UUID()
+            let primaryModel = AIModel.gpt54Pro
+            let secondaryModel = AIModel.claude4Sonnet
+            let prompt = "Review this exact payload"
+
+            viewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: primaryModel, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                toolChatSend: { args, _, context, selection, callbacks in
+                    XCTAssertEqual(args["mode"]?.stringValue, "review")
+                    XCTAssertEqual(selection.model, primaryModel)
+                    XCTAssertEqual(context.tabID, fixture.tabID)
+                    XCTAssertEqual(context.workspaceID, workspaceID)
+                    XCTAssertEqual(context.agentModeSessionID, UUID(uuidString: "00000000-0000-0000-0000-000000000111"))
+                    XCTAssertEqual(context.agentModeRunID, UUID(uuidString: "00000000-0000-0000-0000-000000000222"))
+                    let payload = try XCTUnwrap(context.packaging.prebuiltAIMessage)
+                    XCTAssertTrue(payload.conversationMessages.last?.content.contains(prompt) == true)
+                    XCTAssertTrue(oracleViewModel.acceptsOverrideAIMessageForTesting(payload, userMessage: prompt))
+                    callbacks.modelsResolved?(primaryModel, secondaryModel)
+                    try await callbacks.pairSessionsResolved?(primaryID, secondaryID)
+                    callbacks.primaryProgress?("Paired review response", nil)
+                    return pairedResult(
+                        primaryID: primaryID,
+                        secondaryID: secondaryID,
+                        primaryModel: primaryModel,
+                        secondary: .success(reply(id: secondaryID, text: "Secondary review response")),
+                        context: context
+                    )
+                }
+            ))
+            defer { viewModel.installRunTestHooks(nil) }
+
+            let agentSessionID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000111"))
+            let agentRunID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000222"))
+            let result = try await viewModel.runMCPPlanOrQuestion(
+                for: .init(workspaceID: workspaceID, tabID: fixture.tabID),
+                oracleViewModel: oracleViewModel,
+                agentModeSessionID: agentSessionID,
+                agentModeRunID: agentRunID,
+                mode: .review,
+                prompt: prompt,
+                selection: .init(),
+                reviewGitContext: .automaticOnly(),
+                gitScopeOverride: .selected
+            )
+
+            guard case .paired = result.payload else { return XCTFail("Expected paired review result") }
+            XCTAssertEqual(result.route.contextID, fixture.tabID)
+            XCTAssertEqual(result.route.agentSessionID, agentSessionID)
+            XCTAssertEqual(result.route.agentRunID, agentRunID)
+            XCTAssertEqual(
+                viewModel.sessions[fixture.tabID]?.mcpPlanModel,
+                "\(primaryModel.displayName) + \(secondaryModel.displayName)"
+            )
+            XCTAssertEqual(viewModel.sessions[fixture.tabID]?.generatedAnswerRoute?.chatID, primaryID.uuidString)
+        #endif
+    }
+
+    @MainActor
+    func testAuthorizedReviewWithoutSecondaryPreservesLegacySingleHeadlessResult() async throws {
+        #if DEBUG
+            let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
+            defer { settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+
+            let fixture = try await makeFixture(windowID: -930, deterministicResponse: "Legacy review response")
+            defer { fixture.cleanup() }
+            let viewModel = fixture.composition.contextBuilderAgentViewModel
+            let oracleViewModel = fixture.composition.oracleViewModel
+            let workspaceID = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspaceID)
+            let primaryModel = AIModel.gpt54Pro
+            var pairedRuntimeWasCalled = false
+
+            viewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: primaryModel, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                toolChatSend: { _, _, _, _, _ in
+                    pairedRuntimeWasCalled = true
+                    throw CancellationError()
+                }
+            ))
+            defer { viewModel.installRunTestHooks(nil) }
+
+            let result = try await viewModel.runMCPPlanOrQuestion(
+                for: .init(workspaceID: workspaceID, tabID: fixture.tabID),
+                oracleViewModel: oracleViewModel,
+                mode: .review,
+                prompt: "Review with one Oracle",
+                selection: .init(),
+                reviewGitContext: .automaticOnly(),
+                gitScopeOverride: .selected
+            )
+
+            guard case let .single(reply) = result.payload else { return XCTFail("Expected legacy single review result") }
+            XCTAssertEqual(reply.response, "Legacy review response")
+            XCTAssertFalse(pairedRuntimeWasCalled)
+            XCTAssertEqual(viewModel.sessions[fixture.tabID]?.mcpPlanModel, primaryModel.displayName)
+        #endif
+    }
+
+    @MainActor
+    func testInactiveWorkspaceSingleOracleUsesLegacyHeadlessRoute() async throws {
+        #if DEBUG
+            let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
+            defer { settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+
+            let fixture = try await makeFixture(windowID: -938, deterministicResponse: "Inactive headless response")
+            defer { fixture.cleanup() }
+            let composition = fixture.composition
+            let targetWorkspaceID = try XCTUnwrap(composition.workspaceManager.activeWorkspaceID)
+            var pairedRuntimeWasCalled = false
+            composition.contextBuilderAgentViewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: .gpt54Pro, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                toolChatSend: { _, _, _, _, _ in
+                    pairedRuntimeWasCalled = true
+                    throw CancellationError()
+                }
+            ))
+            defer { composition.contextBuilderAgentViewModel.installRunTestHooks(nil) }
+
+            let ambient = composition.workspaceManager.createWorkspace(
+                name: "Ambient workspace",
+                repoPaths: [fixture.root.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(to: ambient, saveState: false, reason: #function)
+
+            let result = try await composition.contextBuilderAgentViewModel.runMCPPlanOrQuestion(
+                for: .init(workspaceID: targetWorkspaceID, tabID: fixture.tabID),
+                oracleViewModel: composition.oracleViewModel,
+                mode: .plan,
+                prompt: "Use the target workspace headlessly.",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )
+
+            guard case let .single(reply) = result.payload else { return XCTFail("Expected single Oracle result") }
+            XCTAssertEqual(reply.response, "Inactive headless response")
+            XCTAssertFalse(pairedRuntimeWasCalled)
+            XCTAssertEqual(composition.workspaceManager.activeWorkspaceID, ambient.id)
+            XCTAssertFalse(composition.oracleViewModel.sessions.contains(where: { $0.id == reply.chatId }))
+        #endif
+    }
+
+    @MainActor
+    func testInactiveWorkspacePairedOracleKeepsCoordinatedRuntime() async throws {
+        #if DEBUG
+            let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(AIModel.claude4Sonnet.rawValue, commit: false)
+            defer { settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+
+            let fixture = try await makeFixture(windowID: -939)
+            defer { fixture.cleanup() }
+            let composition = fixture.composition
+            let targetWorkspaceID = try XCTUnwrap(composition.workspaceManager.activeWorkspaceID)
+            let primaryID = UUID()
+            let secondaryID = UUID()
+            var pairedRuntimeWasCalled = false
+            composition.contextBuilderAgentViewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: .gpt54Pro, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                toolChatSend: { _, _, context, _, callbacks in
+                    pairedRuntimeWasCalled = true
+                    XCTAssertEqual(context.workspaceID, targetWorkspaceID)
+                    XCTAssertNil(context.packaging.prebuiltAIMessage)
+                    callbacks.modelsResolved?(.gpt54Pro, .claude4Sonnet)
+                    try await callbacks.pairSessionsResolved?(primaryID, secondaryID)
+                    return pairedResult(
+                        primaryID: primaryID,
+                        secondaryID: secondaryID,
+                        primaryModel: .gpt54Pro,
+                        secondary: .success(reply(id: secondaryID, text: "Secondary response")),
+                        context: context
+                    )
+                }
+            ))
+            defer { composition.contextBuilderAgentViewModel.installRunTestHooks(nil) }
+
+            let ambient = composition.workspaceManager.createWorkspace(
+                name: "Ambient paired workspace",
+                repoPaths: [fixture.root.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(to: ambient, saveState: false, reason: #function)
+
+            let result = try await composition.contextBuilderAgentViewModel.runMCPPlanOrQuestion(
+                for: .init(workspaceID: targetWorkspaceID, tabID: fixture.tabID),
+                oracleViewModel: composition.oracleViewModel,
+                mode: .plan,
+                prompt: "Run both target workspace Oracles.",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )
+
+            guard case .paired = result.payload else { return XCTFail("Expected paired Oracle result") }
+            XCTAssertTrue(pairedRuntimeWasCalled)
+            XCTAssertEqual(composition.workspaceManager.activeWorkspaceID, ambient.id)
+        #endif
+    }
+
+    @MainActor
+    func testPairedRuntimePublishesPrimaryPreviewAndNeverActivatesChat() async throws {
+        #if DEBUG
+            let fixture = try await makeFixture(windowID: -931)
+            defer { fixture.cleanup() }
+            let viewModel = fixture.composition.contextBuilderAgentViewModel
+            let oracleViewModel = fixture.composition.oracleViewModel
+            let workspaceID = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspaceID)
+            let primaryID = UUID()
+            let secondaryID = UUID()
+            var runtimeCurrent: UUID?
+            var runtimeActive: UUID?
+            let primaryModel = AIModel.gpt54Pro
+            let primaryPresetID = UUID()
+            let primaryMCPControlInfo = "Plan mode • MCP override"
+            let activityRecorder = DualOracleActivityRecorder()
+
+            viewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (
+                        model: primaryModel,
+                        chatPresetID: primaryPresetID,
+                        mcpControlInfo: primaryMCPControlInfo
+                    )
+                },
+                toolChatSend: { args, _, context, selection, callbacks in
+                    XCTAssertNil(args["model"])
+                    XCTAssertEqual(selection.model, primaryModel)
+                    XCTAssertEqual(selection.chatPresetID, primaryPresetID)
+                    XCTAssertEqual(selection.mcpControlInfo, primaryMCPControlInfo)
+                    XCTAssertFalse(selection.isAutoSelected)
+                    XCTAssertEqual(context.workspaceID, workspaceID)
+                    XCTAssertEqual(context.activationPolicy, .background)
+                    XCTAssertEqual(context.completionPolicy, .contextBuilderStrict)
+                    runtimeCurrent = oracleViewModel.currentSessionID
+                    runtimeActive = fixture.composition.workspaceManager.activeChatSessionID(forTabID: fixture.tabID)
+                    try await callbacks.pairSessionsResolved?(primaryID, secondaryID)
+                    callbacks.laneLifecycle?(.primary, .init(kind: .streamActivity))
+                    callbacks.laneLifecycle?(.secondary, .init(kind: .streamActivity))
+                    callbacks.laneLifecycle?(.primary, .init(kind: .streamActivity))
+                    callbacks.laneLifecycle?(.secondary, .init(kind: .streamActivity))
+                    callbacks.laneLifecycle?(.primary, .init(kind: .finalizationCompleted))
+                    callbacks.laneLifecycle?(.secondary, .init(kind: .streamFailed))
+                    callbacks.laneLifecycle?(.secondary, .init(kind: .streamCancelled))
+                    callbacks.primaryProgress?("Primary preview", "Primary reasoning")
+                    return pairedResult(
+                        primaryID: primaryID,
+                        secondaryID: secondaryID,
+                        primaryModel: primaryModel,
+                        secondary: .failure(.init(message: "Secondary unavailable"))
+                    )
+                }
+            ))
+            defer { viewModel.installRunTestHooks(nil) }
+
+            let result = try await viewModel.runMCPPlanOrQuestion(
+                for: .init(workspaceID: workspaceID, tabID: fixture.tabID),
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "Plan this change",
+                selection: .init(),
+                reviewGitContext: .automaticOnly(),
+                activityReporter: { activity in
+                    await activityRecorder.record(activity)
+                }
+            )
+
+            let state = try XCTUnwrap(viewModel.sessions[fixture.tabID])
+            let reply = primaryReply(from: result)
+            guard case let .paired(pair) = result.payload,
+                  case let .failure(secondaryFailure) = pair.result.secondary
+            else { return XCTFail("Expected the paired result envelope") }
+            XCTAssertEqual(secondaryFailure.message, "Secondary unavailable")
+            XCTAssertEqual(reply.response, "Primary response")
+            XCTAssertEqual(reply.errors, ["Secondary Oracle failed: Secondary unavailable"])
+            XCTAssertEqual(state.backgroundPlanResponseText, "Primary response")
+            XCTAssertEqual(state.backgroundPlanReasoningText, "Primary reasoning")
+            XCTAssertNil(state.followUpPrimarySessionID)
+            XCTAssertNil(state.followUpSecondarySessionID)
+            XCTAssertEqual(state.generatedAnswerRoute?.chatID, primaryID.uuidString)
+            let activities = await activityRecorder.snapshot()
+            XCTAssertEqual(activities.phases, [
+                .streaming,
+                .streaming,
+                .streaming,
+                .streaming,
+                .messageFinalization,
+                .streaming
+            ])
+            XCTAssertEqual(activities.messages, [
+                "Still in Primary Oracle response streaming",
+                "Still in Secondary Oracle response streaming",
+                "Still in Primary Oracle response streaming",
+                "Still in Secondary Oracle response streaming",
+                "Primary Oracle message finalization completed",
+                "Secondary Oracle stream failed"
+            ])
+            XCTAssertEqual(activities.suppressedHeartbeats, [.streaming])
+            XCTAssertFalse(activities.messages.contains("Oracle response streaming"))
+            XCTAssertFalse(activities.messages.contains("Oracle message finalization completed"))
+            XCTAssertEqual(oracleViewModel.currentSessionID, runtimeCurrent)
+            XCTAssertEqual(
+                fixture.composition.workspaceManager.activeChatSessionID(forTabID: fixture.tabID),
+                runtimeActive
+            )
+        #endif
+    }
+
+    @MainActor
+    func testReplacementCancelsBothOldLanesOnceAndRejectsStaleCallbacks() async throws {
+        #if DEBUG
+            let fixture = try await makeFixture(windowID: -932)
+            defer { fixture.cleanup() }
+            let viewModel = fixture.composition.contextBuilderAgentViewModel
+            let oracleViewModel = fixture.composition.oracleViewModel
+            let workspaceID = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspaceID)
+            let oldPrimary = UUID()
+            let oldSecondary = UUID()
+            let replacementPrimary = UUID()
+            let gate = FollowUpGate()
+            let recorder = FollowUpRecorder()
+            let firstStarted = AsyncSignal()
+            let model = AIModel.gpt54Pro
+
+            viewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: model, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                cancelFollowUpOracleSession: { await recorder.recordCancellation($0) },
+                toolChatSend: { _, _, context, _, callbacks in
+                    let dispatch = await recorder.recordDispatch()
+                    if dispatch == 1 {
+                        try await callbacks.pairSessionsResolved?(oldPrimary, oldSecondary)
+                        await firstStarted.signal()
+                        await gate.wait()
+                        callbacks.primaryProgress?("stale preview", nil)
+                        return pairedResult(
+                            primaryID: oldPrimary,
+                            secondaryID: oldSecondary,
+                            primaryModel: model,
+                            secondary: .success(reply(id: oldSecondary, text: "Old secondary"))
+                        )
+                    }
+                    try await callbacks.primarySessionResolved?(replacementPrimary)
+                    callbacks.primaryProgress?("Fresh preview", nil)
+                    return singleResult(id: replacementPrimary, context: context, response: "Fresh response")
+                }
+            ))
+            defer { viewModel.installRunTestHooks(nil) }
+            let identity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: fixture.tabID)
+
+            let first = Task { @MainActor in
+                try await viewModel.runMCPPlanOrQuestion(
+                    for: identity,
+                    oracleViewModel: oracleViewModel,
+                    mode: .plan,
+                    prompt: "First",
+                    selection: .init(),
+                    reviewGitContext: .automaticOnly()
+                )
+            }
+            await firstStarted.wait()
+            let replacement = Task { @MainActor in
+                try await viewModel.runMCPPlanOrQuestion(
+                    for: identity,
+                    oracleViewModel: oracleViewModel,
+                    mode: .plan,
+                    prompt: "Replacement",
+                    selection: .init(),
+                    reviewGitContext: .automaticOnly()
+                )
+            }
+
+            await waitUntil { await recorder.snapshot().cancelledIDs.count == 2 }
+            var snapshot = await recorder.snapshot()
+            XCTAssertEqual(snapshot.dispatchCount, 1)
+            await gate.release()
+            let replacementReply = try await primaryReply(from: replacement.value)
+            _ = try? await first.value
+
+            let state = try XCTUnwrap(viewModel.sessions[fixture.tabID])
+            XCTAssertEqual(replacementReply.response, "Fresh response")
+            XCTAssertEqual(state.backgroundPlanResponseText, "Fresh response")
+            snapshot = await recorder.snapshot()
+            XCTAssertEqual(Set(snapshot.cancelledIDs), [oldPrimary, oldSecondary])
+            XCTAssertEqual(snapshot.cancelledIDs.count, 2)
+        #endif
+    }
+
+    @MainActor
+    func testDrainTimeoutStartsNoReplacementAndRetryWorksAfterRetainedDrainClears() async throws {
+        #if DEBUG
+            let fixture = try await makeFixture(windowID: -933)
+            defer { fixture.cleanup() }
+            let viewModel = fixture.composition.contextBuilderAgentViewModel
+            let oracleViewModel = fixture.composition.oracleViewModel
+            let workspaceID = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspaceID)
+            let gate = FollowUpGate()
+            let recorder = FollowUpRecorder()
+            let firstStarted = AsyncSignal()
+            let model = AIModel.gpt54Pro
+
+            viewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: model, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                cancelFollowUpOracleSession: { await recorder.recordCancellation($0) },
+                toolChatSend: { _, _, context, _, callbacks in
+                    let dispatch = await recorder.recordDispatch()
+                    let primary = UUID()
+                    try await callbacks.primarySessionResolved?(primary)
+                    if dispatch == 1 {
+                        await firstStarted.signal()
+                        await gate.wait()
+                    }
+                    return singleResult(id: primary, context: context, response: "Response \(dispatch)")
+                },
+                supersededDrainTimeout: 0.01
+            ))
+            defer { viewModel.installRunTestHooks(nil) }
+            let identity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: fixture.tabID)
+
+            let first = Task { @MainActor in
+                try await viewModel.runMCPPlanOrQuestion(
+                    for: identity,
+                    oracleViewModel: oracleViewModel,
+                    mode: .plan,
+                    prompt: "First",
+                    selection: .init(),
+                    reviewGitContext: .automaticOnly()
+                )
+            }
+            await firstStarted.wait()
+
+            // swiftformat:disable redundantAwait hoistAwait
+            await XCTAssertThrowsErrorAsync(try await viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "Timed out replacement",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )) { error in
+                XCTAssertEqual(
+                    error.localizedDescription,
+                    "Previous Oracle follow-up did not stop within 0.0s; no replacement was started."
+                )
+            }
+            // swiftformat:enable redundantAwait hoistAwait
+            var snapshot = await recorder.snapshot()
+            XCTAssertEqual(snapshot.dispatchCount, 1)
+            XCTAssertNotNil(viewModel.sessions[fixture.tabID]?.supersededFollowUpDrain)
+
+            await gate.release()
+            _ = try? await first.value
+            await waitUntil { viewModel.sessions[fixture.tabID]?.supersededFollowUpDrain == nil }
+
+            let retry = try await primaryReply(from: viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "Retry",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            ))
+            XCTAssertEqual(retry.response, "Response 2")
+            snapshot = await recorder.snapshot()
+            XCTAssertEqual(snapshot.dispatchCount, 2)
+        #endif
+    }
+
+    @MainActor
+    func testSecondPairedFollowUpContinuesPrimaryChat() async throws {
+        #if DEBUG
+            let fixture = try await makeFixture(windowID: -934)
+            defer { fixture.cleanup() }
+            let viewModel = fixture.composition.contextBuilderAgentViewModel
+            let oracleViewModel = fixture.composition.oracleViewModel
+            let workspaceID = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspaceID)
+            let primaryID = UUID()
+            let secondaryID = UUID()
+            let model = AIModel.gpt54Pro
+            var dispatchCount = 0
+
+            viewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: model, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                toolChatSend: { args, _, _, _, callbacks in
+                    dispatchCount += 1
+                    if dispatchCount == 1 {
+                        XCTAssertEqual(args["new_chat"]?.boolValue, true)
+                        XCTAssertNil(args["chat_id"])
+                    } else {
+                        XCTAssertEqual(args["new_chat"]?.boolValue, false)
+                        XCTAssertEqual(args["chat_id"]?.stringValue, primaryID.uuidString)
+                    }
+                    try await callbacks.pairSessionsResolved?(primaryID, secondaryID)
+                    return pairedResult(
+                        primaryID: primaryID,
+                        secondaryID: secondaryID,
+                        primaryModel: model,
+                        secondary: .success(reply(id: secondaryID, text: "Secondary response"))
+                    )
+                }
+            ))
+            defer { viewModel.installRunTestHooks(nil) }
+            let identity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: fixture.tabID)
+
+            _ = try await viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "First",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )
+            let second = try await viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "Second",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )
+
+            guard case let .paired(pair) = second.payload else {
+                return XCTFail("Expected paired continuation")
+            }
+            XCTAssertEqual(pair.primaryChatID, primaryID.uuidString)
+            XCTAssertEqual(dispatchCount, 2)
+            XCTAssertEqual(viewModel.sessions[fixture.tabID]?.generatedAnswerRoute?.chatID, primaryID.uuidString)
+        #endif
+    }
+
+    @MainActor
+    func testRejectedContinuationFallsBackOnceBeforeAnyLanePublishes() async throws {
+        #if DEBUG
+            let fixture = try await makeFixture(windowID: -935)
+            defer { fixture.cleanup() }
+            let viewModel = fixture.composition.contextBuilderAgentViewModel
+            let oracleViewModel = fixture.composition.oracleViewModel
+            let workspaceID = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspaceID)
+            let firstID = UUID()
+            let freshID = UUID()
+            let model = AIModel.gpt54Pro
+            var dispatchCount = 0
+
+            viewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: model, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                toolChatSend: { args, _, context, _, callbacks in
+                    dispatchCount += 1
+                    switch dispatchCount {
+                    case 1:
+                        XCTAssertEqual(args["new_chat"]?.boolValue, true)
+                        XCTAssertNil(args["chat_id"])
+                        try await callbacks.primarySessionResolved?(firstID)
+                        return singleResult(id: firstID, context: context, response: "First")
+                    case 2:
+                        XCTAssertEqual(args["new_chat"]?.boolValue, false)
+                        XCTAssertEqual(args["chat_id"]?.stringValue, firstID.uuidString)
+                        throw ChatToolError.notFound("stale continuation")
+                    default:
+                        XCTAssertEqual(args["new_chat"]?.boolValue, true)
+                        XCTAssertNil(args["chat_id"])
+                        try await callbacks.primarySessionResolved?(freshID)
+                        return singleResult(id: freshID, context: context, response: "Fresh")
+                    }
+                }
+            ))
+            defer { viewModel.installRunTestHooks(nil) }
+            let identity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: fixture.tabID)
+
+            _ = try await viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "First",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )
+            let retry = try await viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "Retry",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )
+
+            XCTAssertEqual(primaryReply(from: retry).response, "Fresh")
+            XCTAssertEqual(dispatchCount, 3)
+            XCTAssertEqual(viewModel.sessions[fixture.tabID]?.generatedAnswerRoute?.chatID, freshID.uuidString)
+        #endif
+    }
+
+    @MainActor
+    func testMismatchedStoredRouteStartsFreshWithoutContinuationAttempt() async throws {
+        #if DEBUG
+            let fixture = try await makeFixture(windowID: -936)
+            defer { fixture.cleanup() }
+            let viewModel = fixture.composition.contextBuilderAgentViewModel
+            let oracleViewModel = fixture.composition.oracleViewModel
+            let workspaceID = try XCTUnwrap(fixture.composition.workspaceManager.activeWorkspaceID)
+            let firstID = UUID()
+            let secondID = UUID()
+            let model = AIModel.gpt54Pro
+            var dispatchCount = 0
+
+            viewModel.installRunTestHooks(.init(
+                beforeProcessingProviderEvent: nil,
+                providerEventDisposition: nil,
+                teardownCompleted: nil,
+                resolveMCPFollowUpModel: { _ in
+                    (model: model, chatPresetID: nil, mcpControlInfo: nil)
+                },
+                toolChatSend: { args, _, context, _, callbacks in
+                    dispatchCount += 1
+                    XCTAssertEqual(args["new_chat"]?.boolValue, true)
+                    XCTAssertNil(args["chat_id"])
+                    let id = dispatchCount == 1 ? firstID : secondID
+                    try await callbacks.primarySessionResolved?(id)
+                    return singleResult(id: id, context: context, response: "Response")
+                }
+            ))
+            defer { viewModel.installRunTestHooks(nil) }
+            let identity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: fixture.tabID)
+
+            _ = try await viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "First",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )
+            viewModel.sessions[fixture.tabID]?.generatedAnswerRoute = .init(
+                workspaceID: UUID(),
+                tabID: fixture.tabID,
+                chatID: firstID.uuidString
+            )
+            _ = try await viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: oracleViewModel,
+                mode: .plan,
+                prompt: "Second",
+                selection: .init(),
+                reviewGitContext: .automaticOnly()
+            )
+
+            XCTAssertEqual(dispatchCount, 2)
+            XCTAssertEqual(viewModel.sessions[fixture.tabID]?.generatedAnswerRoute?.chatID, secondID.uuidString)
+        #endif
+    }
+
+    @MainActor
+    private func makeFixture(windowID: Int, deterministicResponse: String? = nil) async throws -> Fixture {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let composition: WindowStateComposition = if let deterministicResponse {
+            WindowStateCompositionFactory.make(
+                windowID: windowID,
+                deferredInitialAgentSystemWorkspaceRefresh: true,
+                sharedMCPService: MCPService(),
+                aiQueriesServiceFactory: { keyManager in
+                    AIQueriesService(
+                        keyManager: keyManager,
+                        sendPromptOverride: { _, _ in
+                            let stream = AsyncThrowingStream<ChatStreamOutput, Error> { continuation in
+                                continuation.yield(ChatStreamOutput(
+                                    text: deterministicResponse,
+                                    reasoning: nil,
+                                    tokens: ChatTokenInfo(),
+                                    terminalOutcome: .completed
+                                ))
+                                continuation.finish()
+                            }
+                            return (UUID(), stream)
+                        }
+                    )
+                }
+            )
+        } else {
+            WindowStateCompositionFactory.make(
+                windowID: windowID,
+                deferredInitialAgentSystemWorkspaceRefresh: true,
+                sharedMCPService: MCPService()
+            )
+        }
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        await composition.workspaceManager.awaitInitialized()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContextBuilderDualOracleStateTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let workspace = composition.workspaceManager.createWorkspace(
+            name: "Dual Oracle state test",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        await composition.workspaceManager.switchWorkspace(to: workspace, saveState: false, reason: #function)
+        let active = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
+        let tabID = try XCTUnwrap(active.activeComposeTabID ?? active.composeTabs.first?.id)
+        return Fixture(composition: composition, tabID: tabID, root: root)
+    }
+}
+
+@MainActor
+private struct Fixture {
+    let composition: WindowStateComposition
+    let tabID: UUID
+    let root: URL
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}
+
+private actor AsyncSignal {
+    private var isSignaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        guard !isSignaled else { return }
+        isSignaled = true
+        let pending = waiters
+        waiters.removeAll(keepingCapacity: false)
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+
+    func wait() async {
+        guard !isSignaled else { return }
+        await withCheckedContinuation { continuation in
+            if isSignaled {
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+            }
+        }
+    }
+}
+
+private actor FollowUpGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait() async {
+        guard !released else { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        released = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor FollowUpRecorder {
+    struct Snapshot {
+        let dispatchCount: Int
+        let cancelledIDs: [UUID]
+    }
+
+    private var dispatchCount = 0
+    private var cancelledIDs: [UUID] = []
+
+    func recordDispatch() -> Int {
+        dispatchCount += 1
+        return dispatchCount
+    }
+
+    func recordCancellation(_ id: UUID) {
+        cancelledIDs.append(id)
+    }
+
+    func snapshot() -> Snapshot {
+        .init(dispatchCount: dispatchCount, cancelledIDs: cancelledIDs)
+    }
+}
+
+@MainActor
+private func waitUntil(_ condition: @escaping @MainActor () async -> Bool) async {
+    for _ in 0 ..< 500 {
+        if await condition() { return }
+        await Task.yield()
+    }
+    XCTFail("Condition did not become true")
+}
+
+@MainActor
+private func XCTAssertThrowsErrorAsync(
+    _ expression: @autoclosure () async throws -> some Any,
+    _ verify: (Error) -> Void
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected error")
+    } catch {
+        verify(error)
+    }
+}
+
+private actor DualOracleActivityRecorder {
+    private var phases: [ContextBuilderMCPProgressPhase] = []
+    private var messages: [String] = []
+    private var suppressedHeartbeats: [ContextBuilderMCPProgressPhase] = []
+
+    func record(_ activity: ContextBuilderMCPActivity) {
+        switch activity {
+        case let .report(phase, message):
+            phases.append(phase)
+            messages.append(message)
+        case let .suppressHeartbeat(phase):
+            suppressedHeartbeats.append(phase)
+        }
+    }
+
+    func snapshot() -> (
+        phases: [ContextBuilderMCPProgressPhase],
+        messages: [String],
+        suppressedHeartbeats: [ContextBuilderMCPProgressPhase]
+    ) {
+        (phases, messages, suppressedHeartbeats)
+    }
+}
+
+private func primaryReply(from result: OracleSendResult) -> ChatSendReply {
+    switch result.payload {
+    case let .single(reply): reply
+    case let .paired(pair): pair.primaryReply()
+    }
+}
+
+private func reply(id: UUID, text: String) -> ChatSendReply {
+    ChatSendReply(chatId: id, shortId: id.uuidString, mode: "plan", response: text, errors: nil)
+}
+
+private func singleResult(
+    id: UUID,
+    context: OracleViewModel.OracleSendTabContext,
+    response: String
+) -> OracleSendResult {
+    OracleSendResult(
+        payload: .single(reply(id: id, text: response)),
+        route: .init(
+            contextID: context.tabID,
+            agentSessionID: context.agentModeSessionID,
+            agentRunID: context.agentModeRunID
+        )
+    )
+}
+
+private func pairedResult(
+    primaryID: UUID,
+    secondaryID: UUID,
+    primaryModel: AIModel,
+    secondary: OraclePairCoordinator.LaneExecution<ChatSendReply>,
+    context: OracleViewModel.OracleSendTabContext? = nil
+) -> OracleSendResult {
+    OracleSendResult(
+        payload: .paired(.init(
+            pairID: UUID(),
+            mode: "plan",
+            primaryChatID: primaryID.uuidString,
+            secondaryChatID: secondaryID.uuidString,
+            primaryModel: primaryModel,
+            secondaryModel: .claude4Sonnet,
+            result: .init(
+                primary: .success(reply(id: primaryID, text: "Primary response")),
+                secondary: secondary
+            ),
+            historyDiverged: false,
+            historyPersistenceError: nil
+        )),
+        route: .init(
+            contextID: context?.tabID,
+            agentSessionID: context?.agentModeSessionID,
+            agentRunID: context?.agentModeRunID
+        )
+    )
+}

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderDualOracleStateTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderDualOracleStateTests.swift
@@ -531,6 +531,12 @@ final class ContextBuilderDualOracleStateTests: XCTestCase {
             let model = AIModel.gpt54Pro
             var dispatchCount = 0
 
+            viewModel.sessions[fixture.tabID]?.generatedAnswerRoute = .init(
+                workspaceID: workspaceID,
+                tabID: fixture.tabID,
+                chatID: primaryID.uuidString
+            )
+
             viewModel.installRunTestHooks(.init(
                 beforeProcessingProviderEvent: nil,
                 providerEventDisposition: nil,
@@ -540,13 +546,8 @@ final class ContextBuilderDualOracleStateTests: XCTestCase {
                 },
                 toolChatSend: { args, _, _, _, callbacks in
                     dispatchCount += 1
-                    if dispatchCount == 1 {
-                        XCTAssertEqual(args["new_chat"]?.boolValue, true)
-                        XCTAssertNil(args["chat_id"])
-                    } else {
-                        XCTAssertEqual(args["new_chat"]?.boolValue, false)
-                        XCTAssertEqual(args["chat_id"]?.stringValue, primaryID.uuidString)
-                    }
+                    XCTAssertEqual(args["new_chat"]?.boolValue, false)
+                    XCTAssertEqual(args["chat_id"]?.stringValue, primaryID.uuidString)
                     try await callbacks.pairSessionsResolved?(primaryID, secondaryID)
                     return pairedResult(
                         primaryID: primaryID,
@@ -559,28 +560,20 @@ final class ContextBuilderDualOracleStateTests: XCTestCase {
             defer { viewModel.installRunTestHooks(nil) }
             let identity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: fixture.tabID)
 
-            _ = try await viewModel.runMCPPlanOrQuestion(
+            let result = try await viewModel.runMCPPlanOrQuestion(
                 for: identity,
                 oracleViewModel: oracleViewModel,
                 mode: .plan,
-                prompt: "First",
-                selection: .init(),
-                reviewGitContext: .automaticOnly()
-            )
-            let second = try await viewModel.runMCPPlanOrQuestion(
-                for: identity,
-                oracleViewModel: oracleViewModel,
-                mode: .plan,
-                prompt: "Second",
+                prompt: "Continue",
                 selection: .init(),
                 reviewGitContext: .automaticOnly()
             )
 
-            guard case let .paired(pair) = second.payload else {
+            guard case let .paired(pair) = result.payload else {
                 return XCTFail("Expected paired continuation")
             }
             XCTAssertEqual(pair.primaryChatID, primaryID.uuidString)
-            XCTAssertEqual(dispatchCount, 2)
+            XCTAssertEqual(dispatchCount, 1)
             XCTAssertEqual(viewModel.sessions[fixture.tabID]?.generatedAnswerRoute?.chatID, primaryID.uuidString)
         #endif
     }

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderDualOracleStateTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderDualOracleStateTests.swift
@@ -917,6 +917,7 @@ private func pairedResult(
         payload: .paired(.init(
             pairID: UUID(),
             mode: "plan",
+            primarySessionID: primaryID,
             primaryChatID: primaryID.uuidString,
             secondaryChatID: secondaryID.uuidString,
             primaryModel: primaryModel,

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
@@ -280,10 +280,12 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
     func testRunMCPPlanOrQuestionReportsSingleAndPairedProductionProgressThroughFinalization() async throws {
         #if DEBUG
             let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
-            let previousSecondaryModel = GlobalSettingsStore.shared.secondaryOracleModelRaw()
+            let previousAdditionalModels = GlobalSettingsStore.shared.additionalOracleModelRaws()
             GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
-            GlobalSettingsStore.shared.setSecondaryOracleModelRaw(nil, commit: false)
-            defer { GlobalSettingsStore.shared.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+            GlobalSettingsStore.shared.setAdditionalOracleModelRaws([], commit: false)
+            defer {
+                GlobalSettingsStore.shared.setAdditionalOracleModelRaws(previousAdditionalModels, commit: false)
+            }
             let composition = WindowStateCompositionFactory.make(
                 windowID: -76,
                 deferredInitialAgentSystemWorkspaceRefresh: true,
@@ -422,7 +424,7 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
                 provider: "custom",
                 model: "secondary-test-model"
             )
-            GlobalSettingsStore.shared.setSecondaryOracleModelRaw(secondaryModel.rawValue, commit: false)
+            GlobalSettingsStore.shared.setAdditionalOracleModelRaws([secondaryModel.rawValue], commit: false)
             let pairedActivityRecorder = ContextBuilderActivityMessageRecorder()
             let pairedPhaseRecorder = ContextBuilderProgressPhaseRecorder()
             let pairedHeartbeatSuppressionRecorder = ContextBuilderProgressPhaseRecorder()

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
@@ -49,10 +49,10 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
         await timeline.transition(to: .selectionReplyRendering)
         clock.advance(by: 1.25)
 
-        let renderingHeartbeat = await timeline.heartbeat(
+        guard let renderingHeartbeat = await timeline.heartbeat(
             fallbackStage: "processing",
             fallbackMessage: "Still rendering selection..."
-        )
+        ) else { return XCTFail("Expected rendering heartbeat") }
         XCTAssertEqual(renderingHeartbeat.stage, "processing")
         XCTAssertTrue(
             renderingHeartbeat.message.contains("selection reply rendering"),
@@ -62,10 +62,10 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
 
         await timeline.transition(to: .reviewSelectionAuthorization)
         clock.advance(by: 0.5)
-        let authorizationHeartbeat = await timeline.heartbeat(
+        guard let authorizationHeartbeat = await timeline.heartbeat(
             fallbackStage: "generating",
             fallbackMessage: "Still authorizing review..."
-        )
+        ) else { return XCTFail("Expected authorization heartbeat") }
         XCTAssertEqual(authorizationHeartbeat.stage, "generating")
         XCTAssertTrue(
             authorizationHeartbeat.message.contains("review selection authorization"),
@@ -86,6 +86,91 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
         XCTAssertEqual(events[3].phaseElapsed, 0.5, accuracy: 0.000_1)
         XCTAssertTrue(events[1].message.contains("completed in 1.250s"), events[1].message)
         XCTAssertTrue(events[3].message.contains("total 1.750s"), events[3].message)
+    }
+
+    func testLegacySingleOracleStreamingMessagesRemainByteExact() async {
+        let clock = ContextBuilderProgressTestClock()
+        let recorder = ContextBuilderProgressEventRecorder()
+        let timeline = ContextBuilderMCPProgressTimeline(
+            clock: { clock.now() },
+            sink: { event in await recorder.record(event) }
+        )
+
+        await timeline.transition(to: .streaming)
+        clock.advance(by: 0.5)
+        await timeline.reportActivity(phase: .streaming, message: "Oracle response streaming")
+        clock.advance(by: 0.75)
+        guard let heartbeat = await timeline.heartbeat(
+            fallbackStage: "generating",
+            fallbackMessage: "fallback"
+        ) else { return XCTFail("Expected legacy streaming heartbeat") }
+        await timeline.finishCurrentPhase()
+
+        let events = await recorder.snapshot()
+        XCTAssertEqual(events.map(\.message), [
+            "Oracle response streaming started (total 0.000s)",
+            "Oracle response streaming (total 0.500s)",
+            "Oracle response streaming completed in 1.250s (total 1.250s)"
+        ])
+        XCTAssertEqual(heartbeat.stage, "generating")
+        XCTAssertEqual(
+            heartbeat.message,
+            "Still in Oracle response streaming (phase 1.250s, total 1.250s)"
+        )
+    }
+
+    func testPairedOracleStreamingActivitiesRemainDistinctAndRecurringInTimelineOutput() async {
+        let clock = ContextBuilderProgressTestClock()
+        let recorder = ContextBuilderProgressEventRecorder()
+        let timeline = ContextBuilderMCPProgressTimeline(
+            clock: { clock.now() },
+            sink: { event in await recorder.record(event) }
+        )
+
+        await timeline.suppressHeartbeat(for: .streaming)
+        await timeline.transition(to: .streaming)
+        let genericHeartbeat = await timeline.heartbeat(
+            fallbackStage: "generating",
+            fallbackMessage: "fallback"
+        )
+        XCTAssertNil(genericHeartbeat)
+        for message in [
+            "Still in Primary Oracle response streaming",
+            "Still in Secondary Oracle response streaming",
+            "Still in Primary Oracle response streaming",
+            "Still in Secondary Oracle response streaming"
+        ] {
+            clock.advance(by: 0.25)
+            await timeline.reportActivity(phase: .streaming, message: message)
+        }
+        await timeline.reportActivity(
+            phase: .messageFinalization,
+            message: "Primary Oracle message finalization completed"
+        )
+        await timeline.finishCurrentPhase()
+        await timeline.transition(to: .messageFinalization)
+        let finalizationHeartbeat = await timeline.heartbeat(
+            fallbackStage: "generating",
+            fallbackMessage: "fallback"
+        )
+        XCTAssertNotNil(finalizationHeartbeat)
+        await timeline.finishCurrentPhase()
+
+        let activities = await recorder.snapshot().filter { $0.kind == .activity }
+        XCTAssertEqual(activities.map(\.phase), [
+            .streaming,
+            .streaming,
+            .streaming,
+            .streaming,
+            .messageFinalization
+        ])
+        XCTAssertEqual(activities.map(\.message), [
+            "Still in Primary Oracle response streaming (total 0.250s)",
+            "Still in Secondary Oracle response streaming (total 0.500s)",
+            "Still in Primary Oracle response streaming (total 0.750s)",
+            "Still in Secondary Oracle response streaming (total 1.000s)",
+            "Primary Oracle message finalization completed (total 1.000s)"
+        ])
     }
 
     func testSuspendingSinkPreservesEveryTimedTransitionWhenItReentersTimeline() async {
@@ -113,10 +198,10 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
         }
         await sink.waitUntilSuspended()
 
-        let heartbeat = await timeline.heartbeat(
+        guard let heartbeat = await timeline.heartbeat(
             fallbackStage: "generating",
             fallbackMessage: "fallback"
-        )
+        ) else { return XCTFail("Expected reentrant phase heartbeat") }
         XCTAssertTrue(
             heartbeat.message.contains(ContextBuilderMCPProgressPhase.sessionCreationAndPersist.displayName),
             heartbeat.message
@@ -192,10 +277,13 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
     }
 
     @MainActor
-    func testRunMCPPlanOrQuestionReportsProductionPhaseSequenceThroughFinalization() async throws {
+    func testRunMCPPlanOrQuestionReportsSingleAndPairedProductionProgressThroughFinalization() async throws {
         #if DEBUG
             let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            let previousSecondaryModel = GlobalSettingsStore.shared.secondaryOracleModelRaw()
             GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            GlobalSettingsStore.shared.setSecondaryOracleModelRaw(nil, commit: false)
+            defer { GlobalSettingsStore.shared.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
             let composition = WindowStateCompositionFactory.make(
                 windowID: -76,
                 deferredInitialAgentSystemWorkspaceRefresh: true,
@@ -265,8 +353,9 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
             defer { viewModel.installRunTestHooks(nil) }
 
             let recorder = ContextBuilderProgressPhaseRecorder()
+            let activityRecorder = ContextBuilderActivityMessageRecorder()
             let sessionRetentionRecorder = ContextBuilderSessionRetentionRecorder()
-            let reply = try await viewModel.runMCPPlanOrQuestion(
+            let result = try await viewModel.runMCPPlanOrQuestion(
                 for: tabID,
                 oracleViewModel: composition.oracleViewModel,
                 agentModeSessionID: agentModeSessionID,
@@ -278,7 +367,11 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
                 progressReporter: { phase in
                     await recorder.record(phase)
                 },
-                activityReporter: { phase, _ in
+                activityReporter: { activity in
+                    guard case let .report(phase, message) = activity else {
+                        return XCTFail("Single Oracle mode must not suppress timeline heartbeats")
+                    }
+                    await activityRecorder.record(message)
                     guard phase == .streaming || phase == .messageFinalization else { return }
                     let isPinned: Bool? = await MainActor.run {
                         guard let session = composition.oracleViewModel.sessions.first(where: {
@@ -295,6 +388,7 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
                 }
             )
 
+            let reply = MCPContextBuilderToolProvider.followUpValue(for: result).primary
             XCTAssertEqual(reply.mode, "plan")
             XCTAssertEqual(reply.response, "deterministic follow-up")
             let createdSession = try XCTUnwrap(
@@ -306,8 +400,80 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
             XCTAssertFalse(retentionObservations.isEmpty)
             XCTAssertTrue(retentionObservations.allSatisfy(\.self))
             XCTAssertFalse(composition.oracleViewModel.isSessionPinnedForTesting(reply.chatId))
+            let activities = await activityRecorder.snapshot()
+            XCTAssertEqual(activities, [
+                "Oracle response streaming",
+                "Oracle message finalization completed"
+            ])
+            XCTAssertFalse(activities.contains { $0.contains("Primary Oracle") || $0.contains("Secondary Oracle") })
             let phases = await recorder.snapshot()
             XCTAssertEqual(phases, [
+                .modelResolution,
+                .payloadPackaging,
+                .sessionCreationAndPersist,
+                .messageSend,
+                .activeQueryAcquisition,
+                .streaming,
+                .messageFinalization
+            ])
+
+            let secondaryModel = AIModel.customProvider(
+                name: "Secondary test provider",
+                provider: "custom",
+                model: "secondary-test-model"
+            )
+            GlobalSettingsStore.shared.setSecondaryOracleModelRaw(secondaryModel.rawValue, commit: false)
+            let pairedActivityRecorder = ContextBuilderActivityMessageRecorder()
+            let pairedPhaseRecorder = ContextBuilderProgressPhaseRecorder()
+            let pairedHeartbeatSuppressionRecorder = ContextBuilderProgressPhaseRecorder()
+            let pairedResult = try await viewModel.runMCPPlanOrQuestion(
+                for: tabID,
+                oracleViewModel: composition.oracleViewModel,
+                agentModeSessionID: agentModeSessionID,
+                agentModeRunID: agentModeRunID,
+                mode: .plan,
+                prompt: "Refine the selected context.",
+                selection: StoredSelection(),
+                reviewGitContext: .automaticOnly(),
+                progressReporter: { phase in
+                    await pairedPhaseRecorder.record(phase)
+                },
+                activityReporter: { activity in
+                    switch activity {
+                    case let .report(_, message):
+                        await pairedActivityRecorder.record(message)
+                    case let .suppressHeartbeat(phase):
+                        await pairedHeartbeatSuppressionRecorder.record(phase)
+                    }
+                }
+            )
+            guard case let .paired(pair) = pairedResult.payload else {
+                return XCTFail("Expected paired production follow-up")
+            }
+            XCTAssertEqual(pair.status, .completed)
+            let pairedActivities = await pairedActivityRecorder.snapshot()
+            XCTAssertEqual(pairedActivities.count, 4)
+            XCTAssertEqual(Set(pairedActivities), Set([
+                "Still in Primary Oracle response streaming",
+                "Still in Secondary Oracle response streaming",
+                "Primary Oracle message finalization completed",
+                "Secondary Oracle message finalization completed"
+            ]))
+            let pairedHeartbeatSuppressions = await pairedHeartbeatSuppressionRecorder.snapshot()
+            XCTAssertEqual(pairedHeartbeatSuppressions, [.streaming])
+            XCTAssertFalse(pairedActivities.contains("Oracle response streaming"))
+            XCTAssertFalse(pairedActivities.contains("Oracle message finalization completed"))
+            for lane in ["Primary Oracle", "Secondary Oracle"] {
+                let streamingIndex = try XCTUnwrap(
+                    pairedActivities.firstIndex(of: "Still in \(lane) response streaming")
+                )
+                let finalizationIndex = try XCTUnwrap(
+                    pairedActivities.firstIndex(of: "\(lane) message finalization completed")
+                )
+                XCTAssertLessThan(streamingIndex, finalizationIndex)
+            }
+            let pairedPhases = await pairedPhaseRecorder.snapshot()
+            XCTAssertEqual(pairedPhases, [
                 .modelResolution,
                 .payloadPackaging,
                 .sessionCreationAndPersist,
@@ -407,12 +573,10 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
                             selection: selection
                         )
                         let chatID = UUID()
-                        return ChatSendReply(
-                            chatId: chatID,
-                            shortId: String(chatID.uuidString.prefix(8)).lowercased(),
+                        return contextBuilderSingleResult(
+                            chatID: chatID,
                             mode: mode.mcpModeName,
-                            response: "deterministic provider follow-up",
-                            errors: nil
+                            response: "deterministic provider follow-up"
                         )
                     },
                     afterCommittedTabSnapshotCaptured: { runID, _ in
@@ -630,12 +794,10 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
                             selection: selection
                         )
                         let chatID = UUID()
-                        return ChatSendReply(
-                            chatId: chatID,
-                            shortId: String(chatID.uuidString.prefix(8)).lowercased(),
+                        return contextBuilderSingleResult(
+                            chatID: chatID,
                             mode: mode.mcpModeName,
-                            response: "deterministic provider follow-up",
-                            errors: nil
+                            response: "deterministic provider follow-up"
                         )
                     },
                     committedTabSnapshotCaptured: { runID, snapshot in
@@ -800,12 +962,10 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
                     runMCPFollowUp: { mode, prompt, selection in
                         await followUpRecorder.record(mode: mode, prompt: prompt, selection: selection)
                         let chatID = UUID()
-                        return ChatSendReply(
-                            chatId: chatID,
-                            shortId: String(chatID.uuidString.prefix(8)).lowercased(),
+                        return contextBuilderSingleResult(
+                            chatID: chatID,
                             mode: mode.mcpModeName,
-                            response: "must not be generated",
-                            errors: nil
+                            response: "must not be generated"
                         )
                     },
                     committedTabSnapshotCaptured: { runID, snapshot in
@@ -1859,6 +2019,23 @@ private actor ContextBuilderProgressEventRecorder {
     }
 }
 
+private func contextBuilderSingleResult(
+    chatID: UUID,
+    mode: String,
+    response: String
+) -> OracleSendResult {
+    OracleSendResult(
+        payload: .single(ChatSendReply(
+            chatId: chatID,
+            shortId: String(chatID.uuidString.prefix(8)).lowercased(),
+            mode: mode,
+            response: response,
+            errors: nil
+        )),
+        route: .init(contextID: nil, agentSessionID: nil, agentRunID: nil)
+    )
+}
+
 private actor ContextBuilderProgressPhaseRecorder {
     private var phases: [ContextBuilderMCPProgressPhase] = []
 
@@ -1868,6 +2045,18 @@ private actor ContextBuilderProgressPhaseRecorder {
 
     func snapshot() -> [ContextBuilderMCPProgressPhase] {
         phases
+    }
+}
+
+private actor ContextBuilderActivityMessageRecorder {
+    private var messages: [String] = []
+
+    func record(_ message: String) {
+        messages.append(message)
+    }
+
+    func snapshot() -> [String] {
+        messages
     }
 }
 

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderStrictFinalizationTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderStrictFinalizationTests.swift
@@ -62,6 +62,8 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 })
             )
             XCTAssertEqual(viewModel.currentFollowUpOracleChatID(for: tabID), oracleSession.shortID)
+            let didReloadSession = await composition.oracleViewModel.ensureSessionMessagesLoaded(oracleSession.id)
+            XCTAssertTrue(didReloadSession)
             let retainedResponse = try XCTUnwrap(
                 composition.oracleViewModel.messagesSnapshot(for: oracleSession.id)
                     .first(where: { !$0.isUser })
@@ -368,7 +370,7 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
             installModelHook(on: viewModel)
             defer { viewModel.installRunTestHooks(nil) }
 
-            let reply = try await viewModel.runMCPPlanOrQuestion(
+            let result = try await viewModel.runMCPPlanOrQuestion(
                 for: identity,
                 oracleViewModel: composition.oracleViewModel,
                 mode: .plan,
@@ -376,6 +378,7 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 selection: StoredSelection(),
                 reviewGitContext: .automaticOnly()
             )
+            let reply = result.primaryReply()
 
             XCTAssertEqual(reply.response, "partial response")
             XCTAssertEqual(viewModel.currentFollowUpOracleChatID(for: tabID), reply.shortId)

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderStrictFinalizationTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderStrictFinalizationTests.swift
@@ -7,6 +7,11 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
     @MainActor
     func testActiveContextBuilderIncompleteTerminationFailsAndPreservesOracleChat() async throws {
         #if DEBUG
+            let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
+            defer { settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+
             let composition = makeComposition(
                 windowID: -177,
                 terminalOutcome: .incomplete(reason: "max_tokens")
@@ -26,6 +31,8 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 saveState: false,
                 reason: "ContextBuilderStrictFinalizationTests.active"
             )
+            await composition.oracleViewModel.awaitWorkspaceChatSessionsRestored()
+            _ = await composition.oracleViewModel.ensureActiveSessionForCurrentTab(createIfMissing: true)
             let activeWorkspace = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
             let tabID = try XCTUnwrap(
                 activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
@@ -81,6 +88,11 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
     @MainActor
     func testInteractiveIncompleteTerminationPreservesPartialResponseAndShowsReason() async throws {
         #if DEBUG
+            let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
+            defer { settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+
             let composition = makeComposition(
                 windowID: -180,
                 terminalOutcome: .incomplete(reason: "max_tokens")
@@ -100,6 +112,7 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 saveState: false,
                 reason: "ContextBuilderStrictFinalizationTests.interactive-incomplete"
             )
+            await composition.oracleViewModel.awaitWorkspaceChatSessionsRestored()
 
             let sentQueryID = await composition.oracleViewModel.sendMessage(
                 "Produce a response.",
@@ -147,18 +160,22 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 saveState: false,
                 reason: "ContextBuilderStrictFinalizationTests.ask-oracle-incomplete"
             )
+            await composition.oracleViewModel.awaitWorkspaceChatSessionsRestored()
 
             let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
             let previousShowPresets = settings.mcpShowModelPresets()
             let previousDisablePresets = settings.mcpTemporarilyDisablePresets()
             let previousPlanningModel = composition.promptManager.planningModelName
             let previousCustomProviderValidity = composition.apiSettingsViewModel.isCustomProviderValid
             defer {
+                settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false)
                 settings.setMCPShowModelPresets(previousShowPresets, commit: false)
                 settings.setMCPTemporarilyDisablePresets(previousDisablePresets, commit: false)
                 composition.promptManager.planningModelName = previousPlanningModel
                 composition.apiSettingsViewModel.isCustomProviderValid = previousCustomProviderValidity
             }
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
             settings.setMCPShowModelPresets(false, commit: false)
             settings.setMCPTemporarilyDisablePresets(false, commit: false)
             composition.apiSettingsViewModel.isCustomProviderValid = true
@@ -217,18 +234,22 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 saveState: false,
                 reason: "ContextBuilderStrictFinalizationTests.ask-oracle-completed"
             )
+            await composition.oracleViewModel.awaitWorkspaceChatSessionsRestored()
 
             let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
             let previousShowPresets = settings.mcpShowModelPresets()
             let previousDisablePresets = settings.mcpTemporarilyDisablePresets()
             let previousPlanningModel = composition.promptManager.planningModelName
             let previousCustomProviderValidity = composition.apiSettingsViewModel.isCustomProviderValid
             defer {
+                settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false)
                 settings.setMCPShowModelPresets(previousShowPresets, commit: false)
                 settings.setMCPTemporarilyDisablePresets(previousDisablePresets, commit: false)
                 composition.promptManager.planningModelName = previousPlanningModel
                 composition.apiSettingsViewModel.isCustomProviderValid = previousCustomProviderValidity
             }
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
             settings.setMCPShowModelPresets(false, commit: false)
             settings.setMCPTemporarilyDisablePresets(false, commit: false)
             composition.apiSettingsViewModel.isCustomProviderValid = true
@@ -254,6 +275,11 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
     @MainActor
     func testInactiveContextBuilderCleanEOFFailsBeforePersistence() async throws {
         #if DEBUG
+            let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
+            defer { settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+
             let composition = makeComposition(windowID: -178)
             await composition.workspaceManager.awaitInitialized()
 
@@ -274,6 +300,7 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 saveState: false,
                 reason: "ContextBuilderStrictFinalizationTests.headless-active"
             )
+            await composition.oracleViewModel.awaitWorkspaceChatSessionsRestored()
             let inactiveWorkspace = composition.workspaceManager.createWorkspace(
                 name: "Context Builder strict headless target workspace",
                 repoPaths: [inactiveRoot.path],
@@ -334,6 +361,11 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
     @MainActor
     func testInactiveContextBuilderProviderCompletionPersistsReply() async throws {
         #if DEBUG
+            let settings = GlobalSettingsStore.shared
+            let previousSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
+            defer { settings.setSecondaryOracleModelRaw(previousSecondaryModel, commit: false) }
+
             let composition = makeComposition(windowID: -179, terminalOutcome: .completed)
             await composition.workspaceManager.awaitInitialized()
 
@@ -354,6 +386,7 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 saveState: false,
                 reason: "ContextBuilderStrictFinalizationTests.headless-success-active"
             )
+            await composition.oracleViewModel.awaitWorkspaceChatSessionsRestored()
             let inactiveWorkspace = composition.workspaceManager.createWorkspace(
                 name: "Context Builder strict headless success target workspace",
                 repoPaths: [inactiveRoot.path],

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -326,12 +326,10 @@ import XCTest
                             selection: selection,
                             lookupContext: lookupContext
                         )
-                        return ChatSendReply(
-                            chatId: UUID(),
-                            shortId: "cb-\(mode.mcpModeName)",
+                        return singleOracleResult(
+                            shortID: "cb-\(mode.mcpModeName)",
                             mode: mode.mcpModeName,
-                            response: "generated \(mode.mcpModeName)",
-                            errors: nil
+                            response: "generated \(mode.mcpModeName)"
                         )
                     }
                     defer {
@@ -680,12 +678,10 @@ import XCTest
                             selection: selection,
                             lookupContext: lookupContext
                         )
-                        return ChatSendReply(
-                            chatId: UUID(),
-                            shortId: "cb-deferred-review",
+                        return singleOracleResult(
+                            shortID: "cb-deferred-review",
                             mode: mode.mcpModeName,
-                            response: "generated deferred review",
-                            errors: nil
+                            response: "generated deferred review"
                         )
                     }
                     defer {
@@ -1138,12 +1134,10 @@ import XCTest
                             selection: selection,
                             lookupContext: lookupContext
                         )
-                        return ChatSendReply(
-                            chatId: UUID(),
-                            shortId: "two-root-review",
+                        return singleOracleResult(
+                            shortID: "two-root-review",
                             mode: mode.mcpModeName,
-                            response: "generated review",
-                            errors: nil
+                            response: "generated review"
                         )
                     }
 
@@ -1414,12 +1408,10 @@ import XCTest
                             selection: selection,
                             lookupContext: lookupContext
                         )
-                        return ChatSendReply(
-                            chatId: UUID(),
-                            shortId: "canonical-review",
+                        return singleOracleResult(
+                            shortID: "canonical-review",
                             mode: mode.mcpModeName,
-                            response: "generated review",
-                            errors: nil
+                            response: "generated review"
                         )
                     }
                     let response = try await endpoint.callTool(
@@ -2025,12 +2017,10 @@ import XCTest
                             contextBuilderViewModel.sessions[identity.tabID]?.mcpPlanningModelRaw,
                             AIModel.gpt54Pro.rawValue
                         )
-                        return ChatSendReply(
-                            chatId: UUID(),
-                            shortId: "inactive-b-plan",
+                        return singleOracleResult(
+                            shortID: "inactive-b-plan",
                             mode: mode.mcpModeName,
-                            response: "B-scoped plan",
-                            errors: nil
+                            response: "B-scoped plan"
                         )
                     }
                     defer { window.mcpServer.setContextBuilderFollowUpOverrideForTesting(nil) }
@@ -2964,6 +2954,23 @@ import XCTest
         func snapshot() -> [Entry] {
             entries
         }
+    }
+
+    private func singleOracleResult(
+        shortID: String,
+        mode: String,
+        response: String
+    ) -> OracleSendResult {
+        OracleSendResult(
+            payload: .single(ChatSendReply(
+                chatId: UUID(),
+                shortId: shortID,
+                mode: mode,
+                response: response,
+                errors: nil
+            )),
+            route: .init(contextID: nil, agentSessionID: nil, agentRunID: nil)
+        )
     }
 
     private actor ContextBuilderProbeGate {

--- a/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
+++ b/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
@@ -215,6 +215,51 @@ final class AppSettingsMCPServiceAgentModeSettingsTests: XCTestCase {
         XCTAssertEqual(persisted.scalarPreferences?.modelSelection?.syncChatModelWithOracle, false)
     }
 
+    func testSecondaryOracleModelSettingPersistsIdempotentlyAndClears() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppSettingsMCPServiceAgentModeSettingsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "AppSettingsMCPServiceAgentModeSettingsTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let fileStore = GlobalSettingsFileStore(fileURL: root.appendingPathComponent("globalSettings.json"))
+        let store = GlobalSettingsStore(defaults: defaults, fileStore: fileStore)
+        let service = AppSettingsMCPService(store: store)
+        let key = "models.secondary_oracle_model"
+        let model = AIModel.gpt54Pro.rawValue
+
+        do {
+            _ = try await service.handleForTesting([
+                "op": .string("set"), "key": .string(key), "value": .string("not-a-real-model")
+            ])
+            XCTFail("Expected an unknown Secondary Oracle model to be rejected")
+        } catch {
+            XCTAssertTrue(String(describing: error).contains("not a recognized Oracle model ID"))
+        }
+        XCTAssertNil(store.secondaryOracleModelRaw())
+
+        let set = try await service.handleForTesting([
+            "op": .string("set"), "key": .string(key), "value": .string(model)
+        ])
+        XCTAssertEqual(set.objectValue?["new_value"]?.stringValue, model)
+        XCTAssertEqual(try fileStore.load().scalarPreferences?.modelSelection?.secondaryOracleModel, model)
+        XCTAssertEqual(try fileStore.load().schemaVersion, GlobalSettingsDocument.secondaryOracleSchemaVersion)
+
+        let unchanged = try await service.handleForTesting([
+            "op": .string("set"), "key": .string(key), "value": .string(model)
+        ])
+        XCTAssertEqual(unchanged.objectValue?["changed"]?.boolValue, false)
+
+        let cleared = try await service.handleForTesting([
+            "op": .string("set"), "key": .string(key), "value": .null
+        ])
+        XCTAssertNil(cleared.objectValue?["new_value"]?.stringValue)
+        XCTAssertNil(store.secondaryOracleModelRaw())
+        XCTAssertNil(try fileStore.load().scalarPreferences?.modelSelection?.secondaryOracleModel)
+    }
+
     func testSetWarnsWhenGlobalSettingsPersistenceIsBlocked() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("AppSettingsMCPServiceAgentModeSettingsTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
+++ b/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
@@ -260,6 +260,59 @@ final class AppSettingsMCPServiceAgentModeSettingsTests: XCTestCase {
         XCTAssertNil(try fileStore.load().scalarPreferences?.modelSelection?.secondaryOracleModel)
     }
 
+    func testAdditionalOracleModelsSettingPersistsOrderedRosterAndRejectsOverMaximum() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppSettingsMCPServiceAgentModeSettingsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "AppSettingsMCPServiceAgentModeSettingsTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let fileStore = GlobalSettingsFileStore(fileURL: root.appendingPathComponent("globalSettings.json"))
+        let store = GlobalSettingsStore(defaults: defaults, fileStore: fileStore)
+        let service = AppSettingsMCPService(store: store)
+        let key = "models.additional_oracle_models"
+        let models = [
+            AIModel.gpt54Pro.rawValue,
+            AIModel.claude4Sonnet.rawValue,
+            AIModel.gpt54Pro.rawValue,
+            AIModel.claude4Sonnet.rawValue
+        ]
+
+        let set = try await service.handleForTesting([
+            "op": .string("set"),
+            "key": .string(key),
+            "value": .array(models.map(Value.string))
+        ])
+        XCTAssertEqual(set.objectValue?["new_value"]?.arrayValue?.compactMap(\.stringValue), models)
+        XCTAssertEqual(store.additionalOracleModelRaws(), models)
+        XCTAssertEqual(
+            try fileStore.load().scalarPreferences?.modelSelection?.additionalOracleModels,
+            models
+        )
+
+        do {
+            _ = try await service.handleForTesting([
+                "op": .string("set"),
+                "key": .string(key),
+                "value": .array(Array(repeating: .string(models[0]), count: 5))
+            ])
+            XCTFail("Expected more than four additional Oracles to be rejected")
+        } catch {
+            XCTAssertTrue(String(describing: error).contains("zero to four"))
+        }
+        XCTAssertEqual(store.additionalOracleModelRaws(), models)
+
+        let cleared = try await service.handleForTesting([
+            "op": .string("set"),
+            "key": .string(key),
+            "value": .array([])
+        ])
+        XCTAssertEqual(cleared.objectValue?["new_value"]?.arrayValue?.count, 0)
+        XCTAssertTrue(store.additionalOracleModelRaws().isEmpty)
+    }
+
     func testSetWarnsWhenGlobalSettingsPersistenceIsBlocked() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("AppSettingsMCPServiceAgentModeSettingsTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
@@ -16,6 +16,130 @@ import XCTest
             try await super.tearDown()
         }
 
+        func testDisabledSecondaryPreservesSingleSendValidationError() async {
+            let settings = GlobalSettingsStore.shared
+            let priorSecondaryModel = settings.secondaryOracleModelRaw()
+            settings.setSecondaryOracleModelRaw(nil, commit: false)
+            defer {
+                settings.setSecondaryOracleModelRaw(priorSecondaryModel, commit: false)
+            }
+
+            let oracle = makeOracleViewModel(cleanupRecorder: OracleCleanupRecorder())
+            let args: [String: Value] = ["message": .string("")]
+            let routedError: ChatToolError?
+            do {
+                _ = try await oracle.tool_chatSend(args: args, promptVM: oracle.promptViewModel)
+                routedError = nil
+            } catch {
+                routedError = error as? ChatToolError
+            }
+            XCTAssertEqual(routedError?.message, "message cannot be empty")
+        }
+
+        func testAskOracleMapsOnlyStructuredPairFailuresToMCPServerError() {
+            let pairFailure = ChatToolError(
+                code: .internalError,
+                message: "Both Oracle lanes failed.",
+                details: ["oracle_pair_payload": "{\"status\":\"failed\"}"]
+            )
+            XCTAssertNotNil(MCPOracleToolService.structuredOracleSendMCPError(pairFailure))
+            XCTAssertNil(MCPOracleToolService.structuredOracleSendMCPError(.internalError("ordinary failure")))
+        }
+
+        func testOracleSecondaryModelUsesRoutedWorkspaceProfile() {
+            let oracle = makeOracleViewModel(cleanupRecorder: OracleCleanupRecorder())
+            let workspaceID = UUID()
+            var resolvedWorkspaceID: UUID?
+
+            XCTAssertThrowsError(try oracle.resolveOracleSecondaryModel(
+                workspaceID: workspaceID,
+                effectiveProfile: { requestedWorkspaceID in
+                    resolvedWorkspaceID = requestedWorkspaceID
+                    return AgentModelsSettingsProfile(
+                        secondaryOracleModelRaw: "workspace-secondary-invalid"
+                    )
+                }
+            )) { error in
+                guard let toolError = error as? ChatToolError else {
+                    return XCTFail("Expected ChatToolError, got \(error)")
+                }
+                XCTAssertEqual(toolError.code, .invalidParams)
+                XCTAssertTrue(toolError.message.contains("workspace-secondary-invalid"))
+            }
+            XCTAssertEqual(resolvedWorkspaceID, workspaceID)
+        }
+
+        func testRecognizedSecondaryModelDefersAvailabilityFailureToItsLane() throws {
+            XCTAssertEqual(
+                try OraclePairModelSelectionPolicy.resolveSecondary(raw: AIModel.gpt54Pro.rawValue),
+                .gpt54Pro
+            )
+        }
+
+        func testBackgroundRoutedSessionCreationDoesNotChangeCurrentOrActiveChat() async throws {
+            let oracle = makeOracleViewModel(cleanupRecorder: OracleCleanupRecorder())
+            let workspaceID = UUID()
+            let tabID = UUID()
+            XCTAssertNil(oracle.currentSessionID)
+            XCTAssertNil(oracle.workspaceManager.activeChatSessionID(forTabID: tabID))
+
+            let createdID = try await oracle.locateOrCreateChat(
+                nil,
+                desiredName: "Background Oracle",
+                forceNew: true,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                activateInUI: false,
+                setActiveForTab: false
+            )
+
+            XCTAssertEqual(oracle.sessions.first(where: { $0.id == createdID })?.workspaceID, workspaceID)
+            XCTAssertNil(oracle.currentSessionID)
+            XCTAssertNil(oracle.workspaceManager.activeChatSessionID(forTabID: tabID))
+        }
+
+        func testPublicOracleToolsPreserveLegacyAutomaticActivationPolicy() {
+            XCTAssertEqual(
+                OracleViewModel.OracleSendActivationPolicy.publicMCP,
+                .legacyAutomatic
+            )
+        }
+
+        func testLegacyAndUnknownWorkspaceDeletionPreservesBaselineAndClearsMCPState() async throws {
+            for workspaceID in [UUID?.none, UUID()] {
+                let oracle = makeOracleViewModel(cleanupRecorder: OracleCleanupRecorder())
+                let root = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("LegacyOracleDeletion-\(UUID().uuidString)", isDirectory: true)
+                try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+                defer { try? FileManager.default.removeItem(at: root) }
+                let fileURL = root.appendingPathComponent("ChatSession-\(UUID().uuidString).json")
+                try Data().write(to: fileURL)
+                let session = ChatSession(
+                    workspaceID: workspaceID,
+                    name: "Legacy session",
+                    fileURL: fileURL
+                )
+                oracle.sessions.append(session)
+                oracle.currentSessionID = session.id
+                oracle.setMCPSessionUIState(
+                    .init(
+                        modelInfo: "MCP",
+                        overrideModelName: "Override",
+                        overrideChatPresetName: "Preset"
+                    ),
+                    for: session.id
+                )
+
+                let deleted = await oracle.deleteSession(session)
+                XCTAssertTrue(deleted)
+                XCTAssertFalse(oracle.sessions.contains { $0.id == session.id })
+                XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+                XCTAssertNil(oracle.mcpModelInfo)
+                XCTAssertNil(oracle.mcpOverrideModelName)
+                XCTAssertNil(oracle.mcpOverrideChatPresetName)
+            }
+        }
+
         func testOracleCleanupHelperInvokesAIQueriesServiceDelete() async {
             let recorder = OracleCleanupRecorder()
             let oracle = makeOracleViewModel(cleanupRecorder: recorder)

--- a/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import MCP
+@testable import RepoPromptApp
+import XCTest
+
+final class OraclePairCoordinatorTests: XCTestCase {
+    private func reply(_ lane: String) -> ChatSendReply {
+        ChatSendReply(
+            chatId: UUID(),
+            shortId: "\(lane)-chat",
+            mode: "chat",
+            response: "\(lane) response",
+            errors: nil
+        )
+    }
+
+    @MainActor
+    func testReturnsBothSuccessfulLanesInStableOrder() async throws {
+        let result = try await OraclePairCoordinator.run(
+            primary: { "primary" },
+            secondary: { "secondary" }
+        )
+        guard case let .success(primary) = result.primary,
+              case let .success(secondary) = result.secondary
+        else { return XCTFail("Expected both lanes to succeed") }
+        XCTAssertEqual(primary, "primary")
+        XCTAssertEqual(secondary, "secondary")
+    }
+
+    @MainActor
+    func testPartialFailureKeepsMinimalLanePayload() async throws {
+        let result = try await OraclePairCoordinator.run(
+            primary: { self.reply("primary") },
+            secondary: { throw OracleLaneFailure(message: "secondary failed", partialResponse: "partial") }
+        )
+        let object = OraclePairSendReply(
+            pairID: UUID(),
+            mode: "chat",
+            primaryChatID: "primary-chat",
+            secondaryChatID: "secondary-chat",
+            primaryModel: .gpt54Pro,
+            secondaryModel: .claude4Sonnet,
+            result: result,
+            historyDiverged: false,
+            historyPersistenceError: nil
+        ).toMCPObject()
+
+        XCTAssertEqual(object["status"]?.stringValue, "partial_failure")
+        XCTAssertEqual(object["response"]?.stringValue, "primary response")
+        XCTAssertEqual(
+            object["oracle_results"]?.objectValue?["secondary"]?.objectValue?["partial_response"]?.stringValue,
+            "partial"
+        )
+        XCTAssertNil(object["oracle_decision_policy"])
+        XCTAssertNil(object["oracle_combined_response"])
+    }
+
+    func testHistoryPersistenceFailureDowngradesTypedAndSerializedStatus() {
+        let pair = OraclePairSendReply(
+            pairID: UUID(),
+            mode: "chat",
+            primaryChatID: "primary-chat",
+            secondaryChatID: "secondary-chat",
+            primaryModel: .gpt54Pro,
+            secondaryModel: .claude4Sonnet,
+            result: .init(
+                primary: .success(reply("primary")),
+                secondary: .success(reply("secondary"))
+            ),
+            historyDiverged: false,
+            historyPersistenceError: "disk unavailable"
+        )
+
+        XCTAssertEqual(pair.status, .partialFailure)
+        XCTAssertEqual(pair.toMCPObject()["status"]?.stringValue, "partial_failure")
+    }
+
+    func testPrimaryReplyProjectsSuccessAndPairWarnings() {
+        let primary = reply("primary")
+        let pair = OraclePairSendReply(
+            pairID: UUID(),
+            mode: "chat",
+            primaryChatID: "primary-chat",
+            secondaryChatID: "secondary-chat",
+            primaryModel: .gpt54Pro,
+            secondaryModel: .claude4Sonnet,
+            result: .init(
+                primary: .success(primary),
+                secondary: .failure(.init(message: "secondary failed"))
+            ),
+            historyDiverged: false,
+            historyPersistenceError: "disk unavailable"
+        )
+
+        let projected = pair.primaryReply()
+        XCTAssertEqual(projected.chatId, primary.chatId)
+        XCTAssertEqual(projected.shortId, "primary-chat")
+        XCTAssertEqual(projected.response, "primary response")
+        XCTAssertEqual(
+            projected.errors,
+            ["Secondary Oracle failed: secondary failed\nOracle pair history persistence failed: disk unavailable"]
+        )
+    }
+
+    func testPrimaryReplyUsesFallbackForFailedPrimary() {
+        let fallback = UUID()
+        let pair = OraclePairSendReply(
+            pairID: UUID(),
+            mode: "plan",
+            primaryChatID: "primary-chat",
+            secondaryChatID: "secondary-chat",
+            primaryModel: .gpt54Pro,
+            secondaryModel: .claude4Sonnet,
+            result: .init(
+                primary: .failure(.init(message: "primary failed", partialResponse: "partial")),
+                secondary: .success(reply("secondary"))
+            ),
+            historyDiverged: false,
+            historyPersistenceError: nil
+        )
+
+        let projected = pair.primaryReply(fallbackSessionID: fallback)
+        XCTAssertEqual(projected.chatId, fallback)
+        XCTAssertEqual(projected.shortId, "primary-chat")
+        XCTAssertEqual(projected.mode, "plan")
+        XCTAssertEqual(projected.response, "partial")
+        XCTAssertEqual(projected.errors, ["Primary Oracle failed: primary failed"])
+    }
+
+    @MainActor
+    func testCancellationCancelsThePairInsteadOfReturningLaneFailures() async throws {
+        let started = expectation(description: "both lanes started")
+        started.expectedFulfillmentCount = 2
+        let task = Task {
+            try await OraclePairCoordinator.run(
+                primary: {
+                    started.fulfill()
+                    try await Task.sleep(nanoseconds: .max)
+                    return "primary"
+                },
+                secondary: {
+                    started.fulfill()
+                    try await Task.sleep(nanoseconds: .max)
+                    return "secondary"
+                }
+            )
+        }
+
+        await fulfillment(of: [started])
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {}
+    }
+
+    @MainActor
+    func testRouteAndWorkspaceClaimsConflictAndRelease() async throws {
+        let registry = OracleSendClaimRegistry()
+        let workspaceID = UUID()
+        let route = OracleSendClaimKey.route(OraclePairRoute(
+            workspaceID: workspaceID,
+            tabID: UUID(),
+            agentModeSessionID: UUID(),
+            agentModeRunID: UUID()
+        ))
+        let started = expectation(description: "workspace claim acquired")
+        let first = Task {
+            try await registry.withClaim([.workspace(workspaceID)]) {
+                started.fulfill()
+                try await Task.sleep(nanoseconds: .max)
+            }
+        }
+        await fulfillment(of: [started])
+
+        do {
+            _ = try await registry.withClaim([route]) { "unexpected" }
+            XCTFail("Expected a conflict")
+        } catch let error as OracleSendClaimError {
+            XCTAssertEqual(error, .conflict)
+        }
+
+        first.cancel()
+        do { _ = try await first.value } catch is CancellationError {}
+        let retry = try await registry.withClaim([route]) { "retry" }
+        XCTAssertEqual(retry, "retry")
+    }
+
+    @MainActor
+    func testAllLaneFailureSurvivesStructuredMCPEnvelope() throws {
+        let pairID = UUID()
+        let contextID = UUID()
+        let pairReply = OraclePairSendReply(
+            pairID: pairID,
+            mode: "chat",
+            primaryChatID: "primary-chat",
+            secondaryChatID: "secondary-chat",
+            primaryModel: .gpt54Pro,
+            secondaryModel: .claude4Sonnet,
+            result: .init(
+                primary: .failure(.init(message: "primary failed", partialResponse: "primary partial")),
+                secondary: .failure(.init(message: "secondary failed"))
+            ),
+            historyDiverged: true,
+            historyPersistenceError: nil
+        )
+        let sendResult = OracleSendResult(
+            payload: .paired(pairReply),
+            route: OracleSendRoute(contextID: contextID, agentSessionID: nil, agentRunID: nil)
+        )
+        let payload = ToolOutputFormatter.rawJSONString(.object(sendResult.toMCPObject()))
+        let error = try ChatToolError(
+            code: .internalError,
+            message: XCTUnwrap(pairReply.failureSummary),
+            details: ["oracle_pair_payload": payload]
+        )
+        guard case let .serverError(_, message) = try XCTUnwrap(MCPOracleToolService.structuredOracleSendMCPError(error)) else {
+            return XCTFail("Expected structured server error")
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: ["error": message])
+        let decoded = try JSONDecoder().decode(ToolResultDTOs.ChatSendDTO.self, from: data)
+        XCTAssertEqual(decoded.status, "failed")
+        XCTAssertEqual(decoded.oraclePairID, pairID.uuidString)
+        XCTAssertEqual(decoded.contextID, contextID.uuidString)
+        XCTAssertEqual(decoded.oracleResults?["primary"]?.partialResponse, "primary partial")
+        XCTAssertEqual(decoded.oracleResults?["secondary"]?.error, "secondary failed")
+    }
+
+    func testDuplicateMessageIdentityIsRejectedWithoutTrapping() {
+        let duplicateID = UUID()
+        let messages = [
+            AIChatMessage(id: duplicateID, content: "first", isUser: true),
+            AIChatMessage(id: duplicateID, content: "second", isUser: false)
+        ]
+        XCTAssertThrowsError(try OracleViewModel.storedOracleMessages(messages, preserving: [])) { error in
+            XCTAssertEqual((error as? ChatToolError)?.code, .conflict)
+            XCTAssertEqual((error as? ChatToolError)?.details?["duplicate_id"], duplicateID.uuidString)
+        }
+    }
+
+    func testHistoryDivergenceUsesExactUserTurnSequence() {
+        XCTAssertFalse(OracleViewModel.oracleHistoriesDiverged(
+            primary: ["first", "second"],
+            secondary: ["first", "second"]
+        ))
+        XCTAssertTrue(OracleViewModel.oracleHistoriesDiverged(
+            primary: ["first", "second"],
+            secondary: ["first", "changed"]
+        ))
+    }
+}

--- a/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
@@ -91,9 +91,9 @@ final class OraclePairCoordinatorTests: XCTestCase {
         let modelsByLane = Dictionary(uniqueKeysWithValues: lanes.map { ($0, AIModel.gpt54Pro) })
         var executions: [OracleLane: OraclePairCoordinator.LaneExecution<ChatSendReply>] = [:]
         for lane in lanes {
-            executions[lane] = .success(ChatSendReply(
-                chatId: try XCTUnwrap(sessionIDsByLane[lane]),
-                shortId: try XCTUnwrap(chatIDsByLane[lane]),
+            executions[lane] = try .success(ChatSendReply(
+                chatId: XCTUnwrap(sessionIDsByLane[lane]),
+                shortId: XCTUnwrap(chatIDsByLane[lane]),
                 mode: "chat",
                 response: "\(lane.rawValue) response",
                 errors: nil

--- a/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
@@ -36,6 +36,7 @@ final class OraclePairCoordinatorTests: XCTestCase {
         let object = OraclePairSendReply(
             pairID: UUID(),
             mode: "chat",
+            primarySessionID: UUID(),
             primaryChatID: "primary-chat",
             secondaryChatID: "secondary-chat",
             primaryModel: .gpt54Pro,
@@ -63,6 +64,7 @@ final class OraclePairCoordinatorTests: XCTestCase {
         let pair = OraclePairSendReply(
             pairID: UUID(),
             mode: "chat",
+            primarySessionID: UUID(),
             primaryChatID: "primary-chat",
             secondaryChatID: "secondary-chat",
             primaryModel: .gpt54Pro,
@@ -84,6 +86,7 @@ final class OraclePairCoordinatorTests: XCTestCase {
         let pair = OraclePairSendReply(
             pairID: UUID(),
             mode: "chat",
+            primarySessionID: UUID(),
             primaryChatID: "primary-chat",
             secondaryChatID: "secondary-chat",
             primaryModel: .gpt54Pro,
@@ -106,11 +109,12 @@ final class OraclePairCoordinatorTests: XCTestCase {
         )
     }
 
-    func testPrimaryReplyUsesFallbackForFailedPrimary() {
-        let fallback = UUID()
+    func testPrimaryReplyUsesResolvedSessionForFailedPrimary() {
+        let primarySessionID = UUID()
         let pair = OraclePairSendReply(
             pairID: UUID(),
             mode: "plan",
+            primarySessionID: primarySessionID,
             primaryChatID: "primary-chat",
             secondaryChatID: "secondary-chat",
             primaryModel: .gpt54Pro,
@@ -123,8 +127,8 @@ final class OraclePairCoordinatorTests: XCTestCase {
             historyPersistenceError: nil
         )
 
-        let projected = pair.primaryReply(fallbackSessionID: fallback)
-        XCTAssertEqual(projected.chatId, fallback)
+        let projected = pair.primaryReply()
+        XCTAssertEqual(projected.chatId, primarySessionID)
         XCTAssertEqual(projected.shortId, "primary-chat")
         XCTAssertEqual(projected.mode, "plan")
         XCTAssertEqual(projected.response, "partial")
@@ -197,6 +201,7 @@ final class OraclePairCoordinatorTests: XCTestCase {
         let pairReply = OraclePairSendReply(
             pairID: pairID,
             mode: "chat",
+            primarySessionID: UUID(),
             primaryChatID: "primary-chat",
             secondaryChatID: "secondary-chat",
             primaryModel: .gpt54Pro,

--- a/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
@@ -48,6 +48,10 @@ final class OraclePairCoordinatorTests: XCTestCase {
         XCTAssertEqual(object["status"]?.stringValue, "partial_failure")
         XCTAssertEqual(object["response"]?.stringValue, "primary response")
         XCTAssertEqual(
+            object["errors"]?.arrayValue?.compactMap(\.stringValue),
+            ["Secondary Oracle failed: secondary failed"]
+        )
+        XCTAssertEqual(
             object["oracle_results"]?.objectValue?["secondary"]?.objectValue?["partial_response"]?.stringValue,
             "partial"
         )

--- a/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/MCP/OraclePairCoordinatorTests.swift
@@ -14,6 +14,161 @@ final class OraclePairCoordinatorTests: XCTestCase {
         )
     }
 
+    func testLaneMetadataUsesOneValidatedOrderedPrefix() throws {
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        XCTAssertEqual(lanes.map(\.rawValue), ["primary", "secondary", "oracle_3", "oracle_4", "oracle_5"])
+        XCTAssertEqual(lanes.map(\.ordinal), [1, 2, 3, 4, 5])
+        XCTAssertEqual(
+            lanes.map(\.displayLabel),
+            ["Primary Oracle", "Secondary Oracle", "Oracle 3", "Oracle 4", "Oracle 5"]
+        )
+        XCTAssertNoThrow(try OracleLane.validateOrderedPrefix(lanes))
+        XCTAssertThrowsError(try OracleLane.validateOrderedPrefix([.primary, .oracle3]))
+        XCTAssertThrowsError(try OracleLane.orderedPrefix(count: 0))
+        XCTAssertThrowsError(try OracleLane.orderedPrefix(count: 6))
+    }
+
+    @MainActor
+    func testFiveLaneCoordinatorReturnsConfiguredOrderWhenCompletionOrderDiffers() async throws {
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        var operations: [OracleLane: OraclePairCoordinator.Operation<String>] = [:]
+        for lane in lanes {
+            operations[lane] = {
+                try await Task.sleep(nanoseconds: UInt64(6 - lane.ordinal) * 1_000_000)
+                return lane.rawValue
+            }
+        }
+
+        let result = try await OraclePairCoordinator.run(operationsByLane: operations)
+
+        XCTAssertEqual(result.orderedLanes, lanes)
+        XCTAssertEqual(result.orderedResults.compactMap { laneResult in
+            guard case let .success(value) = laneResult.execution else { return nil }
+            return value
+        }, lanes.map(\.rawValue))
+        XCTAssertThrowsError(try OraclePairCoordinator.Result<String>(executionsByLane: [
+            .primary: .success("primary"),
+            .oracle3: .success("oracle_3")
+        ]))
+    }
+
+    func testChatSessionInfersLegacyPairSizeAndRoundTripsExplicitGroupSize() throws {
+        let pairID = UUID()
+        let legacy = ChatSession(
+            oraclePairID: pairID,
+            oracleLane: .secondary,
+            name: "Legacy pair"
+        )
+        XCTAssertEqual(legacy.oracleGroupSize, 2)
+        XCTAssertEqual(legacy.oracleGroupID, pairID)
+
+        var legacyObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(legacy)) as? [String: Any]
+        )
+        legacyObject.removeValue(forKey: "oracleGroupSize")
+        let decodedLegacy = try JSONDecoder().decode(
+            ChatSession.self,
+            from: JSONSerialization.data(withJSONObject: legacyObject)
+        )
+        XCTAssertEqual(decodedLegacy.oracleGroupSize, 2)
+
+        let grouped = ChatSession(
+            oraclePairID: UUID(),
+            oracleLane: .oracle5,
+            oracleGroupSize: 5,
+            name: "Five Oracles"
+        )
+        let decodedGroup = try JSONDecoder().decode(ChatSession.self, from: JSONEncoder().encode(grouped))
+        XCTAssertEqual(decodedGroup.oracleLane, .oracle5)
+        XCTAssertEqual(decodedGroup.oracleGroupSize, 5)
+    }
+
+    func testFiveLaneTransportIsOrderedAndPreservesPairAliases() throws {
+        let groupID = UUID()
+        let lanes = try OracleLane.orderedPrefix(count: 5)
+        let sessionIDsByLane = Dictionary(uniqueKeysWithValues: lanes.map { ($0, UUID()) })
+        let chatIDsByLane = Dictionary(uniqueKeysWithValues: lanes.map { ($0, "\($0.rawValue)-chat") })
+        let modelsByLane = Dictionary(uniqueKeysWithValues: lanes.map { ($0, AIModel.gpt54Pro) })
+        var executions: [OracleLane: OraclePairCoordinator.LaneExecution<ChatSendReply>] = [:]
+        for lane in lanes {
+            executions[lane] = .success(ChatSendReply(
+                chatId: try XCTUnwrap(sessionIDsByLane[lane]),
+                shortId: try XCTUnwrap(chatIDsByLane[lane]),
+                mode: "chat",
+                response: "\(lane.rawValue) response",
+                errors: nil
+            ))
+        }
+        let result = try OraclePairCoordinator.Result(executionsByLane: executions)
+        var incompleteChatIDs = chatIDsByLane
+        incompleteChatIDs.removeValue(forKey: .oracle5)
+        XCTAssertThrowsError(
+            try OracleGroupSendReply(
+                groupID: groupID,
+                mode: "chat",
+                sessionIDsByLane: sessionIDsByLane,
+                chatIDsByLane: incompleteChatIDs,
+                modelsByLane: modelsByLane,
+                result: result,
+                historyDiverged: false,
+                historyPersistenceError: nil
+            )
+        )
+        let reply = try OracleGroupSendReply(
+            groupID: groupID,
+            mode: "chat",
+            sessionIDsByLane: sessionIDsByLane,
+            chatIDsByLane: chatIDsByLane,
+            modelsByLane: modelsByLane,
+            result: result,
+            historyDiverged: false,
+            historyPersistenceError: nil
+        )
+
+        let object = reply.toMCPObject()
+        XCTAssertEqual(object["chat_id"]?.stringValue, "primary-chat")
+        XCTAssertEqual(object["oracle_group_id"]?.stringValue, groupID.uuidString)
+        XCTAssertEqual(object["oracle_pair_id"]?.stringValue, groupID.uuidString)
+        XCTAssertEqual(object["oracle_count"]?.intValue, 5)
+        XCTAssertEqual(object["primary_chat_id"]?.stringValue, "primary-chat")
+        XCTAssertEqual(object["secondary_chat_id"]?.stringValue, "secondary-chat")
+        XCTAssertEqual(
+            object["oracle_result_order"]?.arrayValue?.compactMap(\.stringValue),
+            lanes.map(\.rawValue)
+        )
+        XCTAssertEqual(
+            object["oracle_chat_ids"]?.objectValue?.compactMapValues(\.stringValue),
+            Dictionary(uniqueKeysWithValues: lanes.compactMap { lane in
+                chatIDsByLane[lane].map { (lane.rawValue, $0) }
+            })
+        )
+        XCTAssertEqual(object["oracle_group_results"]?.arrayValue?.count, 5)
+        XCTAssertEqual(
+            object["oracle_results"]?.objectValue?["oracle_5"]?.objectValue?["oracle_ordinal"]?.intValue,
+            5
+        )
+
+        let payload = ToolOutputFormatter.rawJSONString(.object(object))
+        let decoded = try JSONDecoder().decode(ToolResultDTOs.ChatSendDTO.self, from: Data(payload.utf8))
+        XCTAssertEqual(decoded.oracleGroupID, groupID.uuidString)
+        XCTAssertEqual(decoded.oraclePairID, groupID.uuidString)
+        XCTAssertEqual(decoded.oracleCount, 5)
+        XCTAssertEqual(decoded.oracleResultOrder, lanes.map(\.rawValue))
+        XCTAssertEqual(decoded.oracleChatIDs, chatIDsByLane.reduce(into: [:]) { result, entry in
+            result[entry.key.rawValue] = entry.value
+        })
+        XCTAssertEqual(decoded.oracleGroupResults?.map(\.oracleLane), lanes.map(\.rawValue))
+        XCTAssertEqual(decoded.oracleResults?["oracle_5"]?.oracleLabel, "Oracle 5")
+    }
+
+    func testSingleReplyTransportRemainsFlat() {
+        let object = reply("single").toMCPObject()
+        XCTAssertEqual(Set(object.keys), ["chat_id", "mode", "response"])
+        XCTAssertNil(object["oracle_group_id"])
+        XCTAssertNil(object["oracle_pair_id"])
+        XCTAssertNil(object["oracle_results"])
+    }
+
     @MainActor
     func testReturnsBothSuccessfulLanesInStableOrder() async throws {
         let result = try await OraclePairCoordinator.run(

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -583,12 +583,15 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
                     allowSyntheticRoutingWithoutFinalContext: true,
                     runMCPFollowUp: { mode, _, _ in
                         let chatID = UUID()
-                        return ChatSendReply(
-                            chatId: chatID,
-                            shortId: String(chatID.uuidString.prefix(8)).lowercased(),
-                            mode: mode.mcpModeName,
-                            response: "deterministic worktree export response",
-                            errors: nil
+                        return OracleSendResult(
+                            payload: .single(ChatSendReply(
+                                chatId: chatID,
+                                shortId: String(chatID.uuidString.prefix(8)).lowercased(),
+                                mode: mode.mcpModeName,
+                                response: "deterministic worktree export response",
+                                errors: nil
+                            )),
+                            route: .init(contextID: nil, agentSessionID: nil, agentRunID: nil)
                         )
                     }
                 )

--- a/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
+++ b/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
@@ -596,7 +596,7 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
             fileStore: GlobalSettingsFileStore(fileURL: fileURL)
         )
 
-        XCTAssertEqual(GlobalSettingsDocument.currentSchemaVersion, 5)
+        XCTAssertEqual(GlobalSettingsDocument.currentSchemaVersion, 6)
         XCTAssertTrue(store.worktreeVisualIdentitiesByRepositoryID().isEmpty)
     }
 
@@ -1211,10 +1211,11 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
 
         XCTAssertEqual(GlobalSettingsDocument.workspaceAgentModelsSchemaVersion, 4)
         XCTAssertEqual(GlobalSettingsDocument.secondaryOracleSchemaVersion, 5)
+        XCTAssertEqual(GlobalSettingsDocument.additionalOraclesSchemaVersion, 6)
         XCTAssertEqual(document.requiredSchemaVersion, GlobalSettingsDocument.workspaceAgentModelsSchemaVersion)
         XCTAssertEqual(
             secondaryOracleDocument.requiredSchemaVersion,
-            GlobalSettingsDocument.secondaryOracleSchemaVersion
+            GlobalSettingsDocument.additionalOraclesSchemaVersion
         )
     }
 
@@ -1835,7 +1836,10 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         store.setGlobalAgentModelsProfile(
             AgentModelsSettingsProfile(
                 planningModelRaw: AIModel.gpt54Pro.rawValue,
-                secondaryOracleModelRaw: AIModel.claude4Sonnet.rawValue
+                additionalOracleModelRaws: [
+                    AIModel.claude4Sonnet.rawValue,
+                    AIModel.gpt54Pro.rawValue
+                ]
             ),
             contextBuilderWriteIntent: .preserveExistingOwnership
         )
@@ -1855,6 +1859,10 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         )
         XCTAssertEqual(prompt.planningModelName, AIModel.gpt54Pro.rawValue)
         XCTAssertEqual(prompt.secondaryOracleModelRaw, AIModel.claude4Sonnet.rawValue)
+        XCTAssertEqual(
+            prompt.additionalOracleModelRaws,
+            [AIModel.claude4Sonnet.rawValue, AIModel.gpt54Pro.rawValue]
+        )
     }
 
     func testAgentModelsViewModelDoesNotFallbackUnsyncedBuiltinChatToOracle() async throws {
@@ -2799,6 +2807,246 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         XCTAssertTrue(notifications.contains { $0.scope == "global" && $0.workspaceID == nil })
         XCTAssertTrue(notifications.contains { $0.workspaceID == changedWorkspaceID })
         XCTAssertTrue(notifications.contains { $0.workspaceID == removedWorkspaceID })
+    }
+
+    func testAdditionalOracleProfileDecodesLegacySecondaryAndPrefersOrderedCollection() throws {
+        let primaryAdditional = AIModel.gpt54Pro.rawValue
+        let secondAdditional = AIModel.claude4Sonnet.rawValue
+        let legacyJSON = #"{"secondaryOracleModelRaw":"\#(primaryAdditional)"}"#
+        let legacy = try JSONDecoder().decode(
+            AgentModelsSettingsProfile.self,
+            from: Data(legacyJSON.utf8)
+        )
+
+        XCTAssertEqual(legacy.additionalOracleModelRaws, [primaryAdditional])
+        XCTAssertEqual(legacy.secondaryOracleModelRaw, primaryAdditional)
+
+        let mixedJSON = #"""
+        {
+          "secondaryOracleModelRaw": "legacy",
+          "additionalOracleModelRaws": ["\#(primaryAdditional)", "\#(secondAdditional)", "\#(primaryAdditional)"]
+        }
+        """#
+        let mixed = try JSONDecoder().decode(
+            AgentModelsSettingsProfile.self,
+            from: Data(mixedJSON.utf8)
+        )
+        XCTAssertEqual(
+            mixed.additionalOracleModelRaws,
+            [primaryAdditional, secondAdditional, primaryAdditional],
+            "The ordered collection is authoritative when both new and legacy fields are present"
+        )
+        XCTAssertEqual(mixed.secondaryOracleModelRaw, primaryAdditional)
+
+        let reencoded = try JSONEncoder().encode(mixed)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: reencoded) as? [String: Any])
+        XCTAssertEqual(object["secondaryOracleModelRaw"] as? String, primaryAdditional)
+        XCTAssertEqual(
+            object["additionalOracleModelRaws"] as? [String],
+            [primaryAdditional, secondAdditional, primaryAdditional]
+        )
+    }
+
+    func testAdditionalOracleProfilesPersistOrderedDuplicatesForGlobalAndWorkspaceScopes() throws {
+        let workspaceID = UUID()
+        let globalAdditional = [
+            AIModel.gpt54Pro.rawValue,
+            AIModel.gpt54Pro.rawValue,
+            AIModel.claude4Sonnet.rawValue,
+            AIModel.gpt54Pro.rawValue
+        ]
+        let workspaceAdditional = [
+            AIModel.claude4Sonnet.rawValue,
+            AIModel.gpt54Pro.rawValue
+        ]
+        let fileStore = CountingGlobalSettingsFileStore(document: GlobalSettingsDocument(
+            globalDefaults: GlobalDefaults(discoverAgentRaw: nil, discoverModelsByAgent: nil),
+            scalarPreferences: seededScalarPreferences()
+        ))
+        let store = try GlobalSettingsStore(defaults: makeIsolatedDefaults(), fileStore: fileStore)
+
+        store.setGlobalAgentModelsProfile(
+            AgentModelsSettingsProfile(
+                planningModelRaw: AIModel.gpt54Pro.rawValue,
+                additionalOracleModelRaws: globalAdditional
+            ),
+            contextBuilderWriteIntent: .preserveExistingOwnership
+        )
+        store.setWorkspaceAgentModelsProfile(
+            workspaceID: workspaceID,
+            profile: AgentModelsSettingsProfile(
+                planningModelRaw: AIModel.claude4Sonnet.rawValue,
+                additionalOracleModelRaws: workspaceAdditional
+            )
+        )
+
+        XCTAssertEqual(store.globalAgentModelsProfile().additionalOracleModelRaws, globalAdditional)
+        XCTAssertEqual(store.secondaryOracleModelRaw(), globalAdditional.first)
+        XCTAssertEqual(
+            store.workspaceAgentModelsProfile(for: workspaceID)?.additionalOracleModelRaws,
+            workspaceAdditional
+        )
+        XCTAssertEqual(
+            fileStore.document.scalarPreferences?.modelSelection?.additionalOracleModels,
+            globalAdditional
+        )
+        XCTAssertEqual(
+            fileStore.document.scalarPreferences?.modelSelection?.secondaryOracleModel,
+            globalAdditional.first
+        )
+        XCTAssertEqual(fileStore.document.schemaVersion, GlobalSettingsDocument.additionalOraclesSchemaVersion)
+
+        fileStore.document = try JSONDecoder().decode(
+            GlobalSettingsDocument.self,
+            from: JSONEncoder().encode(fileStore.document)
+        )
+        let reloaded = try GlobalSettingsStore(defaults: makeIsolatedDefaults(), fileStore: fileStore)
+        XCTAssertEqual(reloaded.globalAgentModelsProfile().additionalOracleModelRaws, globalAdditional)
+        XCTAssertEqual(
+            reloaded.workspaceAgentModelsProfile(for: workspaceID)?.additionalOracleModelRaws,
+            workspaceAdditional
+        )
+    }
+
+    func testLegacyGlobalSecondaryProjectsIntoFirstAdditionalOracle() throws {
+        let legacySecondary = AIModel.claude4Sonnet.rawValue
+        let fileStore = CountingGlobalSettingsFileStore(document: GlobalSettingsDocument(
+            globalDefaults: GlobalDefaults(discoverAgentRaw: nil, discoverModelsByAgent: nil),
+            scalarPreferences: GlobalScalarPreferences(
+                modelSelection: .init(secondaryOracleModel: legacySecondary)
+            )
+        ))
+        let store = try GlobalSettingsStore(defaults: makeIsolatedDefaults(), fileStore: fileStore)
+
+        XCTAssertEqual(store.globalAgentModelsProfile().additionalOracleModelRaws, [legacySecondary])
+        XCTAssertEqual(store.secondaryOracleModelRaw(), legacySecondary)
+        XCTAssertNil(fileStore.document.scalarPreferences?.modelSelection?.additionalOracleModels)
+
+        let replacement = AIModel.gpt54Pro.rawValue
+        store.setGlobalAgentModelsProfile(
+            AgentModelsSettingsProfile(
+                planningModelRaw: replacement,
+                additionalOracleModelRaws: [legacySecondary, replacement]
+            ),
+            contextBuilderWriteIntent: .preserveExistingOwnership
+        )
+        store.setSecondaryOracleModelRaw(replacement)
+        XCTAssertEqual(
+            store.globalAgentModelsProfile().additionalOracleModelRaws,
+            [replacement, replacement]
+        )
+
+        store.setSecondaryOracleModelRaw(nil)
+        XCTAssertEqual(store.globalAgentModelsProfile().additionalOracleModelRaws, [replacement])
+        XCTAssertEqual(
+            fileStore.document.scalarPreferences?.modelSelection?.additionalOracleModels,
+            [replacement]
+        )
+        XCTAssertEqual(
+            fileStore.document.scalarPreferences?.modelSelection?.secondaryOracleModel,
+            replacement
+        )
+    }
+
+    func testAgentModelsViewModelAddsAtMostFourAdditionalOraclesAndRemovesInOrder() throws {
+        let primary = AIModel.gpt54Pro.rawValue
+        let replacement = AIModel.claude4Sonnet.rawValue
+        let fileStore = CountingGlobalSettingsFileStore(document: GlobalSettingsDocument(
+            globalDefaults: GlobalDefaults(discoverAgentRaw: nil, discoverModelsByAgent: nil),
+            scalarPreferences: seededScalarPreferences()
+        ))
+        let store = try GlobalSettingsStore(defaults: makeIsolatedDefaults(), fileStore: fileStore)
+        store.setGlobalAgentModelsProfile(
+            AgentModelsSettingsProfile(planningModelRaw: primary),
+            contextBuilderWriteIntent: .preserveExistingOwnership
+        )
+        let viewModel = AgentModelsSettingsViewModel(
+            apiSettingsVM: makeAPISettingsViewModel(),
+            settingsManager: WindowSettingsManager(windowID: -610, store: store),
+            settingsStore: store
+        )
+
+        XCTAssertEqual(viewModel.totalOracleCount, 1)
+        XCTAssertTrue(viewModel.canAddAdditionalOracle)
+        for _ in 0 ..< OraclePairModelSelectionPolicy.maximumAdditionalOracleCount {
+            viewModel.addAdditionalOracle()
+        }
+        viewModel.addAdditionalOracle()
+
+        XCTAssertEqual(viewModel.totalOracleCount, OraclePairModelSelectionPolicy.maximumOracleCount)
+        XCTAssertEqual(viewModel.additionalOracleModelRaws, Array(repeating: primary, count: 4))
+        XCTAssertFalse(viewModel.canAddAdditionalOracle)
+
+        viewModel.additionalOracleModelDestination(at: 2).apply(replacement)
+        XCTAssertEqual(viewModel.additionalOracleModelRaws, [primary, primary, replacement, primary])
+
+        viewModel.removeAdditionalOracle(at: 1)
+        XCTAssertEqual(viewModel.additionalOracleModelRaws, [primary, replacement, primary])
+        XCTAssertEqual(
+            store.globalAgentModelsProfile().additionalOracleModelRaws,
+            [primary, replacement, primary]
+        )
+        XCTAssertTrue(viewModel.canAddAdditionalOracle)
+
+        viewModel.secondaryOracleModelDestination.apply("")
+        XCTAssertEqual(viewModel.additionalOracleModelRaws, [replacement, primary])
+        XCTAssertEqual(store.secondaryOracleModelRaw(), replacement)
+    }
+
+    func testAgentModelsViewModelAdditionalOracleEditsRespectWorkspaceScope() throws {
+        let workspaceID = UUID()
+        let globalPrimary = AIModel.gpt54Pro.rawValue
+        let workspacePrimary = AIModel.claude4Sonnet.rawValue
+        let fileStore = CountingGlobalSettingsFileStore(document: GlobalSettingsDocument(
+            globalDefaults: GlobalDefaults(discoverAgentRaw: nil, discoverModelsByAgent: nil),
+            scalarPreferences: seededScalarPreferences()
+        ))
+        let store = try GlobalSettingsStore(defaults: makeIsolatedDefaults(), fileStore: fileStore)
+        store.setGlobalAgentModelsProfile(
+            AgentModelsSettingsProfile(planningModelRaw: globalPrimary),
+            contextBuilderWriteIntent: .preserveExistingOwnership
+        )
+        store.setWorkspaceAgentModelsProfile(
+            workspaceID: workspaceID,
+            profile: AgentModelsSettingsProfile(planningModelRaw: workspacePrimary)
+        )
+        store.setWorkspaceAgentModelsInheritanceMode(workspaceID: workspaceID, mode: .useWorkspaceOverrides)
+        let viewModel = AgentModelsSettingsViewModel(
+            apiSettingsVM: makeAPISettingsViewModel(),
+            workspaceID: workspaceID,
+            workspaceName: "Additional Oracle scope",
+            settingsManager: WindowSettingsManager(windowID: -611, store: store),
+            settingsStore: store
+        )
+
+        viewModel.addAdditionalOracle()
+
+        XCTAssertTrue(store.globalAgentModelsProfile().additionalOracleModelRaws.isEmpty)
+        XCTAssertEqual(
+            store.workspaceAgentModelsProfile(for: workspaceID)?.additionalOracleModelRaws,
+            [workspacePrimary]
+        )
+    }
+
+    func testAdditionalOraclePolicyAllowsDuplicatesAndRejectsMoreThanFourAdditionalModels() throws {
+        let raw = AIModel.gpt54Pro.rawValue
+        XCTAssertEqual(
+            try OraclePairModelSelectionPolicy.canonicalAdditionalRaws([raw, raw]),
+            [raw, raw]
+        )
+        XCTAssertEqual(
+            try OraclePairModelSelectionPolicy.resolveAdditional(raws: [raw, raw]),
+            [.gpt54Pro, .gpt54Pro]
+        )
+        XCTAssertThrowsError(try OraclePairModelSelectionPolicy.canonicalAdditionalRaws(
+            Array(repeating: raw, count: 5)
+        ))
+        XCTAssertEqual(
+            AgentModelsSettingsProfile(
+                additionalOracleModelRaws: Array(repeating: raw, count: 5)
+            ).additionalOracleModelRaws.count,
+            AgentModelsSettingsProfile.maximumAdditionalOracleModels
+        )
     }
 
     private var obsoleteGitignorePreferenceKey: String {

--- a/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
+++ b/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
@@ -596,7 +596,7 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
             fileStore: GlobalSettingsFileStore(fileURL: fileURL)
         )
 
-        XCTAssertEqual(GlobalSettingsDocument.currentSchemaVersion, 4)
+        XCTAssertEqual(GlobalSettingsDocument.currentSchemaVersion, 5)
         XCTAssertTrue(store.worktreeVisualIdentitiesByRepositoryID().isEmpty)
     }
 
@@ -1165,6 +1165,20 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
 
         try fileStore.save(GlobalSettingsDocument(scalarPreferences: seededScalarPreferences()))
         XCTAssertEqual(try fileStore.load().schemaVersion, GlobalSettingsDocument.baselineSchemaVersion)
+
+        try fileStore.save(GlobalSettingsDocument(
+            scalarPreferences: seededScalarPreferences(
+                modelSelection: .init(secondaryOracleModel: " \n\t ")
+            )
+        ))
+        XCTAssertEqual(try fileStore.load().schemaVersion, GlobalSettingsDocument.baselineSchemaVersion)
+
+        try fileStore.save(GlobalSettingsDocument(
+            scalarPreferences: seededScalarPreferences(
+                modelSelection: .init(secondaryOracleModel: AIModel.gpt54Pro.rawValue)
+            )
+        ))
+        XCTAssertEqual(try fileStore.load().schemaVersion, GlobalSettingsDocument.secondaryOracleSchemaVersion)
     }
 
     func testCompatibleLineagedSchemaV2LoadDoesNotRewriteBytes() throws {
@@ -1182,12 +1196,26 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
     }
 
     func testWorkspaceAgentModelsUsesFixedFeatureSchemaV4() {
+        let workspaceID = UUID()
         let document = GlobalSettingsDocument(
-            agentModelsSettings: [UUID(): WorkspaceAgentModelsSettings(inheritanceMode: .useWorkspaceOverrides)]
+            agentModelsSettings: [workspaceID: WorkspaceAgentModelsSettings(inheritanceMode: .useWorkspaceOverrides)]
+        )
+        let secondaryOracleDocument = GlobalSettingsDocument(
+            agentModelsSettings: [
+                workspaceID: WorkspaceAgentModelsSettings(
+                    inheritanceMode: .useWorkspaceOverrides,
+                    profile: AgentModelsSettingsProfile(secondaryOracleModelRaw: AIModel.gpt54Pro.rawValue)
+                )
+            ]
         )
 
         XCTAssertEqual(GlobalSettingsDocument.workspaceAgentModelsSchemaVersion, 4)
+        XCTAssertEqual(GlobalSettingsDocument.secondaryOracleSchemaVersion, 5)
         XCTAssertEqual(document.requiredSchemaVersion, GlobalSettingsDocument.workspaceAgentModelsSchemaVersion)
+        XCTAssertEqual(
+            secondaryOracleDocument.requiredSchemaVersion,
+            GlobalSettingsDocument.secondaryOracleSchemaVersion
+        )
     }
 
     func testFalseV4BacksUpExactBytesNormalizesOnlyHeaderAndIsIdempotent() throws {
@@ -1294,6 +1322,8 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         let document = try GlobalSettingsFileStore(fileURL: fileURL).load()
 
         XCTAssertEqual(document.schemaVersion, GlobalSettingsDocument.workspaceAgentModelsSchemaVersion)
+        XCTAssertNil(document.scalarPreferences?.modelSelection?.secondaryOracleModel)
+        XCTAssertNil(document.agentModelsSettings[workspaceID]?.profile?.secondaryOracleModelRaw)
         XCTAssertEqual(try Data(contentsOf: fileURL), original)
         XCTAssertFalse(FileManager.default.fileExists(
             atPath: fileURL.deletingLastPathComponent().appendingPathComponent("Backups").path
@@ -1803,7 +1833,10 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         defer { recorder.invalidate() }
 
         store.setGlobalAgentModelsProfile(
-            AgentModelsSettingsProfile(planningModelRaw: AIModel.gpt54Pro.rawValue),
+            AgentModelsSettingsProfile(
+                planningModelRaw: AIModel.gpt54Pro.rawValue,
+                secondaryOracleModelRaw: AIModel.claude4Sonnet.rawValue
+            ),
             contextBuilderWriteIntent: .preserveExistingOwnership
         )
         await drainMainQueue()
@@ -1821,6 +1854,7 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
             originalChatFileTreeOption
         )
         XCTAssertEqual(prompt.planningModelName, AIModel.gpt54Pro.rawValue)
+        XCTAssertEqual(prompt.secondaryOracleModelRaw, AIModel.claude4Sonnet.rawValue)
     }
 
     func testAgentModelsViewModelDoesNotFallbackUnsyncedBuiltinChatToOracle() async throws {
@@ -2236,6 +2270,31 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         )
     }
 
+    func testSecondaryOracleProfilesResolveGlobalAndWorkspaceInheritance() throws {
+        let fileStore = CountingGlobalSettingsFileStore(document: GlobalSettingsDocument(
+            globalDefaults: GlobalDefaults(discoverAgentRaw: nil, discoverModelsByAgent: nil),
+            scalarPreferences: seededScalarPreferences()
+        ))
+        let store = try GlobalSettingsStore(defaults: makeIsolatedDefaults(), fileStore: fileStore)
+        let workspaceID = UUID()
+        let globalProfile = AgentModelsSettingsProfile(
+            secondaryOracleModelRaw: AIModel.claude4Sonnet.rawValue
+        )
+        let workspaceProfile = AgentModelsSettingsProfile(
+            secondaryOracleModelRaw: AIModel.gpt54Pro.rawValue
+        )
+
+        store.setGlobalAgentModelsProfile(globalProfile, contextBuilderWriteIntent: .preserveExistingOwnership)
+        store.setWorkspaceAgentModelsProfile(workspaceID: workspaceID, profile: workspaceProfile)
+        XCTAssertEqual(store.effectiveAgentModelsProfile(workspaceID: workspaceID), workspaceProfile)
+
+        store.setWorkspaceAgentModelsInheritanceMode(workspaceID: workspaceID, mode: .useGlobalSettings)
+        XCTAssertEqual(store.effectiveAgentModelsProfile(workspaceID: workspaceID), globalProfile)
+
+        let reloaded = try GlobalSettingsStore(defaults: makeIsolatedDefaults(), fileStore: fileStore)
+        XCTAssertEqual(reloaded.effectiveAgentModelsProfile(workspaceID: workspaceID), globalProfile)
+    }
+
     func testAgentModelsCopyWorkspaceToGlobalOverwritesContextBuilderModelMap() throws {
         let fileStore = CountingGlobalSettingsFileStore(document: GlobalSettingsDocument(
             globalDefaults: GlobalDefaults(discoverAgentRaw: nil, discoverModelsByAgent: nil),
@@ -2616,6 +2675,7 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
                     inheritanceMode: .useWorkspaceOverrides,
                     profile: AgentModelsSettingsProfile(
                         planningModelRaw: tierRaw,
+                        secondaryOracleModelRaw: tierRaw,
                         preferredComposeModelRaw: tierRaw,
                         mcpAgentRoleOverrides: [
                             "explore": tierSelectionRaw,
@@ -2633,7 +2693,11 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
                 ]
             ),
             scalarPreferences: GlobalScalarPreferences(
-                modelSelection: .init(preferredComposeModel: tierRaw, planningModel: tierRaw)
+                modelSelection: .init(
+                    preferredComposeModel: tierRaw,
+                    planningModel: tierRaw,
+                    secondaryOracleModel: tierRaw
+                )
             )
         ))
         let store = try GlobalSettingsStore(defaults: makeIsolatedDefaults(), fileStore: fileStore)
@@ -2645,6 +2709,7 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
 
         XCTAssertEqual(fileStore.saveCount, 1)
         XCTAssertEqual(store.globalAgentModelsProfile().planningModelRaw, AIModel.gpt54Pro.rawValue)
+        XCTAssertEqual(store.globalAgentModelsProfile().secondaryOracleModelRaw, AIModel.gpt54Pro.rawValue)
         XCTAssertEqual(store.globalAgentModelsProfile().preferredComposeModelRaw, AIModel.gpt54Pro.rawValue)
         XCTAssertEqual(
             store.globalAgentModelsProfile().contextBuilderModelsByAgent?[AgentProviderKind.codexExec.rawValue],
@@ -2657,6 +2722,10 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
             "Parse-invalid overrides must survive byte-identical"
         )
         XCTAssertEqual(store.workspaceAgentModelsProfile(for: workspaceID)?.planningModelRaw, AIModel.gpt54Pro.rawValue)
+        XCTAssertEqual(
+            store.workspaceAgentModelsProfile(for: workspaceID)?.secondaryOracleModelRaw,
+            AIModel.gpt54Pro.rawValue
+        )
         XCTAssertEqual(
             store.workspaceAgentModelsProfile(for: workspaceID)?.mcpAgentRoleOverrides?["explore"],
             normalizedSelectionRaw


### PR DESCRIPTION
## Summary

- keep Primary Oracle permanently configured and add a `+` control for 0–4 removable additional Oracles (five total)
- preserve the exact existing single-Oracle execution path when no additional Oracle is configured
- generalize orchestration, continuation, cancellation, transport, Context Builder integration, and durable history from a fixed pair to ordered 2–5 member groups
- migrate the legacy Secondary setting into an ordered roster while retaining pair-shaped compatibility APIs and payload fields
- add focused coverage for 1-, 2-, and 5-Oracle behavior, partial failures, persistence/recovery/deletion, settings migration, and UI projection

## Review focus

- byte-/behavior-equivalent single-Oracle routing and errors
- deterministic lane ordering with concurrent 2–5 Oracle execution
- Primary-only foreground activation and zero background activation
- strict group cardinality and fail-closed lifecycle handling for incomplete or unreadable history
- legacy pair persistence/settings/transport compatibility
- Context Builder continuation, cancellation, and stale-generation protection

## Validation

- contribution preflight tests: 19 passed
- all 26 files changed by this follow-up parse with the official Swift 6.2.4 compiler
- whitespace and staged/outgoing secret scans passed
- repository static guardrails passed except the Apple-only `xcrun` inspection, unavailable on this Linux runner
- `repoprompt-mcp --backend headless` was investigated, but that target is still Darwin-only and does not compile the app-target Oracle implementation; macOS CI is the authoritative build/test result
