### PR TITLE
Fix: bound MCP structure settlement recovery

### DIFF
--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift
@@ -13,6 +13,12 @@ enum MCPToolExecutionHandlerPhase: String, Equatable {
     case fileActionsPostMutationCatalog = "file_actions.post_mutation_catalog"
     case fileActionsPostMutationSelection = "file_actions.post_mutation_selection"
     case fileActionsReplyConstruction = "file_actions.reply_construction"
+    case readFileRequestResolution = "read_file.request_resolution"
+    case readFileContentRead = "read_file.content_read"
+    case readFileAutoSelection = "read_file.auto_selection"
+    case getFileTreeRequestResolution = "get_file_tree.request_resolution"
+    case getFileTreeIngressWait = "get_file_tree.ingress_wait"
+    case getFileTreeConstruction = "get_file_tree.construction"
     // Graph-first get_code_structure execution stages.
     case getCodeStructureSeedResolution = "get_code_structure.seed_resolution"
     case getCodeStructureGraphSnapshot = "get_code_structure.graph_snapshot"

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -11830,14 +11830,19 @@ actor ServerNetworkManager {
                                         switch self.codeStructureSettlementRegistry.admit(
                                             windowID: windowID,
                                             connectionID: connectionID,
-                                            invocationID: invocationID
+                                            invocationID: invocationID,
+                                            toolName: toolName,
+                                            now: executionWatchdogEnvironment.now(),
+                                            handlerPhase: {
+                                                handlerPhaseRecorder.snapshot()?.phase.rawValue
+                                            }
                                         ) {
                                         case let .admitted(slot):
                                             settlementAdmission = (.detachAndSettle, slot)
-                                        case let .busy(reason):
+                                        case let .busy(context):
                                             throw MCPToolExecutionDispatchError.structureSettlementBusy(
                                                 windowID: windowID,
-                                                reason: reason
+                                                context: context
                                             )
                                         }
                                     } else {
@@ -12181,24 +12186,45 @@ actor ServerNetworkManager {
                                         outcome = "executionContractMissing"
                                         shouldForceDisconnect = false
                                         errorMetadata = [:]
-                                    case let MCPToolExecutionDispatchError.structureSettlementBusy(windowID, reason):
+                                    case let MCPToolExecutionDispatchError.structureSettlementBusy(windowID, busyContext):
                                         code = "tool_execution_structure_settlement_busy"
-                                        let abandoned = reason == .abandoned
-                                        message = abandoned
-                                            ? "A prior canceled MCP operation for window \(windowID) is still settling. Retry after it drains."
-                                            : "A prior timed-out MCP operation for window \(windowID) is still settling. Retry after it drains."
+                                        let limitReached = busyContext.reason == .releasedProviderLimitReached
+                                        let abandoned = busyContext.reason == .abandoned
+                                        if limitReached {
+                                            message = "Window \(windowID) reached its limit of one released cancellation-ignoring structure provider. Wait for it to settle or restart RepoPrompt CE."
+                                        } else if abandoned {
+                                            message = "A prior canceled MCP operation for window \(windowID) is still settling. Retry after the bounded recovery wait."
+                                        } else {
+                                            message = "A prior timed-out MCP operation for window \(windowID) is still settling. Retry after the bounded recovery wait."
+                                        }
                                         outcome = "executionStructureSettlementBusy"
                                         shouldForceDisconnect = false
-                                        errorMetadata = [
-                                            "retryable": .bool(true),
-                                            "retry_after_ms": .int(250),
+
+                                        var busyMetadata: [String: Value] = [
+                                            "retryable": .bool(!limitReached),
                                             "busy_reason": .string(
-                                                abandoned
+                                                limitReached
+                                                    ? "released_provider_limit_reached"
+                                                    : abandoned
                                                     ? "abandoned_settlement_in_progress"
                                                     : "detached_settlement_in_progress"
                                             ),
-                                            "settlement": .string("busy")
+                                            "settlement": .string("busy"),
+                                            "origin_tool": .string(busyContext.originToolName),
+                                            "origin_invocation_id": .string(busyContext.originInvocationID.uuidString),
+                                            "origin_connection_id": .string(busyContext.originConnectionID.uuidString),
+                                            "detached_age_ms": .double(busyContext.detachedAge.mcpMilliseconds),
+                                            "last_handler_phase": .string(busyContext.handlerPhase ?? "unreported"),
+                                            "released_provider_count": .int(busyContext.releasedProviderCount)
                                         ]
+                                        if let recoveryAfter = busyContext.recoveryAfter {
+                                            let recoveryAfterMilliseconds = max(
+                                                0,
+                                                Int(recoveryAfter.mcpMilliseconds.rounded(.up))
+                                            )
+                                            busyMetadata["retry_after_ms"] = .int(recoveryAfterMilliseconds)
+                                        }
+                                        errorMetadata = busyMetadata
                                     case MCPToolExecutionDispatchError.structureSettlementWindowUnresolved:
                                         code = "tool_execution_structure_settlement_window_unresolved"
                                         message = "\(toolName) requires a resolved window before its settlement policy can be selected."

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -306,13 +306,19 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         args: [String: Value],
         appContext: MCPServerViewModel.DomainReadAppExecutionContext?
     ) async throws -> Value {
-        try await withActiveWorktreeStartupBenchmarkTag(appContext: appContext) {
+        await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeRequestResolution)
+        return try await withActiveWorktreeStartupBenchmarkTag(appContext: appContext) {
             let type = args["type"]?.stringValue ?? "files"
             switch type {
             case "roots":
                 let filePathDisplay = await MainActor.run { dependencies.context.promptVM.filePathDisplayOption }
                 let lookupContext = await readAuthority(appContext).lookupContext
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeRequestResolution, transition: .completed)
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeIngressWait)
                 _ = await dependencies.context.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+                try Task.checkCancellation()
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeIngressWait, transition: .completed)
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeConstruction)
                 let worktreeScope = ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: lookupContext.bindingProjection)
                 let snapshot = await dependencies.context.promptVM.workspaceFileContextStore.makeFileTreeSelectionSnapshot(
                     selection: StoredSelection(),
@@ -321,11 +327,13 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                 )
                 if snapshot.roots.isEmpty {
                     let msg = await dependencies.files.workspaceContextMessage(MCPWindowToolName.getFileTree, nil)
+                    await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeConstruction, transition: .completed)
                     return try Value(ToolResultDTOs.FileTreeDTO(rootsCount: 0, usesLegend: false, tree: msg, note: "No workspace loaded", wasTruncated: false, worktreeScope: worktreeScope))
                 }
                 let rootLines = snapshot.roots.map { root in
                     lookupContext.bindingProjection?.projectedLogicalDisplayPath(forPhysicalPath: root.fullPath, display: .full) ?? root.fullPath
                 }
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeConstruction, transition: .completed)
                 return try Value(ToolResultDTOs.FileTreeDTO(rootsCount: snapshot.roots.count, usesLegend: false, tree: rootLines.joined(separator: "\n"), note: nil, wasTruncated: false, worktreeScope: worktreeScope))
             case "files":
                 let mode = args["mode"]?.stringValue ?? "auto"
@@ -339,7 +347,12 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                 let authority = await readAuthority(appContext)
                 let metadata = authority.metadata
                 let lookupContext = authority.lookupContext
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeRequestResolution, transition: .completed)
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeIngressWait)
                 _ = await dependencies.context.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+                try Task.checkCancellation()
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeIngressWait, transition: .completed)
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeConstruction)
                 if mode.lowercased() == "selected" {
                     guard try await dependencies.files.drainReadFileAutoSelection(metadata, .canonicalSelection) == .completed else {
                         throw CancellationError()
@@ -347,6 +360,7 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                 }
                 let worktreeScope = ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: lookupContext.bindingProjection)
                 let resultAndRootCount = try await dependencies.files.buildStoreBackedFileTreeResult(mode, maxDepth, args["path"]?.stringValue, lookupContext)
+                await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeConstruction, transition: .completed)
                 return try Value(ToolResultDTOs.FileTreeDTO(
                     rootsCount: resultAndRootCount.rootCount,
                     usesLegend: resultAndRootCount.result.usesLegend,
@@ -375,6 +389,7 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         sideEffects: MCPDomainReadSideEffectEmitter
     ) async throws -> Value {
         try Task.checkCancellation()
+        await MCPToolExecutionHandlerPhaseContext.report(.readFileRequestResolution)
         EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.ReadFile.providerEntered)
         let providerTotalState = EditFlowPerf.begin(EditFlowPerf.Stage.ReadFile.providerTotal)
         defer { EditFlowPerf.end(EditFlowPerf.Stage.ReadFile.providerTotal, providerTotalState) }
@@ -408,7 +423,9 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         } catch let issue as PathResolutionIssue {
             throw MCPError.invalidParams(PathResolutionIssueRenderer.message(for: issue))
         }
+        await MCPToolExecutionHandlerPhaseContext.report(.readFileRequestResolution, transition: .completed)
         try Task.checkCancellation()
+        await MCPToolExecutionHandlerPhaseContext.report(.readFileContentRead)
         let unprojectedReadResult: MCPAppFileReadResult
         do {
             unprojectedReadResult = try await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerReadEnvelope) {
@@ -430,11 +447,13 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                 )
             }
         } catch WorkspaceAppliedIngressWaitError.timedOut {
+            await MCPToolExecutionHandlerPhaseContext.report(.readFileContentRead, transition: .completed)
             return try Value(Self.readFileFreshnessTimeoutDTO(
                 path: path,
                 worktreeScope: worktreeScope
             ))
         }
+        await MCPToolExecutionHandlerPhaseContext.report(.readFileContentRead, transition: .completed)
         try Task.checkCancellation()
         let unprojectedReply = switch unprojectedReadResult {
         case let .workspace(reply, _), let .nonSelecting(reply): reply
@@ -459,6 +478,7 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         case .workspace: "attempted"
         case .nonSelecting: "skipped"
         }
+        await MCPToolExecutionHandlerPhaseContext.report(.readFileAutoSelection)
         try await EditFlowPerf.measure(
             EditFlowPerf.Stage.ReadFile.providerAutoSelect,
             EditFlowPerf.Dimensions(outcome: autoSelectOutcome)
@@ -475,6 +495,7 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                 }
             }
         }
+        await MCPToolExecutionHandlerPhaseContext.report(.readFileAutoSelection, transition: .completed)
         try Task.checkCancellation()
         let projectedReply = switch readResult {
         case let .workspace(reply, _), let .nonSelecting(reply): reply

--- a/Sources/RepoPromptDomainRuntime/MCPDomainCodeStructureSettlementRegistry.swift
+++ b/Sources/RepoPromptDomainRuntime/MCPDomainCodeStructureSettlementRegistry.swift
@@ -4,20 +4,36 @@ import Foundation
 ///
 /// The fenced tools are `get_code_structure`, `read_file`, and `get_file_tree`. Every admitted
 /// provider receives an invocation-scoped lease. Completion, cleanup-grace expiry, and external
-/// cancellation transition that lease under this registry's single lock. Once any lease becomes
-/// detaching, detached, abandoned, or force-disconnecting, later same-window detach-disposition
-/// calls receive typed busy until every unsettled lease clears.
+/// cancellation transition that lease under this registry's single lock. A blocking lease fences
+/// later same-window detach-disposition calls for a bounded recovery horizon. After that horizon,
+/// one still-running provider may remain tracked without blocking; its exact lease still owns completion.
 package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
+    package static let recoveryHorizon = Duration.seconds(30)
+    package static let releasedProviderLimit = 1
+
     package init() {}
+
     package enum BusyReason: Equatable, Sendable {
         case detached
         case abandoned
         case settling
+        case releasedProviderLimitReached
+    }
+
+    package struct BusyContext: Equatable, Sendable {
+        package let reason: BusyReason
+        package let originToolName: String
+        package let originInvocationID: UUID
+        package let originConnectionID: UUID
+        package let detachedAge: Duration
+        package let recoveryAfter: Duration?
+        package let handlerPhase: String?
+        package let releasedProviderCount: Int
     }
 
     package enum Admission: Sendable {
         case admitted(Slot)
-        case busy(BusyReason)
+        case busy(BusyContext)
     }
 
     package enum CompletionDirective: Equatable, Sendable {
@@ -57,10 +73,12 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
     package struct Snapshot: Equatable, Sendable {
         package let activeCount: Int
         package let detachedCount: Int
+        package let releasedCount: Int
 
-        package init(activeCount: Int, detachedCount: Int) {
+        package init(activeCount: Int, detachedCount: Int, releasedCount: Int = 0) {
             self.activeCount = activeCount
             self.detachedCount = detachedCount
+            self.releasedCount = releasedCount
         }
     }
 
@@ -95,11 +113,12 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
             ) ?? .ignored
         }
 
-        package func resolveGraceExpiry() -> GraceExpiryDirective {
+        package func resolveGraceExpiry(now: Duration) -> GraceExpiryDirective {
             registry?.resolveGraceExpiry(
                 windowID: windowID,
                 leaseID: leaseID,
-                invocationID: invocationID
+                invocationID: invocationID,
+                now: now
             ) ?? .settled
         }
 
@@ -111,11 +130,12 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
             ) ?? .notActivated
         }
 
-        package func cancel() -> CancellationDirective {
+        package func cancel(now: Duration) -> CancellationDirective {
             registry?.cancel(
                 windowID: windowID,
                 leaseID: leaseID,
-                invocationID: invocationID
+                invocationID: invocationID,
+                now: now
             ) ?? .settled
         }
 
@@ -151,7 +171,28 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
         let leaseID: UUID
         let connectionID: UUID
         let invocationID: UUID
+        let toolName: String
+        let handlerPhase: @Sendable () -> String?
         var state: State
+        var blockingSince: Duration?
+        var isReleased: Bool
+
+        var blocksAdmission: Bool {
+            state.blocksAdmission && !isReleased
+        }
+    }
+
+    private struct BusyCandidate {
+        let reason: BusyReason
+        let entry: Entry
+        let detachedAge: Duration
+        let recoveryAfter: Duration?
+        let releasedProviderCount: Int
+    }
+
+    private enum AdmissionDecision {
+        case admitted(Slot)
+        case busy(BusyCandidate)
     }
 
     private let lock = NSLock()
@@ -161,27 +202,80 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
     package func admit(
         windowID: Int,
         connectionID: UUID,
-        invocationID: UUID
+        invocationID: UUID,
+        toolName: String,
+        now: Duration,
+        handlerPhase: @escaping @Sendable () -> String?
     ) -> Admission {
-        lock.withLock {
-            let entries = entriesByWindowID[windowID, default: [:]]
-            if entries.values.contains(where: \.state.blocksAdmission) {
-                return .busy(Self.busyReason(for: entries.values))
+        let decision: AdmissionDecision = lock.withLock {
+            var entries = entriesByWindowID[windowID, default: [:]]
+            let blockingEntries = entries.values.filter(\.blocksAdmission)
+            if !blockingEntries.isEmpty {
+                let releasedProviderCount = entries.values.count(where: \.isReleased)
+                let origin = Self.oldestEntry(in: blockingEntries)
+                let blockingSince = origin.blockingSince
+                precondition(blockingSince != nil, "Blocking settlement entry requires an origin timestamp")
+                let age = Self.elapsed(since: blockingSince!, now: now)
+
+                guard releasedProviderCount + blockingEntries.count <= Self.releasedProviderLimit else {
+                    return .busy(BusyCandidate(
+                        reason: .releasedProviderLimitReached,
+                        entry: origin,
+                        detachedAge: age,
+                        recoveryAfter: nil,
+                        releasedProviderCount: releasedProviderCount
+                    ))
+                }
+
+                let recoveryAfter = max(.zero, Self.recoveryHorizon - age)
+                guard recoveryAfter == .zero else {
+                    return .busy(BusyCandidate(
+                        reason: Self.busyReason(for: blockingEntries),
+                        entry: origin,
+                        detachedAge: age,
+                        recoveryAfter: recoveryAfter,
+                        releasedProviderCount: releasedProviderCount
+                    ))
+                }
+
+                entries[origin.leaseID]?.isReleased = true
+                entriesByWindowID[windowID] = entries
             }
 
             let leaseID = UUID()
-            entriesByWindowID[windowID, default: [:]][leaseID] = Entry(
+            entries[leaseID] = Entry(
                 leaseID: leaseID,
                 connectionID: connectionID,
                 invocationID: invocationID,
-                state: .reserved
+                toolName: toolName,
+                handlerPhase: handlerPhase,
+                state: .reserved,
+                blockingSince: nil,
+                isReleased: false
             )
+            entriesByWindowID[windowID] = entries
             return .admitted(Slot(
                 registry: self,
                 windowID: windowID,
                 leaseID: leaseID,
                 connectionID: connectionID,
                 invocationID: invocationID
+            ))
+        }
+
+        switch decision {
+        case let .admitted(slot):
+            return .admitted(slot)
+        case let .busy(candidate):
+            return .busy(BusyContext(
+                reason: candidate.reason,
+                originToolName: candidate.entry.toolName,
+                originInvocationID: candidate.entry.invocationID,
+                originConnectionID: candidate.entry.connectionID,
+                detachedAge: candidate.detachedAge,
+                recoveryAfter: candidate.recoveryAfter,
+                handlerPhase: candidate.entry.handlerPhase(),
+                releasedProviderCount: candidate.releasedProviderCount
             ))
         }
     }
@@ -191,7 +285,8 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
             let entries = entriesByWindowID[windowID, default: [:]]
             return Snapshot(
                 activeCount: entries.count,
-                detachedCount: entries.values.count { $0.state.isZombie }
+                detachedCount: entries.values.count { $0.state.isZombie },
+                releasedCount: entries.values.count(where: \.isReleased)
             )
         }
     }
@@ -235,7 +330,8 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
     private func resolveGraceExpiry(
         windowID: Int,
         leaseID: UUID,
-        invocationID: UUID
+        invocationID: UUID,
+        now: Duration
     ) -> GraceExpiryDirective {
         lock.withLock {
             guard var entries = entriesByWindowID[windowID],
@@ -246,8 +342,9 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
             switch entry.state {
             case .reserved:
                 let otherUnsettled = entries.values.contains {
-                    $0.leaseID != leaseID && $0.state.blocksAdmission
+                    $0.leaseID != leaseID && $0.blocksAdmission
                 }
+                entry.blockingSince = now
                 if otherUnsettled {
                     entry.state = .forceDisconnecting
                     entries[leaseID] = entry
@@ -301,7 +398,8 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
     private func cancel(
         windowID: Int,
         leaseID: UUID,
-        invocationID: UUID
+        invocationID: UUID,
+        now: Duration
     ) -> CancellationDirective {
         let result: (CancellationDirective, [CheckedContinuation<Void, Never>]) = lock.withLock {
             guard var entries = entriesByWindowID[windowID],
@@ -312,6 +410,7 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
             switch entry.state {
             case .reserved:
                 entry.state = .abandoned
+                entry.blockingSince = now
                 entries[leaseID] = entry
                 entriesByWindowID[windowID] = entries
                 return (.abandoned(nil), [])
@@ -410,9 +509,7 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
         return []
     }
 
-    private static func busyReason(
-        for entries: Dictionary<UUID, Entry>.Values
-    ) -> BusyReason {
+    private static func busyReason(for entries: [Entry]) -> BusyReason {
         if entries.contains(where: {
             if case .abandoned = $0.state { return true }
             return false
@@ -423,6 +520,26 @@ package final class MCPCodeStructureSettlementRegistry: @unchecked Sendable {
             return .detached
         }
         return .settling
+    }
+
+    private static func oldestEntry(in entries: [Entry]) -> Entry {
+        precondition(!entries.isEmpty, "Busy settlement context requires an originating entry")
+        return entries.min { lhs, rhs in
+            let lhsBlockingSince = lhs.blockingSince
+            let rhsBlockingSince = rhs.blockingSince
+            precondition(
+                lhsBlockingSince != nil && rhsBlockingSince != nil,
+                "Blocking settlement entries require origin timestamps"
+            )
+            if lhsBlockingSince == rhsBlockingSince {
+                return lhs.invocationID.uuidString < rhs.invocationID.uuidString
+            }
+            return lhsBlockingSince! < rhsBlockingSince!
+        }!
+    }
+
+    private static func elapsed(since start: Duration, now: Duration) -> Duration {
+        max(.zero, now - start)
     }
 
     #if DEBUG

--- a/Sources/RepoPromptDomainRuntime/MCPDomainToolExecutionContract.swift
+++ b/Sources/RepoPromptDomainRuntime/MCPDomainToolExecutionContract.swift
@@ -59,7 +59,7 @@ package enum MCPToolExecutionContract: Equatable, Sendable {
 
 package enum MCPToolExecutionDispatchError: Error, Equatable, Sendable {
     case missingContract(toolName: String)
-    case structureSettlementBusy(windowID: Int, reason: MCPCodeStructureSettlementRegistry.BusyReason)
+    case structureSettlementBusy(windowID: Int, context: MCPCodeStructureSettlementRegistry.BusyContext)
     case structureSettlementWindowUnresolved
 }
 

--- a/Sources/RepoPromptDomainRuntime/MCPDomainToolExecutionWatchdog.swift
+++ b/Sources/RepoPromptDomainRuntime/MCPDomainToolExecutionWatchdog.swift
@@ -410,7 +410,7 @@ package enum MCPToolExecutionWatchdog {
                     guard deadlineDidExpire else { continue }
 
                     if let settlementSlot {
-                        switch settlementSlot.resolveGraceExpiry() {
+                        switch settlementSlot.resolveGraceExpiry(now: environment.now()) {
                         case .settled:
                             continue
 
@@ -493,7 +493,7 @@ package enum MCPToolExecutionWatchdog {
                 await onEvent(.cancellationRequested(origin: .requestCancellation))
             }
             if let settlementSlot {
-                switch settlementSlot.cancel() {
+                switch settlementSlot.cancel(now: environment.now()) {
                 case let .abandoned(completedSettlement):
                     if let completedSettlement {
                         Task { await onAbandonedSettlement(completedSettlement) }

--- a/Tests/RepoPromptTests/MCP/Control/MCPCodeStructureSettlementRegistryTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPCodeStructureSettlementRegistryTests.swift
@@ -14,20 +14,24 @@ final class MCPCodeStructureSettlementRegistryTests: XCTestCase {
             .init(activeCount: 2, detachedCount: 0)
         )
         XCTAssertEqual(first.recordCompletion(.success), .deliver)
-        XCTAssertEqual(graceWaiting.resolveGraceExpiry(), .detach)
+        XCTAssertEqual(graceWaiting.resolveGraceExpiry(now: .zero), .detach)
         XCTAssertEqual(graceWaiting.activateDetach(), .activated)
         XCTAssertEqual(
             registry.snapshot(windowID: windowID),
             .init(activeCount: 1, detachedCount: 1)
         )
 
-        guard case .busy(.detached) = registry.admit(
+        guard case let .busy(context) = registry.admit(
             windowID: windowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("A detached lease must fence repeated requests")
         }
+        XCTAssertEqual(context.reason, .detached)
 
         XCTAssertEqual(graceWaiting.recordCompletion(.success), .settleDetached)
         await registry.awaitDrained(windowID: windowID)
@@ -38,23 +42,30 @@ final class MCPCodeStructureSettlementRegistryTests: XCTestCase {
         let windowID = 23
         let abandoned = admittedSlot(registry, windowID: windowID)
 
-        XCTAssertEqual(abandoned.cancel(), .abandoned(nil))
-        XCTAssertEqual(abandoned.cancel(), .abandoned(nil))
+        XCTAssertEqual(abandoned.cancel(now: .zero), .abandoned(nil))
+        XCTAssertEqual(abandoned.cancel(now: .zero), .abandoned(nil))
         for _ in 0 ..< 3 {
-            guard case .busy(.abandoned) = registry.admit(
+            guard case let .busy(context) = registry.admit(
                 windowID: windowID,
                 connectionID: UUID(),
-                invocationID: UUID()
+                invocationID: UUID(),
+                toolName: "get_code_structure",
+                now: .zero,
+                handlerPhase: { nil }
             ) else {
                 return XCTFail("An abandoned lease must keep every retry busy")
             }
+            XCTAssertEqual(context.reason, .abandoned)
         }
 
         XCTAssertEqual(abandoned.recordCompletion(.cancellation), .settleAbandoned)
         guard case let .admitted(next) = registry.admit(
             windowID: windowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("Late settlement must lift the busy fence")
         }
@@ -73,15 +84,15 @@ final class MCPCodeStructureSettlementRegistryTests: XCTestCase {
         let windowID = 31
         let detaching = admittedSlot(registry, windowID: windowID)
 
-        XCTAssertEqual(detaching.resolveGraceExpiry(), .detach)
-        XCTAssertEqual(detaching.cancel(), .abandoned(nil))
+        XCTAssertEqual(detaching.resolveGraceExpiry(now: .zero), .detach)
+        XCTAssertEqual(detaching.cancel(now: .zero), .abandoned(nil))
         XCTAssertEqual(detaching.activateDetach(), .notActivated)
         XCTAssertEqual(detaching.recordCompletion(.cancellation), .settleAbandoned)
 
         let detached = admittedSlot(registry, windowID: windowID)
-        XCTAssertEqual(detached.resolveGraceExpiry(), .detach)
+        XCTAssertEqual(detached.resolveGraceExpiry(now: .zero), .detach)
         XCTAssertEqual(detached.activateDetach(), .activated)
-        XCTAssertEqual(detached.cancel(), .alreadyDetached)
+        XCTAssertEqual(detached.cancel(now: .zero), .alreadyDetached)
         XCTAssertEqual(
             registry.snapshot(windowID: windowID),
             .init(activeCount: 1, detachedCount: 1)
@@ -96,21 +107,25 @@ final class MCPCodeStructureSettlementRegistryTests: XCTestCase {
         let first = admittedSlot(registry, windowID: windowID)
         let second = admittedSlot(registry, windowID: windowID)
 
-        XCTAssertEqual(first.cancel(), .abandoned(nil))
-        XCTAssertEqual(second.cancel(), .abandoned(nil))
+        XCTAssertEqual(first.cancel(now: .zero), .abandoned(nil))
+        XCTAssertEqual(second.cancel(now: .zero), .abandoned(nil))
         XCTAssertEqual(
             registry.snapshot(windowID: windowID),
             .init(activeCount: 2, detachedCount: 2)
         )
 
         XCTAssertEqual(second.recordCompletion(.cancellation), .settleAbandoned)
-        guard case .busy(.abandoned) = registry.admit(
+        guard case let .busy(context) = registry.admit(
             windowID: windowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("Settling one abandoned call must not clear the other abandoned lease")
         }
+        XCTAssertEqual(context.reason, .abandoned)
         XCTAssertEqual(first.recordCompletion(.success), .settleAbandoned)
         await registry.awaitDrained(windowID: windowID)
     }
@@ -121,36 +136,182 @@ final class MCPCodeStructureSettlementRegistryTests: XCTestCase {
         let first = admittedSlot(registry, windowID: windowID)
         let second = admittedSlot(registry, windowID: windowID)
 
-        XCTAssertEqual(first.cancel(), .abandoned(nil))
-        XCTAssertEqual(second.resolveGraceExpiry(), .forceDisconnect)
-        XCTAssertEqual(second.cancel(), .forceDisconnect(nil))
+        XCTAssertEqual(first.cancel(now: .zero), .abandoned(nil))
+        XCTAssertEqual(second.resolveGraceExpiry(now: .zero), .forceDisconnect)
+        XCTAssertEqual(second.cancel(now: .zero), .forceDisconnect(nil))
         XCTAssertEqual(
             registry.snapshot(windowID: windowID),
             .init(activeCount: 2, detachedCount: 1)
         )
-
-        XCTAssertEqual(second.recordCompletion(.cancellation), .settleForceDisconnected)
-        guard case .busy(.abandoned) = registry.admit(
+        guard case let .busy(capacityContext) = registry.admit(
             windowID: windowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
+        ) else {
+            return XCTFail("Two escaped providers must exhaust the per-window recovery budget")
+        }
+        XCTAssertEqual(capacityContext.reason, .releasedProviderLimitReached)
+        XCTAssertNil(capacityContext.recoveryAfter)
+        XCTAssertEqual(capacityContext.releasedProviderCount, 0)
+
+        XCTAssertEqual(second.recordCompletion(.cancellation), .settleForceDisconnected)
+        guard case let .busy(context) = registry.admit(
+            windowID: windowID,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("Settling a force-disconnected call must not clear the abandoned lease")
         }
+        XCTAssertEqual(context.reason, .abandoned)
         XCTAssertEqual(first.recordCompletion(.success), .settleAbandoned)
+        await registry.awaitDrained(windowID: windowID)
+    }
+
+    func testDetachedLeaseRecoversAtBoundWithoutClearingReplacement() async {
+        let registry = MCPCodeStructureSettlementRegistry()
+        let windowID = 59
+        let connectionID = UUID()
+        let invocationID = UUID()
+        let detached = admittedSlot(
+            registry,
+            windowID: windowID,
+            connectionID: connectionID,
+            invocationID: invocationID,
+            toolName: "read_file"
+        )
+
+        XCTAssertEqual(detached.resolveGraceExpiry(now: .zero), .detach)
+        XCTAssertEqual(detached.activateDetach(), .activated)
+        guard case let .busy(context) = registry.admit(
+            windowID: windowID,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: "get_file_tree",
+            now: MCPCodeStructureSettlementRegistry.recoveryHorizon - .nanoseconds(1),
+            handlerPhase: { nil }
+        ) else {
+            return XCTFail("The detached lease must fence calls before the recovery bound")
+        }
+        XCTAssertEqual(context.reason, .detached)
+        XCTAssertEqual(context.originToolName, "read_file")
+        XCTAssertEqual(context.originConnectionID, connectionID)
+        XCTAssertEqual(context.originInvocationID, invocationID)
+        XCTAssertEqual(context.recoveryAfter, .nanoseconds(1))
+
+        guard case let .admitted(replacement) = registry.admit(
+            windowID: windowID,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: "get_file_tree",
+            now: MCPCodeStructureSettlementRegistry.recoveryHorizon,
+            handlerPhase: { nil }
+        ) else {
+            return XCTFail("The window must recover at the bounded horizon")
+        }
+        XCTAssertEqual(
+            registry.snapshot(windowID: windowID),
+            .init(activeCount: 2, detachedCount: 1, releasedCount: 1)
+        )
+
+        XCTAssertEqual(detached.recordCompletion(.success), .settleDetached)
+        XCTAssertEqual(
+            registry.snapshot(windowID: windowID),
+            .init(activeCount: 1, detachedCount: 0, releasedCount: 0),
+            "Late completion must remove only the original lease"
+        )
+        XCTAssertEqual(replacement.recordCompletion(.success), .deliver)
+        await registry.awaitDrained(windowID: windowID)
+    }
+
+    func testReleasedProviderLimitStopsRepeatedEscapesUntilSettlement() async {
+        let registry = MCPCodeStructureSettlementRegistry()
+        let windowID = 61
+        let first = admittedSlot(registry, windowID: windowID, toolName: "read_file")
+
+        XCTAssertEqual(first.resolveGraceExpiry(now: .zero), .detach)
+        XCTAssertEqual(first.activateDetach(), .activated)
+        guard case let .admitted(second) = registry.admit(
+            windowID: windowID,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: "get_file_tree",
+            now: MCPCodeStructureSettlementRegistry.recoveryHorizon,
+            handlerPhase: { nil }
+        ) else {
+            return XCTFail("The first escaped provider must permit bounded recovery")
+        }
+
+        XCTAssertEqual(
+            second.resolveGraceExpiry(now: MCPCodeStructureSettlementRegistry.recoveryHorizon),
+            .detach
+        )
+        XCTAssertEqual(second.activateDetach(), .activated)
+        guard case let .busy(preHorizonContext) = registry.admit(
+            windowID: windowID,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: MCPCodeStructureSettlementRegistry.recoveryHorizon + .seconds(1),
+            handlerPhase: { nil }
+        ) else {
+            return XCTFail("An exhausted recovery budget must be terminal immediately")
+        }
+        XCTAssertEqual(preHorizonContext.reason, .releasedProviderLimitReached)
+        XCTAssertNil(preHorizonContext.recoveryAfter)
+        XCTAssertEqual(preHorizonContext.releasedProviderCount, 1)
+
+        guard case let .busy(context) = registry.admit(
+            windowID: windowID,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: MCPCodeStructureSettlementRegistry.recoveryHorizon + MCPCodeStructureSettlementRegistry.recoveryHorizon,
+            handlerPhase: { nil }
+        ) else {
+            return XCTFail("A second escaped provider must not exceed the per-window bound")
+        }
+        XCTAssertEqual(context.reason, .releasedProviderLimitReached)
+        XCTAssertNil(context.recoveryAfter)
+        XCTAssertEqual(context.releasedProviderCount, 1)
+
+        XCTAssertEqual(first.recordCompletion(.success), .settleDetached)
+        guard case let .admitted(replacement) = registry.admit(
+            windowID: windowID,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: MCPCodeStructureSettlementRegistry.recoveryHorizon + MCPCodeStructureSettlementRegistry.recoveryHorizon,
+            handlerPhase: { nil }
+        ) else {
+            return XCTFail("Settlement must restore the released-provider budget")
+        }
+        XCTAssertEqual(second.recordCompletion(.success), .settleDetached)
+        XCTAssertEqual(replacement.recordCompletion(.success), .deliver)
         await registry.awaitDrained(windowID: windowID)
     }
 
     private func admittedSlot(
         _ registry: MCPCodeStructureSettlementRegistry,
         windowID: Int,
+        connectionID: UUID = UUID(),
+        invocationID: UUID = UUID(),
+        toolName: String = "get_code_structure",
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> MCPCodeStructureSettlementRegistry.Slot {
         guard case let .admitted(slot) = registry.admit(
             windowID: windowID,
-            connectionID: UUID(),
-            invocationID: UUID()
+            connectionID: connectionID,
+            invocationID: invocationID,
+            toolName: toolName,
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             XCTFail("Expected admitted settlement lease", file: file, line: line)
             fatalError("Missing settlement lease")

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -2427,6 +2427,162 @@ import XCTest
             }
         }
 
+        func testReadFileDeadlineReportsProductionContentReadPhase() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let clock = ExecutionWatchdogManualClock()
+                let providerGate = MCPExecutionIgnoringCancellationGate()
+                let recorder = MCPExecutionTraceRecorder()
+                let manager = fixture.networkManager
+                let store = fixture.contextA.window.workspaceFileContextStore
+                let rootID = fixture.contextA.rootID
+                let relativePath = "HandlerPhaseRead-\(UUID().uuidString).swift"
+                let fileURL = fixture.contextA.rootURL.appendingPathComponent(relativePath)
+                let windowID = fixture.contextA.window.windowID
+                var originTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                _ = try await store.createFile(
+                    rootID: rootID,
+                    relativePath: relativePath,
+                    content: String(repeating: "let handlerPhaseRead = true\n", count: 4096)
+                )
+                await store.clearSearchDecodedContentCache()
+                try await store.setSearchContentReadChunkHandlerForTesting(rootID: rootID) { path in
+                    guard path == relativePath else { return }
+                    await providerGate.enterAndWait()
+                }
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+
+                do {
+                    let endpoint = try fixture.endpointA()
+                    let activeOriginTask = Task {
+                        try await endpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: [
+                                "path": fileURL.path,
+                                "context_id": fixture.contextA.tabID.uuidString,
+                                "_rawJSON": true
+                            ]
+                        )
+                    }
+                    originTask = activeOriginTask
+                    try await clock.waitForSleeperCount(1)
+                    try await providerGate.waitUntilEntered(count: 1)
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
+
+                    let phaseArrived = await Self.waitUntil {
+                        recorder.snapshot().contains {
+                            $0.toolName == MCPWindowToolName.readFile
+                                && $0.phase == .deadlineExpired
+                                && $0.handlerPhase?.phase == .readFileContentRead
+                        }
+                    }
+                    XCTAssertTrue(phaseArrived)
+                    let deadlineEvent = try XCTUnwrap(recorder.snapshot().first {
+                        $0.toolName == MCPWindowToolName.readFile && $0.phase == .deadlineExpired
+                    })
+                    XCTAssertEqual(deadlineEvent.handlerPhase?.phase, .readFileContentRead)
+                    XCTAssertEqual(deadlineEvent.handlerPhase?.transition, .started)
+
+                    await providerGate.release()
+                    try await store.setSearchContentReadChunkHandlerForTesting(rootID: rootID, nil)
+                    let timeoutPayload = try await Self.toolResultObject(activeOriginTask.value)
+                    originTask = nil
+                    XCTAssertEqual(timeoutPayload["code"] as? String, "tool_execution_timeout")
+                    await manager.debugAwaitCodeStructureSettlementDrain(windowID: windowID)
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    originTask?.cancel()
+                    await providerGate.release()
+                    try? await store.setSearchContentReadChunkHandlerForTesting(rootID: rootID, nil)
+                    if let originTask { _ = try? await originTask.value }
+                    await manager.debugAwaitCodeStructureSettlementDrain(windowID: windowID)
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testFileTreeDeadlineReportsProductionIngressPhase() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let clock = ExecutionWatchdogManualClock()
+                let providerGate = MCPExecutionIgnoringCancellationGate()
+                let recorder = MCPExecutionTraceRecorder()
+                let manager = fixture.networkManager
+                let store = fixture.contextA.window.workspaceFileContextStore
+                let rootID = fixture.contextA.rootID
+                let windowID = fixture.contextA.window.windowID
+                var originTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                    guard observedRootID == rootID else { return }
+                    await providerGate.enterAndWait()
+                }
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+
+                do {
+                    let endpoint = try fixture.endpointA()
+                    let activeOriginTask = Task {
+                        try await endpoint.callTool(
+                            name: MCPWindowToolName.getFileTree,
+                            arguments: [
+                                "type": "files",
+                                "context_id": fixture.contextA.tabID.uuidString,
+                                "_rawJSON": true
+                            ]
+                        )
+                    }
+                    originTask = activeOriginTask
+                    try await clock.waitForSleeperCount(1)
+                    try await providerGate.waitUntilEntered(count: 1)
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
+
+                    let phaseArrived = await Self.waitUntil {
+                        recorder.snapshot().contains {
+                            $0.toolName == MCPWindowToolName.getFileTree
+                                && $0.phase == .deadlineExpired
+                                && $0.handlerPhase?.phase == .getFileTreeIngressWait
+                        }
+                    }
+                    XCTAssertTrue(phaseArrived)
+                    let deadlineEvent = try XCTUnwrap(recorder.snapshot().first {
+                        $0.toolName == MCPWindowToolName.getFileTree && $0.phase == .deadlineExpired
+                    })
+                    XCTAssertEqual(deadlineEvent.handlerPhase?.phase, .getFileTreeIngressWait)
+                    XCTAssertEqual(deadlineEvent.handlerPhase?.transition, .started)
+
+                    await providerGate.release()
+                    await store.setScopedIngressBarrierWillFlushHandler(nil)
+                    let timeoutPayload = try await Self.toolResultObject(activeOriginTask.value)
+                    originTask = nil
+                    XCTAssertEqual(timeoutPayload["code"] as? String, "tool_execution_timeout")
+                    await manager.debugAwaitCodeStructureSettlementDrain(windowID: windowID)
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    originTask?.cancel()
+                    await providerGate.release()
+                    await store.setScopedIngressBarrierWillFlushHandler(nil)
+                    if let originTask { _ = try? await originTask.value }
+                    await manager.debugAwaitCodeStructureSettlementDrain(windowID: windowID)
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
         func testDetachedCodeStructureTimeoutRecoversBeforeLateProviderDrains() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
                 let fixture = try await PersistentMCPTestFixture.make(lease: lease)

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -2357,7 +2357,7 @@ import XCTest
                     let readPayload = try Self.toolResultObject(readResponse)
                     XCTAssertEqual(readPayload["code"] as? String, "tool_execution_structure_settlement_busy")
                     XCTAssertEqual(readPayload["retryable"] as? Bool, true)
-                    XCTAssertEqual((readPayload["retry_after_ms"] as? NSNumber)?.intValue, 250)
+                    XCTAssertEqual((readPayload["retry_after_ms"] as? NSNumber)?.intValue, 30000)
                     XCTAssertEqual(readPayload["busy_reason"] as? String, "abandoned_settlement_in_progress")
                     XCTAssertEqual(readPayload["settlement"] as? String, "busy")
                     XCTAssertTrue((readPayload["error"] as? String)?.contains("prior canceled MCP operation") == true)
@@ -2427,11 +2427,12 @@ import XCTest
             }
         }
 
-        func testDetachedCodeStructureTimeoutKeepsConnectionUsableAndDrainsLateProvider() async throws {
+        func testDetachedCodeStructureTimeoutRecoversBeforeLateProviderDrains() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
                 let fixture = try await PersistentMCPTestFixture.make(lease: lease)
                 let clock = ExecutionWatchdogManualClock()
                 let provider = MCPCodeStructureSettlementProviderProbe()
+                let repeatedEscapeGate = MCPExecutionIgnoringCancellationGate()
                 let recorder = MCPExecutionTraceRecorder()
                 let manager = fixture.networkManager
                 let windowID = fixture.contextA.window.windowID
@@ -2447,7 +2448,8 @@ import XCTest
                 MCPToolExecutionTracer.setTestSink { recorder.append($0) }
                 await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
                 await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.getCodeStructure) {
-                    try await provider.run()
+                    await MCPToolExecutionHandlerPhaseContext.report(.getCodeStructureGraphTraversal)
+                    return try await provider.run()
                 }
 
                 do {
@@ -2508,8 +2510,15 @@ import XCTest
                     )
                     XCTAssertEqual(limiter?.activePermitCount, 0)
 
-                    // Every detach-disposition tool is fenced for this window until the detached
-                    // provider drains, while unrelated MCP traffic remains usable.
+                    let detachEvents = recorder.snapshot().filter {
+                        $0.connectionID == endpoint.connectionID
+                            && $0.toolName == MCPWindowToolName.getCodeStructure
+                            && $0.phase == .detachedForSettlement
+                    }
+                    XCTAssertEqual(detachEvents.count, 1)
+                    let detachedEvent = try XCTUnwrap(detachEvents.first)
+
+                    // The affected window remains fenced until the registry's recovery horizon expires.
                     let readResponse = try await endpoint.callTool(
                         name: MCPWindowToolName.readFile,
                         arguments: [
@@ -2521,8 +2530,26 @@ import XCTest
                     let readPayload = try Self.toolResultObject(readResponse)
                     XCTAssertEqual(readPayload["code"] as? String, "tool_execution_structure_settlement_busy")
                     XCTAssertEqual(readPayload["retryable"] as? Bool, true)
+                    XCTAssertEqual((readPayload["retry_after_ms"] as? NSNumber)?.intValue, 29000)
+                    XCTAssertEqual((readPayload["detached_age_ms"] as? NSNumber)?.intValue, 1000)
+                    XCTAssertEqual(readPayload["origin_tool"] as? String, MCPWindowToolName.getCodeStructure)
+                    XCTAssertEqual(readPayload["origin_invocation_id"] as? String, detachedEvent.invocationID.uuidString)
+                    XCTAssertEqual(readPayload["origin_connection_id"] as? String, endpoint.connectionID.uuidString)
+                    XCTAssertEqual(
+                        readPayload["last_handler_phase"] as? String,
+                        MCPToolExecutionHandlerPhase.getCodeStructureGraphTraversal.rawValue
+                    )
                     XCTAssertTrue((readPayload["error"] as? String)?.contains("prior timed-out MCP operation") == true)
-                    XCTAssertFalse((readPayload["error"] as? String)?.contains("timed-out read_file") == true)
+
+                    // The settlement fence is window-scoped; unrelated MCP traffic stays usable.
+                    let siblingResponse = try await fixture.endpointB().callTool(
+                        name: MCPWindowToolName.readFile,
+                        arguments: [
+                            "path": fixture.contextB.fileURL.path,
+                            "context_id": fixture.contextB.tabID.uuidString
+                        ]
+                    )
+                    XCTAssertTrue(try Self.toolResultText(siblingResponse).contains(fixture.contextB.sentinel))
                     _ = try await endpoint.callTool(
                         name: MCPWindowToolName.manageSelection,
                         arguments: [
@@ -2533,7 +2560,6 @@ import XCTest
                     let readSleepersDrained = await Self.waitUntil { await clock.sleeperCount() == 0 }
                     XCTAssertTrue(readSleepersDrained)
 
-                    // Busy is introduced only after the eligible call actually detached.
                     let busyResponse = try await endpoint.callTool(
                         name: MCPWindowToolName.getCodeStructure,
                         arguments: arguments
@@ -2541,20 +2567,86 @@ import XCTest
                     let busyPayload = try Self.toolResultObject(busyResponse)
                     XCTAssertEqual(busyPayload["code"] as? String, "tool_execution_structure_settlement_busy")
                     XCTAssertEqual(busyPayload["retryable"] as? Bool, true)
-                    XCTAssertEqual((busyPayload["retry_after_ms"] as? NSNumber)?.intValue, 250)
+                    XCTAssertEqual((busyPayload["retry_after_ms"] as? NSNumber)?.intValue, 29000)
                     XCTAssertEqual(busyPayload["busy_reason"] as? String, "detached_settlement_in_progress")
                     XCTAssertEqual(busyPayload["settlement"] as? String, "busy")
-                    XCTAssertTrue((busyPayload["error"] as? String)?.contains("prior timed-out") == true)
-                    let enteredCountBeforeDrain = await provider.enteredCount()
-                    XCTAssertEqual(enteredCountBeforeDrain, 2)
 
-                    let detachEvents = recorder.snapshot().filter {
-                        $0.connectionID == endpoint.connectionID
-                            && $0.toolName == MCPWindowToolName.getCodeStructure
-                            && $0.phase == .detachedForSettlement
+                    // A fresh client succeeds when the recovery horizon expires while the original
+                    // provider remains blocked.
+                    try await clock.advanceWithoutSleepers(by: .seconds(29))
+                    let recoveredEndpoint = try await fixture.makeAdditionalEndpoint(label: "issue-818-recovery")
+                    let recoveredResponse = try await recoveredEndpoint.callTool(
+                        name: MCPWindowToolName.readFile,
+                        arguments: [
+                            "path": fixture.contextA.fileURL.path,
+                            "context_id": fixture.contextA.tabID.uuidString
+                        ]
+                    )
+                    XCTAssertTrue(try Self.toolResultText(recoveredResponse).contains(fixture.contextA.sentinel))
+                    let enteredCountAtRecovery = await provider.enteredCount()
+                    let recoveredSnapshot = await manager.debugCodeStructureSettlementSnapshot(windowID: windowID)
+                    XCTAssertEqual(enteredCountAtRecovery, 2)
+                    XCTAssertEqual(
+                        recoveredSnapshot,
+                        .init(activeCount: 1, detachedCount: 1, releasedCount: 1)
+                    )
+
+                    // A second escaped provider exhausts the window-scoped recovery budget.
+                    await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.getCodeStructure) {
+                        await MCPToolExecutionHandlerPhaseContext.report(.getCodeStructureGraphTraversal)
+                        await repeatedEscapeGate.enterAndWait()
+                        return .null
                     }
-                    XCTAssertEqual(detachEvents.count, 1)
-                    let detachedEvent = try XCTUnwrap(detachEvents.first)
+                    let repeatedEscape = Task {
+                        try await recoveredEndpoint.callTool(
+                            name: MCPWindowToolName.getCodeStructure,
+                            arguments: arguments
+                        )
+                    }
+                    try await clock.waitForSleeperCount(1)
+                    try await repeatedEscapeGate.waitUntilEntered(count: 1)
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
+                    try await clock.waitForSleeperCount(1)
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace)
+                    let repeatedEscapePayload = try await Self.toolResultObject(repeatedEscape.value)
+                    XCTAssertEqual(repeatedEscapePayload["code"] as? String, "tool_execution_timeout")
+                    XCTAssertEqual(repeatedEscapePayload["settlement"] as? String, "detached")
+
+                    try await clock.advanceWithoutSleepers(by: MCPCodeStructureSettlementRegistry.recoveryHorizon)
+                    let terminalResponse = try await recoveredEndpoint.callTool(
+                        name: MCPWindowToolName.readFile,
+                        arguments: [
+                            "path": fixture.contextA.fileURL.path,
+                            "context_id": fixture.contextA.tabID.uuidString,
+                            "_rawJSON": true
+                        ]
+                    )
+                    let terminalPayload = try Self.toolResultObject(terminalResponse)
+                    XCTAssertEqual(terminalPayload["code"] as? String, "tool_execution_structure_settlement_busy")
+                    XCTAssertEqual(terminalPayload["retryable"] as? Bool, false)
+                    XCTAssertNil(terminalPayload["retry_after_ms"])
+                    XCTAssertEqual(terminalPayload["busy_reason"] as? String, "released_provider_limit_reached")
+                    XCTAssertEqual(terminalPayload["origin_tool"] as? String, MCPWindowToolName.getCodeStructure)
+                    XCTAssertEqual(
+                        terminalPayload["origin_connection_id"] as? String,
+                        recoveredEndpoint.connectionID.uuidString
+                    )
+                    XCTAssertEqual((terminalPayload["detached_age_ms"] as? NSNumber)?.intValue, 30000)
+                    XCTAssertEqual(
+                        terminalPayload["last_handler_phase"] as? String,
+                        MCPToolExecutionHandlerPhase.getCodeStructureGraphTraversal.rawValue
+                    )
+                    XCTAssertTrue((terminalPayload["error"] as? String)?.contains("restart RepoPrompt CE") == true)
+
+                    let siblingAtLimitResponse = try await fixture.endpointB().callTool(
+                        name: MCPWindowToolName.readFile,
+                        arguments: [
+                            "path": fixture.contextB.fileURL.path,
+                            "context_id": fixture.contextB.tabID.uuidString
+                        ]
+                    )
+                    XCTAssertTrue(try Self.toolResultText(siblingAtLimitResponse).contains(fixture.contextB.sentinel))
+
                     XCTAssertTrue(detachedEvent.isAlwaysEmitted)
                     XCTAssertEqual(detachedEvent.cleanupDisposition, .detachAndSettle)
                     XCTAssertEqual(detachedEvent.cancellationOrigin, .watchdogDeadline)
@@ -2574,6 +2666,7 @@ import XCTest
                         .count { $0.eventName == "MCP.ToolCall.HandlerResultReady" }
 
                     await provider.releaseFirst()
+                    await repeatedEscapeGate.release()
                     await manager.debugAwaitCodeStructureSettlementDrain(windowID: windowID)
                     let lateTraceArrived = await Self.waitUntil {
                         recorder.snapshot().contains {
@@ -2631,6 +2724,10 @@ import XCTest
                     XCTAssertEqual(sleeperCountAfterDrain, 0)
 
                     // A fresh generation is admitted after drain and completes normally.
+                    await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.getCodeStructure) {
+                        await MCPToolExecutionHandlerPhaseContext.report(.getCodeStructureGraphTraversal)
+                        return try await provider.run()
+                    }
                     let postDrainResponse = try await endpoint.callTool(
                         name: MCPWindowToolName.getCodeStructure,
                         arguments: arguments
@@ -2652,6 +2749,7 @@ import XCTest
                     try await fixture.assertCleanedUp()
                 } catch {
                     await provider.releaseFirst()
+                    await repeatedEscapeGate.release()
                     firstResponseTask?.cancel()
                     if let firstResponseTask { _ = try? await firstResponseTask.value }
                     _ = EditFlowPerf.debugCaptureSnapshot(finish: true)

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogTests.swift
@@ -180,7 +180,10 @@ final class MCPToolExecutionWatchdogTests: XCTestCase {
         guard case let .admitted(settlementSlot) = registry.admit(
             windowID: windowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("Expected settlement lease")
         }
@@ -230,7 +233,10 @@ final class MCPToolExecutionWatchdogTests: XCTestCase {
         guard case let .admitted(settlementSlot) = registry.admit(
             windowID: windowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("Expected settlement lease")
         }
@@ -404,7 +410,10 @@ final class MCPToolExecutionWatchdogTests: XCTestCase {
         guard case let .admitted(settlementSlot) = registry.admit(
             windowID: windowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("Expected settlement lease")
         }
@@ -466,7 +475,10 @@ final class MCPToolExecutionWatchdogTests: XCTestCase {
         guard case let .admitted(settlementSlot) = registry.admit(
             windowID: windowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("Expected settlement lease")
         }

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineManifestWriteTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineManifestWriteTests.swift
@@ -198,11 +198,14 @@ final class CodemapBindingEngineManifestWriteTests: CodemapBindingEngineTestCase
         guard case let .admitted(settlementSlot) = settlementRegistry.admit(
             windowID: settlementWindowID,
             connectionID: UUID(),
-            invocationID: UUID()
+            invocationID: UUID(),
+            toolName: "get_code_structure",
+            now: .zero,
+            handlerPhase: { nil }
         ) else {
             return XCTFail("Expected read-only settlement lease")
         }
-        XCTAssertEqual(settlementSlot.resolveGraceExpiry(), .detach)
+        XCTAssertEqual(settlementSlot.resolveGraceExpiry(now: .zero), .detach)
         XCTAssertEqual(settlementSlot.activateDetach(), .activated)
         defer { _ = settlementSlot.recordCompletion(.cancellation) }
 


### PR DESCRIPTION
This fixes https://github.com/repoprompt/repoprompt-ce/issues/818 (also [mentioned](https://discord.com/channels/1262487703744675901/1365796959616630794/1537839672762441950) on Discord), which is a bug where, whenever `read_file`, `get_file_tree`, or `get_code_structure` would time out and ignore cancellation, RepoPrompt CE could then leave all three tools blocked for that window until the app restarted (even for a new MCP client).  This patch gives that settlement fence a bounded recovery path while continuing to track the original provider.

## Summary

- Recover same-window structure tools 30 seconds after a provider detaches
- Keep late completion tied to the exact invocation so it cannot publish stale output or clear newer work
- Limit each window to one still-running provider after recovery
- Return non-retryable restart guidance if another provider becomes stuck before the first settles
- Include the originating tool, invocation, connection, age, remaining wait, and handler phase in busy responses
- Keep sibling windows usable throughout recovery

## Implementation Notes

- The settlement registry remains the single owner of admission and recovery state
- Providers remain tracked after they stop fencing new calls
- Recovery and escaped-provider accounting remain window-scoped

## Review Approach

- The patch received one focused maintainability review and complete-patch correctness reviews against the scope of #818
- Findings around terminal retry behavior, explicit registry inputs, and duplicate diagnostics were fixed with focused regressions

## Validation

Passed locally:

- `make dev-test FILTER=MCPToolExecutionWatchdog` — 41 tests
- `make dev-test FILTER=MCPCodeStructureSettlementRegistryTests` — 7 tests
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- Commit and push safety preflights

The full root suite was also run. One Codex timing failure passed on focused rerun; remaining local failures were in unrelated Agent-run and Git-policy tests. All structure-settlement-focused tests passed.