### PR TITLE
Fix bind_context active workspace routing

### DIFF
--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -589,7 +589,7 @@ extension OracleViewModel {
             return loaded
         }
         guard let tabID,
-              let candidate = workspaceManager.bindingCandidate(forContextID: tabID),
+              let candidate = workspaceManager.storedBindingCandidate(forContextID: tabID),
               let workspace = workspaceManager.workspaces.first(where: { $0.id == candidate.workspaceID }),
               let persisted = try await chatData.findSession(for: workspace, id: rawID, composeTabID: tabID)
         else {

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -4879,6 +4879,19 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     func bindingCandidate(forContextID id: UUID) -> ComposeTabBindingCandidate? {
+        guard let workspace = activeWorkspace,
+              let tab = workspace.composeTabs.first(where: { $0.id == id })
+        else { return nil }
+        return ComposeTabBindingCandidate(
+            tabID: tab.id,
+            workspaceID: workspace.id,
+            workspaceName: workspace.name,
+            isActiveInWorkspace: workspace.activeComposeTabID == tab.id,
+            repoPaths: workspace.repoPaths
+        )
+    }
+
+    func storedBindingCandidate(forContextID id: UUID) -> ComposeTabBindingCandidate? {
         for workspace in workspaces {
             guard let tab = workspace.composeTabs.first(where: { $0.id == id }) else { continue }
             return ComposeTabBindingCandidate(

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -6505,7 +6505,7 @@ actor ServerNetworkManager {
             collectMatchesForContextID: { contextID in
                 await MainActor.run {
                     WindowStatesManager.shared.allWindows.compactMap { windowState in
-                        guard let candidate = windowState.workspaceManager.bindingCandidate(forContextID: contextID) else {
+                        guard let candidate = windowState.workspaceManager.storedBindingCandidate(forContextID: contextID) else {
                             return nil
                         }
                         return MCPContextBindingMatch(

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
@@ -1672,25 +1672,43 @@ final class WindowRoutingService: Service {
 
         guard !matches.isEmpty else {
             if let windowID {
-                throw MCPError.invalidParams("Window \(windowID) does not host context_id '\(contextID.uuidString)'.")
+                throw MCPError.invalidParams("Window \(windowID) does not actively show context_id '\(contextID.uuidString)'. Bind with working_dirs for the desired workspace's absolute roots, or use bind_context op=list to discover active context_id values.")
             }
-            throw MCPError.invalidParams("No RepoPrompt context matches context_id '\(contextID.uuidString)'. Use bind_context op=list to discover available context_id values.")
+            throw MCPError.invalidParams("No open RepoPrompt window actively shows context_id '\(contextID.uuidString)'. Bind with working_dirs for the desired workspace's absolute roots, or use bind_context op=list to discover active context_id values.")
         }
 
-        if matches.count == 1 {
-            return matches[0]
+        guard let targetWindowID = Self.preferredContextIDBindWindowID(
+            matchingWindowIDs: matches.map(\.windowID),
+            connectionPreferredWindowID: connectionPreferredWindowID
+        ), let target = matches.first(where: { $0.windowID == targetWindowID }) else {
+            throw MCPError.internalError("Failed to select an active context_id bind target.")
         }
+        return target
+    }
 
-        // Same logical tab visible in multiple windows.
-        // Prefer the connection's current window to avoid silently rebinding.
+    private nonisolated static func preferredContextIDBindWindowID(
+        matchingWindowIDs: [Int],
+        connectionPreferredWindowID: Int?
+    ) -> Int? {
+        guard !matchingWindowIDs.isEmpty else { return nil }
         if let connectionPreferredWindowID,
-           let preferred = matches.first(where: { $0.windowID == connectionPreferredWindowID })
+           matchingWindowIDs.contains(connectionPreferredWindowID)
         {
-            return preferred
+            return connectionPreferredWindowID
         }
+        return matchingWindowIDs.min()
+    }
 
-        // Fall back to deterministic selection (lowest window ID).
-        return matches.sorted(by: { $0.windowID < $1.windowID })[0]
+    func test_resolveContextIDBindTarget(
+        contextID: UUID,
+        connectionPreferredWindowID: Int?
+    ) throws -> (windowID: Int, workspaceID: UUID, tabID: UUID, repoPaths: [String]) {
+        let target = try resolveContextIDBindTarget(
+            contextID: contextID,
+            windowID: nil,
+            connectionPreferredWindowID: connectionPreferredWindowID
+        )
+        return (target.windowID, target.workspaceID, target.tabID, target.repoPaths)
     }
 
     private func resolveWorkingDirsBindTarget(

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -15,17 +15,12 @@ import XCTest
     final class ContextBuilderWorktreeInheritanceTests: XCTestCase {
         func testExplicitInactiveWorkspaceContextBuilderUsesTargetAuthorityWithoutVisibleProjection() async throws {
             try await runInactiveWorkspaceAuthorityScenario(
-                bindTargetFirst: false,
                 validationStartsIncomplete: true
             )
         }
 
-        func testBoundInactiveWorkspaceContextBuilderUsesTargetAuthorityWithoutVisibleProjection() async throws {
-            try await runInactiveWorkspaceAuthorityScenario(bindTargetFirst: true)
-        }
-
         func testInactiveWorkspaceContextBuilderSurvivesVisibleTabSwitchAndCancelsWithoutLateProjection() async throws {
-            try await runInactiveWorkspaceAuthorityScenario(bindTargetFirst: false, cancelDuringRun: true)
+            try await runInactiveWorkspaceAuthorityScenario(cancelDuringRun: true)
         }
 
         func testInactiveWorkspaceContextBuilderFailsClosedWhenTargetProjectionIsUnavailable() async throws {
@@ -1863,7 +1858,6 @@ import XCTest
         }
 
         private func runInactiveWorkspaceAuthorityScenario(
-            bindTargetFirst: Bool,
             cancelDuringRun: Bool = false,
             validationStartsIncomplete: Bool = false
         ) async throws {
@@ -2063,20 +2057,12 @@ import XCTest
                     )
 
                     let endpoint = try fixture.endpointA()
-                    if bindTargetFirst {
-                        _ = try await endpoint.callTool(
-                            name: "bind_context",
-                            arguments: ["op": "bind", "context_id": fixture.contextB.tabID.uuidString]
-                        )
-                    }
-                    var arguments: [String: Any] = [
+                    let arguments: [String: Any] = [
                         "instructions": "Inspect workspace B only.",
                         "response_type": "plan",
-                        "_rawJSON": true
+                        "_rawJSON": true,
+                        "context_id": fixture.contextB.tabID.uuidString
                     ]
-                    if !bindTargetFirst {
-                        arguments["context_id"] = fixture.contextB.tabID.uuidString
-                    }
                     var removedTargetSnapshot: ComposeTabState?
                     if let gate {
                         let request = Task {

--- a/Tests/RepoPromptTests/MCP/Control/BindContextRoutingRecoveryTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/BindContextRoutingRecoveryTests.swift
@@ -4,6 +4,101 @@ import MCP
 import XCTest
 
 final class BindContextRoutingRecoveryTests: XCTestCase {
+    @MainActor
+    func testContextIDBindIgnoresStaleAffinityToInactiveSavedWorkspace() async throws {
+        let contextID = UUID()
+        let target = workspace(name: "NickClaw", root: "/tmp/nickclaw", contextID: contextID)
+        let unrelated = workspace(name: "TTA", root: "/tmp/tta", contextID: UUID())
+        let staleWindow = try await makeWindow(activeWorkspace: unrelated, savedWorkspaces: [target])
+        let targetWindow = try await makeWindow(activeWorkspace: target)
+        let service = installWindows([staleWindow, targetWindow])
+        XCTAssertEqual(staleWindow.workspaceManager.activeWorkspaceID, unrelated.id)
+        XCTAssertNotNil(staleWindow.workspaceManager.composeTab(for: .init(
+            workspaceID: target.id,
+            tabID: contextID
+        )))
+
+        let resolved = try service.test_resolveContextIDBindTarget(
+            contextID: contextID,
+            connectionPreferredWindowID: staleWindow.windowID
+        )
+
+        XCTAssertEqual(resolved.windowID, targetWindow.windowID)
+        XCTAssertEqual(resolved.workspaceID, target.id)
+        XCTAssertEqual(resolved.repoPaths, target.repoPaths)
+    }
+
+    @MainActor
+    func testContextIDBindLowestWindowFallbackExcludesInactiveSavedWorkspace() async throws {
+        let contextID = UUID()
+        let target = workspace(name: "NickClaw", root: "/tmp/nickclaw", contextID: contextID)
+        let unrelated = workspace(name: "TTA", root: "/tmp/tta", contextID: UUID())
+        let staleWindow = try await makeWindow(activeWorkspace: unrelated, savedWorkspaces: [target])
+        let targetWindow = try await makeWindow(activeWorkspace: target)
+        let service = installWindows([staleWindow, targetWindow])
+        XCTAssertEqual(staleWindow.workspaceManager.activeWorkspaceID, unrelated.id)
+        XCTAssertNotNil(staleWindow.workspaceManager.composeTab(for: .init(
+            workspaceID: target.id,
+            tabID: contextID
+        )))
+
+        let resolved = try service.test_resolveContextIDBindTarget(
+            contextID: contextID,
+            connectionPreferredWindowID: nil
+        )
+
+        XCTAssertEqual(resolved.windowID, targetWindow.windowID)
+    }
+
+    @MainActor
+    func testContextIDBindPreservesActiveSameWorkspaceMultiWindowRouting() async throws {
+        let contextID = UUID()
+        let target = workspace(name: "Shared", root: "/tmp/shared", contextID: contextID)
+        let firstWindow = try await makeWindow(activeWorkspace: target)
+        let secondWindow = try await makeWindow(activeWorkspace: target)
+        let service = installWindows([firstWindow, secondWindow])
+
+        let preferred = try service.test_resolveContextIDBindTarget(
+            contextID: contextID,
+            connectionPreferredWindowID: secondWindow.windowID
+        )
+        XCTAssertEqual(preferred.windowID, secondWindow.windowID)
+        XCTAssertEqual(preferred.workspaceID, target.id)
+        XCTAssertEqual(preferred.tabID, contextID)
+
+        let lowest = try service.test_resolveContextIDBindTarget(
+            contextID: contextID,
+            connectionPreferredWindowID: nil
+        )
+        XCTAssertEqual(
+            lowest.windowID,
+            min(firstWindow.windowID, secondWindow.windowID)
+        )
+    }
+
+    @MainActor
+    func testContextIDBindFailsClosedWhenContextExistsOnlyInInactiveWorkspace() async throws {
+        let contextID = UUID()
+        let target = workspace(name: "NickClaw", root: "/tmp/nickclaw", contextID: contextID)
+        let unrelated = workspace(name: "TTA", root: "/tmp/tta", contextID: UUID())
+        let staleWindow = try await makeWindow(activeWorkspace: unrelated, savedWorkspaces: [target])
+        let service = installWindows([staleWindow])
+        XCTAssertEqual(staleWindow.workspaceManager.activeWorkspaceID, unrelated.id)
+        XCTAssertNotNil(staleWindow.workspaceManager.composeTab(for: .init(
+            workspaceID: target.id,
+            tabID: contextID
+        )))
+
+        XCTAssertThrowsError(try service.test_resolveContextIDBindTarget(
+            contextID: contextID,
+            connectionPreferredWindowID: staleWindow.windowID
+        )) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("No open RepoPrompt window actively shows context_id"), message)
+            XCTAssertTrue(message.contains("working_dirs"), message)
+        }
+    }
+
     func testBindContextParsesWorkingDirsAndPrefersSelectedWindow() throws {
         let projectSourcePath = "/Users/repoprompt-test/project/Sources"
         let request = try WindowRoutingService.parseBindContextRequest([
@@ -89,5 +184,48 @@ final class BindContextRoutingRecoveryTests: XCTestCase {
         let root = try RepoRoot.url()
         let url = root.appendingPathComponent("Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift")
         return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func workspace(name: String, root: String, contextID: UUID) -> WorkspaceModel {
+        WorkspaceModel(
+            name: name,
+            repoPaths: [root],
+            composeTabs: [ComposeTabState(id: contextID, name: "Context")],
+            activeComposeTabID: contextID
+        )
+    }
+
+    @MainActor
+    private func makeWindow(
+        activeWorkspace: WorkspaceModel,
+        savedWorkspaces: [WorkspaceModel] = []
+    ) async throws -> WindowState {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        window.workspaceManager.workspaces = [activeWorkspace] + savedWorkspaces
+        let result = await window.workspaceManager.switchWorkspace(
+            to: activeWorkspace,
+            saveState: false,
+            reason: "bindContextRoutingRecoveryTest"
+        )
+        guard result.didSwitch else {
+            throw XCTSkip("Could not activate test workspace")
+        }
+        return window
+    }
+
+    @MainActor
+    private func installWindows(_ windows: [WindowState]) -> WindowRoutingService {
+        let previousWindows = WindowStatesManager.shared.allWindows
+        WindowStatesManager.shared.allWindows = windows
+        addTeardownBlock { @MainActor in
+            WindowStatesManager.shared.allWindows = previousWindows
+        }
+        return WindowRoutingService(
+            windowStates: WindowStatesManager.shared,
+            networkMgr: ServerNetworkManager.shared
+        )
     }
 }

--- a/Tests/RepoPromptTests/MCP/Control/MCPProtectedMutationInvocationIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPProtectedMutationInvocationIntegrationTests.swift
@@ -638,6 +638,18 @@ import XCTest
             _ endpoint: PersistentMCPTestEndpoint,
             to context: PersistentMCPTestContext
         ) async throws {
+            let workspace = try XCTUnwrap(
+                context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
+            )
+            await context.window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "MCPProtectedMutationInvocationIntegrationTests"
+            )
+            context.window.promptManager.loadComposeTabsFromWorkspace(
+                workspace,
+                syncPromptText: true
+            )
             let response = try await endpoint.callTool(
                 name: "bind_context",
                 arguments: ["op": "bind", "context_id": context.tabID.uuidString]

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -1478,6 +1478,7 @@ import XCTest
                 }
                 do {
                     let endpoint = try fixture.endpointA()
+                    try await Self.activateWorkspace(for: fixture.contextA)
                     _ = try await endpoint.callTool(
                         name: "bind_context",
                         arguments: [
@@ -1645,6 +1646,7 @@ import XCTest
 
                 do {
                     let endpoint = try fixture.endpointA()
+                    try await Self.activateWorkspace(for: fixture.contextA)
                     _ = try await endpoint.callTool(
                         name: "bind_context",
                         arguments: [
@@ -1785,6 +1787,7 @@ import XCTest
                 }
                 do {
                     let endpoint = try fixture.endpointA()
+                    try await Self.activateWorkspace(for: fixture.contextA)
                     _ = try await endpoint.callTool(
                         name: "bind_context",
                         arguments: [
@@ -1913,6 +1916,7 @@ import XCTest
                     )
                     endpoint = createdEndpoint
                     try await fixture.registerDomainWorkspace(fixture.contextA)
+                    try await Self.activateWorkspace(for: fixture.contextA)
                     let bindResponse = try await createdEndpoint.callTool(
                         name: "bind_context",
                         arguments: ["op": "bind", "context_id": fixture.contextA.tabID.uuidString]
@@ -2666,6 +2670,21 @@ import XCTest
                     throw error
                 }
             }
+        }
+
+        private static func activateWorkspace(for context: PersistentMCPTestContext) async throws {
+            let workspace = try XCTUnwrap(
+                context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
+            )
+            await context.window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "MCPToolExecutionWatchdogIntegrationTests"
+            )
+            context.window.promptManager.loadComposeTabsFromWorkspace(
+                workspace,
+                syncPromptText: true
+            )
         }
 
         private static func waitUntil(

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -279,16 +279,7 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             let readEndpoint = try fixture.endpointA()
             let freshEndpoint = try fixture.endpointARead()
             let context = fixture.contextA
-            let workspace = try XCTUnwrap(
-                context.window.workspaceManager.workspaces.first(where: { $0.id == context.workspaceID })
-            )
-            await context.window.workspaceManager.switchWorkspace(
-                to: workspace,
-                saveState: false,
-                reason: "readSelectionPersistenceCheckpoint"
-            )
-            context.window.promptManager.loadComposeTabsFromWorkspace(workspace, syncPromptText: true)
-            try await Self.bind(readEndpoint, to: context.tabID)
+            try await Self.bind(readEndpoint, to: context)
             _ = try await readEndpoint.callTool(
                 name: MCPWindowToolName.manageSelection,
                 arguments: ["op": "clear"]
@@ -343,7 +334,7 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             await fixture.networkManager.debugRemoveConnection(readEndpoint.connectionID)
             context.window.mcpServer.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
 
-            try await Self.bind(freshEndpoint, to: context.tabID)
+            try await Self.bind(freshEndpoint, to: context)
             let freshSelectionResponse = try await freshEndpoint.callTool(
                 name: MCPWindowToolName.manageSelection,
                 arguments: [
@@ -387,7 +378,7 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 try await endpoints.append(fixture.makeAdditionalEndpoint(label: "shared-search-\(index)"))
             }
             for endpoint in endpoints {
-                try await Self.bind(endpoint, to: fixture.contextA.tabID)
+                try await Self.bind(endpoint, to: fixture.contextA)
             }
 
             let searchFiles = fixture.contextA.searchFileURLs
@@ -649,8 +640,8 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 excludes: fixture.contextA.sentinel
             )
 
-            try await Self.bind(endpointA, to: fixture.contextA.tabID)
-            try await Self.bind(endpointB, to: fixture.contextB.tabID)
+            try await Self.bind(endpointA, to: fixture.contextA)
+            try await Self.bind(endpointB, to: fixture.contextB)
             fixture.assertStableBindings()
 
             let baselineA = await fixture.snapshot(endpointA, context: fixture.contextA)
@@ -733,9 +724,9 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             let endpointAOverflow = try fixture.endpointAOverflowSearch()
             let endpointARead = try fixture.endpointARead()
             let endpointB = try fixture.endpointB()
-            try await Self.bind(endpointAQueued, to: fixture.contextA.tabID)
-            try await Self.bind(endpointAOverflow, to: fixture.contextA.tabID)
-            try await Self.bind(endpointARead, to: fixture.contextA.tabID)
+            try await Self.bind(endpointAQueued, to: fixture.contextA)
+            try await Self.bind(endpointAOverflow, to: fixture.contextA)
+            try await Self.bind(endpointARead, to: fixture.contextA)
             fixture.assertStableBindings(includeAdditionalContextAEndpoints: true)
 
             let heldStore = fixture.contextA.window.workspaceFileContextStore
@@ -1266,12 +1257,24 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             }
         }
 
-        static func bind(_ endpoint: PersistentMCPTestEndpoint, to tabID: UUID) async throws {
+        static func bind(_ endpoint: PersistentMCPTestEndpoint, to context: PersistentMCPTestContext) async throws {
+            let workspace = try XCTUnwrap(
+                context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
+            )
+            await context.window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "PersistentMCPDistinctConnectionConcurrencyTests"
+            )
+            context.window.promptManager.loadComposeTabsFromWorkspace(
+                workspace,
+                syncPromptText: true
+            )
             let response = try await endpoint.callTool(
                 name: "bind_context",
                 arguments: [
                     "op": "bind",
-                    "context_id": tabID.uuidString
+                    "context_id": context.tabID.uuidString
                 ]
             )
             _ = try toolText(from: response)

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1807,6 +1807,15 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             ]
             configuredWorkspace.activeComposeTabID = tabID
             window.workspaceManager.workspaces.append(configuredWorkspace)
+            await window.workspaceManager.switchWorkspace(
+                to: configuredWorkspace,
+                saveState: false,
+                reason: "PersistentMCPTestFixture"
+            )
+            window.promptManager.loadComposeTabsFromWorkspace(
+                configuredWorkspace,
+                syncPromptText: true
+            )
             let rootRecord = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
                 in: window,
                 path: rootURL.path

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1807,15 +1807,6 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             ]
             configuredWorkspace.activeComposeTabID = tabID
             window.workspaceManager.workspaces.append(configuredWorkspace)
-            await window.workspaceManager.switchWorkspace(
-                to: configuredWorkspace,
-                saveState: false,
-                reason: "PersistentMCPTestFixture"
-            )
-            window.promptManager.loadComposeTabsFromWorkspace(
-                configuredWorkspace,
-                syncPromptText: true
-            )
             let rootRecord = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
                 in: window,
                 path: rootURL.path


### PR DESCRIPTION
## Summary

- restrict context_id bind candidates to contexts in the workspace actively shown by each window
- fail closed with actionable working_dirs guidance when no open window actively hosts the context
- preserve intentional stored/inactive lookup for internal routing and Oracle continuation
- add two-window regressions for stale affinity, lowest-window fallback, active matches, and same-workspace multi-window routing
- align protected-mutation integration setup so context_id binding uses a genuinely active synthetic workspace

## Validation

- RepoPrompt CE read-only review: no blockers
- contribution commit and push preflights: passed
- strict SwiftFormat/SwiftLint: passed
- RepoPrompt product build: passed
- BindContextRoutingRecoveryTests: 10 passed
- TabContextRoutingTests: 62 passed
- MCPProtectedMutationInvocationIntegrationTests: 4 passed
- PersistentMCPDistinctConnectionConcurrencyTests: 9 passed
- ContextBuilderWorktreeInheritanceTests: 8 passed
- targeted workspace-index timeout case: passed
- targeted auth-recovery flaky case: passed

The aggregate local pr-ready suite reached its one-hour timeout due suite-order/global-state failures. The routing-related failures found by the first run were corrected; the remaining timeout case and known auth-recovery race both pass independently. Hosted exact-head checks remain the final backstop.

## Scope

No locks, serialization, telemetry, retries, or project-specific routing behavior were added. The broad shared-fixture activation attempted during validation was removed in favor of narrow test-local setup.