### PR TITLE
Add multi-select + bulk actions to Agent Mode chats

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
@@ -1359,15 +1359,37 @@ actor AgentSessionDataService {
     }
 
     func deleteAgentSessions(forComposeTabID tabID: UUID, for workspace: WorkspaceModel) async throws {
-        let agentSessionsFolder = try ensureAgentSessionsFolder(for: workspace)
-        var candidateFilesByPath: [String: URL] = [:]
+        let failures = await deleteAgentSessions(forComposeTabIDs: [tabID], for: workspace)
+        if let failure = failures[tabID] { throw failure }
+    }
+
+    func deleteAgentSessions(
+        forComposeTabIDs tabIDs: Set<UUID>,
+        for workspace: WorkspaceModel
+    ) async -> [UUID: Error] {
+        guard !tabIDs.isEmpty else { return [:] }
+        let agentSessionsFolder: URL
+        do {
+            agentSessionsFolder = try ensureAgentSessionsFolder(for: workspace)
+        } catch {
+            return Dictionary(uniqueKeysWithValues: tabIDs.map { ($0, error) })
+        }
+
+        var candidateByPath: [String: (fileURL: URL, tabID: UUID)] = [:]
         if let index = await readMetadataIndexIfAvailable(folder: agentSessionsFolder) {
-            for record in index.entries where record.composeTabID == tabID {
-                candidateFilesByPath[agentSessionsFolder.appendingPathComponent(record.filename).path] = agentSessionsFolder.appendingPathComponent(record.filename)
+            for record in index.entries {
+                guard let tabID = record.composeTabID, tabIDs.contains(tabID) else { continue }
+                let fileURL = agentSessionsFolder.appendingPathComponent(record.filename)
+                candidateByPath[fileURL.path] = (fileURL, tabID)
             }
         }
 
-        let files = try await listAgentSessions(for: workspace)
+        let files: [URL]
+        do {
+            files = try await listAgentSessions(for: workspace)
+        } catch {
+            return Dictionary(uniqueKeysWithValues: tabIDs.map { ($0, error) })
+        }
         for fileURL in files {
             guard
                 let stub = try? await loadAgentSessionStub(
@@ -1375,15 +1397,28 @@ actor AgentSessionDataService {
                     recoverMissingMetadata: false,
                     persistRecoveredMetadata: false
                 ),
-                stub.composeTabID == tabID
+                let tabID = stub.composeTabID,
+                tabIDs.contains(tabID)
             else { continue }
-            candidateFilesByPath[fileURL.path] = fileURL
+            candidateByPath[fileURL.path] = (fileURL, tabID)
         }
 
-        for fileURL in candidateFilesByPath.values.sorted(by: { $0.path < $1.path }) {
-            try await deleteSessionFileDurably(fileURL.standardizedFileURL)
+        var failures: [UUID: Error] = [:]
+        for candidate in candidateByPath.values.sorted(by: { $0.fileURL.path < $1.fileURL.path }) {
+            do {
+                try await deleteSessionFileDurably(candidate.fileURL.standardizedFileURL)
+            } catch {
+                failures[candidate.tabID] = error
+            }
         }
-        await removeMetadataRecords(matching: { $0.composeTabID == tabID }, folder: agentSessionsFolder)
+        let successfulTabIDs = tabIDs.subtracting(failures.keys)
+        await removeMetadataRecords(
+            matching: { record in
+                record.composeTabID.map { successfulTabIDs.contains($0) } == true
+            },
+            folder: agentSessionsFolder
+        )
+        return failures
     }
 
     private func deleteSessionFileDurably(_ fileURL: URL) async throws {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeSidebarSessionBuilder.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeSidebarSessionBuilder.swift
@@ -283,6 +283,9 @@ struct AgentModeSidebarSessionBuilder {
         let isMCPControlled = mcpControlledTabIDs.contains(tab.id)
         let worktree = sidebarRowWorktree(liveSession: metadataLiveSession, entry: entry)
         let mergeAttention = sidebarRowWorktreeMergeAttention(liveSession: metadataLiveSession, entry: entry)
+        let canStash = boundLiveSession?.items.isEmpty == false
+            || boundLiveSession?.transcript.turns.isEmpty == false
+            || entry.map(Self.sessionIndexEntryHasConversationContent) == true
         let searchFields = Self.searchFields(
             title: title,
             entry: entry,
@@ -302,6 +305,7 @@ struct AgentModeSidebarSessionBuilder {
             activityDate: activityDate,
             isPinned: tab.isPinned,
             sessionID: resolvedSessionID,
+            canStash: canStash,
             parentSessionID: resolvedParentSessionID,
             depth: 0,
             isMCPControlled: isMCPControlled,
@@ -734,6 +738,7 @@ struct AgentModeSidebarSessionBuilder {
             activityDate: session.activityDate,
             isPinned: session.isPinned,
             sessionID: session.sessionID,
+            canStash: session.canStash,
             parentSessionID: session.parentSessionID,
             depth: depth,
             isMCPControlled: session.isMCPControlled,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -387,6 +387,7 @@ extension AgentModeViewModel {
     func sidebarSessions(for tabs: [ComposeTabState]) -> [SidebarSession] {
         buildSidebarSessions(
             for: tabs,
+            workspaceID: workspaceManager?.activeWorkspaceID,
             includeComposeTabsWithoutAgentSessions: false
         )
     }
@@ -395,17 +396,19 @@ extension AgentModeViewModel {
     func agentChatsSidebarSessions(for tabs: [ComposeTabState]) -> [SidebarSession] {
         buildSidebarSessions(
             for: tabs,
+            workspaceID: workspaceManager?.activeWorkspaceID,
             includeComposeTabsWithoutAgentSessions: true
         )
     }
 
     private func buildSidebarSessions(
         for tabs: [ComposeTabState],
+        workspaceID: UUID?,
         includeComposeTabsWithoutAgentSessions: Bool
     ) -> [SidebarSession] {
         let cacheKey = SidebarSessionRowsCacheKey(
-            workspaceID: workspaceManager?.activeWorkspaceID,
-            sidebarRevision: ui.sessionSidebar.snapshot.revision,
+            workspaceID: workspaceID,
+            rowContentRevision: ui.sessionSidebar.snapshot.rowContentRevision,
             tabMetadataSignatures: makeSessionSidebarTabMetadataSignatures(for: tabs)
         )
         let cachedRows = includeComposeTabsWithoutAgentSessions
@@ -445,10 +448,11 @@ extension AgentModeViewModel {
                 ) != nil
             }
         }
+        let liveSessions = sidebarRuntimeWorkspaceID == workspaceID ? sessions : [:]
         let rows = AgentModeSidebarSessionBuilder(
             allTabs: tabs,
             rowTabs: rowTabs,
-            sessions: sessions,
+            sessions: liveSessions,
             authoritativeSessionIDByTabID: authoritativeSessionIDByTabID,
             sessionIndex: currentIndex,
             sessionListSortDates: ownerValidatedSessionListSortDates,
@@ -529,6 +533,7 @@ extension AgentModeViewModel {
     /// search/collapse/attention state, pagination, selection, workspace identity,
     /// compose/stashed tab state, and archive expansion.
     func sidebarListProjection(
+        workspaceID: UUID?,
         composeTabs: [ComposeTabState],
         stashedTabs: [StashedTab],
         currentTabID: UUID?,
@@ -537,7 +542,7 @@ extension AgentModeViewModel {
         showComposeTabsWithoutAgentSessions: Bool
     ) -> SidebarListProjection {
         let key = SidebarListProjectionCacheKey(
-            workspaceID: workspaceManager?.activeWorkspaceID,
+            workspaceID: workspaceID,
             sidebarSnapshot: sidebarSnapshot,
             currentTabID: currentTabID,
             composeTabMetadataSignatures: makeSessionSidebarTabMetadataSignatures(for: composeTabs),
@@ -549,9 +554,11 @@ extension AgentModeViewModel {
             return cached.projection
         }
 
-        let canonicalRows = showComposeTabsWithoutAgentSessions
-            ? agentChatsSidebarSessions(for: composeTabs)
-            : sidebarSessions(for: composeTabs)
+        let canonicalRows = buildSidebarSessions(
+            for: composeTabs,
+            workspaceID: workspaceID,
+            includeComposeTabsWithoutAgentSessions: showComposeTabsWithoutAgentSessions
+        )
         let filteredSessions = filteredSidebarSessions(
             canonicalRows,
             inputTabCount: composeTabs.count,
@@ -574,23 +581,79 @@ extension AgentModeViewModel {
             searchText: sidebarSnapshot.searchText,
             prepareSortedRows: archivedSessionsExpanded
         )
+        let searchActive = !sidebarSnapshot.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let pagedArchivedTabs = searchActive
+            ? archivedSessionTabs.sortedTabs
+            : Array(archivedSessionTabs.sortedTabs.prefix(sidebarSnapshot.archivedVisibleSessionCount))
+        let renderedSelectionOrder = pagedSessions.map {
+            AgentSidebarSelectionIdentity.active(tabID: $0.tabID)
+        } + pagedArchivedTabs.map {
+            AgentSidebarSelectionIdentity.archived(stashedTabID: $0.id, tabID: $0.tab.id)
+        }
+        assert(Set(renderedSelectionOrder).count == renderedSelectionOrder.count)
         let projection = SidebarListProjection(
+            workspaceID: workspaceID,
             filteredSessions: filteredSessions,
             pagedSessions: pagedSessions,
             effectiveVisibleSessionCount: effectiveVisibleSessionCount,
             archivedSessionTabsForHeader: archivedSessionTabs.filteredTabs,
-            sortedArchivedSessionTabsForRows: archivedSessionTabs.sortedTabs,
+            pagedArchivedSessionTabsForRows: pagedArchivedTabs,
             archivedDateInfoByStashedTabID: archivedSessionTabs.dateInfoByStashedTabID,
             defaultCollapseSeedKeys: defaultCollapsedSidebarThreadKeys(
                 in: canonicalRows,
                 searchText: sidebarSnapshot.searchText
-            )
+            ),
+            renderedSelectionOrder: renderedSelectionOrder
         )
         sidebarListProjectionCache = (key, projection)
         #if DEBUG
             test_sidebarListProjectionBuildCount &+= 1
         #endif
         return projection
+    }
+
+    func sidebarBulkMutationTargets(
+        selection: Set<AgentSidebarSelectionIdentity>,
+        selectionWorkspaceID: UUID?,
+        projection: SidebarListProjection,
+        composeTabs: [ComposeTabState],
+        stashedTabs: [StashedTab]
+    ) -> SidebarBulkMutationTargets? {
+        guard let workspaceID = projection.workspaceID,
+              selectionWorkspaceID == workspaceID
+        else { return nil }
+        let validSelection = selection.intersection(projection.renderedSelectionOrder)
+        guard validSelection == selection else { return nil }
+        let activeRowsByID = Dictionary(uniqueKeysWithValues: projection.pagedSessions.map { ($0.tabID, $0) })
+        let composeTabsByID = Dictionary(uniqueKeysWithValues: composeTabs.map { ($0.id, $0) })
+        let archivedTabsByID = Dictionary(uniqueKeysWithValues: stashedTabs.map { ($0.id, $0) })
+        var activeIDs: Set<UUID> = []
+        var archivedTargets: Set<PromptViewModel.ArchivedTabMutationTarget> = []
+        var stashIDs: Set<UUID> = []
+        var pinIDs: Set<UUID> = []
+        var unpinIDs: Set<UUID> = []
+
+        for identity in validSelection {
+            switch identity {
+            case let .active(tabID):
+                guard let row = activeRowsByID[tabID], let tab = composeTabsByID[tabID] else { return nil }
+                activeIDs.insert(tabID)
+                if row.canStash { stashIDs.insert(tabID) }
+                if tab.isPinned { unpinIDs.insert(tabID) } else { pinIDs.insert(tabID) }
+            case let .archived(stashedTabID, tabID):
+                guard archivedTabsByID[stashedTabID]?.tab.id == tabID else { return nil }
+                archivedTargets.insert(.init(stashedTabID: stashedTabID, tabID: tabID))
+            }
+        }
+
+        return SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: activeIDs,
+            archivedDeleteTargets: archivedTargets,
+            stashTabIDs: stashIDs,
+            pinTabIDs: pinIDs,
+            unpinTabIDs: unpinIDs
+        )
     }
 
     func seedDefaultCollapsedSidebarThreads(_ eligibleKeys: [AgentSidebarThreadKey]) {
@@ -842,6 +905,7 @@ extension AgentModeViewModel {
             activityDate: row.activityDate,
             isPinned: row.isPinned,
             sessionID: row.sessionID,
+            canStash: row.canStash,
             parentSessionID: row.parentSessionID,
             depth: row.depth,
             isMCPControlled: row.isMCPControlled,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
@@ -13,7 +13,8 @@ extension AgentModeViewModel {
         #endif
         ui.sessionSidebar.update(
             searchText: sessionSidebarSearchText,
-            visibleSessionCount: sessionSidebarVisibleSessionCount
+            visibleSessionCount: sessionSidebarVisibleSessionCount,
+            archivedVisibleSessionCount: sessionSidebarArchivedVisibleSessionCount
         )
         #if DEBUG
             let storeUpdateDurationMS = storeUpdateStartMS.map { AgentModePerfDiagnostics.elapsedMS(since: $0) }
@@ -114,6 +115,152 @@ extension AgentModeViewModel {
     func showMoreSidebarSessions() {
         sessionSidebarVisibleSessionCount += Self.sessionSidebarPageSize
         syncSidebarUIState()
+    }
+
+    func showMoreArchivedSidebarSessions() {
+        sessionSidebarArchivedVisibleSessionCount += Self.sessionSidebarArchivedPageSize
+        syncSidebarUIState()
+    }
+
+    func handleSidebarSelectionGesture(
+        _ gesture: AgentSidebarSelectionGesture,
+        identity: AgentSidebarSelectionIdentity,
+        renderedOrder: [AgentSidebarSelectionIdentity],
+        workspaceID: UUID?
+    ) -> AgentSidebarSelectionGestureDisposition {
+        guard let workspaceID, workspaceManager?.activeWorkspaceID == workspaceID else { return .ignored }
+        return ui.sessionSidebar.handleSelectionGesture(
+            gesture,
+            identity: identity,
+            renderedOrder: renderedOrder,
+            workspaceID: workspaceID
+        )
+    }
+
+    func performSidebarBulkAction(
+        _ action: AgentSidebarBulkActionKind,
+        targets: SidebarBulkMutationTargets,
+        promptManager: PromptViewModel
+    ) async {
+        let targetCount: Int = switch action {
+        case .delete: targets.activeDeleteTabIDs.count + targets.archivedDeleteTargets.count
+        case .stash: targets.stashTabIDs.count
+        case .pin: targets.pinTabIDs.count
+        case .unpin: targets.unpinTabIDs.count
+        }
+        guard workspaceManager?.activeWorkspaceID == targets.workspaceID,
+              let token = ui.sessionSidebar.beginBulkAction(
+                  kind: action,
+                  targetCount: targetCount,
+                  workspaceID: targets.workspaceID
+              )
+        else { return }
+
+        let workspaceID = targets.workspaceID
+        let contextIsCurrent: @MainActor () -> Bool = { [weak self] in
+            guard let self else { return false }
+            return workspaceManager?.activeWorkspaceID == workspaceID
+                && ui.sessionSidebar.isCurrentBulkAction(token: token, workspaceID: targets.workspaceID)
+        }
+        var notice: AgentSidebarBulkActionNotice?
+
+        switch action {
+        case .delete:
+            #if DEBUG
+                for tabID in targets.activeDeleteTabIDs {
+                    debugBeginSidebarDeleteRequest(
+                        tabID: tabID,
+                        source: "AgentModeViewModel.performSidebarBulkAction",
+                        reason: "bulk_delete"
+                    )
+                }
+            #endif
+            let report = await promptManager.deleteComposeAndStashedTabs(
+                composeTabIDs: targets.activeDeleteTabIDs,
+                archivedTargets: targets.archivedDeleteTargets,
+                isMutationContextCurrent: contextIsCurrent
+            )
+            notice = sidebarBulkActionNotice(for: report, action: action)
+        case .stash:
+            let report = await promptManager.stashComposeTabs(
+                withIDs: targets.stashTabIDs,
+                isMutationContextCurrent: contextIsCurrent
+            )
+            notice = sidebarBulkActionNotice(for: report, action: action)
+        case .pin:
+            let report = promptManager.setComposeTabsPinned(
+                true,
+                for: targets.pinTabIDs,
+                isMutationContextCurrent: contextIsCurrent
+            )
+            if report.contextRejected {
+                notice = AgentSidebarBulkActionNotice(
+                    severity: .warning,
+                    title: "Chats were not pinned",
+                    message: "The workspace or selected chats changed before the action could be applied."
+                )
+            }
+        case .unpin:
+            let report = promptManager.setComposeTabsPinned(
+                false,
+                for: targets.unpinTabIDs,
+                isMutationContextCurrent: contextIsCurrent
+            )
+            if report.contextRejected {
+                notice = AgentSidebarBulkActionNotice(
+                    severity: .warning,
+                    title: "Chats were not unpinned",
+                    message: "The workspace or selected chats changed before the action could be applied."
+                )
+            }
+        }
+        ui.sessionSidebar.finishBulkAction(
+            token: token,
+            workspaceID: targets.workspaceID,
+            notice: notice
+        )
+    }
+
+    func sidebarBulkActionNotice(
+        for report: PromptViewModel.ComposeTabMutationReport,
+        action: AgentSidebarBulkActionKind
+    ) -> AgentSidebarBulkActionNotice? {
+        if let cleanupIssue = report.cleanupIssues.first, !report.rejections.isEmpty {
+            return AgentSidebarBulkActionNotice(
+                severity: .error,
+                title: "Bulk action partially completed",
+                message: "Some chats changed, cleanup failed for \(report.cleanupIssues.count) chat(s), and some selected or related chats were not changed. \(cleanupIssue.message)"
+            )
+        }
+        if let cleanupIssue = report.cleanupIssues.first {
+            return AgentSidebarBulkActionNotice(
+                severity: .error,
+                title: "Some chat cleanup failed",
+                message: "The sidebar was updated, but cleanup failed for \(report.cleanupIssues.count) chat(s). \(cleanupIssue.message)"
+            )
+        }
+        if report.didMutateProjection, !report.rejections.isEmpty {
+            return AgentSidebarBulkActionNotice(
+                severity: .warning,
+                title: "Bulk action partially completed",
+                message: "Some chats changed, but some selected or related chats were rejected before mutation."
+            )
+        }
+        if let rejection = report.rejections.first {
+            return AgentSidebarBulkActionNotice(
+                severity: .warning,
+                title: "No chats were changed",
+                message: rejection.message
+            )
+        }
+        if !report.didMutateProjection, !report.noOpReasons.isEmpty {
+            return AgentSidebarBulkActionNotice(
+                severity: .information,
+                title: "No chats were changed",
+                message: "The selected chats no longer matched the \(action.rawValue) action."
+            )
+        }
+        return nil
     }
 
     func sidebarSearchBinding() -> Binding<String> {
@@ -351,6 +498,7 @@ extension AgentModeViewModel {
                     parentSessionID: session.parentSessionID,
                     hasLoadedPersistedState: session.hasLoadedPersistedState,
                     itemsIsEmpty: session.items.isEmpty,
+                    transcriptTurnsIsEmpty: session.transcript.turns.isEmpty,
                     runState: session.runState,
                     lastActivityAt: session.lastActivityAt,
                     lastUserMessageAt: session.lastUserMessageAt
@@ -529,6 +677,10 @@ extension AgentModeViewModel {
                 if previousSession.itemsIsEmpty != currentSession.itemsIsEmpty { categories.insert("session.itemsIsEmpty")
                     changed = true
                 }
+                if previousSession.transcriptTurnsIsEmpty != currentSession.transcriptTurnsIsEmpty {
+                    categories.insert("session.transcriptTurnsIsEmpty")
+                    changed = true
+                }
                 if previousSession.runState != currentSession.runState {
                     categories.insert("session.runState")
                     changes.changedRunStateCount += 1
@@ -554,7 +706,8 @@ extension AgentModeViewModel {
                 "currentTabID", "sessionListCacheReady", "tabsWithActiveAgentRun", "mcpControlledTabIDs",
                 "tabMetadata.count", "tabMetadata.order", "tabMetadata.name", "tabMetadata.activeAgentSessionID",
                 "tabMetadata.isPinned", "tabMetadata.lastModified", "session.count", "session.activeAgentSessionID",
-                "session.parentSessionID", "session.hasLoadedPersistedState", "session.itemsIsEmpty", "session.runState",
+                "session.parentSessionID", "session.hasLoadedPersistedState", "session.itemsIsEmpty",
+                "session.transcriptTurnsIsEmpty", "session.runState",
                 "session.lastActivityAt", "session.lastUserMessageAt", "sessionIndex", "sessionListSortDates",
                 "sidebarRestoreFrozenOrder"
             ]

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -119,6 +119,17 @@ extension AgentModeViewModel {
         let requestedSessionID: UUID
     }
 
+    struct RemovalPreflightSessionClaim: Equatable {
+        let tabID: UUID
+        let sessionIdentity: ObjectIdentifier?
+        let activeAgentSessionID: UUID?
+        let binding: AgentPersistentSessionBindingIdentity?
+        let bindingTransitionGeneration: UInt64
+        let sourceItemsRevision: Int
+        let persistenceMutationGeneration: UInt64
+        let saveRequestGeneration: UInt64
+    }
+
     struct SessionSaveCommitToken: Equatable {
         let tabID: UUID
         let sessionIdentity: ObjectIdentifier
@@ -174,7 +185,7 @@ extension AgentModeViewModel {
 
     struct SidebarSessionRowsCacheKey: Equatable {
         let workspaceID: UUID?
-        let sidebarRevision: Int
+        let rowContentRevision: Int
         let tabMetadataSignatures: [AgentSessionSidebarTabMetadataSignature]
     }
 
@@ -189,13 +200,15 @@ extension AgentModeViewModel {
     }
 
     struct SidebarListProjection {
+        let workspaceID: UUID?
         let filteredSessions: [SidebarSession]
         let pagedSessions: [SidebarSession]
         let effectiveVisibleSessionCount: Int
         let archivedSessionTabsForHeader: [StashedTab]
-        let sortedArchivedSessionTabsForRows: [StashedTab]
+        let pagedArchivedSessionTabsForRows: [StashedTab]
         let archivedDateInfoByStashedTabID: [UUID: SidebarSessionDateInfo]
         let defaultCollapseSeedKeys: [AgentSidebarThreadKey]
+        let renderedSelectionOrder: [AgentSidebarSelectionIdentity]
 
         var hasMoreSessions: Bool {
             filteredSessions.count > effectiveVisibleSessionCount
@@ -204,6 +217,23 @@ extension AgentModeViewModel {
         var remainingSessionCount: Int {
             max(0, filteredSessions.count - effectiveVisibleSessionCount)
         }
+
+        var hasMoreArchivedSessions: Bool {
+            archivedSessionTabsForHeader.count > pagedArchivedSessionTabsForRows.count
+        }
+
+        var remainingArchivedSessionCount: Int {
+            max(0, archivedSessionTabsForHeader.count - pagedArchivedSessionTabsForRows.count)
+        }
+    }
+
+    struct SidebarBulkMutationTargets: Equatable {
+        let workspaceID: UUID
+        let activeDeleteTabIDs: Set<UUID>
+        let archivedDeleteTargets: Set<PromptViewModel.ArchivedTabMutationTarget>
+        let stashTabIDs: Set<UUID>
+        let pinTabIDs: Set<UUID>
+        let unpinTabIDs: Set<UUID>
     }
 
     /// Signature of a compose tab's sidebar-rendered metadata. Captured separately
@@ -238,6 +268,7 @@ extension AgentModeViewModel {
         let parentSessionID: UUID?
         let hasLoadedPersistedState: Bool
         let itemsIsEmpty: Bool
+        let transcriptTurnsIsEmpty: Bool
         let runState: AgentSessionRunState
         let lastActivityAt: Date
         let lastUserMessageAt: Date?
@@ -761,6 +792,7 @@ extension AgentModeViewModel {
         let activityDate: Date
         let isPinned: Bool
         let sessionID: UUID?
+        let canStash: Bool
         let parentSessionID: UUID?
         let depth: Int
         let isMCPControlled: Bool
@@ -792,6 +824,7 @@ extension AgentModeViewModel {
             activityDate: Date,
             isPinned: Bool,
             sessionID: UUID?,
+            canStash: Bool = false,
             parentSessionID: UUID?,
             depth: Int,
             isMCPControlled: Bool,
@@ -812,6 +845,7 @@ extension AgentModeViewModel {
             self.activityDate = activityDate
             self.isPinned = isPinned
             self.sessionID = sessionID
+            self.canStash = canStash
             self.parentSessionID = parentSessionID
             self.depth = depth
             self.isMCPControlled = isMCPControlled

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -475,6 +475,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
     }
 
+    private var provisionalParentSessionIDBySessionID: [UUID: UUID] = [:]
+
     private struct AgentRunOracleReviewKey: Hashable {
         let sessionID: UUID
         let runID: UUID
@@ -703,6 +705,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         var test_sidebarSessionRowsBuildCount = 0
         var test_sidebarListProjectionBuildCount = 0
         private var test_afterMCPStoreEpochBegan: (@MainActor () async -> Void)?
+        private var test_afterDurableChildTabCreation: (@MainActor () async -> Void)?
         private var test_composeTabRemovalTeardownObserver: (@MainActor (UUID) -> Void)?
         private var test_terminalPublicationOverride: ((
             AgentRunTerminalCommitRevision,
@@ -800,6 +803,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         ) {
             self.promptManager = promptManager
             self.workspaceManager = workspaceManager
+            installPromptManagerCascadeResolvers(promptManager)
             installAgentSessionLifecycleProjectionAuthority()
         }
 
@@ -809,6 +813,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
         func test_setAfterMCPStoreEpochBegan(_ hook: (@MainActor () async -> Void)?) {
             test_afterMCPStoreEpochBegan = hook
+        }
+
+        func test_setAfterDurableChildTabCreation(_ hook: (@MainActor () async -> Void)?) {
+            test_afterDurableChildTabCreation = hook
         }
 
         func test_setTerminalPublicationOverride(
@@ -2863,6 +2871,20 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 self.sessionTreeCascadePlan(forStashedTabIDs: stashedTabIDs)
             }
         }
+        promptManager.agentSessionCascadeSnapshotResolver = makeAgentSessionCascadeSnapshotResolver()
+    }
+
+    private func makeAgentSessionCascadeSnapshotResolver() -> PromptViewModel.AgentSessionCascadeSnapshotResolver {
+        { [weak self] composeTabIDs, archivedTargets, reason in
+            guard let self else { return .init() }
+            var plan = sessionTreeCascadePlan(forComposeTabIDs: composeTabIDs, reason: reason)
+            let archivedPlan = sessionTreeCascadePlan(
+                forStashedTabIDs: Set(archivedTargets.map(\.stashedTabID))
+            )
+            plan.composeTabIDs.formUnion(archivedPlan.composeTabIDs)
+            plan.archivedTargets.formUnion(archivedPlan.archivedTargets)
+            return plan
+        }
     }
 
     func isComposeTabProtectedFromSidebarArchiveSuggestion(_ tabID: UUID) -> Bool {
@@ -3011,6 +3033,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             nodes[sessionID] = node
         }
 
+        for (sessionID, parentSessionID) in provisionalParentSessionIDBySessionID {
+            merge(sessionID: sessionID, parentSessionID: parentSessionID)
+        }
         for session in sessions.values where validComposeTabIDs.contains(session.tabID) {
             guard let sessionID = session.activeAgentSessionID else { continue }
             if let explicitSessionID = explicitSessionIDByTabID[session.tabID],
@@ -6926,14 +6951,21 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             guard createIfNeeded else {
                 throw MCPError.invalidParams("The requested agent session is not currently available.")
             }
+            let effectiveParentSessionID = indexedParentSessionID ?? parentSessionID
             let createdTabID = try await mcpCreateBackgroundSessionTab(
                 name: sessionName,
-                sessionID: sessionID
+                sessionID: sessionID,
+                parentSessionID: effectiveParentSessionID
             )
+            defer { provisionalParentSessionIDBySessionID.removeValue(forKey: sessionID) }
+            #if DEBUG
+                await test_afterDurableChildTabCreation?()
+            #endif
+            try requireSpawnAdmissionStillCurrent(childTabID: createdTabID, parentSessionID: effectiveParentSessionID)
             let hydrated = await ensureSessionReady(tabID: createdTabID)
             await loadSessionFromDisk(for: hydrated)
             applySpawnParentSessionID(
-                indexedParentSessionID ?? parentSessionID,
+                effectiveParentSessionID,
                 to: hydrated,
                 inheritWorktreeBindings: inheritWorktreeBindings
             )
@@ -6982,8 +7014,14 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         let intendedSessionID = UUID()
         let createdTabID = try await mcpCreateBackgroundSessionTab(
             name: sessionName,
-            sessionID: intendedSessionID
+            sessionID: intendedSessionID,
+            parentSessionID: parentSessionID
         )
+        defer { provisionalParentSessionIDBySessionID.removeValue(forKey: intendedSessionID) }
+        #if DEBUG
+            await test_afterDurableChildTabCreation?()
+        #endif
+        try requireSpawnAdmissionStillCurrent(childTabID: createdTabID, parentSessionID: parentSessionID)
         let hydrated = await ensureSessionReady(tabID: createdTabID)
         guard hydrated.activeAgentSessionID == intendedSessionID else {
             throw MCPError.invalidParams("The new tab could not be bound to an agent session.")
@@ -7065,7 +7103,38 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         )
     }
 
+    private func requireSpawnAdmissionStillCurrent(childTabID: UUID, parentSessionID: UUID?) throws {
+        guard workspaceManager?.composeTab(with: childTabID) != nil else {
+            throw MCPError.invalidParams("The new child Agent session was removed before admission completed.")
+        }
+        if let parentSessionID, sessionTreeNodes()[parentSessionID] == nil {
+            throw MCPError.invalidParams("The parent Agent session was removed before child admission completed.")
+        }
+    }
+
     private func mcpCreateBackgroundSessionTab(
+        name: String?,
+        sessionID: UUID,
+        parentSessionID: UUID?
+    ) async throws -> UUID {
+        guard let promptManager else {
+            throw MCPError.internalError("Prompt manager unavailable.")
+        }
+        if let parentSessionID, parentSessionID != sessionID {
+            provisionalParentSessionIDBySessionID[sessionID] = parentSessionID
+        }
+        do {
+            return try await createBackgroundSessionTab(
+                name: name,
+                sessionID: sessionID
+            )
+        } catch {
+            provisionalParentSessionIDBySessionID.removeValue(forKey: sessionID)
+            throw error
+        }
+    }
+
+    private func createBackgroundSessionTab(
         name: String?,
         sessionID: UUID
     ) async throws -> UUID {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -510,6 +510,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     static let sessionSidebarPageSize = 15
+    static let sessionSidebarArchivedPageSize = 20
     @Published var sessionSidebarSearchText: String = "" {
         didSet {
             guard sessionSidebarSearchText != oldValue else { return }
@@ -524,6 +525,13 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     @Published var sessionSidebarVisibleSessionCount: Int = AgentModeViewModel.sessionSidebarPageSize {
         didSet {
             guard sessionSidebarVisibleSessionCount != oldValue else { return }
+            syncSidebarUIState()
+        }
+    }
+
+    @Published var sessionSidebarArchivedVisibleSessionCount: Int = AgentModeViewModel.sessionSidebarArchivedPageSize {
+        didSet {
+            guard sessionSidebarArchivedVisibleSessionCount != oldValue else { return }
             syncSidebarUIState()
         }
     }
@@ -645,6 +653,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         _ canonicalItemCount: Int
     ) async throws -> URL
     typealias AgentSessionsDeleter = @MainActor (_ tabID: UUID, _ workspace: WorkspaceModel) async throws -> Void
+    typealias AgentSessionsBatchDeleter = @MainActor (
+        _ tabIDs: Set<UUID>,
+        _ workspace: WorkspaceModel
+    ) async -> [UUID: Error]
 
     private var saveInFlightSessionIDs: Set<UUID> = []
     private var saveRequestedWhileInFlightSessionIDs: Set<UUID> = []
@@ -659,8 +671,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         )
     }
 
-    private var agentSessionsDeleter: AgentSessionsDeleter = { tabID, workspace in
-        try await AgentSessionDataService.shared.deleteAgentSessions(forComposeTabID: tabID, for: workspace)
+    private var agentSessionsBatchDeleter: AgentSessionsBatchDeleter = { tabIDs, workspace in
+        await AgentSessionDataService.shared.deleteAgentSessions(forComposeTabIDs: tabIDs, for: workspace)
     }
 
     let sidebarAutoArchivePolicy = AgentModeSidebarAutoArchivePolicy()
@@ -675,6 +687,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     var agentChatsSidebarRowsCache: (key: SidebarSessionRowsCacheKey, rows: [SidebarSession])?
     var sidebarListProjectionCache: (key: SidebarListProjectionCacheKey, projection: SidebarListProjection)?
     private var lastKnownWorkspaceSnapshot: WorkspaceModel?
+    var sidebarRuntimeWorkspaceID: UUID? {
+        lastKnownWorkspaceSnapshot?.id
+    }
+
     var tabDraftText: [UUID: String] = [:]
     private var cancellables = Set<AnyCancellable>()
     private let listeners = ListenerRegistry()
@@ -724,7 +740,17 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
 
         func test_setAgentSessionsDeleter(_ deleter: @escaping AgentSessionsDeleter) {
-            agentSessionsDeleter = deleter
+            agentSessionsBatchDeleter = { tabIDs, workspace in
+                var failures: [UUID: Error] = [:]
+                for tabID in tabIDs.sorted(by: { $0.uuidString < $1.uuidString }) {
+                    do {
+                        try await deleter(tabID, workspace)
+                    } catch {
+                        failures[tabID] = error
+                    }
+                }
+                return failures
+            }
         }
 
         func test_setComposeTabRemovalTeardownObserver(_ observer: @escaping @MainActor (UUID) -> Void) {
@@ -2506,8 +2532,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
         listeners.addToken(
             promptManager.addComposeTabsDidRemoveListener { [weak self] tabIDs, reason, workspaceID in
-                guard let self else { return }
-                await handleComposeTabsDidRemove(tabIDs, reason: reason, workspaceID: workspaceID)
+                guard let self else { return [] }
+                return await handleComposeTabsDidRemove(tabIDs, reason: reason, workspaceID: workspaceID)
             }
         ) { [weak promptManager] token in
             promptManager?.removeComposeTabsDidRemoveListener(token)
@@ -2877,7 +2903,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         composeDescendantTabIDs.subtract(tabIDs)
         return .init(
             composeTabIDs: composeDescendantTabIDs,
-            stashedTabIDs: stashedDescendantTabIDs
+            archivedTargets: archivedMutationTargets(for: stashedDescendantTabIDs)
         )
     }
 
@@ -2900,8 +2926,18 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         stashedDescendantTabIDs.subtract(stashedTabIDs)
         return .init(
             composeTabIDs: composeDescendantTabIDs,
-            stashedTabIDs: stashedDescendantTabIDs
+            archivedTargets: archivedMutationTargets(for: stashedDescendantTabIDs)
         )
+    }
+
+    private func archivedMutationTargets(
+        for stashedTabIDs: Set<UUID>
+    ) -> Set<PromptViewModel.ArchivedTabMutationTarget> {
+        let stashedTabs = workspaceManager?.activeWorkspace?.stashedTabs ?? []
+        return Set(stashedTabs.compactMap { stashedTab -> PromptViewModel.ArchivedTabMutationTarget? in
+            guard stashedTabIDs.contains(stashedTab.id) else { return nil }
+            return .init(stashedTabID: stashedTab.id, tabID: stashedTab.tab.id)
+        })
     }
 
     private func sessionTreeRootSessionIDs(
@@ -11208,6 +11244,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         owner: SessionIndexOwner
     ) async {
         guard sessionIndexStore.isWorkspaceActivationCurrent(owner, workspace: workspace) else { return }
+        ui.sessionSidebar.invalidateSelectionForWorkspaceChange()
+        sessionSidebarArchivedVisibleSessionCount = Self.sessionSidebarArchivedPageSize
         lastKnownWorkspaceSnapshot = workspace
         installSessionIndexOwner(owner, workspace: workspace)
         guard sessionIndexStore.isOwnerCurrent(owner) else { return }
@@ -11893,10 +11931,11 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 message: "The owning workspace changed before required session persistence."
             ))
         }
+        var flushedSessionClaims: [RemovalPreflightSessionClaim] = []
         for tabID in tabIDs.sorted(by: { $0.uuidString < $1.uuidString }) {
             switch await flushSaveRequired(for: tabID, workspaceID: workspaceID) {
             case .success:
-                continue
+                flushedSessionClaims.append(removalPreflightSessionClaim(for: tabID))
             case let .failure(failure):
                 return .abort(.init(
                     stage: .requiredSessionFlush,
@@ -11905,29 +11944,111 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 ))
             }
         }
+        guard flushedSessionClaims.allSatisfy({ removalPreflightSessionClaim(for: $0.tabID) == $0 }) else {
+            return .abort(.init(
+                stage: .requiredSessionFlush,
+                tabID: nil,
+                message: "A target session changed after required persistence completed."
+            ))
+        }
         return .proceed
     }
 
     func handleComposeTabsDidRemove(
         _ tabIDs: Set<UUID>,
         reason: PromptViewModel.ComposeTabRemovalReason,
-        workspaceID: UUID? = nil
-    ) async {
-        let removalWorkspace = workspaceID.flatMap { workspaceID in
-            workspaceManager?.workspaces.first(where: { $0.id == workspaceID })
-        } ?? workspaceManager?.activeWorkspace
-
+        workspaceID: UUID
+    ) async -> [PromptViewModel.ComposeTabPostRemovalIssue] {
+        let removalWorkspace = workspaceManager?.workspaces.first(where: { $0.id == workspaceID })
+        var issues: [PromptViewModel.ComposeTabPostRemovalIssue] = []
         let orderedTabIDs = tabIDs.sorted(by: { $0.uuidString < $1.uuidString })
+
+        func tabIsRemoved(_ tabID: UUID, from workspace: WorkspaceModel) -> Bool {
+            !workspace.composeTabs.contains(where: { $0.id == tabID })
+                && !workspace.stashedTabs.contains(where: { $0.tab.id == tabID })
+        }
+
+        let runtimeCleanupTabIDs: Set<UUID> = if workspaceManager == nil {
+            tabIDs
+        } else if let removalWorkspace {
+            Set(tabIDs.filter { tabID in
+                switch reason {
+                case .stash:
+                    !removalWorkspace.composeTabs.contains(where: { $0.id == tabID })
+                case .close, .deleteStashed:
+                    tabIsRemoved(tabID, from: removalWorkspace)
+                }
+            })
+        } else {
+            []
+        }
+        if removalWorkspace != nil {
+            issues.append(contentsOf: tabIDs.subtracting(runtimeCleanupTabIDs).map { tabID in
+                .init(
+                    tabID: tabID,
+                    reason: reason,
+                    message: "The chat was recreated before runtime cleanup."
+                )
+            })
+        }
+
+        if workspaceManager != nil, workspaceManager?.activeWorkspaceID != workspaceID {
+            if reason != .stash {
+                if let removalWorkspace {
+                    let durableTabIDs = Set(tabIDs.filter { tabIsRemoved($0, from: removalWorkspace) })
+                    let reintroducedTabIDs = tabIDs.subtracting(durableTabIDs)
+                    issues.append(contentsOf: reintroducedTabIDs.map { tabID in
+                        .init(
+                            tabID: tabID,
+                            reason: reason,
+                            message: "The chat was recreated before durable cleanup."
+                        )
+                    })
+                    let failures = await agentSessionsBatchDeleter(durableTabIDs, removalWorkspace)
+                    issues.append(contentsOf: failures.map { tabID, failure in
+                        .init(tabID: tabID, reason: reason, message: failure.localizedDescription)
+                    })
+                } else {
+                    issues.append(contentsOf: orderedTabIDs.map { tabID in
+                        .init(
+                            tabID: tabID,
+                            reason: reason,
+                            message: "The owning workspace is no longer available for durable cleanup."
+                        )
+                    })
+                }
+            }
+            return issues
+        }
+        let orderedRuntimeCleanupTabIDs = orderedTabIDs.filter(runtimeCleanupTabIDs.contains)
+        let capturedSessionsByTabID = Dictionary(
+            uniqueKeysWithValues: orderedRuntimeCleanupTabIDs.map { ($0, sessions[$0]) }
+        )
+        let capturedBoundSessionIDByTabID = Dictionary(
+            uniqueKeysWithValues: orderedRuntimeCleanupTabIDs.map { ($0, boundSessionID(for: $0)) }
+        )
+        for tabID in orderedRuntimeCleanupTabIDs {
+            if let capturedSession = capturedSessionsByTabID[tabID] ?? nil,
+               sessions[tabID] === capturedSession
+            {
+                sessions.removeValue(forKey: tabID)
+            }
+        }
         // Drop any sidebar attention / observed run-state for tabs that are
         // going away so we don't leave dangling entries referring to dead IDs.
-        cleanupSidebarRunAttention(tabIDs: tabIDs)
-        for tabID in orderedTabIDs {
+        if workspaceManager == nil || workspaceManager?.activeWorkspaceID == workspaceID {
+            cleanupSidebarRunAttention(tabIDs: runtimeCleanupTabIDs)
+        }
+        for tabID in orderedRuntimeCleanupTabIDs {
             #if DEBUG
                 test_composeTabRemovalTeardownObserver?(tabID)
             #endif
-            let boundID = boundSessionID(for: tabID)
-            if let session = sessions[tabID] {
-                removePendingUIRefresh(for: tabID)
+            let capturedSession = capturedSessionsByTabID[tabID] ?? nil
+            let boundID = capturedBoundSessionIDByTabID[tabID] ?? nil
+            if let session = capturedSession {
+                if sessions[tabID] == nil {
+                    removePendingUIRefresh(for: tabID)
+                }
                 cancelPersistedLoad(for: session)
                 session.cancelEphemeralRuntimeState()
                 // Cancel pending question
@@ -11940,7 +12061,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
                 // Cancel agent run
                 if session.runState.isActive {
-                    await cancelAgentRun(tabID: tabID)
+                    await runService.cancelRun(tabID: tabID, session: session)
                 }
 
                 // All compose-tab removal reasons detach the live TabSession owner from `sessions`.
@@ -11949,43 +12070,36 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 await codexCoordinator.shutdownCodexSession(session)
                 await claudeCoordinator.shutdownClaudeSession(session)
             }
-            await cleanupMCPRunRoutingIfPresent(
-                boundSessionID: boundID,
-                liveSession: sessions[tabID],
-                reason: "compose_tab_close"
-            )
-            await releaseSessionWorktreeOwnership(sessionID: boundID)
-
-            switch reason {
-            case .stash:
-                sessions.removeValue(forKey: tabID)
-                tabsWithActiveAgentRun.remove(tabID)
-            case .close:
-                if let workspace = removalWorkspace {
-                    do {
-                        try await agentSessionsDeleter(tabID, workspace)
-                    } catch {
-                        print("[AgentModeVM] Failed to delete removed tab session data for \(tabID): \(error)")
-                    }
+            if sessions[tabID] == nil {
+                await cleanupMCPRunRoutingIfPresent(
+                    boundSessionID: boundID,
+                    liveSession: capturedSession,
+                    reason: "compose_tab_close"
+                )
+            }
+            if sessions[tabID] == nil {
+                await releaseSessionWorktreeOwnership(sessionID: boundID)
+            }
+            let currentRemovalWorkspace = workspaceManager?.workspaces.first(where: { $0.id == workspaceID })
+            let projectionStillRemoved = currentRemovalWorkspace.map { workspace in
+                switch reason {
+                case .stash:
+                    !workspace.composeTabs.contains(where: { $0.id == tabID })
+                case .close, .deleteStashed:
+                    tabIsRemoved(tabID, from: workspace)
                 }
+            } ?? false
+            let tabCleanupIsStillOwned = sessions[tabID] == nil && (workspaceManager == nil || projectionStillRemoved)
+            if tabCleanupIsStillOwned {
+                tabsWithActiveAgentRun.remove(tabID)
+            }
+            if reason != .stash,
+               workspaceManager == nil || workspaceManager?.activeWorkspaceID == workspaceID,
+               tabCleanupIsStillOwned
+            {
                 removeSessionIndex(forTabID: tabID)
                 tabDraftText.removeValue(forKey: tabID)
                 sessionIndexStore.removeSortDate(forTabID: tabID)
-                sessions.removeValue(forKey: tabID)
-                tabsWithActiveAgentRun.remove(tabID)
-            case .deleteStashed:
-                if let workspace = removalWorkspace {
-                    do {
-                        try await agentSessionsDeleter(tabID, workspace)
-                    } catch {
-                        print("[AgentModeVM] Failed to delete removed stashed session data for \(tabID): \(error)")
-                    }
-                }
-                removeSessionIndex(forTabID: tabID)
-                tabDraftText.removeValue(forKey: tabID)
-                sessionIndexStore.removeSortDate(forTabID: tabID)
-                sessions.removeValue(forKey: tabID)
-                tabsWithActiveAgentRun.remove(tabID)
             }
             #if DEBUG
                 AgentModePerfDiagnostics.markSidebarDeleteAgentCleanupComplete(
@@ -11995,12 +12109,72 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 )
             #endif
         }
+        if reason != .stash {
+            let durableWorkspace = workspaceManager?.workspaces.first(where: { $0.id == workspaceID }) ?? removalWorkspace
+            if let durableWorkspace {
+                let durableTabIDs = Set(tabIDs.filter { tabID in
+                    tabIsRemoved(tabID, from: durableWorkspace) && sessions[tabID] == nil
+                })
+                let unsettledTabIDs = tabIDs.subtracting(durableTabIDs)
+                issues.append(contentsOf: unsettledTabIDs.map { tabID in
+                    .init(
+                        tabID: tabID,
+                        reason: reason,
+                        message: "The chat was recreated before durable cleanup."
+                    )
+                })
+                let failures = await agentSessionsBatchDeleter(durableTabIDs, durableWorkspace)
+                for tabID in failures.keys.sorted(by: { $0.uuidString < $1.uuidString }) {
+                    guard let failure = failures[tabID] else { continue }
+                    print("[AgentModeVM] Failed to delete removed session data for \(tabID): \(failure)")
+                    issues.append(.init(
+                        tabID: tabID,
+                        reason: reason,
+                        message: failure.localizedDescription
+                    ))
+                }
+            } else {
+                issues.append(contentsOf: orderedTabIDs.map { tabID in
+                    .init(
+                        tabID: tabID,
+                        reason: reason,
+                        message: "The owning workspace is no longer available for durable cleanup."
+                    )
+                })
+            }
+        }
         #if DEBUG
             AgentTranscriptDebugInstrumentation.removeRefreshInputSignatures(for: tabIDs)
         #endif
+        return issues
     }
 
     // MARK: - Persistence
+
+    private func removalPreflightSessionClaim(for tabID: UUID) -> RemovalPreflightSessionClaim {
+        guard let session = sessions[tabID] else {
+            return RemovalPreflightSessionClaim(
+                tabID: tabID,
+                sessionIdentity: nil,
+                activeAgentSessionID: nil,
+                binding: nil,
+                bindingTransitionGeneration: 0,
+                sourceItemsRevision: 0,
+                persistenceMutationGeneration: 0,
+                saveRequestGeneration: 0
+            )
+        }
+        return RemovalPreflightSessionClaim(
+            tabID: tabID,
+            sessionIdentity: ObjectIdentifier(session),
+            activeAgentSessionID: session.activeAgentSessionID,
+            binding: session.persistentSessionBindingIdentity,
+            bindingTransitionGeneration: session.bindingTransitionGeneration,
+            sourceItemsRevision: session.sourceItemsRevision,
+            persistenceMutationGeneration: session.persistenceMutationGeneration,
+            saveRequestGeneration: session.saveRequestGeneration
+        )
+    }
 
     private func makeSaveCommitToken(
         for session: TabSession,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -6952,6 +6952,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 throw MCPError.invalidParams("The requested agent session is not currently available.")
             }
             let effectiveParentSessionID = indexedParentSessionID ?? parentSessionID
+            let parentWasLocallyRepresentedAtAdmissionStart = effectiveParentSessionID.map {
+                sessionTreeNodes()[$0] != nil
+            } ?? false
             let createdTabID = try await mcpCreateBackgroundSessionTab(
                 name: sessionName,
                 sessionID: sessionID,
@@ -6961,7 +6964,11 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             #if DEBUG
                 await test_afterDurableChildTabCreation?()
             #endif
-            try requireSpawnAdmissionStillCurrent(childTabID: createdTabID, parentSessionID: effectiveParentSessionID)
+            try requireSpawnAdmissionStillCurrent(
+                childTabID: createdTabID,
+                parentSessionID: effectiveParentSessionID,
+                parentWasLocallyRepresentedAtAdmissionStart: parentWasLocallyRepresentedAtAdmissionStart
+            )
             let hydrated = await ensureSessionReady(tabID: createdTabID)
             await loadSessionFromDisk(for: hydrated)
             applySpawnParentSessionID(
@@ -7012,6 +7019,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             throw MCPError.invalidParams("No target agent session was specified.")
         }
         let intendedSessionID = UUID()
+        let parentWasLocallyRepresentedAtAdmissionStart = parentSessionID.map {
+            sessionTreeNodes()[$0] != nil
+        } ?? false
         let createdTabID = try await mcpCreateBackgroundSessionTab(
             name: sessionName,
             sessionID: intendedSessionID,
@@ -7021,7 +7031,11 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         #if DEBUG
             await test_afterDurableChildTabCreation?()
         #endif
-        try requireSpawnAdmissionStillCurrent(childTabID: createdTabID, parentSessionID: parentSessionID)
+        try requireSpawnAdmissionStillCurrent(
+            childTabID: createdTabID,
+            parentSessionID: parentSessionID,
+            parentWasLocallyRepresentedAtAdmissionStart: parentWasLocallyRepresentedAtAdmissionStart
+        )
         let hydrated = await ensureSessionReady(tabID: createdTabID)
         guard hydrated.activeAgentSessionID == intendedSessionID else {
             throw MCPError.invalidParams("The new tab could not be bound to an agent session.")
@@ -7103,11 +7117,18 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         )
     }
 
-    private func requireSpawnAdmissionStillCurrent(childTabID: UUID, parentSessionID: UUID?) throws {
+    private func requireSpawnAdmissionStillCurrent(
+        childTabID: UUID,
+        parentSessionID: UUID?,
+        parentWasLocallyRepresentedAtAdmissionStart: Bool
+    ) throws {
         guard workspaceManager?.composeTab(with: childTabID) != nil else {
             throw MCPError.invalidParams("The new child Agent session was removed before admission completed.")
         }
-        if let parentSessionID, sessionTreeNodes()[parentSessionID] == nil {
+        if parentWasLocallyRepresentedAtAdmissionStart,
+           let parentSessionID,
+           sessionTreeNodes()[parentSessionID] == nil
+        {
             throw MCPError.invalidParams("The parent Agent session was removed before child admission completed.")
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
@@ -3,6 +3,7 @@ import Foundation
 struct AgentSessionSidebarSnapshot: Equatable {
     var searchText: String
     var visibleSessionCount: Int
+    var archivedVisibleSessionCount: Int
     var collapsedThreadKeys: Set<AgentSidebarThreadKey> = []
     /// Thread keys that have already received one-shot default collapse handling
     /// during this view-model lifetime. Explicit user expand/collapse actions
@@ -20,20 +21,110 @@ struct AgentSessionSidebarSnapshot: Equatable {
     /// with `attentionRunStateByTabID` and intentionally not persisted.
     var attentionMarkedAtByTabID: [UUID: Date] = [:]
     var revision: Int = 0
+    var rowContentRevision: Int = 0
 }
 
 @MainActor
 final class AgentSessionSidebarUIStore: ObservableObject {
     @Published private(set) var snapshot = AgentSessionSidebarSnapshot(
         searchText: "",
-        visibleSessionCount: AgentModeViewModel.sessionSidebarPageSize
+        visibleSessionCount: AgentModeViewModel.sessionSidebarPageSize,
+        archivedVisibleSessionCount: AgentModeViewModel.sessionSidebarArchivedPageSize
     )
+    @Published private(set) var selectionState = AgentSidebarSelectionState()
 
-    func update(searchText: String, visibleSessionCount: Int) {
+    func update(searchText: String, visibleSessionCount: Int, archivedVisibleSessionCount: Int) {
         var next = snapshot
         next.searchText = searchText
         next.visibleSessionCount = visibleSessionCount
-        _ = publish(next, eventName: "sessionSidebar", force: false)
+        next.archivedVisibleSessionCount = archivedVisibleSessionCount
+        _ = publish(
+            next,
+            eventName: "sessionSidebar",
+            force: false,
+            affectsRowContent: false
+        )
+    }
+
+    func handleSelectionGesture(
+        _ gesture: AgentSidebarSelectionGesture,
+        identity: AgentSidebarSelectionIdentity,
+        renderedOrder: [AgentSidebarSelectionIdentity],
+        workspaceID: UUID
+    ) -> AgentSidebarSelectionGestureDisposition {
+        var next = selectionState
+        let disposition = next.handle(
+            gesture,
+            identity: identity,
+            renderedOrder: renderedOrder,
+            workspaceID: workspaceID
+        )
+        publishSelection(next, eventName: "sessionSidebar.selection.gesture")
+        return disposition
+    }
+
+    func selectAll(renderedOrder: [AgentSidebarSelectionIdentity], workspaceID: UUID) {
+        var next = selectionState
+        next.selectAll(renderedOrder: renderedOrder, workspaceID: workspaceID)
+        publishSelection(next, eventName: "sessionSidebar.selection.selectAll")
+    }
+
+    func clearSelection() {
+        var next = selectionState
+        next.clear()
+        publishSelection(next, eventName: "sessionSidebar.selection.clear")
+    }
+
+    func reconcileSelection(renderedOrder: [AgentSidebarSelectionIdentity], workspaceID: UUID?) {
+        var next = selectionState
+        next.reconcile(renderedOrder: renderedOrder, workspaceID: workspaceID)
+        publishSelection(next, eventName: "sessionSidebar.selection.reconcile")
+    }
+
+    func beginBulkAction(kind: AgentSidebarBulkActionKind, targetCount: Int, workspaceID: UUID) -> UUID? {
+        guard selectionState.inFlightAction == nil, targetCount > 0 else { return nil }
+        let token = UUID()
+        var next = selectionState
+        next.workspaceID = workspaceID
+        next.notice = nil
+        next.inFlightAction = AgentSidebarBulkActionOperation(
+            token: token,
+            workspaceID: workspaceID,
+            kind: kind,
+            targetCount: targetCount
+        )
+        next.revision &+= 1
+        publishSelection(next, eventName: "sessionSidebar.selection.bulkBegin")
+        return token
+    }
+
+    func isCurrentBulkAction(token: UUID, workspaceID: UUID) -> Bool {
+        selectionState.inFlightAction?.token == token
+            && selectionState.inFlightAction?.workspaceID == workspaceID
+    }
+
+    func finishBulkAction(token: UUID, workspaceID: UUID, notice: AgentSidebarBulkActionNotice?) {
+        guard isCurrentBulkAction(token: token, workspaceID: workspaceID) else { return }
+        var next = selectionState
+        next.inFlightAction = nil
+        if next.selectedIdentities.isEmpty { next.workspaceID = nil }
+        next.notice = notice
+        next.revision &+= 1
+        publishSelection(next, eventName: "sessionSidebar.selection.bulkFinish")
+    }
+
+    func invalidateSelectionForWorkspaceChange() {
+        var next = AgentSidebarSelectionState()
+        next.revision = selectionState.revision &+ 1
+        publishSelection(next, eventName: "sessionSidebar.selection.workspaceChange")
+    }
+
+    func dismissBulkActionNotice() {
+        guard selectionState.notice != nil else { return }
+        var next = selectionState
+        next.notice = nil
+        next.revision &+= 1
+        publishSelection(next, eventName: "sessionSidebar.selection.noticeDismiss")
     }
 
     func isThreadCollapsed(_ key: AgentSidebarThreadKey) -> Bool {
@@ -151,6 +242,23 @@ final class AgentSessionSidebarUIStore: ObservableObject {
         _ = publish(snapshot, eventName: "sessionSidebar.refresh", force: true)
     }
 
+    private func publishSelection(_ next: AgentSidebarSelectionState, eventName: String) {
+        guard next != selectionState else { return }
+        selectionState = next
+        #if DEBUG
+            AgentModePerfDiagnostics.recordStoreUpdate(
+                eventName,
+                published: true,
+                details: [
+                    "revision": String(next.revision),
+                    "selectedCount": String(next.selectedIdentities.count),
+                    "hasAnchor": String(next.anchor != nil),
+                    "inFlightKind": next.inFlightAction?.kind.rawValue ?? "none"
+                ]
+            )
+        #endif
+    }
+
     /// Publishes the next snapshot if it differs from the current one (or if
     /// `force` is true). Returns whether a new revision was emitted so callers
     /// can fall back to their own refresh path when nothing changed.
@@ -158,7 +266,8 @@ final class AgentSessionSidebarUIStore: ObservableObject {
     private func publish(
         _ proposedSnapshot: AgentSessionSidebarSnapshot,
         eventName: String,
-        force: Bool
+        force: Bool,
+        affectsRowContent: Bool = true
     ) -> Bool {
         var next = proposedSnapshot
         guard force || next != snapshot else {
@@ -168,6 +277,7 @@ final class AgentSessionSidebarUIStore: ObservableObject {
             return false
         }
         next.revision &+= 1
+        if affectsRowContent { next.rowContentRevision &+= 1 }
         snapshot = next
         #if DEBUG
             AgentModePerfDiagnostics.recordStoreUpdate(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+struct AgentSidebarSelectionModifiers: OptionSet {
+    let rawValue: Int
+
+    static let command = Self(rawValue: 1 << 0)
+    static let shift = Self(rawValue: 1 << 1)
+}
+
+enum AgentSidebarSelectionIdentity: Hashable {
+    case active(tabID: UUID)
+    case archived(stashedTabID: UUID, tabID: UUID)
+
+    var tabID: UUID {
+        switch self {
+        case let .active(tabID), let .archived(_, tabID): tabID
+        }
+    }
+}
+
+enum AgentSidebarSelectionGesture: Equatable {
+    case primary
+    case toggle
+    case range
+
+    init(modifiers: AgentSidebarSelectionModifiers) {
+        if modifiers.contains(.shift) {
+            self = .range
+        } else if modifiers.contains(.command) {
+            self = .toggle
+        } else {
+            self = .primary
+        }
+    }
+}
+
+enum AgentSidebarSelectionGestureDisposition: Equatable {
+    case activate
+    case selectionChanged
+    case ignored
+}
+
+enum AgentSidebarBulkActionKind: String, Equatable {
+    case delete
+    case stash
+    case pin
+    case unpin
+}
+
+struct AgentSidebarBulkActionOperation: Equatable {
+    let token: UUID
+    let workspaceID: UUID
+    let kind: AgentSidebarBulkActionKind
+    let targetCount: Int
+}
+
+struct AgentSidebarBulkActionNotice: Equatable {
+    enum Severity: Equatable {
+        case information
+        case warning
+        case error
+    }
+
+    let severity: Severity
+    let title: String
+    let message: String
+}
+
+struct AgentSidebarSelectionState: Equatable {
+    var workspaceID: UUID?
+    var selectedIdentities: Set<AgentSidebarSelectionIdentity> = []
+    var anchor: AgentSidebarSelectionIdentity?
+    var inFlightAction: AgentSidebarBulkActionOperation?
+    var notice: AgentSidebarBulkActionNotice?
+    var revision = 0
+
+    var isSelectionMode: Bool {
+        !selectedIdentities.isEmpty || inFlightAction != nil
+    }
+
+    mutating func handle(
+        _ gesture: AgentSidebarSelectionGesture,
+        identity: AgentSidebarSelectionIdentity,
+        renderedOrder: [AgentSidebarSelectionIdentity],
+        workspaceID: UUID
+    ) -> AgentSidebarSelectionGestureDisposition {
+        guard inFlightAction == nil, renderedOrder.contains(identity) else { return .ignored }
+        if self.workspaceID != nil, self.workspaceID != workspaceID {
+            self = AgentSidebarSelectionState(revision: revision &+ 1)
+        }
+
+        switch gesture {
+        case .primary:
+            guard isSelectionMode else { return .activate }
+            selectedIdentities = [identity]
+            anchor = identity
+        case .toggle:
+            if selectedIdentities.remove(identity) == nil {
+                selectedIdentities.insert(identity)
+            }
+            anchor = selectedIdentities.isEmpty ? nil : identity
+        case .range:
+            guard let anchor,
+                  let anchorIndex = renderedOrder.firstIndex(of: anchor),
+                  let identityIndex = renderedOrder.firstIndex(of: identity)
+            else {
+                self.workspaceID = workspaceID
+                selectedIdentities = [identity]
+                anchor = identity
+                revision &+= 1
+                return .selectionChanged
+            }
+            selectedIdentities = Set(renderedOrder[min(anchorIndex, identityIndex) ... max(anchorIndex, identityIndex)])
+        }
+        self.workspaceID = selectedIdentities.isEmpty ? nil : workspaceID
+        revision &+= 1
+        return .selectionChanged
+    }
+
+    mutating func selectAll(renderedOrder: [AgentSidebarSelectionIdentity], workspaceID: UUID) {
+        guard inFlightAction == nil, !renderedOrder.isEmpty else { return }
+        self.workspaceID = workspaceID
+        selectedIdentities = Set(renderedOrder)
+        anchor = renderedOrder.first
+        revision &+= 1
+    }
+
+    mutating func clear() {
+        guard inFlightAction == nil, !selectedIdentities.isEmpty || anchor != nil else { return }
+        workspaceID = nil
+        selectedIdentities.removeAll()
+        anchor = nil
+        revision &+= 1
+    }
+
+    mutating func reconcile(renderedOrder: [AgentSidebarSelectionIdentity], workspaceID: UUID?) {
+        if self.workspaceID != nil, self.workspaceID != workspaceID {
+            self = AgentSidebarSelectionState(revision: revision &+ 1)
+            return
+        }
+        let rendered = Set(renderedOrder)
+        let nextSelection = selectedIdentities.intersection(rendered)
+        let nextAnchor = anchor.flatMap { rendered.contains($0) ? $0 : nil }
+        guard nextSelection != selectedIdentities || nextAnchor != anchor else { return }
+        selectedIdentities = nextSelection
+        anchor = nextSelection.isEmpty ? nil : nextAnchor
+        if nextSelection.isEmpty, inFlightAction == nil { self.workspaceID = nil }
+        revision &+= 1
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -164,12 +164,15 @@ struct AgentSessionRow: View {
         }
     }
 
+    private func toggleSelection() {
+        guard isSelectionEnabled else { return }
+        _ = onSelectionGesture(.toggle)
+    }
+
     var body: some View {
         HStack(spacing: rowSpacing) {
             if isSelectionMode {
-                Button {
-                    _ = onSelectionGesture(.toggle)
-                } label: {
+                Button(action: toggleSelection) {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
                 }
@@ -301,6 +304,10 @@ struct AgentSessionRow: View {
         .contentShape(Rectangle())
         .contextMenu {
             if !isSelectionMode {
+                Button("Select chat", action: toggleSelection)
+
+                Divider()
+
                 Button(pinActionLabel, action: onTogglePin)
 
                 Button(renameActionLabel, action: beginRename)
@@ -320,8 +327,14 @@ struct AgentSessionRow: View {
         }
         .onHover { isHovered = $0 }
         .onTapGesture(perform: handleRowTap)
+        .focusable()
+        .onKeyPress(.space) {
+            toggleSelection()
+            return .handled
+        }
         .accessibilityLabel(title)
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityAction(named: Text(isSelected ? "Deselect chat" : "Select chat"), toggleSelection)
         .popover(isPresented: $showDeleteConfirmation, attachmentAnchor: .rect(.bounds), arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Delete chat?")
@@ -806,12 +819,15 @@ struct AgentStashedSessionRow: View {
         }
     }
 
+    private func toggleSelection() {
+        guard isSelectionEnabled else { return }
+        _ = onSelectionGesture(.toggle)
+    }
+
     var body: some View {
         HStack(spacing: rowSpacing) {
             if isSelectionMode {
-                Button {
-                    _ = onSelectionGesture(.toggle)
-                } label: {
+                Button(action: toggleSelection) {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
                 }
@@ -878,6 +894,8 @@ struct AgentStashedSessionRow: View {
         .contentShape(Rectangle())
         .contextMenu {
             if !isSelectionMode {
+                Button("Select chat", action: toggleSelection)
+                Divider()
                 Button(restoreActionLabel, action: onRestore)
                 Divider()
                 Button(deleteActionLabel, role: .destructive, action: onDelete)
@@ -885,8 +903,14 @@ struct AgentStashedSessionRow: View {
         }
         .onHover { isHovered = $0 }
         .onTapGesture(perform: handleRowTap)
+        .focusable()
+        .onKeyPress(.space) {
+            toggleSelection()
+            return .handled
+        }
         .accessibilityLabel("\(stashed.tab.name), archived session")
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityAction(named: Text(isSelected ? "Deselect chat" : "Select chat"), toggleSelection)
     }
 }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // MARK: - Agent Session Row
@@ -31,6 +32,10 @@ struct AgentSessionRow: View {
     /// tinted to mirror the mcp-status-style "something happened" cue.
     var hiddenThreadDescendantAttentionCount: Int = 0
     var onToggleThreadCollapse: (() -> Void)?
+    var isSelected = false
+    var isSelectionMode = false
+    var isSelectionEnabled = true
+    let onSelectionGesture: (AgentSidebarSelectionGesture) -> AgentSidebarSelectionGestureDisposition
     let onSelect: () -> Void
     let onTogglePin: () -> Void
     var onStash: (() -> Void)?
@@ -145,8 +150,35 @@ struct AgentSessionRow: View {
         showDeleteConfirmation = true
     }
 
+    private var currentSelectionGesture: AgentSidebarSelectionGesture {
+        var modifiers: AgentSidebarSelectionModifiers = []
+        let flags = NSApp.currentEvent?.modifierFlags ?? []
+        if flags.contains(.command) { modifiers.insert(.command) }
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+        return AgentSidebarSelectionGesture(modifiers: modifiers)
+    }
+
+    private func handleRowTap() {
+        if onSelectionGesture(currentSelectionGesture) == .activate {
+            onSelect()
+        }
+    }
+
     var body: some View {
         HStack(spacing: rowSpacing) {
+            if isSelectionMode {
+                Button {
+                    _ = onSelectionGesture(.toggle)
+                } label: {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(!isSelectionEnabled)
+                .accessibilityLabel("\(isSelected ? "Deselect" : "Select") \(title)")
+                .accessibilityValue(isSelected ? "Selected" : "Not selected")
+            }
+
             if threadDepth > 0 {
                 Spacer()
                     .frame(width: leadingIndent)
@@ -195,7 +227,7 @@ struct AgentSessionRow: View {
             Spacer()
 
             // Trailing indicator (checkmark or delete button)
-            if isHovered {
+            if isHovered, !isSelectionMode {
                 if attentionRunState != nil, let onDismissAttention {
                     Button(action: onDismissAttention) {
                         Image(systemName: "bell.slash")
@@ -254,7 +286,10 @@ struct AgentSessionRow: View {
         .frame(maxWidth: .infinity, minHeight: rowMinHeight, alignment: .leading)
         .background(
             Group {
-                if isActive {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: rowCornerRadius, style: .continuous)
+                        .fill(Color.accentColor.opacity(isActive ? 0.28 : 0.18))
+                } else if isActive {
                     RoundedRectangle(cornerRadius: rowCornerRadius, style: .continuous)
                         .fill(Color.accentColor.opacity(0.15))
                 } else if isHovered {
@@ -265,25 +300,28 @@ struct AgentSessionRow: View {
         )
         .contentShape(Rectangle())
         .contextMenu {
-            Button(pinActionLabel, action: onTogglePin)
+            if !isSelectionMode {
+                Button(pinActionLabel, action: onTogglePin)
 
-            Button(renameActionLabel, action: beginRename)
+                Button(renameActionLabel, action: beginRename)
 
-            if let onStash {
-                Button(stashActionLabel, action: onStash)
+                if let onStash {
+                    Button(stashActionLabel, action: onStash)
+                }
+
+                if attentionRunState != nil, let onDismissAttention {
+                    Button(dismissAttentionActionLabel, action: onDismissAttention)
+                }
+
+                Divider()
+
+                Button(deleteActionLabel, role: .destructive, action: requestDeleteConfirmation)
             }
-
-            if attentionRunState != nil, let onDismissAttention {
-                Button(dismissAttentionActionLabel, action: onDismissAttention)
-            }
-
-            Divider()
-
-            Button(deleteActionLabel, role: .destructive, action: requestDeleteConfirmation)
         }
         .onHover { isHovered = $0 }
-        .onTapGesture { onSelect() }
+        .onTapGesture(perform: handleRowTap)
         .accessibilityLabel(title)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .popover(isPresented: $showDeleteConfirmation, attachmentAnchor: .rect(.bounds), arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Delete chat?")
@@ -695,6 +733,10 @@ struct AgentSessionRow: View {
 
 struct AgentStashedSessionRow: View {
     let stashed: StashedTab
+    var isSelected = false
+    var isSelectionMode = false
+    var isSelectionEnabled = true
+    let onSelectionGesture: (AgentSidebarSelectionGesture) -> AgentSidebarSelectionGestureDisposition
     let onRestore: () -> Void
     let onDelete: () -> Void
 
@@ -750,8 +792,35 @@ struct AgentStashedSessionRow: View {
         "Delete stashed tab"
     }
 
+    private var currentSelectionGesture: AgentSidebarSelectionGesture {
+        var modifiers: AgentSidebarSelectionModifiers = []
+        let flags = NSApp.currentEvent?.modifierFlags ?? []
+        if flags.contains(.command) { modifiers.insert(.command) }
+        if flags.contains(.shift) { modifiers.insert(.shift) }
+        return AgentSidebarSelectionGesture(modifiers: modifiers)
+    }
+
+    private func handleRowTap() {
+        if onSelectionGesture(currentSelectionGesture) == .activate {
+            onRestore()
+        }
+    }
+
     var body: some View {
         HStack(spacing: rowSpacing) {
+            if isSelectionMode {
+                Button {
+                    _ = onSelectionGesture(.toggle)
+                } label: {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(!isSelectionEnabled)
+                .accessibilityLabel("\(isSelected ? "Deselect" : "Select") \(stashed.tab.name)")
+                .accessibilityValue(isSelected ? "Selected" : "Not selected")
+            }
+
             Image(systemName: "tray.and.arrow.down")
                 .font(.system(size: leadingIconSize))
                 .foregroundStyle(.secondary)
@@ -772,7 +841,7 @@ struct AgentStashedSessionRow: View {
 
             Spacer()
 
-            if isHovered {
+            if isHovered, !isSelectionMode {
                 Button(action: onRestore) {
                     Image(systemName: "tray.and.arrow.up")
                         .font(.system(size: 11))
@@ -797,7 +866,10 @@ struct AgentStashedSessionRow: View {
         .frame(maxWidth: .infinity, minHeight: rowMinHeight, alignment: .leading)
         .background(
             Group {
-                if isHovered {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: rowCornerRadius, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.18))
+                } else if isHovered {
                     RoundedRectangle(cornerRadius: rowCornerRadius, style: .continuous)
                         .stroke(Color(NSColor.systemGray).opacity(0.4), lineWidth: 1)
                 }
@@ -805,15 +877,16 @@ struct AgentStashedSessionRow: View {
         )
         .contentShape(Rectangle())
         .contextMenu {
-            Button(restoreActionLabel, action: onRestore)
-
-            Divider()
-
-            Button(deleteActionLabel, role: .destructive, action: onDelete)
+            if !isSelectionMode {
+                Button(restoreActionLabel, action: onRestore)
+                Divider()
+                Button(deleteActionLabel, role: .destructive, action: onDelete)
+            }
         }
         .onHover { isHovered = $0 }
-        .onTapGesture(perform: onRestore)
+        .onTapGesture(perform: handleRowTap)
         .accessibilityLabel("\(stashed.tab.name), archived session")
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
     }
 }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -250,6 +250,84 @@ struct AgentModeSessionsSidebarView: View {
 
 // MARK: - Sessions List
 
+private struct AgentSidebarSelectionRenderIdentity: Equatable {
+    let workspaceID: UUID?
+    let renderedOrder: [AgentSidebarSelectionIdentity]
+}
+
+/// Compact, evenly-sized pill used for the sidebar bulk-action row. Renders an
+/// SF Symbol plus the affected-chat count and matches the app's plain,
+/// `fontPreset`-scaled chip language rather than bordered system buttons.
+private struct BulkActionChip: View {
+    let systemImage: String
+    let verb: String
+    let count: Int
+    var isDestructive = false
+    var tooltip: String?
+    let action: () -> Void
+
+    @ObservedObject private var fontScale = FontScaleManager.shared
+    @State private var isHovered = false
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    private var cornerRadius: CGFloat {
+        fontPreset.scaledClamped(8, max: 11)
+    }
+
+    private var horizontalPadding: CGFloat {
+        fontPreset.scaledClamped(6, max: 9)
+    }
+
+    private var verticalPadding: CGFloat {
+        fontPreset.scaledClamped(5, max: 7)
+    }
+
+    private var iconSize: CGFloat {
+        fontPreset.scaledClamped(11, max: 14)
+    }
+
+    private var fillColor: Color {
+        if isDestructive {
+            return Color.red.opacity(isHovered ? 0.22 : 0.12)
+        }
+        return Color(NSColor.labelColor).opacity(isHovered ? 0.14 : 0.07)
+    }
+
+    private var foreground: Color {
+        if isDestructive { return .red }
+        return isHovered ? Color(NSColor.labelColor) : .secondary
+    }
+
+    private var accessibilityText: String {
+        "\(verb) \(count) \(count == 1 ? "chat" : "chats")"
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: systemImage)
+                    .font(.system(size: iconSize, weight: .semibold))
+                Text("\(count)")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous).fill(fillColor)
+            )
+            .foregroundStyle(foreground)
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .hoverTooltip(tooltip ?? verb)
+        .accessibilityLabel(accessibilityText)
+    }
+}
+
 struct AgentModeSessionsListView: View {
     let agentModeVM: AgentModeViewModel
     @ObservedObject var sidebarUI: AgentSessionSidebarUIStore
@@ -257,6 +335,7 @@ struct AgentModeSessionsListView: View {
     let currentTabID: UUID?
     @State private var archivedSessionsExpanded = false
     @State private var showingClearArchivedConfirmation = false
+    @State private var showingBulkDeleteConfirmation = false
     @AppStorage(SettingKeys.agentModeShowComposeTabsWithoutAgentSessions)
     private var showComposeTabsWithoutAgentSessions = false
     @ObservedObject private var fontScale = FontScaleManager.shared
@@ -296,188 +375,458 @@ struct AgentModeSessionsListView: View {
         fontPreset.scaledClamped(4, max: 6)
     }
 
+    private var bulkBarRowSpacing: CGFloat {
+        fontPreset.scaledClamped(8, max: 10)
+    }
+
+    private var bulkChipSpacing: CGFloat {
+        fontPreset.scaledClamped(6, max: 8)
+    }
+
+    private var bulkBarInnerHorizontalPadding: CGFloat {
+        fontPreset.scaledClamped(10, max: 14)
+    }
+
+    private var bulkBarInnerVerticalPadding: CGFloat {
+        fontPreset.scaledClamped(8, max: 11)
+    }
+
+    private var bulkBarCornerRadius: CGFloat {
+        fontPreset.scaledClamped(12, max: 16)
+    }
+
     var body: some View {
         #if DEBUG
             let _ = Self.recordBodyMetric()
         #endif
         let sidebarSnapshot = sidebarUI.snapshot
+        let activeWorkspaceID = agentModeVM.workspaceManager?.activeWorkspaceID
+        let workspaceSnapshot = promptManager.sidebarWorkspaceSnapshot.flatMap { snapshot in
+            activeWorkspaceID == snapshot.workspaceID ? snapshot : nil
+        }
         let snapshot = agentModeVM.sidebarListProjection(
-            composeTabs: promptManager.currentComposeTabs,
-            stashedTabs: promptManager.currentStashedTabs,
+            workspaceID: workspaceSnapshot?.workspaceID,
+            composeTabs: workspaceSnapshot?.composeTabs ?? [],
+            stashedTabs: workspaceSnapshot?.stashedTabs ?? [],
             currentTabID: currentTabID,
             sidebarSnapshot: sidebarSnapshot,
             archivedSessionsExpanded: archivedSessionsExpanded,
             showComposeTabsWithoutAgentSessions: showComposeTabsWithoutAgentSessions
         )
+        let selectionRenderIdentity = AgentSidebarSelectionRenderIdentity(
+            workspaceID: snapshot.workspaceID,
+            renderedOrder: snapshot.renderedSelectionOrder
+        )
         let defaultCollapseSeedKeys = snapshot.defaultCollapseSeedKeys
         let activeSections = AgentSidebarDateSectionBuilder.activeSections(for: snapshot.pagedSessions)
         let firstActiveSectionID = activeSections.first?.id
-        ScrollView {
-            VStack(spacing: listRowSpacing) {
-                ForEach(activeSections) { section in
-                    AgentSidebarDateSectionHeader(
-                        title: section.bucket.title,
-                        isFirst: section.id == firstActiveSectionID
+        let selectionState = sidebarUI.selectionState
+        VStack(spacing: 4) {
+            if selectionState.isSelectionMode {
+                if let bulkTargets = agentModeVM.sidebarBulkMutationTargets(
+                    selection: selectionState.selectedIdentities,
+                    selectionWorkspaceID: selectionState.workspaceID,
+                    projection: snapshot,
+                    composeTabs: workspaceSnapshot?.composeTabs ?? [],
+                    stashedTabs: workspaceSnapshot?.stashedTabs ?? []
+                ) {
+                    bulkActionBar(
+                        selectionState: selectionState,
+                        targets: bulkTargets,
+                        renderedOrder: snapshot.renderedSelectionOrder
                     )
-
-                    ForEach(section.groups) { group in
-                        ForEach(group.rows, id: \.id) { session in
-                            let hasAgentSession = session.sessionID != nil
-                            let runState: AgentSessionRunState = hasAgentSession
-                                ? agentModeVM.runState(for: session.tabID)
-                                : .idle
-                            let attentionRunState: AgentSessionRunState? = hasAgentSession
-                                ? sidebarUI.snapshot.attentionRunStateByTabID[session.tabID]
-                                : nil
-                            let toggleThreadAction: (() -> Void)? = session.hasThreadChildren
-                                ? { agentModeVM.requestSidebarThreadDisclosureToggle(for: session) }
-                                : nil
-                            // Archived Sessions excludes tabs without indexed conversation content,
-                            // so stashing a session-less tab would hide it from both sidebar lists.
-                            let stashAction: (() -> Void)? = hasAgentSession
-                                ? { Task { await promptManager.stashTab(session.tabID) } }
-                                : nil
-                            let dismissAttentionAction: (() -> Void)? = hasAgentSession
-                                ? { agentModeVM.dismissSidebarRunAttention(tabID: session.tabID) }
-                                : nil
-
-                            AgentSessionRow(
-                                title: session.title,
-                                isActive: session.tabID == currentTabID,
-                                isPinned: session.isPinned,
-                                isMCPControlled: session.isMCPControlled,
-                                runState: runState,
-                                attentionRunState: attentionRunState,
-                                worktree: session.worktree,
-                                worktreeMergeAttention: session.worktreeMergeAttention,
-                                threadDepth: session.depth,
-                                hasThreadChildren: session.hasThreadChildren,
-                                isThreadCollapsed: session.isThreadCollapsed,
-                                hiddenThreadDescendantCount: session.hiddenThreadDescendantCount,
-                                hiddenThreadDescendantAttentionCount: session.hiddenThreadDescendantAttentionCount,
-                                onToggleThreadCollapse: toggleThreadAction,
-                                onSelect: {
-                                    Task { await promptManager.switchComposeTab(session.tabID) }
-                                },
-                                onTogglePin: {
-                                    promptManager.toggleComposeTabPinned(session.tabID)
-                                },
-                                onStash: stashAction,
-                                onDelete: {
-                                    #if DEBUG
-                                        agentModeVM.debugBeginSidebarDeleteRequest(
-                                            tabID: session.tabID,
-                                            source: "AgentSessionsSidebarView.rowDelete",
-                                            reason: "row_delete_confirmation"
-                                        )
-                                    #endif
-                                    Task { await promptManager.closeComposeTab(session.tabID) }
-                                },
-                                onRename: { newName in
-                                    agentModeVM.renameSession(tabID: session.tabID, to: newName)
-                                },
-                                onDismissAttention: dismissAttentionAction
-                            )
-                        }
-                    }
                 }
-
-                if snapshot.hasMoreSessions {
-                    Button {
-                        agentModeVM.showMoreSidebarSessions()
-                    } label: {
-                        Text("Show more (\(snapshot.remainingSessionCount))")
-                            .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, showMoreHorizontalPadding)
-                    .padding(.vertical, showMoreVerticalPadding)
-                    .foregroundColor(.accentColor)
-                }
-
-                if !snapshot.archivedSessionTabsForHeader.isEmpty {
-                    Divider()
-                        .padding(.vertical, dividerVerticalPadding)
-
-                    VStack(spacing: listRowSpacing) {
-                        HStack(spacing: archivedHeaderSpacing) {
-                            Button {
-                                withAnimation(.easeInOut(duration: 0.15)) {
-                                    archivedSessionsExpanded.toggle()
-                                }
-                            } label: {
-                                HStack(spacing: archivedHeaderSpacing) {
-                                    Image(systemName: "chevron.right")
-                                        .font(.system(size: fontPreset.scaledClamped(11, max: 14), weight: .semibold))
-                                        .foregroundStyle(.secondary)
-                                        .rotationEffect(.degrees(archivedSessionsExpanded ? 90 : 0))
-                                        .animation(.easeInOut(duration: 0.15), value: archivedSessionsExpanded)
-                                    Image(systemName: "archivebox")
-                                        .font(.system(size: fontPreset.scaledClamped(13, max: 16)))
-                                        .foregroundStyle(.secondary)
-                                    Text("Archived Sessions")
-                                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
-                                        .foregroundStyle(.secondary)
-                                    Text("\(snapshot.archivedSessionTabsForHeader.count)")
-                                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
-                                        .foregroundStyle(.tertiary)
-                                    Spacer()
-                                }
-                                .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-
-                            Button("Clear…") {
-                                showingClearArchivedConfirmation = true
-                            }
-                            .buttonStyle(.plain)
-                            .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
-                            .foregroundStyle(.tertiary)
-                            .popover(isPresented: $showingClearArchivedConfirmation, arrowEdge: .bottom) {
-                                VStack(alignment: .leading, spacing: 12) {
-                                    Text("Clear archived sessions?")
-                                        .font(.headline)
-                                    Text("This removes \(snapshot.archivedSessionTabsForHeader.count) archived sessions from stashed tabs.")
-                                        .font(.subheadline)
-                                        .foregroundStyle(.secondary)
-                                    HStack {
-                                        Spacer()
-                                        Button("Cancel") {
-                                            showingClearArchivedConfirmation = false
-                                        }
-                                        Button("Clear") {
-                                            showingClearArchivedConfirmation = false
-                                            Task {
-                                                await promptManager.deleteStashedTabs(withIDs: Set(snapshot.archivedSessionTabsForHeader.map(\.id)))
-                                            }
-                                        }
-                                        .keyboardShortcut(.defaultAction)
-                                    }
-                                }
-                                .padding()
-                                .frame(width: 300)
-                            }
-                        }
-                        .padding(.horizontal, archivedHeaderHorizontalPadding)
-                        .padding(.bottom, archivedHeaderBottomPadding)
-
-                        if archivedSessionsExpanded {
-                            ArchivedSessionsPagedList(
-                                allTabs: snapshot.sortedArchivedSessionTabsForRows,
-                                isSearching: !sidebarUI.snapshot.searchText.isEmpty,
-                                dateInfoByStashedTabID: snapshot.archivedDateInfoByStashedTabID,
-                                agentModeVM: agentModeVM,
-                                promptManager: promptManager
-                            )
-                        }
-                    }
-                }
+            } else if let notice = selectionState.notice {
+                bulkNotice(notice)
+                    .padding(.horizontal, listHorizontalPadding)
+                    .padding(.top, 4)
             }
-            .padding(.horizontal, listHorizontalPadding)
+            ScrollView {
+                VStack(spacing: listRowSpacing) {
+                    ForEach(activeSections) { section in
+                        AgentSidebarDateSectionHeader(
+                            title: section.bucket.title,
+                            isFirst: section.id == firstActiveSectionID
+                        )
+
+                        ForEach(section.groups) { group in
+                            ForEach(group.rows, id: \.id) { session in
+                                let hasAgentSession = session.sessionID != nil
+                                let runState: AgentSessionRunState = hasAgentSession
+                                    ? agentModeVM.runState(for: session.tabID)
+                                    : .idle
+                                let attentionRunState: AgentSessionRunState? = hasAgentSession
+                                    ? sidebarUI.snapshot.attentionRunStateByTabID[session.tabID]
+                                    : nil
+                                let toggleThreadAction: (() -> Void)? = session.hasThreadChildren
+                                    ? { agentModeVM.requestSidebarThreadDisclosureToggle(for: session) }
+                                    : nil
+                                let stashAction: (() -> Void)? = session.canStash
+                                    ? { performSingleActiveBulkAction(.stash, tabID: session.tabID, workspaceID: snapshot.workspaceID) }
+                                    : nil
+                                let dismissAttentionAction: (() -> Void)? = hasAgentSession
+                                    ? {
+                                        guard agentModeVM.workspaceManager?.activeWorkspaceID == snapshot.workspaceID else { return }
+                                        agentModeVM.dismissSidebarRunAttention(tabID: session.tabID)
+                                    }
+                                    : nil
+
+                                AgentSessionRow(
+                                    title: session.title,
+                                    isActive: session.tabID == currentTabID,
+                                    isPinned: session.isPinned,
+                                    isMCPControlled: session.isMCPControlled,
+                                    runState: runState,
+                                    attentionRunState: attentionRunState,
+                                    worktree: session.worktree,
+                                    worktreeMergeAttention: session.worktreeMergeAttention,
+                                    threadDepth: session.depth,
+                                    hasThreadChildren: session.hasThreadChildren,
+                                    isThreadCollapsed: session.isThreadCollapsed,
+                                    hiddenThreadDescendantCount: session.hiddenThreadDescendantCount,
+                                    hiddenThreadDescendantAttentionCount: session.hiddenThreadDescendantAttentionCount,
+                                    onToggleThreadCollapse: toggleThreadAction,
+                                    isSelected: selectionState.selectedIdentities.contains(.active(tabID: session.tabID)),
+                                    isSelectionMode: selectionState.isSelectionMode,
+                                    isSelectionEnabled: selectionState.inFlightAction == nil,
+                                    onSelectionGesture: { gesture in
+                                        agentModeVM.handleSidebarSelectionGesture(
+                                            gesture,
+                                            identity: .active(tabID: session.tabID),
+                                            renderedOrder: snapshot.renderedSelectionOrder,
+                                            workspaceID: snapshot.workspaceID
+                                        )
+                                    },
+                                    onSelect: {
+                                        Task {
+                                            guard agentModeVM.workspaceManager?.activeWorkspaceID == snapshot.workspaceID else { return }
+                                            await promptManager.switchComposeTab(session.tabID)
+                                        }
+                                    },
+                                    onTogglePin: {
+                                        performSingleActiveBulkAction(
+                                            session.isPinned ? .unpin : .pin,
+                                            tabID: session.tabID,
+                                            workspaceID: snapshot.workspaceID
+                                        )
+                                    },
+                                    onStash: stashAction,
+                                    onDelete: {
+                                        #if DEBUG
+                                            agentModeVM.debugBeginSidebarDeleteRequest(
+                                                tabID: session.tabID,
+                                                source: "AgentSessionsSidebarView.rowDelete",
+                                                reason: "row_delete_confirmation"
+                                            )
+                                        #endif
+                                        performSingleActiveBulkAction(.delete, tabID: session.tabID, workspaceID: snapshot.workspaceID)
+                                    },
+                                    onRename: { newName in
+                                        guard agentModeVM.workspaceManager?.activeWorkspaceID == snapshot.workspaceID else { return }
+                                        agentModeVM.renameSession(tabID: session.tabID, to: newName)
+                                    },
+                                    onDismissAttention: dismissAttentionAction
+                                )
+                            }
+                        }
+                    }
+
+                    if snapshot.hasMoreSessions {
+                        Button {
+                            agentModeVM.showMoreSidebarSessions()
+                        } label: {
+                            Text("Show more (\(snapshot.remainingSessionCount))")
+                                .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.horizontal, showMoreHorizontalPadding)
+                        .padding(.vertical, showMoreVerticalPadding)
+                        .foregroundColor(.accentColor)
+                    }
+
+                    if !snapshot.archivedSessionTabsForHeader.isEmpty {
+                        Divider()
+                            .padding(.vertical, dividerVerticalPadding)
+
+                        VStack(spacing: listRowSpacing) {
+                            HStack(spacing: archivedHeaderSpacing) {
+                                Button {
+                                    withAnimation(.easeInOut(duration: 0.15)) {
+                                        archivedSessionsExpanded.toggle()
+                                    }
+                                } label: {
+                                    HStack(spacing: archivedHeaderSpacing) {
+                                        Image(systemName: "chevron.right")
+                                            .font(.system(size: fontPreset.scaledClamped(11, max: 14), weight: .semibold))
+                                            .foregroundStyle(.secondary)
+                                            .rotationEffect(.degrees(archivedSessionsExpanded ? 90 : 0))
+                                            .animation(.easeInOut(duration: 0.15), value: archivedSessionsExpanded)
+                                        Image(systemName: "archivebox")
+                                            .font(.system(size: fontPreset.scaledClamped(13, max: 16)))
+                                            .foregroundStyle(.secondary)
+                                        Text("Archived Sessions")
+                                            .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
+                                            .foregroundStyle(.secondary)
+                                        Text("\(snapshot.archivedSessionTabsForHeader.count)")
+                                            .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                                            .foregroundStyle(.tertiary)
+                                        Spacer()
+                                    }
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+
+                                Button("Clear…") {
+                                    showingClearArchivedConfirmation = true
+                                }
+                                .buttonStyle(.plain)
+                                .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                                .foregroundStyle(.tertiary)
+                                .disabled(selectionState.isSelectionMode)
+                                .popover(isPresented: $showingClearArchivedConfirmation, arrowEdge: .bottom) {
+                                    VStack(alignment: .leading, spacing: 12) {
+                                        Text("Clear archived sessions?")
+                                            .font(.headline)
+                                        Text("This permanently deletes \(snapshot.archivedSessionTabsForHeader.count) archived sessions. Related active and archived sub-agent chats may also be deleted.")
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                        HStack {
+                                            Spacer()
+                                            Button("Cancel") {
+                                                showingClearArchivedConfirmation = false
+                                            }
+                                            Button("Clear") {
+                                                showingClearArchivedConfirmation = false
+                                                guard let workspaceID = snapshot.workspaceID else { return }
+                                                let archivedTargets = Set(snapshot.archivedSessionTabsForHeader.map {
+                                                    PromptViewModel.ArchivedTabMutationTarget(
+                                                        stashedTabID: $0.id,
+                                                        tabID: $0.tab.id
+                                                    )
+                                                })
+                                                performBulkAction(.delete, targets: .init(
+                                                    workspaceID: workspaceID,
+                                                    activeDeleteTabIDs: [],
+                                                    archivedDeleteTargets: archivedTargets,
+                                                    stashTabIDs: [],
+                                                    pinTabIDs: [],
+                                                    unpinTabIDs: []
+                                                ))
+                                            }
+                                            .keyboardShortcut(.defaultAction)
+                                        }
+                                    }
+                                    .padding()
+                                    .frame(width: 300)
+                                }
+                            }
+                            .padding(.horizontal, archivedHeaderHorizontalPadding)
+                            .padding(.bottom, archivedHeaderBottomPadding)
+
+                            if archivedSessionsExpanded {
+                                ArchivedSessionsList(
+                                    tabs: snapshot.pagedArchivedSessionTabsForRows,
+                                    hasMore: snapshot.hasMoreArchivedSessions,
+                                    remainingCount: snapshot.remainingArchivedSessionCount,
+                                    dateInfoByStashedTabID: snapshot.archivedDateInfoByStashedTabID,
+                                    workspaceID: snapshot.workspaceID,
+                                    selectionState: selectionState,
+                                    renderedOrder: snapshot.renderedSelectionOrder,
+                                    agentModeVM: agentModeVM,
+                                    promptManager: promptManager
+                                )
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, listHorizontalPadding)
+            }
+        }
+        .id(snapshot.workspaceID)
+        .task(id: activeWorkspaceID) {
+            showingClearArchivedConfirmation = false
+            showingBulkDeleteConfirmation = false
         }
         .task(id: defaultCollapseSeedKeys) {
             agentModeVM.seedDefaultCollapsedSidebarThreads(defaultCollapseSeedKeys)
+        }
+        .task(id: selectionRenderIdentity) {
+            sidebarUI.reconcileSelection(
+                renderedOrder: selectionRenderIdentity.renderedOrder,
+                workspaceID: selectionRenderIdentity.workspaceID
+            )
+            if snapshot.renderedSelectionOrder.isEmpty { showingBulkDeleteConfirmation = false }
+        }
+    }
+
+    private func bulkActionBar(
+        selectionState: AgentSidebarSelectionState,
+        targets: AgentModeViewModel.SidebarBulkMutationTargets,
+        renderedOrder: [AgentSidebarSelectionIdentity]
+    ) -> some View {
+        let selectedCount = selectionState.selectedIdentities.count
+        let deleteCount = targets.activeDeleteTabIDs.count + targets.archivedDeleteTargets.count
+        let isBusy = selectionState.inFlightAction != nil
+        let canSelectAll = !isBusy && selectedCount != renderedOrder.count
+        return VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
+            HStack(spacing: 8) {
+                Text("\(selectedCount) selected")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityAddTraits(.isHeader)
+                Spacer(minLength: 8)
+                Button("Select All") {
+                    sidebarUI.selectAll(renderedOrder: renderedOrder, workspaceID: targets.workspaceID)
+                }
+                .buttonStyle(.plain)
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                .foregroundStyle(canSelectAll ? Color.accentColor : Color.secondary.opacity(0.5))
+                .disabled(!canSelectAll)
+                Button("Cancel") { sidebarUI.clearSelection() }
+                    .buttonStyle(.plain)
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                    .foregroundStyle(isBusy ? Color.secondary.opacity(0.5) : .secondary)
+                    .keyboardShortcut(.cancelAction)
+                    .disabled(isBusy)
+            }
+
+            if let operation = selectionState.inFlightAction {
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text("\(operation.kind.rawValue.capitalized) \(operation.targetCount) chats…")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 0)
+                }
+            } else {
+                HStack(spacing: bulkChipSpacing) {
+                    if !targets.pinTabIDs.isEmpty {
+                        BulkActionChip(systemImage: "pin", verb: "Pin", count: targets.pinTabIDs.count) {
+                            performBulkAction(.pin, targets: targets)
+                        }
+                    }
+                    if !targets.unpinTabIDs.isEmpty {
+                        BulkActionChip(systemImage: "pin.slash", verb: "Unpin", count: targets.unpinTabIDs.count) {
+                            performBulkAction(.unpin, targets: targets)
+                        }
+                    }
+                    if !targets.stashTabIDs.isEmpty {
+                        BulkActionChip(
+                            systemImage: "tray.and.arrow.down",
+                            verb: "Stash",
+                            count: targets.stashTabIDs.count,
+                            tooltip: "Stash — related sub-agent chats may also be stashed"
+                        ) {
+                            performBulkAction(.stash, targets: targets)
+                        }
+                    }
+                    BulkActionChip(
+                        systemImage: "trash",
+                        verb: "Delete",
+                        count: deleteCount,
+                        isDestructive: true
+                    ) {
+                        showingBulkDeleteConfirmation = true
+                    }
+                    .popover(isPresented: $showingBulkDeleteConfirmation, arrowEdge: .bottom) {
+                        bulkDeleteConfirmation(targets: targets)
+                    }
+                }
+            }
+
+            if let notice = selectionState.notice { bulkNotice(notice) }
+        }
+        .padding(.horizontal, bulkBarInnerHorizontalPadding)
+        .padding(.vertical, bulkBarInnerVerticalPadding)
+        .background(
+            RoundedRectangle(cornerRadius: bulkBarCornerRadius, style: .continuous)
+                .fill(Color(NSColor.systemGray).opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: bulkBarCornerRadius, style: .continuous)
+                        .stroke(Color(NSColor.systemGray).opacity(0.3), lineWidth: 0.5)
+                )
+        )
+        .padding(.horizontal, listHorizontalPadding)
+        .padding(.top, 4)
+    }
+
+    @ViewBuilder
+    private func bulkDeleteConfirmation(targets: AgentModeViewModel.SidebarBulkMutationTargets) -> some View {
+        let count = targets.activeDeleteTabIDs.count + targets.archivedDeleteTargets.count
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Delete \(count) chats?").font(.headline)
+            Text("This permanently deletes \(targets.activeDeleteTabIDs.count) active chats and \(targets.archivedDeleteTargets.count) archived chats. Related sub-agent chats may also be removed. This cannot be undone.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            HStack {
+                Spacer()
+                Button("Cancel") { showingBulkDeleteConfirmation = false }
+                    .keyboardShortcut(.cancelAction)
+                Button("Delete", role: .destructive) {
+                    showingBulkDeleteConfirmation = false
+                    performBulkAction(.delete, targets: targets)
+                }
+            }
+        }
+        .padding()
+        .frame(width: 340)
+    }
+
+    private func bulkNotice(_ notice: AgentSidebarBulkActionNotice) -> some View {
+        let presentation: (icon: String, color: Color, accessibilityPrefix: String) = switch notice.severity {
+        case .error:
+            ("exclamationmark.triangle.fill", .red, "Error")
+        case .warning:
+            ("exclamationmark.triangle", .orange, "Warning")
+        case .information:
+            ("info.circle", .secondary, "Information")
+        }
+        return HStack(alignment: .top, spacing: 6) {
+            Image(systemName: presentation.icon)
+                .font(.system(size: fontPreset.scaledClamped(11, max: 14)))
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(notice.title).font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .semibold))
+                Text(notice.message).font(fontPreset.swiftUIFont(sizeAtNormal: 10))
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(presentation.accessibilityPrefix): \(notice.title). \(notice.message)")
+            Spacer(minLength: 0)
+            Button { sidebarUI.dismissBulkActionNotice() } label: { Image(systemName: "xmark") }
+                .buttonStyle(.plain)
+                .font(.system(size: fontPreset.scaledClamped(10, max: 13)))
+                .accessibilityLabel("Dismiss bulk action notice")
+        }
+        .foregroundStyle(presentation.color)
+    }
+
+    private func performSingleActiveBulkAction(
+        _ action: AgentSidebarBulkActionKind,
+        tabID: UUID,
+        workspaceID: UUID?
+    ) {
+        guard let workspaceID else { return }
+        performBulkAction(action, targets: .init(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: action == .delete ? [tabID] : [],
+            archivedDeleteTargets: [],
+            stashTabIDs: action == .stash ? [tabID] : [],
+            pinTabIDs: action == .pin ? [tabID] : [],
+            unpinTabIDs: action == .unpin ? [tabID] : []
+        ))
+    }
+
+    private func performBulkAction(
+        _ action: AgentSidebarBulkActionKind,
+        targets: AgentModeViewModel.SidebarBulkMutationTargets
+    ) {
+        Task {
+            await agentModeVM.performSidebarBulkAction(
+                action,
+                targets: targets,
+                promptManager: promptManager
+            )
         }
     }
 
@@ -728,100 +1077,95 @@ enum AgentSidebarDateSectionBuilder {
     }
 }
 
-// MARK: - Archived Sessions Paged List
+// MARK: - Archived Sessions List
 
-/// Paginated list of archived (stashed) agent sessions.
-/// Owns its own page count so the parent view doesn't recompute on every page tap.
-/// When `isSearching` is true, all matching tabs are shown without pagination.
-struct ArchivedSessionsPagedList: View {
-    let allTabs: [StashedTab]
-    let isSearching: Bool
+struct ArchivedSessionsList: View {
+    let tabs: [StashedTab]
+    let hasMore: Bool
+    let remainingCount: Int
     let dateInfoByStashedTabID: [UUID: AgentModeViewModel.SidebarSessionDateInfo]
+    let workspaceID: UUID?
+    let selectionState: AgentSidebarSelectionState
+    let renderedOrder: [AgentSidebarSelectionIdentity]
     let agentModeVM: AgentModeViewModel
     @ObservedObject var promptManager: PromptViewModel
-    @State private var visibleCount = 20
     @ObservedObject private var fontScale = FontScaleManager.shared
-    private static let pageSize = 20
+
     private var fontPreset: FontScalePreset {
         fontScale.preset
     }
 
-    private var rowSpacing: CGFloat {
-        fontPreset.scaledClamped(2, max: 3)
-    }
-
-    private var showMoreHorizontalPadding: CGFloat {
-        fontPreset.scaledClamped(10, max: 14)
-    }
-
-    private var showMoreVerticalPadding: CGFloat {
-        fontPreset.scaledClamped(8, max: 12)
-    }
-
-    private var topPadding: CGFloat {
-        fontPreset.scaledClamped(4, max: 6)
-    }
-
-    private var displayedTabs: ArraySlice<StashedTab> {
-        isSearching ? allTabs[...] : allTabs.prefix(visibleCount)
-    }
-
-    private var hasMore: Bool {
-        !isSearching && allTabs.count > visibleCount
+    private func deleteArchived(_ stashed: StashedTab) {
+        guard let workspaceID else { return }
+        let target = PromptViewModel.ArchivedTabMutationTarget(
+            stashedTabID: stashed.id,
+            tabID: stashed.tab.id
+        )
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [],
+            archivedDeleteTargets: [target],
+            stashTabIDs: [],
+            pinTabIDs: [],
+            unpinTabIDs: []
+        )
+        Task {
+            await agentModeVM.performSidebarBulkAction(.delete, targets: targets, promptManager: promptManager)
+        }
     }
 
     var body: some View {
-        #if DEBUG
-            let _ = Self.recordBodyMetric()
-        #endif
         let sections = AgentSidebarDateSectionBuilder.archivedSections(
-            for: Array(displayedTabs),
-            dateInfo: { stashed in
-                dateInfoByStashedTabID[stashed.id] ?? agentModeVM.archivedSessionDateInfo(for: stashed)
-            }
+            for: tabs,
+            dateInfo: { dateInfoByStashedTabID[$0.id] ?? agentModeVM.archivedSessionDateInfo(for: $0) }
         )
         let firstSectionID = sections.first?.id
-        VStack(spacing: rowSpacing) {
+        VStack(spacing: fontPreset.scaledClamped(2, max: 3)) {
             ForEach(sections) { section in
-                AgentSidebarDateSectionHeader(
-                    title: section.bucket.title,
-                    isFirst: section.id == firstSectionID
-                )
-
+                AgentSidebarDateSectionHeader(title: section.bucket.title, isFirst: section.id == firstSectionID)
                 ForEach(section.rows) { row in
                     let stashed = row.stashed
+                    let identity = AgentSidebarSelectionIdentity.archived(
+                        stashedTabID: stashed.id,
+                        tabID: stashed.tab.id
+                    )
                     AgentStashedSessionRow(
                         stashed: stashed,
-                        onRestore: {
-                            Task { await promptManager.unstashTab(stashed.id) }
+                        isSelected: selectionState.selectedIdentities.contains(identity),
+                        isSelectionMode: selectionState.isSelectionMode,
+                        isSelectionEnabled: selectionState.inFlightAction == nil,
+                        onSelectionGesture: { gesture in
+                            agentModeVM.handleSidebarSelectionGesture(
+                                gesture,
+                                identity: identity,
+                                renderedOrder: renderedOrder,
+                                workspaceID: workspaceID
+                            )
                         },
-                        onDelete: {
-                            Task { await promptManager.deleteStashedTab(stashed.id) }
-                        }
+                        onRestore: {
+                            Task {
+                                guard agentModeVM.workspaceManager?.activeWorkspaceID == workspaceID else { return }
+                                await promptManager.unstashTab(stashed.id)
+                            }
+                        },
+                        onDelete: { deleteArchived(stashed) }
                     )
                 }
             }
-
             if hasMore {
                 Button {
-                    visibleCount += Self.pageSize
+                    agentModeVM.showMoreArchivedSidebarSessions()
                 } label: {
-                    Text("Show more (\(allTabs.count - visibleCount))")
+                    Text("Show more (\(remainingCount))")
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .buttonStyle(.plain)
-                .padding(.horizontal, showMoreHorizontalPadding)
-                .padding(.vertical, showMoreVerticalPadding)
+                .padding(.horizontal, fontPreset.scaledClamped(10, max: 14))
+                .padding(.vertical, fontPreset.scaledClamped(8, max: 12))
                 .foregroundColor(.accentColor)
             }
         }
-        .padding(.top, topPadding)
+        .padding(.top, fontPreset.scaledClamped(4, max: 6))
     }
-
-    #if DEBUG
-        private static func recordBodyMetric() {
-            AgentModePerfDiagnostics.increment("ui.body.archivedSessionsPagedList")
-        }
-    #endif
 }

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -237,11 +237,17 @@ class PromptViewModel: ObservableObject {
     ) async -> ComposeTabRemovalDecision
     typealias ComposeTabCascadeResolver = @Sendable (_ tabIDs: Set<UUID>, _ reason: ComposeTabRemovalReason) async -> AgentSessionCascadePlan
     typealias StashedTabCascadeResolver = @Sendable (_ stashedTabIDs: Set<UUID>) async -> AgentSessionCascadePlan
+    typealias AgentSessionCascadeSnapshotResolver = @MainActor (
+        _ composeTabIDs: Set<UUID>,
+        _ archivedTargets: Set<ArchivedTabMutationTarget>,
+        _ reason: ComposeTabRemovalReason
+    ) -> AgentSessionCascadePlan
     private var composeTabsWillCloseListeners: [UUID: ComposeTabsWillCloseListener] = [:]
     private var composeTabsDidRemoveListeners: [UUID: ComposeTabsDidRemoveListener] = [:]
     private var composeTabsRemovalPreflight: (token: UUID, hook: ComposeTabsRemovalHook)?
     var composeTabCascadeResolver: ComposeTabCascadeResolver?
     var stashedTabCascadeResolver: StashedTabCascadeResolver?
+    var agentSessionCascadeSnapshotResolver: AgentSessionCascadeSnapshotResolver?
 
     // MARK: - UI State Properties
 
@@ -3035,12 +3041,24 @@ class PromptViewModel: ObservableObject {
             )])
         }
 
+        let expectedComposeTabIDs = resolvedComposeTabIDs
+        let expectedArchivedTargets = allArchivedTargets
+        let cascadeIsCurrentAfterPreflight: @MainActor () -> Bool = {
+            guard mutationContextIsCurrent(),
+                  let agentSessionCascadeSnapshotResolver = self.agentSessionCascadeSnapshotResolver
+            else { return false }
+            let freshCascadePlan = agentSessionCascadeSnapshotResolver(composeTabIDs, archivedTargets, .close)
+            return composeTabIDs.union(freshCascadePlan.composeTabIDs) == expectedComposeTabIDs
+                && archivedTargets.union(freshCascadePlan.archivedTargets) == expectedArchivedTargets
+        }
+
         var report = ComposeTabMutationReport()
         if !resolvedComposeTabIDs.isEmpty {
             await report.merge(removeComposeTabs(
                 withIDs: resolvedComposeTabIDs,
                 expandCascade: false,
-                isMutationContextCurrent: mutationContextIsCurrent
+                isMutationContextCurrent: mutationContextIsCurrent,
+                postPreflightValidation: cascadeIsCurrentAfterPreflight
             ))
         }
         if !allArchivedTargets.isEmpty, report.rejections.isEmpty {
@@ -3121,7 +3139,8 @@ class PromptViewModel: ObservableObject {
         preferredActiveID: UUID? = nil,
         reason: ComposeTabRemovalReason = .close,
         expandCascade: Bool = true,
-        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil,
+        postPreflightValidation: (@MainActor () -> Bool)? = nil
     ) async -> ComposeTabMutationReport {
         guard !ids.isEmpty else {
             return ComposeTabMutationReport(noOpReasons: [reason])
@@ -3240,6 +3259,33 @@ class PromptViewModel: ObservableObject {
         }
         guard mutationContextIsCurrent() else {
             return rejection(.mutationContextChanged, message: "The workspace or selection changed during preflight.")
+        }
+        if expandCascade, composeTabCascadeResolver != nil {
+            guard let agentSessionCascadeSnapshotResolver else {
+                return rejection(.mutationContextChanged, message: "Related chat verification is unavailable.")
+            }
+            let freshCascadePlan = agentSessionCascadeSnapshotResolver(ids, [], reason)
+            let freshResolvedIDs = ids.union(freshCascadePlan.composeTabIDs)
+            let freshArchivedTargets = reason == .close ? freshCascadePlan.archivedTargets : []
+            guard freshResolvedIDs == resolvedIDs,
+                  freshArchivedTargets == archivedTargetsToDelete
+            else {
+                return rejection(
+                    .mutationContextChanged,
+                    message: "The related chat set changed during required persistence."
+                )
+            }
+        }
+        if let postPreflightValidation {
+            guard postPreflightValidation() else {
+                return rejection(
+                    .mutationContextChanged,
+                    message: "The related chat set changed during required persistence."
+                )
+            }
+        }
+        guard mutationContextIsCurrent() else {
+            return rejection(.mutationContextChanged, message: "The workspace or selection changed after cascade verification.")
         }
         tabs = manager.workspaces[index].composeTabs
         tabsBeforeClose = tabs
@@ -3684,6 +3730,19 @@ class PromptViewModel: ObservableObject {
         guard expectedTabIDByStashedID.allSatisfy({ freshTabIDByStashedID[$0.key] == $0.value }) else {
             report.merge(contextRejection("A targeted archived chat changed during preflight."))
             return report
+        }
+        if stashedTabCascadeResolver != nil {
+            guard let agentSessionCascadeSnapshotResolver else {
+                report.merge(contextRejection("Related chat verification is unavailable."))
+                return report
+            }
+            let freshCascadePlan = agentSessionCascadeSnapshotResolver([], targets, .deleteStashed)
+            guard freshCascadePlan.composeTabIDs.isEmpty,
+                  targets.union(freshCascadePlan.archivedTargets) == targets
+            else {
+                report.merge(contextRejection("The related chat set changed during required persistence."))
+                return report
+            }
         }
         manager.workspaces[index].stashedTabs = freshStashedTabs.filter { !stashedTabIDs.contains($0.id) }
         loadComposeTabsFromWorkspace(manager.workspaces[index])

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -109,7 +109,14 @@ class PromptViewModel: ObservableObject {
 
     // MARK: - Compose Tabs
 
+    struct SidebarWorkspaceSnapshot: Equatable {
+        let workspaceID: UUID
+        let composeTabs: [ComposeTabState]
+        let stashedTabs: [StashedTab]
+    }
+
     @Published private(set) var currentComposeTabs: [ComposeTabState] = []
+    @Published private(set) var sidebarWorkspaceSnapshot: SidebarWorkspaceSnapshot?
     @Published private(set) var activeComposeTabID: UUID? {
         didSet {
             guard oldValue != activeComposeTabID else { return }
@@ -132,15 +139,64 @@ class PromptViewModel: ObservableObject {
     // MARK: - Tab Close Listeners
 
     /// Async listeners that are called before tabs are closed, allowing cleanup of running tasks.
-    enum ComposeTabRemovalReason: Equatable {
+    enum ComposeTabRemovalReason: Hashable {
         case close
         case stash
         case deleteStashed
     }
 
+    enum ComposeTabMutationRejectionReason: Equatable {
+        case workspaceUnavailable
+        case mutationContextChanged
+        case requiredSessionPreflight
+    }
+
+    struct ComposeTabMutationRejection: Equatable {
+        let kind: ComposeTabRemovalReason
+        let reason: ComposeTabMutationRejectionReason
+        let tabID: UUID?
+        let message: String
+    }
+
+    struct ComposeTabPostRemovalIssue: Equatable {
+        let tabID: UUID
+        let reason: ComposeTabRemovalReason
+        let message: String
+    }
+
+    struct ComposeTabMutationReport: Equatable {
+        var removedComposeTabIDs: Set<UUID> = []
+        var removedStashedTabIDs: Set<UUID> = []
+        var noOpReasons: Set<ComposeTabRemovalReason> = []
+        var rejections: [ComposeTabMutationRejection] = []
+        var cleanupIssues: [ComposeTabPostRemovalIssue] = []
+
+        var didMutateProjection: Bool {
+            !removedComposeTabIDs.isEmpty || !removedStashedTabIDs.isEmpty
+        }
+
+        mutating func merge(_ other: Self) {
+            removedComposeTabIDs.formUnion(other.removedComposeTabIDs)
+            removedStashedTabIDs.formUnion(other.removedStashedTabIDs)
+            noOpReasons.formUnion(other.noOpReasons)
+            rejections.append(contentsOf: other.rejections)
+            cleanupIssues.append(contentsOf: other.cleanupIssues)
+        }
+    }
+
+    struct ComposeTabPinMutationReport: Equatable {
+        let updatedTabIDs: Set<UUID>
+        let contextRejected: Bool
+    }
+
     struct AgentSessionCascadePlan: Equatable {
         var composeTabIDs: Set<UUID> = []
-        var stashedTabIDs: Set<UUID> = []
+        var archivedTargets: Set<ArchivedTabMutationTarget> = []
+    }
+
+    struct ArchivedTabMutationTarget: Hashable {
+        let stashedTabID: UUID
+        let tabID: UUID
     }
 
     enum ComposeTabRemovalFailureStage: String, Equatable {
@@ -173,7 +229,7 @@ class PromptViewModel: ObservableObject {
         _ tabIDs: Set<UUID>,
         _ reason: ComposeTabRemovalReason,
         _ workspaceID: UUID
-    ) async -> Void
+    ) async -> [ComposeTabPostRemovalIssue]
     typealias ComposeTabsRemovalHook = @MainActor @Sendable (
         _ tabIDs: Set<UUID>,
         _ reason: ComposeTabRemovalReason,
@@ -2427,10 +2483,12 @@ class PromptViewModel: ObservableObject {
         _ tabIDs: Set<UUID>,
         reason: ComposeTabRemovalReason,
         workspaceID: UUID
-    ) async {
+    ) async -> [ComposeTabPostRemovalIssue] {
+        var issues: [ComposeTabPostRemovalIssue] = []
         for listener in Array(composeTabsDidRemoveListeners.values) {
-            await listener(tabIDs, reason, workspaceID)
+            await issues.append(contentsOf: listener(tabIDs, reason, workspaceID))
         }
+        return issues.sorted { $0.tabID.uuidString < $1.tabID.uuidString }
     }
 
     @MainActor
@@ -2461,13 +2519,13 @@ class PromptViewModel: ObservableObject {
         _ tabIDs: Set<UUID>,
         reason: ComposeTabRemovalReason,
         workspaceID: UUID
-    ) async {
+    ) async -> [ComposeTabPostRemovalIssue] {
         if reason != .stash {
             deleteGitDataForClosingTabs(tabIDs: tabIDs)
         }
         await notifyComposeTabsWillClose(tabIDs, reason: reason)
         await cleanupMCPStateForClosingTabs(tabIDs)
-        await notifyComposeTabsDidRemove(tabIDs, reason: reason, workspaceID: workspaceID)
+        let issues = await notifyComposeTabsDidRemove(tabIDs, reason: reason, workspaceID: workspaceID)
         #if DEBUG
             for tabID in tabIDs {
                 AgentModePerfDiagnostics.markSidebarDeleteFullCleanupComplete(
@@ -2477,6 +2535,7 @@ class PromptViewModel: ObservableObject {
                 )
             }
         #endif
+        return issues
     }
 
     @MainActor
@@ -2497,6 +2556,11 @@ class PromptViewModel: ObservableObject {
         dirtyTabIDs = dirtyTabIDs.intersection(validIDs)
         updateActiveTabDirtyState()
         currentStashedTabs = workspace.stashedTabs
+        sidebarWorkspaceSnapshot = SidebarWorkspaceSnapshot(
+            workspaceID: workspace.id,
+            composeTabs: workspace.composeTabs,
+            stashedTabs: workspace.stashedTabs
+        )
 
         // Sync promptText from the active tab to the live UI binding (only when explicitly requested)
         if syncPromptText,
@@ -2852,11 +2916,170 @@ class PromptViewModel: ObservableObject {
     }
 
     @MainActor
+    func closeComposeTabs(
+        withIDs ids: Set<UUID>,
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
+    ) async -> ComposeTabMutationReport {
+        await removeComposeTabs(withIDs: ids, isMutationContextCurrent: isMutationContextCurrent)
+    }
+
+    @MainActor
+    func deleteComposeAndStashedTabs(
+        composeTabIDs: Set<UUID>,
+        archivedTargets: Set<ArchivedTabMutationTarget>,
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
+    ) async -> ComposeTabMutationReport {
+        guard !composeTabIDs.isEmpty || !archivedTargets.isEmpty else {
+            return ComposeTabMutationReport(noOpReasons: [.close, .deleteStashed])
+        }
+        guard let manager = workspaceManager, let workspaceID = manager.activeWorkspace?.id else {
+            let requestedKinds: [ComposeTabRemovalReason?] = [
+                composeTabIDs.isEmpty ? nil : .close,
+                archivedTargets.isEmpty ? nil : .deleteStashed
+            ]
+            let kinds = requestedKinds.compactMap(\.self)
+            return ComposeTabMutationReport(rejections: kinds.map { kind in
+                ComposeTabMutationRejection(
+                    kind: kind,
+                    reason: .workspaceUnavailable,
+                    tabID: nil,
+                    message: "The active workspace is unavailable."
+                )
+            })
+        }
+
+        func mutationContextIsCurrent() -> Bool {
+            manager.activeWorkspace?.id == workspaceID && (isMutationContextCurrent?() ?? true)
+        }
+
+        func archivedTargetsAreCurrent(_ targets: Set<ArchivedTabMutationTarget>) -> Bool {
+            guard mutationContextIsCurrent() else { return false }
+            let tabIDByStashedID = Dictionary(
+                uniqueKeysWithValues: manager.activeWorkspace?.stashedTabs.map { ($0.id, $0.tab.id) } ?? []
+            )
+            return targets.allSatisfy { tabIDByStashedID[$0.stashedTabID] == $0.tabID }
+        }
+
+        let optionalRequestedKinds: [ComposeTabRemovalReason?] = [
+            composeTabIDs.isEmpty ? nil : .close,
+            archivedTargets.isEmpty ? nil : .deleteStashed
+        ]
+        let requestedKinds = optionalRequestedKinds.compactMap(\.self)
+        guard mutationContextIsCurrent() else {
+            return ComposeTabMutationReport(rejections: requestedKinds.map { kind in
+                ComposeTabMutationRejection(
+                    kind: kind,
+                    reason: .mutationContextChanged,
+                    tabID: nil,
+                    message: "The workspace or selection changed before cascade resolution."
+                )
+            })
+        }
+        guard archivedTargets.isEmpty || archivedTargetsAreCurrent(archivedTargets) else {
+            return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: .deleteStashed,
+                reason: .mutationContextChanged,
+                tabID: nil,
+                message: "A selected archived chat changed before cascade resolution."
+            )])
+        }
+        let initiallyPresentComposeTabIDs = composeTabIDs.intersection(
+            Set(manager.activeWorkspace?.composeTabs.map(\.id) ?? [])
+        )
+        guard initiallyPresentComposeTabIDs == composeTabIDs else {
+            return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: .close,
+                reason: .mutationContextChanged,
+                tabID: nil,
+                message: "A requested active chat is no longer available."
+            )])
+        }
+        var resolvedComposeTabIDs = composeTabIDs
+        var allArchivedTargets = archivedTargets
+        if !composeTabIDs.isEmpty, let composeTabCascadeResolver {
+            let cascadePlan = await composeTabCascadeResolver(composeTabIDs, .close)
+            resolvedComposeTabIDs.formUnion(cascadePlan.composeTabIDs)
+            allArchivedTargets.formUnion(cascadePlan.archivedTargets)
+            guard archivedTargetsAreCurrent(allArchivedTargets) else {
+                return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                    kind: .close,
+                    reason: .mutationContextChanged,
+                    tabID: nil,
+                    message: "The workspace or cascade targets changed during cascade resolution."
+                )])
+            }
+        }
+        if !archivedTargets.isEmpty, let stashedTabCascadeResolver {
+            let cascadePlan = await stashedTabCascadeResolver(Set(archivedTargets.map(\.stashedTabID)))
+            resolvedComposeTabIDs.formUnion(cascadePlan.composeTabIDs)
+            allArchivedTargets.formUnion(cascadePlan.archivedTargets)
+            guard archivedTargetsAreCurrent(allArchivedTargets) else {
+                return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                    kind: .deleteStashed,
+                    reason: .mutationContextChanged,
+                    tabID: nil,
+                    message: "The workspace or cascade targets changed during cascade resolution."
+                )])
+            }
+        }
+
+        let currentRequestedComposeTabIDs = composeTabIDs.intersection(
+            Set(manager.activeWorkspace?.composeTabs.map(\.id) ?? [])
+        )
+        guard currentRequestedComposeTabIDs == initiallyPresentComposeTabIDs else {
+            return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: .close,
+                reason: .mutationContextChanged,
+                tabID: nil,
+                message: "The requested active tab targets changed during cascade resolution."
+            )])
+        }
+
+        var report = ComposeTabMutationReport()
+        if !resolvedComposeTabIDs.isEmpty {
+            await report.merge(removeComposeTabs(
+                withIDs: resolvedComposeTabIDs,
+                expandCascade: false,
+                isMutationContextCurrent: mutationContextIsCurrent
+            ))
+        }
+        if !allArchivedTargets.isEmpty, report.rejections.isEmpty {
+            if mutationContextIsCurrent() {
+                await report.merge(deleteResolvedStashedTabs(
+                    targets: allArchivedTargets,
+                    isMutationContextCurrent: mutationContextIsCurrent
+                ))
+            } else {
+                report.rejections.append(ComposeTabMutationRejection(
+                    kind: .deleteStashed,
+                    reason: .mutationContextChanged,
+                    tabID: nil,
+                    message: "The workspace or selection changed before archived deletion."
+                ))
+            }
+        }
+        return report
+    }
+
+    @MainActor
+    func stashComposeTabs(
+        withIDs ids: Set<UUID>,
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
+    ) async -> ComposeTabMutationReport {
+        await removeComposeTabs(
+            withIDs: ids,
+            reason: .stash,
+            isMutationContextCurrent: isMutationContextCurrent
+        )
+    }
+
+    @discardableResult
+    @MainActor
     func closeComposeTab(
         _ id: UUID,
         isMutationContextCurrent: (@MainActor () -> Bool)? = nil
-    ) async {
-        await closeComposeTabs(
+    ) async -> ComposeTabMutationReport {
+        await removeComposeTabs(
             withIDs: [id],
             isMutationContextCurrent: isMutationContextCurrent
         )
@@ -2874,7 +3097,7 @@ class PromptViewModel: ObservableObject {
         guard let targetIndex = tabs.firstIndex(where: { $0.id == id }), targetIndex > 0 else { return }
 
         let idsToClose = Set(tabs[..<targetIndex].map(\.id))
-        await closeComposeTabs(withIDs: idsToClose, preferredActiveID: id)
+        await removeComposeTabs(withIDs: idsToClose, preferredActiveID: id)
     }
 
     @MainActor
@@ -2889,23 +3112,42 @@ class PromptViewModel: ObservableObject {
         guard let targetIndex = tabs.firstIndex(where: { $0.id == id }), targetIndex < tabs.count - 1 else { return }
 
         let idsToClose = Set(tabs[(targetIndex + 1)...].map(\.id))
-        await closeComposeTabs(withIDs: idsToClose, preferredActiveID: id)
+        await removeComposeTabs(withIDs: idsToClose, preferredActiveID: id)
     }
 
     @MainActor
-    private func closeComposeTabs(
+    private func removeComposeTabs(
         withIDs ids: Set<UUID>,
         preferredActiveID: UUID? = nil,
         reason: ComposeTabRemovalReason = .close,
         expandCascade: Bool = true,
         isMutationContextCurrent: (@MainActor () -> Bool)? = nil
-    ) async {
-        guard !ids.isEmpty else { return }
+    ) async -> ComposeTabMutationReport {
+        guard !ids.isEmpty else {
+            return ComposeTabMutationReport(noOpReasons: [reason])
+        }
         guard
             let manager = workspaceManager,
             let workspace = manager.activeWorkspace,
             let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id })
-        else { return }
+        else {
+            return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: reason,
+                reason: .workspaceUnavailable,
+                tabID: nil,
+                message: "The active workspace is unavailable."
+            )])
+        }
+        var report = ComposeTabMutationReport()
+
+        func rejection(_ rejectionReason: ComposeTabMutationRejectionReason, message: String) -> ComposeTabMutationReport {
+            ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: reason,
+                reason: rejectionReason,
+                tabID: nil,
+                message: message
+            )])
+        }
 
         func mutationOwnerIsCurrent() -> Bool {
             manager.activeWorkspace?.id == workspace.id
@@ -2917,38 +3159,69 @@ class PromptViewModel: ObservableObject {
             mutationOwnerIsCurrent() && (isMutationContextCurrent?() ?? true)
         }
 
-        guard mutationContextIsCurrent() else { return }
-        var tabs = manager.workspaces[index].composeTabs
-        let tabsBeforeClose = tabs
-        let originalCount = tabs.count
+        guard mutationContextIsCurrent() else {
+            return rejection(.mutationContextChanged, message: "The workspace or selection changed before removal.")
+        }
+        let initiallyPresentRequestedIDs = ids.intersection(Set(manager.workspaces[index].composeTabs.map(\.id)))
+        guard initiallyPresentRequestedIDs == ids else {
+            return rejection(
+                .mutationContextChanged,
+                message: "A requested active chat is no longer available."
+            )
+        }
         var resolvedIDs = ids
-        var stashedTabIDsToDelete: Set<UUID> = []
+        var archivedTargetsToDelete: Set<ArchivedTabMutationTarget> = []
         if expandCascade, let composeTabCascadeResolver {
             let cascadePlan = await composeTabCascadeResolver(ids, reason)
-            guard mutationContextIsCurrent() else { return }
+            guard mutationContextIsCurrent() else {
+                return rejection(.mutationContextChanged, message: "The workspace or selection changed during cascade resolution.")
+            }
             resolvedIDs.formUnion(cascadePlan.composeTabIDs)
             if reason == .close {
-                stashedTabIDsToDelete.formUnion(cascadePlan.stashedTabIDs)
+                archivedTargetsToDelete.formUnion(cascadePlan.archivedTargets)
+            }
+        }
+        let currentRequestedIDs = ids.intersection(Set(manager.workspaces[index].composeTabs.map(\.id)))
+        guard currentRequestedIDs == initiallyPresentRequestedIDs else {
+            return rejection(
+                .mutationContextChanged,
+                message: "The requested active tab targets changed during cascade resolution."
+            )
+        }
+        if !archivedTargetsToDelete.isEmpty {
+            let tabIDByStashedID = Dictionary(
+                uniqueKeysWithValues: manager.workspaces[index].stashedTabs.map { ($0.id, $0.tab.id) }
+            )
+            guard archivedTargetsToDelete.allSatisfy({
+                tabIDByStashedID[$0.stashedTabID] == $0.tabID
+            }) else {
+                return rejection(
+                    .mutationContextChanged,
+                    message: "An archived cascade target changed during resolution."
+                )
             }
         }
 
-        // Identify which tabs will actually be removed
+        // Freeze the exact target membership before required persistence begins
+        var tabs = manager.workspaces[index].composeTabs
+        var tabsBeforeClose = tabs
+        var originalCount = tabs.count
         let tabsBeingClosed = resolvedIDs.intersection(Set(tabs.map(\.id)))
         guard !tabsBeingClosed.isEmpty else {
-            if reason == .close, expandCascade, !stashedTabIDsToDelete.isEmpty {
-                await deleteStashedTabs(withIDs: stashedTabIDsToDelete, expandCascade: false)
+            report.noOpReasons.insert(reason)
+            if reason == .close, expandCascade, !archivedTargetsToDelete.isEmpty {
+                await report.merge(deleteResolvedStashedTabs(
+                    targets: archivedTargetsToDelete,
+                    isMutationContextCurrent: mutationContextIsCurrent
+                ))
             }
-            return
+            return report
         }
 
-        let fallbackActiveID: UUID? = {
-            guard let previousActiveID = manager.workspaces[index].activeComposeTabID,
-                  tabsBeingClosed.contains(previousActiveID) else { return nil }
-            return adjacentTabID(afterClosing: previousActiveID, tabs: tabsBeforeClose, closingIDs: tabsBeingClosed)
-        }()
-
         // Required persistence must succeed before any runtime teardown or projection mutation.
-        guard mutationContextIsCurrent() else { return }
+        guard mutationContextIsCurrent() else {
+            return rejection(.mutationContextChanged, message: "The workspace or selection changed before preflight.")
+        }
         switch await runComposeTabsRemovalPreflight(
             tabsBeingClosed,
             reason: reason,
@@ -2958,9 +3231,31 @@ class PromptViewModel: ObservableObject {
             break
         case let .abort(failure):
             logComposeTabRemovalAbort(failure)
-            return
+            return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: reason,
+                reason: .requiredSessionPreflight,
+                tabID: failure.tabID,
+                message: failure.message
+            )])
         }
-        guard mutationContextIsCurrent() else { return }
+        guard mutationContextIsCurrent() else {
+            return rejection(.mutationContextChanged, message: "The workspace or selection changed during preflight.")
+        }
+        tabs = manager.workspaces[index].composeTabs
+        tabsBeforeClose = tabs
+        originalCount = tabs.count
+        let freshTargets = resolvedIDs.intersection(Set(tabs.map(\.id)))
+        guard freshTargets == tabsBeingClosed else {
+            return rejection(
+                .mutationContextChanged,
+                message: "The active tab targets changed during preflight."
+            )
+        }
+        let fallbackActiveID: UUID? = {
+            guard let previousActiveID = manager.workspaces[index].activeComposeTabID,
+                  tabsBeingClosed.contains(previousActiveID) else { return nil }
+            return adjacentTabID(afterClosing: previousActiveID, tabs: tabsBeforeClose, closingIDs: tabsBeingClosed)
+        }()
         if reason == .stash,
            let activeID = manager.workspaces[index].activeComposeTabID,
            tabsBeingClosed.contains(activeID)
@@ -2983,11 +3278,16 @@ class PromptViewModel: ObservableObject {
 
         tabs.removeAll { resolvedIDs.contains($0.id) }
         guard tabs.count != originalCount else {
-            if reason == .close, expandCascade, !stashedTabIDsToDelete.isEmpty {
-                await deleteStashedTabs(withIDs: stashedTabIDsToDelete, expandCascade: false)
+            report.noOpReasons.insert(reason)
+            if reason == .close, expandCascade, !archivedTargetsToDelete.isEmpty {
+                await report.merge(deleteResolvedStashedTabs(
+                    targets: archivedTargetsToDelete,
+                    isMutationContextCurrent: mutationContextIsCurrent
+                ))
             }
-            return
+            return report
         }
+        report.removedComposeTabIDs.formUnion(tabsBeingClosed)
 
         dirtyTabIDs.subtract(resolvedIDs)
 
@@ -3008,11 +3308,18 @@ class PromptViewModel: ObservableObject {
             #endif
             manager.markWorkspaceDirty()
             manager.pollAndSaveState()
-            await runPostProjectionComposeTabCleanup(tabsBeingClosed, reason: reason, workspaceID: workspace.id)
-            if reason == .close, expandCascade, !stashedTabIDsToDelete.isEmpty {
-                await deleteStashedTabs(withIDs: stashedTabIDsToDelete, expandCascade: false)
+            await report.cleanupIssues.append(contentsOf: runPostProjectionComposeTabCleanup(
+                tabsBeingClosed,
+                reason: reason,
+                workspaceID: workspace.id
+            ))
+            if reason == .close, expandCascade, !archivedTargetsToDelete.isEmpty {
+                await report.merge(deleteResolvedStashedTabs(
+                    targets: archivedTargetsToDelete,
+                    isMutationContextCurrent: mutationContextIsCurrent
+                ))
             }
-            return
+            return report
         }
 
         var newActiveID = previousActiveID
@@ -3056,10 +3363,18 @@ class PromptViewModel: ObservableObject {
         #endif
         manager.markWorkspaceDirty()
         manager.pollAndSaveState()
-        await runPostProjectionComposeTabCleanup(tabsBeingClosed, reason: reason, workspaceID: workspace.id)
-        if reason == .close, expandCascade, !stashedTabIDsToDelete.isEmpty {
-            await deleteStashedTabs(withIDs: stashedTabIDsToDelete, expandCascade: false)
+        await report.cleanupIssues.append(contentsOf: runPostProjectionComposeTabCleanup(
+            tabsBeingClosed,
+            reason: reason,
+            workspaceID: workspace.id
+        ))
+        if reason == .close, expandCascade, !archivedTargetsToDelete.isEmpty {
+            await report.merge(deleteResolvedStashedTabs(
+                targets: archivedTargetsToDelete,
+                isMutationContextCurrent: mutationContextIsCurrent
+            ))
         }
+        return report
     }
 
     @MainActor
@@ -3165,7 +3480,7 @@ class PromptViewModel: ObservableObject {
         else { return }
         let ids = Set(manager.workspaces[index].composeTabs.map(\.id))
         guard !ids.isEmpty else { return }
-        await closeComposeTabs(withIDs: ids)
+        await removeComposeTabs(withIDs: ids)
     }
 
     @MainActor
@@ -3179,31 +3494,21 @@ class PromptViewModel: ObservableObject {
         let ids = Set(manager.workspaces[index].composeTabs.map(\.id))
         guard !ids.isEmpty else { return }
 
-        await closeComposeTabs(withIDs: ids, reason: .stash)
+        await removeComposeTabs(withIDs: ids, reason: .stash)
     }
 
     // MARK: - Stashed Tabs
 
     @Published private(set) var currentStashedTabs: [StashedTab] = []
 
+    @discardableResult
     @MainActor
     func stashTab(
         _ id: UUID,
         isMutationContextCurrent: (@MainActor () -> Bool)? = nil
-    ) async {
-        guard
-            let manager = workspaceManager,
-            let workspace = manager.activeWorkspace,
-            let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id }),
-            isMutationContextCurrent?() ?? true
-        else { return }
-
-        // Don't allow stashing if it's the last tab
-        guard manager.workspaces[index].composeTabs.count > 1 else { return }
-
-        await closeComposeTabs(
+    ) async -> ComposeTabMutationReport {
+        await stashComposeTabs(
             withIDs: [id],
-            reason: .stash,
             isMutationContextCurrent: isMutationContextCurrent
         )
     }
@@ -3258,118 +3563,100 @@ class PromptViewModel: ObservableObject {
         manager.pollAndSaveState()
     }
 
+    @discardableResult
     @MainActor
-    func deleteStashedTab(_ stashedTabID: UUID) async {
+    func deleteStashedTab(_ stashedTabID: UUID) async -> ComposeTabMutationReport {
         await deleteStashedTabs(withIDs: [stashedTabID])
     }
 
+    @discardableResult
     @MainActor
-    func deleteStashedTabs(withIDs stashedTabIDs: Set<UUID>) async {
-        await deleteStashedTabs(withIDs: stashedTabIDs, expandCascade: true)
+    func deleteStashedTabs(
+        withIDs stashedTabIDs: Set<UUID>,
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
+    ) async -> ComposeTabMutationReport {
+        guard !stashedTabIDs.isEmpty else {
+            return ComposeTabMutationReport(noOpReasons: [.deleteStashed])
+        }
+        guard let stashedTabs = workspaceManager?.activeWorkspace?.stashedTabs else {
+            return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: .deleteStashed,
+                reason: .workspaceUnavailable,
+                tabID: nil,
+                message: "The active workspace is unavailable."
+            )])
+        }
+        let targets = Set(stashedTabs.compactMap { stashedTab -> ArchivedTabMutationTarget? in
+            guard stashedTabIDs.contains(stashedTab.id) else { return nil }
+            return ArchivedTabMutationTarget(stashedTabID: stashedTab.id, tabID: stashedTab.tab.id)
+        })
+        let resolvedStashedTabIDs = Set(targets.map(\.stashedTabID))
+        guard resolvedStashedTabIDs == stashedTabIDs else {
+            return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: .deleteStashed,
+                reason: .mutationContextChanged,
+                tabID: nil,
+                message: "A requested archived chat is no longer available."
+            )])
+        }
+        return await deleteComposeAndStashedTabs(
+            composeTabIDs: [],
+            archivedTargets: targets,
+            isMutationContextCurrent: isMutationContextCurrent
+        )
     }
 
     @MainActor
-    private func deleteStashedTabs(withIDs stashedTabIDs: Set<UUID>, expandCascade: Bool) async {
-        guard !stashedTabIDs.isEmpty else { return }
+    private func deleteResolvedStashedTabs(
+        targets: Set<ArchivedTabMutationTarget>,
+        isMutationContextCurrent: (@MainActor () -> Bool)?
+    ) async -> ComposeTabMutationReport {
+        guard !targets.isEmpty else {
+            return ComposeTabMutationReport(noOpReasons: [.deleteStashed])
+        }
+        let stashedTabIDs = Set(targets.map(\.stashedTabID))
+        let expectedTabIDByStashedID = Dictionary(uniqueKeysWithValues: targets.map { ($0.stashedTabID, $0.tabID) })
         guard
             let manager = workspaceManager,
             let workspace = manager.activeWorkspace,
             let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id })
-        else { return }
-
+        else {
+            return ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: .deleteStashed,
+                reason: .workspaceUnavailable,
+                tabID: nil,
+                message: "The active workspace is unavailable."
+            )])
+        }
         func mutationOwnerIsCurrent() -> Bool {
             manager.activeWorkspace?.id == workspace.id
                 && manager.workspaces.indices.contains(index)
                 && manager.workspaces[index].id == workspace.id
         }
 
-        var resolvedStashedTabIDs = stashedTabIDs
-        var composeTabIDsToDelete: Set<UUID> = []
-        if expandCascade, let stashedTabCascadeResolver {
-            let cascadePlan = await stashedTabCascadeResolver(stashedTabIDs)
-            guard mutationOwnerIsCurrent() else { return }
-            resolvedStashedTabIDs.formUnion(cascadePlan.stashedTabIDs)
-            composeTabIDsToDelete.formUnion(cascadePlan.composeTabIDs)
-        }
-        if !composeTabIDsToDelete.isEmpty {
-            let composeTabsBeforeDelete = manager.workspaces[index].composeTabs
-            let composeTabIDsBeingDeleted = composeTabIDsToDelete.intersection(Set(composeTabsBeforeDelete.map(\.id)))
-            if !composeTabIDsBeingDeleted.isEmpty {
-                let previousActiveID = manager.workspaces[index].activeComposeTabID
-                let fallbackActiveID: UUID? = {
-                    guard let previousActiveID,
-                          composeTabIDsBeingDeleted.contains(previousActiveID)
-                    else {
-                        return nil
-                    }
-                    return adjacentTabID(
-                        afterClosing: previousActiveID,
-                        tabs: composeTabsBeforeDelete,
-                        closingIDs: composeTabIDsBeingDeleted
-                    )
-                }()
-                switch await runComposeTabsRemovalPreflight(
-                    composeTabIDsBeingDeleted,
-                    reason: .close,
-                    workspaceID: workspace.id
-                ) {
-                case .proceed:
-                    break
-                case let .abort(failure):
-                    logComposeTabRemovalAbort(failure)
-                    return
-                }
-                var remainingComposeTabs = composeTabsBeforeDelete
-                remainingComposeTabs.removeAll { composeTabIDsBeingDeleted.contains($0.id) }
-                dirtyTabIDs.subtract(composeTabIDsBeingDeleted)
-                manager.workspaces[index].composeTabs = remainingComposeTabs
-                if remainingComposeTabs.isEmpty {
-                    await appendReplacementBlankComposeTabIfNeeded(manager: manager, workspaceIndex: index)
-                } else {
-                    var newActiveID = previousActiveID
-                    if let previousActiveID,
-                       composeTabIDsBeingDeleted.contains(previousActiveID)
-                    {
-                        if let fallbackActiveID,
-                           remainingComposeTabs.contains(where: { $0.id == fallbackActiveID })
-                        {
-                            newActiveID = fallbackActiveID
-                        } else {
-                            newActiveID = remainingComposeTabs.last?.id ?? remainingComposeTabs.first?.id
-                        }
-                    } else if newActiveID == nil {
-                        newActiveID = remainingComposeTabs.first?.id
-                    }
-                    if newActiveID != previousActiveID,
-                       let newActiveID,
-                       let tab = remainingComposeTabs.first(where: { $0.id == newActiveID })
-                    {
-                        await withComposeTabActivationSnapshotSuspended(targetTabID: newActiveID, manager: manager) {
-                            manager.workspaces[index].activeComposeTabID = newActiveID
-                            activeComposeTabID = newActiveID
-                            await withComposeTabSwitching(targetTabID: newActiveID) {
-                                await manager.applyComposeTabState(tab)
-                            }
-                        }
-                    } else {
-                        manager.workspaces[index].activeComposeTabID = newActiveID
-                        activeComposeTabID = newActiveID
-                    }
-                }
-                loadComposeTabsFromWorkspace(manager.workspaces[index])
-                manager.markWorkspaceDirty()
-                manager.pollAndSaveState()
-                await runPostProjectionComposeTabCleanup(
-                    composeTabIDsBeingDeleted,
-                    reason: .close,
-                    workspaceID: workspace.id
-                )
-            }
+        func mutationContextIsCurrent() -> Bool {
+            mutationOwnerIsCurrent() && (isMutationContextCurrent?() ?? true)
         }
 
-        let stashedTabsToDelete = manager.workspaces[index].stashedTabs.filter { resolvedStashedTabIDs.contains($0.id) }
-        guard !stashedTabsToDelete.isEmpty else { return }
+        func contextRejection(_ message: String) -> ComposeTabMutationReport {
+            ComposeTabMutationReport(rejections: [ComposeTabMutationRejection(
+                kind: .deleteStashed,
+                reason: .mutationContextChanged,
+                tabID: nil,
+                message: message
+            )])
+        }
 
+        guard mutationContextIsCurrent() else {
+            return contextRejection("The workspace or selection changed before archived deletion.")
+        }
+        var report = ComposeTabMutationReport()
+        let currentStashedTabs = manager.workspaces[index].stashedTabs
+        let currentTabIDByStashedID = Dictionary(uniqueKeysWithValues: currentStashedTabs.map { ($0.id, $0.tab.id) })
+        guard expectedTabIDByStashedID.allSatisfy({ currentTabIDByStashedID[$0.key] == $0.value }) else {
+            return contextRejection("A targeted archived chat changed before preflight.")
+        }
+        let stashedTabsToDelete = currentStashedTabs.filter { stashedTabIDs.contains($0.id) }
         let tabIDs = Set(stashedTabsToDelete.map(\.tab.id))
         switch await runComposeTabsRemovalPreflight(
             tabIDs,
@@ -3380,13 +3667,35 @@ class PromptViewModel: ObservableObject {
             break
         case let .abort(failure):
             logComposeTabRemovalAbort(failure)
-            return
+            report.rejections.append(ComposeTabMutationRejection(
+                kind: .deleteStashed,
+                reason: .requiredSessionPreflight,
+                tabID: failure.tabID,
+                message: failure.message
+            ))
+            return report
         }
-        manager.workspaces[index].stashedTabs.removeAll { resolvedStashedTabIDs.contains($0.id) }
+        guard mutationContextIsCurrent() else {
+            report.merge(contextRejection("The workspace or selection changed during archived preflight."))
+            return report
+        }
+        let freshStashedTabs = manager.workspaces[index].stashedTabs
+        let freshTabIDByStashedID = Dictionary(uniqueKeysWithValues: freshStashedTabs.map { ($0.id, $0.tab.id) })
+        guard expectedTabIDByStashedID.allSatisfy({ freshTabIDByStashedID[$0.key] == $0.value }) else {
+            report.merge(contextRejection("A targeted archived chat changed during preflight."))
+            return report
+        }
+        manager.workspaces[index].stashedTabs = freshStashedTabs.filter { !stashedTabIDs.contains($0.id) }
         loadComposeTabsFromWorkspace(manager.workspaces[index])
         manager.markWorkspaceDirty()
         manager.pollAndSaveState()
-        await runPostProjectionComposeTabCleanup(tabIDs, reason: .deleteStashed, workspaceID: workspace.id)
+        report.removedStashedTabIDs.formUnion(stashedTabsToDelete.map(\.id))
+        await report.cleanupIssues.append(contentsOf: runPostProjectionComposeTabCleanup(
+            tabIDs,
+            reason: .deleteStashed,
+            workspaceID: workspace.id
+        ))
+        return report
     }
 
     @MainActor
@@ -3396,6 +3705,15 @@ class PromptViewModel: ObservableObject {
 
     func loadStashedTabsFromWorkspace(_ workspace: WorkspaceModel) {
         currentStashedTabs = workspace.stashedTabs
+        guard sidebarWorkspaceSnapshot?.workspaceID == workspace.id else {
+            sidebarWorkspaceSnapshot = nil
+            return
+        }
+        sidebarWorkspaceSnapshot = SidebarWorkspaceSnapshot(
+            workspaceID: workspace.id,
+            composeTabs: currentComposeTabs,
+            stashedTabs: workspace.stashedTabs
+        )
     }
 
     @MainActor
@@ -3417,20 +3735,43 @@ class PromptViewModel: ObservableObject {
             }
     }
 
+    @discardableResult
     @MainActor
-    func setComposeTabPinned(_ pinned: Bool, for tabID: UUID) {
+    func setComposeTabsPinned(
+        _ pinned: Bool,
+        for tabIDs: Set<UUID>,
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
+    ) -> ComposeTabPinMutationReport {
         guard
             let manager = workspaceManager,
             let workspace = manager.activeWorkspace,
             let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id }),
-            let tabIndex = manager.workspaces[index].composeTabs.firstIndex(where: { $0.id == tabID })
-        else { return }
-        guard manager.workspaces[index].composeTabs[tabIndex].isPinned != pinned else { return }
+            isMutationContextCurrent?() ?? true
+        else { return ComposeTabPinMutationReport(updatedTabIDs: [], contextRejected: true) }
+        let currentTabIDs = Set(manager.workspaces[index].composeTabs.map(\.id))
+        guard tabIDs.isSubset(of: currentTabIDs) else {
+            return ComposeTabPinMutationReport(updatedTabIDs: [], contextRejected: true)
+        }
 
-        manager.workspaces[index].composeTabs[tabIndex].isPinned = pinned
+        var updatedTabIDs: Set<UUID> = []
+        for tabIndex in manager.workspaces[index].composeTabs.indices {
+            let tabID = manager.workspaces[index].composeTabs[tabIndex].id
+            guard tabIDs.contains(tabID), manager.workspaces[index].composeTabs[tabIndex].isPinned != pinned else { continue }
+            manager.workspaces[index].composeTabs[tabIndex].isPinned = pinned
+            updatedTabIDs.insert(tabID)
+        }
+        guard !updatedTabIDs.isEmpty else {
+            return ComposeTabPinMutationReport(updatedTabIDs: [], contextRejected: false)
+        }
         loadComposeTabsFromWorkspace(manager.workspaces[index])
         manager.markWorkspaceDirty()
         manager.pollAndSaveState()
+        return ComposeTabPinMutationReport(updatedTabIDs: updatedTabIDs, contextRejected: false)
+    }
+
+    @MainActor
+    func setComposeTabPinned(_ pinned: Bool, for tabID: UUID) {
+        setComposeTabsPinned(pinned, for: [tabID])
     }
 
     @MainActor

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -698,12 +698,25 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         for (reason, name) in rows {
             let fixture = try await makeRetainedACPFixture(processIDFileName: "compose-\(name)-acp-process-id.txt")
             fixture.host.test_installLiveSession(fixture.session)
+            fixture.host.setAgentRunActive(fixture.session.tabID, isActive: true)
+            XCTAssertTrue(fixture.host.tabsWithActiveAgentRun.contains(fixture.session.tabID), name)
             XCTAssertTrue(Self.processIsRunning(fixture.processID), name)
 
-            await fixture.host.handleComposeTabsDidRemove([fixture.session.tabID], reason: reason)
+            let issues = await fixture.host.handleComposeTabsDidRemove(
+                [fixture.session.tabID],
+                reason: reason,
+                workspaceID: UUID()
+            )
+            if reason == .stash {
+                XCTAssertTrue(issues.isEmpty, name)
+            } else {
+                XCTAssertEqual(issues.count, 1, name)
+                XCTAssertTrue(issues.first?.message.contains("owning workspace") == true, name)
+            }
 
             XCTAssertNil(fixture.session.acpController, name)
             XCTAssertNil(fixture.host.sessions[fixture.session.tabID], name)
+            XCTAssertFalse(fixture.host.tabsWithActiveAgentRun.contains(fixture.session.tabID), name)
             try await waitUntilProcessExits(
                 fixture.processID,
                 "Compose tab \(name) should terminate retained ACP process"

--- a/Tests/RepoPromptTests/AgentMode/AgentModeSidebarSessionBuilderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeSidebarSessionBuilderTests.swift
@@ -543,6 +543,37 @@ final class AgentModeSidebarSessionBuilderTests: XCTestCase {
         )
     }
 
+    func testCanStashUsesPersistedConversationContent() throws {
+        let tabID = id(69)
+        let sessionID = id(169)
+        let rows = build(
+            tabs: [tab(tabID, sessionID: sessionID)],
+            sessionIndex: sessionIndex([
+                entry(sessionID, tabID: tabID, lastUserMessageAt: date(10))
+            ])
+        )
+
+        XCTAssertTrue(try row(for: tabID, in: rows).canStash)
+    }
+
+    func testCanStashUsesLiveConversationItems() throws {
+        let tabID = id(70)
+        let sessionID = id(170)
+        let session = liveSession(
+            tabID: tabID,
+            sessionID: sessionID,
+            lastUserMessageAt: date(10)
+        )
+        session.setItemsSilently([.user("Content", sequenceIndex: 0)], reason: .testOverride)
+        let rows = build(
+            tabs: [tab(tabID, sessionID: sessionID)],
+            sessions: [tabID: session],
+            sessionIndex: [:]
+        )
+
+        XCTAssertTrue(try row(for: tabID, in: rows).canStash)
+    }
+
     private func build(
         tabs: [ComposeTabState],
         sessions: [UUID: AgentModeViewModel.TabSession] = [:],

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -749,7 +749,79 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         }
     }
 
-    func testSidebarListProjectionMemoizesWithinExplicitRenderGeneration() {
+    func testArchivedSelectionUniverseUsesVisiblePageAndAllSearchMatches() {
+        let viewModel = makeViewModel()
+        let composeTab = ComposeTabState(id: UUID(), name: "Active", activeAgentSessionID: UUID())
+        let sessionIDs = (0 ..< 25).map { _ in UUID() }
+        let stashedTabs = sessionIDs.enumerated().map { index, sessionID in
+            StashedTab(
+                tab: ComposeTabState(
+                    id: UUID(),
+                    name: "Archived \(index)",
+                    activeAgentSessionID: sessionID
+                ),
+                stashedAt: Date(timeIntervalSince1970: TimeInterval(index))
+            )
+        }
+        var workspace = makeWorkspace(name: "Archived paging", tabs: [composeTab], activeTabID: composeTab.id)
+        workspace.stashedTabs = stashedTabs
+        let manager = makeWorkspaceManager(workspaces: [workspace])
+        manager.activeWorkspace = workspace
+        viewModel.workspaceManager = manager
+        let owner = AgentModeViewModel.SessionIndexOwner(workspaceID: workspace.id, activationEpoch: 1)
+        let entries = Dictionary(uniqueKeysWithValues: sessionIDs.enumerated().map { index, sessionID in
+            let entry = makeIndexEntry(
+                id: sessionID,
+                tabID: stashedTabs[index].tab.id,
+                lastUserMessageAt: Date(timeIntervalSince1970: TimeInterval(index)),
+                savedAt: Date(timeIntervalSince1970: TimeInterval(index))
+            )
+            return (entry.id, entry)
+        })
+        viewModel.test_installSessionIndexSnapshot(entries, owner: owner, latestOwner: owner, activeWorkspace: workspace)
+
+        let snapshot = viewModel.ui.sessionSidebar.snapshot
+        let firstPage = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: [composeTab],
+            stashedTabs: stashedTabs,
+            currentTabID: composeTab.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
+        )
+        XCTAssertEqual(firstPage.pagedArchivedSessionTabsForRows.count, 20)
+        XCTAssertEqual(firstPage.remainingArchivedSessionCount, 5)
+
+        var expandedSnapshot = snapshot
+        expandedSnapshot.archivedVisibleSessionCount = 40
+        let expanded = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: [composeTab],
+            stashedTabs: stashedTabs,
+            currentTabID: composeTab.id,
+            sidebarSnapshot: expandedSnapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
+        )
+        XCTAssertEqual(expanded.pagedArchivedSessionTabsForRows.count, 25)
+
+        var searchSnapshot = snapshot
+        searchSnapshot.searchText = "Agent"
+        let searched = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: [composeTab],
+            stashedTabs: stashedTabs,
+            currentTabID: composeTab.id,
+            sidebarSnapshot: searchSnapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
+        )
+        XCTAssertEqual(searched.pagedArchivedSessionTabsForRows.count, 25)
+        XCTAssertEqual(searched.renderedSelectionOrder.count, 25)
+    }
+
+    func testSidebarListProjectionMemoizesWithinExplicitRenderGeneration() throws {
         let viewModel = makeViewModel()
         let composeTabs = (0 ..< 400).map { index in
             ComposeTabState(
@@ -798,6 +870,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         let snapshot = viewModel.ui.sessionSidebar.snapshot
 
         let initialProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: composeTabs,
             stashedTabs: stashedTabs,
             currentTabID: composeTabs.first?.id,
@@ -806,6 +879,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             showComposeTabsWithoutAgentSessions: false
         )
         _ = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: composeTabs,
             stashedTabs: stashedTabs,
             currentTabID: composeTabs.first?.id,
@@ -813,8 +887,73 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             archivedSessionsExpanded: true,
             showComposeTabsWithoutAgentSessions: false
         )
-        XCTAssertEqual(initialProjection.sortedArchivedSessionTabsForRows.map(\.id), [stashedTabs[1].id, stashedTabs[0].id])
+        XCTAssertEqual(initialProjection.pagedArchivedSessionTabsForRows.map(\.id), [stashedTabs[1].id, stashedTabs[0].id])
+        XCTAssertEqual(
+            initialProjection.renderedSelectionOrder,
+            initialProjection.pagedSessions.map { .active(tabID: $0.tabID) }
+                + [
+                    .archived(stashedTabID: stashedTabs[1].id, tabID: stashedTabs[1].tab.id),
+                    .archived(stashedTabID: stashedTabs[0].id, tabID: stashedTabs[0].tab.id)
+                ]
+        )
+        let bulkTargets = try XCTUnwrap(viewModel.sidebarBulkMutationTargets(
+            selection: Set(initialProjection.renderedSelectionOrder),
+            selectionWorkspaceID: workspace.id,
+            projection: initialProjection,
+            composeTabs: composeTabs,
+            stashedTabs: stashedTabs
+        ))
+        XCTAssertEqual(
+            bulkTargets.archivedDeleteTargets,
+            Set(initialProjection.pagedArchivedSessionTabsForRows.map {
+                PromptViewModel.ArchivedTabMutationTarget(stashedTabID: $0.id, tabID: $0.tab.id)
+            })
+        )
+        XCTAssertEqual(bulkTargets.activeDeleteTabIDs, Set(composeTabs.map(\.id)))
+        XCTAssertTrue(bulkTargets.stashTabIDs.isEmpty)
+        XCTAssertEqual(bulkTargets.pinTabIDs, Set(composeTabs.map(\.id)))
+        XCTAssertTrue(bulkTargets.unpinTabIDs.isEmpty)
+        var staleSelection = Set(initialProjection.renderedSelectionOrder)
+        staleSelection.insert(.active(tabID: UUID()))
+        XCTAssertNil(viewModel.sidebarBulkMutationTargets(
+            selection: staleSelection,
+            selectionWorkspaceID: workspace.id,
+            projection: initialProjection,
+            composeTabs: composeTabs,
+            stashedTabs: stashedTabs
+        ))
+        let archivedIdentity = try XCTUnwrap(
+            initialProjection.renderedSelectionOrder.first(where: { identity in
+                if case .archived = identity { return true }
+                return false
+            })
+        )
+        XCTAssertNil(viewModel.sidebarBulkMutationTargets(
+            selection: [archivedIdentity],
+            selectionWorkspaceID: workspace.id,
+            projection: initialProjection,
+            composeTabs: composeTabs,
+            stashedTabs: stashedTabs.filter { $0.tab.id != archivedIdentity.tabID }
+        ))
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 1)
+        if let identity = initialProjection.renderedSelectionOrder.first {
+            _ = viewModel.ui.sessionSidebar.handleSelectionGesture(
+                .toggle,
+                identity: identity,
+                renderedOrder: initialProjection.renderedSelectionOrder,
+                workspaceID: workspace.id
+            )
+        }
+        _ = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: composeTabs,
+            stashedTabs: stashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
+        )
         XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 1)
 
         var unrelatedComposeChurn = composeTabs
@@ -827,6 +966,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         unrelatedStashedChurn[0].tab.expandedFolders = ["Sources/RepoPrompt"]
 
         _ = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: unrelatedComposeChurn,
             stashedTabs: unrelatedStashedChurn,
             currentTabID: composeTabs.first?.id,
@@ -841,6 +981,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         var rawRenamedStashedTabs = unrelatedStashedChurn
         rawRenamedStashedTabs[0].tab.name = " Archived 0 "
         let rawRenamedProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: unrelatedComposeChurn,
             stashedTabs: rawRenamedStashedTabs,
             currentTabID: composeTabs.first?.id,
@@ -849,7 +990,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             showComposeTabsWithoutAgentSessions: false
         )
         XCTAssertEqual(
-            rawRenamedProjection.sortedArchivedSessionTabsForRows.first(where: { $0.id == stashedTabs[0].id })?.tab.name,
+            rawRenamedProjection.pagedArchivedSessionTabsForRows.first(where: { $0.id == stashedTabs[0].id })?.tab.name,
             " Archived 0 "
         )
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
@@ -858,6 +999,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         var pinnedStashedTabs = rawRenamedStashedTabs
         pinnedStashedTabs[0].tab.isPinned = true
         let pinnedProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: unrelatedComposeChurn,
             stashedTabs: pinnedStashedTabs,
             currentTabID: composeTabs.first?.id,
@@ -865,13 +1007,14 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             archivedSessionsExpanded: true,
             showComposeTabsWithoutAgentSessions: false
         )
-        XCTAssertEqual(pinnedProjection.sortedArchivedSessionTabsForRows.first?.id, stashedTabs[0].id)
+        XCTAssertEqual(pinnedProjection.pagedArchivedSessionTabsForRows.first?.id, stashedTabs[0].id)
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
         XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 3)
 
         var restashedTabs = rawRenamedStashedTabs
         restashedTabs[0].stashedAt = stashedTabs[1].stashedAt.addingTimeInterval(1)
         let restashedProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: unrelatedComposeChurn,
             stashedTabs: restashedTabs,
             currentTabID: composeTabs.first?.id,
@@ -879,13 +1022,14 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             archivedSessionsExpanded: true,
             showComposeTabsWithoutAgentSessions: false
         )
-        XCTAssertEqual(restashedProjection.sortedArchivedSessionTabsForRows.first?.id, stashedTabs[0].id)
+        XCTAssertEqual(restashedProjection.pagedArchivedSessionTabsForRows.first?.id, stashedTabs[0].id)
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
         XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 4)
 
         var renamedTabs = unrelatedComposeChurn
         renamedTabs[0].name = "Renamed"
         let renamedProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: renamedTabs,
             stashedTabs: restashedTabs,
             currentTabID: composeTabs.first?.id,
@@ -902,6 +1046,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
 
         viewModel.ui.sessionSidebar.refresh()
         _ = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: renamedTabs,
             stashedTabs: restashedTabs,
             currentTabID: composeTabs.first?.id,
@@ -911,6 +1056,19 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         )
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 3)
         XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 6)
+
+        viewModel.showMoreArchivedSidebarSessions()
+        _ = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: renamedTabs,
+            stashedTabs: restashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
+        )
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 3)
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 7)
     }
 
     func testAgentChatsProjectionShowsSessionlessTabsWithoutThrashingSessionRows() {
@@ -943,6 +1101,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         let snapshot = viewModel.ui.sessionSidebar.snapshot
 
         let hiddenProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: composeTabs,
             stashedTabs: workspace.stashedTabs,
             currentTabID: sessionlessTabID,
@@ -953,6 +1112,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertEqual(hiddenProjection.filteredSessions.map(\.tabID), [linkedTabID])
 
         let visibleProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: composeTabs,
             stashedTabs: workspace.stashedTabs,
             currentTabID: sessionlessTabID,
@@ -963,7 +1123,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertEqual(Set(visibleProjection.filteredSessions.map(\.tabID)), Set([linkedTabID, sessionlessTabID]))
         XCTAssertNil(visibleProjection.filteredSessions.first(where: { $0.tabID == sessionlessTabID })?.sessionID)
         XCTAssertTrue(visibleProjection.archivedSessionTabsForHeader.isEmpty)
-        XCTAssertTrue(visibleProjection.sortedArchivedSessionTabsForRows.isEmpty)
+        XCTAssertTrue(visibleProjection.pagedArchivedSessionTabsForRows.isEmpty)
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 2)
         XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 2)
 
@@ -1019,6 +1179,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         viewModel.workspaceManager = manager
         let snapshot = viewModel.ui.sessionSidebar.snapshot
         let initialProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: workspace.composeTabs,
             stashedTabs: [],
             currentTabID: tabID,
@@ -1040,6 +1201,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         )
         let promotedTabs = try XCTUnwrap(manager.activeWorkspace?.composeTabs)
         let promotedProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
             composeTabs: promotedTabs,
             stashedTabs: [],
             currentTabID: tabID,
@@ -1054,6 +1216,15 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertEqual(promotedRow.id, initialRow.id)
         XCTAssertEqual(promotedRow.tabID, initialRow.tabID)
         XCTAssertEqual(promotedRow.sessionID, sessionID)
+        XCTAssertFalse(promotedRow.canStash)
+        let promotedTargets = try XCTUnwrap(viewModel.sidebarBulkMutationTargets(
+            selection: [.active(tabID: tabID)],
+            selectionWorkspaceID: workspace.id,
+            projection: promotedProjection,
+            composeTabs: promotedTabs,
+            stashedTabs: []
+        ))
+        XCTAssertTrue(promotedTargets.stashTabIDs.isEmpty)
         XCTAssertEqual(viewModel.sidebarSessions(for: promotedTabs).map(\.tabID), [tabID])
         XCTAssertTrue(viewModel.hasAgentSession(for: tabID))
     }
@@ -1965,7 +2136,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             reason: .close
         )
         XCTAssertTrue(cascade.composeTabIDs.isEmpty)
-        XCTAssertTrue(cascade.stashedTabIDs.isEmpty)
+        XCTAssertTrue(cascade.archivedTargets.isEmpty)
     }
 
     private func makeIndexEntry(

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -32,6 +32,113 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertEqual(store.snapshot.defaultCollapsedThreadKeysHandled, [root, nested, later])
     }
 
+    func testSelectionGesturesMatchFinderSemantics() {
+        let store = AgentSessionSidebarUIStore()
+        let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        let second = AgentSidebarSelectionIdentity.active(tabID: id(2))
+        let archived = AgentSidebarSelectionIdentity.archived(stashedTabID: id(30), tabID: id(3))
+        let order = [first, second, archived]
+
+        XCTAssertEqual(store.handleSelectionGesture(.primary, identity: first, renderedOrder: order, workspaceID: id(99)), .activate)
+        XCTAssertEqual(store.handleSelectionGesture(.toggle, identity: first, renderedOrder: order, workspaceID: id(99)), .selectionChanged)
+        XCTAssertEqual(store.selectionState.selectedIdentities, [first])
+        XCTAssertEqual(store.handleSelectionGesture(.range, identity: archived, renderedOrder: order, workspaceID: id(99)), .selectionChanged)
+        XCTAssertEqual(store.selectionState.selectedIdentities, Set(order))
+
+        XCTAssertEqual(store.handleSelectionGesture(.primary, identity: second, renderedOrder: order, workspaceID: id(99)), .selectionChanged)
+        XCTAssertEqual(store.selectionState.selectedIdentities, [second])
+    }
+
+    func testShiftWithMissingAnchorStartsSingletonSelection() {
+        let store = AgentSessionSidebarUIStore()
+        let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        let second = AgentSidebarSelectionIdentity.active(tabID: id(2))
+        _ = store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first, second], workspaceID: id(99))
+
+        XCTAssertEqual(store.handleSelectionGesture(.range, identity: second, renderedOrder: [second], workspaceID: id(99)), .selectionChanged)
+        XCTAssertEqual(store.selectionState.selectedIdentities, [second])
+        XCTAssertEqual(store.selectionState.anchor, second)
+    }
+
+    func testSelectAllAndReconcileUseRenderedRowsOnly() {
+        let store = AgentSessionSidebarUIStore()
+        let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        let second = AgentSidebarSelectionIdentity.active(tabID: id(2))
+        store.selectAll(renderedOrder: [first, second], workspaceID: id(99))
+        XCTAssertEqual(store.selectionState.selectedIdentities, [first, second])
+
+        store.reconcileSelection(renderedOrder: [second], workspaceID: id(99))
+        XCTAssertEqual(store.selectionState.selectedIdentities, [second])
+        XCTAssertNil(store.selectionState.anchor)
+    }
+
+    func testBulkActionFreezesSelectionAndRejectsReentry() throws {
+        let store = AgentSessionSidebarUIStore()
+        let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        _ = store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: id(99))
+        let token = store.beginBulkAction(kind: .delete, targetCount: 1, workspaceID: id(99))
+        XCTAssertNotNil(token)
+        XCTAssertNil(store.beginBulkAction(kind: .delete, targetCount: 1, workspaceID: id(99)))
+        XCTAssertEqual(store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: id(99)), .ignored)
+
+        store.reconcileSelection(renderedOrder: [], workspaceID: id(99))
+        XCTAssertTrue(store.selectionState.selectedIdentities.isEmpty)
+        try store.finishBulkAction(token: XCTUnwrap(token), workspaceID: id(99), notice: nil)
+        XCTAssertTrue(store.selectionState.selectedIdentities.isEmpty)
+    }
+
+    func testDirectBulkActionRetainsWorkspaceOwnerWithoutSelection() throws {
+        let store = AgentSessionSidebarUIStore()
+        let workspaceID = id(99)
+        let token = try XCTUnwrap(store.beginBulkAction(
+            kind: .delete,
+            targetCount: 1,
+            workspaceID: workspaceID
+        ))
+
+        store.reconcileSelection(renderedOrder: [], workspaceID: workspaceID)
+
+        XCTAssertEqual(store.selectionState.workspaceID, workspaceID)
+        XCTAssertTrue(store.isCurrentBulkAction(token: token, workspaceID: workspaceID))
+    }
+
+    func testWorkspaceMismatchReconciliationInvalidatesBulkAction() throws {
+        let store = AgentSessionSidebarUIStore()
+        let firstWorkspaceID = id(98)
+        let token = try XCTUnwrap(store.beginBulkAction(
+            kind: .delete,
+            targetCount: 1,
+            workspaceID: firstWorkspaceID
+        ))
+
+        store.reconcileSelection(renderedOrder: [], workspaceID: id(99))
+        store.finishBulkAction(
+            token: token,
+            workspaceID: firstWorkspaceID,
+            notice: .init(severity: .error, title: "Stale", message: "Stale")
+        )
+
+        XCTAssertNil(store.selectionState.inFlightAction)
+        XCTAssertNil(store.selectionState.notice)
+        XCTAssertNil(store.selectionState.workspaceID)
+    }
+
+    func testStaleBulkCompletionCannotMutateNewWorkspaceState() throws {
+        let store = AgentSessionSidebarUIStore()
+        let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        _ = store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: id(99))
+        let token = try XCTUnwrap(store.beginBulkAction(kind: .stash, targetCount: 1, workspaceID: id(99)))
+        store.invalidateSelectionForWorkspaceChange()
+        store.finishBulkAction(token: token, workspaceID: id(99), notice: .init(severity: .error, title: "Old", message: "Old"))
+        XCTAssertEqual(store.selectionState, AgentSidebarSelectionState(revision: store.selectionState.revision))
+    }
+
+    func testModifierMappingGivesShiftPrecedence() {
+        XCTAssertEqual(AgentSidebarSelectionGesture(modifiers: []), .primary)
+        XCTAssertEqual(AgentSidebarSelectionGesture(modifiers: [.command]), .toggle)
+        XCTAssertEqual(AgentSidebarSelectionGesture(modifiers: [.command, .shift]), .range)
+    }
+
     private func id(_ value: Int) -> UUID {
         let suffix = String(format: "%012d", value)
         return UUID(uuidString: "00000000-0000-0000-0000-\(suffix)")!

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -186,6 +186,39 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertEqual(teardownTabIDs, [tabID])
     }
 
+    func testRestoredTabDuringPostStashCleanupKeepsReplacementRuntime() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let tabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let removedSession = viewModel.session(for: tabID)
+        var replacementSession = viewModel.sessions[UUID()]
+
+        viewModel.test_setComposeTabRemovalTeardownObserver { removedTabID in
+            guard let activeWorkspaceID = fixture.manager.activeWorkspaceID,
+                  let workspaceIndex = fixture.manager.workspaces.firstIndex(where: { $0.id == activeWorkspaceID })
+            else {
+                XCTFail("Expected active workspace")
+                return
+            }
+            guard let stashedIndex = fixture.manager.workspaces[workspaceIndex].stashedTabs.firstIndex(
+                where: { $0.tab.id == removedTabID }
+            ) else {
+                XCTFail("Expected stashed tab")
+                return
+            }
+            let restoredTab = fixture.manager.workspaces[workspaceIndex].stashedTabs.remove(at: stashedIndex).tab
+            fixture.manager.workspaces[workspaceIndex].composeTabs.append(restoredTab)
+            replacementSession = viewModel.session(for: removedTabID)
+        }
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+
+        _ = await fixture.prompt.stashComposeTabs(withIDs: [tabID])
+
+        XCTAssertFalse(viewModel.sessions[tabID] === removedSession)
+        XCTAssertTrue(viewModel.sessions[tabID] === replacementSession)
+    }
+
     func testFailedStashedDeletionDoesNotResurrectRemovedProjection() async throws {
         let fixture = makeFixture(initialTabCount: 2)
         let stashedTab = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
@@ -245,6 +278,382 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertNil(viewModel.sessions[tabID])
         let attemptedTabIDs = await attempts.attempted()
         XCTAssertTrue(attemptedTabIDs.isEmpty)
+    }
+
+    func testSingleStashOfLastTabCreatesReplacement() async throws {
+        let fixture = makeFixture(initialTabCount: 1)
+        let originalTab = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first)
+
+        await fixture.prompt.stashTab(originalTab.id)
+
+        let remainingTabs = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs)
+        XCTAssertEqual(remainingTabs.count, 1)
+        XCTAssertNotEqual(remainingTabs.first?.id, originalTab.id)
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.contains(where: { $0.tab.id == originalTab.id }))
+    }
+
+    func testBulkStashAllCreatesOneReplacementAndReportsRemovedTabs() async throws {
+        let fixture = makeFixture(initialTabCount: 3)
+        let originalIDs = try Set(XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.map(\.id)))
+
+        let report = await fixture.prompt.stashComposeTabs(withIDs: originalIDs)
+
+        XCTAssertEqual(report.removedComposeTabIDs, originalIDs)
+        XCTAssertTrue(report.rejections.isEmpty)
+        let remainingTabs = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs)
+        XCTAssertEqual(remainingTabs.count, 1)
+        let replacement = try XCTUnwrap(remainingTabs.first)
+        XCTAssertFalse(originalIDs.contains(replacement.id))
+        XCTAssertEqual(fixture.prompt.activeComposeTabID, replacement.id)
+        let finalStashedIDs = Set(fixture.manager.activeWorkspace?.stashedTabs.map(\.tab.id) ?? [])
+        XCTAssertTrue(finalStashedIDs.isSuperset(of: originalIDs))
+    }
+
+    func testBatchPinUpdatesOnlyChangedTabs() throws {
+        let fixture = makeFixture(initialTabCount: 3)
+        let tabs = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs)
+        fixture.prompt.setComposeTabPinned(true, for: tabs[0].id)
+
+        let report = fixture.prompt.setComposeTabsPinned(true, for: Set(tabs.map(\.id)))
+
+        XCTAssertEqual(report.updatedTabIDs, Set(tabs.dropFirst().map(\.id)))
+        XCTAssertTrue(fixture.prompt.currentComposeTabs.allSatisfy(\.isPinned))
+        XCTAssertTrue(fixture.prompt.setComposeTabsPinned(true, for: Set(tabs.map(\.id))).updatedTabIDs.isEmpty)
+    }
+
+    func testBatchPinRejectsMissingTargetWithoutPartialMutation() throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let tabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.dropFirst().first?.id)
+
+        let report = fixture.prompt.setComposeTabsPinned(true, for: [tabID, UUID()])
+
+        XCTAssertTrue(report.contextRejected)
+        XCTAssertFalse(fixture.prompt.currentComposeTabs.first(where: { $0.id == tabID })?.isPinned == true)
+    }
+
+    func testBulkDeletePreservesConcurrentSameWorkspacePinMutation() async throws {
+        let fixture = makeFixture(initialTabCount: 3)
+        let tabs = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs)
+        let targetID = tabs[0].id
+        let retainedID = tabs[1].id
+        let gate = ComposeRemovalPreflightGate()
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, _, _ in
+            await gate.markStartedAndWaitForRelease()
+            return .proceed
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+
+        let deleteTask = Task { await fixture.prompt.closeComposeTabs(withIDs: [targetID]) }
+        let preflightStarted = await gate.waitUntilStarted()
+        XCTAssertTrue(preflightStarted)
+        fixture.prompt.setComposeTabPinned(true, for: retainedID)
+        await gate.release()
+        _ = await deleteTask.value
+
+        XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == targetID }))
+        XCTAssertEqual(fixture.prompt.currentComposeTabs.first(where: { $0.id == retainedID })?.isPinned, true)
+    }
+
+    func testCloseRejectsMissingRequestedRootBeforeCascadeResolution() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let stashed = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+
+        let report = await fixture.prompt.closeComposeTabs(withIDs: [activeTabID, stashed.tab.id])
+
+        XCTAssertTrue(report.rejections.contains(where: { $0.reason == .mutationContextChanged }))
+        XCTAssertTrue(fixture.prompt.currentComposeTabs.contains(where: { $0.id == activeTabID }))
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.contains(where: { $0.id == stashed.id }))
+    }
+
+    func testArchivedDeleteRejectsSelectedIdentityReplacedDuringCascade() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let selected = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        let replacementTab = ComposeTabState(id: UUID(), name: "Replacement")
+        let gate = ComposeRemovalPreflightGate()
+        fixture.prompt.stashedTabCascadeResolver = { _ in
+            await gate.markStartedAndWaitForRelease()
+            return PromptViewModel.AgentSessionCascadePlan()
+        }
+        let target = PromptViewModel.ArchivedTabMutationTarget(
+            stashedTabID: selected.id,
+            tabID: selected.tab.id
+        )
+
+        let deleteTask = Task {
+            await fixture.prompt.deleteComposeAndStashedTabs(
+                composeTabIDs: [],
+                archivedTargets: [target]
+            )
+        }
+        let cascadeStarted = await gate.waitUntilStarted()
+        XCTAssertTrue(cascadeStarted)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let workspaceIndex = try XCTUnwrap(fixture.manager.workspaces.firstIndex(where: { $0.id == workspaceID }))
+        let selectedIndex = try XCTUnwrap(
+            fixture.manager.workspaces[workspaceIndex].stashedTabs.firstIndex(where: { $0.id == selected.id })
+        )
+        fixture.manager.workspaces[workspaceIndex].stashedTabs[selectedIndex] = StashedTab(
+            id: selected.id,
+            tab: replacementTab
+        )
+        await gate.release()
+        let report = await deleteTask.value
+
+        XCTAssertTrue(report.rejections.contains(where: { $0.reason == .mutationContextChanged }))
+        XCTAssertTrue(fixture.manager.workspaces[workspaceIndex].stashedTabs.contains(where: {
+            $0.id == selected.id && $0.tab.id == replacementTab.id
+        }))
+    }
+
+    func testDeleteRejectsCascadeAddedArchivedIdentityReplacement() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let archived = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        let replacementTab = ComposeTabState(id: UUID(), name: "Replacement descendant")
+        let gate = ComposeRemovalPreflightGate()
+        fixture.prompt.composeTabCascadeResolver = { _, _ in
+            await gate.markStartedAndWaitForRelease()
+            return PromptViewModel.AgentSessionCascadePlan(archivedTargets: [
+                .init(stashedTabID: archived.id, tabID: archived.tab.id)
+            ])
+        }
+
+        let deleteTask = Task { await fixture.prompt.closeComposeTabs(withIDs: [activeTabID]) }
+        let cascadeStarted = await gate.waitUntilStarted()
+        XCTAssertTrue(cascadeStarted)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let workspaceIndex = try XCTUnwrap(fixture.manager.workspaces.firstIndex(where: { $0.id == workspaceID }))
+        let archivedIndex = try XCTUnwrap(
+            fixture.manager.workspaces[workspaceIndex].stashedTabs.firstIndex(where: { $0.id == archived.id })
+        )
+        fixture.manager.workspaces[workspaceIndex].stashedTabs[archivedIndex] = StashedTab(
+            id: archived.id,
+            tab: replacementTab
+        )
+        await gate.release()
+        let report = await deleteTask.value
+
+        XCTAssertTrue(report.rejections.contains(where: { $0.reason == .mutationContextChanged }))
+        XCTAssertTrue(fixture.prompt.currentComposeTabs.contains(where: { $0.id == activeTabID }))
+        XCTAssertTrue(fixture.manager.workspaces[workspaceIndex].stashedTabs.contains(where: {
+            $0.id == archived.id && $0.tab.id == replacementTab.id
+        }))
+    }
+
+    func testBulkCoordinatorAppliesExactMixedDeleteTargets() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let stashed = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        let targets = try AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: XCTUnwrap(fixture.manager.activeWorkspace?.id),
+            activeDeleteTabIDs: [activeTabID],
+            archivedDeleteTargets: [.init(stashedTabID: stashed.id, tabID: stashed.tab.id)],
+            stashTabIDs: [],
+            pinTabIDs: [],
+            unpinTabIDs: []
+        )
+
+        await viewModel.performSidebarBulkAction(.delete, targets: targets, promptManager: fixture.prompt)
+
+        XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == activeTabID }))
+        XCTAssertFalse(fixture.prompt.currentStashedTabs.contains(where: { $0.id == stashed.id }))
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+    }
+
+    func testMixedDeleteDoesNotRetryArchivedTargetRejectedDuringActiveCascade() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let stashed = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        fixture.prompt.composeTabCascadeResolver = { _, _ in
+            PromptViewModel.AgentSessionCascadePlan(archivedTargets: [
+                .init(stashedTabID: stashed.id, tabID: stashed.tab.id)
+            ])
+        }
+        fixture.prompt.stashedTabCascadeResolver = { _ in PromptViewModel.AgentSessionCascadePlan() }
+        let preflightRecorder = RemovalPreflightRecorder()
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, reason, _ in
+            await preflightRecorder.record(reason)
+            if reason == .deleteStashed {
+                return .abort(.init(
+                    stage: .requiredSessionFlush,
+                    tabID: stashed.tab.id,
+                    message: "Injected archived rejection."
+                ))
+            }
+            return .proceed
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+
+        let report = await fixture.prompt.deleteComposeAndStashedTabs(
+            composeTabIDs: [activeTabID],
+            archivedTargets: [.init(stashedTabID: stashed.id, tabID: stashed.tab.id)]
+        )
+
+        let archivedPreflightCount = await preflightRecorder.count(for: .deleteStashed)
+        XCTAssertEqual(archivedPreflightCount, 1)
+        XCTAssertEqual(report.rejections.count(where: { $0.kind == .deleteStashed }), 1)
+        XCTAssertTrue(report.removedComposeTabIDs.contains(activeTabID))
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.contains(where: { $0.id == stashed.id }))
+    }
+
+    func testMixedDeleteKeepsArchivedTargetWhenActiveCascadePreflightRejects() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let stashed = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        fixture.prompt.stashedTabCascadeResolver = { _ in
+            PromptViewModel.AgentSessionCascadePlan(composeTabIDs: [activeTabID])
+        }
+        let preflightRecorder = RemovalPreflightRecorder()
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, reason, _ in
+            await preflightRecorder.record(reason)
+            if reason == .close {
+                return .abort(.init(
+                    stage: .requiredSessionFlush,
+                    tabID: activeTabID,
+                    message: "Injected active rejection."
+                ))
+            }
+            return .proceed
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+
+        let report = await fixture.prompt.deleteComposeAndStashedTabs(
+            composeTabIDs: [],
+            archivedTargets: [.init(stashedTabID: stashed.id, tabID: stashed.tab.id)]
+        )
+
+        let archivedPreflightCount = await preflightRecorder.count(for: .deleteStashed)
+        XCTAssertEqual(archivedPreflightCount, 0)
+        XCTAssertTrue(report.rejections.contains(where: { $0.kind == .close }))
+        XCTAssertTrue(fixture.prompt.currentComposeTabs.contains(where: { $0.id == activeTabID }))
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.contains(where: { $0.id == stashed.id }))
+    }
+
+    func testArchivedDeleteReportPreservesActiveMutationWhenContextExpiresBeforeArchivedPreflight() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let stashed = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        fixture.prompt.stashedTabCascadeResolver = { _ in
+            PromptViewModel.AgentSessionCascadePlan(composeTabIDs: [activeTabID])
+        }
+        let context = MutationContextFlag()
+        let didRemoveToken = fixture.prompt.addComposeTabsDidRemoveListener { _, _, _ in
+            context.isCurrent = false
+            return []
+        }
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+
+        let report = await fixture.prompt.deleteComposeAndStashedTabs(
+            composeTabIDs: [],
+            archivedTargets: [.init(stashedTabID: stashed.id, tabID: stashed.tab.id)],
+            isMutationContextCurrent: { context.isCurrent }
+        )
+
+        XCTAssertEqual(report.removedComposeTabIDs, [activeTabID])
+        XCTAssertTrue(report.rejections.contains(where: { $0.reason == .mutationContextChanged }))
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.contains(where: { $0.id == stashed.id }))
+    }
+
+    func testArchivedDeleteRejectsMissingTargetWithoutPartialMutation() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let target = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+
+        let report = await fixture.prompt.deleteStashedTabs(withIDs: [target.id, UUID()])
+
+        XCTAssertTrue(report.rejections.contains(where: { $0.reason == .mutationContextChanged }))
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.contains(where: { $0.id == target.id }))
+    }
+
+    func testArchivedDeletePreservesConcurrentUnrelatedStashedMutation() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let target = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        let unrelated = StashedTab(tab: ComposeTabState(id: UUID(), name: "Concurrent archive"))
+        let gate = ComposeRemovalPreflightGate()
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, reason, _ in
+            if reason == .deleteStashed {
+                await gate.markStartedAndWaitForRelease()
+            }
+            return .proceed
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+
+        let deleteTask = Task { await fixture.prompt.deleteStashedTabs(withIDs: [target.id]) }
+        let preflightStarted = await gate.waitUntilStarted()
+        XCTAssertTrue(preflightStarted)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let workspaceIndex = try XCTUnwrap(fixture.manager.workspaces.firstIndex(where: { $0.id == workspaceID }))
+        fixture.manager.workspaces[workspaceIndex].stashedTabs.append(unrelated)
+        await gate.release()
+        let report = await deleteTask.value
+
+        XCTAssertEqual(report.removedStashedTabIDs, [target.id])
+        XCTAssertTrue(report.rejections.isEmpty)
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.contains(where: { $0.id == unrelated.id }))
+    }
+
+    func testArchivedOnlyWorkspaceUnavailableUsesArchivedRejection() async {
+        let fixture = makeFixture(initialTabCount: 2)
+        fixture.manager.activeWorkspace = nil
+
+        let report = await fixture.prompt.deleteStashedTabs(withIDs: [UUID()])
+
+        XCTAssertEqual(report.rejections.map(\.kind), [.deleteStashed])
+    }
+
+    func testBulkActionRejectsTargetsCapturedFromPreviousWorkspace() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let sourceWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let tabID = try XCTUnwrap(sourceWorkspace.composeTabs.dropFirst().first?.id)
+        let destinationWorkspace = WorkspaceModel(
+            name: "Destination",
+            repoPaths: sourceWorkspace.repoPaths,
+            ephemeralFlag: true,
+            composeTabs: sourceWorkspace.composeTabs,
+            activeComposeTabID: sourceWorkspace.activeComposeTabID,
+            stashedTabs: sourceWorkspace.stashedTabs
+        )
+        fixture.manager.workspaces.append(destinationWorkspace)
+        fixture.manager.activeWorkspace = destinationWorkspace
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: sourceWorkspace.id,
+            activeDeleteTabIDs: [tabID],
+            archivedDeleteTargets: [],
+            stashTabIDs: [],
+            pinTabIDs: [tabID],
+            unpinTabIDs: []
+        )
+
+        await viewModel.performSidebarBulkAction(.pin, targets: targets, promptManager: fixture.prompt)
+
+        XCTAssertFalse(fixture.manager.activeWorkspace?.composeTabs.first(where: { $0.id == tabID })?.isPinned == true)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+    }
+
+    func testBulkNoticeReportsCleanupFailureAndRejectedGroup() {
+        let fixture = makeFixture(initialTabCount: 2)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let tabID = UUID()
+        let report = PromptViewModel.ComposeTabMutationReport(
+            removedComposeTabIDs: [tabID],
+            rejections: [.init(
+                kind: .deleteStashed,
+                reason: .requiredSessionPreflight,
+                tabID: UUID(),
+                message: "Required persistence failed."
+            )],
+            cleanupIssues: [.init(tabID: tabID, reason: .close, message: "Cleanup failed.")]
+        )
+
+        let notice = viewModel.sidebarBulkActionNotice(for: report, action: .delete)
+
+        XCTAssertEqual(notice?.severity, .error)
+        XCTAssertTrue(notice?.message.contains("cleanup failed for 1") == true)
+        XCTAssertTrue(notice?.message.contains("selected or related chats") == true)
     }
 
     func testPostRemovalClearsOnlyRemovedTabTranscriptRefreshSignature() async throws {
@@ -694,4 +1103,47 @@ private final class ComposeAdmissionFakeCodexController: CodexSessionControllerT
     func cancelCurrentTurn() async {}
     func shutdown() async {}
     func respondToServerRequest(id _: CodexAppServerRequestID, result _: [String: Any]) async {}
+}
+
+@MainActor
+private final class MutationContextFlag {
+    var isCurrent = true
+}
+
+private actor RemovalPreflightRecorder {
+    private var reasons: [PromptViewModel.ComposeTabRemovalReason] = []
+
+    func record(_ reason: PromptViewModel.ComposeTabRemovalReason) {
+        reasons.append(reason)
+    }
+
+    func count(for reason: PromptViewModel.ComposeTabRemovalReason) -> Int {
+        reasons.count { $0 == reason }
+    }
+}
+
+private actor ComposeRemovalPreflightGate {
+    private var started = false
+    private var released = false
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func markStartedAndWaitForRelease() async {
+        started = true
+        guard !released else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitUntilStarted() async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while !started, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return started
+    }
+
+    func release() {
+        released = true
+        releaseWaiters.forEach { $0.resume() }
+        releaseWaiters.removeAll()
+    }
 }

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -406,6 +406,102 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         }))
     }
 
+    func testParentDeleteIncludesChildPausedAfterDurableAdmission() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let parentTab = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first)
+        let parentSessionID = try XCTUnwrap(parentTab.activeAgentSessionID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let admissionGate = ComposeRemovalPreflightGate()
+        viewModel.test_setAfterDurableChildTabCreation {
+            await admissionGate.markStartedAndWaitForRelease()
+        }
+
+        let admissionTask = Task {
+            try await viewModel.mcpResolveOrCreateSessionTarget(
+                tabID: nil,
+                sessionID: nil,
+                createIfNeeded: true,
+                sessionName: "Paused child",
+                parentSessionID: parentSessionID
+            )
+        }
+        let admissionPaused = await admissionGate.waitUntilStarted()
+        XCTAssertTrue(admissionPaused)
+        let childTabID = try XCTUnwrap(
+            fixture.manager.activeWorkspace?.composeTabs.first(where: { $0.id != parentTab.id && $0.name == "Paused child" })?.id
+        )
+
+        let report = await fixture.prompt.deleteComposeAndStashedTabs(
+            composeTabIDs: [parentTab.id],
+            archivedTargets: []
+        )
+        await admissionGate.release()
+
+        XCTAssertTrue(report.removedComposeTabIDs.contains(parentTab.id))
+        XCTAssertTrue(report.removedComposeTabIDs.contains(childTabID))
+        XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == parentTab.id || $0.id == childTabID }))
+        do {
+            _ = try await admissionTask.value
+            XCTFail("Expected paused child admission to reject after cascade deletion")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("removed before admission completed"))
+        }
+    }
+
+    func testArchivedDeleteRejectsChildAdmittedDuringRequiredPersistence() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let archived = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        let parentSessionID = try XCTUnwrap(archived.tab.activeAgentSessionID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let preflightGate = ComposeRemovalPreflightGate()
+        let admissionGate = ComposeRemovalPreflightGate()
+        viewModel.test_setAfterDurableChildTabCreation {
+            await admissionGate.markStartedAndWaitForRelease()
+        }
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, reason, _ in
+            if reason == .deleteStashed {
+                await preflightGate.markStartedAndWaitForRelease()
+            }
+            return .proceed
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+        let target = PromptViewModel.ArchivedTabMutationTarget(
+            stashedTabID: archived.id,
+            tabID: archived.tab.id
+        )
+
+        let deleteTask = Task {
+            await fixture.prompt.deleteComposeAndStashedTabs(
+                composeTabIDs: [],
+                archivedTargets: [target]
+            )
+        }
+        let preflightStarted = await preflightGate.waitUntilStarted()
+        XCTAssertTrue(preflightStarted)
+        let admissionTask = Task {
+            try await viewModel.mcpResolveOrCreateSessionTarget(
+                tabID: nil,
+                sessionID: nil,
+                createIfNeeded: true,
+                sessionName: "Late archived child",
+                parentSessionID: parentSessionID
+            )
+        }
+        let admissionPaused = await admissionGate.waitUntilStarted()
+        XCTAssertTrue(admissionPaused)
+        let childTabID = try XCTUnwrap(
+            fixture.manager.activeWorkspace?.composeTabs.first(where: { $0.name == "Late archived child" })?.id
+        )
+        await preflightGate.release()
+        let report = await deleteTask.value
+        await admissionGate.release()
+        _ = try await admissionTask.value
+
+        XCTAssertTrue(report.rejections.contains(where: { $0.reason == .mutationContextChanged }))
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.contains(where: { $0.id == archived.id }))
+        XCTAssertTrue(fixture.prompt.currentComposeTabs.contains(where: { $0.id == childTabID }))
+    }
+
     func testDeleteRejectsCascadeAddedArchivedIdentityReplacement() async throws {
         let fixture = makeFixture(initialTabCount: 2)
         let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
@@ -474,6 +570,11 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             ])
         }
         fixture.prompt.stashedTabCascadeResolver = { _ in PromptViewModel.AgentSessionCascadePlan() }
+        fixture.prompt.agentSessionCascadeSnapshotResolver = { _, _, _ in
+            PromptViewModel.AgentSessionCascadePlan(archivedTargets: [
+                .init(stashedTabID: stashed.id, tabID: stashed.tab.id)
+            ])
+        }
         let preflightRecorder = RemovalPreflightRecorder()
         let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, reason, _ in
             await preflightRecorder.record(reason)
@@ -507,6 +608,9 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         fixture.prompt.stashedTabCascadeResolver = { _ in
             PromptViewModel.AgentSessionCascadePlan(composeTabIDs: [activeTabID])
         }
+        fixture.prompt.agentSessionCascadeSnapshotResolver = { _, _, _ in
+            PromptViewModel.AgentSessionCascadePlan(composeTabIDs: [activeTabID])
+        }
         let preflightRecorder = RemovalPreflightRecorder()
         let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, reason, _ in
             await preflightRecorder.record(reason)
@@ -538,6 +642,9 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
         let stashed = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
         fixture.prompt.stashedTabCascadeResolver = { _ in
+            PromptViewModel.AgentSessionCascadePlan(composeTabIDs: [activeTabID])
+        }
+        fixture.prompt.agentSessionCascadeSnapshotResolver = { _, _, _ in
             PromptViewModel.AgentSessionCascadePlan(composeTabIDs: [activeTabID])
         }
         let context = MutationContextFlag()


### PR DESCRIPTION
This adds macOS Finder-style multi-selection to Agent Mode chats and provides bulk Pin, Unpin, Stash, and Delete actions across active and archived chats.  Use case: painless cleanup of the many chats that get created over time, especially via MCP and subagent runs.

Multi-selection follows established macOS gestures: **Command-click** toggles an individual chat, while **Shift-click** selects a contiguous range from the current anchor.  Selection circles and the bulk-action panel appear only after entering selection mode, preserving the full row width during normal browsing.

## Summary

- Add Command-click selection toggling and Shift-click range selection
- Show selection controls only while multi-selection is active
- Add bulk Pin, Unpin, Stash, and Delete actions with affected-chat counts
- Support active and archived chats in one selection
- Add visible-row Select All and Escape/Cancel handling
- Keep selections and in-flight actions scoped to their owning workspace
- Protect replacements and recreated chats during asynchronous cleanup

## Implementation Notes

- `PromptViewModel` remains the canonical mutation authority
- Archived mutations use both archive and chat identity to reject stale targets
- Bulk requests fail closed instead of silently applying to a surviving subset
- Related sub-agent chats are included through the existing cascade rules
- The bulk-action panel uses the sidebar’s scaled typography, compact action chips, and accessibility labels

## Review Approach

- The patch received repeated maintainability and integration reviews covering selection semantics, workspace ownership, mutation exactness, async cleanup, replacement races, accessibility, and projection performance
- Review findings were fixed with focused regressions

## Validation

Passed locally:

- `make dev-test FILTER=RepoPromptTests.BackgroundComposeTabAdmissionTests` — 32 tests
- `make dev-test FILTER=RepoPromptTests.AgentModeRunServiceLifecycleTests` — 47 tests
- `make dev-test FILTER=RepoPromptTests.AgentModeViewModelInactiveRefreshTests` — 42 tests
- `make dev-test FILTER=RepoPromptTests.AgentSessionSidebarUIStoreTests` — 9 tests
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make guardrails`
- Outgoing-range secret scan

The full root suite was also run. Remaining failures were in unrelated Agent-run, Codex liveness, Context Builder, headless transport, worktree, and seeded-root suites.

All added features were also manually validated e2e.

## Screenshots

### Before cmd+click or shift+click gesture:
<p align="center">
<img width="382" height="538" alt="Screenshot 2026-08-12 at 8 18 46 AM" src="https://github.com/user-attachments/assets/ec311da2-048a-4b34-bd13-c56b977bac5a" />
</p>

### After cmd-click or shift-click gesture:
<p align="center">
<img width="376" height="616" alt="Screenshot 2026-08-12 at 8 18 56 AM" src="https://github.com/user-attachments/assets/e459edd4-214f-4e42-b9d2-8cf7c2e19add" />

<img width="497" height="618" alt="Screenshot 2026-08-12 at 8 19 08 AM" src="https://github.com/user-attachments/assets/89830cb5-8dfc-4596-8c7f-7ead1df6dedb" />

<img width="431" height="590" alt="Screenshot 2026-08-12 at 8 20 06 AM" src="https://github.com/user-attachments/assets/f06e9a98-9591-4b67-9cc1-05c41b3ae165" />
</p>