### PR TITLE
Agent Mode: share transient execution classification

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RepoPromptDomainRuntime
 
 @MainActor
 final class HeadlessAgentModeRunner {
@@ -167,7 +168,9 @@ final class HeadlessAgentModeRunner {
         lease: MCPBootstrapLease
     ) async {
         var providerInitializationCompleted = false
-        do {
+        let report = await DomainAgentRunExecutionCore.execute(
+            failureText: { "Agent failed: \($0.localizedDescription)" }
+        ) {
             await lease.providerInitializationStarted(provider: session.selectedAgent.rawValue)
             let stream = try await provider.streamAgentMessage(initialMessage, runID: runID)
             providerInitializationCompleted = true
@@ -182,7 +185,9 @@ final class HeadlessAgentModeRunner {
 
             for try await result in stream {
                 guard !Task.isCancelled else { break }
-                guard session.isCurrentRunAttempt(ownership, expectedRunID: runID) else { return }
+                guard session.isCurrentRunAttempt(ownership, expectedRunID: runID) else {
+                    return .superseded
+                }
                 session.recordRunProgress(ownership: ownership, kind: .providerEvent, stage: .running)
                 await hooks.transcript.handleHeadlessStreamResult(result, session, runID, runAttemptID)
             }
@@ -190,71 +195,59 @@ final class HeadlessAgentModeRunner {
             guard session.runID == runID,
                   session.activeRunAttemptID == runAttemptID
             else {
-                return
+                return .superseded
             }
+            return .completed(assistantText: nil)
+        }
 
-            await terminalCommitBarrier.commit(.init(
-                binding: hooks.bindTerminalSession(session),
-                ownership: ownership,
-                expectedRunID: runID,
-                terminalState: .completed,
-                source: "headless.completed",
-                attachmentReservationID: attachmentReservationID,
-                attachmentDisposition: .deleteFiles,
-                finalizeNonCodexUsage: true,
-                supportsFollowUp: false,
-                notifyTurnComplete: true,
-                prepareProviderState: {
-                    session.provider = nil
-                    session.clearRunID(ifCurrent: runID)
-                    return nil
-                }
-            ))
-        } catch is CancellationError {
+        guard case let .terminal(outcome) = report.result else { return }
+        let terminalState: AgentSessionRunState
+        let source: String
+        let notifyTurnComplete: Bool
+        let errorText: String?
+        switch outcome.kind {
+        case .completed:
+            terminalState = .completed
+            source = "headless.completed"
+            notifyTurnComplete = true
+            errorText = nil
+        case .cancelled:
             if !providerInitializationCompleted {
                 await lease.providerInitializationCompleted(provider: session.selectedAgent.rawValue, outcome: "cancelled")
             }
             hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
-            await terminalCommitBarrier.commit(.init(
-                binding: hooks.bindTerminalSession(session),
-                ownership: ownership,
-                expectedRunID: runID,
-                terminalState: .cancelled,
-                source: "headless.cancelled",
-                attachmentReservationID: attachmentReservationID,
-                attachmentDisposition: .deleteFiles,
-                finalizeNonCodexUsage: true,
-                supportsFollowUp: false,
-                notifyTurnComplete: false,
-                prepareProviderState: {
-                    session.provider = nil
-                    session.clearRunID(ifCurrent: runID)
-                    return nil
-                }
-            ))
-        } catch {
+            terminalState = .cancelled
+            source = "headless.cancelled"
+            notifyTurnComplete = false
+            errorText = nil
+        case .failed:
             if !providerInitializationCompleted {
                 await lease.providerInitializationCompleted(provider: session.selectedAgent.rawValue, outcome: "failed")
             }
             hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
-            await terminalCommitBarrier.commit(.init(
-                binding: hooks.bindTerminalSession(session),
-                ownership: ownership,
-                expectedRunID: runID,
-                terminalState: .failed,
-                source: "headless.failed",
-                errorText: "Agent failed: \(error.localizedDescription)",
-                attachmentReservationID: attachmentReservationID,
-                attachmentDisposition: .deleteFiles,
-                finalizeNonCodexUsage: true,
-                supportsFollowUp: false,
-                notifyTurnComplete: false,
-                prepareProviderState: {
-                    session.provider = nil
-                    session.clearRunID(ifCurrent: runID)
-                    return nil
-                }
-            ))
+            terminalState = .failed
+            source = "headless.failed"
+            notifyTurnComplete = false
+            errorText = outcome.assistantText
         }
+
+        await terminalCommitBarrier.commit(.init(
+            binding: hooks.bindTerminalSession(session),
+            ownership: ownership,
+            expectedRunID: runID,
+            terminalState: terminalState,
+            source: source,
+            errorText: errorText,
+            attachmentReservationID: attachmentReservationID,
+            attachmentDisposition: .deleteFiles,
+            finalizeNonCodexUsage: true,
+            supportsFollowUp: false,
+            notifyTurnComplete: notifyTurnComplete,
+            prepareProviderState: {
+                session.provider = nil
+                session.clearRunID(ifCurrent: runID)
+                return nil
+            }
+        ))
     }
 }

--- a/Sources/RepoPromptDomainRuntime/DomainAgentRunExecutionCore.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainAgentRunExecutionCore.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+// MARK: - Shared transient Agent run execution
+
+/// The host-controlled result of one provider operation.
+///
+/// Cancellation and failure are expressed by thrown errors so every execution
+/// host shares the same classification order. Supersession is explicit because
+/// it must never be mistaken for a missing terminal result.
+package enum DomainAgentRunExecutionOperationResult: Equatable, Sendable {
+    case completed(assistantText: String?)
+    case superseded
+}
+
+/// The presentation-free result returned to an Agent execution host.
+///
+/// Hosts remain responsible for mapping terminal outcomes into their canonical
+/// publication surface. This value owns no session, provider, or settlement
+/// state.
+package enum DomainAgentRunExecutionResult: Equatable, Sendable {
+    case terminal(DomainAgentRunTerminalOutcome)
+    case superseded
+}
+
+/// Deterministic lifecycle facts produced by one execution-core invocation.
+///
+/// The trace intentionally excludes provider payloads, display text, IDs, and
+/// timestamps so streaming and one-shot hosts can assert lifecycle parity.
+package enum DomainAgentRunExecutionTraceEvent: Equatable, Sendable {
+    case executionStarted
+    case terminalOutcomeProduced(DomainAgentRunTerminalOutcome.Kind)
+    case executionSuperseded
+}
+
+/// Immutable report from one shared execution-core invocation.
+package struct DomainAgentRunExecutionReport: Equatable, Sendable {
+    package let result: DomainAgentRunExecutionResult
+    package let trace: [DomainAgentRunExecutionTraceEvent]
+
+    package init(
+        result: DomainAgentRunExecutionResult,
+        trace: [DomainAgentRunExecutionTraceEvent]
+    ) {
+        self.result = result
+        self.trace = trace
+    }
+}
+
+/// Stateless classifier shared by app-hosted and direct/headless Agent runs.
+///
+/// This namespace deliberately owns no task, stream, provider, registration,
+/// epoch, cancellation handler, teardown, or publication capability. The
+/// caller supplies exactly one operation on its own isolation domain, then maps
+/// the returned report into its existing host and canonical lifecycle surfaces.
+package enum DomainAgentRunExecutionCore {
+    package static func execute(
+        isolation _: isolated (any Actor)? = #isolation,
+        failureReason: DomainAgentRunSnapshot.FailureReason = .agentError,
+        failureText: (any Error) -> String = { $0.localizedDescription },
+        operation: () async throws -> DomainAgentRunExecutionOperationResult
+    ) async -> DomainAgentRunExecutionReport {
+        let started: [DomainAgentRunExecutionTraceEvent] = [.executionStarted]
+        do {
+            switch try await operation() {
+            case let .completed(assistantText):
+                let outcome = DomainAgentRunTerminalOutcome.completed(assistantText: assistantText)
+                return terminalReport(outcome, after: started)
+            case .superseded:
+                return DomainAgentRunExecutionReport(
+                    result: .superseded,
+                    trace: started + [.executionSuperseded]
+                )
+            }
+        } catch is CancellationError {
+            return terminalReport(.cancelled(), after: started)
+        } catch {
+            return terminalReport(
+                .failed(assistantText: failureText(error), reason: failureReason),
+                after: started
+            )
+        }
+    }
+
+    private static func terminalReport(
+        _ outcome: DomainAgentRunTerminalOutcome,
+        after trace: [DomainAgentRunExecutionTraceEvent]
+    ) -> DomainAgentRunExecutionReport {
+        DomainAgentRunExecutionReport(
+            result: .terminal(outcome),
+            trace: trace + [.terminalOutcomeProduced(outcome.kind)]
+        )
+    }
+}

--- a/Sources/RepoPromptMCP/DirectHeadlessProviderCoordinator.swift
+++ b/Sources/RepoPromptMCP/DirectHeadlessProviderCoordinator.swift
@@ -157,7 +157,7 @@ actor DirectHeadlessProviderCoordinator {
         let capturedCarrierEnvironment = DomainChildLaunchContext.current?.environment ?? [:]
         let task = Task { [weak self] in
             guard let self else { return }
-            do {
+            let report = await DomainAgentRunExecutionCore.execute {
                 let text = try await runProviderOnce(
                     message: message,
                     providerID: descriptor.id,
@@ -165,15 +165,10 @@ actor DirectHeadlessProviderCoordinator {
                     request: capturedRequest,
                     carrierEnvironment: capturedCarrierEnvironment
                 )
-                await finishAgent(sessionID: sessionID, outcome: .completed(assistantText: text))
-            } catch is CancellationError {
-                await finishAgent(sessionID: sessionID, outcome: .cancelled())
-            } catch {
-                await finishAgent(
-                    sessionID: sessionID,
-                    outcome: .failed(assistantText: error.localizedDescription)
-                )
+                return .completed(assistantText: text)
             }
+            guard case let .terminal(outcome) = report.result else { return }
+            await finishAgent(sessionID: sessionID, outcome: outcome)
         }
         agents[sessionID]?.task = task
         await runtime.agentSessionStore.installCancellationHandler(registration: registration) { [weak self] in

--- a/Tests/RepoPromptDomainRuntimeTests/DomainAgentRunExecutionContractsTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainAgentRunExecutionContractsTests.swift
@@ -40,6 +40,133 @@ final class DomainAgentRunExecutionContractsTests: XCTestCase {
         assertSendable(DomainAgentRunCancellationCompletion.terminalPublished)
         assertSendable(DomainAgentRunAttachmentTurnDisposition.restoreToPending)
         assertSendable(DomainAgentRunTerminalOutcome.completed(assistantText: "done"))
+        assertSendable(DomainAgentRunExecutionOperationResult.completed(assistantText: "done"))
+        assertSendable(DomainAgentRunExecutionResult.superseded)
+        assertSendable(DomainAgentRunExecutionTraceEvent.executionStarted)
+        assertSendable(DomainAgentRunExecutionReport(
+            result: .superseded,
+            trace: [.executionStarted, .executionSuperseded]
+        ))
+    }
+
+    // MARK: - Shared transient execution core
+
+    func testExecutionCoreClassifiesCompletionAndInvokesOperationOnce() async {
+        var invocationCount = 0
+
+        let report = await DomainAgentRunExecutionCore.execute {
+            invocationCount += 1
+            return .completed(assistantText: "done")
+        }
+
+        XCTAssertEqual(invocationCount, 1)
+        XCTAssertEqual(
+            report,
+            DomainAgentRunExecutionReport(
+                result: .terminal(.completed(assistantText: "done")),
+                trace: [.executionStarted, .terminalOutcomeProduced(.completed)]
+            )
+        )
+    }
+
+    func testExecutionCoreClassifiesCancellationWithoutCallingFailureMapper() async {
+        var failureMapperCallCount = 0
+
+        let report = await DomainAgentRunExecutionCore.execute(failureText: { _ in
+            failureMapperCallCount += 1
+            return "unexpected"
+        }) {
+            throw CancellationError()
+        }
+
+        XCTAssertEqual(failureMapperCallCount, 0)
+        XCTAssertEqual(
+            report,
+            DomainAgentRunExecutionReport(
+                result: .terminal(.cancelled()),
+                trace: [.executionStarted, .terminalOutcomeProduced(.cancelled)]
+            )
+        )
+    }
+
+    func testExecutionCorePreservesFailureMappingAndClassification() async {
+        var failureMapperCallCount = 0
+
+        let report = await DomainAgentRunExecutionCore.execute(
+            failureReason: .timeout,
+            failureText: { _ in
+                failureMapperCallCount += 1
+                return "mapped failure"
+            }
+        ) {
+            throw ExecutionFixtureError.failed
+        }
+
+        XCTAssertEqual(failureMapperCallCount, 1)
+        XCTAssertEqual(
+            report,
+            DomainAgentRunExecutionReport(
+                result: .terminal(.failed(assistantText: "mapped failure", reason: .timeout)),
+                trace: [.executionStarted, .terminalOutcomeProduced(.failed)]
+            )
+        )
+    }
+
+    func testExecutionCoreKeepsSupersessionExplicitAndNonterminal() async {
+        var failureMapperCallCount = 0
+
+        let report = await DomainAgentRunExecutionCore.execute(failureText: { _ in
+            failureMapperCallCount += 1
+            return "unexpected"
+        }) {
+            .superseded
+        }
+
+        XCTAssertEqual(failureMapperCallCount, 0)
+        XCTAssertEqual(
+            report,
+            DomainAgentRunExecutionReport(
+                result: .superseded,
+                trace: [.executionStarted, .executionSuperseded]
+            )
+        )
+    }
+
+    func testOneShotAndStreamingFixturesHaveDeterministicLifecycleParity() async {
+        for scenario in ExecutionFixtureScenario.allCases {
+            let oneShot = await executionFixtureReport(style: .oneShot, scenario: scenario)
+            let streaming = await executionFixtureReport(style: .streaming, scenario: scenario)
+
+            XCTAssertEqual(streaming, oneShot, "scenario: \(scenario)")
+        }
+    }
+
+    func testExecutionCorePreservesCallerActorIsolation() async {
+        let mainActorProbe = await MainActorExecutionProbe()
+        let mainActorReport = await mainActorProbe.execute()
+        let actorProbe = ExecutionActorProbe()
+        let actorReport = await actorProbe.execute()
+        let mainActorInvocationCount = await mainActorProbe.invocationCount
+        let actorInvocationCount = await actorProbe.invocationCount
+
+        XCTAssertEqual(mainActorInvocationCount, 1)
+        XCTAssertEqual(actorInvocationCount, 1)
+        XCTAssertEqual(mainActorReport.trace, [.executionStarted, .terminalOutcomeProduced(.completed)])
+        XCTAssertEqual(actorReport.trace, mainActorReport.trace)
+    }
+
+    func testExecutionCoreDoesNotReinterpretAlreadyCancelledTask() async {
+        let report = await Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await DomainAgentRunExecutionCore.execute {
+                .completed(assistantText: "provider returned normally")
+            }
+        }.value
+
+        XCTAssertEqual(
+            report.result,
+            .terminal(.completed(assistantText: "provider returned normally"))
+        )
     }
 
     // MARK: - Terminal outcome result contracts
@@ -134,6 +261,52 @@ final class DomainAgentRunExecutionContractsTests: XCTestCase {
 
     // MARK: - Helpers
 
+    private enum ExecutionFixtureError: Error {
+        case failed
+    }
+
+    private enum ExecutionFixtureStyle {
+        case oneShot
+        case streaming
+    }
+
+    private enum ExecutionFixtureScenario: CaseIterable {
+        case completed
+        case cancelled
+        case failed
+        case superseded
+    }
+
+    private func executionFixtureReport(
+        style: ExecutionFixtureStyle,
+        scenario: ExecutionFixtureScenario
+    ) async -> DomainAgentRunExecutionReport {
+        await DomainAgentRunExecutionCore.execute(failureText: { _ in "fixture failure" }) {
+            switch scenario {
+            case .completed:
+                if style == .streaming {
+                    let events = AsyncStream<Int> { continuation in
+                        continuation.yield(1)
+                        continuation.yield(2)
+                        continuation.finish()
+                    }
+                    var consumed: [Int] = []
+                    for await event in events {
+                        consumed.append(event)
+                    }
+                    XCTAssertEqual(consumed, [1, 2])
+                }
+                return .completed(assistantText: "fixture complete")
+            case .cancelled:
+                throw CancellationError()
+            case .failed:
+                throw ExecutionFixtureError.failed
+            case .superseded:
+                return .superseded
+            }
+        }
+    }
+
     private func assertSendable(_ value: some Sendable & Equatable) {
         XCTAssertEqual(value, value)
     }
@@ -204,5 +377,28 @@ final class DomainAgentRunExecutionContractsTests: XCTestCase {
             persistence: DomainPersistenceCoordinator(configuration: configuration, identity: identity),
             profileIdentifier: profile
         )
+    }
+}
+
+@MainActor
+private final class MainActorExecutionProbe {
+    private(set) var invocationCount = 0
+
+    func execute() async -> DomainAgentRunExecutionReport {
+        await DomainAgentRunExecutionCore.execute {
+            invocationCount += 1
+            return .completed(assistantText: nil)
+        }
+    }
+}
+
+private actor ExecutionActorProbe {
+    private(set) var invocationCount = 0
+
+    func execute() async -> DomainAgentRunExecutionReport {
+        await DomainAgentRunExecutionCore.execute {
+            invocationCount += 1
+            return .completed(assistantText: nil)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a stateless domain execution classifier for completed, cancelled, failed, and superseded outcomes
- route both HeadlessAgentModeRunner and DirectHeadlessProviderCoordinator through the shared classifier
- add focused classification, streaming parity, actor-isolation, cancellation, and settlement-composition coverage

## Why
The app-integrated headless runner and direct-headless coordinator independently classified the same transient provider outcomes before handing terminal publication to existing domain authorities. This creates one neutral execution vocabulary without moving durable settlement, persistence, or provider ownership.

## Authority boundaries
- DomainAgentRunSessionStore remains the sole domain session and persistence authority
- existing terminal commit barriers and finishAgent retain settlement and publication ownership
- no parallel cancellation, restoration, persistence, stream, or provider authority
- no schema, Package.swift, SwiftUI, Oracle, Prompt, or Settings changes

## Validation
- make dev-test FILTER=DomainAgentRunExecutionContractsTests: 13 tests, 0 failures, ticket c1c59b58-b280-4d41-81a8-e372da139621
- make dev-lint: passed, ticket 4ff3f93d-62b2-4d0b-adaa-27b9b73b13a8
- coordinated format: passed, ticket 87e95fd8-6b7f-4902-939b-a366860b8620
- mandatory commit and push preflights: passed

## Review
Independent Fable 5 High review found no must-fix issues and judged the change merge-ready. It verified statelessness, parity with both prior adapters, bounded privacy-safe traces, caller actor-isolation preservation, and unchanged durable terminal authority.

## Non-goals
- migrate all providers
- redesign cancellation semantics
- move durable settlement
- thin the SwiftUI presentation layer
- add a module boundary