### PR TITLE
feat: streamline Context Composer entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ is unchanged and does not use the generated workspace.
   files, and curate context within a token budget. Long-running MCP calls expose
   [request-scoped progress](docs/mcp-progress.md) when the client supplies a
   progress token.
-- **Compose inspector**: Review selected files and codemaps, configure prompt packaging and Git context, and copy a fresh model-ready prompt without leaving Agent Mode.
+- **Context Composer**: Review selected files and codemaps, configure prompt packaging and Git context, and copy a fresh model-ready prompt without leaving Agent Mode.
 - **Agent orchestration**: Run and coordinate CLI-backed coding agents from the
   native macOS app. See [`docs/worktrees.md`](docs/worktrees.md) for app-managed
   worktrees and `.worktreeinclude` local file copying.
@@ -157,7 +157,7 @@ third-party notices in
   checks, source placement, and contribution preflight
 - [`CONTRIBUTING.md`](CONTRIBUTING.md): contribution policy and pull request
   steps
-- [`docs/architecture/compose.md`](docs/architecture/compose.md): Compose inspector architecture, invariants, and state ownership
+- [`docs/architecture/context-composer.md`](docs/architecture/context-composer.md): Context Composer architecture, invariants, and state ownership
 - [`docs/architecture/source-layout.md`](docs/architecture/source-layout.md):
   source ownership and placement rules
 - [`docs/architecture/provider-plugins.md`](docs/architecture/provider-plugins.md):

--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -751,7 +751,7 @@ print_matches \
 # promoted into the contributor-facing documentation set.
 allowed_tracked_docs=(
   "docs/architecture/codex-app-server-schema-gate.md"
-  "docs/architecture/compose.md"
+  "docs/architecture/context-composer.md"
   "docs/architecture/headless-mcp-runtime.md"
   "docs/architecture/provider-plugins.md"
   "docs/architecture/settings-persistence.md"

--- a/Sources/RepoPrompt/App/GlobalKeyboardShortcutsCoordinator.swift
+++ b/Sources/RepoPrompt/App/GlobalKeyboardShortcutsCoordinator.swift
@@ -213,7 +213,7 @@ final class GlobalKeyboardShortcutsCoordinator {
     private func registerAgentShortcuts() {
         register(.agentNewChat) { [weak self] in self?.startNewAgentSessionFromShortcut() }
         register(.toggleNavigationSidebar) { [weak self] in self?.toggleNavigationSidebarFromShortcut() }
-        register(.toggleComposeInspector) { [weak self] in self?.toggleComposeInspectorFromShortcut() }
+        register(.toggleContextComposer) { [weak self] in self?.toggleContextComposerFromShortcut() }
         register(.previousParentAgentSession) { [weak self] in self?.focusAdjacentParentAgentSession(forward: false) }
         register(.nextParentAgentSession) { [weak self] in self?.focusAdjacentParentAgentSession(forward: true) }
         register(.showCurrentWindowAgentNavigationHUD) { [weak self] in self?.showAgentNavigationHUD(mode: .currentWindow) }
@@ -234,18 +234,18 @@ final class GlobalKeyboardShortcutsCoordinator {
         )
     }
 
-    private func toggleComposeInspectorFromShortcut() {
+    private func toggleContextComposerFromShortcut() {
         guard let win = guardedFocusedWindowState() else { return }
-        toggleComposeInspector(in: win)
+        toggleContextComposer(in: win)
     }
 
-    private func toggleComposeInspector(in win: WindowState) {
-        win.agentModeViewModel.toggleComposeInspectorIfActive()
+    private func toggleContextComposer(in win: WindowState) {
+        win.agentModeViewModel.toggleContextComposerIfActive()
     }
 
     #if DEBUG
-        func test_toggleComposeInspector(in win: WindowState) {
-            toggleComposeInspector(in: win)
+        func test_toggleContextComposer(in win: WindowState) {
+            toggleContextComposer(in: win)
         }
     #endif
 

--- a/Sources/RepoPrompt/App/Views/ContentView.swift
+++ b/Sources/RepoPrompt/App/Views/ContentView.swift
@@ -36,7 +36,6 @@ struct ContentView: View {
             ContentViewToolbarContent(
                 windowState: viewModel.state,
                 recommendationWizardViewModel: recommendationWizardViewModel,
-                isAgentModeActive: viewModel.rootRoute == .main,
                 showRecommendationsPopover: $showRecommendationsPopover,
                 showMCPServerPopover: $showMCPServerPopover
             )

--- a/Sources/RepoPrompt/App/Views/ContentViewToolbarContent.swift
+++ b/Sources/RepoPrompt/App/Views/ContentViewToolbarContent.swift
@@ -5,24 +5,10 @@ import SwiftUI
 struct ContentViewToolbarContent: ToolbarContent {
     let windowState: WindowState
     let recommendationWizardViewModel: RecommendationWizardViewModel?
-    let isAgentModeActive: Bool
     @Binding var showRecommendationsPopover: Bool
     @Binding var showMCPServerPopover: Bool
 
     var body: some ToolbarContent {
-        // Agent Mode context drawer button
-        ToolbarItem(placement: .automatic) {
-            if isAgentModeActive {
-                Button {
-                    windowState.agentModeViewModel.ui.contextDrawer.toggle()
-                } label: {
-                    Label("Compose", systemImage: "pencil")
-                        .labelStyle(.titleAndIcon)
-                }
-                .hoverTooltip("Generate prompts from selected files")
-            }
-        }
-
         if #available(macOS 26.0, *) {
             agentChatTitleItem
                 .sharedBackgroundVisibility(.hidden)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -3159,7 +3159,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         refreshSessionListCache(for: workspace, owner: owner)
     }
 
-    func toggleComposeInspectorIfActive() {
+    func toggleContextComposerIfActive() {
         guard isAgentModeActive else { return }
         ui.contextDrawer.toggle()
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentContextPill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentContextPill.swift
@@ -1,3 +1,6 @@
+import Combine
+import Foundation
+import KeyboardShortcuts
 import SwiftUI
 
 // MARK: - Context Pill
@@ -13,6 +16,8 @@ struct AgentContextPill: View {
     let worktreeBindingsProvider: @MainActor (UUID, UUID?) -> [AgentSessionWorktreeBinding]
 
     @ObservedObject private var fontScale = FontScaleManager.shared
+    @State private var contextComposerShortcut = KeyboardShortcuts.getShortcut(for: .toggleContextComposer)
+
     private var fontPreset: FontScalePreset {
         fontScale.preset
     }
@@ -61,6 +66,11 @@ struct AgentContextPill: View {
         runtimeVM.snapshot.selectionTokens
     }
 
+    private var contextComposerActionText: String {
+        guard let contextComposerShortcut else { return "Click to review and edit" }
+        return "Click to review and edit · \(contextComposerShortcut)"
+    }
+
     private func contextUsageTooltip(detailedFileSummaryText: String) -> String {
         var lines: [String] = []
 
@@ -80,6 +90,7 @@ struct AgentContextPill: View {
         if let selectionTokens {
             lines.append("Selection: \(AgentContextIndicator.formatTokens(selectionTokens)) tokens")
         }
+        lines.append(contextComposerActionText)
 
         return lines.joined(separator: "\n")
     }
@@ -97,6 +108,10 @@ struct AgentContextPill: View {
             openContextDrawerFiles()
         } label: {
             HStack(spacing: 6) {
+                Image(systemName: "square.stack.3d.up")
+                    .imageScale(.small)
+                    .foregroundStyle(.secondary)
+
                 Text(compactFileSummaryText)
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
                     .foregroundStyle(.secondary)
@@ -121,6 +136,9 @@ struct AgentContextPill: View {
         .buttonStyle(.plain)
         .hoverTooltip(contextUsageTooltip(detailedFileSummaryText: detailedFileSummaryText), .top)
         .accessibilityLabel("Agent context: \(detailedFileSummaryText)")
-        .accessibilityHint("Opens Compose selections")
+        .accessibilityHint("Review and edit selected context")
+        .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+            contextComposerShortcut = KeyboardShortcuts.getShortcut(for: .toggleContextComposer)
+        }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextControlDrawerView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextControlDrawerView.swift
@@ -354,9 +354,6 @@ struct AgentContextControlDrawerView: View {
 
     private var header: some View {
         HStack(spacing: 14) {
-            Text("Compose")
-                .font(fontPreset.swiftUIFont(sizeAtNormal: 15, weight: .semibold))
-
             AgentContextDrawerTokenEstimatePill(
                 tokenCounter: promptManager.tokenCountingViewModel,
                 runtimeVM: runtimeVM,
@@ -374,7 +371,7 @@ struct AgentContextControlDrawerView: View {
                     .frame(width: 28, height: 28)
             }
             .buttonStyle(.plain)
-            .hoverTooltip("Close Compose")
+            .hoverTooltip("Close Context Composer")
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 14)

--- a/Sources/RepoPrompt/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
@@ -20,10 +20,10 @@ enum KeyboardShortcutCatalog {
                 .init(id: "agent-new", title: "New Agent chat", detail: nil, name: .agentNewChat),
                 .init(id: "toggle-sidebar", title: "Toggle session sidebar", detail: "Show or hide the Agent sessions list.", name: .toggleNavigationSidebar),
                 .init(
-                    id: "toggle-compose",
-                    title: "Toggle Compose",
-                    detail: "Show or hide the Compose inspector.",
-                    name: .toggleComposeInspector
+                    id: "toggle-context-composer",
+                    title: "Toggle Context Composer",
+                    detail: "Show or hide the Context Composer",
+                    name: .toggleContextComposer
                 ),
                 .init(id: "agent-nav-current", title: "Show Agent Session Switcher", detail: "Jump between Agent sessions in the focused window.", name: .showCurrentWindowAgentNavigationHUD),
                 .init(id: "agent-nav-all", title: "Search all Agent sessions", detail: "Jump to active or recent Agent sessions across windows.", name: .showAllAgentsNavigationHUD)

--- a/Sources/RepoPrompt/Infrastructure/UI/Components/MCPServerToggleView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/MCPServerToggleView.swift
@@ -96,16 +96,11 @@ struct MCPServerToggleView: View {
 
     var body: some View {
         Button(action: { showPopover.toggle() }) {
-            HStack(spacing: 6) {
-                Image(systemName: "server.rack")
-                    .imageScale(.medium)
-                    .foregroundColor(buttonIconColor)
-                Text("MCP Server")
-            }
+            Label("MCP Server", systemImage: "server.rack")
+                .labelStyle(.iconOnly)
+                .imageScale(.medium)
+                .foregroundColor(buttonIconColor)
         }
-        .buttonStyle(CustomButtonStyle())
-        .padding(.leading, 8)
-        .padding(.trailing, 8)
         .hoverTooltip(toolbarStateObserver.visualState.helpText, .bottom)
         .accessibilityHint(toolbarStateObserver.visualState.helpText)
         .popover(isPresented: $showPopover, attachmentAnchor: .rect(.bounds), arrowEdge: .top) {

--- a/Sources/RepoPrompt/Infrastructure/UI/Components/RecommendationToolbarButtonView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/RecommendationToolbarButtonView.swift
@@ -44,10 +44,12 @@ struct RecommendationToolbarButtonView: View {
             }
             showPopover.toggle()
         }) {
-            Image(systemName: "lightbulb")
+            Label("Setup Wizard", systemImage: "lightbulb")
+                .labelStyle(.iconOnly)
                 .imageScale(.medium)
                 .foregroundColor(toolbarStateObserver.state.hasActiveRecommendations ? .yellow : .secondary)
         }
+        .hoverTooltip("Setup Wizard", .bottom)
         .popover(isPresented: $showPopover, attachmentAnchor: .rect(.bounds), arrowEdge: .bottom) {
             RecommendationWizardPopoverView(
                 viewModel: viewModel,

--- a/Sources/RepoPrompt/Infrastructure/UI/ScreenVisibleFrameResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/ScreenVisibleFrameResolver.swift
@@ -1,0 +1,43 @@
+import AppKit
+
+struct ScreenGeometrySnapshot: Equatable {
+    let frame: NSRect
+    let visibleFrame: NSRect
+}
+
+enum ScreenVisibleFrameResolver {
+    static func selectedVisibleFrame(
+        for anchor: NSRect,
+        screens: [ScreenGeometrySnapshot]
+    ) -> NSRect? {
+        guard !screens.isEmpty else { return nil }
+
+        let intersecting = screens.enumerated().map { index, screen in
+            (index, screen, intersectionArea(anchor, screen.frame))
+        }
+        if let best = intersecting.max(by: { lhs, rhs in
+            lhs.2 == rhs.2 ? lhs.0 > rhs.0 : lhs.2 < rhs.2
+        }), best.2 > 0 {
+            return best.1.visibleFrame
+        }
+
+        let anchorCenter = NSPoint(x: anchor.midX, y: anchor.midY)
+        return screens.enumerated().min { lhs, rhs in
+            let leftDistance = squaredDistance(from: anchorCenter, to: lhs.element.frame)
+            let rightDistance = squaredDistance(from: anchorCenter, to: rhs.element.frame)
+            return leftDistance == rightDistance ? lhs.offset < rhs.offset : leftDistance < rightDistance
+        }?.element.visibleFrame
+    }
+
+    private static func intersectionArea(_ lhs: NSRect, _ rhs: NSRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull else { return 0 }
+        return max(intersection.width, 0) * max(intersection.height, 0)
+    }
+
+    private static func squaredDistance(from point: NSPoint, to rect: NSRect) -> CGFloat {
+        let dx = max(max(rect.minX - point.x, 0), point.x - rect.maxX)
+        let dy = max(max(rect.minY - point.y, 0), point.y - rect.maxY)
+        return dx * dx + dy * dy
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
@@ -10,10 +10,7 @@ final class MentionOverlayController {
         case below
     }
 
-    struct ScreenGeometry: Equatable {
-        let frame: NSRect
-        let visibleFrame: NSRect
-    }
+    typealias ScreenGeometry = ScreenGeometrySnapshot
 
     struct RootPlacementResult: Equatable {
         let frame: NSRect
@@ -239,23 +236,7 @@ final class MentionOverlayController {
         for caret: NSRect,
         screens: [ScreenGeometry]
     ) -> NSRect? {
-        guard !screens.isEmpty else { return nil }
-
-        let intersecting = screens.enumerated().map { index, screen in
-            (index, screen, visibleIntersectionArea(caret, screen.frame))
-        }
-        if let best = intersecting.max(by: { lhs, rhs in
-            lhs.2 == rhs.2 ? lhs.0 > rhs.0 : lhs.2 < rhs.2
-        }), best.2 > 0 {
-            return best.1.visibleFrame
-        }
-
-        let caretCenter = NSPoint(x: caret.midX, y: caret.midY)
-        return screens.enumerated().min { lhs, rhs in
-            let leftDistance = squaredDistance(from: caretCenter, to: lhs.element.frame)
-            let rightDistance = squaredDistance(from: caretCenter, to: rhs.element.frame)
-            return leftDistance == rightDistance ? lhs.offset < rhs.offset : leftDistance < rightDistance
-        }?.element.visibleFrame
+        ScreenVisibleFrameResolver.selectedVisibleFrame(for: caret, screens: screens)
     }
 
     static func clampedFrame(_ frame: NSRect, to visibleFrame: NSRect?) -> NSRect {
@@ -308,12 +289,6 @@ final class MentionOverlayController {
         let intersection = lhs.intersection(rhs)
         guard !intersection.isNull else { return 0 }
         return max(intersection.width, 0) * max(intersection.height, 0)
-    }
-
-    private static func squaredDistance(from point: NSPoint, to rect: NSRect) -> CGFloat {
-        let dx = max(max(rect.minX - point.x, 0), point.x - rect.maxX)
-        let dy = max(max(rect.minY - point.y, 0), point.y - rect.maxY)
-        return dx * dx + dy * dy
     }
 
     private func chainWindow(_ w: SuggestionWindow, after prev: NSWindow) {

--- a/Sources/RepoPrompt/Infrastructure/UI/Tooltip/TooltipOverlayController.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Tooltip/TooltipOverlayController.swift
@@ -64,7 +64,7 @@ final class TooltipOverlayController {
         let arrow = Self.arrowGap * preset.scaleFactor
 
         // 3. Compute *top-left* window position for every placement
-        let topLeft: NSPoint = {
+        let proposedTopLeft: NSPoint = {
             switch cachedPlacement {
             case .top:
                 // Bubble ABOVE anchor – its bottom is arrow pts above anchor.top
@@ -112,6 +112,18 @@ final class TooltipOverlayController {
             }
         }()
 
+        guard let topLeft = Self.constrainedTopLeft(
+            proposedTopLeft,
+            bubbleSize: bubble,
+            anchor: anchor,
+            screens: NSScreen.screens.map {
+                ScreenGeometrySnapshot(frame: $0.frame, visibleFrame: $0.visibleFrame)
+            }
+        ) else {
+            hide()
+            return
+        }
+
         // Skip redundant frame sets (reduces display-cycle flush churn)
         let currentTopLeft = NSPoint(x: win.frame.origin.x, y: win.frame.origin.y + win.frame.height)
         let eps: CGFloat = 0.5
@@ -148,6 +160,26 @@ final class TooltipOverlayController {
         cachedText = nil
         cachedPlacement = .top
         cachedPreset = nil
+    }
+
+    static func constrainedTopLeft(
+        _ proposedTopLeft: NSPoint,
+        bubbleSize: NSSize,
+        anchor: NSRect,
+        screens: [ScreenGeometrySnapshot]
+    ) -> NSPoint? {
+        guard let visibleFrame = ScreenVisibleFrameResolver.selectedVisibleFrame(for: anchor, screens: screens) else {
+            return nil
+        }
+
+        var constrainedTopLeft = proposedTopLeft
+        constrainedTopLeft.x = bubbleSize.width <= visibleFrame.width
+            ? min(max(proposedTopLeft.x, visibleFrame.minX), visibleFrame.maxX - bubbleSize.width)
+            : visibleFrame.minX
+        constrainedTopLeft.y = bubbleSize.height <= visibleFrame.height
+            ? min(max(proposedTopLeft.y, visibleFrame.minY + bubbleSize.height), visibleFrame.maxY)
+            : visibleFrame.maxY
+        return constrainedTopLeft
     }
 
     // MARK: – Private

--- a/Sources/RepoPrompt/Infrastructure/Utilities/Shortcuts.swift
+++ b/Sources/RepoPrompt/Infrastructure/Utilities/Shortcuts.swift
@@ -39,8 +39,9 @@ extension KeyboardShortcuts.Name {
     static let agentNewChat = Self("agentNewChat", default: .init(.n, modifiers: [.command, .option]))
     /// Toggle the Agent session sidebar.
     static let toggleNavigationSidebar = Self("toggleNavigationSidebar", default: .init(.b, modifiers: [.command, .option]))
-    /// Toggle the Compose inspector.
-    static let toggleComposeInspector = Self("toggleComposeInspector", default: .init(.p, modifiers: [.command]))
+    /// Toggle Context Composer.
+    /// The raw key remains stable so existing custom bindings continue to resolve.
+    static let toggleContextComposer = Self("toggleComposeInspector", default: .init(.p, modifiers: [.command]))
     /// Show the current-window Agent navigation HUD.
     static let showCurrentWindowAgentNavigationHUD = Self("showCurrentWindowAgentNavigationHUD", default: .init(.k, modifiers: [.command]))
     /// Show the all-active/recent Agents navigation HUD.

--- a/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
@@ -245,20 +245,20 @@ final class AgentModeChatSwitchActivationTests: XCTestCase {
         )
     }
 
-    func testToggleComposeShortcutOutsideAgentModeDoesNotArmPresentation() async throws {
+    func testToggleContextComposerShortcutOutsideAgentModeDoesNotArmPresentation() async throws {
         try await withFixture { fixture in
             let drawerStore = fixture.viewModel.ui.contextDrawer
             XCTAssertFalse(drawerStore.isPresented)
 
             fixture.viewModel.setAgentModeActive(false)
-            GlobalKeyboardShortcutsCoordinator.shared.test_toggleComposeInspector(in: fixture.window)
+            GlobalKeyboardShortcutsCoordinator.shared.test_toggleContextComposer(in: fixture.window)
             XCTAssertFalse(drawerStore.isPresented)
 
             fixture.viewModel.setAgentModeActive(true)
-            GlobalKeyboardShortcutsCoordinator.shared.test_toggleComposeInspector(in: fixture.window)
+            GlobalKeyboardShortcutsCoordinator.shared.test_toggleContextComposer(in: fixture.window)
             XCTAssertTrue(drawerStore.isPresented)
 
-            GlobalKeyboardShortcutsCoordinator.shared.test_toggleComposeInspector(in: fixture.window)
+            GlobalKeyboardShortcutsCoordinator.shared.test_toggleContextComposer(in: fixture.window)
             XCTAssertFalse(drawerStore.isPresented)
         }
     }

--- a/Tests/RepoPromptTests/UI/TooltipOverlayControllerTests.swift
+++ b/Tests/RepoPromptTests/UI/TooltipOverlayControllerTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class TooltipOverlayControllerTests: XCTestCase {
+    func testConstrainedTopLeftUsesScreenIntersectingAnchor() throws {
+        let firstVisibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 760)
+        let secondVisibleFrame = NSRect(x: 1000, y: 0, width: 1000, height: 780)
+        let screens = [
+            ScreenGeometrySnapshot(
+                frame: NSRect(x: 0, y: 0, width: 1000, height: 800),
+                visibleFrame: firstVisibleFrame
+            ),
+            ScreenGeometrySnapshot(
+                frame: NSRect(x: 1000, y: 0, width: 1000, height: 800),
+                visibleFrame: secondVisibleFrame
+            )
+        ]
+
+        let topLeft = try XCTUnwrap(
+            TooltipOverlayController.constrainedTopLeft(
+                NSPoint(x: 900, y: 500),
+                bubbleSize: NSSize(width: 200, height: 80),
+                anchor: NSRect(x: 900, y: 300, width: 300, height: 20),
+                screens: screens
+            )
+        )
+
+        XCTAssertEqual(topLeft.x, secondVisibleFrame.minX)
+        XCTAssertEqual(topLeft.y, 500)
+    }
+
+    func testConstrainedTopLeftClampsWithinAnchorScreenVisibleFrame() throws {
+        let visibleFrame = NSRect(x: 1000, y: 40, width: 1000, height: 740)
+        let screens = [
+            ScreenGeometrySnapshot(
+                frame: NSRect(x: 1000, y: 0, width: 1000, height: 800),
+                visibleFrame: visibleFrame
+            )
+        ]
+        let bubbleSize = NSSize(width: 240, height: 100)
+
+        let topRight = try XCTUnwrap(
+            TooltipOverlayController.constrainedTopLeft(
+                NSPoint(x: 1950, y: 900),
+                bubbleSize: bubbleSize,
+                anchor: NSRect(x: 1900, y: 700, width: 20, height: 20),
+                screens: screens
+            )
+        )
+        let bottomLeft = try XCTUnwrap(
+            TooltipOverlayController.constrainedTopLeft(
+                NSPoint(x: 900, y: 20),
+                bubbleSize: bubbleSize,
+                anchor: NSRect(x: 1100, y: 100, width: 20, height: 20),
+                screens: screens
+            )
+        )
+
+        XCTAssertEqual(topRight.x, visibleFrame.maxX - bubbleSize.width)
+        XCTAssertEqual(topRight.y, visibleFrame.maxY)
+        XCTAssertEqual(bottomLeft.x, visibleFrame.minX)
+        XCTAssertEqual(bottomLeft.y, visibleFrame.minY + bubbleSize.height)
+    }
+}

--- a/docs/architecture/context-composer.md
+++ b/docs/architecture/context-composer.md
@@ -1,10 +1,10 @@
-# Compose Inspector
+# Context Composer
 
-This contributor guide covers the Agent Mode Compose inspector, including selected-context review, prompt packaging, Copy Prompt, Context Builder, and the services that support them.
+This contributor guide covers the Agent Mode Context Composer, including selected-context review, prompt packaging, Copy Prompt, Context Builder, and the services that support them.
 
 ## Scope and goals
 
-Compose lets a user review the context selected for the current agent chat, shape the prompt handed to another model, and run Context Builder without leaving the transcript.
+Context Composer lets a user review the context selected for the current agent chat, shape the prompt handed to another model, and run Context Builder without leaving the transcript.
 
 The inspector renders a resolved view of the current selection and sends user changes through the shared workspace selection services. Repository lookup, codemap resolution, and selection persistence stay outside the view layer; [`source-layout.md`](source-layout.md) defines the source-ownership boundary.
 
@@ -14,7 +14,7 @@ Inspector visibility and navigation are scoped to the current app window. Select
 
 ### Open and close
 
-Compose opens from the **Compose** button in the top-right Agent Mode toolbar, from the selected-context pill below the composer, or from `⌘P` (configurable under Settings → Keyboard Shortcuts → Toggle Compose). The toolbar and shortcut toggle the inspector. The selected-context pill opens **Selections**, switches to it from another Compose tab, or closes the inspector when **Selections** is already active. The header control closes the inspector directly.
+Context Composer opens from the selected-context pill below the message composer or from `⌘P` (configurable under Settings → Keyboard Shortcuts → Toggle Context Composer). The selected-context pill is the only visible entry point: it opens **Selections**, switches to it from another Context Composer tab, or closes Context Composer when **Selections** is already active. The shortcut toggles Context Composer, and the header close control closes it directly.
 
 The native macOS inspector column is resizable and adapts to preserve useful space for the chat.
 
@@ -34,13 +34,13 @@ Context Builder's **Preview**, **Open Oracle**, and **View in Chat** actions ope
 
 ### Loading behavior
 
-When the active chat changes, Compose waits for the new chat's selection before showing rows and totals. During updates to the current chat, matching rows remain visible while their data refreshes. File and codemap counts become available independently, and metrics remain hidden until their values are known.
+When the active chat changes, Context Composer waits for the new chat's selection before showing rows and totals. During updates to the current chat, matching rows remain visible while their data refreshes. File and codemap counts become available independently, and metrics remain hidden until their values are known.
 
 ## Layering
 
 ```mermaid
 flowchart LR
-    UI["Compose inspector"] --> STORE["AgentContextDrawerUIStore"]
+    UI["Context Composer"] --> STORE["AgentContextDrawerUIStore"]
     UI --> MODEL["AgentSelectedFilesModelCoordinator"]
     MODEL --> RESOLVER["AgentContextExportResolver"]
     RESOLVER --> CONTEXT["WorkspaceFileContextStore"]
@@ -54,7 +54,7 @@ flowchart LR
 
 ## Invariants and rationale
 
-**Observation isolation.** Compose detail state is observed within the inspector subtree. The chat surface receives only the presentation state and the action that opens Compose, keeping filter, sort, navigation, loading, and row updates from invalidating the transcript.
+**Observation isolation.** Context Composer detail state is observed within the inspector subtree. The chat surface receives only the presentation state and the action that opens Context Composer, keeping filter, sort, navigation, loading, and row updates from invalidating the transcript.
 
 **Context Builder Oracle presentation.** Context Builder routes each follow-up conversation by workspace, tab, and chat. `AgentOraclePill` presents the shared chat transcript with its non-mutating action policy, while the chat session remains the source of truth for live message updates.
 
@@ -72,7 +72,7 @@ flowchart LR
 | --- | --- |
 | Inspector visibility | `AgentContextDrawerPresentationStore` |
 | Active tab, filter, and sort | `AgentContextDrawerDetailStore` |
-| Open, close, and toggle behavior shared by Compose entry points | `AgentContextDrawerUIStore` |
+| Open, close, and toggle behavior shared by Context Composer entry points | `AgentContextDrawerUIStore` |
 | Selected files and active-tab mutations | `StoredSelection` and `WorkspaceSelectionCoordinator` |
 | Instructions, copy configuration, and token counting | `PromptViewModel` |
 | Context Builder execution and generated output | `ContextBuilderAgentViewModel` |
@@ -103,12 +103,12 @@ make dev-test FILTER=AgentSelectedFilesModelCoordinatorTests
 make dev-test FILTER=AgentContextInspectorColumnSizingTests
 ```
 
-Selection-card presentation, token accounting, Git actions, and chat-switch behavior have additional focused coverage in `AgentContextSelectedFileCardTests`, `TokenCountingViewModelTests`, `GitViewModelSelectionClearTests`, and `AgentModeChatSwitchActivationTests`. Use the contribution matrix in [`../../AGENTS.md`](../../AGENTS.md) for repository-wide lint, build, and PR-ready gates. Because Compose is running-app Agent Mode UI, also follow the live CE MCP smoke flow there when behavior changes.
+Selection-card presentation, token accounting, Git actions, and chat-switch behavior have additional focused coverage in `AgentContextSelectedFileCardTests`, `TokenCountingViewModelTests`, `GitViewModelSelectionClearTests`, and `AgentModeChatSwitchActivationTests`. Use the contribution matrix in [`../../AGENTS.md`](../../AGENTS.md) for repository-wide lint, build, and PR-ready gates. Because Context Composer is running-app Agent Mode UI, also follow the live CE MCP smoke flow there when behavior changes.
 
 ## References
 
 - `Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift` — native inspector mounting, presenter, and detail-width column policy.
-- `Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/` — Compose shell, tabs, selected-context rows, previews, and click-time export context.
+- `Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/` — Context Composer shell, tabs, selected-context rows, previews, and click-time export context.
 - `Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextDrawerUIStore.swift` — presentation and runtime detail state.
 - `Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift` — context-aware loading, caching, readiness, and mutation gating.
 - `Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift` — selection resolution, previews, metrics, and clipboard assembly.

--- a/docs/architecture/source-layout.md
+++ b/docs/architecture/source-layout.md
@@ -17,7 +17,7 @@ Sources/
       Views/
     Features/
       AgentMode/                 # Agent Mode UI, models, view models, onboarding, recommendations, and shared agent runtime ownership
-        Views/ContextDrawer/     # Compose inspector shell, tabs, selected-context rows, previews, and click-time export context
+        Views/ContextDrawer/     # Context Composer shell, tabs, selected-context rows, previews, and click-time export context
         Runtime/Providers/       # provider/runtime enum and provider factory shared by Context Builder, Agent Mode, MCP, and recommendations
         History/                 # cross-workspace session history scanner, MCP tool service (history.list_sessions / search / time / get_session)
       Chat/                      # chat/oracle models, services, diff state, view models, and views
@@ -85,7 +85,7 @@ The old native file-tree visualization is no longer a live product surface. Do n
 
 “File tree” remains valid when it refers to compatibility or textual context contracts, including the MCP `get_file_tree` tool, tool result cards, API/persisted symbols such as `FileTreeOption`, historical plans, and prompt/context output such as `<file_map>` / project structure maps. Contributor-facing UI and docs should prefer “project structure map” when describing generated textual context so it is not confused with the removed native UI.
 
-The old IDE-era Prompt selected-files panel is also removed. Do not add back `PresetBottomBar`, `SelectedFilesContentView`, `SelectedFilesPanelViewModel`, or the Prompt-owned copy/chat preset picker helpers. The compact Prompt selected-files UI remains `SelectedFilesGrid` plus `FilePreviewPopover`. Agent Mode owns its current selected-context workflow in the native Compose inspector under `Features/AgentMode/Views/ContextDrawer`; see [`compose.md`](compose.md). The Settings chat preset picker lives under `Features/Settings`. Textual file previews use the read-only `TextKitView`; app syntax queries remain a separate parsing and validation concern rather than a colored preview renderer.
+The old IDE-era Prompt selected-files panel is also removed. Do not add back `PresetBottomBar`, `SelectedFilesContentView`, `SelectedFilesPanelViewModel`, or the Prompt-owned copy/chat preset picker helpers. The compact Prompt selected-files UI remains `SelectedFilesGrid` plus `FilePreviewPopover`. Agent Mode owns its current selected-context workflow in Context Composer under `Features/AgentMode/Views/ContextDrawer`; see [`context-composer.md`](context-composer.md). The Settings chat preset picker lives under `Features/Settings`. Textual file previews use the read-only `TextKitView`; app syntax queries remain a separate parsing and validation concern rather than a colored preview renderer.
 
 ## Placement rules for new files
 


### PR DESCRIPTION
This tidies up a few matters of UI polish: it makes the selected-context pill the primary visible entry point, renames "Compose" to "Context Composer" and adopts that terminology throughout the user-facing surface, compacts the toolbar controls, and makes tooltip placement display-aware.

## Summary

* Remove the top-right **Compose** button and the redundant drawer title
* Add the Context Composer icon to the selected-file pill and make it the sole visible non-keyboard entry point
* Show the configured Context Composer shortcut in the context-usage tooltip
* Present Setup Wizard and MCP Server as compact icon-only toolbar controls
* Rename the Settings action to **Toggle Context Composer**
* Clamp tooltips to the display containing their hovered anchor
* Rename and refresh the Context Composer architecture documentation

## Implementation Notes

* Swift-facing shortcut and handler names use `toggleContextComposer` while retaining the persisted `toggleComposeInspector` key for existing custom bindings
* Setup Wizard and MCP Server remain semantically labeled for accessibility despite their icon-only presentation
* Tooltip and mention overlays share one screen-selection policy based on anchor intersection rather than the owner window’s majority display
* Tooltip geometry is isolated behind deterministic positioning coverage

## Review Approach

* A staged-diff `rp-review` covered toolbar behavior, shortcut persistence, accessibility, tooltip geometry, tests, and documentation
* Review identified the cross-display tooltip bug and icon-only accessibility gaps; both were fixed, with focused geometry regressions added

## Validation

Passed locally:

* `make dev-test FILTER=AgentModeChatSwitchActivationTests`
* `make dev-test FILTER=TooltipOverlayControllerTests`
* `make dev-test FILTER=MentionOverlayControllerTests`
* `make dev-lint`
* `make dev-swift-build PRODUCT=RepoPrompt`
* `make guardrails`
* Final packaged-app MCP smoke
* Push safety and outgoing-range secret scan

The full root suite was also run. Remaining Agent-run and Git-policy failures reproduced on the unchanged base commit; the Git fixtures additionally inherit a machine-global `.repo_ignore` rule.

## Screenshots
<p align="center">
<img width="955" height="1079" alt="Screenshot 2026-08-10 at 4 32 22 AM" src="https://github.com/user-attachments/assets/5ba42e4f-738f-43e8-954e-96cce9156609" />

<img width="958" height="1079" alt="Screenshot 2026-08-10 at 4 32 28 AM" src="https://github.com/user-attachments/assets/03635ec4-a3f3-45d0-896b-d9c1fe649725" />

<img width="1065" height="1078" alt="Screenshot 2026-08-10 at 4 32 32 AM" src="https://github.com/user-attachments/assets/a4faf753-7abb-42b2-8cff-03cf091a4ac7" />

<img width="957" height="1075" alt="Screenshot 2026-08-10 at 4 32 36 AM" src="https://github.com/user-attachments/assets/e5a8e826-8834-4e2e-90a9-51d5cee65a99" />

<img width="945" height="1072" alt="Screenshot 2026-08-10 at 4 32 48 AM" src="https://github.com/user-attachments/assets/cd9a37f3-3433-466f-b8bf-faaddd291e35" />

<img width="1505" height="611" alt="Screenshot 2026-08-10 at 4 33 49 AM" src="https://github.com/user-attachments/assets/ee55bbd0-7841-4017-80c1-050c8d0e3b69" />

<img width="1508" height="613" alt="Screenshot 2026-08-10 at 4 33 35 AM" src="https://github.com/user-attachments/assets/2472c1e6-794f-430a-91ad-d7f22900b578" />

<img width="742" height="121" alt="Screenshot 2026-08-10 at 4 33 11 AM" src="https://github.com/user-attachments/assets/e99b27bf-036a-4c63-a2ce-4fe11fe38728" />

<img width="1508" height="974" alt="Screenshot 2026-08-10 at 4 33 06 AM" src="https://github.com/user-attachments/assets/891e5f34-ac81-4a22-8f02-78d969cd6302" />
</p>