### PR TITLE
Support exact secondary-root Agent worktrees

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorktreeRuntimeWorkspaceResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorktreeRuntimeWorkspaceResolver.swift
@@ -1,34 +1,78 @@
 import Foundation
 
+enum AgentWorktreeRuntimeWorkspaceResolutionError: LocalizedError, Equatable {
+    case activeWorkspaceRootsUnavailable
+    case invalidActiveWorkspaceRoot
+    case duplicateActiveWorkspaceRoot(path: String)
+    case emptyLogicalRoot
+    case logicalRootNotInActiveWorkspace(path: String)
+    case duplicateLogicalRoot(path: String)
+    case ambiguousExecutionBinding
+
+    var errorDescription: String? {
+        switch self {
+        case .activeWorkspaceRootsUnavailable:
+            "The active workspace has no roots, so its Agent worktree binding cannot be authorized. Restore the workspace root or unbind the session."
+        case .invalidActiveWorkspaceRoot:
+            "The active workspace contains an invalid root path, so its Agent worktree binding cannot be authorized. Correct the workspace roots or unbind the session."
+        case let .duplicateActiveWorkspaceRoot(path):
+            "The active workspace contains duplicate canonical root '\(path)', so its Agent worktree binding is ambiguous. Remove the duplicate root or unbind the session."
+        case .emptyLogicalRoot:
+            "The Agent worktree binding has no logical root. Rebind the session to a current workspace root."
+        case let .logicalRootNotInActiveWorkspace(path):
+            "The Agent worktree binding targets logical root '\(path)', which is not part of the active workspace. Rebind the session to a current workspace root."
+        case let .duplicateLogicalRoot(path):
+            "The Agent session has duplicate worktree bindings for logical root '\(path)'. Remove the duplicate binding before starting the provider."
+        case .ambiguousExecutionBinding:
+            "The Agent session has multiple secondary worktree bindings but no canonical-primary binding. Bind the canonical primary root or leave only one authorized binding."
+        }
+    }
+}
+
 enum AgentWorktreeRuntimeWorkspaceResolver {
     static func primaryExecutionBinding(
         in bindings: [AgentSessionWorktreeBinding],
-        fallbackWorkspacePath: String?
-    ) -> AgentSessionWorktreeBinding? {
-        guard let firstBinding = bindings.first else {
+        workspaceRootPaths: [String]
+    ) throws -> AgentSessionWorktreeBinding? {
+        guard !bindings.isEmpty else {
             return nil
         }
-        guard bindings.count > 1 else {
-            return firstBinding
+
+        let authorizedRoots = try canonicalWorkspaceRoots(workspaceRootPaths)
+        let canonicalPrimaryPath = authorizedRoots[0]
+        let authorizedRootSet = Set(authorizedRoots)
+        var bindingsByCanonicalRoot: [String: AgentSessionWorktreeBinding] = [:]
+
+        for binding in bindings {
+            guard let logicalRootPath = standardizedWorkspacePath(binding.logicalRootPath) else {
+                throw AgentWorktreeRuntimeWorkspaceResolutionError.emptyLogicalRoot
+            }
+            let canonicalLogicalRoot = GitRepoRootAuthorization.canonicalPath(logicalRootPath)
+            guard authorizedRootSet.contains(canonicalLogicalRoot) else {
+                throw AgentWorktreeRuntimeWorkspaceResolutionError.logicalRootNotInActiveWorkspace(path: logicalRootPath)
+            }
+            guard bindingsByCanonicalRoot.updateValue(binding, forKey: canonicalLogicalRoot) == nil else {
+                throw AgentWorktreeRuntimeWorkspaceResolutionError.duplicateLogicalRoot(path: logicalRootPath)
+            }
         }
-        guard let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath) else {
-            return nil
+
+        if bindings.count == 1 {
+            return bindings[0]
         }
-        let canonicalPrimaryPath = GitRepoRootAuthorization.canonicalPath(primaryWorkspacePath)
-        return bindings.first { binding in
-            standardizedWorkspacePath(binding.logicalRootPath).map(GitRepoRootAuthorization.canonicalPath)
-                == canonicalPrimaryPath
+        guard let primaryBinding = bindingsByCanonicalRoot[canonicalPrimaryPath] else {
+            throw AgentWorktreeRuntimeWorkspaceResolutionError.ambiguousExecutionBinding
         }
+        return primaryBinding
     }
 
     static func effectiveWorkspacePath(
         bindings: [AgentSessionWorktreeBinding],
-        fallbackWorkspacePath: String?
+        workspaceRootPaths: [String]
     ) throws -> String? {
-        let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
-        let binding = primaryExecutionBinding(
+        let primaryWorkspacePath = standardizedWorkspacePath(workspaceRootPaths.first)
+        let binding = try primaryExecutionBinding(
             in: bindings,
-            fallbackWorkspacePath: fallbackWorkspacePath
+            workspaceRootPaths: workspaceRootPaths
         )
 
         guard let binding else {
@@ -44,12 +88,12 @@ enum AgentWorktreeRuntimeWorkspaceResolver {
     /// opaque process-spawn error.
     static func codexRuntimeWorkspacePaths(
         bindings: [AgentSessionWorktreeBinding],
-        fallbackWorkspacePath: String?
+        workspaceRootPaths: [String]
     ) throws -> CodexRuntimeWorkspacePaths {
-        let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
-        let binding = primaryExecutionBinding(
+        let primaryWorkspacePath = standardizedWorkspacePath(workspaceRootPaths.first)
+        let binding = try primaryExecutionBinding(
             in: bindings,
-            fallbackWorkspacePath: fallbackWorkspacePath
+            workspaceRootPaths: workspaceRootPaths
         )
 
         guard let binding else {
@@ -71,6 +115,23 @@ enum AgentWorktreeRuntimeWorkspaceResolver {
     static func validateBindingsAvailable(_ bindings: [AgentSessionWorktreeBinding]) throws {
         for binding in bindings {
             _ = try validatedWorktreeRootPath(for: binding)
+        }
+    }
+
+    private static func canonicalWorkspaceRoots(_ workspaceRootPaths: [String]) throws -> [String] {
+        guard !workspaceRootPaths.isEmpty else {
+            throw AgentWorktreeRuntimeWorkspaceResolutionError.activeWorkspaceRootsUnavailable
+        }
+        var seen: Set<String> = []
+        return try workspaceRootPaths.map { rootPath in
+            guard let standardizedRoot = standardizedWorkspacePath(rootPath) else {
+                throw AgentWorktreeRuntimeWorkspaceResolutionError.invalidActiveWorkspaceRoot
+            }
+            let canonicalRoot = GitRepoRootAuthorization.canonicalPath(standardizedRoot)
+            guard seen.insert(canonicalRoot).inserted else {
+                throw AgentWorktreeRuntimeWorkspaceResolutionError.duplicateActiveWorkspaceRoot(path: standardizedRoot)
+            }
+            return canonicalRoot
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorktreeRuntimeWorkspaceResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorktreeRuntimeWorkspaceResolver.swift
@@ -5,12 +5,20 @@ enum AgentWorktreeRuntimeWorkspaceResolver {
         in bindings: [AgentSessionWorktreeBinding],
         fallbackWorkspacePath: String?
     ) -> AgentSessionWorktreeBinding? {
-        let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
-        return primaryWorkspacePath.flatMap { primaryPath in
-            bindings.first { binding in
-                standardizedWorkspacePath(binding.logicalRootPath) == primaryPath
-            }
-        } ?? (primaryWorkspacePath == nil && bindings.count == 1 ? bindings[0] : nil)
+        guard let firstBinding = bindings.first else {
+            return nil
+        }
+        guard bindings.count > 1 else {
+            return firstBinding
+        }
+        guard let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath) else {
+            return nil
+        }
+        let canonicalPrimaryPath = GitRepoRootAuthorization.canonicalPath(primaryWorkspacePath)
+        return bindings.first { binding in
+            standardizedWorkspacePath(binding.logicalRootPath).map(GitRepoRootAuthorization.canonicalPath)
+                == canonicalPrimaryPath
+        }
     }
 
     static func effectiveWorkspacePath(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -576,6 +576,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     let attachmentStore = AgentAttachmentStore()
     let attachmentWorkspaceDirectoryProvider: () -> URL?
     private let workspacePathProvider: () -> String?
+    private let workspaceRootPathsProvider: () -> [String]
     private let skillCatalog: AgentSkillCatalog
     private let headlessProviderFactory: HeadlessProviderFactory
     private let acpProviderFactory: ACPProviderFactory
@@ -1597,12 +1598,14 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         self.oracleViewModel = oracleViewModel
         self.applyEditsApprovalStore = applyEditsApprovalStore
         self.skillCatalog = skillCatalog ?? AgentSkillCatalog()
-        let codexWorkspacePathProvider = { [weak workspaceManager] in
-            workspaceManager?.activeWorkspace?.repoPaths.first
+        let codexWorkspaceRootPathsProvider = { [weak workspaceManager] in
+            workspaceManager?.activeWorkspace?.repoPaths ?? []
         }
+        let codexWorkspacePathProvider = { codexWorkspaceRootPathsProvider().first }
         let (sessionWorkspacePathProvider, codexRuntimeWorkspacePathsProvider) =
-            Self.makeSessionWorkspaceProviders(fallbackWorkspacePath: codexWorkspacePathProvider)
+            Self.makeSessionWorkspaceProviders(workspaceRootPaths: codexWorkspaceRootPathsProvider)
         workspacePathProvider = codexWorkspacePathProvider
+        workspaceRootPathsProvider = codexWorkspaceRootPathsProvider
         attachmentWorkspaceDirectoryProvider = { [weak workspaceManager] in
             guard let workspaceManager, workspaceManager.activeWorkspace != nil else {
                 return nil
@@ -1768,6 +1771,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         init(
             testWindowID: Int = 1,
             testWorkspacePath: String? = nil,
+            testWorkspacePaths: [String]? = nil,
             testWorkspaceDirectory: URL? = nil,
             applyEditsApprovalStore: ApplyEditsApprovalStore = .shared,
             clearConsumedAttachmentsAfterProviderConsumption: Bool = true,
@@ -1839,10 +1843,14 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 }
                 return FileManager.default.temporaryDirectory
             }
-            let codexWorkspacePathProvider = { testWorkspacePath }
+            let codexWorkspaceRootPathsProvider = {
+                testWorkspacePaths ?? testWorkspacePath.map { [$0] } ?? []
+            }
+            let codexWorkspacePathProvider = { codexWorkspaceRootPathsProvider().first }
             let (sessionWorkspacePathProvider, codexRuntimeWorkspacePathsProvider) =
-                Self.makeSessionWorkspaceProviders(fallbackWorkspacePath: codexWorkspacePathProvider)
+                Self.makeSessionWorkspaceProviders(workspaceRootPaths: codexWorkspaceRootPathsProvider)
             workspacePathProvider = codexWorkspacePathProvider
+            workspaceRootPathsProvider = codexWorkspaceRootPathsProvider
             let codexControllerFactory: CodexAgentModeCoordinator.CodexControllerFactory = codexControllerFactoryWithComputerUse
                 ?? { runID, tabID, windowID, workspacePaths, permissionProfile, taskLabelKind, _ in
                     codexControllerFactory(runID, tabID, windowID, workspacePaths, permissionProfile, taskLabelKind)
@@ -2039,19 +2047,19 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     func effectiveWorkspacePath(for session: TabSession) throws -> String? {
         try Self.effectiveWorkspacePath(
             for: session,
-            fallbackWorkspacePath: workspacePathProvider()
+            workspaceRootPaths: workspaceRootPathsProvider()
         )
     }
 
     func codexRuntimeWorkspacePaths(for session: TabSession) throws -> CodexRuntimeWorkspacePaths {
         try Self.codexRuntimeWorkspacePaths(
             for: session,
-            fallbackWorkspacePath: workspacePathProvider()
+            workspaceRootPaths: workspaceRootPathsProvider()
         )
     }
 
     func primaryExecutionBinding(for session: TabSession) -> AgentSessionWorktreeBinding? {
-        Self.primaryExecutionBinding(in: session.worktreeBindings, fallbackWorkspacePath: workspacePathProvider())
+        Self.primaryExecutionBinding(in: session.worktreeBindings, workspaceRootPaths: workspaceRootPathsProvider())
     }
 
     func primaryExecutionWorktreeIndicator(forTabID tabID: UUID) -> AgentWorktreeIndicator? {
@@ -2067,29 +2075,29 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
     private static func primaryExecutionBinding(
         in bindings: [AgentSessionWorktreeBinding],
-        fallbackWorkspacePath: String?
+        workspaceRootPaths: [String]
     ) -> AgentSessionWorktreeBinding? {
-        AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+        try? AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
             in: bindings,
-            fallbackWorkspacePath: fallbackWorkspacePath
+            workspaceRootPaths: workspaceRootPaths
         )
     }
 
     private static func effectiveWorkspacePath(
         for session: TabSession,
-        fallbackWorkspacePath: String?
+        workspaceRootPaths: [String]
     ) throws -> String? {
         try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
             bindings: session.worktreeBindings,
-            fallbackWorkspacePath: fallbackWorkspacePath
+            workspaceRootPaths: workspaceRootPaths
         )
     }
 
     /// One projection contract for both initializers: session-scoped scalar
     /// workspace path and Codex launch/execution path pair, derived from the
-    /// same fallback workspace provider.
+    /// complete active workspace root provider.
     private static func makeSessionWorkspaceProviders(
-        fallbackWorkspacePath: @escaping () -> String?
+        workspaceRootPaths: @escaping () -> [String]
     ) -> (
         sessionWorkspacePath: (TabSession) throws -> String?,
         codexRuntimeWorkspacePaths: (TabSession) throws -> CodexRuntimeWorkspacePaths
@@ -2098,13 +2106,13 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             sessionWorkspacePath: { session in
                 try Self.effectiveWorkspacePath(
                     for: session,
-                    fallbackWorkspacePath: fallbackWorkspacePath()
+                    workspaceRootPaths: workspaceRootPaths()
                 )
             },
             codexRuntimeWorkspacePaths: { session in
                 try Self.codexRuntimeWorkspacePaths(
                     for: session,
-                    fallbackWorkspacePath: fallbackWorkspacePath()
+                    workspaceRootPaths: workspaceRootPaths()
                 )
             }
         )
@@ -2112,11 +2120,11 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
     private static func codexRuntimeWorkspacePaths(
         for session: TabSession,
-        fallbackWorkspacePath: String?
+        workspaceRootPaths: [String]
     ) throws -> CodexRuntimeWorkspacePaths {
         try AgentWorktreeRuntimeWorkspaceResolver.codexRuntimeWorkspacePaths(
             bindings: session.worktreeBindings,
-            fallbackWorkspacePath: fallbackWorkspacePath
+            workspaceRootPaths: workspaceRootPaths
         )
     }
 
@@ -6719,7 +6727,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     private func executionDestinationIdentity(in bindings: [AgentSessionWorktreeBinding]) -> ExecutionDestinationIdentity {
-        let binding = Self.primaryExecutionBinding(in: bindings, fallbackWorkspacePath: workspacePathProvider())
+        let binding = Self.primaryExecutionBinding(in: bindings, workspaceRootPaths: workspaceRootPathsProvider())
         return ExecutionDestinationIdentity(
             repositoryID: binding?.repositoryID,
             worktreeID: binding?.worktreeID,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -2059,7 +2059,16 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     func primaryExecutionBinding(for session: TabSession) -> AgentSessionWorktreeBinding? {
-        Self.primaryExecutionBinding(in: session.worktreeBindings, workspaceRootPaths: workspaceRootPathsProvider())
+        do {
+            return try Self.primaryExecutionBinding(
+                in: session.worktreeBindings,
+                workspaceRootPaths: workspaceRootPathsProvider()
+            )
+        } catch {
+            // Indicators are presentation-only. Execution transitions resolve the same binding
+            // through the throwing path and preserve invalid state as a distinct destination.
+            return nil
+        }
     }
 
     func primaryExecutionWorktreeIndicator(forTabID tabID: UUID) -> AgentWorktreeIndicator? {
@@ -2076,8 +2085,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     private static func primaryExecutionBinding(
         in bindings: [AgentSessionWorktreeBinding],
         workspaceRootPaths: [String]
-    ) -> AgentSessionWorktreeBinding? {
-        try? AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+    ) throws -> AgentSessionWorktreeBinding? {
+        try AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
             in: bindings,
             workspaceRootPaths: workspaceRootPaths
         )
@@ -6549,11 +6558,23 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         else {
             return .blocked("This thread cannot change execution location right now.")
         }
-        let previousPrimary = primaryExecutionBinding(for: session)
+        let previousPrimary: AgentSessionWorktreeBinding?
+        let previousBindingsAreInvalid: Bool
+        do {
+            previousPrimary = try Self.primaryExecutionBinding(
+                in: session.worktreeBindings,
+                workspaceRootPaths: workspaceRootPathsProvider()
+            )
+            previousBindingsAreInvalid = false
+        } catch {
+            previousPrimary = nil
+            previousBindingsAreInvalid = true
+        }
         switch choice {
-        case .local where previousPrimary == nil:
+        case .local where previousPrimary == nil && !previousBindingsAreInvalid:
             return .unchanged
-        case let .existingWorktree(selection) where previousPrimary?.worktreeID == selection.worktreeID:
+        case let .existingWorktree(selection)
+            where !previousBindingsAreInvalid && previousPrimary?.worktreeID == selection.worktreeID:
             return .unchanged
         default:
             break
@@ -6578,7 +6599,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         do {
             let desiredBindings: [AgentSessionWorktreeBinding] = switch choice {
             case .local:
-                session.worktreeBindings.filter { $0.id != previousPrimary?.id }
+                previousBindingsAreInvalid
+                    ? []
+                    : session.worktreeBindings.filter { $0.id != previousPrimary?.id }
             case .newWorktree, .existingWorktree:
                 try await prepareStartedExecutionLocationBinding(
                     choice,
@@ -6720,20 +6743,28 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
     }
 
-    private struct ExecutionDestinationIdentity: Equatable {
-        let repositoryID: String?
-        let worktreeID: String?
-        let path: String?
+    private enum ExecutionDestinationIdentity: Equatable {
+        case local(path: String?)
+        case worktree(repositoryID: String?, worktreeID: String?, path: String?)
+        case invalid(bindings: [AgentSessionWorktreeBinding])
     }
 
     private func executionDestinationIdentity(in bindings: [AgentSessionWorktreeBinding]) -> ExecutionDestinationIdentity {
-        let binding = Self.primaryExecutionBinding(in: bindings, workspaceRootPaths: workspaceRootPathsProvider())
-        return ExecutionDestinationIdentity(
-            repositoryID: binding?.repositoryID,
-            worktreeID: binding?.worktreeID,
-            path: Self.standardizedWorkspacePath(binding?.worktreeRootPath)
-                ?? Self.standardizedWorkspacePath(workspacePathProvider())
-        )
+        do {
+            guard let binding = try Self.primaryExecutionBinding(
+                in: bindings,
+                workspaceRootPaths: workspaceRootPathsProvider()
+            ) else {
+                return .local(path: Self.standardizedWorkspacePath(workspacePathProvider()))
+            }
+            return .worktree(
+                repositoryID: binding.repositoryID,
+                worktreeID: binding.worktreeID,
+                path: Self.standardizedWorkspacePath(binding.worktreeRootPath)
+            )
+        } catch {
+            return .invalid(bindings: bindings)
+        }
     }
 
     private func executionLocationContext() async throws -> ExecutionLocationContext {

--- a/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderWorkspaceContext.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderWorkspaceContext.swift
@@ -91,23 +91,25 @@ struct ContextBuilderWorkspaceContext {
             store: store
         )
 
-        let providerWorkspacePath: String
-        if let target = reviewTargetResolution.availableTarget {
-            providerWorkspacePath = target.primaryCheckout.checkoutRootPath
-        } else if !bindings.isEmpty {
-            guard let projected = try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
+        let executionPath: String
+        do {
+            guard let resolvedExecutionPath = try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
                 bindings: bindings,
                 workspaceRootPaths: workspaceRepoPaths
             ) else {
                 throw ContextBuilderWorkspaceContextError.missingWorkspaceRoot
             }
-            providerWorkspacePath = projected
-        } else if workspaceRepoPaths.count == 1, let onlyRoot = workspaceRepoPaths.first {
-            providerWorkspacePath = onlyRoot
+            executionPath = resolvedExecutionPath
+        } catch let error as ContextBuilderWorkspaceContextError {
+            throw error
+        } catch {
+            throw ContextBuilderWorkspaceContextError.unavailableWorktreeProjection
+        }
+
+        let providerWorkspacePath: String = if let target = reviewTargetResolution.availableTarget {
+            target.primaryCheckout.checkoutRootPath
         } else {
-            // A neutral CWD is not Git authority. Nested Agent Context Builder Git calls use the
-            // frozen selected-repository target carried in the run-scoped tab snapshot.
-            providerWorkspacePath = workspaceDirectoryPath
+            executionPath
         }
 
         let context = ContextBuilderWorkspaceContext(

--- a/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderWorkspaceContext.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderWorkspaceContext.swift
@@ -95,10 +95,9 @@ struct ContextBuilderWorkspaceContext {
         if let target = reviewTargetResolution.availableTarget {
             providerWorkspacePath = target.primaryCheckout.checkoutRootPath
         } else if !bindings.isEmpty {
-            let fallback = workspaceRepoPaths.first ?? workspaceDirectoryPath
             guard let projected = try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
                 bindings: bindings,
-                fallbackWorkspacePath: fallback
+                workspaceRootPaths: workspaceRepoPaths
             ) else {
                 throw ContextBuilderWorkspaceContextError.missingWorkspaceRoot
             }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentExploreMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentExploreMCPToolService.swift
@@ -251,10 +251,12 @@ struct AgentExploreMCPToolService {
         context: ExploreStartContext,
         worktreeRequest: AgentMCPStartWorktreeCoordinator.Request
     ) async throws -> [StartedExploreRun] {
+        let effectiveParentWorktreeInheritance = worktreeRequest.inheritParentWorktreeBindings
+            && !worktreeRequest.hasExplicitWorktreeArgs
         let targets = try await createFreshExploreTargets(
             count: messages.count,
             context: context,
-            inheritWorktreeBindings: worktreeRequest.inheritParentWorktreeBindings
+            inheritWorktreeBindings: effectiveParentWorktreeInheritance
         )
         var started: [StartedExploreRun] = []
         started.reserveCapacity(messages.count)

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentMCPStartWorktreeCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentMCPStartWorktreeCoordinator.swift
@@ -175,7 +175,6 @@ struct AgentMCPStartWorktreeCoordinator {
                     request: request,
                     targetWindow: targetWindow
                 )
-                try validateRuntimeRoot(context.logicalRoot, targetWindow: targetWindow)
                 let worktree: GitWorktreeDescriptor
                 let initializationReceipt: GitWorktreeCreationReceipt?
                 let initializationFallbackReason: WorkspaceRootSeedFallbackReason?
@@ -233,7 +232,7 @@ struct AgentMCPStartWorktreeCoordinator {
                     repositoryRelativeRootPrefix: rootPrefix,
                     visualIdentity: identity,
                     replacing: agentModeVM.worktreeBindings(forAgentSessionID: targetSessionID).first {
-                        standardizedPath($0.logicalRootPath) == standardizedPath(context.logicalRoot.standardizedFullPath)
+                        logicalRootsEqual($0.logicalRootPath, context.logicalRoot.standardizedFullPath)
                     }
                 )
                 #if DEBUG
@@ -251,7 +250,7 @@ struct AgentMCPStartWorktreeCoordinator {
                     }
                 #endif
                 var desiredBindings = agentModeVM.worktreeBindings(forAgentSessionID: targetSessionID)
-                    .filter { standardizedPath($0.logicalRootPath) != standardizedPath(context.logicalRoot.standardizedFullPath) }
+                    .filter { !logicalRootsEqual($0.logicalRootPath, context.logicalRoot.standardizedFullPath) }
                 desiredBindings.append(binding)
                 let initializationHintsByBindingID: [String: WorkspaceRootMaterializationHint] = if let initializationReceipt,
                                                                                                     let startupContext
@@ -423,17 +422,24 @@ struct AgentMCPStartWorktreeCoordinator {
     ) async throws -> RepositoryContext {
         let store = targetWindow.promptManager.workspaceFileContextStore
         let visibleRoots = await store.rootRefs(scope: .visibleWorkspace)
+        let declaredPrimaryRoot = targetWindow.workspaceManager.activeWorkspace?.repoPaths.first
         let discoveryRoots = Self.repositoryDiscoveryRoots(
-            primaryRoot: targetWindow.workspaceManager.activeWorkspace?.repoPaths.first,
+            primaryRoot: declaredPrimaryRoot,
             visibleRoots: visibleRoots
         )
+        let declaredPrimaryPath = declaredPrimaryRoot.map(GitRepoRootAuthorization.canonicalPath)
+        var declaredPrimaryCandidate: RepositoryCandidate?
         var candidates: [RepositoryCandidate] = []
         var seen = Set<String>()
         for root in discoveryRoots {
             if let resolved = await vcsService.resolveRepo(from: URL(fileURLWithPath: root.standardizedFullPath)) {
                 let descriptor = GitRepoDescriptor(rootURL: resolved.rootURL)
+                let candidate = RepositoryCandidate(repo: descriptor, logicalRoot: root)
+                if GitRepoRootAuthorization.canonicalPath(root.standardizedFullPath) == declaredPrimaryPath {
+                    declaredPrimaryCandidate = candidate
+                }
                 if seen.insert(descriptor.rootPath.lowercased()).inserted {
-                    candidates.append(RepositoryCandidate(repo: descriptor, logicalRoot: root))
+                    candidates.append(candidate)
                 }
             }
         }
@@ -458,8 +464,19 @@ struct AgentMCPStartWorktreeCoordinator {
                 throw MCPError.invalidParams(error.message)
             }
         } else {
-            repo = defaultCandidate.repo
-            explicitLogicalRoot = defaultCandidate.logicalRoot
+            let implicitCandidate: RepositoryCandidate
+            if declaredPrimaryPath != nil {
+                guard let declaredPrimaryCandidate else {
+                    throw MCPError.invalidParams(
+                        "The primary workspace root is not a Git repository for \(operationName) worktree binding. Select another loaded repository explicitly with worktree_repo_root."
+                    )
+                }
+                implicitCandidate = declaredPrimaryCandidate
+            } else {
+                implicitCandidate = defaultCandidate
+            }
+            repo = implicitCandidate.repo
+            explicitLogicalRoot = implicitCandidate.logicalRoot
         }
         let logicalRoot = try await logicalRoot(
             for: repo,
@@ -471,18 +488,6 @@ struct AgentMCPStartWorktreeCoordinator {
             visibleRoots: visibleRoots,
             logicalRoot: logicalRoot
         )
-    }
-
-    private func validateRuntimeRoot(_ logicalRoot: WorkspaceRootRef, targetWindow: WindowState) throws {
-        guard let primaryRoot = targetWindow.workspaceManager.activeWorkspace?.repoPaths.first else {
-            return
-        }
-        let primary = standardizedPath((primaryRoot as NSString).expandingTildeInPath)
-        guard standardizedPath(logicalRoot.standardizedFullPath) == primary else {
-            throw MCPError.invalidParams(
-                "\(operationName) worktree binding currently supports the primary workspace root only. Requested root '\(logicalRoot.name)' at \(logicalRoot.standardizedFullPath), but the provider runtime cwd resolves from primary root \(primary)."
-            )
-        }
     }
 
     private func createWorktree(
@@ -617,8 +622,8 @@ struct AgentMCPStartWorktreeCoordinator {
         logicalRoot: WorkspaceRootRef,
         repositoryRoot: URL
     ) throws -> GitRepositoryRelativeRootPrefix {
-        let rootPath = StandardizedPath.absolute(logicalRoot.standardizedFullPath)
-        let repositoryPath = StandardizedPath.absolute(repositoryRoot.path)
+        let rootPath = GitRepoRootAuthorization.canonicalPath(logicalRoot.standardizedFullPath)
+        let repositoryPath = GitRepoRootAuthorization.canonicalPath(repositoryRoot.path)
         guard rootPath == repositoryPath || rootPath.hasPrefix(repositoryPath + "/") else {
             throw MCPError.invalidParams("The logical root is outside the selected Git repository.")
         }
@@ -762,6 +767,10 @@ struct AgentMCPStartWorktreeCoordinator {
             branch: worktree.branch,
             isMain: worktree.isMain
         )
+    }
+
+    private func logicalRootsEqual(_ lhs: String, _ rhs: String) -> Bool {
+        GitRepoRootAuthorization.canonicalPath(lhs) == GitRepoRootAuthorization.canonicalPath(rhs)
     }
 
     private func standardizedPath(_ path: String) -> String {

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentMCPStartWorktreeCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentMCPStartWorktreeCoordinator.swift
@@ -55,6 +55,13 @@ struct AgentMCPStartWorktreeCoordinator {
         let repo: GitRepoDescriptor
         let visibleRoots: [WorkspaceRootRef]
         let logicalRoot: WorkspaceRootRef
+        let workspaceAuthority: WorkspaceAuthority
+    }
+
+    private struct WorkspaceAuthority: Equatable {
+        let workspaceID: UUID
+        let primaryRootPath: String
+        let rootPaths: Set<String>
     }
 
     private struct RepositoryCandidate {
@@ -181,6 +188,7 @@ struct AgentMCPStartWorktreeCoordinator {
                 let expectedOwnerBindingGeneration = await targetWindow.promptManager
                     .workspaceFileContextStore
                     .nextSessionWorktreeOwnershipGeneration(ownerID: targetSessionID)
+                try validateWorkspaceAuthority(context, targetWindow: targetWindow)
                 switch request.mode {
                 case .none:
                     throw MCPError.internalError("\(operationName) worktree preparation reached an unexpected empty worktree mode.")
@@ -205,7 +213,8 @@ struct AgentMCPStartWorktreeCoordinator {
                         context: context,
                         sessionID: targetSessionID,
                         expectedOwnerBindingGeneration: expectedOwnerBindingGeneration,
-                        startupContext: startupContext
+                        startupContext: startupContext,
+                        targetWindow: targetWindow
                     )
                     worktree = result.descriptor
                     initializationReceipt = result.initializationReceipt
@@ -221,6 +230,7 @@ struct AgentMCPStartWorktreeCoordinator {
                     #endif
                 }
                 try Task.checkCancellation()
+                try validateWorkspaceAuthority(context, targetWindow: targetWindow)
                 let identity = try persistVisualIdentity(for: worktree, request: request)
                 let rootPrefix = try repositoryRelativeRootPrefix(
                     logicalRoot: context.logicalRoot,
@@ -289,6 +299,7 @@ struct AgentMCPStartWorktreeCoordinator {
                     startupContext,
                     initializationHintsByBindingID
                 )
+                try validateWorkspaceAuthority(context, targetWindow: targetWindow)
                 #if DEBUG
                     if WorktreeStartupBenchmarkDiagnostics.currentPendingStart != nil,
                        let correlationID = startupContext?.correlationID
@@ -422,12 +433,13 @@ struct AgentMCPStartWorktreeCoordinator {
     ) async throws -> RepositoryContext {
         let store = targetWindow.promptManager.workspaceFileContextStore
         let visibleRoots = await store.rootRefs(scope: .visibleWorkspace)
-        let declaredPrimaryRoot = targetWindow.workspaceManager.activeWorkspace?.repoPaths.first
+        let workspaceAuthority = try workspaceAuthority(targetWindow: targetWindow)
+        let declaredPrimaryRoot = workspaceAuthority.primaryRootPath
         let discoveryRoots = Self.repositoryDiscoveryRoots(
             primaryRoot: declaredPrimaryRoot,
             visibleRoots: visibleRoots
         )
-        let declaredPrimaryPath = declaredPrimaryRoot.map(GitRepoRootAuthorization.canonicalPath)
+        let declaredPrimaryPath = GitRepoRootAuthorization.canonicalPath(declaredPrimaryRoot)
         var declaredPrimaryCandidate: RepositoryCandidate?
         var candidates: [RepositoryCandidate] = []
         var seen = Set<String>()
@@ -465,16 +477,12 @@ struct AgentMCPStartWorktreeCoordinator {
             }
         } else {
             let implicitCandidate: RepositoryCandidate
-            if declaredPrimaryPath != nil {
-                guard let declaredPrimaryCandidate else {
-                    throw MCPError.invalidParams(
-                        "The primary workspace root is not a Git repository for \(operationName) worktree binding. Select another loaded repository explicitly with worktree_repo_root."
-                    )
-                }
-                implicitCandidate = declaredPrimaryCandidate
-            } else {
-                implicitCandidate = defaultCandidate
+            guard let declaredPrimaryCandidate else {
+                throw MCPError.invalidParams(
+                    "The primary workspace root is not a Git repository for \(operationName) worktree binding. Select another loaded repository explicitly with worktree_repo_root."
+                )
             }
+            implicitCandidate = declaredPrimaryCandidate
             repo = implicitCandidate.repo
             explicitLogicalRoot = implicitCandidate.logicalRoot
         }
@@ -483,11 +491,14 @@ struct AgentMCPStartWorktreeCoordinator {
             explicitLogicalRoot: explicitLogicalRoot,
             visibleRoots: discoveryRoots
         )
-        return RepositoryContext(
+        let context = RepositoryContext(
             repo: repo,
             visibleRoots: visibleRoots,
-            logicalRoot: logicalRoot
+            logicalRoot: logicalRoot,
+            workspaceAuthority: workspaceAuthority
         )
+        try validateWorkspaceAuthority(context, targetWindow: targetWindow)
+        return context
     }
 
     private func createWorktree(
@@ -495,7 +506,8 @@ struct AgentMCPStartWorktreeCoordinator {
         context: RepositoryContext,
         sessionID: UUID,
         expectedOwnerBindingGeneration: UInt64,
-        startupContext: WorktreeStartupContext?
+        startupContext: WorktreeStartupContext?,
+        targetWindow: WindowState
     ) async throws -> GitWorktreeCreateResult {
         let existingWorktrees = try await vcsService.listGitWorktrees(at: context.repo.rootURL)
         let mainRootPath = existingWorktrees.first(where: \.isMain)?.path ?? context.repo.rootPath
@@ -579,6 +591,7 @@ struct AgentMCPStartWorktreeCoordinator {
         } else {
             nil
         }
+        try validateWorkspaceAuthority(context, targetWindow: targetWindow)
         let result: GitWorktreeCreateResult
         #if DEBUG
             result = try await WorktreeStartupInstrumentation.$currentBenchmarkMetricTag.withValue(benchmarkMetricTag) {
@@ -616,6 +629,45 @@ struct AgentMCPStartWorktreeCoordinator {
             )
         #endif
         return result
+    }
+
+    private func workspaceAuthority(targetWindow: WindowState) throws -> WorkspaceAuthority {
+        guard let workspace = targetWindow.workspaceManager.activeWorkspace,
+              let primaryRoot = workspace.repoPaths.first
+        else {
+            throw MCPError.invalidParams("An active saved workspace with at least one root is required for \(operationName) worktree binding.")
+        }
+        let canonicalRoots = try workspace.repoPaths.map { rootPath in
+            guard let standardized = AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath(rootPath) else {
+                throw MCPError.invalidParams("The active saved workspace contains an invalid root for \(operationName) worktree binding.")
+            }
+            return GitRepoRootAuthorization.canonicalPath(standardized)
+        }
+        let rootPaths = Set(canonicalRoots)
+        guard rootPaths.count == canonicalRoots.count else {
+            throw MCPError.invalidParams("The active saved workspace contains duplicate canonical roots for \(operationName) worktree binding.")
+        }
+        return WorkspaceAuthority(
+            workspaceID: workspace.id,
+            primaryRootPath: GitRepoRootAuthorization.canonicalPath(primaryRoot),
+            rootPaths: rootPaths
+        )
+    }
+
+    private func validateWorkspaceAuthority(
+        _ context: RepositoryContext,
+        targetWindow: WindowState
+    ) throws {
+        let currentAuthority = try workspaceAuthority(targetWindow: targetWindow)
+        guard currentAuthority == context.workspaceAuthority else {
+            throw MCPError.invalidParams("The active saved workspace changed while \(operationName) was preparing its worktree binding. Retry from the current workspace.")
+        }
+        let logicalRootPath = GitRepoRootAuthorization.canonicalPath(context.logicalRoot.standardizedFullPath)
+        guard currentAuthority.rootPaths.contains(logicalRootPath) else {
+            throw MCPError.invalidParams(
+                "The selected root '\(context.logicalRoot.name)' is no longer part of the active saved workspace for \(operationName) worktree binding."
+            )
+        }
     }
 
     private func repositoryRelativeRootPrefix(

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorkspaceContextTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorkspaceContextTests.swift
@@ -442,6 +442,47 @@ final class ContextBuilderWorkspaceContextTests: XCTestCase {
         XCTAssertEqual(Set(nestedRoots.map(\.standardizedFullPath)), Set([logicalRoot.standardizedFileURL.path]))
     }
 
+    func testResolveWithoutBindingsUsesSelectedExecutionRootInsteadOfWorkspaceDirectory() async throws {
+        let selectedRoot = try makeTemporaryDirectory(name: "ContextBuilderSelectedExecution")
+        let secondaryRoot = try makeTemporaryDirectory(name: "ContextBuilderSecondaryExecution")
+        let activeWorkspaceDirectory = try makeTemporaryDirectory(name: "ContextBuilderActiveWorkspaceDirectory")
+        defer {
+            try? FileManager.default.removeItem(at: selectedRoot)
+            try? FileManager.default.removeItem(at: secondaryRoot)
+            try? FileManager.default.removeItem(at: activeWorkspaceDirectory)
+        }
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: selectedRoot.path, kind: .primaryWorkspace)
+        _ = try await store.loadRoot(path: secondaryRoot.path, kind: .primaryWorkspace)
+        let snapshot = MCPServerViewModel.TabContextSnapshot(
+            tabID: UUID(),
+            windowID: 51,
+            workspaceID: UUID(),
+            promptText: "Discover the selected workspace",
+            selection: StoredSelection(codemapAutoEnabled: false),
+            selectedMetaPromptIDs: [],
+            tabName: "Selected execution root",
+            runID: UUID(),
+            activeAgentSessionID: UUID(),
+            worktreeBindings: [],
+            explicitlyBound: false
+        )
+
+        let context = try await ContextBuilderWorkspaceContext.resolve(
+            from: snapshot,
+            workspaceRepoPaths: [selectedRoot.path, secondaryRoot.path],
+            workspaceDirectoryPath: activeWorkspaceDirectory.path,
+            store: store
+        )
+
+        guard case .deferred = context.reviewTargetResolution else {
+            return XCTFail("Expected empty initial selection to defer")
+        }
+        XCTAssertEqual(context.providerWorkspacePath, selectedRoot.standardizedFileURL.path)
+        XCTAssertNotEqual(context.providerWorkspacePath, activeWorkspaceDirectory.standardizedFileURL.path)
+    }
+
     func testTwoRootUnboundSliceElectsSelectedRepositoryAndIgnoresCrossRootAutoCodemap() async throws {
         let fixture = try ReviewGitRepositoryFixture(name: "ContextBuilderTwoRootElection")
         defer { fixture.cleanup() }

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -481,6 +481,53 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         }
     }
 
+    func testPrimaryExecutionBindingUsesSoleBindingAndCanonicalPrimaryForMultipleBindings() throws {
+        let primaryRoot = try makeTemporaryDirectory(named: "binding-primary-root")
+        let primaryAlias = primaryRoot.deletingLastPathComponent().appendingPathComponent("binding-primary-alias")
+        try FileManager.default.createSymbolicLink(at: primaryAlias, withDestinationURL: primaryRoot)
+        let primaryWorktree = try makeTemporaryDirectory(named: "binding-primary-worktree")
+        let secondaryRoot = try makeTemporaryDirectory(named: "binding-secondary-root")
+        let secondaryWorktree = try makeTemporaryDirectory(named: "binding-secondary-worktree")
+        let unmatchedRoot = try makeTemporaryDirectory(named: "binding-unmatched-root")
+        let primaryBinding = makeBinding(
+            logicalRoot: primaryAlias.path,
+            worktreeRoot: primaryWorktree.path,
+            worktreeID: "wt_primary"
+        )
+        let secondaryBinding = makeBinding(
+            logicalRoot: secondaryRoot.path,
+            worktreeRoot: secondaryWorktree.path,
+            worktreeID: "wt_secondary"
+        )
+
+        for bindings in [
+            [primaryBinding, secondaryBinding],
+            [secondaryBinding, primaryBinding]
+        ] {
+            XCTAssertEqual(
+                AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+                    in: bindings,
+                    fallbackWorkspacePath: primaryRoot.path
+                )?.worktreeID,
+                primaryBinding.worktreeID
+            )
+        }
+        XCTAssertEqual(
+            try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
+                bindings: [primaryBinding, secondaryBinding],
+                fallbackWorkspacePath: unmatchedRoot.path
+            ),
+            unmatchedRoot.path
+        )
+        XCTAssertEqual(
+            try AgentWorktreeRuntimeWorkspaceResolver.codexRuntimeWorkspacePaths(
+                bindings: [primaryBinding, secondaryBinding],
+                fallbackWorkspacePath: unmatchedRoot.path
+            ),
+            .uniform(unmatchedRoot.path)
+        )
+    }
+
     func testCodexRuntimeWorkspacePathsProjectionCoversBoundUnboundSecondaryAndMissingWorktree() throws {
         let root = try makeTemporaryDirectory(named: "projection-root")
         let worktree = try makeTemporaryDirectory(named: "projection-worktree")
@@ -503,20 +550,28 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         )
         XCTAssertEqual(try viewModel.codexRuntimeWorkspacePaths(for: boundSession), boundPair)
 
-        // Adding a secondary-root binding must not move either directory of the primary pair.
-        boundSession.worktreeBindings.append(
-            makeBinding(logicalRoot: secondaryRoot.path, worktreeRoot: secondaryWorktree.path)
+        // Adding a secondary-root binding must not move either directory of the primary pair,
+        // regardless of binding order.
+        let secondaryBinding = makeBinding(
+            logicalRoot: secondaryRoot.path,
+            worktreeRoot: secondaryWorktree.path
         )
+        boundSession.worktreeBindings.append(secondaryBinding)
+        XCTAssertEqual(try viewModel.codexRuntimeWorkspacePaths(for: boundSession), boundPair)
+        boundSession.worktreeBindings.reverse()
         XCTAssertEqual(try viewModel.codexRuntimeWorkspacePaths(for: boundSession), boundPair)
 
-        // A secondary-only binding leaves the session on the unbound fallback pair.
+        // A secondary-only binding is authoritative even when the workspace fallback is primary.
         let secondaryOnlySession = AgentModeViewModel.TabSession(tabID: UUID())
         secondaryOnlySession.worktreeBindings = [
             makeBinding(logicalRoot: secondaryRoot.path, worktreeRoot: secondaryWorktree.path)
         ]
         XCTAssertEqual(
             try viewModel.codexRuntimeWorkspacePaths(for: secondaryOnlySession),
-            .uniform(root.path)
+            .worktreeBound(
+                logicalRootPath: secondaryRoot.path,
+                validatedWorktreeRootPath: secondaryWorktree.path
+            )
         )
 
         // Unavailable worktrees keep the existing typed worktree failure.
@@ -2918,6 +2973,132 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         XCTAssertEqual(exploreChild.worktreeBindings, observation.bindings)
     }
 
+    func testAgentExploreExplicitSecondaryWorktreeSuppressesInheritedPrimaryAtProviderStart() async throws {
+        let primaryFixture = try makeGitFixture()
+        let secondaryFixture = try makeGitFixture()
+        let secondaryBranch = "feature/explore-secondary-\(secondaryFixture.suffix)"
+        let secondaryWorktree = secondaryFixture.sandbox.appendingPathComponent(
+            "explore-secondary-worktree",
+            isDirectory: true
+        )
+        try runGit(
+            ["worktree", "add", "-b", secondaryBranch, secondaryWorktree.path, "HEAD"],
+            cwd: secondaryFixture.repo
+        )
+        let expectedHead = try runGitOutput(["rev-parse", "HEAD"], cwd: secondaryFixture.repo)
+        let secondaryDescriptor = try await GitWorktreeTestSupport.waitForStableDescriptor(
+            repo: secondaryFixture.repo,
+            path: secondaryWorktree,
+            expectedBranch: secondaryBranch,
+            expectedHead: expectedHead,
+            listDescriptors: { try await VCSService.shared.listGitWorktrees(at: secondaryFixture.repo) }
+        )
+        let window = try await makeWindow(roots: [primaryFixture.repo, secondaryFixture.repo])
+        let sourceTabID = try XCTUnwrap(window.workspaceManager.activeWorkspace?.activeComposeTabID)
+        let parentID = UUID()
+        let inheritedPrimaryBinding = makeBinding(
+            logicalRoot: primaryFixture.repo.path,
+            worktreeRoot: primaryFixture.repo.path,
+            worktreeID: "wt_inherited_primary"
+        )
+        installParentAgentSession(
+            parentID,
+            binding: inheritedPrimaryBinding,
+            sourceTabID: sourceTabID,
+            in: window
+        )
+        let recorder = ExploreStartRecorder(capturesRuntimePaths: true)
+        let service = makeAgentExploreStartService(
+            window: window,
+            sourceTabID: sourceTabID,
+            recorder: recorder
+        )
+
+        _ = try await service.execute(args: [
+            "op": .string("start"),
+            "message": .string("inspect declared secondary repository"),
+            "worktree_id": .string(secondaryDescriptor.worktreeID),
+            "worktree_repo_root": .string(secondaryFixture.repo.path),
+            "detach": .bool(true),
+            "timeout": .int(0)
+        ])
+
+        let observation = try XCTUnwrap(recorder.observations.first)
+        XCTAssertEqual(recorder.observations.count, 1)
+        let binding = try XCTUnwrap(observation.bindings.first)
+        XCTAssertEqual(observation.bindings.count, 1)
+        XCTAssertEqual(binding.repositoryID, secondaryDescriptor.repository.repositoryID)
+        XCTAssertEqual(binding.worktreeID, secondaryDescriptor.worktreeID)
+        XCTAssertEqual(observation.effectiveWorkspacePath, secondaryDescriptor.path)
+        XCTAssertEqual(
+            observation.codexRuntimeWorkspacePaths,
+            .worktreeBound(
+                logicalRootPath: secondaryFixture.repo.path,
+                validatedWorktreeRootPath: secondaryDescriptor.path
+            )
+        )
+    }
+
+    func testCoordinatorCanonicallyReplacesAliasLogicalRootBinding() async throws {
+        let fixture = try makeGitFixture()
+        let branch = "feature/alias-replacement-\(fixture.suffix)"
+        let worktree = fixture.sandbox.appendingPathComponent("alias-replacement-worktree", isDirectory: true)
+        try runGit(["worktree", "add", "-b", branch, worktree.path, "HEAD"], cwd: fixture.repo)
+        let expectedHead = try runGitOutput(["rev-parse", "HEAD"], cwd: fixture.repo)
+        let descriptor = try await GitWorktreeTestSupport.waitForStableDescriptor(
+            repo: fixture.repo,
+            path: worktree,
+            expectedBranch: branch,
+            expectedHead: expectedHead,
+            listDescriptors: { try await VCSService.shared.listGitWorktrees(at: fixture.repo) }
+        )
+        let alias = fixture.sandbox.appendingPathComponent("repo-alias")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: fixture.repo)
+        let window = try await makeWindow(root: alias)
+        let viewModel = window.agentModeViewModel
+        let target = try await viewModel.mcpResolveOrCreateSessionTarget(
+            tabID: nil,
+            sessionID: nil,
+            createIfNeeded: true,
+            sessionName: nil
+        )
+        let sessionID = try XCTUnwrap(target.sessionID)
+        let session = viewModel.session(for: target.tabID)
+        session.testInstallPersistentSessionBinding(sessionID: sessionID)
+        let aliasBinding = makeBinding(
+            logicalRoot: alias.path,
+            worktreeRoot: fixture.repo.path,
+            worktreeID: "wt_alias"
+        )
+        session.worktreeBindings = [aliasBinding]
+        let coordinator = AgentMCPStartWorktreeCoordinator(
+            operationName: "agent_run.start",
+            vcsService: .shared,
+            gitTargetResolver: .init()
+        )
+        let request = try coordinator.parseRequest(args: [
+            "worktree_id": .string(descriptor.worktreeID),
+            "worktree_repo_root": .string(fixture.repo.path)
+        ])
+
+        try await coordinator.prepare(
+            request: request,
+            target: target,
+            targetWindow: window
+        )
+
+        let bindings = viewModel.worktreeBindings(forAgentSessionID: sessionID, tabID: target.tabID)
+        let binding = try XCTUnwrap(bindings.first)
+        XCTAssertEqual(bindings.count, 1)
+        XCTAssertEqual(binding.id, aliasBinding.id)
+        XCTAssertEqual(
+            GitRepoRootAuthorization.canonicalPath(binding.logicalRootPath),
+            GitRepoRootAuthorization.canonicalPath(fixture.repo.path)
+        )
+        XCTAssertEqual(binding.worktreeID, descriptor.worktreeID)
+        XCTAssertEqual(binding.worktreeRootPath, descriptor.path)
+    }
+
     func testAgentStartWorktreeSelectorsDefaultToWorkspacePrimaryRepoWhenRootsLoadedOutOfOrder() async throws {
         let primaryFixture = try makeGitFixture()
         let secondaryFixture = try makeGitFixture()
@@ -3099,7 +3280,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         }
     }
 
-    func testAgentStartWorktreeSelectorRejectsSecondaryGitRepoWhenPrimaryRootIsNonGit() async throws {
+    func testAgentStartWorktreeSelectorRequiresExplicitSecondaryRepoWhenPrimaryRootIsNonGit() async throws {
         let primaryRoot = try makeTemporaryDirectory(named: "non-git-primary-root")
         let secondaryFixture = try makeGitFixture()
         let branch = "feature/secondary-selector-\(secondaryFixture.suffix)"
@@ -3120,22 +3301,52 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
             listDescriptors: { try await VCSService.shared.listGitWorktrees(at: secondaryFixture.repo) }
         )
         let window = try await makeWindow(roots: [primaryRoot, secondaryFixture.repo])
+        let viewModel = window.agentModeViewModel
         let initialTabCount = try XCTUnwrap(window.workspaceManager.activeWorkspace).composeTabs.count
+        let initialSessionCount = viewModel.sessions.count
 
-        let service = makeAgentRunStartService(window: window, sourceTabID: nil)
+        let implicitService = makeAgentRunStartService(window: window, sourceTabID: nil)
         do {
-            _ = try await service.execute(args: [
+            _ = try await implicitService.execute(args: [
                 "op": .string("start"),
-                "message": .string("reject secondary repository"),
+                "message": .string("do not drift into secondary repository"),
                 "detach": .bool(true),
                 "timeout": .int(0),
                 "worktree_id": .string(descriptor.worktreeID)
             ])
-            XCTFail("Expected a secondary-repository worktree to be rejected when the primary root is non-Git")
+            XCTFail("Expected implicit selection to reject a non-Git primary root")
         } catch {
-            XCTAssertTrue(error.localizedDescription.contains("supports the primary workspace root only"))
+            XCTAssertTrue(error.localizedDescription.contains("primary workspace root is not a Git repository"))
         }
         XCTAssertEqual(window.workspaceManager.activeWorkspace?.composeTabs.count, initialTabCount)
+        XCTAssertEqual(viewModel.sessions.count, initialSessionCount)
+
+        let explicitService = makeAgentRunStartService(window: window, sourceTabID: nil)
+        let value = try await explicitService.execute(args: [
+            "op": .string("start"),
+            "message": .string("select declared secondary repository"),
+            "detach": .bool(true),
+            "timeout": .int(0),
+            "worktree_id": .string(descriptor.worktreeID),
+            "worktree_repo_root": .string(secondaryFixture.repo.path)
+        ])
+        let object = try XCTUnwrap(value.objectValue)
+        let bindings = try XCTUnwrap(object["worktree_bindings"]?.arrayValue)
+        let binding = try XCTUnwrap(bindings.first?.objectValue)
+        XCTAssertEqual(bindings.count, 1)
+        XCTAssertEqual(binding["repository_id"]?.stringValue, descriptor.repository.repositoryID)
+        XCTAssertEqual(binding["logical_root_path"]?.stringValue, secondaryFixture.repo.path)
+        XCTAssertEqual(binding["worktree_id"]?.stringValue, descriptor.worktreeID)
+        XCTAssertEqual(binding["worktree_root_path"]?.stringValue, descriptor.path)
+
+        let sessionObject = try XCTUnwrap(object["session"]?.objectValue)
+        let tabID = try XCTUnwrap(try UUID(uuidString: XCTUnwrap(sessionObject["context_id"]?.stringValue)))
+        let session = viewModel.session(for: tabID)
+        let storedBinding = try XCTUnwrap(session.worktreeBindings.first)
+        XCTAssertEqual(session.worktreeBindings.count, 1)
+        XCTAssertEqual(binding["id"]?.stringValue, storedBinding.id)
+        XCTAssertEqual(window.workspaceManager.activeWorkspace?.composeTabs.count, initialTabCount + 1)
+        XCTAssertEqual(viewModel.sessions.count, initialSessionCount + 1)
     }
 
     func testSharedStartWorktreeCoordinatorHonorsPreCancelledCreateWithoutMutation() async throws {
@@ -4741,21 +4952,26 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
             let taskLabelKind: AgentModelCatalog.TaskLabelKind?
             let workflow: AgentWorkflowDefinition?
             let bindings: [AgentSessionWorktreeBinding]
+            let effectiveWorkspacePath: String?
+            let codexRuntimeWorkspacePaths: CodexRuntimeWorkspacePaths?
         }
 
         let failureAtObservationIndex: Int?
         let failureKind: ExploreStartFailureKind
         let activatesControlContext: Bool
+        let capturesRuntimePaths: Bool
         var observations: [Observation] = []
 
         init(
             failureAtObservationIndex: Int? = nil,
             failureKind: ExploreStartFailureKind = .provider,
-            activatesControlContext: Bool = false
+            activatesControlContext: Bool = false,
+            capturesRuntimePaths: Bool = false
         ) {
             self.failureAtObservationIndex = failureAtObservationIndex
             self.failureKind = failureKind
             self.activatesControlContext = activatesControlContext
+            self.capturesRuntimePaths = capturesRuntimePaths
         }
     }
 
@@ -4792,6 +5008,12 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
                         startPending: true
                     )
                 }
+                let effectiveWorkspacePath = recorder.capturesRuntimePaths
+                    ? try agentModeVM.effectiveWorkspacePath(for: session)
+                    : nil
+                let codexRuntimeWorkspacePaths = recorder.capturesRuntimePaths
+                    ? try agentModeVM.codexRuntimeWorkspacePaths(for: session)
+                    : nil
                 let observationIndex = recorder.observations.count
                 recorder.observations.append(
                     .init(
@@ -4800,7 +5022,9 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
                         message: message,
                         taskLabelKind: taskLabelKind,
                         workflow: workflow,
-                        bindings: bindings
+                        bindings: bindings,
+                        effectiveWorkspacePath: effectiveWorkspacePath,
+                        codexRuntimeWorkspacePaths: codexRuntimeWorkspacePaths
                     )
                 )
                 if recorder.failureAtObservationIndex == observationIndex {

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -2873,6 +2873,48 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["in-flight prompt"])
     }
 
+    func testInvalidActiveBindingRequiresStopConfirmationAndCanBeRepairedToLocal() async throws {
+        let currentRoot = try makeTemporaryDirectory(named: "invalid-active-current-root")
+        let staleRoot = try makeTemporaryDirectory(named: "invalid-active-stale-root")
+        let staleWorktree = try makeTemporaryDirectory(named: "invalid-active-stale-worktree")
+        let viewModel = makeViewModel(workspacePath: currentRoot.path)
+        let tabID = UUID()
+        let session = viewModel.session(for: tabID)
+        let sessionID = UUID()
+        session.testInstallPersistentSessionBinding(sessionID: sessionID)
+        session.hasLoadedPersistedState = true
+        session.hasSentFirstMessage = true
+        session.runState = .running
+        session.installRunID(UUID())
+        session.beginRunAttempt(source: "test")
+        session.providerSessionID = "provider-from-invalid-binding"
+        let staleBinding = makeBinding(
+            logicalRoot: staleRoot.path,
+            worktreeRoot: staleWorktree.path,
+            worktreeID: "wt_stale"
+        )
+        session.worktreeBindings = [staleBinding]
+        viewModel.test_setCurrentTabIDOverride(tabID)
+        defer { viewModel.test_setCurrentTabIDOverride(nil) }
+
+        let unconfirmed = await viewModel.selectExecutionLocation(.local, for: tabID)
+
+        XCTAssertEqual(unconfirmed, .confirmationRequired(.activeRunStop))
+        XCTAssertEqual(session.worktreeBindings, [staleBinding])
+        XCTAssertEqual(session.providerSessionID, "provider-from-invalid-binding")
+
+        let repaired = await viewModel.selectExecutionLocation(
+            .local,
+            for: tabID,
+            confirmedChange: .activeRunStop
+        )
+
+        XCTAssertEqual(repaired, .applied)
+        XCTAssertTrue(session.worktreeBindings.isEmpty)
+        XCTAssertNil(session.providerSessionID)
+        XCTAssertFalse(session.runState.isActive)
+    }
+
     func testExternalPrimaryRebindRejectsDuringActiveRunWithoutDroppingOldIdentity() async throws {
         let root = try makeTemporaryDirectory(named: "managed-active-root")
         let oldWorktree = try makeTemporaryDirectory(named: "managed-old-worktree")
@@ -3475,6 +3517,62 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         XCTAssertEqual(binding["id"]?.stringValue, storedBinding.id)
         XCTAssertEqual(window.workspaceManager.activeWorkspace?.composeTabs.count, initialTabCount + 1)
         XCTAssertEqual(viewModel.sessions.count, initialSessionCount + 1)
+    }
+
+    func testCoordinatorRejectsLoadedSecondaryRootRemovedFromSavedWorkspaceBeforeCreate() async throws {
+        let primaryFixture = try makeGitFixture()
+        let secondaryFixture = try makeGitFixture()
+        let branch = "feature/stale-secondary-\(secondaryFixture.suffix)"
+        let destination = secondaryFixture.sandbox.appendingPathComponent(
+            "stale-secondary-worktree",
+            isDirectory: true
+        )
+        defer {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try? runGit(["worktree", "remove", "--force", destination.path], cwd: secondaryFixture.repo)
+            }
+        }
+
+        let window = try await makeWindow(roots: [primaryFixture.repo, secondaryFixture.repo])
+        let workspaceID = try XCTUnwrap(window.workspaceManager.activeWorkspace?.id)
+        let workspaceIndex = try XCTUnwrap(window.workspaceManager.workspaces.firstIndex { $0.id == workspaceID })
+        window.workspaceManager.workspaces[workspaceIndex].repoPaths = [primaryFixture.repo.path]
+        let viewModel = window.agentModeViewModel
+        let target = try await viewModel.mcpResolveOrCreateSessionTarget(
+            tabID: nil,
+            sessionID: nil,
+            createIfNeeded: true,
+            sessionName: nil
+        )
+        let sessionID = try XCTUnwrap(target.sessionID)
+        let coordinator = AgentMCPStartWorktreeCoordinator(
+            operationName: "agent_run.start",
+            vcsService: .shared,
+            gitTargetResolver: .init()
+        )
+        let request = try coordinator.parseRequest(args: [
+            "worktree_create": .bool(true),
+            "worktree_repo_root": .string(secondaryFixture.repo.path),
+            "worktree_branch": .string(branch),
+            "worktree_path": .string(destination.path),
+            "allow_external_worktree_path": .bool(true)
+        ])
+
+        do {
+            try await coordinator.prepare(
+                request: request,
+                target: target,
+                targetWindow: window
+            )
+            XCTFail("Expected a loaded root removed from the saved workspace to be rejected")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("saved workspace"), error.localizedDescription)
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+        XCTAssertTrue(viewModel.worktreeBindings(forAgentSessionID: sessionID).isEmpty)
+        let descriptors = try await VCSService.shared.listGitWorktrees(at: secondaryFixture.repo)
+        XCTAssertTrue(descriptors.allSatisfy(\.isMain))
     }
 
     func testSharedStartWorktreeCoordinatorHonorsPreCancelledCreateWithoutMutation() async throws {

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -481,14 +481,15 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         }
     }
 
-    func testPrimaryExecutionBindingUsesSoleBindingAndCanonicalPrimaryForMultipleBindings() throws {
+    func testPrimaryExecutionBindingRequiresCurrentRootMembershipAndSelectsCanonicalPrimary() throws {
         let primaryRoot = try makeTemporaryDirectory(named: "binding-primary-root")
         let primaryAlias = primaryRoot.deletingLastPathComponent().appendingPathComponent("binding-primary-alias")
         try FileManager.default.createSymbolicLink(at: primaryAlias, withDestinationURL: primaryRoot)
         let primaryWorktree = try makeTemporaryDirectory(named: "binding-primary-worktree")
         let secondaryRoot = try makeTemporaryDirectory(named: "binding-secondary-root")
         let secondaryWorktree = try makeTemporaryDirectory(named: "binding-secondary-worktree")
-        let unmatchedRoot = try makeTemporaryDirectory(named: "binding-unmatched-root")
+        let tertiaryRoot = try makeTemporaryDirectory(named: "binding-tertiary-root")
+        let tertiaryWorktree = try makeTemporaryDirectory(named: "binding-tertiary-worktree")
         let primaryBinding = makeBinding(
             logicalRoot: primaryAlias.path,
             worktreeRoot: primaryWorktree.path,
@@ -499,32 +500,156 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
             worktreeRoot: secondaryWorktree.path,
             worktreeID: "wt_secondary"
         )
+        let tertiaryBinding = makeBinding(
+            logicalRoot: tertiaryRoot.path,
+            worktreeRoot: tertiaryWorktree.path,
+            worktreeID: "wt_tertiary"
+        )
+        let workspaceRoots = [primaryRoot.path, secondaryRoot.path, tertiaryRoot.path]
 
+        XCTAssertEqual(
+            try AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+                in: [secondaryBinding],
+                workspaceRootPaths: workspaceRoots
+            )?.worktreeID,
+            secondaryBinding.worktreeID
+        )
         for bindings in [
             [primaryBinding, secondaryBinding],
             [secondaryBinding, primaryBinding]
         ] {
             XCTAssertEqual(
-                AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+                try AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
                     in: bindings,
-                    fallbackWorkspacePath: primaryRoot.path
+                    workspaceRootPaths: workspaceRoots
                 )?.worktreeID,
                 primaryBinding.worktreeID
             )
         }
-        XCTAssertEqual(
+
+        XCTAssertThrowsError(
             try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
-                bindings: [primaryBinding, secondaryBinding],
-                fallbackWorkspacePath: unmatchedRoot.path
-            ),
-            unmatchedRoot.path
+                bindings: [secondaryBinding],
+                workspaceRootPaths: [primaryRoot.path]
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? AgentWorktreeRuntimeWorkspaceResolutionError,
+                .logicalRootNotInActiveWorkspace(path: secondaryRoot.standardizedFileURL.path)
+            )
+        }
+        XCTAssertThrowsError(
+            try AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+                in: [secondaryBinding, secondaryBinding],
+                workspaceRootPaths: workspaceRoots
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? AgentWorktreeRuntimeWorkspaceResolutionError,
+                .duplicateLogicalRoot(path: secondaryRoot.standardizedFileURL.path)
+            )
+        }
+        XCTAssertThrowsError(
+            try AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+                in: [secondaryBinding, tertiaryBinding],
+                workspaceRootPaths: workspaceRoots
+            )
+        ) { error in
+            XCTAssertEqual(error as? AgentWorktreeRuntimeWorkspaceResolutionError, .ambiguousExecutionBinding)
+        }
+        XCTAssertThrowsError(
+            try AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+                in: [primaryBinding],
+                workspaceRootPaths: [primaryRoot.path, primaryAlias.path]
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? AgentWorktreeRuntimeWorkspaceResolutionError,
+                .duplicateActiveWorkspaceRoot(path: primaryAlias.standardizedFileURL.path)
+            )
+        }
+    }
+
+    func testCreateBindAndReviewSteerProjectsExactSecondaryWorktree() async throws {
+        let primaryFixture = try makeGitFixture()
+        let secondaryFixture = try makeGitFixture()
+        let secondaryWorktree = secondaryFixture.sandbox.appendingPathComponent("review-secondary-worktree", isDirectory: true)
+        let branch = "feature/review-secondary-\(secondaryFixture.suffix)"
+        try runGit(["worktree", "add", "-b", branch, secondaryWorktree.path, "HEAD"], cwd: secondaryFixture.repo)
+        let expectedHead = try runGitOutput(["rev-parse", "HEAD"], cwd: secondaryFixture.repo)
+        let descriptor = try await GitWorktreeTestSupport.waitForStableDescriptor(
+            repo: secondaryFixture.repo,
+            path: secondaryWorktree,
+            expectedBranch: branch,
+            expectedHead: expectedHead,
+            listDescriptors: { try await VCSService.shared.listGitWorktrees(at: secondaryFixture.repo) }
         )
+
+        let otherWindow = try await makeWindow(root: makeTemporaryDirectory(named: "review-other-window"))
+        let targetWindow = try await makeWindow(roots: [primaryFixture.repo, secondaryFixture.repo])
+        XCTAssertNotEqual(targetWindow.windowID, otherWindow.windowID)
+
+        let agentManage = try await windowTool(named: MCPWindowToolName.agentManage, in: targetWindow)
+        let manageWorktree = try await windowTool(named: MCPWindowToolName.manageWorktree, in: targetWindow)
+        let created = try await agentManage([
+            "op": .string("create_session"),
+            "session_name": .string("Secondary review lifecycle")
+        ])
+        let sessionID = try XCTUnwrap(
+            created.objectValue?["session_id"]?.stringValue.flatMap(UUID.init(uuidString:))
+        )
+
+        _ = try await manageWorktree([
+            "op": .string("bind"),
+            "repo_root": .string(secondaryFixture.repo.path),
+            "worktree_id": .string(descriptor.worktreeID),
+            "session_id": .string(sessionID.uuidString)
+        ])
+
+        var capturedWorkflowID: String?
+        var capturedMessage: String?
+        var capturedPaths: CodexRuntimeWorkspacePaths?
+        var capturedBindings: [AgentSessionWorktreeBinding] = []
+        var service = makeAgentRunStartService(window: targetWindow, sourceTabID: nil)
+        service.testDispatchSteerInstruction = { capturedSessionID, text, workflow, agentModeVM in
+            XCTAssertEqual(capturedSessionID, sessionID)
+            let session = try XCTUnwrap(agentModeVM.mcpControlledSession(sessionID: capturedSessionID))
+            capturedWorkflowID = workflow?.id
+            capturedMessage = text
+            capturedPaths = try agentModeVM.codexRuntimeWorkspacePaths(for: session)
+            capturedBindings = session.worktreeBindings
+            session.runState = .running
+            agentModeVM.publishMCPStateChange(for: session)
+            return .startedRun
+        }
+
+        _ = try await service.execute(args: [
+            "op": .string("steer"),
+            "session_id": .string(sessionID.uuidString),
+            "message": .string("Review the bound secondary checkout."),
+            "workflow_id": .string("builtin-review"),
+            "wait": .bool(false)
+        ])
+
+        XCTAssertEqual(capturedWorkflowID, "builtin-review")
+        XCTAssertEqual(capturedMessage, "Review the bound secondary checkout.")
         XCTAssertEqual(
-            try AgentWorktreeRuntimeWorkspaceResolver.codexRuntimeWorkspacePaths(
-                bindings: [primaryBinding, secondaryBinding],
-                fallbackWorkspacePath: unmatchedRoot.path
-            ),
-            .uniform(unmatchedRoot.path)
+            capturedPaths,
+            .worktreeBound(
+                logicalRootPath: secondaryFixture.repo.standardizedFileURL.path,
+                validatedWorktreeRootPath: secondaryWorktree.standardizedFileURL.path
+            )
+        )
+        XCTAssertEqual(capturedBindings.count, 1)
+        XCTAssertEqual(capturedBindings.first?.worktreeID, descriptor.worktreeID)
+        XCTAssertEqual(capturedBindings.first?.logicalRootPath, secondaryFixture.repo.standardizedFileURL.path)
+
+        let session = try XCTUnwrap(targetWindow.agentModeViewModel.mcpControlledSession(sessionID: sessionID))
+        session.runState = .completed
+        targetWindow.agentModeViewModel.publishMCPStateChange(for: session)
+        await targetWindow.agentModeViewModel.mcpDeactivateControlContext(
+            sessionID: sessionID,
+            cleanupSessionStore: true
         )
     }
 
@@ -534,7 +659,10 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         let secondaryRoot = try makeTemporaryDirectory(named: "projection-secondary-root")
         let secondaryWorktree = try makeTemporaryDirectory(named: "projection-secondary-worktree")
         let missingWorktree = root.appendingPathComponent("missing-worktree")
-        let viewModel = makeViewModel(workspacePath: root.path)
+        let viewModel = makeViewModel(
+            workspacePath: root.path,
+            workspacePaths: [root.path, secondaryRoot.path]
+        )
 
         let unboundSession = AgentModeViewModel.TabSession(tabID: UUID())
         XCTAssertEqual(
@@ -591,16 +719,16 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         XCTAssertThrowsError(
             try AgentWorktreeRuntimeWorkspaceResolver.codexRuntimeWorkspacePaths(
                 bindings: [makeBinding(logicalRoot: "   ", worktreeRoot: worktree.path)],
-                fallbackWorkspacePath: nil
+                workspaceRootPaths: [worktree.path]
             )
         ) { error in
-            XCTAssertEqual(error as? CodexRuntimeWorkspacePathsError, .emptyLogicalRoot)
+            XCTAssertEqual(error as? AgentWorktreeRuntimeWorkspaceResolutionError, .emptyLogicalRoot)
         }
 
         XCTAssertThrowsError(
             try AgentWorktreeRuntimeWorkspaceResolver.codexRuntimeWorkspacePaths(
                 bindings: [makeBinding(logicalRoot: missingRoot.path, worktreeRoot: worktree.path)],
-                fallbackWorkspacePath: missingRoot.path
+                workspaceRootPaths: [missingRoot.path]
             )
         ) { error in
             XCTAssertEqual(
@@ -612,7 +740,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         XCTAssertEqual(
             try AgentWorktreeRuntimeWorkspaceResolver.codexRuntimeWorkspacePaths(
                 bindings: [],
-                fallbackWorkspacePath: nil
+                workspaceRootPaths: []
             ),
             .uniform(nil)
         )
@@ -624,7 +752,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
 
         var installedController: ReplacementIdentityFakeCodexController?
         let viewModel = AgentModeViewModel(
-            testWorkspacePath: nil,
+            testWorkspacePath: root.path,
             codexControllerFactory: { _, _, _, _, _, _ in
                 let controller = ReplacementIdentityFakeCodexController()
                 installedController = controller
@@ -783,7 +911,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         let shutdownGate = AgentRunWorktreeStartAsyncGate()
         let controller = ReplacementIdentityFakeCodexController(shutdownGate: shutdownGate)
         let viewModel = AgentModeViewModel(
-            testWorkspacePath: nil,
+            testWorkspacePath: root.path,
             codexControllerFactory: { _, _, _, _, _, _ in controller }
         )
         viewModel.test_initializeRunService()
@@ -848,7 +976,8 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         var controllerCreationCountByTabID: [UUID: Int] = [:]
 
         let viewModel = AgentModeViewModel(
-            testWorkspacePath: nil,
+            testWorkspacePath: rootA.path,
+            testWorkspacePaths: [rootA.path, rootB.path],
             codexControllerFactory: { _, tabID, _, _, _, _ in
                 let creationIndex = controllerCreationCountByTabID[tabID, default: 0]
                 controllerCreationCountByTabID[tabID] = creationIndex + 1
@@ -978,7 +1107,8 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         var firstControllerByTabID: [UUID: ReplacementIdentityFakeCodexController] = [:]
 
         let viewModel = AgentModeViewModel(
-            testWorkspacePath: nil,
+            testWorkspacePath: rootA.path,
+            testWorkspacePaths: [rootA.path, rootB.path],
             codexControllerFactory: { _, tabID, _, workspacePaths, _, _ in
                 createdPathsByTabID[tabID, default: []].append(workspacePaths)
                 let controller = ReplacementIdentityFakeCodexController(
@@ -1054,6 +1184,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         var createdPaths: [CodexRuntimeWorkspacePaths] = []
         let viewModel = AgentModeViewModel(
             testWorkspacePath: root.path,
+            testWorkspacePaths: [root.path, secondaryRoot.path],
             codexControllerFactory: { _, _, _, workspacePaths, _, _ in
                 createdPaths.append(workspacePaths)
                 return ReplacementIdentityFakeCodexController()
@@ -1112,10 +1243,9 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         let worktree = try makeTemporaryDirectory(named: "launch-only-worktree")
 
         var createdPaths: [CodexRuntimeWorkspacePaths] = []
-        // No fallback workspace: the single binding is the selected primary regardless of its
-        // logical root, which lets the launch directory move while the execution directory stays.
         let viewModel = AgentModeViewModel(
-            testWorkspacePath: nil,
+            testWorkspacePath: rootA.path,
+            testWorkspacePaths: [rootA.path, rootB.path],
             codexControllerFactory: { _, _, _, workspacePaths, _, _ in
                 createdPaths.append(workspacePaths)
                 return ReplacementIdentityFakeCodexController()
@@ -2604,9 +2734,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
             atomically: true,
             encoding: .utf8
         )
-        let window = try await makeWindow(root: primaryRoot)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: missingSecondaryRoot.path)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: validSecondaryRoot.path)
+        let window = try await makeWindow(roots: [primaryRoot, missingSecondaryRoot, validSecondaryRoot])
         let viewModel = window.agentModeViewModel
         let createdTabID = await viewModel.createAndActivateSessionTab()
         let tabID = try XCTUnwrap(createdTabID)
@@ -5256,9 +5384,67 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         try await lifecycleFixture.makeWindow(roots: roots)
     }
 
-    private func makeViewModel(workspacePath: String) -> AgentModeViewModel {
+    private func windowTool(named name: String, in window: WindowState) async throws -> RepoPromptApp.Tool {
+        let tools = await window.mcpServer.windowMCPTools
+        let tool = try XCTUnwrap(tools.first { $0.name == name })
+        return RepoPromptApp.Tool(
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+            annotations: tool.annotations,
+            isEnabledByDefault: tool.isEnabledByDefault,
+            returnsValue: { arguments in
+                if ServerNetworkManager.currentConnectionID != nil {
+                    return try await tool(arguments)
+                }
+
+                let connectionID = UUID()
+                let clientName = "Agent Worktree Lifecycle Test"
+                try await MainActor.run {
+                    let workspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+                    let tabID = try XCTUnwrap(workspace.activeComposeTabID)
+                    try window.mcpServer.bindTabForConnection(
+                        connectionID: connectionID,
+                        clientName: clientName,
+                        tabID: tabID,
+                        workspaceID: workspace.id,
+                        windowID: window.windowID,
+                        explicitlyBound: true
+                    )
+                }
+                do {
+                    let result = try await ServerNetworkManager.withConnectionID(connectionID) {
+                        try await tool(arguments)
+                    }
+                    await MainActor.run {
+                        window.mcpServer.removeTabContext(
+                            forConnectionID: connectionID,
+                            clientName: clientName,
+                            windowID: window.windowID
+                        )
+                    }
+                    return result
+                } catch {
+                    await MainActor.run {
+                        window.mcpServer.removeTabContext(
+                            forConnectionID: connectionID,
+                            clientName: clientName,
+                            windowID: window.windowID
+                        )
+                    }
+                    throw error
+                }
+            }
+        )
+    }
+
+    private func makeViewModel(
+        workspacePath: String,
+        workspacePaths: [String]? = nil
+    ) -> AgentModeViewModel {
         AgentModeViewModel(
             testWorkspacePath: workspacePath,
+            testWorkspacePaths: workspacePaths,
             codexControllerFactory: { _, _, _, _, _, _ in WorktreeStartFakeCodexController() }
         )
     }


### PR DESCRIPTION
## Summary

- authorize Agent worktree execution against the complete canonical saved-workspace root set, including exact worktrees for secondary repository roots
- keep saved-workspace identity separate from session worktree projection while failing closed for stale, unmatched, duplicate, or ambiguous root bindings
- preserve explicit secondary-repository selection through Agent start/explore paths and add direct create-session, bind, and builtin-review steer coverage

## Validation

- `make dev-test FILTER=AgentRunWorktreeStartTests` — 55 tests passed
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- independent read-only review of `origin/main..HEAD` — no blockers

## Additional validation context

The full local PR-ready root suite was attempted. It progressed through the affected coverage but did not complete: an unrelated durable-artifact concurrency test reported a busy publication result, and the run later stopped producing output in workspace-context tests. The focused Agent worktree suite, strict lint, and affected product build all passed.
