### PR TITLE
Add stored prompt management controls

### DIFF
--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -1489,12 +1489,18 @@ class WindowState: ObservableObject {
         // Apply new prompt if provided
         if let prompt = command.newPrompt {
             // 1. add to the PromptViewModel's storage
-            let stored = promptManager.addStoredPrompt(
+            let result = promptManager.addStoredPrompt(
                 title: prompt.title,
                 content: prompt.content
             )
             // 2. select it so it appears checked/active
-            promptManager.selectNewPrompt(stored)
+            switch result {
+            case let .created(stored):
+                promptManager.selectNewPrompt(stored)
+            case .persistenceFailed:
+                presentStoredPromptCommandPersistenceFailure()
+                return
+            }
 
             // 3. if this window isn't front-most and focus flag was set, focus us
             if command.focus == true {
@@ -1622,6 +1628,19 @@ class WindowState: ObservableObject {
         if command.focus == true {
             NSApplication.shared.activate(ignoringOtherApps: true)
             focusWindowIfPossible()
+        }
+    }
+
+    private func presentStoredPromptCommandPersistenceFailure() {
+        let alert = NSAlert()
+        alert.messageText = "Stored Prompt Could Not Be Saved"
+        alert.informativeText = "The command was stopped because the stored prompt could not be written."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        if let nsWindow, nsWindow.attachedSheet == nil {
+            alert.beginSheetModal(for: nsWindow)
+        } else {
+            alert.runModal()
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerPromptTab.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerPromptTab.swift
@@ -8,11 +8,15 @@ struct AgentContextDrawerPromptTab: View {
 
     @ObservedObject private var fontScale = FontScaleManager.shared
     @State private var copyStatus: CopyStatus = .idle
+    @State private var fullContextCopyGeneration: UInt = 0
+    @State private var showCopyError = false
     @State private var showCopyPresetPopover = false
     @State private var showFileTreePopover = false
     @State private var showCodeMapPopover = false
     @State private var showGitPopover = false
     @State private var showPromptsPopover = false
+    @State private var storedPromptEditorMode: AgentContextStoredPromptEditorMode?
+    @State private var storedPromptActionMessage: String?
 
     private enum CopyStatus: Equatable {
         case idle
@@ -34,6 +38,7 @@ struct AgentContextDrawerPromptTab: View {
         let isManualPreset: Bool
         let selectedPromptIDs: Set<UUID>
         let selectedPrompts: [PromptViewModel.StoredPrompt]
+        let promptRows: [AgentContextStoredPromptRowPresentation]
 
         var selectedPresetID: UUID {
             selectedOption.id
@@ -95,7 +100,30 @@ struct AgentContextDrawerPromptTab: View {
             guard !isSwitchBlankingSelectedFiles else { return }
             guard !exportContext.promptManager.isSwitchingComposeTab else { return }
             copyStatus = .idle
+            storedPromptActionMessage = nil
             refreshIfNeeded()
+        }
+        .sheet(item: $storedPromptEditorMode) { mode in
+            AgentContextStoredPromptEditorSheet(
+                mode: mode,
+                onCreate: { title, content in
+                    let prompt = promptManager.addStoredPrompt(title: title, content: content)
+                    promptManager.selectNewPrompt(prompt)
+                    copyStatus = .idle
+                    storedPromptActionMessage = nil
+                },
+                onSave: { target, title, content in
+                    let result = promptManager.updateStoredPrompt(
+                        matching: target,
+                        title: title,
+                        content: content
+                    )
+                    if result == .updated {
+                        copyStatus = .idle
+                    }
+                    return result
+                }
+            )
         }
     }
 
@@ -139,6 +167,20 @@ struct AgentContextDrawerPromptTab: View {
             Set(resolvedConfig.storedPromptIds ?? currentPreset.storedPromptIds ?? [])
         }
         let selectedPrompts = promptManager.storedPrompts.filter { selectedPromptIDs.contains($0.id) }
+        let builtInPromptIDs = Set(promptManager.builtInStoredPrompts.map(\.id))
+        let promptRows = if isManualPreset {
+            promptManager.storedPrompts.map { prompt in
+                let isSelected = selectedPromptIDs.contains(prompt.id)
+                let access: AgentContextStoredPromptRowPresentation.Access = builtInPromptIDs.contains(prompt.id)
+                    ? .manualBuiltIn(isSelected: isSelected)
+                    : .manualCustom(isSelected: isSelected)
+                return AgentContextStoredPromptRowPresentation(prompt: prompt, access: access)
+            }
+        } else {
+            selectedPrompts.map {
+                AgentContextStoredPromptRowPresentation(prompt: $0, access: .presetSupplied)
+            }
+        }
 
         return RenderState(
             presetOptions: presetOptions,
@@ -146,7 +188,8 @@ struct AgentContextDrawerPromptTab: View {
             resolvedConfig: resolvedConfig,
             isManualPreset: isManualPreset,
             selectedPromptIDs: selectedPromptIDs,
-            selectedPrompts: selectedPrompts
+            selectedPrompts: selectedPrompts,
+            promptRows: promptRows
         )
     }
 
@@ -310,6 +353,11 @@ struct AgentContextDrawerPromptTab: View {
         }
         .buttonStyle(CustomButtonStyle(verticalPadding: 6, horizontalPadding: 12, height: 30))
         .disabled(copyStatus == .copying)
+        .alert("Copy failed", isPresented: $showCopyError) {
+            Button("OK") {}
+        } message: {
+            Text("The prompt could not be written to the clipboard.")
+        }
     }
 
     private func copyPresetPopover(_ state: RenderState) -> some View {
@@ -412,45 +460,64 @@ struct AgentContextDrawerPromptTab: View {
 
     private func promptsPopover(_ state: RenderState) -> some View {
         VStack(alignment: .leading, spacing: 10) {
-            popoverHeader(
-                title: "Prompts",
-                subtitle: state.isManualPreset
-                    ? "Choose stored prompts for Manual copy mode."
-                    : "This preset supplies its stored prompt selection."
-            )
+            HStack(alignment: .top, spacing: 12) {
+                popoverHeader(
+                    title: "Prompts",
+                    subtitle: state.isManualPreset
+                        ? "Choose stored prompts for Manual copy mode."
+                        : "This preset supplies its stored prompt selection."
+                )
+
+                Spacer(minLength: 8)
+
+                if state.isManualPreset {
+                    Button {
+                        beginCreatingStoredPrompt()
+                    } label: {
+                        Label("New Prompt", systemImage: "plus")
+                            .font(fontPreset.captionFont.weight(.semibold))
+                    }
+                    .buttonStyle(CustomButtonStyle(verticalPadding: 4, horizontalPadding: 8, height: 26))
+                    .accessibilityLabel("New Stored Prompt")
+                }
+            }
+
+            if let storedPromptActionMessage {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle")
+                    Text(storedPromptActionMessage)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button {
+                        self.storedPromptActionMessage = nil
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .buttonStyle(.plain)
+                    .hoverTooltip("Dismiss")
+                    .accessibilityLabel("Dismiss stored prompt message")
+                }
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.orange)
+                .accessibilityLabel(storedPromptActionMessage)
+            }
 
             if promptManager.storedPrompts.isEmpty {
                 emptyPopoverText("No stored prompts available")
-            } else if state.isManualPreset {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 4) {
-                        ForEach(promptManager.storedPrompts) { prompt in
-                            promptSelectionRow(
-                                prompt,
-                                isSelected: state.selectedPromptIDs.contains(prompt.id),
-                                isEditable: true
-                            ) {
-                                toggleManualPrompt(prompt)
-                            }
-                        }
-                    }
-                }
-                .frame(maxHeight: 320)
-            } else if state.selectedPrompts.isEmpty {
+            } else if state.promptRows.isEmpty {
                 emptyPopoverText("No stored prompts selected")
             } else {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 4) {
-                        ForEach(state.selectedPrompts) { prompt in
-                            promptSelectionRow(prompt, isSelected: true, isEditable: false) {}
+                        ForEach(state.promptRows) { row in
+                            promptSelectionRow(row)
                         }
                     }
                 }
-                .frame(maxHeight: 260)
+                .frame(maxHeight: state.isManualPreset ? 320 : 260)
             }
         }
         .padding(12)
-        .frame(width: 380)
+        .frame(width: 440)
     }
 
     private func popoverHeader(title: String, subtitle: String) -> some View {
@@ -507,36 +574,15 @@ struct AgentContextDrawerPromptTab: View {
         .buttonStyle(.plain)
     }
 
-    private func promptSelectionRow(
-        _ prompt: PromptViewModel.StoredPrompt,
-        isSelected: Bool,
-        isEditable: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        HStack(spacing: 8) {
-            Button(action: action) {
-                HStack(spacing: 7) {
-                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
-                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
-                    Text(prompt.title)
-                        .font(fontPreset.captionFont.weight(.medium))
-                        .lineLimit(1)
-                    Spacer(minLength: 4)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .disabled(!isEditable)
-
-            AgentContextStoredPromptPreviewButton(prompt: prompt)
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 7)
-        .background(isSelected ? Color.teal.opacity(0.10) : Color(NSColor.controlBackgroundColor).opacity(0.18))
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .textSelection(.disabled)
+    private func promptSelectionRow(_ row: AgentContextStoredPromptRowPresentation) -> some View {
+        AgentContextStoredPromptRow(
+            presentation: row,
+            fontPreset: fontPreset,
+            onToggle: { toggleManualPrompt(row.prompt) },
+            onCopy: copyStoredPrompt,
+            onEdit: beginEditingStoredPrompt,
+            onConfirmDelete: confirmStoredPromptDeletion
+        )
     }
 
     private func emptyPopoverText(_ text: String) -> some View {
@@ -701,6 +747,9 @@ struct AgentContextDrawerPromptTab: View {
     }
 
     private func copyPromptContext() {
+        fullContextCopyGeneration &+= 1
+        let localCopyGeneration = fullContextCopyGeneration
+        let copyIntent = AgentContextCopyIntentCoordinator.shared.begin()
         let currentPreset = promptManager.currentCopyPreset()
         let cfg = promptManager.resolvePromptContext()
         copyStatus = .copying
@@ -714,16 +763,77 @@ struct AgentContextDrawerPromptTab: View {
                 selectedPromptIDsOverride: selectedPromptIDsOverride
             )
             await MainActor.run {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(clipboard, forType: .string)
+                guard localCopyGeneration == fullContextCopyGeneration else { return }
+                guard AgentContextCopyIntentCoordinator.shared.isCurrent(copyIntent) else {
+                    copyStatus = .idle
+                    return
+                }
+                guard AgentContextStoredPromptClipboard.writeFullContext(clipboard, intent: copyIntent) else {
+                    copyStatus = .idle
+                    showCopyError = true
+                    return
+                }
                 copyStatus = .copied
             }
             try? await Task.sleep(nanoseconds: 500_000_000)
             await MainActor.run {
+                guard localCopyGeneration == fullContextCopyGeneration else { return }
                 if copyStatus == .copied {
                     copyStatus = .idle
                 }
             }
+        }
+    }
+
+    private func copyStoredPrompt(_ promptID: UUID) -> Bool {
+        _ = AgentContextCopyIntentCoordinator.shared.begin()
+        copyStatus = .idle
+        storedPromptActionMessage = nil
+        guard let didWrite = AgentContextStoredPromptClipboard.write(
+            promptID: promptID,
+            from: promptManager.storedPrompts
+        ) else {
+            storedPromptActionMessage = "The stored prompt is no longer available to copy."
+            return false
+        }
+        guard didWrite else {
+            storedPromptActionMessage = "The prompt could not be written to the clipboard."
+            return false
+        }
+        return true
+    }
+
+    private func beginCreatingStoredPrompt() {
+        storedPromptActionMessage = nil
+        showPromptsPopover = false
+        DispatchQueue.main.async {
+            storedPromptEditorMode = .create(id: UUID())
+        }
+    }
+
+    private func beginEditingStoredPrompt(_ promptID: UUID) {
+        storedPromptActionMessage = nil
+        guard let prompt = promptManager.customStoredPrompts.first(where: { $0.id == promptID }) else {
+            storedPromptActionMessage = "The stored prompt is no longer available to edit."
+            return
+        }
+        showPromptsPopover = false
+        DispatchQueue.main.async {
+            storedPromptEditorMode = .edit(prompt)
+        }
+    }
+
+    private func confirmStoredPromptDeletion(_ prompt: PromptViewModel.StoredPrompt) {
+        switch promptManager.removeStoredPrompt(matching: prompt) {
+        case .deleted:
+            storedPromptActionMessage = nil
+            copyStatus = .idle
+        case .targetMissing:
+            storedPromptActionMessage = "The stored prompt was already deleted. Nothing else changed."
+        case .targetChanged:
+            storedPromptActionMessage = "The stored prompt changed after confirmation opened. Nothing was deleted; reopen Delete to confirm the current version."
+        case .targetProtected:
+            storedPromptActionMessage = "Built-in stored prompts cannot be deleted."
         }
     }
 
@@ -1229,42 +1339,5 @@ private struct AgentContextDrawerControlLabel: View {
         .contentShape(Rectangle())
         .textSelection(.disabled)
         .onHover { isHovering = $0 }
-    }
-}
-
-private struct AgentContextStoredPromptPreviewButton: View {
-    let prompt: PromptViewModel.StoredPrompt
-
-    @ObservedObject private var fontScale = FontScaleManager.shared
-    @State private var showPreview = false
-
-    private var fontPreset: FontScalePreset {
-        fontScale.preset
-    }
-
-    var body: some View {
-        Button {
-            showPreview = true
-        } label: {
-            Image(systemName: "eye")
-                .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
-                .foregroundStyle(.secondary)
-        }
-        .buttonStyle(.plain)
-        .hoverTooltip("Preview prompt")
-        .popover(isPresented: $showPreview) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(prompt.title)
-                    .font(fontPreset.standardFont.weight(.semibold))
-                ScrollView {
-                    Text(prompt.content)
-                        .font(fontPreset.standardFont)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(width: 360, height: 260)
-            }
-            .padding(12)
-        }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerPromptTab.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerPromptTab.swift
@@ -107,10 +107,13 @@ struct AgentContextDrawerPromptTab: View {
             AgentContextStoredPromptEditorSheet(
                 mode: mode,
                 onCreate: { title, content in
-                    let prompt = promptManager.addStoredPrompt(title: title, content: content)
-                    promptManager.selectNewPrompt(prompt)
-                    copyStatus = .idle
-                    storedPromptActionMessage = nil
+                    let result = promptManager.addStoredPrompt(title: title, content: content)
+                    if case let .created(prompt) = result {
+                        promptManager.selectNewPrompt(prompt)
+                        copyStatus = .idle
+                        storedPromptActionMessage = nil
+                    }
+                    return result
                 },
                 onSave: { target, title, content in
                     let result = promptManager.updateStoredPrompt(
@@ -749,7 +752,7 @@ struct AgentContextDrawerPromptTab: View {
     private func copyPromptContext() {
         fullContextCopyGeneration &+= 1
         let localCopyGeneration = fullContextCopyGeneration
-        let copyIntent = AgentContextCopyIntentCoordinator.shared.begin()
+        let copyIntent = PromptClipboardIntentCoordinator.shared.begin()
         let currentPreset = promptManager.currentCopyPreset()
         let cfg = promptManager.resolvePromptContext()
         copyStatus = .copying
@@ -764,7 +767,7 @@ struct AgentContextDrawerPromptTab: View {
             )
             await MainActor.run {
                 guard localCopyGeneration == fullContextCopyGeneration else { return }
-                guard AgentContextCopyIntentCoordinator.shared.isCurrent(copyIntent) else {
+                guard PromptClipboardIntentCoordinator.shared.isCurrent(copyIntent) else {
                     copyStatus = .idle
                     return
                 }
@@ -786,7 +789,6 @@ struct AgentContextDrawerPromptTab: View {
     }
 
     private func copyStoredPrompt(_ promptID: UUID) -> Bool {
-        _ = AgentContextCopyIntentCoordinator.shared.begin()
         copyStatus = .idle
         storedPromptActionMessage = nil
         guard let didWrite = AgentContextStoredPromptClipboard.write(
@@ -834,6 +836,8 @@ struct AgentContextDrawerPromptTab: View {
             storedPromptActionMessage = "The stored prompt changed after confirmation opened. Nothing was deleted; reopen Delete to confirm the current version."
         case .targetProtected:
             storedPromptActionMessage = "Built-in stored prompts cannot be deleted."
+        case .persistenceFailed:
+            storedPromptActionMessage = "The stored prompt could not be deleted. Nothing changed on disk."
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextStoredPromptManagement.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextStoredPromptManagement.swift
@@ -1,0 +1,456 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class AgentContextCopyIntentCoordinator {
+    static let shared = AgentContextCopyIntentCoordinator()
+
+    private var generation: UInt = 0
+
+    private init() {}
+
+    func begin() -> UInt {
+        generation &+= 1
+        return generation
+    }
+
+    func isCurrent(_ candidate: UInt) -> Bool {
+        candidate == generation
+    }
+
+    func commitIfCurrent(_ candidate: UInt, action: () -> Void) -> Bool {
+        guard isCurrent(candidate) else { return false }
+        action()
+        return true
+    }
+}
+
+@MainActor
+enum AgentContextStoredPromptClipboard {
+    static func write(
+        prompt: PromptViewModel.StoredPrompt,
+        to pasteboard: NSPasteboard = .general
+    ) -> Bool {
+        pasteboard.clearContents()
+        return pasteboard.setString(prompt.content, forType: .string)
+    }
+
+    static func write(
+        promptID: UUID,
+        from prompts: [PromptViewModel.StoredPrompt],
+        to pasteboard: NSPasteboard = .general
+    ) -> Bool? {
+        guard let prompt = prompts.first(where: { $0.id == promptID }) else { return nil }
+        return write(prompt: prompt, to: pasteboard)
+    }
+
+    static func writeFullContext(
+        _ content: String,
+        intent: UInt,
+        to pasteboard: NSPasteboard = .general
+    ) -> Bool {
+        var didWrite = false
+        let didCommit = AgentContextCopyIntentCoordinator.shared.commitIfCurrent(intent) {
+            pasteboard.clearContents()
+            didWrite = pasteboard.setString(content, forType: .string)
+        }
+        return didCommit && didWrite
+    }
+}
+
+struct AgentContextStoredPromptRowPresentation: Identifiable {
+    enum Access {
+        case manualBuiltIn(isSelected: Bool)
+        case manualCustom(isSelected: Bool)
+        case presetSupplied
+    }
+
+    let prompt: PromptViewModel.StoredPrompt
+    let access: Access
+
+    var id: UUID {
+        prompt.id
+    }
+
+    var isSelected: Bool {
+        switch access {
+        case let .manualBuiltIn(isSelected), let .manualCustom(isSelected):
+            isSelected
+        case .presetSupplied:
+            true
+        }
+    }
+
+    var allowsSelectionMutation: Bool {
+        switch access {
+        case .manualBuiltIn, .manualCustom:
+            true
+        case .presetSupplied:
+            false
+        }
+    }
+
+    var allowsCopy: Bool {
+        switch access {
+        case .manualBuiltIn, .manualCustom:
+            true
+        case .presetSupplied:
+            false
+        }
+    }
+
+    var allowsDestructiveManagement: Bool {
+        if case .manualCustom = access {
+            return true
+        }
+        return false
+    }
+}
+
+struct AgentContextStoredPromptRow: View {
+    let presentation: AgentContextStoredPromptRowPresentation
+    let fontPreset: FontScalePreset
+    let onToggle: () -> Void
+    let onCopy: (UUID) -> Bool
+    let onEdit: (UUID) -> Void
+    let onConfirmDelete: (PromptViewModel.StoredPrompt) -> Void
+
+    @State private var deleteTarget: PromptViewModel.StoredPrompt?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(action: onToggle) {
+                HStack(spacing: 7) {
+                    Image(systemName: presentation.isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+                        .foregroundStyle(presentation.isSelected ? Color.accentColor : Color.secondary)
+                    Text(presentation.prompt.title)
+                        .font(fontPreset.captionFont.weight(.medium))
+                        .lineLimit(1)
+                    Spacer(minLength: 4)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!presentation.allowsSelectionMutation)
+
+            AgentContextStoredPromptActions(
+                presentation: presentation,
+                fontPreset: fontPreset,
+                onCopy: onCopy,
+                onEdit: onEdit,
+                onRequestDelete: { deleteTarget = presentation.prompt }
+            )
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(
+            presentation.isSelected
+                ? Color.teal.opacity(0.10)
+                : Color(NSColor.controlBackgroundColor).opacity(0.18)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .textSelection(.disabled)
+        .popover(
+            isPresented: deleteConfirmationBinding,
+            attachmentAnchor: .rect(.bounds),
+            arrowEdge: .bottom
+        ) {
+            deleteConfirmation
+        }
+    }
+
+    private var deleteConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { deleteTarget != nil },
+            set: { isPresented in
+                if !isPresented {
+                    deleteTarget = nil
+                }
+            }
+        )
+    }
+
+    private var deleteConfirmation: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Delete stored prompt?")
+                .font(.headline)
+            Text("This permanently deletes “\(deleteTarget?.title ?? presentation.prompt.title)” and removes it from Copy and Chat prompt selections.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    deleteTarget = nil
+                }
+                Button("Delete", role: .destructive) {
+                    guard let target = deleteTarget else { return }
+                    deleteTarget = nil
+                    onConfirmDelete(target)
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding()
+        .frame(width: 280)
+    }
+}
+
+private struct AgentContextStoredPromptActions: View {
+    let presentation: AgentContextStoredPromptRowPresentation
+    let fontPreset: FontScalePreset
+    let onCopy: (UUID) -> Bool
+    let onEdit: (UUID) -> Void
+    let onRequestDelete: () -> Void
+
+    @State private var copied = false
+    @State private var copiedResetTask: Task<Void, Never>?
+
+    var body: some View {
+        HStack(spacing: 2) {
+            AgentContextStoredPromptPreviewButton(
+                prompt: presentation.prompt,
+                fontPreset: fontPreset
+            )
+
+            if presentation.allowsCopy {
+                actionButton(
+                    icon: copied ? "checkmark" : "doc.on.doc",
+                    tooltip: copied ? "Copied prompt" : "Copy prompt",
+                    accessibilityLabel: copied ? "Copied \(presentation.prompt.title)" : "Copy \(presentation.prompt.title)"
+                ) {
+                    guard onCopy(presentation.id) else { return }
+                    copied = true
+                    copiedResetTask?.cancel()
+                    copiedResetTask = Task {
+                        try? await Task.sleep(nanoseconds: 1_000_000_000)
+                        guard !Task.isCancelled else { return }
+                        copied = false
+                    }
+                }
+            }
+
+            if presentation.allowsDestructiveManagement {
+                actionButton(
+                    icon: "pencil",
+                    tooltip: "Edit prompt",
+                    accessibilityLabel: "Edit \(presentation.prompt.title)"
+                ) {
+                    onEdit(presentation.id)
+                }
+                actionButton(
+                    icon: "trash",
+                    tooltip: "Delete prompt",
+                    accessibilityLabel: "Delete \(presentation.prompt.title)",
+                    tint: .red
+                ) {
+                    onRequestDelete()
+                }
+            }
+        }
+        .onDisappear {
+            copiedResetTask?.cancel()
+            copiedResetTask = nil
+            copied = false
+        }
+    }
+
+    private func actionButton(
+        icon: String,
+        tooltip: String,
+        accessibilityLabel: String,
+        tint: Color = .secondary,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+        }
+        .buttonStyle(SmallRoundButtonStyle(size: 24, iconSize: 11))
+        .hoverTooltip(tooltip)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}
+
+enum AgentContextStoredPromptEditorMode: Identifiable {
+    case create(id: UUID)
+    case edit(PromptViewModel.StoredPrompt)
+
+    var id: UUID {
+        switch self {
+        case let .create(id):
+            id
+        case let .edit(prompt):
+            prompt.id
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .create:
+            "New Stored Prompt"
+        case .edit:
+            "Edit Stored Prompt"
+        }
+    }
+
+    var initialTitle: String {
+        switch self {
+        case .create:
+            ""
+        case let .edit(prompt):
+            prompt.title
+        }
+    }
+
+    var initialContent: String {
+        switch self {
+        case .create:
+            ""
+        case let .edit(prompt):
+            prompt.content
+        }
+    }
+}
+
+struct AgentContextStoredPromptEditorSheet: View {
+    let mode: AgentContextStoredPromptEditorMode
+    let onCreate: (String, String) -> Void
+    let onSave: (PromptViewModel.StoredPrompt, String, String) -> PromptViewModel.StoredPromptEditResult
+
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var fontScale = FontScaleManager.shared
+    @State private var title: String
+    @State private var content: String
+    @State private var errorMessage: String?
+
+    init(
+        mode: AgentContextStoredPromptEditorMode,
+        onCreate: @escaping (String, String) -> Void,
+        onSave: @escaping (PromptViewModel.StoredPrompt, String, String) -> PromptViewModel.StoredPromptEditResult
+    ) {
+        self.mode = mode
+        self.onCreate = onCreate
+        self.onSave = onSave
+        _title = State(initialValue: mode.initialTitle)
+        _content = State(initialValue: mode.initialContent)
+    }
+
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    private var normalizedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var saveDisabled: Bool {
+        guard errorMessage == nil, !normalizedTitle.isEmpty else { return true }
+        if case let .edit(prompt) = mode {
+            return normalizedTitle == prompt.title && content == prompt.content
+        }
+        return false
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(mode.title)
+                .font(fontPreset.titleFont)
+
+            TextField("Prompt Title", text: $title)
+                .font(fontPreset.standardFont)
+                .textFieldStyle(.roundedBorder)
+
+            TextEditor(text: $content)
+                .font(fontPreset.standardFont)
+                .accessibilityLabel("Prompt Content")
+                .scrollContentBackground(.hidden)
+                .frame(height: 300)
+                .padding(8)
+                .background(Color(NSColor.textBackgroundColor).opacity(0.65))
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.secondary.opacity(0.18), lineWidth: 0.5)
+                )
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(fontPreset.captionFont)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityLabel(errorMessage)
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                Button("Save") {
+                    save()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(saveDisabled)
+            }
+        }
+        .padding()
+        .frame(width: 480)
+    }
+
+    private func save() {
+        switch mode {
+        case .create:
+            onCreate(normalizedTitle, content)
+            dismiss()
+        case let .edit(prompt):
+            switch onSave(prompt, title, content) {
+            case .updated, .unchanged:
+                dismiss()
+            case .targetMissing:
+                errorMessage = "This stored prompt was deleted while the editor was open. Your changes were not saved."
+            case .targetChanged:
+                errorMessage = "This stored prompt changed while the editor was open. Close and reopen it before saving."
+            case .targetProtected:
+                errorMessage = "Built-in stored prompts cannot be edited."
+            case .invalidTitle:
+                errorMessage = "Enter a prompt title before saving."
+            }
+        }
+    }
+}
+
+private struct AgentContextStoredPromptPreviewButton: View {
+    let prompt: PromptViewModel.StoredPrompt
+    let fontPreset: FontScalePreset
+
+    @State private var showPreview = false
+
+    var body: some View {
+        Button {
+            showPreview = true
+        } label: {
+            Image(systemName: "eye")
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(SmallRoundButtonStyle(size: 24, iconSize: 11))
+        .hoverTooltip("Preview prompt")
+        .accessibilityLabel("Preview \(prompt.title)")
+        .popover(isPresented: $showPreview) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(prompt.title)
+                    .font(fontPreset.standardFont.weight(.semibold))
+                ScrollView {
+                    Text(prompt.content)
+                        .font(fontPreset.standardFont)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(width: 360, height: 260)
+            }
+            .padding(12)
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextStoredPromptManagement.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextStoredPromptManagement.swift
@@ -2,37 +2,13 @@ import AppKit
 import SwiftUI
 
 @MainActor
-final class AgentContextCopyIntentCoordinator {
-    static let shared = AgentContextCopyIntentCoordinator()
-
-    private var generation: UInt = 0
-
-    private init() {}
-
-    func begin() -> UInt {
-        generation &+= 1
-        return generation
-    }
-
-    func isCurrent(_ candidate: UInt) -> Bool {
-        candidate == generation
-    }
-
-    func commitIfCurrent(_ candidate: UInt, action: () -> Void) -> Bool {
-        guard isCurrent(candidate) else { return false }
-        action()
-        return true
-    }
-}
-
-@MainActor
 enum AgentContextStoredPromptClipboard {
     static func write(
         prompt: PromptViewModel.StoredPrompt,
         to pasteboard: NSPasteboard = .general
     ) -> Bool {
-        pasteboard.clearContents()
-        return pasteboard.setString(prompt.content, forType: .string)
+        let intent = PromptClipboardIntentCoordinator.shared.begin()
+        return PromptClipboardIntentCoordinator.shared.write(prompt.content, intent: intent, to: pasteboard)
     }
 
     static func write(
@@ -49,12 +25,7 @@ enum AgentContextStoredPromptClipboard {
         intent: UInt,
         to pasteboard: NSPasteboard = .general
     ) -> Bool {
-        var didWrite = false
-        let didCommit = AgentContextCopyIntentCoordinator.shared.commitIfCurrent(intent) {
-            pasteboard.clearContents()
-            didWrite = pasteboard.setString(content, forType: .string)
-        }
-        return didCommit && didWrite
+        PromptClipboardIntentCoordinator.shared.write(content, intent: intent, to: pasteboard)
     }
 }
 
@@ -317,7 +288,7 @@ enum AgentContextStoredPromptEditorMode: Identifiable {
 
 struct AgentContextStoredPromptEditorSheet: View {
     let mode: AgentContextStoredPromptEditorMode
-    let onCreate: (String, String) -> Void
+    let onCreate: (String, String) -> PromptViewModel.StoredPromptCreateResult
     let onSave: (PromptViewModel.StoredPrompt, String, String) -> PromptViewModel.StoredPromptEditResult
 
     @Environment(\.dismiss) private var dismiss
@@ -325,10 +296,11 @@ struct AgentContextStoredPromptEditorSheet: View {
     @State private var title: String
     @State private var content: String
     @State private var errorMessage: String?
+    @State private var saveBlocked = false
 
     init(
         mode: AgentContextStoredPromptEditorMode,
-        onCreate: @escaping (String, String) -> Void,
+        onCreate: @escaping (String, String) -> PromptViewModel.StoredPromptCreateResult,
         onSave: @escaping (PromptViewModel.StoredPrompt, String, String) -> PromptViewModel.StoredPromptEditResult
     ) {
         self.mode = mode
@@ -347,7 +319,7 @@ struct AgentContextStoredPromptEditorSheet: View {
     }
 
     private var saveDisabled: Bool {
-        guard errorMessage == nil, !normalizedTitle.isEmpty else { return true }
+        guard !saveBlocked, !normalizedTitle.isEmpty else { return true }
         if case let .edit(prompt) = mode {
             return normalizedTitle == prompt.title && content == prompt.content
         }
@@ -403,20 +375,31 @@ struct AgentContextStoredPromptEditorSheet: View {
     private func save() {
         switch mode {
         case .create:
-            onCreate(normalizedTitle, content)
-            dismiss()
+            switch onCreate(normalizedTitle, content) {
+            case .created:
+                dismiss()
+            case .persistenceFailed:
+                saveBlocked = false
+                errorMessage = "This stored prompt could not be saved. Your draft is still open."
+            }
         case let .edit(prompt):
             switch onSave(prompt, title, content) {
             case .updated, .unchanged:
                 dismiss()
             case .targetMissing:
+                saveBlocked = true
                 errorMessage = "This stored prompt was deleted while the editor was open. Your changes were not saved."
             case .targetChanged:
+                saveBlocked = true
                 errorMessage = "This stored prompt changed while the editor was open. Close and reopen it before saving."
             case .targetProtected:
+                saveBlocked = true
                 errorMessage = "Built-in stored prompts cannot be edited."
             case .invalidTitle:
                 errorMessage = "Enter a prompt title before saving."
+            case .persistenceFailed:
+                saveBlocked = false
+                errorMessage = "This stored prompt could not be saved. Your changes remain in the editor."
             }
         }
     }

--- a/Sources/RepoPrompt/Features/Prompt/Models/PromptStorage.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Models/PromptStorage.swift
@@ -132,25 +132,40 @@ class PromptStorage {
         completion: ((Result<Void, Error>) -> Void)? = nil
     ) {
         Self.queue.async {
-            do {
-                let data = try JSONEncoder().encode(prompts)
-                // Use .atomicWrite so it writes to a temp file, then renames it on success
-                try data.write(to: self.fileURL, options: .atomicWrite)
-
-                // If we got here, the write succeeded.
-                // Jump back to the main thread (or stay on the same queue) to call completion:
-                DispatchQueue.main.async {
-                    completion?(.success(()))
-                }
-            } catch {
+            let result = Result { try self.writePrompts(prompts) }
+            if case let .failure(error) = result {
                 print("Failed to write prompts: \(error)")
-
-                // If there's an error, pass it back via completion as well
-                DispatchQueue.main.async {
-                    completion?(.failure(error))
-                }
+            }
+            DispatchQueue.main.async {
+                completion?(result)
             }
         }
+    }
+
+    func mutatePrompts<Value>(
+        _ mutation: (inout [StoredPromptRecord]) -> (value: Value, shouldSave: Bool)
+    ) -> Result<(value: Value, prompts: [StoredPromptRecord]), Error> {
+        Self.queue.sync {
+            Result {
+                var prompts = try readPrompts()
+                let result = mutation(&prompts)
+                if result.shouldSave {
+                    try writePrompts(prompts)
+                }
+                return (result.value, prompts)
+            }
+        }
+    }
+
+    private func readPrompts() throws -> [StoredPromptRecord] {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [] }
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode([StoredPromptRecord].self, from: data)
+    }
+
+    private func writePrompts(_ prompts: [StoredPromptRecord]) throws {
+        let data = try JSONEncoder().encode(prompts)
+        try data.write(to: fileURL, options: .atomicWrite)
     }
 }
 

--- a/Sources/RepoPrompt/Features/Prompt/Services/StoredPromptPersistenceService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/StoredPromptPersistenceService.swift
@@ -5,15 +5,37 @@ struct StoredPromptImportResult: Equatable {
     let addedCount: Int
 }
 
+enum StoredPromptPersistenceMutationStatus: Equatable {
+    case created
+    case updated
+    case deleted
+    case unchanged
+    case targetMissing
+    case targetChanged
+    case targetProtected
+}
+
+struct StoredPromptPersistenceMutationResult: Equatable {
+    let status: StoredPromptPersistenceMutationStatus
+    let prompts: [StoredPromptRecord]
+}
+
 @MainActor
 protocol StoredPromptPersistenceServing {
     func loadPrompts() -> Result<[StoredPromptRecord], Error>
     func savePrompts(_ prompts: [StoredPromptRecord])
+    func createPrompt(_ prompt: StoredPromptRecord) -> Result<StoredPromptPersistenceMutationResult, Error>
+    func updatePrompt(
+        matching expected: StoredPromptRecord,
+        replacement: StoredPromptRecord,
+        protectedIDs: Set<UUID>
+    ) -> Result<StoredPromptPersistenceMutationResult, Error>
+    func deletePrompt(
+        matching expected: StoredPromptRecord,
+        protectedIDs: Set<UUID>
+    ) -> Result<StoredPromptPersistenceMutationResult, Error>
     func exportPrompts(to url: URL, prompts: [StoredPromptRecord]) throws
-    func importPrompts(
-        from url: URL,
-        mergingInto current: [StoredPromptRecord]
-    ) throws -> StoredPromptImportResult
+    func importPrompts(from url: URL) throws -> StoredPromptImportResult
 }
 
 @MainActor
@@ -32,25 +54,82 @@ struct StoredPromptPersistenceService: StoredPromptPersistenceServing {
         storage.savePrompts(prompts)
     }
 
+    func createPrompt(_ prompt: StoredPromptRecord) -> Result<StoredPromptPersistenceMutationResult, Error> {
+        storage.mutatePrompts { prompts in
+            prompts.append(prompt)
+            return (.created, true)
+        }
+        .map { StoredPromptPersistenceMutationResult(status: $0.value, prompts: $0.prompts) }
+    }
+
+    func updatePrompt(
+        matching expected: StoredPromptRecord,
+        replacement: StoredPromptRecord,
+        protectedIDs: Set<UUID>
+    ) -> Result<StoredPromptPersistenceMutationResult, Error> {
+        storage.mutatePrompts { prompts in
+            guard let index = prompts.firstIndex(where: { $0.id == expected.id }) else {
+                return (.targetMissing, false)
+            }
+            let current = prompts[index]
+            guard !protectedIDs.contains(current.id) else {
+                return (.targetProtected, false)
+            }
+            guard exactlyMatches(current, expected) else {
+                return (.targetChanged, false)
+            }
+            guard !exactlyMatches(current, replacement) else {
+                return (.unchanged, false)
+            }
+            prompts[index] = replacement
+            return (.updated, true)
+        }
+        .map { StoredPromptPersistenceMutationResult(status: $0.value, prompts: $0.prompts) }
+    }
+
+    func deletePrompt(
+        matching expected: StoredPromptRecord,
+        protectedIDs: Set<UUID>
+    ) -> Result<StoredPromptPersistenceMutationResult, Error> {
+        storage.mutatePrompts { prompts in
+            guard let index = prompts.firstIndex(where: { $0.id == expected.id }) else {
+                return (.targetMissing, false)
+            }
+            let current = prompts[index]
+            guard !protectedIDs.contains(current.id) else {
+                return (.targetProtected, false)
+            }
+            guard exactlyMatches(current, expected) else {
+                return (.targetChanged, false)
+            }
+            prompts.remove(at: index)
+            return (.deleted, true)
+        }
+        .map { StoredPromptPersistenceMutationResult(status: $0.value, prompts: $0.prompts) }
+    }
+
     func exportPrompts(to url: URL, prompts: [StoredPromptRecord]) throws {
         try storage.exportPrompts(to: url, prompts: prompts)
     }
 
-    func importPrompts(
-        from url: URL,
-        mergingInto current: [StoredPromptRecord]
-    ) throws -> StoredPromptImportResult {
+    func importPrompts(from url: URL) throws -> StoredPromptImportResult {
         let external = try storage.loadExternalPrompts(from: url)
-        let (merged, addedCount) = storage.mergeExternalPrompts(
-            current: current,
-            external: external
-        )
-        if addedCount > 0 {
-            storage.savePrompts(merged)
+        let result = try storage.mutatePrompts { prompts in
+            let mergeResult = storage.mergeExternalPrompts(current: prompts, external: external)
+            prompts = mergeResult.merged
+            return (mergeResult.addedCount, mergeResult.addedCount > 0)
         }
+        .get()
         return StoredPromptImportResult(
-            mergedPrompts: merged,
-            addedCount: addedCount
+            mergedPrompts: result.prompts,
+            addedCount: result.value
         )
+    }
+
+    private func exactlyMatches(_ lhs: StoredPromptRecord, _ rhs: StoredPromptRecord) -> Bool {
+        lhs.id == rhs.id &&
+            lhs.title == rhs.title &&
+            lhs.content == rhs.content &&
+            lhs.isUserEdited == rhs.isUserEdited
     }
 }

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -91,6 +91,22 @@ class PromptViewModel: ObservableObject {
 
     typealias StoredPrompt = StoredPromptRecord
 
+    enum StoredPromptEditResult: Equatable {
+        case updated
+        case unchanged
+        case targetMissing
+        case targetChanged
+        case targetProtected
+        case invalidTitle
+    }
+
+    enum StoredPromptDeleteResult: Equatable {
+        case deleted
+        case targetMissing
+        case targetChanged
+        case targetProtected
+    }
+
     // MARK: - Core Properties
 
     @Published private(set) var fileManager: WorkspaceFilesViewModel
@@ -4283,7 +4299,64 @@ class PromptViewModel: ObservableObject {
         return newPrompt
     }
 
-    func removeStoredPrompt(_ prompt: StoredPrompt) {
+    func removeStoredPrompt(matching expected: StoredPrompt) -> StoredPromptDeleteResult {
+        guard let current = storedPrompts.first(where: { $0.id == expected.id }) else {
+            return .targetMissing
+        }
+        guard !builtInPromptIDs.contains(current.id) else {
+            return .targetProtected
+        }
+        guard storedPromptExactlyMatches(current, expected) else {
+            return .targetChanged
+        }
+
+        removeStoredPrompt(current)
+        return .deleted
+    }
+
+    func updateStoredPrompt(
+        matching expected: StoredPrompt,
+        title: String,
+        content: String
+    ) -> StoredPromptEditResult {
+        guard let index = storedPrompts.firstIndex(where: { $0.id == expected.id }) else {
+            return .targetMissing
+        }
+        let current = storedPrompts[index]
+        guard !builtInPromptIDs.contains(current.id) else {
+            return .targetProtected
+        }
+        guard storedPromptExactlyMatches(current, expected) else {
+            return .targetChanged
+        }
+
+        let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedTitle.isEmpty else {
+            return .invalidTitle
+        }
+        guard normalizedTitle != current.title || content != current.content else {
+            return .unchanged
+        }
+
+        storedPrompts[index] = StoredPrompt(
+            id: current.id,
+            title: normalizedTitle,
+            content: content,
+            isUserEdited: current.isUserEdited
+        )
+        saveStoredPrompts()
+        updateSelectedInstructions()
+        return .updated
+    }
+
+    private func storedPromptExactlyMatches(_ lhs: StoredPrompt, _ rhs: StoredPrompt) -> Bool {
+        lhs.id == rhs.id &&
+            lhs.title == rhs.title &&
+            lhs.content == rhs.content &&
+            lhs.isUserEdited == rhs.isUserEdited
+    }
+
+    private func removeStoredPrompt(_ prompt: StoredPrompt) {
         storedPrompts.removeAll { $0.id == prompt.id }
         if selectedPromptIDs.contains(prompt.id) {
             var currentCopySelection = selectedPromptIDs
@@ -4296,19 +4369,6 @@ class PromptViewModel: ObservableObject {
             updatePromptSelection(currentChatSelection, for: .chat)
         }
         saveStoredPrompts()
-    }
-
-    func updateStoredPrompt(_ prompt: StoredPrompt) {
-        if let index = storedPrompts.firstIndex(where: { $0.id == prompt.id }) {
-            var updated = prompt
-            // Mark built-in prompts as user-edited so auto-upgrades are skipped
-            if builtInPromptIDs.contains(prompt.id) {
-                updated.isUserEdited = true
-            }
-            storedPrompts[index] = updated
-            saveStoredPrompts()
-            updateSelectedInstructions()
-        }
     }
 
     /// Clears out all saved prompts and re-adds the default ones.

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -91,6 +91,11 @@ class PromptViewModel: ObservableObject {
 
     typealias StoredPrompt = StoredPromptRecord
 
+    enum StoredPromptCreateResult: Equatable {
+        case created(StoredPrompt)
+        case persistenceFailed
+    }
+
     enum StoredPromptEditResult: Equatable {
         case updated
         case unchanged
@@ -98,6 +103,7 @@ class PromptViewModel: ObservableObject {
         case targetChanged
         case targetProtected
         case invalidTitle
+        case persistenceFailed
     }
 
     enum StoredPromptDeleteResult: Equatable {
@@ -105,6 +111,7 @@ class PromptViewModel: ObservableObject {
         case targetMissing
         case targetChanged
         case targetProtected
+        case persistenceFailed
     }
 
     // MARK: - Core Properties
@@ -2106,6 +2113,12 @@ class PromptViewModel: ObservableObject {
 
     private let settingsManager: SettingsManaging
     private let storedPromptPersistence: any StoredPromptPersistenceServing
+    private let promptClipboardPasteboard: NSPasteboard
+
+    #if DEBUG
+        var clipboardContentBuilderOverrideForTesting: (() async -> String?)?
+        var clipboardCommitCompletionForTesting: ((Bool) -> Void)?
+    #endif
 
     init(
         fileManager: WorkspaceFilesViewModel,
@@ -2113,7 +2126,8 @@ class PromptViewModel: ObservableObject {
         apiSettingsViewModel: APISettingsViewModel,
         windowID: Int,
         settingsManager: SettingsManaging,
-        storedPromptPersistence: (any StoredPromptPersistenceServing)? = nil
+        storedPromptPersistence: (any StoredPromptPersistenceServing)? = nil,
+        promptClipboardPasteboard: NSPasteboard = .general
     ) {
         self.fileManager = fileManager
         gitViewModel = GitViewModel(fileManager: fileManager)
@@ -2122,6 +2136,7 @@ class PromptViewModel: ObservableObject {
         self.windowID = windowID
         self.settingsManager = settingsManager
         self.storedPromptPersistence = storedPromptPersistence ?? StoredPromptPersistenceService()
+        self.promptClipboardPasteboard = promptClipboardPasteboard
         codeMapsGloballyDisabled = GlobalSettingsStore.shared.globalCodeMapsDisabled()
 
         // Removed usage of workspaceManager to load an initial prompt
@@ -4163,41 +4178,49 @@ class PromptViewModel: ObservableObject {
             return ""
         }()
 
+        let copyIntent = PromptClipboardIntentCoordinator.shared.begin()
         Task {
-            let clipboardContent: String
-            do {
-                clipboardContent = try await self.withPreassembledPromptContext(
-                    cfg: promptContext,
-                    selection: selectionSnapshot,
-                    lookupContext: self.allLoadedWorkspaceLookupContext()
-                ) { preAssembly in
-                    let includeFiles = includeFilesInClipboard && !preAssembly.entries.isEmpty
-                    return await PromptPackagingService.generateClipboardContent(
-                        metaInstructions: metaInstructions,
-                        userInstructions: promptText,
-                        files: preAssembly.entries,
-                        fileTreeContent: preAssembly.fileTreeContent,
-                        gitDiff: preAssembly.gitDiff,
-                        includeSavedPrompts: includeSavedPrompts,
-                        includeFiles: includeFiles,
-                        includeUserPrompt: includeUserPrompt,
-                        filePathDisplay: filePathDisplayOption,
-                        codemapPresentation: preAssembly.codemapPresentation,
-                        includeDatetimeInUserInstructions: includeDatetime,
-                        promptSectionsOrder: promptSectionsOrder,
-                        disabledPromptSections: disabledPromptSections,
-                        duplicateUserInstructionsAtTop: duplicateUserInstructions,
-                        tabTitle: tabTitleForClipboard
-                    )
+            let didWrite = await PromptClipboardIntentCoordinator.shared.buildAndWrite(
+                intent: copyIntent,
+                to: self.promptClipboardPasteboard
+            ) {
+                #if DEBUG
+                    if let builder = self.clipboardContentBuilderOverrideForTesting {
+                        return await builder()
+                    }
+                #endif
+                do {
+                    return try await self.withPreassembledPromptContext(
+                        cfg: promptContext,
+                        selection: selectionSnapshot,
+                        lookupContext: self.allLoadedWorkspaceLookupContext()
+                    ) { preAssembly in
+                        let includeFiles = includeFilesInClipboard && !preAssembly.entries.isEmpty
+                        return await PromptPackagingService.generateClipboardContent(
+                            metaInstructions: metaInstructions,
+                            userInstructions: promptText,
+                            files: preAssembly.entries,
+                            fileTreeContent: preAssembly.fileTreeContent,
+                            gitDiff: preAssembly.gitDiff,
+                            includeSavedPrompts: includeSavedPrompts,
+                            includeFiles: includeFiles,
+                            includeUserPrompt: includeUserPrompt,
+                            filePathDisplay: filePathDisplayOption,
+                            codemapPresentation: preAssembly.codemapPresentation,
+                            includeDatetimeInUserInstructions: includeDatetime,
+                            promptSectionsOrder: promptSectionsOrder,
+                            disabledPromptSections: disabledPromptSections,
+                            duplicateUserInstructionsAtTop: duplicateUserInstructions,
+                            tabTitle: tabTitleForClipboard
+                        )
+                    }
+                } catch {
+                    return nil
                 }
-            } catch {
-                return
             }
-
-            await MainActor.run {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(clipboardContent, forType: .string)
-            }
+            #if DEBUG
+                self.clipboardCommitCompletionForTesting?(didWrite)
+            #endif
         }
     }
 
@@ -4291,27 +4314,39 @@ class PromptViewModel: ObservableObject {
         updateSelectedInstructions()
     }
 
-    func addStoredPrompt(title: String, content: String) -> StoredPrompt {
+    func addStoredPrompt(title: String, content: String) -> StoredPromptCreateResult {
         let newPrompt = StoredPrompt(id: UUID(), title: title, content: content)
-        storedPrompts.append(newPrompt)
-        saveStoredPrompts()
-        updateMetaInstructions()
-        return newPrompt
+        switch storedPromptPersistence.createPrompt(newPrompt) {
+        case let .success(result):
+            adoptAuthoritativeStoredPrompts(result.prompts)
+            return .created(newPrompt)
+        case let .failure(error):
+            print("Failed to create stored prompt: \(error)")
+            return .persistenceFailed
+        }
     }
 
     func removeStoredPrompt(matching expected: StoredPrompt) -> StoredPromptDeleteResult {
-        guard let current = storedPrompts.first(where: { $0.id == expected.id }) else {
-            return .targetMissing
+        switch storedPromptPersistence.deletePrompt(matching: expected, protectedIDs: builtInPromptIDs) {
+        case let .failure(error):
+            print("Failed to delete stored prompt: \(error)")
+            return .persistenceFailed
+        case let .success(result):
+            adoptAuthoritativeStoredPrompts(result.prompts)
+            switch result.status {
+            case .deleted:
+                return .deleted
+            case .targetMissing:
+                return .targetMissing
+            case .targetChanged:
+                return .targetChanged
+            case .targetProtected:
+                return .targetProtected
+            case .created, .updated, .unchanged:
+                assertionFailure("Unexpected stored prompt delete result: \(result.status)")
+                return .persistenceFailed
+            }
         }
-        guard !builtInPromptIDs.contains(current.id) else {
-            return .targetProtected
-        }
-        guard storedPromptExactlyMatches(current, expected) else {
-            return .targetChanged
-        }
-
-        removeStoredPrompt(current)
-        return .deleted
     }
 
     func updateStoredPrompt(
@@ -4319,56 +4354,57 @@ class PromptViewModel: ObservableObject {
         title: String,
         content: String
     ) -> StoredPromptEditResult {
-        guard let index = storedPrompts.firstIndex(where: { $0.id == expected.id }) else {
-            return .targetMissing
-        }
-        let current = storedPrompts[index]
-        guard !builtInPromptIDs.contains(current.id) else {
-            return .targetProtected
-        }
-        guard storedPromptExactlyMatches(current, expected) else {
-            return .targetChanged
-        }
-
         let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedTitle.isEmpty else {
             return .invalidTitle
         }
-        guard normalizedTitle != current.title || content != current.content else {
-            return .unchanged
-        }
-
-        storedPrompts[index] = StoredPrompt(
-            id: current.id,
+        let replacement = StoredPrompt(
+            id: expected.id,
             title: normalizedTitle,
             content: content,
-            isUserEdited: current.isUserEdited
+            isUserEdited: expected.isUserEdited
         )
-        saveStoredPrompts()
+
+        switch storedPromptPersistence.updatePrompt(
+            matching: expected,
+            replacement: replacement,
+            protectedIDs: builtInPromptIDs
+        ) {
+        case let .failure(error):
+            print("Failed to update stored prompt: \(error)")
+            return .persistenceFailed
+        case let .success(result):
+            adoptAuthoritativeStoredPrompts(result.prompts)
+            switch result.status {
+            case .updated:
+                return .updated
+            case .unchanged:
+                return .unchanged
+            case .targetMissing:
+                return .targetMissing
+            case .targetChanged:
+                return .targetChanged
+            case .targetProtected:
+                return .targetProtected
+            case .created, .deleted:
+                assertionFailure("Unexpected stored prompt edit result: \(result.status)")
+                return .persistenceFailed
+            }
+        }
+    }
+
+    private func adoptAuthoritativeStoredPrompts(_ prompts: [StoredPrompt]) {
+        storedPrompts = prompts
+        let promptIDs = Set(prompts.map(\.id))
+        let copySelection = selectedPromptIDs.intersection(promptIDs)
+        let chatSelection = selectedPromptIDsForChat.intersection(promptIDs)
+        if copySelection != selectedPromptIDs {
+            updatePromptSelection(copySelection, for: .copy, markManual: hasManualCopyPromptSelection)
+        }
+        if chatSelection != selectedPromptIDsForChat {
+            updatePromptSelection(chatSelection, for: .chat, markManual: hasManualChatPromptSelection)
+        }
         updateSelectedInstructions()
-        return .updated
-    }
-
-    private func storedPromptExactlyMatches(_ lhs: StoredPrompt, _ rhs: StoredPrompt) -> Bool {
-        lhs.id == rhs.id &&
-            lhs.title == rhs.title &&
-            lhs.content == rhs.content &&
-            lhs.isUserEdited == rhs.isUserEdited
-    }
-
-    private func removeStoredPrompt(_ prompt: StoredPrompt) {
-        storedPrompts.removeAll { $0.id == prompt.id }
-        if selectedPromptIDs.contains(prompt.id) {
-            var currentCopySelection = selectedPromptIDs
-            currentCopySelection.remove(prompt.id)
-            updatePromptSelection(currentCopySelection, for: .copy)
-        }
-        if selectedPromptIDsForChat.contains(prompt.id) {
-            var currentChatSelection = selectedPromptIDsForChat
-            currentChatSelection.remove(prompt.id)
-            updatePromptSelection(currentChatSelection, for: .chat)
-        }
-        saveStoredPrompts()
     }
 
     /// Clears out all saved prompts and re-adds the default ones.
@@ -4481,14 +4517,8 @@ class PromptViewModel: ObservableObject {
     }
 
     func importPrompts(from url: URL) throws -> Int {
-        let result = try storedPromptPersistence.importPrompts(
-            from: url,
-            mergingInto: storedPrompts
-        )
-        if result.addedCount > 0 {
-            storedPrompts = result.mergedPrompts
-            updateSelectedInstructions() // refresh anything that depends on storedPrompts
-        }
+        let result = try storedPromptPersistence.importPrompts(from: url)
+        adoptAuthoritativeStoredPrompts(result.mergedPrompts)
         return result.addedCount
     }
 
@@ -5962,10 +5992,22 @@ extension PromptViewModel {
     /// The `openApplyXMLTab` parameter is retained for existing Agent call sites but is ignored now that the Apply XML UI is removed.
     func performCopy(using preset: CopyPreset, promptTextOverride: String? = nil, openApplyXMLTab: Bool = true) {
         let cfg = resolvePromptContext(preset, custom: workingCopyCustomizations)
+        let copyIntent = PromptClipboardIntentCoordinator.shared.begin()
         Task {
-            let clipboard = await buildClipboard(for: cfg, promptTextOverride: promptTextOverride)
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(clipboard, forType: .string)
+            let didWrite = await PromptClipboardIntentCoordinator.shared.buildAndWrite(
+                intent: copyIntent,
+                to: self.promptClipboardPasteboard
+            ) {
+                #if DEBUG
+                    if let builder = self.clipboardContentBuilderOverrideForTesting {
+                        return await builder()
+                    }
+                #endif
+                return await self.buildClipboard(for: cfg, promptTextOverride: promptTextOverride)
+            }
+            #if DEBUG
+                self.clipboardCommitCompletionForTesting?(didWrite)
+            #endif
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/UI/Services/PromptClipboardIntentCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Services/PromptClipboardIntentCoordinator.swift
@@ -1,0 +1,38 @@
+import AppKit
+
+@MainActor
+final class PromptClipboardIntentCoordinator {
+    static let shared = PromptClipboardIntentCoordinator()
+
+    private var generation: UInt = 0
+
+    private init() {}
+
+    func begin() -> UInt {
+        generation &+= 1
+        return generation
+    }
+
+    func isCurrent(_ candidate: UInt) -> Bool {
+        candidate == generation
+    }
+
+    func write(
+        _ content: String,
+        intent: UInt,
+        to pasteboard: NSPasteboard = .general
+    ) -> Bool {
+        guard isCurrent(intent) else { return false }
+        pasteboard.clearContents()
+        return pasteboard.setString(content, forType: .string)
+    }
+
+    func buildAndWrite(
+        intent: UInt,
+        to pasteboard: NSPasteboard = .general,
+        build: () async -> String?
+    ) async -> Bool {
+        guard let content = await build() else { return false }
+        return write(content, intent: intent, to: pasteboard)
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -2097,26 +2097,29 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
     }
 
     @MainActor
-    func testSupersededContextCopyCannotOverwriteStoredPromptCopyAcrossOwners() {
+    func testSupersededContextCopyCannotOverwriteStoredPromptCopyAcrossOwners() async {
         let pasteboard = NSPasteboard(name: NSPasteboard.Name("StoredPromptIntent-\(UUID().uuidString)"))
         defer { pasteboard.clearContents() }
-        let authority = AgentContextCopyIntentCoordinator.shared
-        let staleFullContextIntent = authority.begin()
+        let buildFence = TestReleaseFence(name: "suspended prompt context build")
         let prompt = PromptViewModel.StoredPrompt(
             id: UUID(),
             title: "Latest",
             content: "newer stored prompt content"
         )
+        let staleIntent = PromptClipboardIntentCoordinator.shared.begin()
+        let staleCopy = Task {
+            await PromptClipboardIntentCoordinator.shared.buildAndWrite(intent: staleIntent, to: pasteboard) {
+                await buildFence.enterAndWait()
+                return "stale full context"
+            }
+        }
 
-        _ = authority.begin()
+        await buildFence.waitUntilEntered()
         XCTAssertTrue(AgentContextStoredPromptClipboard.write(prompt: prompt, to: pasteboard))
-        XCTAssertFalse(
-            AgentContextStoredPromptClipboard.writeFullContext(
-                "stale full context",
-                intent: staleFullContextIntent,
-                to: pasteboard
-            )
-        )
+        buildFence.release()
+
+        let staleCopyDidWrite = await staleCopy.value
+        XCTAssertFalse(staleCopyDidWrite)
         XCTAssertEqual(pasteboard.string(forType: .string), prompt.content)
     }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 @testable import RepoPromptApp
 import XCTest
@@ -1976,6 +1977,147 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertEqual(state.selectedPrompts.map(\.id), [storedPromptID])
         XCTAssertEqual(state.selectedPrompts.map(\.content), [storedPrompt.content])
         XCTAssertEqual(promptManager.promptSelection(for: .copy), [storedPromptID])
+    }
+
+    @MainActor
+    func testPromptRowPresentationsGateManagementToManualCustomPrompts() throws {
+        let store = WorkspaceFileContextStore()
+        let promptManager = makePrompt(store: store, windowID: 41012)
+        let builtIn = try XCTUnwrap(promptManager.builtInStoredPrompts.first)
+        let custom = PromptViewModel.StoredPrompt(
+            id: UUID(),
+            title: "Custom instructions",
+            content: "Custom body"
+        )
+        promptManager.storedPrompts = [builtIn, custom]
+        promptManager.selectCopyPreset(
+            BuiltInCopyPresets.manual.id,
+            applySettings: false,
+            restoreManualSnapshot: false
+        )
+        promptManager.updatePromptSelection([custom.id], for: .copy)
+        let exportContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: nil,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil
+        )
+        let promptTab = AgentContextDrawerPromptTab(
+            promptManager: promptManager,
+            modelCoordinator: AgentSelectedFilesModelCoordinator(),
+            exportContext: exportContext,
+            isSwitchBlankingSelectedFiles: false
+        )
+
+        let manualRows = promptTab.makeRenderState().promptRows
+
+        XCTAssertEqual(manualRows.map(\.id), [builtIn.id, custom.id])
+        XCTAssertTrue(manualRows[0].allowsSelectionMutation)
+        XCTAssertTrue(manualRows[0].allowsCopy)
+        XCTAssertFalse(manualRows[0].allowsDestructiveManagement)
+        XCTAssertFalse(manualRows[0].isSelected)
+        XCTAssertTrue(manualRows[1].allowsSelectionMutation)
+        XCTAssertTrue(manualRows[1].allowsCopy)
+        XCTAssertTrue(manualRows[1].allowsDestructiveManagement)
+        XCTAssertTrue(manualRows[1].isSelected)
+
+        let customPreset = CopyPreset(
+            name: "Stored prompt presentation",
+            includeMetaPrompts: true,
+            storedPromptIds: [custom.id]
+        )
+        let presetManager = CopyPresetManager.shared
+        presetManager.add(customPreset)
+        defer { presetManager.remove(id: customPreset.id) }
+        promptManager.selectCopyPreset(customPreset.id)
+
+        let presetRows = promptTab.makeRenderState().promptRows
+
+        XCTAssertEqual(presetRows.map(\.id), [custom.id])
+        XCTAssertFalse(presetRows[0].allowsSelectionMutation)
+        XCTAssertFalse(presetRows[0].allowsCopy)
+        XCTAssertFalse(presetRows[0].allowsDestructiveManagement)
+        XCTAssertTrue(presetRows[0].isSelected)
+    }
+
+    @MainActor
+    func testStoredPromptClipboardWritesExactContentWithoutPackaging() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("StoredPromptClipboard-\(UUID().uuidString)"))
+        defer { pasteboard.clearContents() }
+        let prompt = PromptViewModel.StoredPrompt(
+            id: UUID(),
+            title: "Title that must not be copied",
+            content: "  first line\n<instructions>exact</instructions>\n\n"
+        )
+
+        let didWrite = AgentContextStoredPromptClipboard.write(prompt: prompt, to: pasteboard)
+
+        XCTAssertTrue(didWrite)
+        XCTAssertEqual(pasteboard.string(forType: .string), prompt.content)
+        XCTAssertFalse(pasteboard.string(forType: .string)?.contains(prompt.title) ?? true)
+    }
+
+    @MainActor
+    func testStoredPromptClipboardMissingIDPreservesExistingContent() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("StoredPromptMissing-\(UUID().uuidString)"))
+        defer { pasteboard.clearContents() }
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.setString("existing clipboard content", forType: .string))
+
+        let didWrite = AgentContextStoredPromptClipboard.write(
+            promptID: UUID(),
+            from: [],
+            to: pasteboard
+        )
+
+        XCTAssertNil(didWrite)
+        XCTAssertEqual(pasteboard.string(forType: .string), "existing clipboard content")
+    }
+
+    @MainActor
+    func testStoredPromptCopyResolvesLatestContentAtInvocation() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("StoredPromptLatest-\(UUID().uuidString)"))
+        defer { pasteboard.clearContents() }
+        let promptID = UUID()
+        let latestPrompt = PromptViewModel.StoredPrompt(
+            id: promptID,
+            title: "Current",
+            content: "latest content"
+        )
+
+        let didWrite = AgentContextStoredPromptClipboard.write(
+            promptID: promptID,
+            from: [latestPrompt],
+            to: pasteboard
+        )
+
+        XCTAssertEqual(didWrite, true)
+        XCTAssertEqual(pasteboard.string(forType: .string), latestPrompt.content)
+    }
+
+    @MainActor
+    func testSupersededContextCopyCannotOverwriteStoredPromptCopyAcrossOwners() {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("StoredPromptIntent-\(UUID().uuidString)"))
+        defer { pasteboard.clearContents() }
+        let authority = AgentContextCopyIntentCoordinator.shared
+        let staleFullContextIntent = authority.begin()
+        let prompt = PromptViewModel.StoredPrompt(
+            id: UUID(),
+            title: "Latest",
+            content: "newer stored prompt content"
+        )
+
+        _ = authority.begin()
+        XCTAssertTrue(AgentContextStoredPromptClipboard.write(prompt: prompt, to: pasteboard))
+        XCTAssertFalse(
+            AgentContextStoredPromptClipboard.writeFullContext(
+                "stale full context",
+                intent: staleFullContextIntent,
+                to: pasteboard
+            )
+        )
+        XCTAssertEqual(pasteboard.string(forType: .string), prompt.content)
     }
 
     @MainActor

--- a/Tests/RepoPromptTests/Prompt/StoredPromptPersistenceBoundaryTests.swift
+++ b/Tests/RepoPromptTests/Prompt/StoredPromptPersistenceBoundaryTests.swift
@@ -101,6 +101,134 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
     }
 
     @MainActor
+    func testCreatedPromptPersistsOnceAndCanBeSelectedWithoutResavingPrompts() {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        persistence.savedSnapshots.removeAll()
+
+        let prompt = viewModel.addStoredPrompt(title: "New prompt", content: "New body\n")
+        viewModel.selectNewPrompt(prompt)
+
+        XCTAssertEqual(viewModel.storedPrompts.last, prompt)
+        XCTAssertEqual(viewModel.promptSelection(for: .copy), [prompt.id])
+        XCTAssertEqual(persistence.savedSnapshots.count, 1)
+        XCTAssertEqual(persistence.savedSnapshots[0].last, prompt)
+    }
+
+    @MainActor
+    func testMatchingEditNormalizesTitleAndPersistsOnce() throws {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let prompt = viewModel.addStoredPrompt(title: "Original", content: "Old body")
+        viewModel.updatePromptSelection([prompt.id], for: .copy)
+        persistence.savedSnapshots.removeAll()
+
+        let result = viewModel.updateStoredPrompt(
+            matching: prompt,
+            title: "  Updated title  ",
+            content: "New body\n"
+        )
+
+        XCTAssertEqual(result, .updated)
+        let updated = try XCTUnwrap(viewModel.storedPrompts.first { $0.id == prompt.id })
+        XCTAssertEqual(updated.title, "Updated title")
+        XCTAssertEqual(updated.content, "New body\n")
+        XCTAssertEqual(viewModel.promptSelection(for: .copy), [prompt.id])
+        XCTAssertEqual(persistence.savedSnapshots.count, 1)
+        XCTAssertEqual(persistence.savedSnapshots[0].first { $0.id == prompt.id }, updated)
+    }
+
+    @MainActor
+    func testMatchingEditRejectsInvalidUnchangedAndProtectedTargetsWithoutSaving() throws {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let prompt = viewModel.addStoredPrompt(title: "Custom", content: "Body")
+        let builtIn = try XCTUnwrap(viewModel.builtInStoredPrompts.first)
+        viewModel.updatePromptSelection([prompt.id], for: .copy)
+        viewModel.updatePromptSelection([prompt.id], for: .chat)
+        persistence.savedSnapshots.removeAll()
+
+        XCTAssertEqual(
+            viewModel.updateStoredPrompt(matching: prompt, title: " Custom ", content: "Body"),
+            .unchanged
+        )
+        XCTAssertEqual(
+            viewModel.updateStoredPrompt(matching: prompt, title: "\n\t", content: "Body"),
+            .invalidTitle
+        )
+        XCTAssertEqual(viewModel.promptSelection(for: .copy), [prompt.id])
+        XCTAssertEqual(viewModel.promptSelection(for: .chat), [prompt.id])
+
+        viewModel.updatePromptSelection([builtIn.id], for: .copy)
+        viewModel.updatePromptSelection([builtIn.id], for: .chat)
+
+        XCTAssertEqual(
+            viewModel.updateStoredPrompt(matching: builtIn, title: "Changed", content: builtIn.content),
+            .targetProtected
+        )
+        XCTAssertEqual(viewModel.removeStoredPrompt(matching: builtIn), .targetProtected)
+        XCTAssertEqual(viewModel.promptSelection(for: .copy), [builtIn.id])
+        XCTAssertEqual(viewModel.promptSelection(for: .chat), [builtIn.id])
+        XCTAssertTrue(persistence.savedSnapshots.isEmpty)
+    }
+
+    @MainActor
+    func testMatchingMutationsRejectChangedAndMissingTargetsWithoutSaving() {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let prompt = viewModel.addStoredPrompt(title: "Custom", content: "Body")
+        viewModel.updatePromptSelection([prompt.id], for: .copy)
+        viewModel.updatePromptSelection([prompt.id], for: .chat)
+        persistence.savedSnapshots.removeAll()
+
+        viewModel.storedPrompts = viewModel.storedPrompts.map { current in
+            guard current.id == prompt.id else { return current }
+            return StoredPromptRecord(
+                id: current.id,
+                title: current.title,
+                content: current.content,
+                isUserEdited: true
+            )
+        }
+
+        XCTAssertEqual(
+            viewModel.updateStoredPrompt(matching: prompt, title: "Changed", content: "Body"),
+            .targetChanged
+        )
+        XCTAssertEqual(viewModel.removeStoredPrompt(matching: prompt), .targetChanged)
+
+        viewModel.storedPrompts.removeAll { $0.id == prompt.id }
+
+        XCTAssertEqual(
+            viewModel.updateStoredPrompt(matching: prompt, title: "Changed", content: "Body"),
+            .targetMissing
+        )
+        XCTAssertEqual(viewModel.removeStoredPrompt(matching: prompt), .targetMissing)
+        XCTAssertEqual(viewModel.promptSelection(for: .copy), [prompt.id])
+        XCTAssertEqual(viewModel.promptSelection(for: .chat), [prompt.id])
+        XCTAssertTrue(persistence.savedSnapshots.isEmpty)
+    }
+
+    @MainActor
+    func testMatchingDeleteCleansCopyAndChatSelectionsBeforeSavingOnce() {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let prompt = viewModel.addStoredPrompt(title: "Custom", content: "Body")
+        viewModel.updatePromptSelection([prompt.id], for: .copy)
+        viewModel.updatePromptSelection([prompt.id], for: .chat)
+        persistence.savedSnapshots.removeAll()
+
+        let result = viewModel.removeStoredPrompt(matching: prompt)
+
+        XCTAssertEqual(result, .deleted)
+        XCTAssertFalse(viewModel.storedPrompts.contains { $0.id == prompt.id })
+        XCTAssertFalse(viewModel.promptSelection(for: .copy).contains(prompt.id))
+        XCTAssertFalse(viewModel.promptSelection(for: .chat).contains(prompt.id))
+        XCTAssertEqual(persistence.savedSnapshots.count, 1)
+        XCTAssertFalse(persistence.savedSnapshots[0].contains { $0.id == prompt.id })
+    }
+
+    @MainActor
     private func makePromptViewModel(
         persistence: any StoredPromptPersistenceServing
     ) -> PromptViewModel {

--- a/Tests/RepoPromptTests/Prompt/StoredPromptPersistenceBoundaryTests.swift
+++ b/Tests/RepoPromptTests/Prompt/StoredPromptPersistenceBoundaryTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 @testable import RepoPromptApp
 import XCTest
 
@@ -51,8 +52,9 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
             PromptExport(title: "Second", content: "New two")
         ]
         try JSONEncoder().encode(external).write(to: importURL, options: .atomic)
+        _ = try service.createPrompt(current[0]).get()
 
-        let result = try service.importPrompts(from: importURL, mergingInto: current)
+        let result = try service.importPrompts(from: importURL)
 
         XCTAssertEqual(result.addedCount, 2)
         XCTAssertEqual(result.mergedPrompts.map(\.title), ["Existing", "First", "Second"])
@@ -63,6 +65,56 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
 
         let persisted = try storage.loadPrompts().get()
         XCTAssertEqual(persisted, result.mergedPrompts)
+    }
+
+    @MainActor
+    func testConcreteServiceSerializesCrossOwnerCompareAndMutate() throws {
+        let directory = try makeTestDirectory()
+        let storage = PromptStorage(fileURL: directory.appendingPathComponent("SavedPrompts.json"))
+        let firstOwner = StoredPromptPersistenceService(storage: storage)
+        let secondOwner = StoredPromptPersistenceService(storage: storage)
+        let original = StoredPromptRecord(id: UUID(), title: "Original", content: "Body")
+        _ = try firstOwner.createPrompt(original).get()
+        let firstReplacement = StoredPromptRecord(id: original.id, title: "First", content: "First body")
+        let secondReplacement = StoredPromptRecord(id: original.id, title: "Second", content: "Second body")
+
+        let firstResult = try firstOwner.updatePrompt(
+            matching: original,
+            replacement: firstReplacement,
+            protectedIDs: []
+        ).get()
+        let secondResult = try secondOwner.updatePrompt(
+            matching: original,
+            replacement: secondReplacement,
+            protectedIDs: []
+        ).get()
+
+        XCTAssertEqual(firstResult.status, .updated)
+        XCTAssertEqual(secondResult.status, .targetChanged)
+        XCTAssertEqual(secondResult.prompts, [firstReplacement])
+        XCTAssertEqual(try storage.loadPrompts().get(), [firstReplacement])
+    }
+
+    @MainActor
+    func testConcreteImportRebasesOntoAuthoritativePrompts() throws {
+        let directory = try makeTestDirectory()
+        let importURL = directory.appendingPathComponent("Import.json")
+        let storage = PromptStorage(fileURL: directory.appendingPathComponent("SavedPrompts.json"))
+        let firstOwner = StoredPromptPersistenceService(storage: storage)
+        let staleOwner = StoredPromptPersistenceService(storage: storage)
+        let original = StoredPromptRecord(id: UUID(), title: "Original", content: "Body")
+        let updated = StoredPromptRecord(id: original.id, title: "Updated", content: "New body")
+        _ = try firstOwner.createPrompt(original).get()
+        _ = try firstOwner.updatePrompt(matching: original, replacement: updated, protectedIDs: []).get()
+        try JSONEncoder().encode([PromptExport(title: "Imported", content: "Import body")])
+            .write(to: importURL, options: .atomic)
+
+        let result = try staleOwner.importPrompts(from: importURL)
+
+        XCTAssertEqual(result.addedCount, 1)
+        XCTAssertEqual(result.mergedPrompts.first, updated)
+        XCTAssertEqual(result.mergedPrompts.last?.title, "Imported")
+        XCTAssertEqual(try storage.loadPrompts().get(), result.mergedPrompts)
     }
 
     @MainActor
@@ -92,7 +144,6 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
 
         XCTAssertEqual(addedCount, 1)
         XCTAssertEqual(persistence.importedURL, importURL)
-        XCTAssertEqual(persistence.importedCurrent, original)
         XCTAssertEqual(viewModel.storedPrompts, original + [imported])
         XCTAssertTrue(
             persistence.savedSnapshots.isEmpty,
@@ -101,12 +152,44 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
     }
 
     @MainActor
-    func testCreatedPromptPersistsOnceAndCanBeSelectedWithoutResavingPrompts() {
+    func testNoOpImportRebaseRefreshesSelectedPromptInstructions() throws {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let prompt = try XCTUnwrap(viewModel.addStoredPrompt(title: "Original", content: "Old body").prompt)
+        viewModel.updatePromptSelection([prompt.id], for: .copy)
+        let updated = StoredPromptRecord(id: prompt.id, title: "Updated", content: "New body")
+        persistence.importResult = StoredPromptImportResult(
+            mergedPrompts: viewModel.storedPrompts.map { $0.id == prompt.id ? updated : $0 },
+            addedCount: 0
+        )
+
+        let addedCount = try viewModel.importPrompts(from: URL(fileURLWithPath: "/tmp/no-op-import.json"))
+
+        XCTAssertEqual(addedCount, 0)
+        XCTAssertTrue(viewModel.selectedInstructionsText.contains("New body"))
+        XCTAssertFalse(viewModel.selectedInstructionsText.contains("Old body"))
+    }
+
+    @MainActor
+    func testImportPersistenceFailureDoesNotPublishMergedPrompts() {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let original = viewModel.storedPrompts
+        persistence.importError = TestError.saveFailed
+
+        XCTAssertThrowsError(
+            try viewModel.importPrompts(from: URL(fileURLWithPath: "/tmp/import-failure.json"))
+        )
+        XCTAssertEqual(viewModel.storedPrompts, original)
+    }
+
+    @MainActor
+    func testCreatedPromptPersistsOnceAndCanBeSelectedWithoutResavingPrompts() throws {
         let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
         let viewModel = makePromptViewModel(persistence: persistence)
         persistence.savedSnapshots.removeAll()
 
-        let prompt = viewModel.addStoredPrompt(title: "New prompt", content: "New body\n")
+        let prompt = try XCTUnwrap(viewModel.addStoredPrompt(title: "New prompt", content: "New body\n").prompt)
         viewModel.selectNewPrompt(prompt)
 
         XCTAssertEqual(viewModel.storedPrompts.last, prompt)
@@ -119,7 +202,7 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
     func testMatchingEditNormalizesTitleAndPersistsOnce() throws {
         let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
         let viewModel = makePromptViewModel(persistence: persistence)
-        let prompt = viewModel.addStoredPrompt(title: "Original", content: "Old body")
+        let prompt = try XCTUnwrap(viewModel.addStoredPrompt(title: "Original", content: "Old body").prompt)
         viewModel.updatePromptSelection([prompt.id], for: .copy)
         persistence.savedSnapshots.removeAll()
 
@@ -142,7 +225,7 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
     func testMatchingEditRejectsInvalidUnchangedAndProtectedTargetsWithoutSaving() throws {
         let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
         let viewModel = makePromptViewModel(persistence: persistence)
-        let prompt = viewModel.addStoredPrompt(title: "Custom", content: "Body")
+        let prompt = try XCTUnwrap(viewModel.addStoredPrompt(title: "Custom", content: "Body").prompt)
         let builtIn = try XCTUnwrap(viewModel.builtInStoredPrompts.first)
         viewModel.updatePromptSelection([prompt.id], for: .copy)
         viewModel.updatePromptSelection([prompt.id], for: .chat)
@@ -173,23 +256,22 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
     }
 
     @MainActor
-    func testMatchingMutationsRejectChangedAndMissingTargetsWithoutSaving() {
+    func testMatchingMutationsRejectChangedAndMissingTargetsWithoutSaving() throws {
         let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
         let viewModel = makePromptViewModel(persistence: persistence)
-        let prompt = viewModel.addStoredPrompt(title: "Custom", content: "Body")
+        let prompt = try XCTUnwrap(viewModel.addStoredPrompt(title: "Custom", content: "Body").prompt)
         viewModel.updatePromptSelection([prompt.id], for: .copy)
         viewModel.updatePromptSelection([prompt.id], for: .chat)
         persistence.savedSnapshots.removeAll()
 
-        viewModel.storedPrompts = viewModel.storedPrompts.map { current in
-            guard current.id == prompt.id else { return current }
-            return StoredPromptRecord(
-                id: current.id,
-                title: current.title,
-                content: current.content,
+        persistence.replaceAuthoritativePrompt(
+            StoredPromptRecord(
+                id: prompt.id,
+                title: prompt.title,
+                content: prompt.content,
                 isUserEdited: true
             )
-        }
+        )
 
         XCTAssertEqual(
             viewModel.updateStoredPrompt(matching: prompt, title: "Changed", content: "Body"),
@@ -197,23 +279,102 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
         )
         XCTAssertEqual(viewModel.removeStoredPrompt(matching: prompt), .targetChanged)
 
-        viewModel.storedPrompts.removeAll { $0.id == prompt.id }
+        persistence.removeAuthoritativePrompt(prompt.id)
 
         XCTAssertEqual(
             viewModel.updateStoredPrompt(matching: prompt, title: "Changed", content: "Body"),
             .targetMissing
         )
         XCTAssertEqual(viewModel.removeStoredPrompt(matching: prompt), .targetMissing)
-        XCTAssertEqual(viewModel.promptSelection(for: .copy), [prompt.id])
-        XCTAssertEqual(viewModel.promptSelection(for: .chat), [prompt.id])
+        XCTAssertTrue(viewModel.promptSelection(for: .copy).isEmpty)
+        XCTAssertTrue(viewModel.promptSelection(for: .chat).isEmpty)
         XCTAssertTrue(persistence.savedSnapshots.isEmpty)
     }
 
     @MainActor
-    func testMatchingDeleteCleansCopyAndChatSelectionsBeforeSavingOnce() {
+    func testAuthoritativeMutationRebaseRemovesUnrelatedMissingSelections() throws {
         let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
         let viewModel = makePromptViewModel(persistence: persistence)
-        let prompt = viewModel.addStoredPrompt(title: "Custom", content: "Body")
+        let editedPrompt = try XCTUnwrap(viewModel.addStoredPrompt(title: "Edit", content: "Body").prompt)
+        let deletedElsewhere = try XCTUnwrap(viewModel.addStoredPrompt(title: "Delete", content: "Body").prompt)
+        viewModel.updatePromptSelection([editedPrompt.id, deletedElsewhere.id], for: .copy)
+        viewModel.updatePromptSelection([deletedElsewhere.id], for: .chat)
+        persistence.removeAuthoritativePrompt(deletedElsewhere.id)
+
+        XCTAssertEqual(
+            viewModel.updateStoredPrompt(matching: editedPrompt, title: "Edited", content: "New body"),
+            .updated
+        )
+        XCTAssertEqual(viewModel.promptSelection(for: .copy), [editedPrompt.id])
+        XCTAssertTrue(viewModel.promptSelection(for: .chat).isEmpty)
+    }
+
+    @MainActor
+    func testSecondWindowCannotOverwriteFirstWindowStoredPromptEdit() throws {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let firstWindow = makePromptViewModel(persistence: persistence)
+        let prompt = try XCTUnwrap(firstWindow.addStoredPrompt(title: "Original", content: "Body").prompt)
+        let secondWindow = makePromptViewModel(persistence: persistence)
+        let secondWindowSnapshot = try XCTUnwrap(secondWindow.storedPrompts.first { $0.id == prompt.id })
+        persistence.savedSnapshots.removeAll()
+
+        XCTAssertEqual(
+            firstWindow.updateStoredPrompt(matching: prompt, title: "First window", content: "First body"),
+            .updated
+        )
+        XCTAssertEqual(
+            secondWindow.updateStoredPrompt(
+                matching: secondWindowSnapshot,
+                title: "Second window",
+                content: "Second body"
+            ),
+            .targetChanged
+        )
+
+        let authoritative = try XCTUnwrap(secondWindow.storedPrompts.first { $0.id == prompt.id })
+        XCTAssertEqual(authoritative.title, "First window")
+        XCTAssertEqual(authoritative.content, "First body")
+        XCTAssertEqual(persistence.savedSnapshots.count, 1)
+    }
+
+    @MainActor
+    func testPersistenceFailureDoesNotPublishStoredPromptMutation() throws {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let prompt = try XCTUnwrap(viewModel.addStoredPrompt(title: "Original", content: "Body").prompt)
+        let originalPrompts = viewModel.storedPrompts
+        persistence.savedSnapshots.removeAll()
+        persistence.mutationError = TestError.saveFailed
+
+        XCTAssertEqual(
+            viewModel.updateStoredPrompt(matching: prompt, title: "Changed", content: "Changed body"),
+            .persistenceFailed
+        )
+        XCTAssertEqual(viewModel.removeStoredPrompt(matching: prompt), .persistenceFailed)
+        XCTAssertEqual(viewModel.addStoredPrompt(title: "Unsaved", content: "Body"), .persistenceFailed)
+        XCTAssertEqual(viewModel.storedPrompts, originalPrompts)
+        XCTAssertTrue(persistence.savedSnapshots.isEmpty)
+    }
+
+    @MainActor
+    func testCopyToClipboardCannotOverwriteNewerStoredPromptCopy() async throws {
+        try await assertPromptCopyCannotOverwriteNewerStoredPromptCopy { viewModel in
+            viewModel.copyToClipboard()
+        }
+    }
+
+    @MainActor
+    func testPerformCopyCannotOverwriteNewerStoredPromptCopy() async throws {
+        try await assertPromptCopyCannotOverwriteNewerStoredPromptCopy { viewModel in
+            viewModel.performCopy(using: viewModel.currentCopyPreset())
+        }
+    }
+
+    @MainActor
+    func testMatchingDeleteCleansCopyAndChatSelectionsBeforeSavingOnce() throws {
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence)
+        let prompt = try XCTUnwrap(viewModel.addStoredPrompt(title: "Custom", content: "Body").prompt)
         viewModel.updatePromptSelection([prompt.id], for: .copy)
         viewModel.updatePromptSelection([prompt.id], for: .chat)
         persistence.savedSnapshots.removeAll()
@@ -229,8 +390,38 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
     }
 
     @MainActor
+    private func assertPromptCopyCannotOverwriteNewerStoredPromptCopy(
+        invokeCopy: (PromptViewModel) -> Void
+    ) async throws {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("PromptViewModelIntent-\(UUID().uuidString)"))
+        defer { pasteboard.clearContents() }
+        let persistence = StoredPromptPersistenceSpy(loadResult: .success([]))
+        let viewModel = makePromptViewModel(persistence: persistence, promptClipboardPasteboard: pasteboard)
+        let buildFence = TestReleaseFence(name: "PromptViewModel clipboard builder")
+        let completion = AsyncTestCondition<Bool?>(nil)
+        let prompt = StoredPromptRecord(id: UUID(), title: "Latest", content: "newer stored prompt content")
+        viewModel.clipboardContentBuilderOverrideForTesting = {
+            await buildFence.enterAndWait()
+            return "stale prompt context"
+        }
+        viewModel.clipboardCommitCompletionForTesting = { didWrite in
+            completion.update { $0 = didWrite }
+        }
+
+        invokeCopy(viewModel)
+        await buildFence.waitUntilEntered()
+        XCTAssertTrue(AgentContextStoredPromptClipboard.write(prompt: prompt, to: pasteboard))
+        buildFence.release()
+        try await completion.waitUntil("PromptViewModel clipboard commit finished") { $0 != nil }
+
+        XCTAssertEqual(completion.snapshot(), false)
+        XCTAssertEqual(pasteboard.string(forType: .string), prompt.content)
+    }
+
+    @MainActor
     private func makePromptViewModel(
-        persistence: any StoredPromptPersistenceServing
+        persistence: any StoredPromptPersistenceServing,
+        promptClipboardPasteboard: NSPasteboard = .general
     ) -> PromptViewModel {
         let secureService = SecureKeysService(secureStorage: TestSecureStorageBackend(values: [:]))
         let keyManager = KeyManager(secureService: secureService)
@@ -244,13 +435,24 @@ final class StoredPromptPersistenceBoundaryTests: XCTestCase {
             apiSettingsViewModel: apiSettings,
             windowID: -902,
             settingsManager: WindowSettingsManager(windowID: -902),
-            storedPromptPersistence: persistence
+            storedPromptPersistence: persistence,
+            promptClipboardPasteboard: promptClipboardPasteboard
         )
     }
 }
 
 private enum TestError: Error {
     case loadFailed
+    case saveFailed
+}
+
+private extension PromptViewModel.StoredPromptCreateResult {
+    var prompt: PromptViewModel.StoredPrompt? {
+        if case let .created(prompt) = self {
+            return prompt
+        }
+        return nil
+    }
 }
 
 @MainActor
@@ -260,19 +462,79 @@ private final class StoredPromptPersistenceSpy: StoredPromptPersistenceServing {
     var exportedURL: URL?
     var exportedPrompts: [StoredPromptRecord] = []
     var importedURL: URL?
-    var importedCurrent: [StoredPromptRecord] = []
     var importResult = StoredPromptImportResult(mergedPrompts: [], addedCount: 0)
+    var importError: Error?
+    var mutationError: Error?
+    private var authoritativePrompts: [StoredPromptRecord]
 
     init(loadResult: Result<[StoredPromptRecord], Error>) {
         self.loadResult = loadResult
+        authoritativePrompts = (try? loadResult.get()) ?? []
     }
 
     func loadPrompts() -> Result<[StoredPromptRecord], Error> {
-        loadResult
+        switch loadResult {
+        case .failure:
+            loadResult
+        case .success:
+            .success(authoritativePrompts)
+        }
     }
 
     func savePrompts(_ prompts: [StoredPromptRecord]) {
         savedSnapshots.append(prompts)
+        authoritativePrompts = prompts
+    }
+
+    func createPrompt(_ prompt: StoredPromptRecord) -> Result<StoredPromptPersistenceMutationResult, Error> {
+        if let mutationError { return .failure(mutationError) }
+        authoritativePrompts.append(prompt)
+        savedSnapshots.append(authoritativePrompts)
+        return .success(.init(status: .created, prompts: authoritativePrompts))
+    }
+
+    func updatePrompt(
+        matching expected: StoredPromptRecord,
+        replacement: StoredPromptRecord,
+        protectedIDs: Set<UUID>
+    ) -> Result<StoredPromptPersistenceMutationResult, Error> {
+        if let mutationError { return .failure(mutationError) }
+        guard let index = authoritativePrompts.firstIndex(where: { $0.id == expected.id }) else {
+            return .success(.init(status: .targetMissing, prompts: authoritativePrompts))
+        }
+        let current = authoritativePrompts[index]
+        guard !protectedIDs.contains(current.id) else {
+            return .success(.init(status: .targetProtected, prompts: authoritativePrompts))
+        }
+        guard exactlyMatches(current, expected) else {
+            return .success(.init(status: .targetChanged, prompts: authoritativePrompts))
+        }
+        guard !exactlyMatches(current, replacement) else {
+            return .success(.init(status: .unchanged, prompts: authoritativePrompts))
+        }
+        authoritativePrompts[index] = replacement
+        savedSnapshots.append(authoritativePrompts)
+        return .success(.init(status: .updated, prompts: authoritativePrompts))
+    }
+
+    func deletePrompt(
+        matching expected: StoredPromptRecord,
+        protectedIDs: Set<UUID>
+    ) -> Result<StoredPromptPersistenceMutationResult, Error> {
+        if let mutationError { return .failure(mutationError) }
+        guard let index = authoritativePrompts.firstIndex(where: { $0.id == expected.id }) else {
+            return .success(.init(status: .targetMissing, prompts: authoritativePrompts))
+        }
+        let current = authoritativePrompts[index]
+        guard !protectedIDs.contains(current.id) else {
+            return .success(.init(status: .targetProtected, prompts: authoritativePrompts))
+        }
+        guard exactlyMatches(current, expected) else {
+            return .success(.init(status: .targetChanged, prompts: authoritativePrompts))
+        }
+        authoritativePrompts.remove(at: index)
+        savedSnapshots.append(authoritativePrompts)
+        return .success(.init(status: .deleted, prompts: authoritativePrompts))
     }
 
     func exportPrompts(to url: URL, prompts: [StoredPromptRecord]) throws {
@@ -280,12 +542,26 @@ private final class StoredPromptPersistenceSpy: StoredPromptPersistenceServing {
         exportedPrompts = prompts
     }
 
-    func importPrompts(
-        from url: URL,
-        mergingInto current: [StoredPromptRecord]
-    ) throws -> StoredPromptImportResult {
+    func importPrompts(from url: URL) throws -> StoredPromptImportResult {
         importedURL = url
-        importedCurrent = current
+        if let importError { throw importError }
+        authoritativePrompts = importResult.mergedPrompts
         return importResult
+    }
+
+    func replaceAuthoritativePrompt(_ prompt: StoredPromptRecord) {
+        guard let index = authoritativePrompts.firstIndex(where: { $0.id == prompt.id }) else { return }
+        authoritativePrompts[index] = prompt
+    }
+
+    func removeAuthoritativePrompt(_ promptID: UUID) {
+        authoritativePrompts.removeAll { $0.id == promptID }
+    }
+
+    private func exactlyMatches(_ lhs: StoredPromptRecord, _ rhs: StoredPromptRecord) -> Bool {
+        lhs.id == rhs.id &&
+            lhs.title == rhs.title &&
+            lhs.content == rhs.content &&
+            lhs.isUserEdited == rhs.isUserEdited
     }
 }


### PR DESCRIPTION
This adds stored-prompt management directly to the Context Composer’s Prompt tab. Manual mode now supports creating, previewing, copying, editing, and deleting custom prompts without needing to edit `~/Library/Application Support/com.pvncher.repoprompt/SavedPrompts.json` directly, or doing a roundabout edit within RepoPrompt Classic and then exporting its prompts and importing them into RPCE.

## Summary

* Add **New Prompt** to the Manual stored-prompts menu
* Add Preview, Copy, Edit, and confirmed Delete actions for custom prompts
* Keep built-in prompts limited to Preview and Copy
* Copy the exact current prompt content
* Automatically select newly created prompts for Manual Copy
* Protect stale, changed, missing, and built-in prompts from unintended mutation

## Implementation Notes

* Stored-prompt persistence and selection remain owned by `PromptViewModel`
* Create and Edit share one sheet while edits retain snapshot-matching conflict detection
* Delete uses a row-anchored destructive confirmation
* App-wide copy intent prevents stale asynchronous context copies from overwriting newer prompt copies

## Review Approach

* Focused maintainability and complete-patch reviews covered persistence ownership, SwiftUI lifecycle, clipboard ordering, accessibility, and test determinism
* Review findings around copy-status ownership, accessibility, and mutation accuracy were fixed with regressions

## Validation

Passed locally:

* `make dev-test FILTER=RepoPromptTests.StoredPromptPersistenceBoundaryTests` — 9 tests
* `make dev-test FILTER=RepoPromptTests.AgentContextExportResolverTests` — 62 tests
* `make dev-lint`
* `make dev-swift-build PRODUCT=RepoPrompt`
* `make guardrails`
* Commit preflight and staged secret scan
* Final packaged-app MCP smoke

The full root suite was run; remaining Agent-run failure reproduced on unchanged current `main`, while Git-policy and timing-sensitive failures passed under clean or focused reruns.

I also manually confirmed all features of the management flow in the live CE debug app. 

## Screenshots
<p align="center">
<img width="1182" height="611" alt="Screenshot 2026-08-12 at 6 41 17 AM" src="https://github.com/user-attachments/assets/09c23b3b-9602-4644-9fd2-b2dc397b49d5" />
<img width="1172" height="588" alt="Screenshot 2026-08-12 at 6 41 05 AM" src="https://github.com/user-attachments/assets/04afc261-a57f-4f5d-a8cd-e78ef1db4f30" />
<img width="736" height="560" alt="Screenshot 2026-08-12 at 6 41 11 AM" src="https://github.com/user-attachments/assets/b961c23d-dc83-4cfa-9417-94fb5e20a463" />
<img width="774" height="662" alt="Screenshot 2026-08-12 at 6 41 02 AM" src="https://github.com/user-attachments/assets/05365da9-9fed-4290-9d25-5263ec1b4865" />
</p>