### PR TITLE
chore(allowlist): add dlroW0lleH to contributor allowlist

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -223,6 +223,7 @@ DipankarJDutta pr
 Dishage pr
 dlbroadfoot pr
 dlcen pr
+dlroW0lleH pr
 dnnaji pr
 dnszero pr
 doetschnet pr


### PR DESCRIPTION
### Summary 

I am adding my GitHub username(`dlroW0lleH`) to the contributor allowlist file. Because I am not yet on the approved list, my PRs and issues would normally be automatically closed by the repository bot. So, I am opening this PR to register my username and can contribute to this project in the future without any blockers.