### PR TITLE
Agent Mode: share Claude transient execution classification

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
@@ -2,11 +2,18 @@ import Foundation
 
 @MainActor
 final class ClaudeIntegratedAgentModeRunner {
-    private struct ConsumeEventsOutcome {
-        let terminalState: AgentSessionRunState
-        let errorText: String?
-        let shouldShutdownSession: Bool
+    private enum ConsumeEventsOutcome {
+        case completed
+        case cancelled
+        case failed(errorText: String?, shouldShutdownSession: Bool)
     }
+
+    /// Claude's native stream reports terminal cancellation and failure as values,
+    /// while the shared transient execution core accepts those classifications as
+    /// thrown errors. This marker is intentionally runner-local: the coordinator
+    /// and native controller remain the authorities for the underlying terminal
+    /// event and its provider-specific metadata.
+    private struct NativeTerminalFailure: Error {}
 
     private let claudeCoordinator: ClaudeAgentModeCoordinator
     private let hooks: AgentModeRunService.Hooks
@@ -111,40 +118,72 @@ final class ClaudeIntegratedAgentModeRunner {
                 )
 
                 let providerName = session.selectedAgent.rawValue
-                await lease.providerInitializationStarted(provider: providerName)
-                let sendOutcome = await self.claudeCoordinator.sendClaudeNativeMessage(
-                    session: session,
-                    text: initialMessageForRun,
-                    attachments: attachments,
-                    intent: .runAttempt(ownership: ownership, runID: runID)
-                )
-                let providerInitializationOutcome = switch sendOutcome {
-                case .sent:
-                    "ready"
-                case .failed:
-                    Task.isCancelled ? "cancelled" : "failed"
-                case .superseded:
-                    "superseded"
-                }
-                await lease.providerInitializationCompleted(
-                    provider: providerName,
-                    outcome: providerInitializationOutcome
-                )
-                switch sendOutcome {
-                case .sent:
-                    self.hooks.providerInput.recordPendingHandoffSendOutcome(session, true)
-                case .failed:
-                    self.hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
-                    await self.finalize(
+                var didSendToProvider = false
+                var nativeFailureMetadata: (errorText: String?, shouldShutdownSession: Bool)?
+                let report = await DomainAgentRunExecutionCore.execute(
+                    failureText: { _ in nativeFailureMetadata?.errorText ?? "" }
+                ) {
+                    await lease.providerInitializationStarted(provider: providerName)
+                    let sendOutcome = await self.claudeCoordinator.sendClaudeNativeMessage(
+                        session: session,
+                        text: initialMessageForRun,
+                        attachments: attachments,
+                        intent: .runAttempt(ownership: ownership, runID: runID)
+                    )
+                    let providerInitializationOutcome = switch sendOutcome {
+                    case .sent:
+                        "ready"
+                    case .failed:
+                        Task.isCancelled ? "cancelled" : "failed"
+                    case .superseded:
+                        "superseded"
+                    }
+                    await lease.providerInitializationCompleted(
+                        provider: providerName,
+                        outcome: providerInitializationOutcome
+                    )
+
+                    switch sendOutcome {
+                    case .sent:
+                        didSendToProvider = true
+                        self.hooks.providerInput.recordPendingHandoffSendOutcome(session, true)
+                    case .failed:
+                        nativeFailureMetadata = (errorText: nil, shouldShutdownSession: false)
+                        throw NativeTerminalFailure()
+                    case .superseded:
+                        return .superseded
+                    }
+
+                    self.hooks.attachments.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
+                    self.hooks.attachments.markAttachmentsConsumed(session, attachmentReservationID)
+                    _ = await lease.releaseWhenRouted()
+
+                    guard let events = await self.claudeCoordinator.events(for: session) else {
+                        nativeFailureMetadata = (
+                            errorText: "Claude native events stream not available.",
+                            shouldShutdownSession: false
+                        )
+                        throw NativeTerminalFailure()
+                    }
+
+                    session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .running)
+                    switch await self.consumeEvents(
+                        events,
                         session: session,
                         runID: runID,
-                        ownership: ownership,
-                        attachmentReservationID: attachmentReservationID,
-                        terminalState: .failed,
-                        errorText: nil,
-                        notifyTurnComplete: false
-                    )
-                    return
+                        runAttemptID: runAttemptID
+                    ) {
+                    case .completed:
+                        return .completed(assistantText: nil)
+                    case .cancelled:
+                        throw CancellationError()
+                    case let .failed(errorText, shouldShutdownSession):
+                        nativeFailureMetadata = (errorText, shouldShutdownSession)
+                        throw NativeTerminalFailure()
+                    }
+                }
+
+                switch report.result {
                 case .superseded:
                     if self.claudeCoordinator.runAttemptIsCurrent(
                         ownership,
@@ -167,43 +206,27 @@ final class ClaudeIntegratedAgentModeRunner {
                     } else {
                         await lease.cancelAndCleanup()
                     }
-                    return
-                }
-
-                self.hooks.attachments.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
-                self.hooks.attachments.markAttachmentsConsumed(session, attachmentReservationID)
-                _ = await lease.releaseWhenRouted()
-
-                guard let events = await self.claudeCoordinator.events(for: session) else {
+                case let .terminal(outcome):
+                    let terminalState: AgentSessionRunState = switch outcome.kind {
+                    case .completed: .completed
+                    case .cancelled: .cancelled
+                    case .failed: .failed
+                    }
+                    if !didSendToProvider {
+                        self.hooks.providerInput.recordPendingHandoffSendOutcome(session, false)
+                    }
                     await self.finalize(
                         session: session,
                         runID: runID,
                         ownership: ownership,
                         attachmentReservationID: attachmentReservationID,
-                        terminalState: .failed,
-                        errorText: "Claude native events stream not available.",
-                        notifyTurnComplete: false
+                        terminalState: terminalState,
+                        errorText: outcome.kind == .failed ? nativeFailureMetadata?.errorText : nil,
+                        notifyTurnComplete: outcome.kind == .completed,
+                        shouldShutdownSession: outcome.kind == .failed
+                            && nativeFailureMetadata?.shouldShutdownSession == true
                     )
-                    return
                 }
-
-                session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .running)
-                let outcome = await self.consumeEvents(
-                    events,
-                    session: session,
-                    runID: runID,
-                    runAttemptID: runAttemptID
-                )
-                await self.finalize(
-                    session: session,
-                    runID: runID,
-                    ownership: ownership,
-                    attachmentReservationID: attachmentReservationID,
-                    terminalState: outcome.terminalState,
-                    errorText: outcome.errorText,
-                    notifyTurnComplete: outcome.terminalState == .completed,
-                    shouldShutdownSession: outcome.shouldShutdownSession
-                )
             } onCancel: {}
         }
     }
@@ -256,8 +279,7 @@ final class ClaudeIntegratedAgentModeRunner {
                     hooks.persistence.scheduleSave(session)
                 }
                 if status.isRepoPromptServerFailed {
-                    return ConsumeEventsOutcome(
-                        terminalState: .failed,
+                    return .failed(
                         errorText: "RepoPrompt MCP failed to initialize for Claude (session \(status.sessionID ?? "unknown")).",
                         shouldShutdownSession: true
                     )
@@ -309,11 +331,11 @@ final class ClaudeIntegratedAgentModeRunner {
                 session.claudeSupersedingProtectedTurnIDs.removeAll()
                 switch turnStatus {
                 case .completed:
-                    return ConsumeEventsOutcome(terminalState: .completed, errorText: nil, shouldShutdownSession: false)
+                    return .completed
                 case .cancelled:
-                    return ConsumeEventsOutcome(terminalState: .cancelled, errorText: nil, shouldShutdownSession: false)
+                    return .cancelled
                 case .failed:
-                    return ConsumeEventsOutcome(terminalState: .failed, errorText: nil, shouldShutdownSession: false)
+                    return .failed(errorText: nil, shouldShutdownSession: false)
                 }
             case let .error(message):
                 session.clearClaudeReasoningStatus(clearDisplayedStatus: true)
@@ -336,14 +358,13 @@ final class ClaudeIntegratedAgentModeRunner {
         // If we exited because the attempt changed (cancel / new attempt)
         // or the task was cancelled, this is expected — not a stream failure.
         if exitedDueToAttemptMismatch || Task.isCancelled {
-            return ConsumeEventsOutcome(terminalState: .cancelled, errorText: nil, shouldShutdownSession: false)
+            return .cancelled
         }
 
         // The events stream ended without a terminal turnCompleted event while this
         // attempt was still active.  This means the stream was finished or the Claude
         // process exited unexpectedly.
-        return ConsumeEventsOutcome(
-            terminalState: .failed,
+        return .failed(
             errorText: "Claude events stream ended unexpectedly. The run may need to be restarted.",
             shouldShutdownSession: false
         )

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -549,9 +549,11 @@ extension AgentModeRunServiceLifecycleTests {
             mcpServerStatuses: [MCPIntegrationHelper.repoPromptMCPServerName: "failed"],
             initializeResponse: nil
         )
+        let shutdownGate = LifecycleAsyncGate()
         let controller = LifecycleFakeNativeController(
             recorder: recorder,
             label: "runtime-init-failure",
+            shutdownGate: shutdownGate,
             runtimeInitStatusOnSend: runtimeInitFailure
         )
         let harness = makeHarness(recorder: recorder, claudeController: controller)
@@ -576,6 +578,8 @@ extension AgentModeRunServiceLifecycleTests {
             "RepoPrompt MCP failed to initialize for Claude (session runtime-init-failure)."
         )
         XCTAssertNil(session.claudeController)
+        await shutdownGate.waitUntilArrived()
+        await shutdownGate.release()
         await harness.host.claudeCoordinator.awaitPendingClaudeResumeTransferIfNeeded(for: session)
         XCTAssertTrue(recorder.contains("runtime-init-failure:shutdown"))
         XCTAssertEqual(recorder.events.count(where: { $0.hasPrefix("commit:") }), 1)

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -458,6 +458,129 @@ extension AgentModeRunServiceLifecycleTests {
         XCTAssertFalse(recorder.contains("runner-replacement:shutdown"))
     }
 
+    func testClaudeRunnerClassifiesNativeTerminalEventsThroughSharedExecutionCore() async throws {
+        let rows: [(
+            name: String,
+            nativeStatus: NativeAgentRuntimeTurnStatus,
+            expectedState: AgentSessionRunState
+        )] = [
+            ("completed", .completed, .completed),
+            ("cancelled", .cancelled, .cancelled),
+            ("failed", .failed, .failed)
+        ]
+
+        for row in rows {
+            let recorder = LifecycleRecorder()
+            let controller = LifecycleFakeNativeController(
+                recorder: recorder,
+                label: "terminal-\(row.name)",
+                turnStatusOnSend: row.nativeStatus
+            )
+            let harness = makeHarness(recorder: recorder, claudeController: controller)
+            let session = AgentModeViewModel.TabSession(tabID: UUID())
+            session.selectedAgent = .claudeCode
+            harness.host.test_installLiveSession(session)
+
+            _ = await harness.service.startRun(
+                tabID: session.tabID,
+                session: session,
+                initialUserMessage: row.name,
+                initialMessageForRun: row.name,
+                attachments: []
+            )
+            let ownership = try XCTUnwrap(session.activeRunOwnership)
+            let agentTask = try XCTUnwrap(session.agentTask)
+            await agentTask.value
+
+            XCTAssertEqual(session.runState, row.expectedState, row.name)
+            XCTAssertNil(session.activeRunOwnership, row.name)
+            XCTAssertEqual(session.lastTerminalCommitRevision?.ownership, ownership, row.name)
+            XCTAssertEqual(session.lastTerminalCommitRevision?.terminalState, row.expectedState, row.name)
+            XCTAssertEqual(recorder.events.count(where: { $0.hasPrefix("commit:") }), 1, row.name)
+            XCTAssertEqual(recorder.events.count(where: { $0 == "run-active:false" }), 1, row.name)
+            XCTAssertEqual(recorder.events.count(where: { $0 == "handoff:true" }), 1, row.name)
+            XCTAssertEqual(recorder.events.count(where: { $0 == "handoff:false" }), 0, row.name)
+            XCTAssertTrue(recorder.contains("attachments:deleteFiles"), row.name)
+            XCTAssertNotNil(session.claudeController, row.name)
+            XCTAssertFalse(recorder.contains("terminal-\(row.name):shutdown"), row.name)
+        }
+    }
+
+    func testClaudeRunnerPreservesUnexpectedStreamEndFailureEvidenceWithoutShutdown() async throws {
+        let recorder = LifecycleRecorder()
+        let controller = LifecycleFakeNativeController(
+            recorder: recorder,
+            label: "stream-end",
+            finishEventsAfterSend: true
+        )
+        let harness = makeHarness(recorder: recorder, claudeController: controller)
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        harness.host.test_installLiveSession(session)
+
+        _ = await harness.service.startRun(
+            tabID: session.tabID,
+            session: session,
+            initialUserMessage: "end stream",
+            initialMessageForRun: "end stream",
+            attachments: []
+        )
+        let agentTask = try XCTUnwrap(session.agentTask)
+        await agentTask.value
+
+        XCTAssertEqual(session.runState, .failed)
+        XCTAssertEqual(session.lastTerminalCommitRevision?.terminalState, .failed)
+        XCTAssertEqual(
+            session.items.last(where: { $0.kind == .error })?.text,
+            "Claude events stream ended unexpectedly. The run may need to be restarted."
+        )
+        XCTAssertEqual(recorder.events.count(where: { $0.hasPrefix("commit:") }), 1)
+        XCTAssertEqual(recorder.events.count(where: { $0 == "handoff:true" }), 1)
+        XCTAssertEqual(recorder.events.count(where: { $0 == "handoff:false" }), 0)
+        XCTAssertNotNil(session.claudeController)
+        XCTAssertFalse(recorder.contains("stream-end:shutdown"))
+    }
+
+    func testClaudeRunnerPreservesRuntimeInitFailureShutdownPolicy() async throws {
+        let recorder = LifecycleRecorder()
+        let runtimeInitFailure = NativeAgentRuntimeRuntimeInitStatus(
+            sessionID: "runtime-init-failure",
+            tools: [],
+            mcpServerStatuses: [MCPIntegrationHelper.repoPromptMCPServerName: "failed"],
+            initializeResponse: nil
+        )
+        let controller = LifecycleFakeNativeController(
+            recorder: recorder,
+            label: "runtime-init-failure",
+            runtimeInitStatusOnSend: runtimeInitFailure
+        )
+        let harness = makeHarness(recorder: recorder, claudeController: controller)
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.selectedAgent = .claudeCode
+        harness.host.test_installLiveSession(session)
+
+        _ = await harness.service.startRun(
+            tabID: session.tabID,
+            session: session,
+            initialUserMessage: "fail runtime init",
+            initialMessageForRun: "fail runtime init",
+            attachments: []
+        )
+        let agentTask = try XCTUnwrap(session.agentTask)
+        await agentTask.value
+
+        XCTAssertEqual(session.runState, .failed)
+        XCTAssertEqual(session.lastTerminalCommitRevision?.terminalState, .failed)
+        XCTAssertEqual(
+            session.items.last(where: { $0.kind == .error })?.text,
+            "RepoPrompt MCP failed to initialize for Claude (session runtime-init-failure)."
+        )
+        XCTAssertNil(session.claudeController)
+        await harness.host.claudeCoordinator.awaitPendingClaudeResumeTransferIfNeeded(for: session)
+        XCTAssertTrue(recorder.contains("runtime-init-failure:shutdown"))
+        XCTAssertEqual(recorder.events.count(where: { $0.hasPrefix("commit:") }), 1)
+    }
+
     func testClaudeSendFailureReportsEvidenceWithoutTerminalizingSession() async {
         let recorder = LifecycleRecorder()
         let controller = LifecycleFakeNativeController(
@@ -1007,8 +1130,12 @@ actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
     private let shutdownGate: LifecycleAsyncGate?
     private let repeatsStartOrResumeFailure: Bool
     private var pendingStartOrResumeFailure: Error?
+    private let turnStatusOnSend: NativeAgentRuntimeTurnStatus?
+    private let runtimeInitStatusOnSend: NativeAgentRuntimeRuntimeInitStatus?
+    private let finishEventsAfterSend: Bool
     private let sessionRef = NativeAgentRuntimeSessionRef(sessionID: "lifecycle-claude-session")
     private let stream: AsyncStream<NativeAgentRuntimeEvent>
+    private let eventsContinuation: AsyncStream<NativeAgentRuntimeEvent>.Continuation
 
     init(
         recorder: LifecycleRecorder,
@@ -1021,7 +1148,10 @@ actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
         sendUserMessageGate: LifecycleAsyncGate? = nil,
         shutdownGate: LifecycleAsyncGate? = nil,
         startOrResumeFailure: Error? = nil,
-        repeatsStartOrResumeFailure: Bool = false
+        repeatsStartOrResumeFailure: Bool = false,
+        turnStatusOnSend: NativeAgentRuntimeTurnStatus? = nil,
+        runtimeInitStatusOnSend: NativeAgentRuntimeRuntimeInitStatus? = nil,
+        finishEventsAfterSend: Bool = false
     ) {
         self.recorder = recorder
         self.label = label
@@ -1034,7 +1164,12 @@ actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
         self.shutdownGate = shutdownGate
         self.repeatsStartOrResumeFailure = repeatsStartOrResumeFailure
         pendingStartOrResumeFailure = startOrResumeFailure
-        stream = AsyncStream { _ in }
+        self.turnStatusOnSend = turnStatusOnSend
+        self.runtimeInitStatusOnSend = runtimeInitStatusOnSend
+        self.finishEventsAfterSend = finishEventsAfterSend
+        let eventPipe = AsyncStream<NativeAgentRuntimeEvent>.makeStream()
+        stream = eventPipe.stream
+        eventsContinuation = eventPipe.continuation
     }
 
     var hasActiveSession: Bool {
@@ -1097,7 +1232,17 @@ actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
         if failSend {
             throw LifecycleTestError.expectedClaudeSendFailure
         }
-        return UUID()
+        let turnID = UUID()
+        if let runtimeInitStatusOnSend {
+            eventsContinuation.yield(.runtimeInit(runtimeInitStatusOnSend))
+        }
+        if let turnStatusOnSend {
+            eventsContinuation.yield(.turnCompleted(turnID: turnID, status: turnStatusOnSend))
+        }
+        if finishEventsAfterSend {
+            eventsContinuation.finish()
+        }
+        return turnID
     }
 
     func interruptTurn(reason: String) async -> NativeAgentRuntimeInterruptOutcome {


### PR DESCRIPTION
## Summary

- route Claude native send and stream terminal outcomes through DomainAgentRunExecutionCore
- preserve Claude coordinator/controller, resume-transfer, exact-attempt fencing, and terminal settlement authorities
- add deterministic coverage for completion, cancellation, failure, unexpected EOF, and runtime-init teardown

## Architecture

This is a Thin UI Wave 2 convergence step. The shared core classifies transient outcomes; the Claude coordinator remains process/session/event/teardown authority and AgentRunTerminalCommitBarrier remains the sole terminal publication authority. No persisted formats or shared composition boundaries change.

## Validation

- complete ClaudeRunner filter: 4 passed, 0 failed (ticket 1a9f54e5-2fb7-4b62-a17a-ef870050e920)
- deterministic runtime-init shutdown test: 1 passed (ticket 080b8d27-fca6-495d-941e-bcf7d080e7f8)
- changed-file SwiftFormat and strict SwiftLint passed
- commit and push contribution preflights passed
- Fable 5 High static review: approved, no blocking findings

## Notes

The second commit replaces a race-prone immediate shutdown assertion with the coordinator-owned asynchronous teardown contract. No app lifecycle action was performed.