### PR TITLE
Prompt: extract stored-prompt persistence boundary

### DIFF
--- a/Sources/RepoPrompt/Features/Prompt/Models/PromptStorage.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Models/PromptStorage.swift
@@ -7,6 +7,36 @@
 
 import Foundation
 
+struct StoredPromptRecord: Identifiable, Codable, Equatable {
+    let id: UUID
+    var title: String
+    var content: String
+    /// Tracks whether the user has manually edited a built-in prompt.
+    /// When true, auto-upgrades of built-in content are skipped.
+    var isUserEdited: Bool
+
+    init(id: UUID, title: String, content: String, isUserEdited: Bool = false) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.isUserEdited = isUserEdited
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        content = try container.decode(String.self, forKey: .content)
+        isUserEdited = try container.decodeIfPresent(Bool.self, forKey: .isUserEdited) ?? false
+    }
+
+    static func == (lhs: StoredPromptRecord, rhs: StoredPromptRecord) -> Bool {
+        lhs.id == rhs.id &&
+            lhs.title == rhs.title &&
+            lhs.content == rhs.content
+    }
+}
+
 /// <summary>
 /// Represents the external structure used for importing and exporting prompts,
 /// without relying on our internal UUID.
@@ -25,12 +55,25 @@ class PromptStorage {
     static let shared = PromptStorage()
 
     private let filename = "SavedPrompts.json"
+    private let configuredFileURL: URL?
 
     /// This serial queue ensures file reads/writes are never interleaved.
     private static let queue = DispatchQueue(label: "com.pvncher.repoprompt.PromptStorageQueue")
 
-    /// Compute the file URL in Application Support under com.pvncher.repoprompt
+    init(fileURL: URL? = nil) {
+        configuredFileURL = fileURL
+    }
+
+    /// Compute the file URL in Application Support under com.pvncher.repoprompt.
     private var fileURL: URL {
+        if let configuredFileURL {
+            try? FileManager.default.createDirectory(
+                at: configuredFileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            return configuredFileURL
+        }
+
         let supportDir = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
@@ -52,8 +95,8 @@ class PromptStorage {
     /// Returns .success([]) if the file doesn't exist (first run scenario).
     /// Returns .failure(error) if the file exists but can't be read/decoded.
     /// </summary>
-    func loadPrompts() -> Result<[PromptViewModel.StoredPrompt], Error> {
-        var result: Result<[PromptViewModel.StoredPrompt], Error> = .success([])
+    func loadPrompts() -> Result<[StoredPromptRecord], Error> {
+        var result: Result<[StoredPromptRecord], Error> = .success([])
 
         // Use a synchronous block so we can return the result directly
         Self.queue.sync {
@@ -66,7 +109,7 @@ class PromptStorage {
 
             do {
                 let data = try Data(contentsOf: fileURL)
-                let prompts = try JSONDecoder().decode([PromptViewModel.StoredPrompt].self, from: data)
+                let prompts = try JSONDecoder().decode([StoredPromptRecord].self, from: data)
                 result = .success(prompts)
             } catch {
                 // File exists but can't be read or decoded - this is an error!
@@ -85,7 +128,7 @@ class PromptStorage {
     /// This version supports an optional callback that fires after success/failure.
     /// </summary>
     func savePrompts(
-        _ prompts: [PromptViewModel.StoredPrompt],
+        _ prompts: [StoredPromptRecord],
         completion: ((Result<Void, Error>) -> Void)? = nil
     ) {
         Self.queue.async {
@@ -113,9 +156,9 @@ class PromptStorage {
 
 extension PromptStorage {
     /// <summary>
-    /// Export our internal `StoredPrompt` array into an array of `PromptExport` for writing to disk.
+    /// Export our internal `StoredPromptRecord` array into an array of `PromptExport` for writing to disk.
     /// </summary>
-    func exportPrompts(to url: URL, prompts: [PromptViewModel.StoredPrompt]) throws {
+    func exportPrompts(to url: URL, prompts: [StoredPromptRecord]) throws {
         let exports = prompts.map { PromptExport(title: $0.title, content: $0.content) }
         let data = try JSONEncoder().encode(exports)
 
@@ -132,18 +175,18 @@ extension PromptStorage {
     }
 
     /// <summary>
-    /// Given the array of existing `StoredPrompt` and newly loaded external `PromptExport`,
-    /// convert the external prompts into new `StoredPrompt`s, skipping duplicates.
+    /// Given the array of existing `StoredPromptRecord` and newly loaded external `PromptExport`,
+    /// convert the external prompts into new records, skipping duplicates.
     /// Returns a tuple: (merged array, count of new items).
     ///
     /// Duplicates are checked by matching (title, content).
     /// If a prompt with the same title + content already exists, we skip adding a new one.
-    /// Otherwise, create a new `StoredPrompt` with a fresh UUID.
+    /// Otherwise, create a new record with a fresh UUID.
     /// </summary>
     func mergeExternalPrompts(
-        current: [PromptViewModel.StoredPrompt],
+        current: [StoredPromptRecord],
         external: [PromptExport]
-    ) -> (merged: [PromptViewModel.StoredPrompt], addedCount: Int) {
+    ) -> (merged: [StoredPromptRecord], addedCount: Int) {
         var merged = current
         var addedCount = 0
 
@@ -154,7 +197,7 @@ extension PromptStorage {
             })
 
             if !duplicateExists {
-                let newPrompt = PromptViewModel.StoredPrompt(
+                let newPrompt = StoredPromptRecord(
                     id: UUID(), // Always new ID
                     title: item.title,
                     content: item.content

--- a/Sources/RepoPrompt/Features/Prompt/Services/StoredPromptPersistenceService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/StoredPromptPersistenceService.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+struct StoredPromptImportResult: Equatable {
+    let mergedPrompts: [StoredPromptRecord]
+    let addedCount: Int
+}
+
+@MainActor
+protocol StoredPromptPersistenceServing {
+    func loadPrompts() -> Result<[StoredPromptRecord], Error>
+    func savePrompts(_ prompts: [StoredPromptRecord])
+    func exportPrompts(to url: URL, prompts: [StoredPromptRecord]) throws
+    func importPrompts(
+        from url: URL,
+        mergingInto current: [StoredPromptRecord]
+    ) throws -> StoredPromptImportResult
+}
+
+@MainActor
+struct StoredPromptPersistenceService: StoredPromptPersistenceServing {
+    private let storage: PromptStorage
+
+    init(storage: PromptStorage = .shared) {
+        self.storage = storage
+    }
+
+    func loadPrompts() -> Result<[StoredPromptRecord], Error> {
+        storage.loadPrompts()
+    }
+
+    func savePrompts(_ prompts: [StoredPromptRecord]) {
+        storage.savePrompts(prompts)
+    }
+
+    func exportPrompts(to url: URL, prompts: [StoredPromptRecord]) throws {
+        try storage.exportPrompts(to: url, prompts: prompts)
+    }
+
+    func importPrompts(
+        from url: URL,
+        mergingInto current: [StoredPromptRecord]
+    ) throws -> StoredPromptImportResult {
+        let external = try storage.loadExternalPrompts(from: url)
+        let (merged, addedCount) = storage.mergeExternalPrompts(
+            current: current,
+            external: external
+        )
+        if addedCount > 0 {
+            storage.savePrompts(merged)
+        }
+        return StoredPromptImportResult(
+            mergedPrompts: merged,
+            addedCount: addedCount
+        )
+    }
+}

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -89,35 +89,7 @@ class PromptViewModel: ObservableObject {
         case chat
     }
 
-    struct StoredPrompt: Identifiable, Codable, Equatable {
-        let id: UUID
-        var title: String
-        var content: String
-        /// Tracks whether the user has manually edited a built-in prompt.
-        /// When true, auto-upgrades of built-in content are skipped.
-        var isUserEdited: Bool
-
-        init(id: UUID, title: String, content: String, isUserEdited: Bool = false) {
-            self.id = id
-            self.title = title
-            self.content = content
-            self.isUserEdited = isUserEdited
-        }
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            id = try container.decode(UUID.self, forKey: .id)
-            title = try container.decode(String.self, forKey: .title)
-            content = try container.decode(String.self, forKey: .content)
-            isUserEdited = try container.decodeIfPresent(Bool.self, forKey: .isUserEdited) ?? false
-        }
-
-        static func == (lhs: StoredPrompt, rhs: StoredPrompt) -> Bool {
-            lhs.id == rhs.id &&
-                lhs.title == rhs.title &&
-                lhs.content == rhs.content
-        }
-    }
+    typealias StoredPrompt = StoredPromptRecord
 
     // MARK: - Core Properties
 
@@ -2117,13 +2089,15 @@ class PromptViewModel: ObservableObject {
     // MARK: - Initialization
 
     private let settingsManager: SettingsManaging
+    private let storedPromptPersistence: any StoredPromptPersistenceServing
 
     init(
         fileManager: WorkspaceFilesViewModel,
         aiQueriesService: AIQueriesService? = nil,
         apiSettingsViewModel: APISettingsViewModel,
         windowID: Int,
-        settingsManager: SettingsManaging
+        settingsManager: SettingsManaging,
+        storedPromptPersistence: (any StoredPromptPersistenceServing)? = nil
     ) {
         self.fileManager = fileManager
         gitViewModel = GitViewModel(fileManager: fileManager)
@@ -2131,6 +2105,7 @@ class PromptViewModel: ObservableObject {
         self.apiSettingsViewModel = apiSettingsViewModel
         self.windowID = windowID
         self.settingsManager = settingsManager
+        self.storedPromptPersistence = storedPromptPersistence ?? StoredPromptPersistenceService()
         codeMapsGloballyDisabled = GlobalSettingsStore.shared.globalCodeMapsDisabled()
 
         // Removed usage of workspaceManager to load an initial prompt
@@ -4438,25 +4413,23 @@ class PromptViewModel: ObservableObject {
     }
 
     func saveStoredPrompts() {
-        PromptStorage.shared.savePrompts(storedPrompts)
+        storedPromptPersistence.savePrompts(storedPrompts)
     }
 
     func exportPrompts(to url: URL) throws {
-        try PromptStorage.shared.exportPrompts(to: url, prompts: storedPrompts)
+        try storedPromptPersistence.exportPrompts(to: url, prompts: storedPrompts)
     }
 
     func importPrompts(from url: URL) throws -> Int {
-        let external = try PromptStorage.shared.loadExternalPrompts(from: url)
-        let (merged, addedCount) = PromptStorage.shared.mergeExternalPrompts(
-            current: storedPrompts,
-            external: external
+        let result = try storedPromptPersistence.importPrompts(
+            from: url,
+            mergingInto: storedPrompts
         )
-        if addedCount > 0 {
-            storedPrompts = merged
-            saveStoredPrompts()
+        if result.addedCount > 0 {
+            storedPrompts = result.mergedPrompts
             updateSelectedInstructions() // refresh anything that depends on storedPrompts
         }
-        return addedCount
+        return result.addedCount
     }
 
     /// Checks if a persisted built-in prompt matches a known previous canonical version.
@@ -4531,7 +4504,7 @@ class PromptViewModel: ObservableObject {
     }
 
     func loadStoredPrompts() {
-        let loadResult = PromptStorage.shared.loadPrompts()
+        let loadResult = storedPromptPersistence.loadPrompts()
 
         // Handle the load result
         let loadedPrompts: [StoredPrompt]

--- a/Tests/RepoPromptTests/Prompt/StoredPromptPersistenceBoundaryTests.swift
+++ b/Tests/RepoPromptTests/Prompt/StoredPromptPersistenceBoundaryTests.swift
@@ -1,0 +1,163 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class StoredPromptPersistenceBoundaryTests: XCTestCase {
+    func testStoredRecordPreservesLegacyDecodingAndEqualitySemantics() throws {
+        let id = UUID()
+        let legacyJSON = """
+        {
+          "id": "\(id.uuidString)",
+          "title": "Legacy",
+          "content": "Prompt"
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(StoredPromptRecord.self, from: legacyJSON)
+        XCTAssertFalse(decoded.isUserEdited)
+        XCTAssertEqual(
+            decoded,
+            StoredPromptRecord(
+                id: id,
+                title: "Legacy",
+                content: "Prompt",
+                isUserEdited: true
+            ),
+            "Stored prompt equality intentionally ignores the migration metadata flag"
+        )
+
+        let encoded = try JSONEncoder().encode(decoded)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(Set(object.keys), ["id", "title", "content", "isUserEdited"])
+        XCTAssertEqual(object["id"] as? String, id.uuidString)
+        XCTAssertEqual(object["title"] as? String, "Legacy")
+        XCTAssertEqual(object["content"] as? String, "Prompt")
+        XCTAssertEqual(object["isUserEdited"] as? Bool, false)
+    }
+
+    @MainActor
+    func testConcreteServiceImportsUniquePromptsAndPersistsMergedSnapshot() throws {
+        let directory = try makeTestDirectory()
+        let storageURL = directory.appendingPathComponent("SavedPrompts.json")
+        let importURL = directory.appendingPathComponent("Import.json")
+        let storage = PromptStorage(fileURL: storageURL)
+        let service = StoredPromptPersistenceService(storage: storage)
+        let current = [
+            StoredPromptRecord(id: UUID(), title: "Existing", content: "Keep")
+        ]
+        let external = [
+            PromptExport(title: "Existing", content: "Keep"),
+            PromptExport(title: "First", content: "New one"),
+            PromptExport(title: "First", content: "New one"),
+            PromptExport(title: "Second", content: "New two")
+        ]
+        try JSONEncoder().encode(external).write(to: importURL, options: .atomic)
+
+        let result = try service.importPrompts(from: importURL, mergingInto: current)
+
+        XCTAssertEqual(result.addedCount, 2)
+        XCTAssertEqual(result.mergedPrompts.map(\.title), ["Existing", "First", "Second"])
+        XCTAssertEqual(result.mergedPrompts.first?.id, current[0].id)
+        XCTAssertFalse(result.mergedPrompts[1].isUserEdited)
+        XCTAssertFalse(result.mergedPrompts[2].isUserEdited)
+        XCTAssertNotEqual(result.mergedPrompts[1].id, result.mergedPrompts[2].id)
+
+        let persisted = try storage.loadPrompts().get()
+        XCTAssertEqual(persisted, result.mergedPrompts)
+    }
+
+    @MainActor
+    func testViewModelLoadFailurePreservesCorruptionProtection() {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .failure(TestError.loadFailed))
+
+        let viewModel = makePromptViewModel(persistence: persistence)
+
+        XCTAssertTrue(viewModel.storedPrompts.isEmpty)
+        XCTAssertTrue(persistence.savedSnapshots.isEmpty)
+    }
+
+    @MainActor
+    func testViewModelImportDelegatesStateTransitionWithoutSecondSave() throws {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let original = viewModel.storedPrompts
+        let imported = StoredPromptRecord(id: UUID(), title: "Imported", content: "Body")
+        persistence.savedSnapshots.removeAll()
+        persistence.importResult = StoredPromptImportResult(
+            mergedPrompts: original + [imported],
+            addedCount: 1
+        )
+        let importURL = URL(fileURLWithPath: "/tmp/StoredPromptPersistenceBoundaryTests-import.json")
+
+        let addedCount = try viewModel.importPrompts(from: importURL)
+
+        XCTAssertEqual(addedCount, 1)
+        XCTAssertEqual(persistence.importedURL, importURL)
+        XCTAssertEqual(persistence.importedCurrent, original)
+        XCTAssertEqual(viewModel.storedPrompts, original + [imported])
+        XCTAssertTrue(
+            persistence.savedSnapshots.isEmpty,
+            "The persistence command owns the import save; the view model must not enqueue a duplicate"
+        )
+    }
+
+    @MainActor
+    private func makePromptViewModel(
+        persistence: any StoredPromptPersistenceServing
+    ) -> PromptViewModel {
+        let secureService = SecureKeysService(secureStorage: TestSecureStorageBackend(values: [:]))
+        let keyManager = KeyManager(secureService: secureService)
+        let apiSettings = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        return PromptViewModel(
+            fileManager: WorkspaceFilesViewModel(),
+            apiSettingsViewModel: apiSettings,
+            windowID: -902,
+            settingsManager: WindowSettingsManager(windowID: -902),
+            storedPromptPersistence: persistence
+        )
+    }
+}
+
+private enum TestError: Error {
+    case loadFailed
+}
+
+@MainActor
+private final class StoredPromptPersistenceSpy: StoredPromptPersistenceServing {
+    var loadResult: Result<[StoredPromptRecord], Error>
+    var savedSnapshots: [[StoredPromptRecord]] = []
+    var exportedURL: URL?
+    var exportedPrompts: [StoredPromptRecord] = []
+    var importedURL: URL?
+    var importedCurrent: [StoredPromptRecord] = []
+    var importResult = StoredPromptImportResult(mergedPrompts: [], addedCount: 0)
+
+    init(loadResult: Result<[StoredPromptRecord], Error>) {
+        self.loadResult = loadResult
+    }
+
+    func loadPrompts() -> Result<[StoredPromptRecord], Error> {
+        loadResult
+    }
+
+    func savePrompts(_ prompts: [StoredPromptRecord]) {
+        savedSnapshots.append(prompts)
+    }
+
+    func exportPrompts(to url: URL, prompts: [StoredPromptRecord]) throws {
+        exportedURL = url
+        exportedPrompts = prompts
+    }
+
+    func importPrompts(
+        from url: URL,
+        mergingInto current: [StoredPromptRecord]
+    ) throws -> StoredPromptImportResult {
+        importedURL = url
+        importedCurrent = current
+        return importResult
+    }
+}


### PR DESCRIPTION
## Summary
- move the persisted prompt record into a top-level StoredPromptRecord while retaining a source-compatible PromptViewModel alias
- add a stateless StoredPromptPersistenceServing boundary
- move load, save, export, import, merge, and conditional-save orchestration out of PromptViewModel
- add focused legacy-format, error-path, import, and duplicate-save coverage

## Why
PromptViewModel directly coordinated stored-prompt persistence while also owning presentation and selection state. This creates an explicit application boundary without duplicating PromptStorage or changing its format and write authority.

## Authority boundaries
- PromptStorage remains the sole authority for paths, JSON formats, UUID generation, duplicate rules, queueing, and atomic writes
- the new service is stateless and delegates all persistence operations to PromptStorage
- PromptViewModel retains published prompt and selection state, built-in policy, user-edit marking, instruction derivation, and packaging-facing projections
- persisted JSON and compatibility behavior remain unchanged
- no AgentMode, Oracle, shared execution, WindowState, Package.swift, or broad Settings changes

## Validation
- make dev-test FILTER=StoredPromptPersistenceBoundaryTests: passed, ticket 2f0cb12b-0484-4881-8ced-2fed92a6604e
- repository-pinned scoped SwiftFormat: 0 of 4 files require formatting
- git diff --check: clean
- mandatory commit and push preflights: passed

## Review
Independent Fable 5 High review found no must-fix issues and judged the change merge-ready. It verified preserved import and corruption semantics, unchanged on-disk format, source compatibility, stateless service behavior, and continued single persistence authority.

## Non-goals
- extract built-in catalog policy
- redesign async save error presentation
- move packaging, Git, or compose lifecycle in this PR
- change Settings wiring
- introduce a module boundary