### PR TITLE
Agent Mode: share Codex transient execution classification

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedAgentModeRunner.swift
@@ -47,35 +47,26 @@ final class CodexIntegratedAgentModeRunner {
             #if DEBUG || EDIT_FLOW_PERF
                 EditFlowPerf.end(EditFlowPerf.Stage.MCPWindowToolCatalog.codexTurnMCPServerEnable, codexTurnMCPServerEnableState)
             #endif
-            guard mcpServerReady else {
-                let outcome = CodexAgentModeCoordinator.NativeSendOutcome.failed(
-                    message: "MCP catalog registration failed before Agent launch."
+            let execution = await CodexIntegratedRunExecutionAdapter.execute {
+                guard mcpServerReady else {
+                    return .failed(message: "MCP catalog registration failed before Agent launch.")
+                }
+                return await codexCoordinator.sendCodexNativeMessage(
+                    session: session,
+                    text: initialMessageForRun,
+                    attachments: attachments,
+                    fallbackContext: fallbackContext,
+                    attachmentReservationID: attachmentReservationID,
+                    terminalizeRejectedSend: createdOwnership
                 )
-                hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
-                if createdOwnership {
-                    session.endRunAttempt(ifCurrent: ownership, source: "codex.mcpBootstrapRejected")
-                }
-                return outcome
             }
-
-            let outcome = await codexCoordinator.sendCodexNativeMessage(
-                session: session,
-                text: initialMessageForRun,
-                attachments: attachments,
-                fallbackContext: fallbackContext,
-                attachmentReservationID: attachmentReservationID,
-                terminalizeRejectedSend: createdOwnership
-            )
+            let outcome = execution.nativeOutcome
             hooks.providerInput.recordPendingHandoffSendOutcome(session, outcome.didSend)
-            switch outcome {
-            case .sent:
+            if execution.didStartProviderRun {
                 session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .running)
-            case .preDispatchRejected, .cancelled, .failed, .stale:
-                if createdOwnership {
-                    session.endRunAttempt(ifCurrent: ownership, source: "codex.sendRejected")
-                }
-            case .queuedFallback:
-                break
+            } else if createdOwnership, execution.shouldReleaseCreatedOwnership {
+                let source = mcpServerReady ? "codex.sendRejected" : "codex.mcpBootstrapRejected"
+                session.endRunAttempt(ifCurrent: ownership, source: source)
             }
             return outcome
         }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedRunExecutionAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedRunExecutionAdapter.swift
@@ -1,0 +1,71 @@
+import Foundation
+import RepoPromptDomainRuntime
+
+/// Maps Codex's dispatch-specific result vocabulary onto the shared transient
+/// execution classifier without transferring any Codex lifecycle authority.
+///
+/// A completed report means only that the provider accepted or durably queued
+/// the dispatch operation. The report must never be published as a terminal
+/// Agent run result; Codex events and `AgentRunTerminalCommitBarrier` remain the
+/// sole terminal settlement path.
+@MainActor
+enum CodexIntegratedRunExecutionAdapter {
+    struct Result {
+        let nativeOutcome: CodexAgentModeCoordinator.NativeSendOutcome
+        let executionReport: DomainAgentRunExecutionReport
+
+        var didStartProviderRun: Bool {
+            if case .sent = nativeOutcome {
+                return true
+            }
+            return false
+        }
+
+        var shouldReleaseCreatedOwnership: Bool {
+            switch executionReport.result {
+            case .superseded:
+                true
+            case let .terminal(outcome):
+                outcome.kind != .completed
+            }
+        }
+    }
+
+    static func execute(
+        operation: () async -> CodexAgentModeCoordinator.NativeSendOutcome
+    ) async -> Result {
+        var nativeOutcome: CodexAgentModeCoordinator.NativeSendOutcome?
+        let executionReport = await DomainAgentRunExecutionCore.execute {
+            let outcome = await operation()
+            nativeOutcome = outcome
+            return try operationResult(for: outcome)
+        }
+        guard let nativeOutcome else {
+            preconditionFailure("Codex transient execution completed without a native outcome")
+        }
+        return Result(nativeOutcome: nativeOutcome, executionReport: executionReport)
+    }
+
+    private static func operationResult(
+        for outcome: CodexAgentModeCoordinator.NativeSendOutcome
+    ) throws -> DomainAgentRunExecutionOperationResult {
+        switch outcome {
+        case .sent, .queuedFallback:
+            .completed(assistantText: nil)
+        case .stale:
+            .superseded
+        case .cancelled:
+            throw CancellationError()
+        case let .preDispatchRejected(message), let .failed(message):
+            throw DispatchFailure(message: message)
+        }
+    }
+
+    private struct DispatchFailure: LocalizedError {
+        let message: String
+
+        var errorDescription: String? {
+            message
+        }
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexIntegratedRunExecutionAdapterTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexIntegratedRunExecutionAdapterTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+@testable import RepoPromptApp
+import RepoPromptDomainRuntime
+import XCTest
+
+@MainActor
+final class CodexIntegratedRunExecutionAdapterTests: XCTestCase {
+    func testAcceptedDispatchOutcomesPreserveNativeResultAndClassifyAsTransientCompletion() async {
+        let queueID = UUID()
+        let outcomes: [CodexAgentModeCoordinator.NativeSendOutcome] = [
+            .sent,
+            .queuedFallback(queueID: queueID, reason: .activeWithoutAuthoritativeIdentity)
+        ]
+
+        for outcome in outcomes {
+            var invocationCount = 0
+            let result = await CodexIntegratedRunExecutionAdapter.execute {
+                invocationCount += 1
+                return outcome
+            }
+
+            XCTAssertEqual(invocationCount, 1)
+            XCTAssertEqual(result.nativeOutcome, outcome)
+            XCTAssertEqual(
+                result.executionReport,
+                DomainAgentRunExecutionReport(
+                    result: .terminal(.completed(assistantText: nil)),
+                    trace: [.executionStarted, .terminalOutcomeProduced(.completed)]
+                )
+            )
+            XCTAssertEqual(result.didStartProviderRun, outcome == .sent)
+            XCTAssertFalse(result.shouldReleaseCreatedOwnership)
+        }
+    }
+
+    func testRejectedDispatchOutcomesPreserveMessageAndClassifyAsTransientFailure() async {
+        let fixtures: [(CodexAgentModeCoordinator.NativeSendOutcome, String)] = [
+            (.preDispatchRejected(message: "pre-dispatch rejected"), "pre-dispatch rejected"),
+            (.failed(message: "provider failed"), "provider failed")
+        ]
+
+        for (outcome, message) in fixtures {
+            let result = await CodexIntegratedRunExecutionAdapter.execute { outcome }
+
+            XCTAssertEqual(result.nativeOutcome, outcome)
+            XCTAssertEqual(
+                result.executionReport,
+                DomainAgentRunExecutionReport(
+                    result: .terminal(.failed(assistantText: message, reason: .agentError)),
+                    trace: [.executionStarted, .terminalOutcomeProduced(.failed)]
+                )
+            )
+            XCTAssertFalse(result.didStartProviderRun)
+            XCTAssertTrue(result.shouldReleaseCreatedOwnership)
+        }
+    }
+
+    func testCancelledDispatchClassifiesAsCancellationWithoutLosingNativeResult() async {
+        let result = await CodexIntegratedRunExecutionAdapter.execute { .cancelled }
+
+        XCTAssertEqual(result.nativeOutcome, .cancelled)
+        XCTAssertEqual(
+            result.executionReport,
+            DomainAgentRunExecutionReport(
+                result: .terminal(.cancelled()),
+                trace: [.executionStarted, .terminalOutcomeProduced(.cancelled)]
+            )
+        )
+        XCTAssertFalse(result.didStartProviderRun)
+        XCTAssertTrue(result.shouldReleaseCreatedOwnership)
+    }
+
+    func testStaleDispatchClassifiesAsNonterminalSupersession() async {
+        let outcome = CodexAgentModeCoordinator.NativeSendOutcome.stale(reason: "run changed")
+        let result = await CodexIntegratedRunExecutionAdapter.execute { outcome }
+
+        XCTAssertEqual(result.nativeOutcome, outcome)
+        XCTAssertEqual(
+            result.executionReport,
+            DomainAgentRunExecutionReport(
+                result: .superseded,
+                trace: [.executionStarted, .executionSuperseded]
+            )
+        )
+        XCTAssertFalse(result.didStartProviderRun)
+        XCTAssertTrue(result.shouldReleaseCreatedOwnership)
+    }
+
+    func testAlreadyCancelledTaskDoesNotOverrideAcceptedNativeDispatch() async {
+        let result = await Task { @MainActor in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await CodexIntegratedRunExecutionAdapter.execute { .sent }
+        }.value
+
+        XCTAssertEqual(result.nativeOutcome, .sent)
+        XCTAssertEqual(result.executionReport.result, .terminal(.completed(assistantText: nil)))
+        XCTAssertTrue(result.didStartProviderRun)
+        XCTAssertFalse(result.shouldReleaseCreatedOwnership)
+    }
+}


### PR DESCRIPTION
## Summary

- route Codex integrated dispatch outcomes through DomainAgentRunExecutionCore
- keep Codex-native send vocabulary behind a narrow provider-local adapter
- preserve coordinator/process/session, exact-attempt fencing, terminal settlement, and pending-handoff authorities

## Architecture

This is a Thin UI Wave 2 convergence step. The shared core classifies transient execution outcomes only; AgentRunTerminalCommitBarrier and the existing Codex coordinator/stores remain the sole terminal and lifecycle authorities. No persisted formats or shared composition boundaries change.

## Validation

- CodexIntegratedRunExecutionAdapterTests: 5 passed, 0 failed (conductor ticket 4d50e269-465a-4d82-82d0-1647504c88a6)
- RepoPrompt product build passed (ticket fd97f48f-4088-4ed3-86eb-602700933181)
- changed-file SwiftFormat: 0/3 requiring formatting
- changed-file strict SwiftLint: 0 violations
- commit and push contribution preflights passed
- Fable 5 High static review: approved, no blocking findings

## Notes

The repository-wide lint lane still encounters known pre-existing SwiftFormat timeout hotspots; changed-file style evidence is clean. No app lifecycle action was performed.