### PR TITLE
Agent Mode: share ACP transient execution classification

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -3,8 +3,32 @@ import MCP
 
 @MainActor
 final class ACPIntegratedAgentModeRunner {
-    private struct ConsumeEventsOutcome {
-        let terminalState: AgentSessionRunState
+    private enum TransientOperationResult {
+        case completed
+        case cancelled
+        case failed(errorText: String?)
+        case superseded
+
+        var debugDescription: String {
+            switch self {
+            case .completed:
+                "state=completed error=nil"
+            case .cancelled:
+                "state=cancelled error=nil"
+            case let .failed(errorText):
+                "state=failed error=\(errorText ?? "nil")"
+            case .superseded:
+                "state=superseded error=nil"
+            }
+        }
+    }
+
+    private struct TransientExecutionClassification {
+        let report: DomainAgentRunExecutionReport
+        let errorText: String?
+    }
+
+    private struct ExplicitTerminalFailure: Error {
         let errorText: String?
     }
 
@@ -66,6 +90,41 @@ final class ACPIntegratedAgentModeRunner {
             }
         }
         return String(describing: error)
+    }
+
+    private static func executeTransientOperation(
+        _ operation: () async throws -> TransientOperationResult
+    ) async -> TransientExecutionClassification {
+        var explicitFailureText: String??
+        let report = await DomainAgentRunExecutionCore.execute(
+            failureText: { error in
+                if let failure = error as? ExplicitTerminalFailure {
+                    return failure.errorText ?? ""
+                }
+                return displayText(for: error)
+            }
+        ) {
+            switch try await operation() {
+            case .completed:
+                return .completed(assistantText: nil)
+            case .cancelled:
+                throw CancellationError()
+            case let .failed(errorText):
+                explicitFailureText = .some(errorText)
+                throw ExplicitTerminalFailure(errorText: errorText)
+            case .superseded:
+                return .superseded
+            }
+        }
+
+        let errorText: String? = if case let .some(explicitText) = explicitFailureText {
+            explicitText
+        } else if case let .terminal(outcome) = report.result, outcome.kind == .failed {
+            outcome.assistantText
+        } else {
+            nil
+        }
+        return TransientExecutionClassification(report: report, errorText: errorText)
     }
 
     init(
@@ -480,112 +539,99 @@ final class ACPIntegratedAgentModeRunner {
         }
 
         var providerInitializationCompleted = false
-        do {
-            let providerName = runRequest.agentKind.rawValue
-            await lease.providerInitializationStarted(provider: providerName)
-            log("bootstrap begin", runID: runID)
-            let bootstrap = try await controller.bootstrap()
-            providerInitializationCompleted = true
-            await lease.providerInitializationCompleted(provider: providerName, outcome: "ready")
-            log("bootstrap completed sessionID=\(bootstrap.sessionID)", runID: runID)
-            guard session.runID == runID,
-                  session.activeRunAttemptID == runAttemptID
-            else {
-                await controller.shutdown()
-                return
-            }
-            var initialMessageForPromptTurn = initialMessageForRun
-            if bootstrap.didFallbackToNewSessionAfterLoadFailure {
-                await hooks.providerInput.stageResumeRecoveryHandoffIfNeeded(session)
-                initialMessageForPromptTurn = hooks.providerInput.prependPendingHandoffIfNeeded(initialMessageForRun, session)
-            }
-            applyProviderSessionIdentity(
-                bootstrap.providerSessionIdentity,
-                invalidatedResumeSessionID: bootstrap.invalidatedResumeSessionID,
-                session: session
-            )
-            _ = syncACPSelectedModelFromRegistryIfNeeded(agentKind: runRequest.agentKind, session: session)
-            session.isDirty = true
-            hooks.persistence.scheduleSave(session)
-            hooks.bindingObservation.updateBindings(session)
-
-            try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
-            await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
-            try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
-            setRunningStatus(waitingForConnectionStatusText(for: runRequest.agentKind), source: .transport, session: session, urgent: true)
-
-            if runRequest.agentKind.requiresPrePromptAgentModeMCPRouting {
-                let routed = await lease.releaseWhenRouted()
-                log("releaseWhenRouted routed=\(routed)", runID: runID)
-                guard routed else {
-                    await finalize(
-                        session: session,
-                        runID: runID,
-                        runAttemptID: runAttemptID,
-                        controller: controller,
-                        attachmentReservationID: attachmentReservationID,
-                        terminalState: .failed,
-                        errorText: "RepoPrompt MCP routing did not complete before \(runRequest.agentKind.displayName) ACP prompt submission.",
-                        notifyTurnComplete: false,
-                        shouldShutdownController: true
-                    )
-                    return
+        let classification = await Self.executeTransientOperation {
+            do {
+                let providerName = runRequest.agentKind.rawValue
+                await lease.providerInitializationStarted(provider: providerName)
+                log("bootstrap begin", runID: runID)
+                let bootstrap = try await controller.bootstrap()
+                providerInitializationCompleted = true
+                await lease.providerInitializationCompleted(provider: providerName, outcome: "ready")
+                log("bootstrap completed sessionID=\(bootstrap.sessionID)", runID: runID)
+                guard session.runID == runID,
+                      session.activeRunAttemptID == runAttemptID
+                else {
+                    await controller.shutdown()
+                    return .superseded
                 }
-            } else {
-                await lease.releaseGateForDeferredRouting()
-                log("deferred MCP routing until ACP prompt", runID: runID)
-            }
+                var initialMessageForPromptTurn = initialMessageForRun
+                if bootstrap.didFallbackToNewSessionAfterLoadFailure {
+                    await hooks.providerInput.stageResumeRecoveryHandoffIfNeeded(session)
+                    initialMessageForPromptTurn = hooks.providerInput.prependPendingHandoffIfNeeded(initialMessageForRun, session)
+                }
+                applyProviderSessionIdentity(
+                    bootstrap.providerSessionIdentity,
+                    invalidatedResumeSessionID: bootstrap.invalidatedResumeSessionID,
+                    session: session
+                )
+                _ = syncACPSelectedModelFromRegistryIfNeeded(agentKind: runRequest.agentKind, session: session)
+                session.isDirty = true
+                hooks.persistence.scheduleSave(session)
+                hooks.bindingObservation.updateBindings(session)
 
-            await runPromptTurn(
-                session: session,
-                runID: runID,
-                runAttemptID: runAttemptID,
-                initialMessageForRun: initialMessageForPromptTurn,
-                attachments: attachments,
-                controller: controller,
-                runRequest: runRequest,
-                attachmentReservationID: attachmentReservationID,
-                prepareControllerForNextTurn: false
-            )
-        } catch is CancellationError {
-            if !providerInitializationCompleted {
-                await lease.providerInitializationCompleted(provider: runRequest.agentKind.rawValue, outcome: "cancelled")
+                try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
+                await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
+                try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
+                setRunningStatus(waitingForConnectionStatusText(for: runRequest.agentKind), source: .transport, session: session, urgent: true)
+
+                if runRequest.agentKind.requiresPrePromptAgentModeMCPRouting {
+                    let routed = await lease.releaseWhenRouted()
+                    log("releaseWhenRouted routed=\(routed)", runID: runID)
+                    guard routed else {
+                        return .failed(
+                            errorText: "RepoPrompt MCP routing did not complete before \(runRequest.agentKind.displayName) ACP prompt submission."
+                        )
+                    }
+                } else {
+                    await lease.releaseGateForDeferredRouting()
+                    log("deferred MCP routing until ACP prompt", runID: runID)
+                }
+
+                return await runPromptTurn(
+                    session: session,
+                    runID: runID,
+                    runAttemptID: runAttemptID,
+                    initialMessageForRun: initialMessageForPromptTurn,
+                    attachments: attachments,
+                    controller: controller,
+                    runRequest: runRequest,
+                    attachmentReservationID: attachmentReservationID,
+                    prepareControllerForNextTurn: false
+                )
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                let normalized = await controller.normalizeError(error)
+                let normalizedText = displayText(for: normalized)
+                log("fresh start failed raw=\(String(describing: error)) normalized=\(normalizedText)", runID: runID)
+                return .failed(errorText: normalizedText)
             }
-            log("fresh start cancelled", runID: runID)
-            await finalize(
-                session: session,
-                runID: runID,
-                runAttemptID: runAttemptID,
-                controller: controller,
-                attachmentReservationID: attachmentReservationID,
-                terminalState: .cancelled,
-                errorText: nil,
-                notifyTurnComplete: false,
-                shouldShutdownController: true
-            )
-        } catch {
-            if !providerInitializationCompleted {
-                await lease.providerInitializationCompleted(provider: runRequest.agentKind.rawValue, outcome: "failed")
-            }
-            let normalized = await controller.normalizeError(error)
-            let normalizedText = displayText(for: normalized)
-            log("fresh start failed raw=\(String(describing: error)) normalized=\(normalizedText)", runID: runID)
-            await finalize(
-                session: session,
-                runID: runID,
-                runAttemptID: runAttemptID,
-                controller: controller,
-                attachmentReservationID: attachmentReservationID,
-                terminalState: .failed,
-                errorText: normalizedText,
-                notifyTurnComplete: false,
-                shouldShutdownController: true
+        }
+
+        if !providerInitializationCompleted,
+           case let .terminal(outcome) = classification.report.result,
+           outcome.kind == .cancelled || outcome.kind == .failed
+        {
+            await lease.providerInitializationCompleted(
+                provider: runRequest.agentKind.rawValue,
+                outcome: outcome.kind == .cancelled ? "cancelled" : "failed"
             )
         }
+        if case let .terminal(outcome) = classification.report.result, outcome.kind == .cancelled {
+            log("fresh start cancelled", runID: runID)
+        }
+        await settleTransientExecution(
+            classification,
+            session: session,
+            runID: runID,
+            runAttemptID: runAttemptID,
+            controller: controller,
+            attachmentReservationID: attachmentReservationID
+        )
     }
 
     private func continueRun(
-        tabID: UUID,
+        tabID _: UUID,
         session: AgentTabSession,
         runID: UUID,
         runAttemptID: UUID,
@@ -596,85 +642,56 @@ final class ACPIntegratedAgentModeRunner {
         deferredLease: MCPBootstrapLease?,
         attachmentReservationID: UUID?
     ) async {
-        do {
-            guard await controller.hasReusableSession else {
-                await finalize(
+        let classification = await Self.executeTransientOperation {
+            do {
+                guard await controller.hasReusableSession else {
+                    return .failed(errorText: "\(runRequest.agentKind.displayName) ACP session is no longer reusable.")
+                }
+
+                try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
+                await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
+                try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
+
+                if let deferredLease {
+                    let acquired = await deferredLease.acquire()
+                    guard acquired else {
+                        return .failed(
+                            errorText: "RepoPrompt MCP routing policy could not be prepared before \(runRequest.agentKind.displayName) ACP prompt submission."
+                        )
+                    }
+                    await deferredLease.releaseGateForDeferredRouting()
+                    log("deferred MCP routing until ACP follow-up prompt", runID: runID)
+                }
+
+                return await runPromptTurn(
                     session: session,
                     runID: runID,
                     runAttemptID: runAttemptID,
+                    initialMessageForRun: initialMessageForRun,
+                    attachments: attachments,
                     controller: controller,
+                    runRequest: runRequest,
                     attachmentReservationID: attachmentReservationID,
-                    terminalState: .failed,
-                    errorText: "\(runRequest.agentKind.displayName) ACP session is no longer reusable.",
-                    notifyTurnComplete: false,
-                    shouldShutdownController: true
+                    prepareControllerForNextTurn: true
                 )
-                return
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                let normalized = await controller.normalizeError(error)
+                let normalizedText = displayText(for: normalized)
+                log("continue failed raw=\(String(describing: error)) normalized=\(normalizedText)", runID: runID)
+                return .failed(errorText: normalizedText)
             }
-
-            try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
-            await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
-            try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
-
-            if let deferredLease {
-                let acquired = await deferredLease.acquire()
-                guard acquired else {
-                    await finalize(
-                        session: session,
-                        runID: runID,
-                        runAttemptID: runAttemptID,
-                        controller: controller,
-                        attachmentReservationID: attachmentReservationID,
-                        terminalState: .failed,
-                        errorText: "RepoPrompt MCP routing policy could not be prepared before \(runRequest.agentKind.displayName) ACP prompt submission.",
-                        notifyTurnComplete: false,
-                        shouldShutdownController: true
-                    )
-                    return
-                }
-                await deferredLease.releaseGateForDeferredRouting()
-                log("deferred MCP routing until ACP follow-up prompt", runID: runID)
-            }
-
-            await runPromptTurn(
-                session: session,
-                runID: runID,
-                runAttemptID: runAttemptID,
-                initialMessageForRun: initialMessageForRun,
-                attachments: attachments,
-                controller: controller,
-                runRequest: runRequest,
-                attachmentReservationID: attachmentReservationID,
-                prepareControllerForNextTurn: true
-            )
-        } catch is CancellationError {
-            await finalize(
-                session: session,
-                runID: runID,
-                runAttemptID: runAttemptID,
-                controller: controller,
-                attachmentReservationID: attachmentReservationID,
-                terminalState: .cancelled,
-                errorText: nil,
-                notifyTurnComplete: false,
-                shouldShutdownController: true
-            )
-        } catch {
-            let normalized = await controller.normalizeError(error)
-            let normalizedText = displayText(for: normalized)
-            log("continue failed raw=\(String(describing: error)) normalized=\(normalizedText)", runID: runID)
-            await finalize(
-                session: session,
-                runID: runID,
-                runAttemptID: runAttemptID,
-                controller: controller,
-                attachmentReservationID: attachmentReservationID,
-                terminalState: .failed,
-                errorText: normalizedText,
-                notifyTurnComplete: false,
-                shouldShutdownController: true
-            )
         }
+
+        await settleTransientExecution(
+            classification,
+            session: session,
+            runID: runID,
+            runAttemptID: runAttemptID,
+            controller: controller,
+            attachmentReservationID: attachmentReservationID
+        )
     }
 
     private func runPromptTurn(
@@ -687,7 +704,7 @@ final class ACPIntegratedAgentModeRunner {
         runRequest: ACPRunRequest,
         attachmentReservationID: UUID?,
         prepareControllerForNextTurn: Bool
-    ) async {
+    ) async -> TransientOperationResult {
         log("prompt turn begin prepare=\(prepareControllerForNextTurn)", runID: runID)
         setRunningStatus("Thinking…", source: .transport, session: session, urgent: true)
         let agentMessage = hooks.providerInput.buildHeadlessAgentMessage(
@@ -703,24 +720,13 @@ final class ACPIntegratedAgentModeRunner {
         if prepareControllerForNextTurn {
             let prepared = await controller.prepareForNextTurn()
             guard prepared else {
-                await finalize(
-                    session: session,
-                    runID: runID,
-                    runAttemptID: runAttemptID,
-                    controller: controller,
-                    attachmentReservationID: attachmentReservationID,
-                    terminalState: .failed,
-                    errorText: "\(runRequest.agentKind.displayName) ACP session is no longer reusable.",
-                    notifyTurnComplete: false,
-                    shouldShutdownController: true
-                )
-                return
+                return .failed(errorText: "\(runRequest.agentKind.displayName) ACP session is no longer reusable.")
             }
         }
         let events = await controller.events
         let consumeTask = Task { @MainActor [weak self, weak session] in
             guard let self, let session else {
-                return ConsumeEventsOutcome(terminalState: .failed, errorText: "ACP event consumer deallocated.")
+                return TransientOperationResult.failed(errorText: "ACP event consumer deallocated.")
             }
             return await consumeEvents(
                 events,
@@ -743,35 +749,12 @@ final class ACPIntegratedAgentModeRunner {
             let normalizedText = displayText(for: normalizedError)
             log("controller.prompt failed raw=\(String(describing: error)) normalized=\(normalizedText)", runID: runID)
             let outcome = await consumeTask.value
-            let errorText = promptFailureErrorText(outcome: outcome, fallback: normalizedText)
-            await finalize(
-                session: session,
-                runID: runID,
-                runAttemptID: runAttemptID,
-                controller: controller,
-                attachmentReservationID: attachmentReservationID,
-                terminalState: .failed,
-                errorText: errorText,
-                notifyTurnComplete: false,
-                shouldShutdownController: true
-            )
-            return
+            return .failed(errorText: promptFailureErrorText(outcome: outcome, fallback: normalizedText))
         }
 
         let outcome = await consumeTask.value
-        let outcomeErrorDescription = outcome.errorText ?? "nil"
-        log("event consumer completed state=\(outcome.terminalState.rawValue) error=\(outcomeErrorDescription)", runID: runID)
-        await finalize(
-            session: session,
-            runID: runID,
-            runAttemptID: runAttemptID,
-            controller: controller,
-            attachmentReservationID: attachmentReservationID,
-            terminalState: outcome.terminalState,
-            errorText: outcome.errorText,
-            notifyTurnComplete: outcome.terminalState == .completed,
-            shouldShutdownController: outcome.terminalState != .completed
-        )
+        log("event consumer completed \(outcome.debugDescription)", runID: runID)
+        return outcome
     }
 
     private func applyProviderSessionIdentity(
@@ -841,12 +824,17 @@ final class ACPIntegratedAgentModeRunner {
     }
 
     private func promptFailureErrorText(
-        outcome: ConsumeEventsOutcome,
+        outcome: TransientOperationResult,
         fallback: String
     ) -> String {
         let unexpectedStreamEnd = "ACP events stream ended unexpectedly."
         let trimmedFallback = fallback.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let outcomeError = outcome.errorText?.trimmingCharacters(in: .whitespacesAndNewlines),
+        let outcomeError: String? = if case let .failed(errorText) = outcome {
+            errorText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            nil
+        }
+        guard let outcomeError,
               !outcomeError.isEmpty,
               outcomeError != unexpectedStreamEnd
         else {
@@ -860,7 +848,7 @@ final class ACPIntegratedAgentModeRunner {
         session: AgentTabSession,
         runID: UUID,
         runAttemptID: UUID
-    ) async -> ConsumeEventsOutcome {
+    ) async -> TransientOperationResult {
         if let ownership = session.activeRunOwnership, ownership.attemptID == runAttemptID {
             session.recordRunProgress(ownership: ownership, kind: .stageTransition, stage: .running)
         }
@@ -868,7 +856,7 @@ final class ACPIntegratedAgentModeRunner {
             guard session.runID == runID,
                   session.activeRunAttemptID == runAttemptID
             else {
-                return ConsumeEventsOutcome(terminalState: .cancelled, errorText: nil)
+                return .superseded
             }
 
             if let ownership = session.activeRunOwnership, ownership.attemptID == runAttemptID {
@@ -900,14 +888,21 @@ final class ACPIntegratedAgentModeRunner {
                     }
                     continue
                 }
-                return ConsumeEventsOutcome(terminalState: state, errorText: errorText)
+                switch state {
+                case .completed:
+                    return .completed
+                case .cancelled:
+                    return .cancelled
+                case .failed:
+                    return .failed(errorText: errorText)
+                default:
+                    assertionFailure("ACP terminal event must carry a terminal run state")
+                    return .failed(errorText: errorText)
+                }
             }
         }
 
-        return ConsumeEventsOutcome(
-            terminalState: .failed,
-            errorText: "ACP events stream ended unexpectedly."
-        )
+        return .failed(errorText: "ACP events stream ended unexpectedly.")
     }
 
     private func handleAcquireFailure(
@@ -942,6 +937,36 @@ final class ACPIntegratedAgentModeRunner {
                 return { await controller.shutdown() }
             }
         ))
+    }
+
+    private func settleTransientExecution(
+        _ classification: TransientExecutionClassification,
+        session: AgentTabSession,
+        runID: UUID,
+        runAttemptID: UUID,
+        controller: ACPAgentSessionController,
+        attachmentReservationID: UUID?
+    ) async {
+        guard case let .terminal(outcome) = classification.report.result else { return }
+        let terminalState: AgentSessionRunState = switch outcome.kind {
+        case .completed:
+            .completed
+        case .cancelled:
+            .cancelled
+        case .failed:
+            .failed
+        }
+        await finalize(
+            session: session,
+            runID: runID,
+            runAttemptID: runAttemptID,
+            controller: controller,
+            attachmentReservationID: attachmentReservationID,
+            terminalState: terminalState,
+            errorText: classification.errorText,
+            notifyTurnComplete: terminalState == .completed,
+            shouldShutdownController: terminalState != .completed
+        )
     }
 
     private func finalize(
@@ -1608,6 +1633,45 @@ final class ACPIntegratedAgentModeRunner {
             session: AgentTabSession
         ) -> Bool {
             syncACPSelectedModelFromRegistryIfNeeded(agentKind: agentKind, session: session)
+        }
+
+        static func testClassifyTransientTerminal(
+            state: AgentSessionRunState,
+            errorText: String?
+        ) async -> (
+            result: DomainAgentRunExecutionResult,
+            errorText: String?,
+            trace: [DomainAgentRunExecutionTraceEvent]
+        ) {
+            let operationResult: TransientOperationResult = switch state {
+            case .completed:
+                .completed
+            case .cancelled:
+                .cancelled
+            case .failed:
+                .failed(errorText: errorText)
+            default:
+                fatalError("Test requires a terminal ACP state")
+            }
+            let classification = await executeTransientOperation { operationResult }
+            return (
+                classification.report.result,
+                classification.errorText,
+                classification.report.trace
+            )
+        }
+
+        static func testClassifyTransientSupersession() async -> (
+            result: DomainAgentRunExecutionResult,
+            errorText: String?,
+            trace: [DomainAgentRunExecutionTraceEvent]
+        ) {
+            let classification = await executeTransientOperation { .superseded }
+            return (
+                classification.report.result,
+                classification.errorText,
+                classification.report.trace
+            )
         }
     #endif
 

--- a/Tests/RepoPromptTests/AgentMode/ACPIntegratedAgentModeRunnerExecutionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPIntegratedAgentModeRunnerExecutionTests.swift
@@ -1,0 +1,85 @@
+@testable import RepoPromptApp
+import RepoPromptDomainRuntime
+import XCTest
+
+@MainActor
+final class ACPIntegratedAgentModeRunnerExecutionTests: XCTestCase {
+    func testCompletedTerminalUsesSharedExecutionClassification() async {
+        let classification = await ACPIntegratedAgentModeRunner.testClassifyTransientTerminal(
+            state: .completed,
+            errorText: nil
+        )
+
+        XCTAssertEqual(
+            classification.result,
+            .terminal(.completed(assistantText: nil))
+        )
+        XCTAssertNil(classification.errorText)
+        XCTAssertEqual(
+            classification.trace,
+            [.executionStarted, .terminalOutcomeProduced(.completed)]
+        )
+    }
+
+    func testCancelledTerminalUsesSharedExecutionClassification() async {
+        let classification = await ACPIntegratedAgentModeRunner.testClassifyTransientTerminal(
+            state: .cancelled,
+            errorText: nil
+        )
+
+        XCTAssertEqual(
+            classification.result,
+            .terminal(.cancelled())
+        )
+        XCTAssertNil(classification.errorText)
+        XCTAssertEqual(
+            classification.trace,
+            [.executionStarted, .terminalOutcomeProduced(.cancelled)]
+        )
+    }
+
+    func testFailedTerminalPreservesProviderErrorText() async {
+        let classification = await ACPIntegratedAgentModeRunner.testClassifyTransientTerminal(
+            state: .failed,
+            errorText: "ACP provider refused the turn."
+        )
+
+        XCTAssertEqual(
+            classification.result,
+            .terminal(.failed(assistantText: "ACP provider refused the turn."))
+        )
+        XCTAssertEqual(classification.errorText, "ACP provider refused the turn.")
+        XCTAssertEqual(
+            classification.trace,
+            [.executionStarted, .terminalOutcomeProduced(.failed)]
+        )
+    }
+
+    func testFailedTerminalPreservesAbsentProviderErrorTextForSettlement() async {
+        let classification = await ACPIntegratedAgentModeRunner.testClassifyTransientTerminal(
+            state: .failed,
+            errorText: nil
+        )
+
+        guard case let .terminal(outcome) = classification.result else {
+            return XCTFail("Expected terminal classification")
+        }
+        XCTAssertEqual(outcome.kind, .failed)
+        XCTAssertNil(classification.errorText)
+        XCTAssertEqual(
+            classification.trace,
+            [.executionStarted, .terminalOutcomeProduced(.failed)]
+        )
+    }
+
+    func testSupersededExecutionRemainsNonterminal() async {
+        let classification = await ACPIntegratedAgentModeRunner.testClassifyTransientSupersession()
+
+        XCTAssertEqual(classification.result, .superseded)
+        XCTAssertNil(classification.errorText)
+        XCTAssertEqual(
+            classification.trace,
+            [.executionStarted, .executionSuperseded]
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- classify ACP fresh, continue, bootstrap, routing, prompt, event-stream, cancellation, failure, and supersession outcomes through DomainAgentRunExecutionCore
- retain ACP controller/session/bootstrap/error-normalization and exact-attempt authorities
- keep the existing terminal barrier as the sole settlement, cleanup, attachment, usage, and persistence authority

## Architecture

This is a Thin UI Wave 2 convergence step. The shared core classifies transient execution results without becoming a provider lifecycle or persistence authority. No persisted formats, shared core files, or composition boundaries change.

## Validation

- ACPIntegratedAgentModeRunnerExecutionTests: 5 passed, 0 failed (ticket cc4842e0-b794-4974-ae60-5b2e597e08f5)
- AgentModeRunServiceLifecycleTests: 47 passed, 0 failed (ticket 7d55ca48-642f-4967-857d-e1b2b770e088)
- changed-file SwiftFormat and strict SwiftLint passed
- git diff check passed
- commit and push contribution preflights passed
- Fable 5 High static review: approved, no blocking findings

## Notes

The migration also makes malformed nonterminal ACP terminal events fail closed instead of passing a nonterminal state to settlement. No app lifecycle action was performed.