### PR TITLE
Oracle: extract headless streaming runtime

### DIFF
--- a/Sources/RepoPrompt/Features/Chat/Services/OracleHeadlessRuntime.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/OracleHeadlessRuntime.swift
@@ -59,7 +59,7 @@ final class OracleHeadlessRuntime {
                 )
                 #if DEBUG
                     print(
-                        "[OracleViewModel] provider conversation cleanup action=delete " +
+                        "[OracleHeadlessRuntime] provider conversation cleanup action=delete " +
                             "provider=\(handle.provider) status=\(outcome.status) " +
                             "message=\(outcome.message ?? "")"
                     )
@@ -114,7 +114,7 @@ final class OracleHeadlessRuntime {
         ) { group in
             group.addTask {
                 try await Task.sleep(for: timeout)
-                throw ChatToolError.internalError("Stream timed out after 4 hours of inactivity.")
+                throw ChatToolError.internalError("Stream timed out before completion.")
             }
 
             group.addTask { [stream, onProgress, cleanupHandleBox] in

--- a/Sources/RepoPrompt/Features/Chat/Services/OracleHeadlessRuntime.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/OracleHeadlessRuntime.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+private actor OracleHeadlessCleanupHandleBox {
+    private var handle: ProviderConversationCleanupHandle?
+
+    func update(_ handle: ProviderConversationCleanupHandle) {
+        self.handle = handle
+    }
+
+    func current() -> ProviderConversationCleanupHandle? {
+        handle
+    }
+}
+
+/// Executes Oracle requests that do not participate in the live chat transcript.
+///
+/// This runtime owns only provider-stream lifecycle. Prompt construction, chat-session
+/// persistence, transcript state, and presentation remain with `OracleViewModel`.
+@MainActor
+final class OracleHeadlessRuntime {
+    struct Output {
+        let text: String
+        let tokenInfo: ChatTokenInfo
+        let providerCleanupHandle: ProviderConversationCleanupHandle?
+    }
+
+    typealias SendPrompt = (
+        _ message: AIMessage,
+        _ model: AIModel
+    ) async throws -> (
+        id: ChatStreamID,
+        stream: AsyncThrowingStream<ChatStreamOutput, Error>
+    )
+    typealias CancelStream = (_ id: ChatStreamID) async -> Void
+    typealias CleanupConversation = (
+        _ handle: ProviderConversationCleanupHandle,
+        _ model: AIModel
+    ) async -> Void
+
+    private let sendPrompt: SendPrompt
+    private let cancelStream: CancelStream
+    private let cleanupConversation: CleanupConversation
+    private let timeout: Duration
+    private var streamIDsByTabID: [UUID: ChatStreamID] = [:]
+
+    convenience init(aiQueriesService: AIQueriesService) {
+        self.init(
+            sendPrompt: { message, model in
+                try await aiQueriesService.sendPrompt(message, model: model)
+            },
+            cancelStream: { streamID in
+                await aiQueriesService.cancelStream(id: streamID)
+            },
+            cleanupConversation: { handle, model in
+                let outcome = await aiQueriesService.cleanupProviderConversation(
+                    handle: handle,
+                    model: model,
+                    action: .delete
+                )
+                #if DEBUG
+                    print(
+                        "[OracleViewModel] provider conversation cleanup action=delete " +
+                            "provider=\(handle.provider) status=\(outcome.status) " +
+                            "message=\(outcome.message ?? "")"
+                    )
+                #endif
+            }
+        )
+    }
+
+    init(
+        sendPrompt: @escaping SendPrompt,
+        cancelStream: @escaping CancelStream,
+        cleanupConversation: @escaping CleanupConversation,
+        timeout: Duration = .seconds(4 * 60 * 60)
+    ) {
+        self.sendPrompt = sendPrompt
+        self.cancelStream = cancelStream
+        self.cleanupConversation = cleanupConversation
+        self.timeout = timeout
+    }
+
+    func execute(
+        message: AIMessage,
+        model: AIModel,
+        tabID: UUID,
+        completionPolicy: OracleResponseCompletionPolicy,
+        onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
+    ) async throws -> Output {
+        try Task.checkCancellation()
+
+        let (streamID, stream) = try await sendPrompt(message, model)
+        let cleanupHandleBox = OracleHeadlessCleanupHandleBox()
+        var completedSuccessfully = false
+        defer {
+            if !completedSuccessfully {
+                Task {
+                    await self.cleanup(
+                        cleanupHandleBox.current(),
+                        model: model
+                    )
+                }
+            }
+        }
+
+        streamIDsByTabID[tabID] = streamID
+        defer {
+            streamIDsByTabID.removeValue(forKey: tabID)
+        }
+
+        let timeout = timeout
+        let (finalText, _, finalTokenInfo, providerCleanupHandle, terminalOutcome) = try await withThrowingTaskGroup(
+            of: (String, String, ChatTokenInfo, ProviderConversationCleanupHandle?, ChatStreamTerminalOutcome?).self
+        ) { group in
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw ChatToolError.internalError("Stream timed out after 4 hours of inactivity.")
+            }
+
+            group.addTask { [stream, onProgress, cleanupHandleBox] in
+                var accumulatedText = ""
+                var accumulatedReasoning = ""
+                var tokens = ChatTokenInfo()
+                var cleanupHandle: ProviderConversationCleanupHandle?
+                var terminalOutcome: ChatStreamTerminalOutcome?
+                var iterator = stream.makeAsyncIterator()
+
+                while let chunk = try await iterator.next() {
+                    accumulatedText += chunk.text
+                    if let reasoning = chunk.reasoning, !reasoning.isEmpty {
+                        accumulatedReasoning += reasoning
+                        accumulatedReasoning = ReasoningTextFormatter.normalize(accumulatedReasoning)
+                    }
+                    if chunk.tokens.promptTokens != nil ||
+                        chunk.tokens.completionTokens != nil ||
+                        chunk.tokens.cost != nil
+                    {
+                        tokens = chunk.tokens
+                    }
+                    if let handle = chunk.cleanupHandle {
+                        cleanupHandle = handle
+                        await cleanupHandleBox.update(handle)
+                    }
+                    if let onProgress {
+                        let text = accumulatedText
+                        let reasoning = accumulatedReasoning.isEmpty ? nil : accumulatedReasoning
+                        await MainActor.run { onProgress(text, reasoning) }
+                    }
+                    if let outcome = chunk.terminalOutcome {
+                        terminalOutcome = outcome
+                        break
+                    }
+                }
+                return (
+                    accumulatedText,
+                    accumulatedReasoning,
+                    tokens,
+                    cleanupHandle,
+                    terminalOutcome
+                )
+            }
+
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+
+        if completionPolicy == .contextBuilderStrict {
+            switch terminalOutcome {
+            case .completed:
+                break
+            case let .incomplete(reason):
+                throw OracleContextBuilderCompletionError.providerTerminatedIncomplete(reason: reason)
+            case nil:
+                throw OracleContextBuilderCompletionError.streamEndedWithoutProviderCompletion
+            }
+        }
+
+        let trimmedResponse = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedResponse.isEmpty else {
+            if completionPolicy == .contextBuilderStrict {
+                throw OracleContextBuilderCompletionError.emptyProcessedContent
+            }
+            throw ChatToolError.internalError("Request produced no content.")
+        }
+
+        completedSuccessfully = true
+        return Output(
+            text: trimmedResponse,
+            tokenInfo: finalTokenInfo,
+            providerCleanupHandle: providerCleanupHandle
+        )
+    }
+
+    func hasActiveStream(for tabID: UUID) -> Bool {
+        streamIDsByTabID[tabID] != nil
+    }
+
+    func cancelStream(for tabID: UUID) async {
+        guard let streamID = streamIDsByTabID.removeValue(forKey: tabID) else { return }
+        await cancelStream(streamID)
+    }
+
+    func cancelAllStreams() async {
+        let streamIDs = Array(streamIDsByTabID.values)
+        streamIDsByTabID.removeAll(keepingCapacity: false)
+        for streamID in streamIDs {
+            await cancelStream(streamID)
+        }
+    }
+
+    func cleanup(
+        _ handle: ProviderConversationCleanupHandle?,
+        model: AIModel
+    ) async {
+        guard let handle else { return }
+        await cleanupConversation(handle, model)
+    }
+}

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -1,18 +1,6 @@
 import Foundation
 import MCP // <- required for `Value`
 
-private actor OracleProviderCleanupHandleBox {
-    private var handle: ProviderConversationCleanupHandle?
-
-    func update(_ handle: ProviderConversationCleanupHandle) {
-        self.handle = handle
-    }
-
-    func current() -> ProviderConversationCleanupHandle? {
-        handle
-    }
-}
-
 // MARK: - MCP Tool helpers (moved from MCPServerViewModel)
 
 extension OracleViewModel {
@@ -1640,101 +1628,29 @@ extension OracleViewModel {
 
         try Task.checkCancellation()
 
-        // 4) Stream via AIQueriesService WITHOUT touching OracleViewModel.messages
-        let (streamID, stream) = try await aiQueriesService.sendPrompt(aiMessage, model: model)
-        let cleanupHandleBox = OracleProviderCleanupHandleBox()
+        // 4) Execute provider streaming without touching OracleViewModel.messages.
+        let runtimeOutput = try await headlessRuntime.execute(
+            message: aiMessage,
+            model: model,
+            tabID: tabID,
+            completionPolicy: completionPolicy,
+            onProgress: onProgress
+        )
         var didScheduleProviderCleanup = false
         defer {
             if !didScheduleProviderCleanup {
                 Task {
-                    await self.cleanupOracleProviderConversation(cleanupHandleBox.current(), model: model)
+                    await self.headlessRuntime.cleanup(
+                        runtimeOutput.providerCleanupHandle,
+                        model: model
+                    )
                 }
             }
         }
 
-        // Register this headless stream by tab ID so Discover can cancel it.
-        headlessStreamsByTabID[tabID] = streamID
-        defer {
-            // Always clean up mapping when this headless run finishes or errors.
-            headlessStreamsByTabID.removeValue(forKey: tabID)
-        }
-
-        // Stream with 4-hour timeout using single task group
-        // (One Task.sleep for entire stream, not per-chunk - avoids CPU churn)
-        let timeout: Duration = .seconds(4 * 60 * 60)
-
-        let (finalText, _, finalTokenInfo, providerCleanupHandle, terminalOutcome) = try await withThrowingTaskGroup(
-            of: (String, String, ChatTokenInfo, ProviderConversationCleanupHandle?, ChatStreamTerminalOutcome?).self
-        ) { group in
-            // Timeout task - throws after 4 hours
-            group.addTask {
-                try await Task.sleep(for: timeout)
-                throw ChatToolError.internalError("Stream timed out after 4 hours of inactivity.")
-            }
-
-            // Streaming task - accumulates locally, returns result
-            group.addTask { [stream, onProgress, cleanupHandleBox] in
-                var accText = ""
-                var accReasoning = ""
-                var tokens = ChatTokenInfo()
-                var cleanupHandle: ProviderConversationCleanupHandle?
-                var terminalOutcome: ChatStreamTerminalOutcome?
-                var iterator = stream.makeAsyncIterator()
-
-                while let chunk = try await iterator.next() {
-                    accText += chunk.text
-                    if let reasoning = chunk.reasoning, !reasoning.isEmpty {
-                        accReasoning += reasoning
-                        accReasoning = ReasoningTextFormatter.normalize(accReasoning)
-                    }
-                    if chunk.tokens.promptTokens != nil ||
-                        chunk.tokens.completionTokens != nil ||
-                        chunk.tokens.cost != nil
-                    {
-                        tokens = chunk.tokens
-                    }
-                    if let handle = chunk.cleanupHandle {
-                        cleanupHandle = handle
-                        await cleanupHandleBox.update(handle)
-                    }
-                    // Only hop to MainActor for progress callback
-                    if let onProgress {
-                        let text = accText
-                        let reasoning = accReasoning.isEmpty ? nil : accReasoning
-                        await MainActor.run { onProgress(text, reasoning) }
-                    }
-                    if let outcome = chunk.terminalOutcome {
-                        terminalOutcome = outcome
-                        break
-                    }
-                }
-                return (accText, accReasoning, tokens, cleanupHandle, terminalOutcome)
-            }
-
-            // Wait for stream to complete or timeout to fire
-            let result = try await group.next()!
-            group.cancelAll()
-            return result
-        }
-
-        if completionPolicy == .contextBuilderStrict {
-            switch terminalOutcome {
-            case .completed:
-                break
-            case let .incomplete(reason):
-                throw OracleContextBuilderCompletionError.providerTerminatedIncomplete(reason: reason)
-            case nil:
-                throw OracleContextBuilderCompletionError.streamEndedWithoutProviderCompletion
-            }
-        }
-
-        let trimmedResponse = finalText.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        guard !trimmedResponse.isEmpty else {
-            if completionPolicy == .contextBuilderStrict {
-                throw OracleContextBuilderCompletionError.emptyProcessedContent
-            }
-            throw ChatToolError.internalError("Request produced no content.")
-        }
+        let trimmedResponse = runtimeOutput.text
+        let finalTokenInfo = runtimeOutput.tokenInfo
+        let providerCleanupHandle = runtimeOutput.providerCleanupHandle
 
         // 5) Create persisted ChatSession
         let (session, shortID) = try await createSessionFromHeadlessRun(
@@ -1752,7 +1668,7 @@ extension OracleViewModel {
         )
 
         didScheduleProviderCleanup = true
-        Task { await cleanupOracleProviderConversation(providerCleanupHandle, model: model) }
+        Task { await headlessRuntime.cleanup(providerCleanupHandle, model: model) }
 
         // 6) Return ChatSendReply
         return ChatSendReply(

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -468,11 +468,6 @@ class OracleViewModel: ObservableObject {
     /// Maps AI message/query IDs to the underlying AIQueriesService stream IDs for targeted cancellation.
     private var streamIDsByQueryId: [UUID: ChatStreamID] = [:]
 
-    /// Active headless (plan/question) streams keyed by tab ID.
-    /// Used by Discover to cancel background plan generation.
-    /// Note: Internal (not private) to allow access from OracleViewModel+MCP.swift extension.
-    var headlessStreamsByTabID: [UUID: ChatStreamID] = [:]
-
     /// Stores ephemeral message state that persists even when messages array is cleared
     let ephemeralState = EphemeralMessageState()
 
@@ -1071,6 +1066,7 @@ class OracleViewModel: ObservableObject {
 
     // Dependencies
     let aiQueriesService: AIQueriesService
+    let headlessRuntime: OracleHeadlessRuntime
     var promptViewModel: PromptViewModel
 
     #if DEBUG
@@ -1133,6 +1129,7 @@ class OracleViewModel: ObservableObject {
         chatData: ChatDataService
     ) {
         self.aiQueriesService = aiQueriesService
+        headlessRuntime = OracleHeadlessRuntime(aiQueriesService: aiQueriesService)
         self.promptViewModel = promptViewModel
         self.workspaceManager = workspaceManager
         self.chatData = chatData
@@ -1225,15 +1222,11 @@ class OracleViewModel: ObservableObject {
         activeRetryTask?.cancel()
 
         // Cancel any active headless and chat streams
-        let headlessStreamIDs = Array(headlessStreamsByTabID.values)
+        let headlessRuntime = headlessRuntime
         let chatStreamIDs = Array(streamIDsByQueryId.values)
         let queriesService = aiQueriesService
         Task {
-            // Cancel headless streams (plan/question generation)
-            for streamID in headlessStreamIDs {
-                await queriesService.cancelStream(id: streamID)
-            }
-            // Cancel any active chat streams
+            await headlessRuntime.cancelAllStreams()
             for streamID in chatStreamIDs {
                 await queriesService.cancelStream(id: streamID)
             }
@@ -3619,9 +3612,7 @@ class OracleViewModel: ObservableObject {
     /// Called by ContextBuilderAgentViewModel when user cancels background plan generation.
     @MainActor
     func cancelHeadlessStream(forTabID tabID: UUID) async {
-        guard let streamID = headlessStreamsByTabID[tabID] else { return }
-        headlessStreamsByTabID.removeValue(forKey: tabID)
-        await aiQueriesService.cancelStream(id: streamID)
+        await headlessRuntime.cancelStream(for: tabID)
     }
 
     @MainActor
@@ -3636,7 +3627,7 @@ class OracleViewModel: ObservableObject {
     private func handleComposeTabsWillClose(_ tabIDs: Set<UUID>) async {
         for tabID in tabIDs {
             // 1. Cancel headless stream (plan/question generation) for this tab
-            if headlessStreamsByTabID[tabID] != nil {
+            if headlessRuntime.hasActiveStream(for: tabID) {
                 await cancelHeadlessStream(forTabID: tabID)
             }
 

--- a/Tests/RepoPromptTests/Chat/OracleHeadlessRuntimeTests.swift
+++ b/Tests/RepoPromptTests/Chat/OracleHeadlessRuntimeTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class OracleHeadlessRuntimeTests: XCTestCase {
+    @MainActor
+    func testExecuteAccumulatesStreamOutputAndClearsTabRegistration() async throws {
+        let tabID = UUID()
+        let streamID = UUID()
+        var progressText: [String] = []
+
+        let runtime = OracleHeadlessRuntime(
+            sendPrompt: { _, _ in
+                let stream = AsyncThrowingStream<ChatStreamOutput, Error> { continuation in
+                    continuation.yield(
+                        ChatStreamOutput(
+                            text: "  Hello ",
+                            reasoning: nil,
+                            tokens: ChatTokenInfo(promptTokens: 1)
+                        )
+                    )
+                    continuation.yield(
+                        ChatStreamOutput(
+                            text: "world  ",
+                            reasoning: nil,
+                            tokens: ChatTokenInfo(promptTokens: 2, completionTokens: 3, cost: 0.25),
+                            terminalOutcome: .completed
+                        )
+                    )
+                    continuation.finish()
+                }
+                return (streamID, stream)
+            },
+            cancelStream: { _ in },
+            cleanupConversation: { _, _ in }
+        )
+
+        let output = try await runtime.execute(
+            message: AIMessage(systemPrompt: "system", userMessage: "prompt"),
+            model: .claude4Sonnet,
+            tabID: tabID,
+            completionPolicy: .contextBuilderStrict,
+            onProgress: { text, _ in progressText.append(text) }
+        )
+
+        XCTAssertEqual(output.text, "Hello world")
+        XCTAssertEqual(output.tokenInfo.promptTokens, 2)
+        XCTAssertEqual(output.tokenInfo.completionTokens, 3)
+        XCTAssertEqual(output.tokenInfo.cost, 0.25)
+        XCTAssertEqual(progressText, ["  Hello ", "  Hello world  "])
+        XCTAssertFalse(runtime.hasActiveStream(for: tabID))
+    }
+
+    @MainActor
+    func testStrictIncompleteTerminationFailsAndCleansUpProviderConversation() async throws {
+        let tabID = UUID()
+        let handle = ProviderConversationCleanupHandle(
+            provider: "test-provider",
+            conversationID: "conversation-1"
+        )
+        let cleanupExpectation = expectation(description: "provider cleanup")
+
+        let runtime = OracleHeadlessRuntime(
+            sendPrompt: { _, _ in
+                let stream = AsyncThrowingStream<ChatStreamOutput, Error> { continuation in
+                    continuation.yield(
+                        ChatStreamOutput(
+                            text: "partial",
+                            reasoning: nil,
+                            tokens: ChatTokenInfo(),
+                            terminalOutcome: .incomplete(reason: "max_tokens"),
+                            cleanupHandle: handle
+                        )
+                    )
+                    continuation.finish()
+                }
+                return (UUID(), stream)
+            },
+            cancelStream: { _ in },
+            cleanupConversation: { cleanedHandle, _ in
+                XCTAssertEqual(cleanedHandle, handle)
+                cleanupExpectation.fulfill()
+            }
+        )
+
+        do {
+            _ = try await runtime.execute(
+                message: AIMessage(systemPrompt: "system", userMessage: "prompt"),
+                model: .claude4Sonnet,
+                tabID: tabID,
+                completionPolicy: .contextBuilderStrict
+            )
+            XCTFail("Expected strict incomplete termination to fail")
+        } catch {
+            XCTAssertEqual(
+                error as? OracleContextBuilderCompletionError,
+                .providerTerminatedIncomplete(reason: "max_tokens")
+            )
+        }
+
+        await fulfillment(of: [cleanupExpectation], timeout: 1)
+        XCTAssertFalse(runtime.hasActiveStream(for: tabID))
+    }
+
+    @MainActor
+    func testCancelStreamTargetsOnlyRegisteredTabStream() async throws {
+        let tabID = UUID()
+        let streamID = UUID()
+        let controller = OracleHeadlessTestStreamController()
+
+        let runtime = OracleHeadlessRuntime(
+            sendPrompt: { _, _ in
+                let stream = AsyncThrowingStream<ChatStreamOutput, Error> { continuation in
+                    Task { await controller.install(continuation) }
+                    continuation.yield(
+                        ChatStreamOutput(
+                            text: "partial",
+                            reasoning: nil,
+                            tokens: ChatTokenInfo()
+                        )
+                    )
+                }
+                return (streamID, stream)
+            },
+            cancelStream: { cancelledStreamID in
+                await controller.recordCancellation(cancelledStreamID)
+                await controller.finish()
+            },
+            cleanupConversation: { _, _ in }
+        )
+
+        let execution = Task { @MainActor in
+            try await runtime.execute(
+                message: AIMessage(systemPrompt: "system", userMessage: "prompt"),
+                model: .claude4Sonnet,
+                tabID: tabID,
+                completionPolicy: .interactive
+            )
+        }
+
+        for _ in 0 ..< 100 where !runtime.hasActiveStream(for: tabID) {
+            await Task.yield()
+        }
+        XCTAssertTrue(runtime.hasActiveStream(for: tabID))
+
+        await runtime.cancelStream(for: tabID)
+        let output = try await execution.value
+
+        XCTAssertEqual(output.text, "partial")
+        let cancelledStreamIDs = await controller.cancelledStreamIDs()
+        XCTAssertEqual(cancelledStreamIDs, [streamID])
+        XCTAssertFalse(runtime.hasActiveStream(for: tabID))
+    }
+}
+
+private actor OracleHeadlessTestStreamController {
+    private var continuation: AsyncThrowingStream<ChatStreamOutput, Error>.Continuation?
+    private var cancellations: [ChatStreamID] = []
+
+    func install(_ continuation: AsyncThrowingStream<ChatStreamOutput, Error>.Continuation) {
+        self.continuation = continuation
+    }
+
+    func recordCancellation(_ streamID: ChatStreamID) {
+        cancellations.append(streamID)
+    }
+
+    func finish() {
+        continuation?.finish()
+        continuation = nil
+    }
+
+    func cancelledStreamIDs() -> [ChatStreamID] {
+        cancellations
+    }
+}

--- a/Tests/RepoPromptTests/Chat/OracleHeadlessRuntimeTests.swift
+++ b/Tests/RepoPromptTests/Chat/OracleHeadlessRuntimeTests.swift
@@ -107,11 +107,16 @@ final class OracleHeadlessRuntimeTests: XCTestCase {
         let tabID = UUID()
         let streamID = UUID()
         let controller = OracleHeadlessTestStreamController()
+        let continuationInstalled = expectation(description: "stream continuation installed")
+        let progressObserved = expectation(description: "runtime consumed first stream chunk")
 
         let runtime = OracleHeadlessRuntime(
             sendPrompt: { _, _ in
                 let stream = AsyncThrowingStream<ChatStreamOutput, Error> { continuation in
-                    Task { await controller.install(continuation) }
+                    Task {
+                        await controller.install(continuation)
+                        await MainActor.run { continuationInstalled.fulfill() }
+                    }
                     continuation.yield(
                         ChatStreamOutput(
                             text: "partial",
@@ -126,7 +131,8 @@ final class OracleHeadlessRuntimeTests: XCTestCase {
                 await controller.recordCancellation(cancelledStreamID)
                 await controller.finish()
             },
-            cleanupConversation: { _, _ in }
+            cleanupConversation: { _, _ in },
+            timeout: .seconds(2)
         )
 
         let execution = Task { @MainActor in
@@ -134,22 +140,37 @@ final class OracleHeadlessRuntimeTests: XCTestCase {
                 message: AIMessage(systemPrompt: "system", userMessage: "prompt"),
                 model: .claude4Sonnet,
                 tabID: tabID,
-                completionPolicy: .interactive
+                completionPolicy: .interactive,
+                onProgress: { _, _ in progressObserved.fulfill() }
             )
         }
 
-        for _ in 0 ..< 100 where !runtime.hasActiveStream(for: tabID) {
-            await Task.yield()
+        await fulfillment(of: [continuationInstalled, progressObserved], timeout: 1)
+        guard await controller.hasInstalledContinuation(),
+              runtime.hasActiveStream(for: tabID)
+        else {
+            await controller.finish()
+            execution.cancel()
+            _ = try? await execution.value
+            XCTFail("Expected a registered stream with an installed continuation")
+            return
         }
-        XCTAssertTrue(runtime.hasActiveStream(for: tabID))
 
-        await runtime.cancelStream(for: tabID)
-        let output = try await execution.value
+        do {
+            await runtime.cancelStream(for: tabID)
+            let output = try await execution.value
+            await controller.finish()
 
-        XCTAssertEqual(output.text, "partial")
-        let cancelledStreamIDs = await controller.cancelledStreamIDs()
-        XCTAssertEqual(cancelledStreamIDs, [streamID])
-        XCTAssertFalse(runtime.hasActiveStream(for: tabID))
+            XCTAssertEqual(output.text, "partial")
+            let cancelledStreamIDs = await controller.cancelledStreamIDs()
+            XCTAssertEqual(cancelledStreamIDs, [streamID])
+            XCTAssertFalse(runtime.hasActiveStream(for: tabID))
+        } catch {
+            await controller.finish()
+            execution.cancel()
+            _ = try? await execution.value
+            throw error
+        }
     }
 }
 
@@ -163,6 +184,10 @@ private actor OracleHeadlessTestStreamController {
 
     func recordCancellation(_ streamID: ChatStreamID) {
         cancellations.append(streamID)
+    }
+
+    func hasInstalledContinuation() -> Bool {
+        continuation != nil
     }
 
     func finish() {


### PR DESCRIPTION
## Summary
- extract headless provider streaming, timeout, progress accumulation, terminal validation, cleanup, and tab-scoped cancellation into OracleHeadlessRuntime
- keep prompt and model construction, transcript and message stores, session persistence, and presentation state in OracleViewModel
- add focused runtime completion, terminal validation, and cancellation coverage

## Why
OracleViewModel directly owned transport and stream lifecycle orchestration alongside presentation and persistence concerns. This introduces a closed headless runtime boundary without creating another transcript, session, or persistence authority.

## Authority boundaries
- existing Oracle transcript, message, session, and persistence stores remain canonical
- OracleHeadlessRuntime owns only one in-flight execution lifecycle and tab-scoped cancellation registration
- cleanup remains exactly once across the runtime and caller defer paths
- persisted formats and visible behavior are unchanged
- no AgentMode, Prompt, Settings, WindowState, Package.swift, or app-composition changes

## Validation
- final bounded focused run: 3 of 3 OracleHeadlessRuntimeTests explicitly started and passed, 0 failures, ticket d53f3393-61df-42f4-9ce2-01a363ca189f
- scoped SwiftFormat and diff check: passed
- mandatory commit and push preflights: passed

Two earlier conductor attempts completed compilation but stalled before any test method executed. They were recorded as invalid test-start evidence and were not counted as passing validation. The cancellation test was then hardened with a bounded timeout, deterministic registration gates, and guaranteed continuation cleanup before the final green run.

## Review
Fable 5 High found the product extraction faithful and merge-quality, with no product-code correctness defect. Its must-fix test hang finding was addressed in the follow-up commit before the successful 3 of 3 run.

## Non-goals
- move transcript or session persistence authority
- redesign provider timeout or cancellation semantics
- thin the entire Oracle presentation adapter
- modify shared Agent execution contracts
- introduce a new module