### PR TITLE
Fix: decode legacy mutation journal status

### DIFF
--- a/Sources/RepoPromptDomainRuntime/DomainMutationJournal.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainMutationJournal.swift
@@ -8,6 +8,29 @@ package enum DomainMutationJournalStatus: String, Codable, Sendable {
     case cancelledBeforeCommit = "cancelled_before_commit"
     case failedBeforeCommit = "failed_before_commit"
     case indeterminateAfterCommit = "indeterminate_after_commit"
+
+    package init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        if rawValue == "failed_before_write" {
+            // Schema-v1 builds emitted this spelling. Delete this alias when v1 documents are no longer accepted;
+            // encoding below rewrites the record with the canonical current spelling.
+            self = .failedBeforeCommit
+            return
+        }
+        guard let status = Self(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Cannot initialize DomainMutationJournalStatus from invalid String value \(rawValue)"
+            )
+        }
+        self = status
+    }
+
+    package func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
 }
 
 package struct DomainMutationJournalRecord: Codable, Sendable {

--- a/Tests/RepoPromptDomainRuntimeTests/DomainProtectedMutationJournalTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainProtectedMutationJournalTests.swift
@@ -4,6 +4,73 @@ import MCP
 import XCTest
 
 final class DomainProtectedMutationJournalTests: XCTestCase {
+    func testFailedBeforeWriteStatusDecodesAndReencodesCanonically() throws {
+        let decoder = JSONDecoder()
+        let status = try decoder.decode(
+            DomainMutationJournalStatus.self,
+            from: Data(#""failed_before_write""#.utf8)
+        )
+
+        XCTAssertEqual(status, .failedBeforeCommit)
+        XCTAssertEqual(
+            String(data: try JSONEncoder().encode(status), encoding: .utf8),
+            #""failed_before_commit""#
+        )
+        XCTAssertThrowsError(
+            try decoder.decode(
+                DomainMutationJournalStatus.self,
+                from: Data(#""unknown_status""#.utf8)
+            )
+        )
+    }
+
+    func testLegacyFailedBeforeWriteJournalRetriesAndRewritesCanonicalStatus() async throws {
+        let fixture = try M4BFixture()
+        let arguments = fixture.arguments(operationID: "legacy-failed-before-write")
+        let failingBinding = fixture.binding { _ in
+            throw DomainMutationPathFenceError.scopeUnavailable
+        }
+
+        await XCTAssertThrowsErrorAsync({
+            try await fixture.invoke(
+                failingBinding,
+                arguments: arguments,
+                requestIdentitySeed: "legacy-failed-before-write-request"
+            )
+        })
+
+        let persistence = fixture.runtime.persistenceCoordinator
+        let persistedCanonicalData = try await persistence.loadProtectedMutationJournalData()
+        let canonicalData = try XCTUnwrap(persistedCanonicalData)
+        let canonicalJSON = try XCTUnwrap(String(data: canonicalData, encoding: .utf8))
+        let legacyJSON = canonicalJSON.replacingOccurrences(
+            of: #""failed_before_commit""#,
+            with: #""failed_before_write""#
+        )
+        XCTAssertNotEqual(legacyJSON, canonicalJSON)
+        try await persistence.compareAndSwapProtectedMutationJournalData(
+            expectedDigest: DomainContentDigest.sha256(canonicalData),
+            data: Data(legacyJSON.utf8)
+        )
+
+        let restarted = try M4BFixture(storage: fixture.storage, root: fixture.root)
+        let retriedBinding = restarted.binding { _ in
+            try await MCPDomainMutationCommitContext.willCommit()
+            return .string("retried")
+        }
+        let result = try await restarted.invoke(
+            retriedBinding,
+            arguments: arguments,
+            requestIdentitySeed: "legacy-failed-before-write-request"
+        )
+
+        XCTAssertEqual(result.stringValue, "retried")
+        let persistedRewrittenData = try await restarted.runtime.persistenceCoordinator.loadProtectedMutationJournalData()
+        let rewrittenData = try XCTUnwrap(persistedRewrittenData)
+        let rewrittenJSON = try XCTUnwrap(String(data: rewrittenData, encoding: .utf8))
+        XCTAssertFalse(rewrittenJSON.contains("failed_before_write"))
+    }
+
     func testInternalMutationKeyReplaysWhilePublicCorrelationIDCanBeReused() async throws {
         let fixture = try M4BFixture()
         let calls = MutationCounter()


### PR DESCRIPTION
An earlier RepoPrompt CE development build could persist protected mutation journal records with the status `failed_before_write`.  Because journal state survives build changes, current stable and Tip builds fail to decode those records, blocking unrelated MCP mutations such as `file_actions` and `apply_edits`.  Example shown in https://discord.com/channels/1262487703744675901/1365796959616630794/1537557255136739471 

This patch restores that schema-v1 read boundary while preserving the current canonical journal state.

## Summary

- Decode `failed_before_write` as the current retryable `failedBeforeCommit` state
- Continue writing only the canonical `failed_before_commit` value
- Keep unknown journal statuses fail-closed
- Cover restart, retry, and on-disk canonical rewrite behavior

## Review Approach

- The patch received focused maintainability reviews and final integration reviews from 5.6-Sol-Pro
- Historical status transitions and adjacent persistence paths were checked to confirm the mapping and scope

## Validation

Passed locally:

- `make dev-test FILTER=DomainProtectedMutationJournalTests` — 13 tests
- `make dev-lint`
- `make guardrails`
- Commit and exact outgoing-range secret scans

The full root suite was also run. Remaining Agent-run and Git-policy failures reproduced on unchanged `main`; all journal-focused tests passed.