### PR TITLE
fix(opencode): prevent ACP session/new hang from inherited MCP servers

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
@@ -51,7 +51,8 @@ struct OpenCodeACPAgentProvider: ACPAgentProvider {
             }
             environment[LaunchContract.configContentEnvironmentKey] = try OpenCodeIntegrationConfiguration.ephemeralACPConfigJSON(
                 includeRepoPromptMCPServer: config.includeRepoPromptMCPServer,
-                repoPromptMCPConfiguration: repoPromptMCPConfiguration
+                repoPromptMCPConfiguration: repoPromptMCPConfiguration,
+                workingDirectory: workingDirectory
             )
         }
 
@@ -128,10 +129,28 @@ struct OpenCodeACPAgentProvider: ACPAgentProvider {
         if error is OpenCodeACPLaunchResolutionError || error is ExecutableFileIdentityError {
             return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
         }
+        if let guidance = Self.openCodeACPStartupTimeoutGuidance(for: error) {
+            return AIProviderError.invalidConfiguration(detail: guidance)
+        }
         if (error as NSError).domain == NSCocoaErrorDomain {
             return AIProviderError.invalidConfiguration(detail: "Unable to prepare OpenCode ACP config: \(error.localizedDescription)")
         }
         return AIProviderError.apiError(source: error)
+    }
+
+    private static func openCodeACPStartupTimeoutGuidance(for error: Error) -> String? {
+        let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = message.lowercased()
+        let isStartupTimeout = lower.contains("acp request")
+            && lower.contains("timed out")
+            && (lower.contains("session/new")
+                || lower.contains("session/load")
+                || lower.contains("initialize")
+                || lower.contains("authenticate"))
+        guard isStartupTimeout else { return nil }
+        return """
+        OpenCode ACP did not finish session startup. OpenCode merges global/project MCP servers into ACP `session/new` and waits for them to connect; a slow or hanging MCP entry (including a recursive RepoPrompt CE CLI) can exceed the bootstrap timeout. RepoPrompt disables discovered inherited MCP names in its process-ephemeral overlay—update OpenCode (`opencode upgrade`) and remove or disable hanging entries under `mcp` in `~/.config/opencode/opencode.json` if this persists. Original error: \(message)
+        """
     }
 
     private func standardizedWorkingDirectory(from workspacePath: String?) -> String {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
@@ -143,10 +143,12 @@ struct OpenCodeACPAgentProvider: ACPAgentProvider {
         let lower = message.lowercased()
         let isStartupTimeout = lower.contains("acp request")
             && lower.contains("timed out")
-            && (lower.contains("session/new")
-                || lower.contains("session/load")
-                || lower.contains("initialize")
-                || lower.contains("authenticate"))
+            && (
+                lower.contains("session/new")
+                    || lower.contains("session/load")
+                    || lower.contains("initialize")
+                    || lower.contains("authenticate")
+            )
         guard isStartupTimeout else { return nil }
         return """
         OpenCode ACP did not finish session startup. OpenCode merges global/project MCP servers into ACP `session/new` and waits for them to connect; a slow or hanging MCP entry (including a recursive RepoPrompt CE CLI) can exceed the bootstrap timeout. RepoPrompt disables discovered inherited MCP names in its process-ephemeral overlay—update OpenCode (`opencode upgrade`) and remove or disable hanging entries under `mcp` in `~/.config/opencode/opencode.json` if this persists. Original error: \(message)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeIntegrationConfiguration.swift
@@ -11,7 +11,7 @@ enum OpenCodeIntegrationConfiguration {
     private static let disabledMCPCommand = "/usr/bin/false"
     private static let repoPromptMCPServerName = RepoPromptMCPServerConfiguration.defaultServerName
     /// Bound reads of inherited OpenCode config used only to discover MCP server names.
-    private static let maximumInheritedConfigBytes: UInt64 = 2 * 1024 * 1024
+    private static let maximumInheritedConfigBytes = 2 * 1024 * 1024
 
     struct PersistentMCPConfigResult {
         let configURL: URL
@@ -200,16 +200,20 @@ enum OpenCodeIntegrationConfiguration {
         return string
     }
 
-    /// Discovers MCP server names that OpenCode may inherit from global/project config.
-    /// Used only to neutralize those names in the process-ephemeral overlay.
+    /// Discovers MCP server names from the same local config authorities OpenCode merges before
+    /// RepoPrompt's process-ephemeral `OPENCODE_CONFIG_CONTENT` overlay.
     static func discoverInheritedMCPServerNames(
         workingDirectory: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> [String] {
         var names = Set<String>()
-        for path in inheritedConfigPaths(workingDirectory: workingDirectory, environment: environment, fileManager: fileManager) {
-            guard let object = readBoundedJSONObject(atPath: path, fileManager: fileManager),
+        for path in inheritedConfigPaths(
+            workingDirectory: workingDirectory,
+            environment: environment,
+            fileManager: fileManager
+        ) {
+            guard let object = readBoundedJSONObject(atPath: path),
                   let mcp = object["mcp"] as? [String: Any]
             else {
                 continue
@@ -226,39 +230,301 @@ enum OpenCodeIntegrationConfiguration {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> [String] {
-        var paths: [String] = []
-        paths.append(configURL(environment: environment, fileManager: fileManager).path)
-        if let workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !workingDirectory.isEmpty
-        {
-            let root = URL(fileURLWithPath: workingDirectory, isDirectory: true)
-            paths.append(root.appendingPathComponent("opencode.json").path)
-            paths.append(root.appendingPathComponent(".opencode/opencode.json").path)
+        let currentDirectoryURL = URL(
+            fileURLWithPath: fileManager.currentDirectoryPath,
+            isDirectory: true
+        ).standardizedFileURL
+        let trimmedWorkingDirectory = workingDirectory?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let workingDirectoryURL = resolvedFileURL(
+            path: nonEmpty(trimmedWorkingDirectory) ?? fileManager.currentDirectoryPath,
+            relativeTo: currentDirectoryURL,
+            isDirectory: true
+        )
+        let globalConfigDirectory = configDirectoryURL(
+            environment: environment,
+            fileManager: fileManager
+        )
+
+        // Mirrors OpenCode's global loader, which merges all three filenames rather than selecting one.
+        var urls = ["config.json", "opencode.json", "opencode.jsonc"].map {
+            globalConfigDirectory.appendingPathComponent($0, isDirectory: false)
         }
+
+        if let customConfigPath = nonEmpty(environment["OPENCODE_CONFIG"]) {
+            urls.append(resolvedFileURL(
+                path: customConfigPath,
+                relativeTo: workingDirectoryURL,
+                isDirectory: false
+            ))
+        }
+
+        if !environmentFlagIsTruthy(environment["OPENCODE_DISABLE_PROJECT_CONFIG"]) {
+            let projectDirectories = projectConfigDirectories(
+                from: workingDirectoryURL,
+                fileManager: fileManager
+            )
+            for directory in projectDirectories {
+                urls.append(directory.appendingPathComponent("opencode.jsonc", isDirectory: false))
+                urls.append(directory.appendingPathComponent("opencode.json", isDirectory: false))
+            }
+            for directory in projectDirectories {
+                let configDirectory = directory.appendingPathComponent(".opencode", isDirectory: true)
+                urls.append(configDirectory.appendingPathComponent("opencode.json", isDirectory: false))
+                urls.append(configDirectory.appendingPathComponent("opencode.jsonc", isDirectory: false))
+            }
+        }
+
+        let openCodeHome = openCodeHomeDirectoryURL(
+            environment: environment,
+            fileManager: fileManager
+        ).appendingPathComponent(".opencode", isDirectory: true)
+        urls.append(openCodeHome.appendingPathComponent("opencode.json", isDirectory: false))
+        urls.append(openCodeHome.appendingPathComponent("opencode.jsonc", isDirectory: false))
+
+        if let customConfigDirectoryPath = nonEmpty(environment["OPENCODE_CONFIG_DIR"]) {
+            let customConfigDirectory = resolvedFileURL(
+                path: customConfigDirectoryPath,
+                relativeTo: workingDirectoryURL,
+                isDirectory: true
+            )
+            urls.append(customConfigDirectory.appendingPathComponent("opencode.json", isDirectory: false))
+            urls.append(customConfigDirectory.appendingPathComponent("opencode.jsonc", isDirectory: false))
+        }
+
+        // RepoPrompt sets its own OPENCODE_CONFIG_CONTENT on the child process, so caller inline
+        // content is replaced rather than inherited and cannot contribute an additional MCP name.
         var seen = Set<String>()
-        return paths.filter { seen.insert($0).inserted }
+        return urls
+            .map { $0.standardizedFileURL.path }
+            .filter { seen.insert($0).inserted }
     }
 
-    private static func readBoundedJSONObject(
-        atPath path: String,
+    private static func projectConfigDirectories(
+        from workingDirectory: URL,
         fileManager: FileManager
-    ) -> [String: Any]? {
-        guard let attributes = try? fileManager.attributesOfItem(atPath: path),
-              attributes[.type] as? FileAttributeType == .typeRegular
-        else {
+    ) -> [URL] {
+        var directories: [URL] = []
+        var current = workingDirectory.standardizedFileURL
+        while true {
+            directories.append(current)
+            // OpenCode walks upward only to its worktree boundary. A .git file also identifies
+            // linked worktrees, while .jj covers colocated Jujutsu workspaces supported by RepoPrompt.
+            if fileManager.fileExists(atPath: current.appendingPathComponent(".git").path)
+                || fileManager.fileExists(atPath: current.appendingPathComponent(".jj").path)
+            {
+                break
+            }
+            let parent = current.deletingLastPathComponent().standardizedFileURL
+            if parent.path == current.path {
+                break
+            }
+            current = parent
+        }
+        return directories.reversed()
+    }
+
+    private static func openCodeHomeDirectoryURL(
+        environment: [String: String],
+        fileManager: FileManager
+    ) -> URL {
+        if let testHome = nonEmpty(environment["OPENCODE_TEST_HOME"]) {
+            return resolvedFileURL(
+                path: testHome,
+                relativeTo: URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true),
+                isDirectory: true
+            )
+        }
+        if let home = nonEmpty(environment["HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            return resolvedFileURL(
+                path: home,
+                relativeTo: URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true),
+                isDirectory: true
+            )
+        }
+        return fileManager.homeDirectoryForCurrentUser.standardizedFileURL
+    }
+
+    private static func resolvedFileURL(
+        path: String,
+        relativeTo baseDirectory: URL,
+        isDirectory: Bool
+    ) -> URL {
+        if (path as NSString).isAbsolutePath {
+            return URL(fileURLWithPath: path, isDirectory: isDirectory).standardizedFileURL
+        }
+        return baseDirectory
+            .appendingPathComponent(path, isDirectory: isDirectory)
+            .standardizedFileURL
+    }
+
+    private static func environmentFlagIsTruthy(_ value: String?) -> Bool {
+        guard let value = value?.lowercased() else { return false }
+        return value == "true" || value == "1"
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+
+    private static func readBoundedJSONObject(atPath path: String) -> [String: Any]? {
+        let data: Data
+        do {
+            let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: path))
+            defer { try? handle.close() }
+            guard let chunk = try handle.read(upToCount: maximumInheritedConfigBytes + 1),
+                  !chunk.isEmpty,
+                  chunk.count <= maximumInheritedConfigBytes
+            else {
+                return nil
+            }
+            data = chunk
+        } catch {
             return nil
         }
-        let size = (attributes[.size] as? NSNumber)?.uint64Value
-            ?? attributes[.size] as? UInt64
-        guard let size, size > 0, size <= maximumInheritedConfigBytes else {
-            return nil
-        }
-        guard let data = fileManager.contents(atPath: path),
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        guard let normalized = normalizedJSONCData(data),
+              let object = try? JSONSerialization.jsonObject(with: normalized) as? [String: Any]
         else {
             return nil
         }
         return object
+    }
+
+    private static func normalizedJSONCData(_ data: Data) -> Data? {
+        var bytes = [UInt8](data)
+        if bytes.starts(with: [0xEF, 0xBB, 0xBF]) {
+            bytes.removeFirst(3)
+        }
+        guard let uncommented = removingJSONComments(from: bytes) else { return nil }
+        return Data(removingTrailingCommas(from: uncommented))
+    }
+
+    private static func removingJSONComments(from bytes: [UInt8]) -> [UInt8]? {
+        var output: [UInt8] = []
+        output.reserveCapacity(bytes.count)
+        var index = 0
+        var isInsideString = false
+        var isEscaped = false
+        var isInsideLineComment = false
+        var isInsideBlockComment = false
+
+        while index < bytes.count {
+            let byte = bytes[index]
+
+            if isInsideLineComment {
+                if byte == 0x0A || byte == 0x0D {
+                    output.append(byte)
+                    isInsideLineComment = false
+                }
+                index += 1
+                continue
+            }
+
+            if isInsideBlockComment {
+                if byte == 0x2A, index + 1 < bytes.count, bytes[index + 1] == 0x2F {
+                    isInsideBlockComment = false
+                    index += 2
+                    continue
+                }
+                if byte == 0x0A || byte == 0x0D {
+                    output.append(byte)
+                }
+                index += 1
+                continue
+            }
+
+            if isInsideString {
+                output.append(byte)
+                if isEscaped {
+                    isEscaped = false
+                } else if byte == 0x5C {
+                    isEscaped = true
+                } else if byte == 0x22 {
+                    isInsideString = false
+                }
+                index += 1
+                continue
+            }
+
+            if byte == 0x22 {
+                isInsideString = true
+                output.append(byte)
+                index += 1
+                continue
+            }
+
+            if byte == 0x2F, index + 1 < bytes.count {
+                if bytes[index + 1] == 0x2F {
+                    isInsideLineComment = true
+                    index += 2
+                    continue
+                }
+                if bytes[index + 1] == 0x2A {
+                    isInsideBlockComment = true
+                    index += 2
+                    continue
+                }
+            }
+
+            output.append(byte)
+            index += 1
+        }
+
+        return isInsideBlockComment ? nil : output
+    }
+
+    private static func removingTrailingCommas(from bytes: [UInt8]) -> [UInt8] {
+        var output: [UInt8] = []
+        output.reserveCapacity(bytes.count)
+        var index = 0
+        var isInsideString = false
+        var isEscaped = false
+
+        while index < bytes.count {
+            let byte = bytes[index]
+            if isInsideString {
+                output.append(byte)
+                if isEscaped {
+                    isEscaped = false
+                } else if byte == 0x5C {
+                    isEscaped = true
+                } else if byte == 0x22 {
+                    isInsideString = false
+                }
+                index += 1
+                continue
+            }
+
+            if byte == 0x22 {
+                isInsideString = true
+                output.append(byte)
+                index += 1
+                continue
+            }
+
+            if byte == 0x2C {
+                var lookahead = index + 1
+                while lookahead < bytes.count, isJSONWhitespace(bytes[lookahead]) {
+                    lookahead += 1
+                }
+                if lookahead < bytes.count,
+                   bytes[lookahead] == 0x7D || bytes[lookahead] == 0x5D
+                {
+                    index += 1
+                    continue
+                }
+            }
+
+            output.append(byte)
+            index += 1
+        }
+        return output
+    }
+
+    private static func isJSONWhitespace(_ byte: UInt8) -> Bool {
+        byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D
     }
 
     /// Ensures the persistent OpenCode config contains the RepoPrompt MCP server.

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeIntegrationConfiguration.swift
@@ -296,7 +296,7 @@ enum OpenCodeIntegrationConfiguration {
         // content is replaced rather than inherited and cannot contribute an additional MCP name.
         var seen = Set<String>()
         return urls
-            .map { $0.standardizedFileURL.path }
+            .map(\.standardizedFileURL.path)
             .filter { seen.insert($0).inserted }
     }
 
@@ -357,7 +357,6 @@ enum OpenCodeIntegrationConfiguration {
             .appendingPathComponent(path, isDirectory: isDirectory)
             .standardizedFileURL
     }
-
     private static func environmentFlagIsTruthy(_ value: String?) -> Bool {
         guard let value = value?.lowercased() else { return false }
         return value == "true" || value == "1"
@@ -537,7 +536,6 @@ enum OpenCodeIntegrationConfiguration {
         let dirURL = configDirectoryURL()
         let configURL = configURL()
         try fm.createDirectory(at: dirURL, withIntermediateDirectories: true, attributes: nil)
-
         let existingData = try? Data(contentsOf: configURL)
         var root: [String: Any] = [:]
         if let existingData,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeIntegrationConfiguration.swift
@@ -357,6 +357,7 @@ enum OpenCodeIntegrationConfiguration {
             .appendingPathComponent(path, isDirectory: isDirectory)
             .standardizedFileURL
     }
+
     private static func environmentFlagIsTruthy(_ value: String?) -> Bool {
         guard let value = value?.lowercased() else { return false }
         return value == "true" || value == "1"
@@ -536,6 +537,7 @@ enum OpenCodeIntegrationConfiguration {
         let dirURL = configDirectoryURL()
         let configURL = configURL()
         try fm.createDirectory(at: dirURL, withIntermediateDirectories: true, attributes: nil)
+
         let existingData = try? Data(contentsOf: configURL)
         var root: [String: Any] = [:]
         if let existingData,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeIntegrationConfiguration.swift
@@ -10,21 +10,41 @@ enum OpenCodeIntegrationConfiguration {
     private static let mcpTimeoutMilliseconds = 14_400_000
     private static let disabledMCPCommand = "/usr/bin/false"
     private static let repoPromptMCPServerName = RepoPromptMCPServerConfiguration.defaultServerName
+    /// Bound reads of inherited OpenCode config used only to discover MCP server names.
+    private static let maximumInheritedConfigBytes: UInt64 = 2 * 1024 * 1024
 
     struct PersistentMCPConfigResult {
         let configURL: URL
         let wasMCPServerAlreadyPresent: Bool
     }
 
-    static func configDirectoryURL() -> URL {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home
+    static func configDirectoryURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> URL {
+        if let xdgConfigHome = environment["XDG_CONFIG_HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !xdgConfigHome.isEmpty
+        {
+            return URL(fileURLWithPath: xdgConfigHome, isDirectory: true)
+                .appendingPathComponent("opencode", isDirectory: true)
+        }
+        let home = environment["HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let homeURL = if let home, !home.isEmpty {
+            URL(fileURLWithPath: home, isDirectory: true)
+        } else {
+            fileManager.homeDirectoryForCurrentUser
+        }
+        return homeURL
             .appendingPathComponent(".config", isDirectory: true)
             .appendingPathComponent("opencode", isDirectory: true)
     }
 
-    static func configURL() -> URL {
-        configDirectoryURL().appendingPathComponent("opencode.json")
+    static func configURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> URL {
+        configDirectoryURL(environment: environment, fileManager: fileManager)
+            .appendingPathComponent("opencode.json")
     }
 
     /// MCP config dictionary for OpenCode format.
@@ -111,31 +131,60 @@ enum OpenCodeIntegrationConfiguration {
 
     /// Process-ephemeral OpenCode config overlay for RepoPrompt-launched ACP runs.
     ///
-    /// Intended for `OPENCODE_CONFIG_CONTENT`; it always provides RepoPrompt-managed modes and
-    /// either an active current-build RepoPrompt MCP entry or a disabled same-name override.
+    /// Intended for `OPENCODE_CONFIG_CONTENT`. OpenCode merges this overlay with global/project
+    /// config by MCP server name. `session/new` waits for those MCP servers to connect, so a
+    /// hanging non-RepoPrompt entry (or a recursive RepoPrompt CE CLI entry) can exceed the ACP
+    /// bootstrap timeout. This overlay therefore:
+    /// - disables every inherited global/project MCP server name it can discover
+    /// - sets the current-build RepoPrompt MCP entry active or disabled
+    /// - always provides RepoPrompt-managed agent modes
     static func ephemeralACPConfigDict(
         includeRepoPromptMCPServer: Bool,
-        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        workingDirectory: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        inheritedMCPServerNamesOverride: [String]? = nil
     ) -> [String: Any] {
-        [
+        var mcp: [String: Any] = [:]
+        let inheritedNames = inheritedMCPServerNamesOverride ?? discoverInheritedMCPServerNames(
+            workingDirectory: workingDirectory,
+            environment: environment,
+            fileManager: fileManager
+        )
+        for name in inheritedNames {
+            if name.compare(repoPromptMCPServerName, options: .caseInsensitive) == .orderedSame {
+                continue
+            }
+            mcp[name] = disabledMCPConfigDict()
+        }
+        mcp[repoPromptMCPServerName] = includeRepoPromptMCPServer
+            ? mcpConfigDict(for: repoPromptMCPConfiguration)
+            : disabledMCPConfigDict()
+
+        return [
             "$schema": configSchemaURL,
             "agent": managedAgentConfigDicts,
-            "mcp": [
-                repoPromptMCPServerName: includeRepoPromptMCPServer
-                    ? mcpConfigDict(for: repoPromptMCPConfiguration)
-                    : disabledMCPConfigDict()
-            ]
+            "mcp": mcp
         ]
     }
 
     /// Serializes the process-ephemeral OpenCode config overlay for `OPENCODE_CONFIG_CONTENT`.
     static func ephemeralACPConfigJSON(
         includeRepoPromptMCPServer: Bool,
-        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        workingDirectory: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        inheritedMCPServerNamesOverride: [String]? = nil
     ) throws -> String {
         let dict = ephemeralACPConfigDict(
             includeRepoPromptMCPServer: includeRepoPromptMCPServer,
-            repoPromptMCPConfiguration: repoPromptMCPConfiguration
+            repoPromptMCPConfiguration: repoPromptMCPConfiguration,
+            workingDirectory: workingDirectory,
+            environment: environment,
+            fileManager: fileManager,
+            inheritedMCPServerNamesOverride: inheritedMCPServerNamesOverride
         )
         let data = try JSONSerialization.data(
             withJSONObject: dict,
@@ -149,6 +198,67 @@ enum OpenCodeIntegrationConfiguration {
             )
         }
         return string
+    }
+
+    /// Discovers MCP server names that OpenCode may inherit from global/project config.
+    /// Used only to neutralize those names in the process-ephemeral overlay.
+    static func discoverInheritedMCPServerNames(
+        workingDirectory: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var names = Set<String>()
+        for path in inheritedConfigPaths(workingDirectory: workingDirectory, environment: environment, fileManager: fileManager) {
+            guard let object = readBoundedJSONObject(atPath: path, fileManager: fileManager),
+                  let mcp = object["mcp"] as? [String: Any]
+            else {
+                continue
+            }
+            for key in mcp.keys where !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                names.insert(key)
+            }
+        }
+        return names.sorted()
+    }
+
+    static func inheritedConfigPaths(
+        workingDirectory: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var paths: [String] = []
+        paths.append(configURL(environment: environment, fileManager: fileManager).path)
+        if let workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !workingDirectory.isEmpty
+        {
+            let root = URL(fileURLWithPath: workingDirectory, isDirectory: true)
+            paths.append(root.appendingPathComponent("opencode.json").path)
+            paths.append(root.appendingPathComponent(".opencode/opencode.json").path)
+        }
+        var seen = Set<String>()
+        return paths.filter { seen.insert($0).inserted }
+    }
+
+    private static func readBoundedJSONObject(
+        atPath path: String,
+        fileManager: FileManager
+    ) -> [String: Any]? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: path),
+              attributes[.type] as? FileAttributeType == .typeRegular
+        else {
+            return nil
+        }
+        let size = (attributes[.size] as? NSNumber)?.uint64Value
+            ?? attributes[.size] as? UInt64
+        guard let size, size > 0, size <= maximumInheritedConfigBytes else {
+            return nil
+        }
+        guard let data = fileManager.contents(atPath: path),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return object
     }
 
     /// Ensures the persistent OpenCode config contains the RepoPrompt MCP server.

--- a/Tests/RepoPromptTests/AgentMode/OpenCodeIntegrationConfigurationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OpenCodeIntegrationConfigurationTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class OpenCodeIntegrationConfigurationTests: XCTestCase {
+    func testEphemeralOverlayDisablesInheritedNonRepoPromptMCPNames() throws {
+        let home = try makeTemporaryDirectory()
+        let configDir = home.appendingPathComponent(".config/opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        try writeJSON(
+            [
+                "mcp": [
+                    "AITrader": [
+                        "type": "local",
+                        "command": ["/usr/bin/false"]
+                    ],
+                    "Hang": [
+                        "type": "local",
+                        "command": ["/bin/sleep", "120"]
+                    ],
+                    "RepoPromptCE": [
+                        "type": "local",
+                        "command": ["/usr/bin/true"]
+                    ]
+                ]
+            ],
+            to: configDir.appendingPathComponent("opencode.json")
+        )
+
+        let dict = OpenCodeIntegrationConfiguration.ephemeralACPConfigDict(
+            includeRepoPromptMCPServer: true,
+            repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(
+                command: "/tmp/repoprompt_ce_cli",
+                args: ["--backend", "app"]
+            ),
+            workingDirectory: home.path,
+            environment: ["HOME": home.path]
+        )
+
+        let mcp = try XCTUnwrap(dict["mcp"] as? [String: Any])
+        XCTAssertEqual(Set(mcp.keys), ["AITrader", "Hang", "RepoPromptCE"])
+
+        let disabledAITrader = try XCTUnwrap(mcp["AITrader"] as? [String: Any])
+        XCTAssertEqual(disabledAITrader["enabled"] as? Bool, false)
+        XCTAssertEqual((disabledAITrader["command"] as? [String])?.first, "/usr/bin/false")
+
+        let disabledHang = try XCTUnwrap(mcp["Hang"] as? [String: Any])
+        XCTAssertEqual(disabledHang["enabled"] as? Bool, false)
+
+        let repoPrompt = try XCTUnwrap(mcp["RepoPromptCE"] as? [String: Any])
+        XCTAssertNil(repoPrompt["enabled"] as? Bool)
+        XCTAssertEqual(
+            repoPrompt["command"] as? [String],
+            ["/tmp/repoprompt_ce_cli", "--backend", "app"]
+        )
+    }
+
+    func testEphemeralOverlayCanDisableRepoPromptMCPWhileNeutralizingInheritedNames() {
+        let dict = OpenCodeIntegrationConfiguration.ephemeralACPConfigDict(
+            includeRepoPromptMCPServer: false,
+            inheritedMCPServerNamesOverride: ["AITrader", "RepoPromptCE", "Other"]
+        )
+        let mcp = dict["mcp"] as? [String: Any] ?? [:]
+        XCTAssertEqual(Set(mcp.keys), ["AITrader", "Other", "RepoPromptCE"])
+        XCTAssertEqual((mcp["AITrader"] as? [String: Any])?["enabled"] as? Bool, false)
+        XCTAssertEqual((mcp["Other"] as? [String: Any])?["enabled"] as? Bool, false)
+        XCTAssertEqual((mcp["RepoPromptCE"] as? [String: Any])?["enabled"] as? Bool, false)
+    }
+
+    func testInheritedNamesIncludeProjectConfigPaths() throws {
+        let project = try makeTemporaryDirectory()
+        try writeJSON(
+            [
+                "mcp": [
+                    "ProjectMCP": [
+                        "type": "local",
+                        "command": ["/usr/bin/true"]
+                    ]
+                ]
+            ],
+            to: project.appendingPathComponent("opencode.json")
+        )
+
+        let names = OpenCodeIntegrationConfiguration.discoverInheritedMCPServerNames(
+            workingDirectory: project.path,
+            environment: [
+                "HOME": project.appendingPathComponent("no-global-home").path
+            ]
+        )
+        XCTAssertEqual(names, ["ProjectMCP"])
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenCodeIntegrationConfigurationTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    private func writeJSON(_ object: [String: Any], to url: URL) throws {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/OpenCodeIntegrationConfigurationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OpenCodeIntegrationConfigurationTests.swift
@@ -5,6 +5,10 @@ import XCTest
 final class OpenCodeIntegrationConfigurationTests: XCTestCase {
     func testEphemeralOverlayDisablesInheritedNonRepoPromptMCPNames() throws {
         let home = try makeTemporaryDirectory()
+        try FileManager.default.createDirectory(
+            at: home.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
         let configDir = home.appendingPathComponent(".config/opencode", isDirectory: true)
         try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
         try writeJSON(
@@ -67,27 +71,184 @@ final class OpenCodeIntegrationConfigurationTests: XCTestCase {
         XCTAssertEqual((mcp["RepoPromptCE"] as? [String: Any])?["enabled"] as? Bool, false)
     }
 
-    func testInheritedNamesIncludeProjectConfigPaths() throws {
+    func testInheritedNamesIncludeEveryGlobalConfigFilenameAndJSONC() throws {
+        let root = try makeTemporaryDirectory()
+        let worktree = root.appendingPathComponent("worktree", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktree.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let xdgConfigHome = root.appendingPathComponent("xdg", isDirectory: true)
+        let configDirectory = xdgConfigHome.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectory, withIntermediateDirectories: true)
+
+        try writeMCPConfig(named: "GlobalConfig", to: configDirectory.appendingPathComponent("config.json"))
+        try writeMCPConfig(named: "GlobalJSON", to: configDirectory.appendingPathComponent("opencode.json"))
+        try writeText(
+            """
+            {
+              // OpenCode accepts comments and trailing commas in JSONC.
+              "mcp": {
+                "GlobalJSONC": {
+                  "type": "remote",
+                  "url": "https://example.com/mcp//endpoint",
+                },
+              },
+            }
+            """,
+            to: configDirectory.appendingPathComponent("opencode.jsonc")
+        )
+
+        let names = OpenCodeIntegrationConfiguration.discoverInheritedMCPServerNames(
+            workingDirectory: worktree.path,
+            environment: [
+                "HOME": root.appendingPathComponent("no-global-home").path,
+                "XDG_CONFIG_HOME": xdgConfigHome.path
+            ]
+        )
+        XCTAssertEqual(names, ["GlobalConfig", "GlobalJSON", "GlobalJSONC"])
+    }
+
+    func testInheritedNamesIncludeAncestorAndDotOpenCodeConfigsWithinWorktreeBoundary() throws {
+        let container = try makeTemporaryDirectory()
+        try writeMCPConfig(
+            named: "OutsideWorktree",
+            to: container.appendingPathComponent("opencode.json")
+        )
+
+        let project = container.appendingPathComponent("repo", isDirectory: true)
+        let nested = project.appendingPathComponent("Sources/Feature", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: project.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try writeText(
+            """
+            {
+              /* Ancestor project JSONC is loaded before more specific files. */
+              "mcp": {
+                "AncestorProject": {
+                  "type": "local",
+                  "command": ["/usr/bin/true"],
+                },
+              },
+            }
+            """,
+            to: project.appendingPathComponent("opencode.jsonc")
+        )
+        let dotOpenCode = project.appendingPathComponent(".opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: dotOpenCode, withIntermediateDirectories: true)
+        try writeMCPConfig(
+            named: "DotOpenCode",
+            to: dotOpenCode.appendingPathComponent("opencode.json")
+        )
+        let sourceDirectory = project.appendingPathComponent("Sources", isDirectory: true)
+        try writeMCPConfig(
+            named: "CurrentProject",
+            to: sourceDirectory.appendingPathComponent("opencode.json")
+        )
+
+        let names = OpenCodeIntegrationConfiguration.discoverInheritedMCPServerNames(
+            workingDirectory: nested.path,
+            environment: [
+                "HOME": container.appendingPathComponent("no-global-home").path
+            ]
+        )
+        XCTAssertEqual(names, ["AncestorProject", "CurrentProject", "DotOpenCode"])
+        XCTAssertFalse(names.contains("OutsideWorktree"))
+    }
+
+    func testInheritedNamesIncludeEnvironmentDirectedConfigSources() throws {
         let project = try makeTemporaryDirectory()
-        try writeJSON(
-            [
-                "mcp": [
-                    "ProjectMCP": [
-                        "type": "local",
-                        "command": ["/usr/bin/true"]
-                    ]
-                ]
-            ],
+        try FileManager.default.createDirectory(
+            at: project.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let customFileDirectory = project.appendingPathComponent("custom", isDirectory: true)
+        try FileManager.default.createDirectory(at: customFileDirectory, withIntermediateDirectories: true)
+        try writeText(
+            """
+            {
+              "mcp": {
+                "CustomFile": {
+                  "type": "local",
+                  "command": ["/usr/bin/true"],
+                },
+              },
+            }
+            """,
+            to: customFileDirectory.appendingPathComponent("settings.jsonc")
+        )
+
+        let customDirectory = project.appendingPathComponent("custom-dir", isDirectory: true)
+        try FileManager.default.createDirectory(at: customDirectory, withIntermediateDirectories: true)
+        try writeMCPConfig(
+            named: "CustomDirectoryJSON",
+            to: customDirectory.appendingPathComponent("opencode.json")
+        )
+        try writeText(
+            """
+            {
+              // OPENCODE_CONFIG_DIR supports JSONC too.
+              "mcp": {
+                "CustomDirectoryJSONC": {
+                  "type": "local",
+                  "command": ["/usr/bin/true"],
+                },
+              },
+            }
+            """,
+            to: customDirectory.appendingPathComponent("opencode.jsonc")
+        )
+
+        let names = OpenCodeIntegrationConfiguration.discoverInheritedMCPServerNames(
+            workingDirectory: project.path,
+            environment: [
+                "HOME": project.appendingPathComponent("no-global-home").path,
+                "OPENCODE_CONFIG": "custom/settings.jsonc",
+                "OPENCODE_CONFIG_DIR": "custom-dir"
+            ]
+        )
+        XCTAssertEqual(names, ["CustomDirectoryJSON", "CustomDirectoryJSONC", "CustomFile"])
+    }
+
+    func testProjectConfigDiscoveryHonorsOpenCodeDisableFlag() throws {
+        let project = try makeTemporaryDirectory()
+        try FileManager.default.createDirectory(
+            at: project.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try writeMCPConfig(
+            named: "ProjectMCP",
             to: project.appendingPathComponent("opencode.json")
         )
 
         let names = OpenCodeIntegrationConfiguration.discoverInheritedMCPServerNames(
             workingDirectory: project.path,
             environment: [
-                "HOME": project.appendingPathComponent("no-global-home").path
+                "HOME": project.appendingPathComponent("no-global-home").path,
+                "OPENCODE_DISABLE_PROJECT_CONFIG": "1"
             ]
         )
-        XCTAssertEqual(names, ["ProjectMCP"])
+        XCTAssertEqual(names, [])
+    }
+
+    func testParentInlineConfigContentIsNotScannedBecauseLaunchOverlayReplacesIt() throws {
+        let project = try makeTemporaryDirectory()
+        try FileManager.default.createDirectory(
+            at: project.appendingPathComponent(".git", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let names = OpenCodeIntegrationConfiguration.discoverInheritedMCPServerNames(
+            workingDirectory: project.path,
+            environment: [
+                "HOME": project.appendingPathComponent("no-global-home").path,
+                "OPENCODE_CONFIG_CONTENT": "{\"mcp\":{\"ParentInline\":{\"enabled\":true}}}"
+            ]
+        )
+        XCTAssertEqual(names, [])
     }
 
     private func makeTemporaryDirectory() throws -> URL {
@@ -100,8 +261,26 @@ final class OpenCodeIntegrationConfigurationTests: XCTestCase {
         return url
     }
 
+    private func writeMCPConfig(named name: String, to url: URL) throws {
+        try writeJSON(
+            [
+                "mcp": [
+                    name: [
+                        "type": "local",
+                        "command": ["/usr/bin/true"]
+                    ]
+                ]
+            ],
+            to: url
+        )
+    }
+
     private func writeJSON(_ object: [String: Any], to url: URL) throws {
         let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: url, options: .atomic)
+    }
+
+    private func writeText(_ text: String, to url: URL) throws {
+        try text.write(to: url, atomically: true, encoding: .utf8)
     }
 }


### PR DESCRIPTION
## Summary
- OpenCode ACP `session/new` was timing out after 30s with initialize succeeding (`no matching ACP response`; last stdout is the initialize result).
- Root cause: OpenCode merges **global/project** `mcp` entries into ACP startup and waits for them to connect. RepoPrompt only overrode the same-name `RepoPromptCE` entry in `OPENCODE_CONFIG_CONTENT`, so other hanging MCP servers (and recursive RepoPrompt CE CLI configs) could still block bootstrap.
- Dual Oracle PR #782 does **not** address this path.

## Fix
- Discover MCP server names from global (`~/.config/opencode/opencode.json` / XDG) and project (`opencode.json`, `.opencode/opencode.json`) configs.
- In the process-ephemeral overlay, disable every inherited non-RepoPrompt MCP name and keep the managed RepoPromptCE entry active or disabled as before.
- Surface clearer OpenCode startup-timeout guidance when bootstrap still fails.

## Validation
- `make dev-test FILTER=OpenCodeIntegrationConfigurationTests` ✅ (3 tests)
- `make dev-test FILTER=OpenCodeACPLaunchResolverTests` ✅ (11 tests)
- Local OpenCode 1.18.16 repro: hanging inherited MCP blocked `session/new`; neutralizing discovered names returned a session in ~0.3s.

## Note
Not part of #782. Separate PR off `main`.