### PR TITLE
Add inline file browser to manually add files/codemaps to selected set in Context Composer

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileBrowseService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileBrowseService.swift
@@ -1,0 +1,883 @@
+import Foundation
+import OSLog
+
+struct AgentContextFileBrowseRoot: Equatable, Hashable {
+    let id: UUID
+    let physicalPath: String
+    let displayName: String
+    let scopeLabel: String
+}
+
+struct AgentContextFileBrowseFolder: Equatable, Hashable {
+    let id: UUID
+    let rootID: UUID
+    let parentFolderID: UUID?
+    let name: String
+    let standardizedRelativePath: String
+    let standardizedFullPath: String
+    let modificationDate: Date?
+}
+
+struct AgentContextFileBrowseFile: Equatable, Hashable {
+    let id: UUID
+    let rootID: UUID
+    let rootGeneration: UInt64
+    let parentFolderID: UUID?
+    let name: String
+    let standardizedRelativePath: String
+    let standardizedFullPath: String
+    let projectedDisplayPath: String
+    let projectedDirectoryPath: String
+    let modificationDate: Date?
+    let supportsCodemap: Bool
+}
+
+enum AgentContextFileBrowseNodeID: Equatable, Hashable {
+    case root(UUID)
+    case folder(UUID)
+    case file(UUID)
+    case searchRootHeader(UUID)
+    case searchDirectoryHeader(rootID: UUID, directoryPath: String)
+}
+
+enum AgentContextFileBrowseAddMode: Equatable, Hashable {
+    case full
+    case codemapOnly
+}
+
+enum AgentContextFileBrowseHeldMode: Equatable, Hashable {
+    case full
+    case slice
+    case codemap
+}
+
+enum AgentContextFileBrowseContainerMembership: Equatable, Hashable {
+    case none
+    case mixed
+    case all
+}
+
+enum AgentContextFileBrowseTokenEstimate: Equatable, Hashable {
+    case notRequested
+    case loading
+    case known(Int)
+    case unavailable
+}
+
+enum AgentContextFileBrowseRootScope: Equatable, Hashable {
+    case allRoots
+    case root(UUID)
+}
+
+struct AgentContextFileBrowseRootsSnapshot: Equatable {
+    let catalogGeneration: UInt64
+    let roots: [AgentContextFileBrowseRoot]
+}
+
+enum AgentContextFileBrowseRootsResult: Equatable {
+    case available(AgentContextFileBrowseRootsSnapshot)
+    case unavailable(missingPhysicalRootPaths: [String])
+}
+
+enum AgentContextFileBrowseSessionScopedResult<Value> {
+    case available(Value)
+    case missing(catalogGeneration: UInt64)
+    case sessionRootsUnavailable
+}
+
+extension AgentContextFileBrowseSessionScopedResult: Equatable where Value: Equatable {}
+
+struct AgentContextFileBrowseHierarchy: Equatable {
+    let catalogGeneration: UInt64
+    let rootGeneration: UInt64
+    let folders: [AgentContextFileBrowseFolder]
+    let files: [AgentContextFileBrowseFile]
+    let descendantFiles: [AgentContextFileBrowseFile]
+}
+
+struct AgentContextFileBrowseSearchMatch: Equatable {
+    let file: AgentContextFileBrowseFile
+    let score: Int32
+}
+
+struct AgentContextFileBrowseSearchDirectoryGroup: Equatable {
+    let id: AgentContextFileBrowseNodeID
+    let directoryPath: String
+    let matches: [AgentContextFileBrowseSearchMatch]
+}
+
+struct AgentContextFileBrowseSearchRootGroup: Equatable {
+    let id: AgentContextFileBrowseNodeID
+    let root: AgentContextFileBrowseRoot
+    let matchCount: Int
+    let rootMatches: [AgentContextFileBrowseSearchMatch]
+    let directories: [AgentContextFileBrowseSearchDirectoryGroup]
+}
+
+enum AgentContextFileBrowseSearchSource: Equatable {
+    case indexedVisibleWorkspace
+    case storeCatalog
+}
+
+struct AgentContextFileBrowseSearchResult: Equatable {
+    let catalogGeneration: UInt64
+    let source: AgentContextFileBrowseSearchSource
+    let groups: [AgentContextFileBrowseSearchRootGroup]
+
+    var matches: [AgentContextFileBrowseSearchMatch] {
+        groups.flatMap { $0.rootMatches + $0.directories.flatMap(\.matches) }
+    }
+}
+
+struct AgentContextFileBrowseRevalidationResult: Equatable {
+    let catalogGeneration: UInt64
+    let files: [AgentContextFileBrowseFile]
+    let rejectedCount: Int
+}
+
+actor AgentContextFileBrowseService {
+    typealias IndexedSearch = @Sendable (String, Int) async -> WorkspaceSearchQueryResult
+
+    private struct RootTreeIndex {
+        let root: WorkspaceRootRecord
+        let generation: UInt64
+        let rootFolderID: UUID
+        let foldersByID: [UUID: WorkspaceFolderRecord]
+        let directFoldersByParentID: [UUID: [WorkspaceFolderRecord]]
+        let directFilesByParentID: [UUID: [WorkspaceFileRecord]]
+        let orderedFiles: [WorkspaceFileRecord]
+        var descendantsByFolderID: [UUID: [WorkspaceFileRecord]] = [:]
+    }
+
+    private struct SearchIndexKey: Hashable {
+        let rootScope: WorkspaceLookupRootScope
+        let catalogGeneration: UInt64
+        let projectionIdentity: String
+        let selectedRootID: UUID?
+    }
+
+    private struct StoreSearchIndex {
+        let entries: [WorkspaceSearchCatalogEntry]
+        let index: PathSearchIndex
+    }
+
+    private struct RevalidatedRecord {
+        let record: WorkspaceFileRecord
+        let rootGeneration: UInt64
+    }
+
+    private struct RankedRecord {
+        let record: WorkspaceFileRecord
+        let file: AgentContextFileBrowseFile
+        let score: Int32
+    }
+
+    private static let excludedPathComponent = "_git_data"
+    private static let fuzzyThreshold = 0.85
+    private static let indexCandidateMultiplier = 8
+    private static let minimumIndexCandidateLimit = 64
+    private static let logger = Logger(subsystem: "com.repoprompt.agents", category: "ContextFileBrowse")
+
+    private let store: WorkspaceFileContextStore
+    private let indexedSearch: IndexedSearch?
+    private var treeIndexesByRootID: [UUID: RootTreeIndex] = [:]
+    private var searchIndexesByKey: [SearchIndexKey: StoreSearchIndex] = [:]
+
+    init(store: WorkspaceFileContextStore, searchService: WorkspaceSearchService?) {
+        self.store = store
+        if let searchService {
+            indexedSearch = { @Sendable query, limit in
+                await searchService.search(query, limit: limit)
+            }
+        } else {
+            indexedSearch = nil
+        }
+    }
+
+    init(store: WorkspaceFileContextStore, indexedSearch: IndexedSearch? = nil) {
+        self.store = store
+        self.indexedSearch = indexedSearch
+    }
+
+    func pruneCaches(
+        retainingRootIDs: Set<UUID>,
+        lookupContext: WorkspaceLookupContext
+    ) {
+        treeIndexesByRootID = treeIndexesByRootID.filter { retainingRootIDs.contains($0.key) }
+        let projectionIdentity = Self.projectionIdentity(lookupContext.bindingProjection)
+        searchIndexesByKey = searchIndexesByKey.filter { key, _ in
+            key.rootScope == lookupContext.rootScope
+                && key.projectionIdentity == projectionIdentity
+                && key.selectedRootID.map(retainingRootIDs.contains) != false
+        }
+    }
+
+    func roots(lookupContext: WorkspaceLookupContext) async -> AgentContextFileBrowseRootsResult {
+        guard lookupContext.bindingProjection?.isFullyMaterialized != false else {
+            return .unavailable(missingPhysicalRootPaths: [])
+        }
+        let validation = await store.readFileAutoSelectionCatalogValidationSnapshot(
+            rootScope: lookupContext.rootScope
+        )
+        guard case .available = validation.rootScopeAvailability else {
+            if case let .sessionWorktreeUnavailable(missingPhysicalRootPaths) = validation.rootScopeAvailability {
+                Self.logger.notice("Context file browse roots unavailable for the current session scope")
+                return .unavailable(missingPhysicalRootPaths: missingPhysicalRootPaths)
+            }
+            preconditionFailure("Workspace root-scope availability gained an unhandled case")
+        }
+
+        let physicalRoots = await store.rootRefs(scope: lookupContext.rootScope)
+            .filter { !Self.isGitDataRoot($0) }
+        let displayRoots = projectedDisplayRoots(from: physicalRoots, lookupContext: lookupContext)
+        return .available(AgentContextFileBrowseRootsSnapshot(
+            catalogGeneration: validation.rootScopeCatalogGeneration,
+            roots: displayRoots
+        ))
+    }
+
+    func hierarchy(
+        rootID: UUID,
+        folderID: UUID?,
+        lookupContext: WorkspaceLookupContext
+    ) async throws -> AgentContextFileBrowseSessionScopedResult<AgentContextFileBrowseHierarchy> {
+        try Task.checkCancellation()
+        guard case let .available(physicalRoots) = await allowedPhysicalRoots(lookupContext: lookupContext) else {
+            return .sessionRootsUnavailable
+        }
+        guard var index = await currentTreeIndex(rootID: rootID, allowedRoots: physicalRoots) else {
+            guard case let .available(catalogGeneration) = await currentCatalogGeneration(lookupContext: lookupContext) else {
+                return .sessionRootsUnavailable
+            }
+            return .missing(catalogGeneration: catalogGeneration)
+        }
+        let parentID = folderID ?? index.rootFolderID
+        let descendantRecords: [WorkspaceFileRecord]
+        if let folderID {
+            guard index.foldersByID[folderID] != nil else {
+                guard case let .available(catalogGeneration) = await currentCatalogGeneration(lookupContext: lookupContext) else {
+                    return .sessionRootsUnavailable
+                }
+                return .missing(catalogGeneration: catalogGeneration)
+            }
+            if let cached = index.descendantsByFolderID[folderID] {
+                descendantRecords = cached
+            } else {
+                descendantRecords = Self.resolveDescendants(folderID: folderID, index: index)
+                index.descendantsByFolderID[folderID] = descendantRecords
+                treeIndexesByRootID[rootID] = index
+            }
+        } else {
+            descendantRecords = index.orderedFiles
+        }
+        let makeBrowseFile = { record in
+            self.makeFile(
+                record: record,
+                rootGeneration: index.generation,
+                physicalRoots: physicalRoots,
+                lookupContext: lookupContext
+            )
+        }
+        let folders = (index.directFoldersByParentID[parentID] ?? []).map(Self.makeFolder)
+        let files = (index.directFilesByParentID[parentID] ?? []).compactMap(makeBrowseFile)
+        let descendantFiles = descendantRecords.compactMap(makeBrowseFile)
+        try Task.checkCancellation()
+        guard case let .available(catalogGeneration) = await currentCatalogGeneration(lookupContext: lookupContext) else {
+            return .sessionRootsUnavailable
+        }
+        return .available(AgentContextFileBrowseHierarchy(
+            catalogGeneration: catalogGeneration,
+            rootGeneration: index.generation,
+            folders: folders,
+            files: files,
+            descendantFiles: descendantFiles
+        ))
+    }
+
+    func search(
+        query rawQuery: String,
+        scope: AgentContextFileBrowseRootScope,
+        lookupContext: WorkspaceLookupContext,
+        limit: Int = 300
+    ) async throws -> AgentContextFileBrowseSessionScopedResult<AgentContextFileBrowseSearchResult> {
+        guard lookupContext.bindingProjection?.isFullyMaterialized != false else {
+            return .sessionRootsUnavailable
+        }
+        let query = RepoSearchQueryFactory.make(rawQuery, supportsWildcards: false)
+        let boundedLimit = max(0, limit)
+        guard !query.isEmpty, boundedLimit > 0 else {
+            let validation = await store.readFileAutoSelectionCatalogValidationSnapshot(rootScope: lookupContext.rootScope)
+            guard case .available = validation.rootScopeAvailability else {
+                return .sessionRootsUnavailable
+            }
+            return .available(AgentContextFileBrowseSearchResult(
+                catalogGeneration: validation.rootScopeCatalogGeneration,
+                source: .storeCatalog,
+                groups: []
+            ))
+        }
+        try Task.checkCancellation()
+
+        let rootsResult = await roots(lookupContext: lookupContext)
+        guard case let .available(rootSnapshot) = rootsResult else {
+            return .sessionRootsUnavailable
+        }
+        let allowedRoots = rootsForScope(scope, in: rootSnapshot.roots)
+        let allowedRootIDs = Set(allowedRoots.map(\.id))
+        guard !allowedRootIDs.isEmpty else {
+            return .available(AgentContextFileBrowseSearchResult(
+                catalogGeneration: rootSnapshot.catalogGeneration,
+                source: .storeCatalog,
+                groups: []
+            ))
+        }
+
+        let candidateLimit = max(boundedLimit * Self.indexCandidateMultiplier, Self.minimumIndexCandidateLimit)
+        let candidates: [WorkspaceSearchCatalogEntry]
+        let source: AgentContextFileBrowseSearchSource
+        if indexedSearchIsAdmissible(scope: scope, lookupContext: lookupContext), let indexedSearch {
+            let result = await indexedSearch(query.raw, candidateLimit)
+            if result.isIndexReady, !result.isStale {
+                candidates = Array(result.results.lazy.filter {
+                    allowedRootIDs.contains($0.rootID) && !Self.isGitDataPath($0.standardizedRelativePath)
+                }.prefix(candidateLimit))
+                source = .indexedVisibleWorkspace
+            } else {
+                Self.logger.debug("Visible workspace search index unavailable or stale; using store catalog")
+                candidates = try await storeBackedCandidates(
+                    query: query.raw,
+                    scope: scope,
+                    lookupContext: lookupContext,
+                    allowedRootIDs: allowedRootIDs,
+                    limit: candidateLimit
+                )
+                source = .storeCatalog
+            }
+        } else {
+            candidates = try await storeBackedCandidates(
+                query: query.raw,
+                scope: scope,
+                lookupContext: lookupContext,
+                allowedRootIDs: allowedRootIDs,
+                limit: candidateLimit
+            )
+            source = .storeCatalog
+        }
+
+        try Task.checkCancellation()
+        let records = await revalidatedRecords(for: candidates, allowedRootIDs: allowedRootIDs)
+        try Task.checkCancellation()
+        let physicalRoots = allowedRoots.map(Self.makePhysicalRootRef)
+        var ranked = score(
+            records: records,
+            query: query,
+            physicalRoots: physicalRoots,
+            lookupContext: lookupContext
+        )
+        if ranked.count > boundedLimit {
+            ranked.removeSubrange(boundedLimit...)
+        }
+        guard case let .available(catalogGeneration) = await currentCatalogGeneration(lookupContext: lookupContext) else {
+            return .sessionRootsUnavailable
+        }
+        return .available(AgentContextFileBrowseSearchResult(
+            catalogGeneration: catalogGeneration,
+            source: source,
+            groups: group(ranked: ranked, roots: allowedRoots)
+        ))
+    }
+
+    func revalidate(
+        files: [AgentContextFileBrowseFile],
+        lookupContext: WorkspaceLookupContext
+    ) async throws -> AgentContextFileBrowseSessionScopedResult<AgentContextFileBrowseRevalidationResult> {
+        try Task.checkCancellation()
+        guard case let .available(roots) = await allowedPhysicalRoots(lookupContext: lookupContext) else {
+            return .sessionRootsUnavailable
+        }
+        let rootsByID = Dictionary(uniqueKeysWithValues: roots.map { ($0.id, $0) })
+        let requestedByRoot = Dictionary(grouping: files.filter { rootsByID[$0.rootID] != nil }, by: \.rootID)
+        var validByID: [UUID: RevalidatedRecord] = [:]
+        validByID.reserveCapacity(files.count)
+
+        for (rootID, candidates) in requestedByRoot {
+            try Task.checkCancellation()
+            guard let lookup = await store.appliedIndexRecordLookup(
+                rootID: rootID,
+                fileIDs: candidates.map(\.id),
+                folderIDs: []
+            ), lookup.root.standardizedFullPath == rootsByID[rootID]?.standardizedFullPath else {
+                continue
+            }
+            for candidate in candidates {
+                guard let record = lookup.filesByID[candidate.id],
+                      record.standardizedFullPath == candidate.standardizedFullPath
+                else { continue }
+                validByID[candidate.id] = RevalidatedRecord(record: record, rootGeneration: lookup.generation)
+            }
+        }
+
+        try Task.checkCancellation()
+        var seenIDs = Set<UUID>()
+        let validFiles = files.compactMap { candidate -> AgentContextFileBrowseFile? in
+            guard seenIDs.insert(candidate.id).inserted,
+                  let revalidated = validByID[candidate.id]
+            else { return nil }
+            return makeFile(
+                record: revalidated.record,
+                rootGeneration: revalidated.rootGeneration,
+                physicalRoots: roots,
+                lookupContext: lookupContext
+            )
+        }
+        guard case let .available(catalogGeneration) = await currentCatalogGeneration(lookupContext: lookupContext) else {
+            return .sessionRootsUnavailable
+        }
+        return .available(AgentContextFileBrowseRevalidationResult(
+            catalogGeneration: catalogGeneration,
+            files: validFiles,
+            rejectedCount: files.count - validFiles.count
+        ))
+    }
+
+    private func currentTreeIndex(
+        rootID: UUID,
+        allowedRoots: [WorkspaceRootRef]
+    ) async -> RootTreeIndex? {
+        guard let allowedRoot = allowedRoots.first(where: { $0.id == rootID }) else {
+            treeIndexesByRootID.removeValue(forKey: rootID)
+            return nil
+        }
+
+        if let cached = treeIndexesByRootID[rootID],
+           let current = await store.appliedIndexRecordLookup(rootID: rootID, fileIDs: [], folderIDs: []),
+           current.root.standardizedFullPath == allowedRoot.standardizedFullPath,
+           current.generation == cached.generation,
+           current.root.standardizedFullPath == cached.root.standardizedFullPath
+        {
+            return cached
+        }
+
+        guard let snapshot = await store.appliedIndexRootSnapshot(rootID: rootID),
+              snapshot.root.standardizedFullPath == allowedRoot.standardizedFullPath,
+              let rootFolder = snapshot.folders.first(where: { $0.standardizedRelativePath.isEmpty })
+        else {
+            treeIndexesByRootID.removeValue(forKey: rootID)
+            return nil
+        }
+        let index = Self.makeTreeIndex(snapshot: snapshot, rootFolderID: rootFolder.id)
+        treeIndexesByRootID[rootID] = index
+        return index
+    }
+
+    private static func makeTreeIndex(
+        snapshot: WorkspaceAppliedIndexRootSnapshot,
+        rootFolderID: UUID
+    ) -> RootTreeIndex {
+        let folders = snapshot.folders.filter {
+            $0.id == rootFolderID || !isGitDataPath($0.standardizedRelativePath)
+        }
+        let files = snapshot.files.filter { !isGitDataPath($0.standardizedRelativePath) }
+        let foldersByID = Dictionary(uniqueKeysWithValues: folders.map { ($0.id, $0) })
+        let directFolders = Dictionary(grouping: folders.filter { $0.id != rootFolderID }) { folder in
+            precondition(folder.parentFolderID != nil, "Indexed non-root folder must have a parent")
+            return folder.parentFolderID!
+        }.mapValues(sortFolders)
+        let directFiles = Dictionary(grouping: files) { file in
+            precondition(file.parentFolderID != nil, "Indexed file must have a parent folder")
+            return file.parentFolderID!
+        }.mapValues(sortFiles)
+        return RootTreeIndex(
+            root: snapshot.root,
+            generation: snapshot.generation,
+            rootFolderID: rootFolderID,
+            foldersByID: foldersByID,
+            directFoldersByParentID: directFolders,
+            directFilesByParentID: directFiles,
+            orderedFiles: sortFiles(files)
+        )
+    }
+
+    private static func resolveDescendants(folderID: UUID, index: RootTreeIndex) -> [WorkspaceFileRecord] {
+        var stack = [folderID]
+        var seenFolders = Set<UUID>()
+        var seenFiles = Set<UUID>()
+        var files: [WorkspaceFileRecord] = []
+        while let current = stack.popLast() {
+            guard seenFolders.insert(current).inserted else { continue }
+            for file in index.directFilesByParentID[current] ?? [] where seenFiles.insert(file.id).inserted {
+                files.append(file)
+            }
+            let children = index.directFoldersByParentID[current] ?? []
+            stack.append(contentsOf: children.reversed().map(\.id))
+        }
+        return sortFiles(files)
+    }
+
+    private func storeBackedCandidates(
+        query: String,
+        scope: AgentContextFileBrowseRootScope,
+        lookupContext: WorkspaceLookupContext,
+        allowedRootIDs: Set<UUID>,
+        limit: Int
+    ) async throws -> [WorkspaceSearchCatalogEntry] {
+        let access = await store.searchCatalogAccess(
+            rootScope: lookupContext.rootScope,
+            requirement: .recordsOnly
+        )
+        guard case let .available(snapshot) = access else { return [] }
+        try Task.checkCancellation()
+        let selectedRootID: UUID? = if case let .root(rootID) = scope { rootID } else { nil }
+        let key = SearchIndexKey(
+            rootScope: lookupContext.rootScope,
+            catalogGeneration: snapshot.generation,
+            projectionIdentity: Self.projectionIdentity(lookupContext.bindingProjection),
+            selectedRootID: selectedRootID
+        )
+        let cached: StoreSearchIndex
+        if let existing = searchIndexesByKey[key] {
+            cached = existing
+        } else {
+            let entries = snapshot.entries.filter {
+                allowedRootIDs.contains($0.rootID) && !Self.isGitDataPath($0.standardizedRelativePath)
+            }
+            let haystacks = entries.map { searchHaystack(for: $0, lookupContext: lookupContext) }
+            try Task.checkCancellation()
+            let built = await StoreSearchIndex(entries: entries, index: PathSearchIndex.build(paths: haystacks))
+            try Task.checkCancellation()
+            searchIndexesByKey = searchIndexesByKey.filter {
+                $0.key.rootScope != key.rootScope || $0.key.catalogGeneration == key.catalogGeneration
+            }
+            searchIndexesByKey[key] = built
+            cached = built
+        }
+        let hits = await cached.index.search(query, limit: limit)
+        try Task.checkCancellation()
+        var seen = Set<UUID>()
+        return hits.compactMap { hit in
+            guard cached.entries.indices.contains(hit.index) else { return nil }
+            let entry = cached.entries[hit.index]
+            return seen.insert(entry.id).inserted ? entry : nil
+        }
+    }
+
+    private func revalidatedRecords(
+        for entries: [WorkspaceSearchCatalogEntry],
+        allowedRootIDs: Set<UUID>
+    ) async -> [RevalidatedRecord] {
+        let requested = entries.filter { allowedRootIDs.contains($0.rootID) }
+        let entriesByRoot = Dictionary(grouping: requested, by: \.rootID)
+        var validByID: [UUID: RevalidatedRecord] = [:]
+        for (rootID, rootEntries) in entriesByRoot {
+            guard let lookup = await store.appliedIndexRecordLookup(
+                rootID: rootID,
+                fileIDs: rootEntries.map(\.id),
+                folderIDs: []
+            ) else { continue }
+            for entry in rootEntries {
+                guard let record = lookup.filesByID[entry.id],
+                      record.standardizedFullPath == entry.standardizedFullPath,
+                      !Self.isGitDataPath(record.standardizedRelativePath)
+                else { continue }
+                validByID[entry.id] = RevalidatedRecord(record: record, rootGeneration: lookup.generation)
+            }
+        }
+        var seen = Set<UUID>()
+        return requested.compactMap { entry in
+            guard seen.insert(entry.id).inserted else { return nil }
+            return validByID[entry.id]
+        }
+    }
+
+    private func score(
+        records: [RevalidatedRecord],
+        query: RepoSearchQuery,
+        physicalRoots: [WorkspaceRootRef],
+        lookupContext: WorkspaceLookupContext
+    ) -> [RankedRecord] {
+        let projected = records.compactMap { revalidated -> (RevalidatedRecord, AgentContextFileBrowseFile)? in
+            guard let file = makeFile(
+                record: revalidated.record,
+                rootGeneration: revalidated.rootGeneration,
+                physicalRoots: physicalRoots,
+                lookupContext: lookupContext
+            ) else { return nil }
+            return (revalidated, file)
+        }
+        let candidates = projected.map {
+            RepoSearchBatchScorer.Candidate(
+                name: $0.1.name,
+                path: $0.1.projectedDisplayPath,
+                nameLower: $0.1.name.lowercased(),
+                pathLower: $0.1.projectedDisplayPath.lowercased()
+            )
+        }
+        let scores = RepoSearchBatchScorer.scores(
+            for: candidates,
+            query: query,
+            fuzzyThreshold: Self.fuzzyThreshold
+        )
+        var ranked: [RankedRecord] = []
+        for index in projected.indices where scores[index] > 0 {
+            ranked.append(RankedRecord(
+                record: projected[index].0.record,
+                file: projected[index].1,
+                score: scores[index]
+            ))
+        }
+        ranked.sort { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            if lhs.file.projectedDisplayPath.count != rhs.file.projectedDisplayPath.count {
+                return lhs.file.projectedDisplayPath.count < rhs.file.projectedDisplayPath.count
+            }
+            let lhsLower = lhs.file.projectedDisplayPath.lowercased()
+            let rhsLower = rhs.file.projectedDisplayPath.lowercased()
+            if lhsLower != rhsLower { return lhsLower < rhsLower }
+            return lhs.record.standardizedFullPath < rhs.record.standardizedFullPath
+        }
+        return ranked
+    }
+
+    private func group(
+        ranked: [RankedRecord],
+        roots: [AgentContextFileBrowseRoot]
+    ) -> [AgentContextFileBrowseSearchRootGroup] {
+        let rootsByID = Dictionary(uniqueKeysWithValues: roots.map { ($0.id, $0) })
+        var orderedRootIDs: [UUID] = []
+        var matchesByRootID: [UUID: [AgentContextFileBrowseSearchMatch]] = [:]
+        for item in ranked where rootsByID[item.file.rootID] != nil {
+            if matchesByRootID[item.file.rootID] == nil { orderedRootIDs.append(item.file.rootID) }
+            matchesByRootID[item.file.rootID, default: []].append(
+                AgentContextFileBrowseSearchMatch(file: item.file, score: item.score)
+            )
+        }
+
+        return orderedRootIDs.compactMap { rootID in
+            guard let root = rootsByID[rootID], let matches = matchesByRootID[rootID] else { return nil }
+            var rootMatches: [AgentContextFileBrowseSearchMatch] = []
+            var orderedDirectories: [String] = []
+            var directoryMatches: [String: [AgentContextFileBrowseSearchMatch]] = [:]
+            for match in matches {
+                if match.file.projectedDirectoryPath.isEmpty {
+                    rootMatches.append(match)
+                } else {
+                    if directoryMatches[match.file.projectedDirectoryPath] == nil {
+                        orderedDirectories.append(match.file.projectedDirectoryPath)
+                    }
+                    directoryMatches[match.file.projectedDirectoryPath, default: []].append(match)
+                }
+            }
+            let directories = orderedDirectories.map { directory in
+                AgentContextFileBrowseSearchDirectoryGroup(
+                    id: .searchDirectoryHeader(rootID: rootID, directoryPath: directory),
+                    directoryPath: directory,
+                    matches: directoryMatches[directory] ?? []
+                )
+            }
+            return AgentContextFileBrowseSearchRootGroup(
+                id: .searchRootHeader(rootID),
+                root: root,
+                matchCount: matches.count,
+                rootMatches: rootMatches,
+                directories: directories
+            )
+        }
+    }
+
+    private func makeFile(
+        record: WorkspaceFileRecord,
+        rootGeneration: UInt64,
+        physicalRoots: [WorkspaceRootRef],
+        lookupContext: WorkspaceLookupContext
+    ) -> AgentContextFileBrowseFile? {
+        let projectedPath: String
+        if let projected = lookupContext.bindingProjection?.projectedLogicalPathComponents(
+            forPhysicalPath: record.standardizedFullPath
+        ) {
+            projectedPath = ClientPathFormatter.nonAbsoluteDisplayPath(
+                root: projected.root,
+                relativePath: projected.relativePath,
+                visibleRoots: lookupContext.bindingProjection?.visibleLogicalRootRefs ?? physicalRoots
+            )
+        } else {
+            guard let root = physicalRoots.first(where: { $0.id == record.rootID }) else { return nil }
+            projectedPath = ClientPathFormatter.nonAbsoluteDisplayPath(
+                root: root,
+                relativePath: record.standardizedRelativePath,
+                visibleRoots: physicalRoots
+            )
+        }
+        let directory = Self.parentDirectory(of: record.standardizedRelativePath)
+        return AgentContextFileBrowseFile(
+            id: record.id,
+            rootID: record.rootID,
+            rootGeneration: rootGeneration,
+            parentFolderID: record.parentFolderID,
+            name: record.name,
+            standardizedRelativePath: record.standardizedRelativePath,
+            standardizedFullPath: record.standardizedFullPath,
+            projectedDisplayPath: projectedPath,
+            projectedDirectoryPath: directory,
+            modificationDate: record.modificationDate,
+            supportsCodemap: WorkspaceSelectionMutationService.supportsCodemap(record)
+        )
+    }
+
+    private func projectedDisplayRoots(
+        from physicalRoots: [WorkspaceRootRef],
+        lookupContext: WorkspaceLookupContext
+    ) -> [AgentContextFileBrowseRoot] {
+        let projectedRoots = physicalRoots.map { physicalRoot -> WorkspaceRootRef in
+            lookupContext.bindingProjection?.projectedLogicalPathComponents(
+                forPhysicalPath: physicalRoot.standardizedFullPath
+            )?.root ?? physicalRoot
+        }
+        return zip(physicalRoots, projectedRoots).map { physicalRoot, projectedRoot in
+            AgentContextFileBrowseRoot(
+                id: physicalRoot.id,
+                physicalPath: physicalRoot.standardizedFullPath,
+                displayName: projectedRoot.name,
+                scopeLabel: ClientPathFormatter.nonAbsoluteRootAlias(
+                    root: projectedRoot,
+                    visibleRoots: projectedRoots
+                )
+            )
+        }
+    }
+
+    private func currentCatalogGeneration(
+        lookupContext: WorkspaceLookupContext
+    ) async -> AgentContextFileBrowseSessionScopedResult<UInt64> {
+        guard lookupContext.bindingProjection?.isFullyMaterialized != false else {
+            return .sessionRootsUnavailable
+        }
+        let validation = await store.readFileAutoSelectionCatalogValidationSnapshot(
+            rootScope: lookupContext.rootScope
+        )
+        guard case .available = validation.rootScopeAvailability else {
+            return .sessionRootsUnavailable
+        }
+        return .available(validation.rootScopeCatalogGeneration)
+    }
+
+    private func allowedPhysicalRoots(
+        lookupContext: WorkspaceLookupContext
+    ) async -> AgentContextFileBrowseSessionScopedResult<[WorkspaceRootRef]> {
+        guard lookupContext.bindingProjection?.isFullyMaterialized != false else {
+            return .sessionRootsUnavailable
+        }
+        let validation = await store.readFileAutoSelectionCatalogValidationSnapshot(
+            rootScope: lookupContext.rootScope
+        )
+        guard case .available = validation.rootScopeAvailability else {
+            Self.logger.notice("Context file browse roots unavailable for the current session scope")
+            return .sessionRootsUnavailable
+        }
+        let roots = await store.rootRefs(scope: lookupContext.rootScope).filter { !Self.isGitDataRoot($0) }
+        return .available(roots)
+    }
+
+    private func rootsForScope(
+        _ scope: AgentContextFileBrowseRootScope,
+        in roots: [AgentContextFileBrowseRoot]
+    ) -> [AgentContextFileBrowseRoot] {
+        switch scope {
+        case .allRoots:
+            roots
+        case let .root(rootID):
+            roots.filter { $0.id == rootID }
+        }
+    }
+
+    private func indexedSearchIsAdmissible(
+        scope: AgentContextFileBrowseRootScope,
+        lookupContext: WorkspaceLookupContext
+    ) -> Bool {
+        scope == .allRoots
+            && lookupContext.rootScope == .visibleWorkspace
+            && lookupContext.bindingProjection == nil
+    }
+
+    private func searchHaystack(
+        for entry: WorkspaceSearchCatalogEntry,
+        lookupContext: WorkspaceLookupContext
+    ) -> String {
+        let logicalPath = lookupContext.bindingProjection?.projectedLogicalDisplayPath(
+            forPhysicalPath: entry.standardizedFullPath,
+            display: .relative
+        )
+        return [
+            logicalPath,
+            entry.displayPath,
+            entry.name,
+            entry.standardizedRelativePath,
+            entry.standardizedFullPath
+        ]
+        .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+        .joined(separator: "\n")
+    }
+
+    private static func makeFolder(_ record: WorkspaceFolderRecord) -> AgentContextFileBrowseFolder {
+        AgentContextFileBrowseFolder(
+            id: record.id,
+            rootID: record.rootID,
+            parentFolderID: record.parentFolderID,
+            name: record.name,
+            standardizedRelativePath: record.standardizedRelativePath,
+            standardizedFullPath: record.standardizedFullPath,
+            modificationDate: record.modificationDate
+        )
+    }
+
+    private static func sortFolders(_ folders: [WorkspaceFolderRecord]) -> [WorkspaceFolderRecord] {
+        folders.sorted {
+            let comparison = $0.name.localizedCaseInsensitiveCompare($1.name)
+            if comparison != .orderedSame { return comparison == .orderedAscending }
+            return $0.standardizedRelativePath < $1.standardizedRelativePath
+        }
+    }
+
+    private static func sortFiles(_ files: [WorkspaceFileRecord]) -> [WorkspaceFileRecord] {
+        files.sorted {
+            let comparison = $0.name.localizedCaseInsensitiveCompare($1.name)
+            if comparison != .orderedSame { return comparison == .orderedAscending }
+            return $0.standardizedRelativePath < $1.standardizedRelativePath
+        }
+    }
+
+    private static func isGitDataRoot(_ root: WorkspaceRootRef) -> Bool {
+        root.name.caseInsensitiveCompare(excludedPathComponent) == .orderedSame
+            || URL(fileURLWithPath: root.standardizedFullPath).lastPathComponent
+            .caseInsensitiveCompare(excludedPathComponent) == .orderedSame
+    }
+
+    private static func isGitDataPath(_ path: String) -> Bool {
+        path.split(whereSeparator: { $0 == "/" || $0 == "\\" }).contains {
+            String($0).caseInsensitiveCompare(excludedPathComponent) == .orderedSame
+        }
+    }
+
+    private static func makePhysicalRootRef(_ root: AgentContextFileBrowseRoot) -> WorkspaceRootRef {
+        WorkspaceRootRef(
+            id: root.id,
+            name: URL(fileURLWithPath: root.physicalPath).lastPathComponent,
+            fullPath: root.physicalPath
+        )
+    }
+
+    private static func parentDirectory(of path: String) -> String {
+        let normalized = path.replacingOccurrences(of: "\\", with: "/")
+        let components = normalized.split(separator: "/").map(String.init)
+        guard components.count > 1 else { return "" }
+        return components.dropLast().joined(separator: "/")
+    }
+
+    private static func projectionIdentity(_ projection: WorkspaceRootBindingProjection?) -> String {
+        guard let projection else { return "unprojected" }
+        let roots = projection.boundRootsForMetadata.map {
+            "\($0.logicalRoot.id.uuidString):\($0.logicalRoot.standardizedFullPath)->\($0.physicalRoot.id.uuidString):\($0.physicalRoot.standardizedFullPath)"
+        }
+        return ([projection.sessionID.uuidString] + roots).joined(separator: "|")
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileSizeEstimator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileSizeEstimator.swift
@@ -46,7 +46,6 @@ actor AgentContextFileSizeEstimator {
     private var pendingReadTasks: [CacheKey: Task<CachedEstimate?, Never>] = [:]
     private var activeReadPermitIDs: Set<UUID> = []
     private var queuedReadPermits: [QueuedReadPermit] = []
-    private var canceledReadPermitIDs: Set<UUID> = []
 
     init(
         maximumConcurrentReads: Int = 16,
@@ -109,6 +108,10 @@ actor AgentContextFileSizeEstimator {
         }
     }
 
+    func readPermitStateCountForTesting() -> Int {
+        activeReadPermitIDs.count + queuedReadPermits.count
+    }
+
     func pruneCaches(retainingRootIDs: Set<UUID>) {
         cache = cache.filter { retainingRootIDs.contains($0.key.rootID) }
         currentGenerationByRootID = currentGenerationByRootID.filter { retainingRootIDs.contains($0.key) }
@@ -168,7 +171,7 @@ actor AgentContextFileSizeEstimator {
     private func acquireReadPermit(id: UUID) async -> Bool {
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
-                if canceledReadPermitIDs.remove(id) != nil || Task.isCancelled {
+                if Task.isCancelled {
                     continuation.resume(returning: false)
                 } else if activeReadPermitIDs.count < maximumConcurrentReads {
                     activeReadPermitIDs.insert(id)
@@ -183,26 +186,18 @@ actor AgentContextFileSizeEstimator {
     }
 
     private func cancelReadPermit(id: UUID) {
-        if let index = queuedReadPermits.firstIndex(where: { $0.id == id }) {
-            let queued = queuedReadPermits.remove(at: index)
-            queued.continuation.resume(returning: false)
-        } else if !activeReadPermitIDs.contains(id) {
-            canceledReadPermitIDs.insert(id)
-        }
+        guard let index = queuedReadPermits.firstIndex(where: { $0.id == id }) else { return }
+        let queued = queuedReadPermits.remove(at: index)
+        queued.continuation.resume(returning: false)
     }
 
     private func releaseReadPermit(id: UUID) {
-        guard activeReadPermitIDs.remove(id) != nil else { return }
-        while !queuedReadPermits.isEmpty {
-            let next = queuedReadPermits.removeFirst()
-            if canceledReadPermitIDs.remove(next.id) != nil {
-                next.continuation.resume(returning: false)
-                continue
-            }
-            activeReadPermitIDs.insert(next.id)
-            next.continuation.resume(returning: true)
-            break
-        }
+        guard activeReadPermitIDs.remove(id) != nil,
+              !queuedReadPermits.isEmpty
+        else { return }
+        let next = queuedReadPermits.removeFirst()
+        activeReadPermitIDs.insert(next.id)
+        next.continuation.resume(returning: true)
     }
 
     private func invalidateRootIfNeeded(rootID: UUID, generation: UInt64) {

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileSizeEstimator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileSizeEstimator.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+struct AgentContextFileMetadataSnapshot: Equatable {
+    let byteCount: Int64?
+    let modificationDate: Date?
+    let isRegularFile: Bool
+}
+
+struct AgentContextFileSizeEstimateRequest: Equatable {
+    let file: AgentContextFileBrowseFile
+    let rootGeneration: UInt64
+}
+
+struct AgentContextFileSizeEstimateResult: Equatable {
+    let fileID: UUID
+    let rootID: UUID
+    let rootGeneration: UInt64
+    let estimate: AgentContextFileBrowseTokenEstimate
+    let modificationDate: Date?
+}
+
+actor AgentContextFileSizeEstimator {
+    typealias MetadataReader = @Sendable (String) async throws -> AgentContextFileMetadataSnapshot
+
+    private struct CacheKey: Equatable, Hashable {
+        let rootID: UUID
+        let fileID: UUID
+        let standardizedFullPath: String
+        let rootGeneration: UInt64
+    }
+
+    private struct CachedEstimate: Equatable {
+        let estimate: AgentContextFileBrowseTokenEstimate
+        let modificationDate: Date?
+    }
+
+    private struct QueuedReadPermit {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private let metadataReader: MetadataReader
+    private let maximumConcurrentReads: Int
+    private var currentGenerationByRootID: [UUID: UInt64] = [:]
+    private var cache: [CacheKey: CachedEstimate] = [:]
+    private var pendingReadTasks: [CacheKey: Task<CachedEstimate?, Never>] = [:]
+    private var activeReadPermitIDs: Set<UUID> = []
+    private var queuedReadPermits: [QueuedReadPermit] = []
+    private var canceledReadPermitIDs: Set<UUID> = []
+
+    init(
+        maximumConcurrentReads: Int = 16,
+        metadataReader: MetadataReader? = nil
+    ) {
+        precondition(maximumConcurrentReads > 0, "Metadata concurrency must be positive")
+        self.maximumConcurrentReads = maximumConcurrentReads
+        if let metadataReader {
+            self.metadataReader = metadataReader
+        } else {
+            self.metadataReader = { @Sendable path in
+                try await Self.readMetadata(path: path)
+            }
+        }
+    }
+
+    func estimate(
+        for file: AgentContextFileBrowseFile,
+        rootGeneration: UInt64
+    ) async -> AgentContextFileSizeEstimateResult {
+        let request = AgentContextFileSizeEstimateRequest(file: file, rootGeneration: rootGeneration)
+        return await estimates(for: [request])[0]
+    }
+
+    func estimates(
+        for requests: [AgentContextFileSizeEstimateRequest]
+    ) async -> [AgentContextFileSizeEstimateResult] {
+        guard !requests.isEmpty else { return [] }
+        precondition(Self.hasOneGenerationPerRoot(requests), "A metadata batch must use one generation per root")
+
+        for request in requests {
+            invalidateRootIfNeeded(rootID: request.file.rootID, generation: request.rootGeneration)
+        }
+
+        let uniqueRequests = Dictionary(requests.map { (Self.cacheKey(for: $0), $0) }, uniquingKeysWith: { first, _ in first })
+        let completed = await withTaskGroup(of: (CacheKey, CachedEstimate?).self) { group in
+            for (key, request) in uniqueRequests {
+                group.addTask { [weak self] in
+                    guard let self else { return (key, nil) }
+                    return await (key, cachedEstimate(for: request))
+                }
+            }
+            var results: [CacheKey: CachedEstimate] = [:]
+            for await (key, estimate) in group {
+                results[key] = estimate
+            }
+            return results
+        }
+
+        return requests.map { request in
+            let key = Self.cacheKey(for: request)
+            let cached = completed[key] ?? cache[key]
+            return AgentContextFileSizeEstimateResult(
+                fileID: request.file.id,
+                rootID: request.file.rootID,
+                rootGeneration: request.rootGeneration,
+                estimate: cached?.estimate ?? .notRequested,
+                modificationDate: cached?.modificationDate
+            )
+        }
+    }
+
+    func pruneCaches(retainingRootIDs: Set<UUID>) {
+        cache = cache.filter { retainingRootIDs.contains($0.key.rootID) }
+        currentGenerationByRootID = currentGenerationByRootID.filter { retainingRootIDs.contains($0.key) }
+        for (key, task) in pendingReadTasks where !retainingRootIDs.contains(key.rootID) {
+            task.cancel()
+            pendingReadTasks[key] = nil
+        }
+    }
+
+    private func cachedEstimate(
+        for request: AgentContextFileSizeEstimateRequest
+    ) async -> CachedEstimate? {
+        let key = Self.cacheKey(for: request)
+        if let cached = cache[key] { return cached }
+        let task: Task<CachedEstimate?, Never>
+        if let pending = pendingReadTasks[key] {
+            task = pending
+        } else {
+            task = Task { [weak self, metadataReader] in
+                guard let self else { return nil }
+                return await performScheduledRead(
+                    path: request.file.standardizedFullPath,
+                    metadataReader: metadataReader
+                )
+            }
+            pendingReadTasks[key] = task
+        }
+
+        let estimate = await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        if pendingReadTasks[key] != nil {
+            pendingReadTasks[key] = nil
+        }
+        guard !Task.isCancelled,
+              currentGenerationByRootID[key.rootID] == key.rootGeneration,
+              let estimate
+        else { return nil }
+        cache[key] = estimate
+        return estimate
+    }
+
+    private func performScheduledRead(
+        path: String,
+        metadataReader: MetadataReader
+    ) async -> CachedEstimate? {
+        let permitID = UUID()
+        guard await acquireReadPermit(id: permitID) else { return nil }
+        defer { releaseReadPermit(id: permitID) }
+        guard !Task.isCancelled else { return nil }
+        return await Self.readEstimate(path: path, metadataReader: metadataReader)
+    }
+
+    private func acquireReadPermit(id: UUID) async -> Bool {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if canceledReadPermitIDs.remove(id) != nil || Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else if activeReadPermitIDs.count < maximumConcurrentReads {
+                    activeReadPermitIDs.insert(id)
+                    continuation.resume(returning: true)
+                } else {
+                    queuedReadPermits.append(QueuedReadPermit(id: id, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelReadPermit(id: id) }
+        }
+    }
+
+    private func cancelReadPermit(id: UUID) {
+        if let index = queuedReadPermits.firstIndex(where: { $0.id == id }) {
+            let queued = queuedReadPermits.remove(at: index)
+            queued.continuation.resume(returning: false)
+        } else if !activeReadPermitIDs.contains(id) {
+            canceledReadPermitIDs.insert(id)
+        }
+    }
+
+    private func releaseReadPermit(id: UUID) {
+        guard activeReadPermitIDs.remove(id) != nil else { return }
+        while !queuedReadPermits.isEmpty {
+            let next = queuedReadPermits.removeFirst()
+            if canceledReadPermitIDs.remove(next.id) != nil {
+                next.continuation.resume(returning: false)
+                continue
+            }
+            activeReadPermitIDs.insert(next.id)
+            next.continuation.resume(returning: true)
+            break
+        }
+    }
+
+    private func invalidateRootIfNeeded(rootID: UUID, generation: UInt64) {
+        guard currentGenerationByRootID[rootID] != generation else { return }
+        currentGenerationByRootID[rootID] = generation
+        cache = cache.filter { $0.key.rootID != rootID }
+        for (key, task) in pendingReadTasks where key.rootID == rootID {
+            task.cancel()
+            pendingReadTasks[key] = nil
+        }
+    }
+
+    private static func readEstimate(
+        path: String,
+        metadataReader: MetadataReader
+    ) async -> CachedEstimate? {
+        do {
+            let metadata = try await metadataReader(path)
+            guard metadata.isRegularFile,
+                  let byteCount = metadata.byteCount,
+                  byteCount >= 0,
+                  byteCount <= Int64(Int.max)
+            else {
+                return CachedEstimate(estimate: .unavailable, modificationDate: metadata.modificationDate)
+            }
+            return CachedEstimate(
+                estimate: .known(TokenCalculationService.estimateTokens(utf8ByteCount: Int(byteCount))),
+                modificationDate: metadata.modificationDate
+            )
+        } catch is CancellationError {
+            return nil
+        } catch {
+            return CachedEstimate(estimate: .unavailable, modificationDate: nil)
+        }
+    }
+
+    private nonisolated static func readMetadata(path: String) async throws -> AgentContextFileMetadataSnapshot {
+        let task = Task.detached(priority: .utility) {
+            try Task.checkCancellation()
+            let values = try URL(fileURLWithPath: path).resourceValues(forKeys: [
+                .contentModificationDateKey,
+                .fileSizeKey,
+                .isRegularFileKey
+            ])
+            return AgentContextFileMetadataSnapshot(
+                byteCount: values.fileSize.map(Int64.init),
+                modificationDate: values.contentModificationDate,
+                isRegularFile: values.isRegularFile == true
+            )
+        }
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    private static func cacheKey(for request: AgentContextFileSizeEstimateRequest) -> CacheKey {
+        CacheKey(
+            rootID: request.file.rootID,
+            fileID: request.file.id,
+            standardizedFullPath: request.file.standardizedFullPath,
+            rootGeneration: request.rootGeneration
+        )
+    }
+
+    private static func hasOneGenerationPerRoot(_ requests: [AgentContextFileSizeEstimateRequest]) -> Bool {
+        Dictionary(grouping: requests, by: { $0.file.rootID }).values.allSatisfy { rootRequests in
+            Set(rootRequests.map(\.rootGeneration)).count == 1
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileSizeEstimator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileSizeEstimator.swift
@@ -122,6 +122,7 @@ actor AgentContextFileSizeEstimator {
         for request: AgentContextFileSizeEstimateRequest
     ) async -> CachedEstimate? {
         let key = Self.cacheKey(for: request)
+        guard currentGenerationByRootID[key.rootID] == key.rootGeneration else { return nil }
         if let cached = cache[key] { return cached }
         let task: Task<CachedEstimate?, Never>
         if let pending = pendingReadTasks[key] {
@@ -205,7 +206,9 @@ actor AgentContextFileSizeEstimator {
     }
 
     private func invalidateRootIfNeeded(rootID: UUID, generation: UInt64) {
-        guard currentGenerationByRootID[rootID] != generation else { return }
+        if let currentGeneration = currentGenerationByRootID[rootID] {
+            guard generation > currentGeneration else { return }
+        }
         currentGenerationByRootID[rootID] = generation
         cache = cache.filter { $0.key.rootID != rootID }
         for (key, task) in pendingReadTasks where key.rootID == rootID {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextFileBrowseModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextFileBrowseModel.swift
@@ -162,6 +162,11 @@ final class AgentContextFileBrowseModel: ObservableObject {
         let task: Task<Void, Never>
     }
 
+    private struct ContainerFileContribution {
+        let fileID: UUID
+        let supportsCodemap: Bool
+    }
+
     private struct ContainerAggregate {
         var totalFileCount = 0
         var selectableFileCount = 0
@@ -219,8 +224,8 @@ final class AgentContextFileBrowseModel: ObservableObject {
     private var hierarchyByContainer: [AgentContextFileBrowseNodeID: AgentContextFileBrowseHierarchy] = [:]
     private var containerAggregates: [AgentContextFileBrowseNodeID: ContainerAggregate] = [:]
     private var containerIDsByFileID: [UUID: Set<AgentContextFileBrowseNodeID>] = [:]
+    private var containerFileContributionByPath: [String: ContainerFileContribution] = [:]
     private var filesByID: [UUID: AgentContextFileBrowseFile] = [:]
-    private var fileIDByPath: [String: UUID] = [:]
     private var foldersByID: [UUID: AgentContextFileBrowseFolder] = [:]
     private var tokenEstimatesByFileID: [UUID: AgentContextFileBrowseTokenEstimate] = [:]
     private var estimateOwnerByFileID: [UUID: AgentContextFileBrowseNodeID] = [:]
@@ -260,6 +265,7 @@ final class AgentContextFileBrowseModel: ObservableObject {
         exportRows: [AgentContextExportRow],
         codeMapsGloballyDisabled: Bool
     ) async {
+        guard !Task.isCancelled else { return }
         end()
         pendingExpansionRestorePaths = if let retainedExpansion,
                                           retainedExpansion.identity == target.identity,
@@ -352,8 +358,8 @@ final class AgentContextFileBrowseModel: ObservableObject {
         hierarchyByContainer = [:]
         containerAggregates = [:]
         containerIDsByFileID = [:]
+        containerFileContributionByPath = [:]
         filesByID = [:]
-        fileIDByPath = [:]
         foldersByID = [:]
         tokenEstimatesByFileID = [:]
         estimateOwnerByFileID = [:]
@@ -427,7 +433,7 @@ final class AgentContextFileBrowseModel: ObservableObject {
     }
 
     func fileStatus(for file: AgentContextFileBrowseFile) -> AgentContextFileBrowseFileStatus {
-        let path = Self.normalizedPath(file.standardizedFullPath)
+        let path = file.standardizedFullPath
         let heldMode = heldModesByPath[path]
         let eligibility: AgentContextFileBrowseToggleEligibility = if !routeIsCurrent() {
             .disabled(.routeUnavailable)
@@ -601,7 +607,7 @@ final class AgentContextFileBrowseModel: ObservableObject {
             hierarchy.descendantFiles
         } else {
             selectableDescendants(from: hierarchy.descendantFiles).filter {
-                heldModesByPath[Self.normalizedPath($0.standardizedFullPath)] == nil
+                heldModesByPath[$0.standardizedFullPath] == nil
             }
         }
         guard !files.isEmpty else { return false }
@@ -664,8 +670,9 @@ final class AgentContextFileBrowseModel: ObservableObject {
         for path in sliced {
             projection[path] = .slice
         }
-        updateSelectionAggregates(from: heldModesByPath, to: projection)
+        let previousProjection = heldModesByPath
         heldModesByPath = projection
+        updateSelectionAggregates(from: previousProjection, to: projection)
         selectedAncestorDirectoryPaths = Self.ancestorDirectoryPaths(of: projection.keys)
 
         automaticCodemapPaths = Set(exportRows.compactMap { row -> String? in
@@ -680,24 +687,20 @@ final class AgentContextFileBrowseModel: ObservableObject {
         from previous: [String: AgentContextFileBrowseHeldMode],
         to current: [String: AgentContextFileBrowseHeldMode]
     ) {
-        let changedPaths = Set(previous.keys).union(current.keys).filter {
-            (previous[$0] != nil) != (current[$0] != nil)
-        }
+        let changedPaths = Set(previous.keys).symmetricDifference(Set(current.keys))
         for path in changedPaths {
-            guard let fileID = fileIDByPath[path], let file = filesByID[fileID] else { continue }
-            let wasSelected = previous[path] != nil
-            let isSelected = current[path] != nil
-            for containerID in containerIDsByFileID[fileID] ?? [] {
+            guard let contribution = containerFileContributionByPath[path] else { continue }
+            for containerID in containerIDsByFileID[contribution.fileID] ?? [] {
                 guard var aggregate = containerAggregates[containerID] else { continue }
                 applySelectionContribution(
-                    file: file,
-                    isSelected: wasSelected,
+                    supportsCodemap: contribution.supportsCodemap,
+                    isSelected: previous[path] != nil,
                     multiplier: -1,
                     to: &aggregate
                 )
                 applySelectionContribution(
-                    file: file,
-                    isSelected: isSelected,
+                    supportsCodemap: contribution.supportsCodemap,
+                    isSelected: current[path] != nil,
                     multiplier: 1,
                     to: &aggregate
                 )
@@ -707,14 +710,14 @@ final class AgentContextFileBrowseModel: ObservableObject {
     }
 
     private func applySelectionContribution(
-        file: AgentContextFileBrowseFile,
+        supportsCodemap: Bool,
         isSelected: Bool,
         multiplier: Int,
         to aggregate: inout ContainerAggregate
     ) {
         let isSelectable = addMode == .full
             || isSelected
-            || (file.supportsCodemap && !codeMapsGloballyDisabled)
+            || (supportsCodemap && !codeMapsGloballyDisabled)
         aggregate.selectableFileCount += isSelectable ? multiplier : 0
         aggregate.selectedFileCount += isSelected && isSelectable ? multiplier : 0
         aggregate.unsupportedFileCount += isSelectable ? 0 : multiplier
@@ -725,7 +728,7 @@ final class AgentContextFileBrowseModel: ObservableObject {
     ) -> [AgentContextFileBrowseFile] {
         guard addMode == .codemapOnly else { return files }
         return files.filter {
-            heldModesByPath[Self.normalizedPath($0.standardizedFullPath)] != nil
+            heldModesByPath[$0.standardizedFullPath] != nil
                 || ($0.supportsCodemap && !codeMapsGloballyDisabled)
         }
     }
@@ -733,23 +736,33 @@ final class AgentContextFileBrowseModel: ObservableObject {
     private func rebuildContainerAggregates() {
         var aggregates: [AgentContextFileBrowseNodeID: ContainerAggregate] = [:]
         var containerIDs: [UUID: Set<AgentContextFileBrowseNodeID>] = [:]
+        var contributionsByPath: [String: ContainerFileContribution] = [:]
         for (nodeID, hierarchy) in hierarchyByContainer {
             var aggregate = ContainerAggregate()
             for file in hierarchy.descendantFiles {
                 containerIDs[file.id, default: []].insert(nodeID)
+                contributionsByPath[file.standardizedFullPath] = ContainerFileContribution(
+                    fileID: file.id,
+                    supportsCodemap: file.supportsCodemap
+                )
                 accumulate(file: file, into: &aggregate)
             }
             aggregates[nodeID] = aggregate
         }
         containerAggregates = aggregates
         containerIDsByFileID = containerIDs
+        containerFileContributionByPath = contributionsByPath
     }
 
     private func accumulate(file: AgentContextFileBrowseFile, into aggregate: inout ContainerAggregate) {
-        let path = Self.normalizedPath(file.standardizedFullPath)
-        let isSelected = heldModesByPath[path] != nil
+        let path = file.standardizedFullPath
         aggregate.totalFileCount += 1
-        applySelectionContribution(file: file, isSelected: isSelected, multiplier: 1, to: &aggregate)
+        applySelectionContribution(
+            supportsCodemap: file.supportsCodemap,
+            isSelected: heldModesByPath[path] != nil,
+            multiplier: 1,
+            to: &aggregate
+        )
         aggregate.inFlightFileCount += inFlightPaths.contains(path) ? 1 : 0
         Self.applyEstimate(tokenEstimatesByFileID[file.id], multiplier: 1, to: &aggregate)
     }
@@ -1018,9 +1031,9 @@ final class AgentContextFileBrowseModel: ObservableObject {
         targetState: WorkspacePreResolvedSelectionTargetState
     ) {
         guard let session, let sessionCatalogGeneration else { return }
-        let normalizedPaths = Set(files.map { Self.normalizedPath($0.standardizedFullPath) })
-        guard inFlightPaths.isDisjoint(with: normalizedPaths) else { return }
-        inFlightPaths.formUnion(normalizedPaths)
+        let paths = Set(files.map(\.standardizedFullPath))
+        guard inFlightPaths.isDisjoint(with: paths) else { return }
+        inFlightPaths.formUnion(paths)
         updateInFlightAggregates(for: files, multiplier: 1)
         mutationQueue.append(MutationRequest(
             generation: session.generation,
@@ -1146,7 +1159,7 @@ final class AgentContextFileBrowseModel: ObservableObject {
         guard isCurrentSession(generation) else { return }
         updateInFlightAggregates(for: files, multiplier: -1)
         for file in files {
-            inFlightPaths.remove(Self.normalizedPath(file.standardizedFullPath))
+            inFlightPaths.remove(file.standardizedFullPath)
         }
     }
 
@@ -1300,7 +1313,6 @@ final class AgentContextFileBrowseModel: ObservableObject {
         expandedNodeIDs.subtract(containerNodeIDs)
         foldersByID = foldersByID.filter { $0.value.rootID != rootID }
         filesByID = filesByID.filter { $0.value.rootID != rootID }
-        fileIDByPath = fileIDByPath.filter { !fileIDs.contains($0.value) }
         for fileID in fileIDs {
             tokenEstimatesByFileID[fileID] = nil
             estimateOwnerByFileID[fileID] = nil
@@ -1315,13 +1327,12 @@ final class AgentContextFileBrowseModel: ObservableObject {
         for folder in hierarchy.folders {
             foldersByID[folder.id] = folder
         }
-        indexSearchFiles(hierarchy.descendantFiles)
+        indexSearchFiles(hierarchy.files)
     }
 
     private func indexSearchFiles(_ files: [AgentContextFileBrowseFile]) {
         for file in files {
             filesByID[file.id] = file
-            fileIDByPath[Self.normalizedPath(file.standardizedFullPath)] = file.id
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextFileBrowseModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextFileBrowseModel.swift
@@ -1,0 +1,1375 @@
+import Combine
+import Foundation
+import OSLog
+
+enum AgentContextFileBrowseUnavailableReason: Equatable {
+    case sessionRootsUnavailable
+    case catalogChanged
+    case selectionTargetUnavailable
+    case noRoots
+}
+
+enum AgentContextFileBrowsePhase: Equatable {
+    case inactive
+    case loadingRoots
+    case ready
+    case unavailable(AgentContextFileBrowseUnavailableReason)
+}
+
+enum AgentContextFileBrowseFocusTarget: Equatable, Hashable {
+    case search
+    case row(AgentContextFileBrowseNodeID)
+}
+
+struct AgentContextFileBrowseNotice: Equatable {
+    let message: String
+}
+
+struct AgentContextFileBrowseRouteProof: Equatable {
+    let identity: WorkspaceSelectionIdentity
+    let lookupContext: WorkspaceLookupContext
+}
+
+enum AgentContextFileBrowseToggleDisabledReason: Equatable {
+    case inFlight
+    case unsupportedCodemap
+    case codemapsDisabled
+    case noSelectableFiles
+    case obsoleteRequest
+    case routeUnavailable
+}
+
+enum AgentContextFileBrowseToggleEligibility: Equatable {
+    case enabled(WorkspacePreResolvedSelectionTargetState)
+    case disabled(AgentContextFileBrowseToggleDisabledReason)
+
+    var targetState: WorkspacePreResolvedSelectionTargetState? {
+        guard case let .enabled(targetState) = self else { return nil }
+        return targetState
+    }
+}
+
+struct AgentContextFileBrowseFileStatus: Equatable {
+    let heldMode: AgentContextFileBrowseHeldMode?
+    let isAutomaticallyMapped: Bool
+    let toggleEligibility: AgentContextFileBrowseToggleEligibility
+
+    var isInFlight: Bool {
+        toggleEligibility == .disabled(.inFlight)
+    }
+
+    var isCodemapBlocked: Bool {
+        switch toggleEligibility {
+        case .disabled(.unsupportedCodemap), .disabled(.codemapsDisabled): true
+        case .enabled, .disabled: false
+        }
+    }
+}
+
+struct AgentContextFileBrowseContainerStatus: Equatable {
+    let membership: AgentContextFileBrowseContainerMembership
+    let totalFileCount: Int
+    let selectableFileCount: Int
+    let selectedFileCount: Int
+    let unsupportedFileCount: Int
+    let toggleEligibility: AgentContextFileBrowseToggleEligibility
+
+    var isInFlight: Bool {
+        toggleEligibility == .disabled(.inFlight)
+    }
+
+    var addableFileCount: Int {
+        selectableFileCount - selectedFileCount
+    }
+}
+
+struct AgentContextFileBrowseAccessibilityAnnouncement: Equatable {
+    let id: UUID
+    let message: String
+}
+
+enum AgentContextFileBrowseRow: Equatable, Identifiable {
+    enum ID: Equatable, Hashable {
+        case node(AgentContextFileBrowseNodeID)
+        case loading(AgentContextFileBrowseNodeID)
+        case emptyContainer(AgentContextFileBrowseNodeID)
+    }
+
+    case root(AgentContextFileBrowseRoot)
+    case folder(AgentContextFileBrowseFolder, depth: Int)
+    case file(AgentContextFileBrowseFile, depth: Int)
+    case searchRootHeader(AgentContextFileBrowseSearchRootGroup)
+    case searchDirectoryHeader(AgentContextFileBrowseSearchDirectoryGroup)
+    case loading(parent: AgentContextFileBrowseNodeID, depth: Int)
+    case emptyContainer(parent: AgentContextFileBrowseNodeID, depth: Int)
+
+    var id: ID {
+        switch self {
+        case let .root(root): .node(.root(root.id))
+        case let .folder(folder, _): .node(.folder(folder.id))
+        case let .file(file, _): .node(.file(file.id))
+        case let .searchRootHeader(group): .node(group.id)
+        case let .searchDirectoryHeader(group): .node(group.id)
+        case let .loading(parent, _): .loading(parent)
+        case let .emptyContainer(parent, _): .emptyContainer(parent)
+        }
+    }
+
+    var interactiveNodeID: AgentContextFileBrowseNodeID? {
+        switch self {
+        case let .root(root): .root(root.id)
+        case let .folder(folder, _): .folder(folder.id)
+        case let .file(file, _): .file(file.id)
+        case .searchRootHeader, .searchDirectoryHeader, .loading, .emptyContainer: nil
+        }
+    }
+}
+
+@MainActor
+final class AgentContextFileBrowseModel: ObservableObject {
+    typealias MutationExecutor = @MainActor (
+        _ paths: [String],
+        _ targetState: WorkspacePreResolvedSelectionTargetState,
+        _ identity: WorkspaceSelectionIdentity,
+        _ lookupContext: WorkspaceLookupContext
+    ) async -> WorkspaceSelectionCoordinator.TransactionResult?
+    private struct Session {
+        let generation: UInt64
+        let identity: WorkspaceSelectionIdentity
+        let lookupContext: WorkspaceLookupContext
+    }
+
+    /// Expanded container paths carried from the previous browse session on the same route, so
+    /// leaving and re-entering browse mode returns the user to the tree they were working in.
+    private struct RetainedExpansion {
+        let identity: WorkspaceSelectionIdentity
+        let lookupContext: WorkspaceLookupContext
+        let containerPaths: Set<String>
+    }
+
+    private struct MutationRequest {
+        let generation: UInt64
+        let catalogGeneration: UInt64
+        let identity: WorkspaceSelectionIdentity
+        let lookupContext: WorkspaceLookupContext
+        let files: [AgentContextFileBrowseFile]
+        let targetState: WorkspacePreResolvedSelectionTargetState
+    }
+
+    private struct MutationWorker {
+        let id: UUID
+        let generation: UInt64
+        let task: Task<Void, Never>
+    }
+
+    private struct ContainerAggregate {
+        var totalFileCount = 0
+        var selectableFileCount = 0
+        var selectedFileCount = 0
+        var unsupportedFileCount = 0
+        var inFlightFileCount = 0
+        var knownEstimateCount = 0
+        var knownTokenTotal = 0
+        var unavailableEstimateCount = 0
+        var loadingEstimateCount = 0
+    }
+
+    private static let logger = Logger(subsystem: "com.repoprompt.agents", category: "ContextFileBrowse")
+
+    @Published private(set) var phase: AgentContextFileBrowsePhase = .inactive
+    @Published private(set) var roots: [AgentContextFileBrowseRoot] = []
+    @Published private(set) var rows: [AgentContextFileBrowseRow] = []
+    @Published private(set) var visibleInteractiveRowOrder: [AgentContextFileBrowseNodeID] = []
+    @Published private(set) var searchGroups: [AgentContextFileBrowseSearchRootGroup] = []
+    @Published private(set) var expandedNodeIDs: Set<AgentContextFileBrowseNodeID> = []
+    @Published private(set) var loadingChildNodeIDs: Set<AgentContextFileBrowseNodeID> = []
+    @Published private(set) var inFlightPaths: Set<String> = []
+    @Published private(set) var pendingMutationIdentities: Set<WorkspaceSelectionIdentity> = []
+    @Published private(set) var focusTarget: AgentContextFileBrowseFocusTarget?
+    @Published private(set) var notice: AgentContextFileBrowseNotice?
+    @Published private(set) var accessibilityAnnouncement: AgentContextFileBrowseAccessibilityAnnouncement?
+    @Published private(set) var query = ""
+    @Published private(set) var rootScope: AgentContextFileBrowseRootScope = .allRoots
+    @Published private(set) var addMode: AgentContextFileBrowseAddMode = .full
+    @Published private(set) var codeMapsGloballyDisabled = false
+    @Published private(set) var tokenReadinessRevision: UInt64 = 0
+
+    private let service: AgentContextFileBrowseService
+    private let estimator: AgentContextFileSizeEstimator
+    private let mutationExecutor: MutationExecutor
+    private let searchDebounceNanoseconds: UInt64
+    private let noticeDurationNanoseconds: UInt64
+
+    private var session: Session?
+    private var mutationRouteProof: AgentContextFileBrowseRouteProof?
+    private var sessionGeneration: UInt64 = 0
+    private var sessionCatalogGeneration: UInt64?
+    private var searchGeneration: UInt64 = 0
+    private var authoritativeSelection = StoredSelection()
+    private var authoritativeSelectionUpdateVersion: UInt64 = 0
+    private var exportRows: [AgentContextExportRow] = []
+    private var heldModesByPath: [String: AgentContextFileBrowseHeldMode] = [:]
+    private var automaticCodemapPaths: Set<String> = []
+    private var didLogSelectionOverlap = false
+    private var acceptedRootGenerationByRootID: [UUID: UInt64] = [:]
+    private var selectedAncestorDirectoryPaths: Set<String> = []
+    private var retainedExpansion: RetainedExpansion?
+    private var pendingExpansionRestorePaths: Set<String> = []
+    private var enabledNodeIDs: Set<AgentContextFileBrowseNodeID> = []
+    private var hierarchyByContainer: [AgentContextFileBrowseNodeID: AgentContextFileBrowseHierarchy] = [:]
+    private var containerAggregates: [AgentContextFileBrowseNodeID: ContainerAggregate] = [:]
+    private var containerIDsByFileID: [UUID: Set<AgentContextFileBrowseNodeID>] = [:]
+    private var filesByID: [UUID: AgentContextFileBrowseFile] = [:]
+    private var fileIDByPath: [String: UUID] = [:]
+    private var foldersByID: [UUID: AgentContextFileBrowseFolder] = [:]
+    private var tokenEstimatesByFileID: [UUID: AgentContextFileBrowseTokenEstimate] = [:]
+    private var estimateOwnerByFileID: [UUID: AgentContextFileBrowseNodeID] = [:]
+    private var hierarchyTasks: [AgentContextFileBrowseNodeID: Task<Void, Never>] = [:]
+    private var tokenTasks: [AgentContextFileBrowseNodeID: Task<Void, Never>] = [:]
+    private var searchTask: Task<Void, Never>?
+    private var mutationWorker: MutationWorker?
+    private var mutationQueue: [MutationRequest] = []
+    private var pendingMutationCountByIdentity: [WorkspaceSelectionIdentity: Int] = [:]
+    private var noticeDismissalTask: Task<Void, Never>?
+
+    init(
+        service: AgentContextFileBrowseService,
+        estimator: AgentContextFileSizeEstimator,
+        searchDebounceNanoseconds: UInt64 = 120_000_000,
+        noticeDurationNanoseconds: UInt64 = 4_000_000_000,
+        mutationExecutor: @escaping MutationExecutor
+    ) {
+        self.service = service
+        self.estimator = estimator
+        self.searchDebounceNanoseconds = searchDebounceNanoseconds
+        self.noticeDurationNanoseconds = noticeDurationNanoseconds
+        self.mutationExecutor = mutationExecutor
+    }
+
+    var isActive: Bool {
+        phase != .inactive
+    }
+
+    var capturedIdentity: WorkspaceSelectionIdentity? {
+        session?.identity
+    }
+
+    func begin(
+        target: AgentContextSelectionMutationTarget,
+        lookupContext: WorkspaceLookupContext,
+        exportRows: [AgentContextExportRow],
+        codeMapsGloballyDisabled: Bool
+    ) async {
+        end()
+        pendingExpansionRestorePaths = if let retainedExpansion,
+                                          retainedExpansion.identity == target.identity,
+                                          retainedExpansion.lookupContext == lookupContext
+        {
+            retainedExpansion.containerPaths
+        } else {
+            []
+        }
+        sessionGeneration &+= 1
+        let generation = sessionGeneration
+        session = Session(generation: generation, identity: target.identity, lookupContext: lookupContext)
+        phase = .loadingRoots
+        rootScope = .allRoots
+        addMode = .full
+        self.codeMapsGloballyDisabled = codeMapsGloballyDisabled
+        authoritativeSelection = target.expectedSelection
+        self.exportRows = exportRows
+        rebuildSelectionProjection()
+
+        let result = await service.roots(lookupContext: lookupContext)
+        guard isCurrentSession(generation) else { return }
+        switch result {
+        case .unavailable:
+            async let servicePrune: Void = service.pruneCaches(
+                retainingRootIDs: [],
+                lookupContext: lookupContext
+            )
+            async let estimatorPrune: Void = estimator.pruneCaches(retainingRootIDs: [])
+            _ = await (servicePrune, estimatorPrune)
+            guard isCurrentSession(generation) else { return }
+            phase = .unavailable(.sessionRootsUnavailable)
+        case let .available(snapshot):
+            sessionCatalogGeneration = snapshot.catalogGeneration
+            roots = snapshot.roots
+            let retainedRootIDs = Set(roots.map(\.id))
+            async let servicePrune: Void = service.pruneCaches(
+                retainingRootIDs: retainedRootIDs,
+                lookupContext: lookupContext
+            )
+            async let estimatorPrune: Void = estimator.pruneCaches(retainingRootIDs: retainedRootIDs)
+            _ = await (servicePrune, estimatorPrune)
+            guard isCurrentSession(generation) else { return }
+            guard !roots.isEmpty else {
+                phase = .unavailable(.noRoots)
+                return
+            }
+            phase = .ready
+            focusTarget = .search
+            restorePendingExpansion(for: roots.map {
+                (nodeID: AgentContextFileBrowseNodeID.root($0.id), path: $0.physicalPath)
+            })
+            rebuildRows()
+        }
+    }
+
+    func end() {
+        if let session {
+            retainedExpansion = RetainedExpansion(
+                identity: session.identity,
+                lookupContext: session.lookupContext,
+                containerPaths: Set(expandedNodeIDs.compactMap(containerPath(for:)))
+            )
+        }
+        sessionGeneration &+= 1
+        session = nil
+        sessionCatalogGeneration = nil
+        cancelBrowseWork()
+        phase = .inactive
+        roots = []
+        rows = []
+        visibleInteractiveRowOrder = []
+        searchGroups = []
+        expandedNodeIDs = []
+        loadingChildNodeIDs = []
+        inFlightPaths = []
+        focusTarget = nil
+        notice = nil
+        accessibilityAnnouncement = nil
+        query = ""
+        rootScope = .allRoots
+        addMode = .full
+        codeMapsGloballyDisabled = false
+        tokenReadinessRevision = 0
+        authoritativeSelection = StoredSelection()
+        exportRows = []
+        heldModesByPath = [:]
+        automaticCodemapPaths = []
+        didLogSelectionOverlap = false
+        hierarchyByContainer = [:]
+        containerAggregates = [:]
+        containerIDsByFileID = [:]
+        filesByID = [:]
+        fileIDByPath = [:]
+        foldersByID = [:]
+        tokenEstimatesByFileID = [:]
+        estimateOwnerByFileID = [:]
+        enabledNodeIDs = []
+        acceptedRootGenerationByRootID = [:]
+        selectedAncestorDirectoryPaths = []
+        pendingExpansionRestorePaths = []
+    }
+
+    func sessionMatches(identity: WorkspaceSelectionIdentity, lookupContext: WorkspaceLookupContext) -> Bool {
+        session?.identity == identity && session?.lookupContext == lookupContext
+    }
+
+    func updateMutationRouteProof(_ proof: AgentContextFileBrowseRouteProof?) {
+        mutationRouteProof = proof
+    }
+
+    func applySelectionChange(
+        _ change: WorkspaceSelectionCoordinator.Change,
+        exportRows: [AgentContextExportRow]
+    ) {
+        guard let session, change.tabID == session.identity.tabID else { return }
+        authoritativeSelection = change.selection
+        authoritativeSelectionUpdateVersion &+= 1
+        self.exportRows = exportRows
+        rebuildSelectionProjection()
+    }
+
+    func updateAuthoritativeSelection(_ selection: StoredSelection, exportRows: [AgentContextExportRow]) {
+        guard session != nil else { return }
+        authoritativeSelection = selection
+        authoritativeSelectionUpdateVersion &+= 1
+        self.exportRows = exportRows
+        rebuildSelectionProjection()
+    }
+
+    func setQuery(_ value: String) {
+        guard session != nil else { return }
+        query = value
+        scheduleSearch()
+    }
+
+    func setRootScope(_ scope: AgentContextFileBrowseRootScope) {
+        guard session != nil, rootScope != scope else { return }
+        rootScope = scope
+        scheduleSearch()
+    }
+
+    func setAddMode(_ mode: AgentContextFileBrowseAddMode) {
+        guard session != nil else { return }
+        guard mode != .codemapOnly || !codeMapsGloballyDisabled else { return }
+        addMode = mode
+        rebuildContainerAggregates()
+        rebuildRows()
+    }
+
+    func setCodeMapsGloballyDisabled(_ disabled: Bool) {
+        guard session != nil else { return }
+        codeMapsGloballyDisabled = disabled
+        if disabled { addMode = .full }
+        rebuildContainerAggregates()
+        rebuildRows()
+    }
+
+    func heldMode(for file: AgentContextFileBrowseFile) -> AgentContextFileBrowseHeldMode? {
+        fileStatus(for: file).heldMode
+    }
+
+    func isAutomaticallyMapped(_ file: AgentContextFileBrowseFile) -> Bool {
+        fileStatus(for: file).isAutomaticallyMapped
+    }
+
+    func fileStatus(for file: AgentContextFileBrowseFile) -> AgentContextFileBrowseFileStatus {
+        let path = Self.normalizedPath(file.standardizedFullPath)
+        let heldMode = heldModesByPath[path]
+        let eligibility: AgentContextFileBrowseToggleEligibility = if !routeIsCurrent() {
+            .disabled(.routeUnavailable)
+        } else if !enabledNodeIDs.contains(.file(file.id)) {
+            .disabled(.obsoleteRequest)
+        } else if inFlightPaths.contains(path) {
+            .disabled(.inFlight)
+        } else if heldMode != nil {
+            .enabled(.unselected)
+        } else if addMode == .full {
+            .enabled(.full)
+        } else if codeMapsGloballyDisabled {
+            .disabled(.codemapsDisabled)
+        } else if !file.supportsCodemap {
+            .disabled(.unsupportedCodemap)
+        } else {
+            .enabled(.codemapOnly)
+        }
+        return AgentContextFileBrowseFileStatus(
+            heldMode: heldMode,
+            isAutomaticallyMapped: automaticCodemapPaths.contains(path),
+            toggleEligibility: eligibility
+        )
+    }
+
+    func containerStatus(for nodeID: AgentContextFileBrowseNodeID) -> AgentContextFileBrowseContainerStatus? {
+        guard let aggregate = containerAggregates[nodeID],
+              let membership = membership(for: nodeID)
+        else { return nil }
+        let addableFileCount = aggregate.selectableFileCount - aggregate.selectedFileCount
+        let eligibility: AgentContextFileBrowseToggleEligibility = if !routeIsCurrent() {
+            .disabled(.routeUnavailable)
+        } else if !enabledNodeIDs.contains(nodeID) {
+            .disabled(.obsoleteRequest)
+        } else if aggregate.inFlightFileCount > 0 {
+            .disabled(.inFlight)
+        } else if membership == .all, aggregate.totalFileCount > 0 {
+            .enabled(.unselected)
+        } else if addableFileCount > 0 {
+            .enabled(addMode == .full ? .full : .codemapOnly)
+        } else {
+            .disabled(.noSelectableFiles)
+        }
+        return AgentContextFileBrowseContainerStatus(
+            membership: membership,
+            totalFileCount: aggregate.totalFileCount,
+            selectableFileCount: aggregate.selectableFileCount,
+            selectedFileCount: aggregate.selectedFileCount,
+            unsupportedFileCount: aggregate.unsupportedFileCount,
+            toggleEligibility: eligibility
+        )
+    }
+
+    func membership(for nodeID: AgentContextFileBrowseNodeID) -> AgentContextFileBrowseContainerMembership? {
+        guard let aggregate = containerAggregates[nodeID] else { return nil }
+        guard aggregate.selectableFileCount > 0 else { return AgentContextFileBrowseContainerMembership.none }
+        if aggregate.selectedFileCount == 0 { return AgentContextFileBrowseContainerMembership.none }
+        if aggregate.selectedFileCount == aggregate.selectableFileCount { return .all }
+        return .mixed
+    }
+
+    /// Checkbox state for a container row. A resolved container reports exact membership. An
+    /// unresolved container still reports `.mixed` when the selection holds one of its
+    /// descendants, so a collapsed folder shows that selected files came from inside it.
+    func containerDisplayMembership(
+        for nodeID: AgentContextFileBrowseNodeID
+    ) -> AgentContextFileBrowseContainerMembership {
+        if let membership = membership(for: nodeID) { return membership }
+        guard let path = containerPath(for: nodeID) else {
+            return AgentContextFileBrowseContainerMembership.none
+        }
+        return selectedAncestorDirectoryPaths.contains(path)
+            ? .mixed
+            : AgentContextFileBrowseContainerMembership.none
+    }
+
+    private func containerPath(for nodeID: AgentContextFileBrowseNodeID) -> String? {
+        switch nodeID {
+        case let .root(rootID):
+            guard let root = roots.first(where: { $0.id == rootID }) else { return nil }
+            return Self.normalizedPath(root.physicalPath)
+        case let .folder(folderID):
+            guard let folder = foldersByID[folderID] else { return nil }
+            return Self.normalizedPath(folder.standardizedFullPath)
+        case .file, .searchRootHeader, .searchDirectoryHeader:
+            return nil
+        }
+    }
+
+    private static func ancestorDirectoryPaths(of paths: some Collection<String>) -> Set<String> {
+        var ancestors: Set<String> = []
+        for path in paths {
+            var current = (path as NSString).deletingLastPathComponent
+            while current.count > 1, !ancestors.contains(current) {
+                ancestors.insert(current)
+                current = (current as NSString).deletingLastPathComponent
+            }
+        }
+        return ancestors
+    }
+
+    func tokenEstimate(for nodeID: AgentContextFileBrowseNodeID) -> AgentContextFileBrowseTokenEstimate {
+        switch nodeID {
+        case let .file(fileID):
+            return tokenEstimatesByFileID[fileID] ?? .notRequested
+        case .root, .folder:
+            guard let aggregate = containerAggregates[nodeID] else { return .notRequested }
+            if aggregate.loadingEstimateCount > 0 { return .loading }
+            if aggregate.knownEstimateCount + aggregate.unavailableEstimateCount < aggregate.totalFileCount {
+                return .notRequested
+            }
+            if aggregate.unavailableEstimateCount > 0 { return .unavailable }
+            return .known(aggregate.knownTokenTotal)
+        case .searchRootHeader, .searchDirectoryHeader:
+            return .notRequested
+        }
+    }
+
+    func toggleExpansion(_ nodeID: AgentContextFileBrowseNodeID) {
+        guard session != nil, Self.isContainer(nodeID) else { return }
+        if expandedNodeIDs.remove(nodeID) != nil {
+            rebuildRows()
+            return
+        }
+        expandedNodeIDs.insert(nodeID)
+        rebuildRows()
+        requestHierarchy(for: nodeID)
+    }
+
+    /// Re-expands containers the previous session left open. Each path is consumed as it is
+    /// applied, so a container the user collapses during this session stays collapsed.
+    private func restorePendingExpansion(
+        for containers: [(nodeID: AgentContextFileBrowseNodeID, path: String)]
+    ) {
+        guard !pendingExpansionRestorePaths.isEmpty else { return }
+        for container in containers {
+            guard pendingExpansionRestorePaths.remove(Self.normalizedPath(container.path)) != nil else { continue }
+            guard expandedNodeIDs.insert(container.nodeID).inserted else { continue }
+            requestHierarchy(for: container.nodeID)
+        }
+    }
+
+    func rowBecameVisible(_ nodeID: AgentContextFileBrowseNodeID) {
+        switch nodeID {
+        case .root, .folder:
+            break
+        case let .file(fileID):
+            guard let file = filesByID[fileID] else { return }
+            requestFileEstimate(file)
+        case .searchRootHeader, .searchDirectoryHeader:
+            break
+        }
+    }
+
+    func rowDisappeared(_ nodeID: AgentContextFileBrowseNodeID) {
+        guard case .file = nodeID else { return }
+        cancelEstimateRequest(owner: nodeID)
+    }
+
+    func toggleFile(_ file: AgentContextFileBrowseFile) -> Bool {
+        guard let targetState = fileStatus(for: file).toggleEligibility.targetState else { return false }
+        enqueueMutation(files: [file], targetState: targetState)
+        return true
+    }
+
+    func toggleContainer(_ nodeID: AgentContextFileBrowseNodeID) -> Bool {
+        guard let hierarchy = hierarchyByContainer[nodeID],
+              let targetState = containerStatus(for: nodeID)?.toggleEligibility.targetState
+        else { return false }
+        let files = if targetState == .unselected {
+            hierarchy.descendantFiles
+        } else {
+            selectableDescendants(from: hierarchy.descendantFiles).filter {
+                heldModesByPath[Self.normalizedPath($0.standardizedFullPath)] == nil
+            }
+        }
+        guard !files.isEmpty else { return false }
+        enqueueMutation(files: files, targetState: targetState)
+        return true
+    }
+
+    func focusNextRow() {
+        moveFocus(offset: 1)
+    }
+
+    func focusPreviousRow() {
+        moveFocus(offset: -1)
+    }
+
+    func focusSearch() {
+        focusTarget = .search
+    }
+
+    func setFocusTarget(_ target: AgentContextFileBrowseFocusTarget) {
+        guard session != nil else { return }
+        focusTarget = target
+    }
+
+    func clearQueryOrEnd() {
+        if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            setQuery("")
+        } else {
+            end()
+        }
+    }
+
+    func dismissNotice() {
+        noticeDismissalTask?.cancel()
+        noticeDismissalTask = nil
+        notice = nil
+    }
+
+    private func rebuildSelectionProjection() {
+        guard let session else { return }
+        let physical = session.lookupContext.physicalizeSelection(authoritativeSelection)
+        let selected = Set(StoredSelectionPathNormalization.standardizedPaths(physical.selectedPaths))
+        let sliced = Set(StoredSelectionPathNormalization.standardizedSlices(physical.slices).compactMap { path, ranges in
+            ranges.isEmpty ? nil : path
+        })
+        let manual = Set(StoredSelectionPathNormalization.standardizedPaths(physical.manualCodemapPaths))
+        if !didLogSelectionOverlap, !manual.intersection(selected.union(sliced)).isEmpty {
+            didLogSelectionOverlap = true
+            Self.logger.error("Context file browse found overlapping explicit selection representations")
+        }
+
+        var projection: [String: AgentContextFileBrowseHeldMode] = [:]
+        projection.reserveCapacity(selected.count + sliced.count + manual.count)
+        for path in manual {
+            projection[path] = .codemap
+        }
+        for path in selected {
+            projection[path] = .full
+        }
+        for path in sliced {
+            projection[path] = .slice
+        }
+        updateSelectionAggregates(from: heldModesByPath, to: projection)
+        heldModesByPath = projection
+        selectedAncestorDirectoryPaths = Self.ancestorDirectoryPaths(of: projection.keys)
+
+        automaticCodemapPaths = Set(exportRows.compactMap { row -> String? in
+            guard row.kind == .codemap, let physicalPath = row.physicalPath else { return nil }
+            let normalized = Self.normalizedPath(physicalPath)
+            return manual.contains(normalized) ? nil : normalized
+        })
+        rebuildRows()
+    }
+
+    private func updateSelectionAggregates(
+        from previous: [String: AgentContextFileBrowseHeldMode],
+        to current: [String: AgentContextFileBrowseHeldMode]
+    ) {
+        let changedPaths = Set(previous.keys).union(current.keys).filter {
+            (previous[$0] != nil) != (current[$0] != nil)
+        }
+        for path in changedPaths {
+            guard let fileID = fileIDByPath[path], let file = filesByID[fileID] else { continue }
+            let wasSelected = previous[path] != nil
+            let isSelected = current[path] != nil
+            for containerID in containerIDsByFileID[fileID] ?? [] {
+                guard var aggregate = containerAggregates[containerID] else { continue }
+                applySelectionContribution(
+                    file: file,
+                    isSelected: wasSelected,
+                    multiplier: -1,
+                    to: &aggregate
+                )
+                applySelectionContribution(
+                    file: file,
+                    isSelected: isSelected,
+                    multiplier: 1,
+                    to: &aggregate
+                )
+                containerAggregates[containerID] = aggregate
+            }
+        }
+    }
+
+    private func applySelectionContribution(
+        file: AgentContextFileBrowseFile,
+        isSelected: Bool,
+        multiplier: Int,
+        to aggregate: inout ContainerAggregate
+    ) {
+        let isSelectable = addMode == .full
+            || isSelected
+            || (file.supportsCodemap && !codeMapsGloballyDisabled)
+        aggregate.selectableFileCount += isSelectable ? multiplier : 0
+        aggregate.selectedFileCount += isSelected && isSelectable ? multiplier : 0
+        aggregate.unsupportedFileCount += isSelectable ? 0 : multiplier
+    }
+
+    private func selectableDescendants(
+        from files: [AgentContextFileBrowseFile]
+    ) -> [AgentContextFileBrowseFile] {
+        guard addMode == .codemapOnly else { return files }
+        return files.filter {
+            heldModesByPath[Self.normalizedPath($0.standardizedFullPath)] != nil
+                || ($0.supportsCodemap && !codeMapsGloballyDisabled)
+        }
+    }
+
+    private func rebuildContainerAggregates() {
+        var aggregates: [AgentContextFileBrowseNodeID: ContainerAggregate] = [:]
+        var containerIDs: [UUID: Set<AgentContextFileBrowseNodeID>] = [:]
+        for (nodeID, hierarchy) in hierarchyByContainer {
+            var aggregate = ContainerAggregate()
+            for file in hierarchy.descendantFiles {
+                containerIDs[file.id, default: []].insert(nodeID)
+                accumulate(file: file, into: &aggregate)
+            }
+            aggregates[nodeID] = aggregate
+        }
+        containerAggregates = aggregates
+        containerIDsByFileID = containerIDs
+    }
+
+    private func accumulate(file: AgentContextFileBrowseFile, into aggregate: inout ContainerAggregate) {
+        let path = Self.normalizedPath(file.standardizedFullPath)
+        let isSelected = heldModesByPath[path] != nil
+        aggregate.totalFileCount += 1
+        applySelectionContribution(file: file, isSelected: isSelected, multiplier: 1, to: &aggregate)
+        aggregate.inFlightFileCount += inFlightPaths.contains(path) ? 1 : 0
+        Self.applyEstimate(tokenEstimatesByFileID[file.id], multiplier: 1, to: &aggregate)
+    }
+
+    private func setTokenEstimate(
+        _ estimate: AgentContextFileBrowseTokenEstimate?,
+        fileID: UUID
+    ) {
+        let previous = tokenEstimatesByFileID[fileID]
+        guard previous != estimate else { return }
+        tokenEstimatesByFileID[fileID] = estimate
+        for containerID in containerIDsByFileID[fileID] ?? [] {
+            guard var aggregate = containerAggregates[containerID] else { continue }
+            Self.applyEstimate(previous, multiplier: -1, to: &aggregate)
+            Self.applyEstimate(estimate, multiplier: 1, to: &aggregate)
+            containerAggregates[containerID] = aggregate
+        }
+    }
+
+    private static func applyEstimate(
+        _ estimate: AgentContextFileBrowseTokenEstimate?,
+        multiplier: Int,
+        to aggregate: inout ContainerAggregate
+    ) {
+        switch estimate {
+        case let .known(tokens):
+            aggregate.knownEstimateCount += multiplier
+            aggregate.knownTokenTotal += tokens * multiplier
+        case .unavailable:
+            aggregate.unavailableEstimateCount += multiplier
+        case .loading:
+            aggregate.loadingEstimateCount += multiplier
+        case .notRequested, nil:
+            break
+        }
+    }
+
+    private func updateInFlightAggregates(
+        for files: [AgentContextFileBrowseFile],
+        multiplier: Int
+    ) {
+        for file in files {
+            for containerID in containerIDsByFileID[file.id] ?? [] {
+                guard var aggregate = containerAggregates[containerID] else { continue }
+                aggregate.inFlightFileCount += multiplier
+                containerAggregates[containerID] = aggregate
+            }
+        }
+    }
+
+    private func routeIsCurrent() -> Bool {
+        guard let session else { return false }
+        return mutationRouteProof == AgentContextFileBrowseRouteProof(
+            identity: session.identity,
+            lookupContext: session.lookupContext
+        )
+    }
+
+    private func scheduleSearch() {
+        searchGeneration &+= 1
+        let requestGeneration = searchGeneration
+        searchTask?.cancel()
+        searchGroups = []
+        rebuildRows()
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let session, !trimmedQuery.isEmpty else {
+            searchGroups = []
+            rebuildRows()
+            return
+        }
+        let sessionGeneration = session.generation
+        let scope = rootScope
+        let lookupContext = session.lookupContext
+        searchTask = Task { [weak self, service, searchDebounceNanoseconds] in
+            do {
+                if searchDebounceNanoseconds > 0 {
+                    try await Task.sleep(nanoseconds: searchDebounceNanoseconds)
+                }
+                let scopedResult = try await service.search(
+                    query: trimmedQuery,
+                    scope: scope,
+                    lookupContext: lookupContext
+                )
+                try Task.checkCancellation()
+                guard let self,
+                      isCurrentSession(sessionGeneration),
+                      searchGeneration == requestGeneration
+                else { return }
+                guard case let .available(result) = scopedResult else {
+                    transitionToSessionRootsUnavailable()
+                    return
+                }
+                guard result.catalogGeneration == sessionCatalogGeneration else {
+                    transitionToCatalogChanged()
+                    return
+                }
+                searchGroups = acceptingSearchGroups(result.groups)
+                let matchedFiles = searchGroups.flatMap { group in
+                    group.rootMatches.map(\.file) + group.directories.flatMap { $0.matches.map(\.file) }
+                }
+                indexSearchFiles(matchedFiles)
+                rebuildRows()
+            } catch is CancellationError {
+                return
+            } catch {
+                guard let self, isCurrentSession(sessionGeneration) else { return }
+                Self.logger.error("Context file browse search failed: \(error.localizedDescription, privacy: .public)")
+                searchGroups = []
+                rebuildRows()
+            }
+        }
+    }
+
+    private func requestHierarchy(for nodeID: AgentContextFileBrowseNodeID) {
+        guard hierarchyByContainer[nodeID] == nil,
+              hierarchyTasks[nodeID] == nil,
+              let session,
+              let location = containerLocation(nodeID)
+        else { return }
+        loadingChildNodeIDs.insert(nodeID)
+        rebuildRows()
+        let generation = session.generation
+        hierarchyTasks[nodeID] = Task { [weak self, service] in
+            do {
+                let scopedResult = try await service.hierarchy(
+                    rootID: location.rootID,
+                    folderID: location.folderID,
+                    lookupContext: session.lookupContext
+                )
+                try Task.checkCancellation()
+                guard let self, isCurrentSession(generation) else { return }
+                hierarchyTasks[nodeID] = nil
+                loadingChildNodeIDs.remove(nodeID)
+                let hierarchy: AgentContextFileBrowseHierarchy
+                switch scopedResult {
+                case let .available(result):
+                    hierarchy = result
+                case let .missing(catalogGeneration):
+                    guard catalogGeneration == sessionCatalogGeneration else {
+                        transitionToCatalogChanged()
+                        return
+                    }
+                    expandedNodeIDs.remove(nodeID)
+                    showNotice("This folder is no longer available")
+                    rebuildRows()
+                    return
+                case .sessionRootsUnavailable:
+                    transitionToSessionRootsUnavailable()
+                    return
+                }
+                guard hierarchy.catalogGeneration == sessionCatalogGeneration else {
+                    transitionToCatalogChanged()
+                    return
+                }
+                let wasExpanded = expandedNodeIDs.contains(nodeID)
+                guard acceptAppliedRootGeneration(
+                    rootID: location.rootID,
+                    generation: hierarchy.rootGeneration
+                ) else {
+                    rebuildRows()
+                    return
+                }
+                if wasExpanded { expandedNodeIDs.insert(nodeID) }
+                hierarchyByContainer[nodeID] = hierarchy
+                indexHierarchy(hierarchy)
+                rebuildContainerAggregates()
+                restorePendingExpansion(for: hierarchy.folders.map {
+                    (nodeID: AgentContextFileBrowseNodeID.folder($0.id), path: $0.standardizedFullPath)
+                })
+                rebuildRows()
+            } catch is CancellationError {
+                return
+            } catch {
+                guard let self, isCurrentSession(generation) else { return }
+                hierarchyTasks[nodeID] = nil
+                loadingChildNodeIDs.remove(nodeID)
+                showNotice("This folder could not be loaded")
+                rebuildRows()
+            }
+        }
+    }
+
+    private func transitionToSessionRootsUnavailable() {
+        phase = .unavailable(.sessionRootsUnavailable)
+        searchGroups = []
+        rebuildRows()
+    }
+
+    private func transitionToCatalogChanged() {
+        phase = .unavailable(.catalogChanged)
+        searchGroups = []
+        rebuildRows()
+    }
+
+    private func requestFileEstimate(_ file: AgentContextFileBrowseFile) {
+        let nodeID = AgentContextFileBrowseNodeID.file(file.id)
+        guard let session,
+              tokenTasks[nodeID] == nil,
+              let request = claimEstimateRequests(files: [file], owner: nodeID).first
+        else { return }
+        let generation = session.generation
+        tokenTasks[nodeID] = Task { [weak self, estimator] in
+            let results = await estimator.estimates(for: [request])
+            guard let self, !Task.isCancelled, isCurrentSession(generation) else { return }
+            applyEstimateResults(results, owner: nodeID)
+        }
+    }
+
+    private func claimEstimateRequests(
+        files: [AgentContextFileBrowseFile],
+        owner: AgentContextFileBrowseNodeID
+    ) -> [AgentContextFileSizeEstimateRequest] {
+        let pending = files.filter {
+            tokenEstimatesByFileID[$0.id] == nil && estimateOwnerByFileID[$0.id] == nil
+        }
+        guard !pending.isEmpty else { return [] }
+        for file in pending {
+            estimateOwnerByFileID[file.id] = owner
+            setTokenEstimate(.loading, fileID: file.id)
+        }
+        tokenReadinessRevision &+= 1
+        return pending.map {
+            AgentContextFileSizeEstimateRequest(file: $0, rootGeneration: $0.rootGeneration)
+        }
+    }
+
+    private func applyEstimateResults(
+        _ results: [AgentContextFileSizeEstimateResult],
+        owner: AgentContextFileBrowseNodeID
+    ) {
+        tokenTasks[owner] = nil
+        var changed = false
+        for result in results where estimateOwnerByFileID[result.fileID] == owner {
+            estimateOwnerByFileID[result.fileID] = nil
+            if filesByID[result.fileID]?.rootGeneration == result.rootGeneration,
+               acceptedRootGenerationByRootID[result.rootID] == result.rootGeneration,
+               result.estimate != .notRequested
+            {
+                setTokenEstimate(result.estimate, fileID: result.fileID)
+            } else {
+                setTokenEstimate(nil, fileID: result.fileID)
+            }
+            changed = true
+        }
+        if changed { tokenReadinessRevision &+= 1 }
+    }
+
+    private func cancelEstimateRequest(owner: AgentContextFileBrowseNodeID) {
+        tokenTasks[owner]?.cancel()
+        tokenTasks[owner] = nil
+        let ownedFileIDs = estimateOwnerByFileID.compactMap { fileID, currentOwner in
+            currentOwner == owner ? fileID : nil
+        }
+        guard !ownedFileIDs.isEmpty else { return }
+        for fileID in ownedFileIDs {
+            estimateOwnerByFileID[fileID] = nil
+            if tokenEstimatesByFileID[fileID] == .loading {
+                setTokenEstimate(nil, fileID: fileID)
+            }
+        }
+        tokenReadinessRevision &+= 1
+    }
+
+    private func enqueueMutation(
+        files: [AgentContextFileBrowseFile],
+        targetState: WorkspacePreResolvedSelectionTargetState
+    ) {
+        guard let session, let sessionCatalogGeneration else { return }
+        let normalizedPaths = Set(files.map { Self.normalizedPath($0.standardizedFullPath) })
+        guard inFlightPaths.isDisjoint(with: normalizedPaths) else { return }
+        inFlightPaths.formUnion(normalizedPaths)
+        updateInFlightAggregates(for: files, multiplier: 1)
+        mutationQueue.append(MutationRequest(
+            generation: session.generation,
+            catalogGeneration: sessionCatalogGeneration,
+            identity: session.identity,
+            lookupContext: session.lookupContext,
+            files: files,
+            targetState: targetState
+        ))
+        pendingMutationCountByIdentity[session.identity, default: 0] += 1
+        pendingMutationIdentities.insert(session.identity)
+        startMutationWorkerIfNeeded()
+    }
+
+    private func startMutationWorkerIfNeeded() {
+        guard mutationWorker == nil, let generation = mutationQueue.first?.generation else { return }
+        let workerID = UUID()
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await drainMutationQueue(workerID: workerID, generation: generation)
+        }
+        mutationWorker = MutationWorker(id: workerID, generation: generation, task: task)
+    }
+
+    private func drainMutationQueue(workerID: UUID, generation: UInt64) async {
+        while !mutationQueue.isEmpty {
+            guard mutationWorker?.id == workerID,
+                  mutationWorker?.generation == generation,
+                  mutationQueue.first?.generation == generation,
+                  !Task.isCancelled
+            else { break }
+            let request = mutationQueue.removeFirst()
+            defer { finishPendingMutation(request) }
+            do {
+                let scopedResult = try await service.revalidate(
+                    files: request.files,
+                    lookupContext: request.lookupContext
+                )
+                try Task.checkCancellation()
+                guard case let .available(revalidated) = scopedResult else {
+                    clearInFlight(request.files, generation: generation)
+                    if isCurrentSession(generation) {
+                        transitionToSessionRootsUnavailable()
+                    }
+                    break
+                }
+                guard revalidated.catalogGeneration == request.catalogGeneration else {
+                    clearInFlight(request.files, generation: generation)
+                    if isCurrentSession(generation) {
+                        transitionToCatalogChanged()
+                    }
+                    break
+                }
+                let acceptedFiles = if isCurrentSession(generation) {
+                    revalidated.files.filter {
+                        acceptAppliedRootGeneration(rootID: $0.rootID, generation: $0.rootGeneration)
+                    }
+                } else {
+                    revalidated.files
+                }
+                let rejectedCount = revalidated.rejectedCount + revalidated.files.count - acceptedFiles.count
+                if rejectedCount > 0, isCurrentSession(generation) {
+                    showNotice(Self.rejectedFileNotice(count: rejectedCount))
+                }
+                guard !acceptedFiles.isEmpty else {
+                    clearInFlight(request.files, generation: generation)
+                    continue
+                }
+                let paths = acceptedFiles.map(\.standardizedFullPath)
+                // This task survives session exit so an accepted coordinator transaction can finish
+                let selectionUpdateVersion = authoritativeSelectionUpdateVersion
+                let transactionTask = Task { @MainActor [mutationExecutor] in
+                    await mutationExecutor(
+                        paths,
+                        request.targetState,
+                        request.identity,
+                        request.lookupContext
+                    )
+                }
+                let transaction = await transactionTask.value
+                if let transaction {
+                    if isCurrentSession(generation),
+                       authoritativeSelectionUpdateVersion == selectionUpdateVersion
+                    {
+                        authoritativeSelection = transaction.after
+                        rebuildSelectionProjection()
+                    }
+                } else if isCurrentSession(generation) {
+                    showNotice("Selection is no longer available")
+                    phase = .unavailable(.selectionTargetUnavailable)
+                }
+            } catch is CancellationError {
+                clearInFlight(request.files, generation: generation)
+                break
+            } catch {
+                if isCurrentSession(generation) {
+                    Self.logger.error("Context file browse mutation failed: \(error.localizedDescription, privacy: .public)")
+                    showNotice("Selection could not be updated")
+                }
+            }
+            clearInFlight(request.files, generation: generation)
+        }
+        finishMutationWorker(workerID: workerID, generation: generation)
+    }
+
+    private func finishMutationWorker(workerID: UUID, generation: UInt64) {
+        guard mutationWorker?.id == workerID, mutationWorker?.generation == generation else { return }
+        mutationWorker = nil
+        if !mutationQueue.isEmpty { startMutationWorkerIfNeeded() }
+    }
+
+    private func finishPendingMutation(_ request: MutationRequest) {
+        let remaining = (pendingMutationCountByIdentity[request.identity] ?? 1) - 1
+        if remaining > 0 {
+            pendingMutationCountByIdentity[request.identity] = remaining
+        } else {
+            pendingMutationCountByIdentity[request.identity] = nil
+            pendingMutationIdentities.remove(request.identity)
+        }
+    }
+
+    private func clearInFlight(_ files: [AgentContextFileBrowseFile], generation: UInt64) {
+        guard isCurrentSession(generation) else { return }
+        updateInFlightAggregates(for: files, multiplier: -1)
+        for file in files {
+            inFlightPaths.remove(Self.normalizedPath(file.standardizedFullPath))
+        }
+    }
+
+    private func showNotice(_ message: String) {
+        noticeDismissalTask?.cancel()
+        notice = AgentContextFileBrowseNotice(message: message)
+        accessibilityAnnouncement = AgentContextFileBrowseAccessibilityAnnouncement(id: UUID(), message: message)
+        guard noticeDurationNanoseconds > 0 else { return }
+        let generation = session?.generation
+        noticeDismissalTask = Task { [weak self, noticeDurationNanoseconds] in
+            do {
+                try await Task.sleep(nanoseconds: noticeDurationNanoseconds)
+                guard let self, session?.generation == generation else { return }
+                notice = nil
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func rebuildRows() {
+        guard phase == .ready else {
+            rows = []
+            visibleInteractiveRowOrder = []
+            enabledNodeIDs = []
+            reconcileFocus()
+            return
+        }
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedQuery.isEmpty {
+            rows = searchGroups.flatMap { group in
+                var groupRows: [AgentContextFileBrowseRow] = [.searchRootHeader(group)]
+                groupRows.append(contentsOf: group.rootMatches.map { .file($0.file, depth: 0) })
+                for directory in group.directories {
+                    groupRows.append(.searchDirectoryHeader(directory))
+                    groupRows.append(contentsOf: directory.matches.map { .file($0.file, depth: 0) })
+                }
+                return groupRows
+            }
+        } else {
+            let scopedRoots = switch rootScope {
+            case .allRoots: roots
+            case let .root(rootID): roots.filter { $0.id == rootID }
+            }
+            rows = scopedRoots.flatMap { root -> [AgentContextFileBrowseRow] in
+                let nodeID = AgentContextFileBrowseNodeID.root(root.id)
+                var rootRows: [AgentContextFileBrowseRow] = [.root(root)]
+                if expandedNodeIDs.contains(nodeID) {
+                    appendChildren(of: nodeID, depth: 1, to: &rootRows)
+                }
+                return rootRows
+            }
+        }
+        visibleInteractiveRowOrder = rows.compactMap(\.interactiveNodeID)
+        enabledNodeIDs = Set(visibleInteractiveRowOrder)
+        reconcileFocus()
+    }
+
+    private func appendChildren(
+        of nodeID: AgentContextFileBrowseNodeID,
+        depth: Int,
+        to rows: inout [AgentContextFileBrowseRow]
+    ) {
+        guard let children = hierarchyByContainer[nodeID] else {
+            if loadingChildNodeIDs.contains(nodeID) {
+                rows.append(.loading(parent: nodeID, depth: depth))
+            }
+            return
+        }
+        if children.folders.isEmpty, children.files.isEmpty {
+            rows.append(.emptyContainer(parent: nodeID, depth: depth))
+            return
+        }
+        for folder in children.folders {
+            let folderNodeID = AgentContextFileBrowseNodeID.folder(folder.id)
+            rows.append(.folder(folder, depth: depth))
+            if expandedNodeIDs.contains(folderNodeID) {
+                appendChildren(of: folderNodeID, depth: depth + 1, to: &rows)
+            }
+        }
+        rows.append(contentsOf: children.files.map { .file($0, depth: depth) })
+    }
+
+    private func reconcileFocus() {
+        guard case let .row(nodeID) = focusTarget else { return }
+        if !visibleInteractiveRowOrder.contains(nodeID) {
+            focusTarget = visibleInteractiveRowOrder.first.map(AgentContextFileBrowseFocusTarget.row) ?? .search
+        }
+    }
+
+    private func moveFocus(offset: Int) {
+        guard !visibleInteractiveRowOrder.isEmpty else {
+            focusTarget = .search
+            return
+        }
+        let nextIndex: Int
+        switch focusTarget {
+        case let .row(nodeID):
+            let current = visibleInteractiveRowOrder.firstIndex(of: nodeID) ?? 0
+            nextIndex = min(max(current + offset, 0), visibleInteractiveRowOrder.count - 1)
+        case .search, nil:
+            nextIndex = offset < 0 ? visibleInteractiveRowOrder.count - 1 : 0
+        }
+        focusTarget = .row(visibleInteractiveRowOrder[nextIndex])
+    }
+
+    private func acceptingSearchGroups(
+        _ groups: [AgentContextFileBrowseSearchRootGroup]
+    ) -> [AgentContextFileBrowseSearchRootGroup] {
+        for group in groups {
+            let files = group.rootMatches.map(\.file) + group.directories.flatMap { $0.matches.map(\.file) }
+            if let generation = files.map(\.rootGeneration).max() {
+                _ = acceptAppliedRootGeneration(rootID: group.root.id, generation: generation)
+            }
+        }
+        return groups.filter { group in
+            let files = group.rootMatches.map(\.file) + group.directories.flatMap { $0.matches.map(\.file) }
+            guard let accepted = acceptedRootGenerationByRootID[group.root.id] else { return false }
+            return files.allSatisfy { $0.rootGeneration == accepted }
+        }
+    }
+
+    private func acceptAppliedRootGeneration(rootID: UUID, generation: UInt64) -> Bool {
+        if let accepted = acceptedRootGenerationByRootID[rootID] {
+            guard generation >= accepted else { return false }
+            guard generation > accepted else { return true }
+            invalidateRootDerivedState(rootID: rootID)
+        }
+        acceptedRootGenerationByRootID[rootID] = generation
+        return true
+    }
+
+    private func invalidateRootDerivedState(rootID: UUID) {
+        let folderNodeIDs = Set(foldersByID.values.lazy.filter { $0.rootID == rootID }.map {
+            AgentContextFileBrowseNodeID.folder($0.id)
+        })
+        let fileIDs = Set(filesByID.values.lazy.filter { $0.rootID == rootID }.map(\.id))
+        let fileNodeIDs = Set(fileIDs.map(AgentContextFileBrowseNodeID.file))
+        let containerNodeIDs = folderNodeIDs.union([.root(rootID)])
+        let derivedNodeIDs = containerNodeIDs.union(fileNodeIDs)
+
+        for nodeID in derivedNodeIDs {
+            hierarchyTasks[nodeID]?.cancel()
+            hierarchyTasks[nodeID] = nil
+            cancelEstimateRequest(owner: nodeID)
+        }
+        for nodeID in containerNodeIDs {
+            hierarchyByContainer[nodeID] = nil
+            loadingChildNodeIDs.remove(nodeID)
+        }
+        expandedNodeIDs.subtract(containerNodeIDs)
+        foldersByID = foldersByID.filter { $0.value.rootID != rootID }
+        filesByID = filesByID.filter { $0.value.rootID != rootID }
+        fileIDByPath = fileIDByPath.filter { !fileIDs.contains($0.value) }
+        for fileID in fileIDs {
+            tokenEstimatesByFileID[fileID] = nil
+            estimateOwnerByFileID[fileID] = nil
+        }
+        rebuildContainerAggregates()
+        searchGroups.removeAll { $0.root.id == rootID }
+        enabledNodeIDs.subtract(derivedNodeIDs)
+        if phase == .ready { rebuildRows() }
+    }
+
+    private func indexHierarchy(_ hierarchy: AgentContextFileBrowseHierarchy) {
+        for folder in hierarchy.folders {
+            foldersByID[folder.id] = folder
+        }
+        indexSearchFiles(hierarchy.descendantFiles)
+    }
+
+    private func indexSearchFiles(_ files: [AgentContextFileBrowseFile]) {
+        for file in files {
+            filesByID[file.id] = file
+            fileIDByPath[Self.normalizedPath(file.standardizedFullPath)] = file.id
+        }
+    }
+
+    private func containerLocation(
+        _ nodeID: AgentContextFileBrowseNodeID
+    ) -> (rootID: UUID, folderID: UUID?)? {
+        switch nodeID {
+        case let .root(rootID):
+            return (rootID, nil)
+        case let .folder(folderID):
+            guard let folder = foldersByID[folderID] else { return nil }
+            return (folder.rootID, folderID)
+        case .file, .searchRootHeader, .searchDirectoryHeader:
+            return nil
+        }
+    }
+
+    private func cancelBrowseWork() {
+        searchTask?.cancel()
+        searchTask = nil
+        noticeDismissalTask?.cancel()
+        noticeDismissalTask = nil
+        for task in hierarchyTasks.values {
+            task.cancel()
+        }
+        for task in tokenTasks.values {
+            task.cancel()
+        }
+        hierarchyTasks = [:]
+        tokenTasks = [:]
+    }
+
+    private func isCurrentSession(_ generation: UInt64) -> Bool {
+        session?.generation == generation
+    }
+
+    private static func isContainer(_ nodeID: AgentContextFileBrowseNodeID) -> Bool {
+        switch nodeID {
+        case .root, .folder: true
+        case .file, .searchRootHeader, .searchDirectoryHeader: false
+        }
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        StoredSelectionPathNormalization.standardizedPaths([path])[0]
+    }
+
+    private static func rejectedFileNotice(count: Int) -> String {
+        count == 1 ? "1 file is no longer available" : "\(count) files are no longer available"
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
@@ -4,6 +4,14 @@ struct AgentSelectedFilesModelIdentity: Equatable, Hashable {
     let exportContextIdentity: AgentContextExportIdentity
     let filePathDisplay: FilePathDisplay
     let codeMapUsage: CodeMapUsage
+
+    func hasSameMutationRoute(as other: AgentSelectedFilesModelIdentity) -> Bool {
+        exportContextIdentity.tabID == other.exportContextIdentity.tabID
+            && exportContextIdentity.activeAgentSessionID == other.exportContextIdentity.activeAgentSessionID
+            && exportContextIdentity.worktreeBindingFingerprint == other.exportContextIdentity.worktreeBindingFingerprint
+            && filePathDisplay == other.filePathDisplay
+            && codeMapUsage == other.codeMapUsage
+    }
 }
 
 struct AgentSelectedFilesModelRequest {
@@ -271,6 +279,11 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         return completedDisplayedModelMatches(displayedIdentity)
     }
 
+    private func displayedModelCanMutateDuringRefresh(to identity: AgentSelectedFilesModelIdentity) -> Bool {
+        guard displayedModelIsMutable, let displayedIdentity else { return false }
+        return displayedIdentity.hasSameMutationRoute(as: identity)
+    }
+
     private var refreshTask: Task<Void, Never>?
     private let cachedModelLimit = 5
     private var cachedModels: [AgentSelectedFilesModelIdentity: AgentContextExportModel] = [:]
@@ -414,7 +427,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         }
 
         let canMutatePreservedDisplayedModel = preserveDisplayedModel
-            && completedDisplayedModelMatches(request.identity)
+            && displayedModelCanMutateDuringRefresh(to: request.identity)
         cancelActiveRefresh(reason: "startReplacement", fields: refreshFields)
 
         let shouldClearLoadedModel = loadedIdentity != request.identity

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
@@ -413,6 +413,8 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
             return .skippedLoaded
         }
 
+        let canMutatePreservedDisplayedModel = preserveDisplayedModel
+            && completedDisplayedModelMatches(request.identity)
         cancelActiveRefresh(reason: "startReplacement", fields: refreshFields)
 
         let shouldClearLoadedModel = loadedIdentity != request.identity
@@ -430,7 +432,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
             model: shouldClearDisplayedModel ? nil : state.model,
             rowSplit: shouldClearDisplayedModel ? .empty : state.rowSplit,
             isLoading: true,
-            canMutateDisplayedModel: false
+            canMutateDisplayedModel: canMutatePreservedDisplayedModel
         )
         debugStats.resolverStarts += 1
         refreshFields["shouldClearLoadedModel"] = String(shouldClearLoadedModel)
@@ -477,7 +479,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                         model: publishedFileRowsModel,
                         rowSplit: fileRowsSplit,
                         isLoading: true,
-                        canMutateDisplayedModel: false
+                        canMutateDisplayedModel: canMutatePreservedDisplayedModel
                     )
                     displayedIdentity = request.identity
                     recordVisibleFileMetricsSnapshot(

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift
@@ -141,6 +141,7 @@ struct AgentModeDetailWithSidebarView: View {
                 contextBuilderAgentVM: contextBuilderAgentVM,
                 oracleViewModel: oracleViewModel,
                 selectionCoordinator: selectionCoordinator,
+                workspaceSearchService: workspaceSearchService,
                 activeAgentSessionID: statusPillsUI.snapshot.activeAgentSessionID,
                 agentModeVM: agentModeVM,
                 windowID: windowID,
@@ -209,6 +210,7 @@ struct AgentModeDetailWithSidebarView: View {
                 contextBuilderAgentVM: contextBuilderAgentVM,
                 oracleViewModel: oracleViewModel,
                 selectionCoordinator: selectionCoordinator,
+                workspaceSearchService: workspaceSearchService,
                 activeAgentSessionID: statusPillsUI.snapshot.activeAgentSessionID,
                 agentModeVM: agentModeVM,
                 windowID: windowID,
@@ -341,6 +343,8 @@ private struct AgentContextInspectorPresenter<PrimaryContent: View>: View {
     let contextBuilderAgentVM: ContextBuilderAgentViewModel
     let oracleViewModel: OracleViewModel
     let selectionCoordinator: WorkspaceSelectionCoordinator
+    let workspaceSearchService: WorkspaceSearchService
+    @StateObject private var fileBrowseModel: AgentContextFileBrowseModel
     let activeAgentSessionID: UUID?
     let agentModeVM: AgentModeViewModel
     let windowID: Int
@@ -354,6 +358,7 @@ private struct AgentContextInspectorPresenter<PrimaryContent: View>: View {
         contextBuilderAgentVM: ContextBuilderAgentViewModel,
         oracleViewModel: OracleViewModel,
         selectionCoordinator: WorkspaceSelectionCoordinator,
+        workspaceSearchService: WorkspaceSearchService,
         activeAgentSessionID: UUID?,
         agentModeVM: AgentModeViewModel,
         windowID: Int,
@@ -367,6 +372,21 @@ private struct AgentContextInspectorPresenter<PrimaryContent: View>: View {
         self.contextBuilderAgentVM = contextBuilderAgentVM
         self.oracleViewModel = oracleViewModel
         self.selectionCoordinator = selectionCoordinator
+        self.workspaceSearchService = workspaceSearchService
+        _fileBrowseModel = StateObject(wrappedValue: AgentContextFileBrowseModel(
+            service: AgentContextFileBrowseService(
+                store: promptManager.workspaceFileContextStore,
+                searchService: workspaceSearchService
+            ),
+            estimator: AgentContextFileSizeEstimator()
+        ) { paths, targetState, identity, lookupContext in
+            await selectionCoordinator.setPreResolvedFilePathsInSelection(
+                paths,
+                targetState: targetState,
+                for: identity,
+                lookupContext: lookupContext
+            )
+        })
         self.activeAgentSessionID = activeAgentSessionID
         self.agentModeVM = agentModeVM
         self.windowID = windowID
@@ -390,6 +410,7 @@ private struct AgentContextInspectorPresenter<PrimaryContent: View>: View {
                         contextBuilderAgentVM: contextBuilderAgentVM,
                         oracleViewModel: oracleViewModel,
                         selectionCoordinator: selectionCoordinator,
+                        fileBrowseModel: fileBrowseModel,
                         windowID: windowID,
                         currentTabID: currentTabID,
                         activeAgentSessionID: activeAgentSessionID,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextControlDrawerView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextControlDrawerView.swift
@@ -23,6 +23,7 @@ struct AgentContextControlDrawerView: View {
     let contextBuilderAgentVM: ContextBuilderAgentViewModel
     let oracleViewModel: OracleViewModel
     let selectionCoordinator: WorkspaceSelectionCoordinator
+    @ObservedObject var fileBrowseModel: AgentContextFileBrowseModel
     let windowID: Int
     let currentTabID: UUID?
     let activeAgentSessionID: UUID?
@@ -385,7 +386,8 @@ struct AgentContextControlDrawerView: View {
                 detailStore: detailStore,
                 modelCoordinator: modelCoordinator,
                 exportContext: exportContext,
-                isSwitchBlankingRows: isSwitchBlankingSelectedFiles
+                isSwitchBlankingRows: isSwitchBlankingSelectedFiles,
+                browseModel: fileBrowseModel
             )
         case .builder:
             AgentContextDrawerBuilderTab(

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerFilesTab.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerFilesTab.swift
@@ -8,12 +8,51 @@ func presentedSelectedContextCount(
     return authoritativeRowCount
 }
 
+func agentContextFilesCanMutateCurrentModel(
+    isSwitchBlankingRows: Bool,
+    isSwitchingComposeTab: Bool,
+    canMutateDisplayedModel: Bool,
+    sourceTabID: UUID?,
+    activeTabID: UUID?
+) -> Bool {
+    !isSwitchBlankingRows
+        && !isSwitchingComposeTab
+        && canMutateDisplayedModel
+        && sourceTabID != nil
+        && sourceTabID == activeTabID
+}
+
+func agentContextFilesReviewMutationIsFenced(
+    pendingIdentities: Set<WorkspaceSelectionIdentity>,
+    targetIdentity: WorkspaceSelectionIdentity?
+) -> Bool {
+    targetIdentity.map(pendingIdentities.contains) ?? false
+}
+
+func agentContextFileBrowseRouteProof(
+    activeIdentity: WorkspaceSelectionIdentity?,
+    sourceTabID: UUID?,
+    lookupContext: WorkspaceLookupContext
+) -> AgentContextFileBrowseRouteProof? {
+    guard let activeIdentity, activeIdentity.tabID == sourceTabID else { return nil }
+    return AgentContextFileBrowseRouteProof(identity: activeIdentity, lookupContext: lookupContext)
+}
+
+func agentContextFileBrowseShouldTerminateForTargetChange(
+    isBrowseActive: Bool,
+    hasMutationTarget: Bool,
+    sessionMatchesTarget: Bool
+) -> Bool {
+    isBrowseActive && (!hasMutationTarget || !sessionMatchesTarget)
+}
+
 struct AgentContextDrawerFilesTab: View {
     @ObservedObject var detailStore: AgentContextDrawerDetailStore
     @ObservedObject var modelCoordinator: AgentSelectedFilesModelCoordinator
     let exportContext: AgentContextExportViewContext
     let isSwitchBlankingRows: Bool
 
+    @ObservedObject var browseModel: AgentContextFileBrowseModel
     @ObservedObject private var fontScale = FontScaleManager.shared
     @StateObject private var previewCoordinator = AgentSelectedFilePreviewLoadCoordinator()
 
@@ -124,33 +163,57 @@ struct AgentContextDrawerFilesTab: View {
     }
 
     private var previewVisibleRows: [AgentContextExportRow] {
-        isSwitchHidingRows ? [] : activeRows
+        (isSwitchHidingRows || browseModel.isActive) ? [] : activeRows
+    }
+
+    private var canMutateDisplayedModel: Bool {
+        agentContextFilesCanMutateCurrentModel(
+            isSwitchBlankingRows: isSwitchBlankingRows,
+            isSwitchingComposeTab: exportContext.promptManager.isSwitchingComposeTab,
+            canMutateDisplayedModel: modelCoordinator.canMutateDisplayedModel,
+            sourceTabID: currentModel?.source.tabID,
+            activeTabID: exportContext.selectionCoordinator?.activeTabID()
+        )
     }
 
     private var canMutateCurrentModel: Bool {
-        guard !isSwitchBlankingRows else { return false }
-        guard !exportContext.promptManager.isSwitchingComposeTab else { return false }
-        guard modelCoordinator.canMutateDisplayedModel else { return false }
-        guard let model = currentModel,
-              let sourceTabID = model.source.tabID,
-              let selectionCoordinator = exportContext.selectionCoordinator
-        else { return false }
-        return selectionCoordinator.activeTabID() == sourceTabID
+        guard let routeProof = currentMutationRouteProof else { return false }
+        return !agentContextFilesReviewMutationIsFenced(
+            pendingIdentities: browseModel.pendingMutationIdentities,
+            targetIdentity: routeProof.identity
+        )
+    }
+
+    private var currentMutationRouteProof: AgentContextFileBrowseRouteProof? {
+        guard canMutateDisplayedModel,
+              let model = currentModel
+        else { return nil }
+        return agentContextFileBrowseRouteProof(
+            activeIdentity: exportContext.selectionCoordinator?.activeSelectionIdentity(),
+            sourceTabID: model.source.tabID,
+            lookupContext: model.lookupContext
+        )
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            controls
-            subtabSwitcher
-            content
+            if browseModel.isActive {
+                AgentContextFileBrowseView(model: browseModel)
+            } else {
+                controls
+                subtabSwitcher
+                content
+            }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
         .onAppear {
+            browseModel.updateMutationRouteProof(currentMutationRouteProof)
             refreshIfNeeded()
             adjustActiveSubtab()
         }
         .onDisappear {
+            terminateBrowseSession()
             previewCoordinator.reconcileVisibleRows([])
             if !isSwitchBlankingRows {
                 modelCoordinator.cancelLoading(keepLoadedModel: true)
@@ -159,12 +222,45 @@ struct AgentContextDrawerFilesTab: View {
         .onReceive(exportContext.selectionChangesPublisher) { change in
             guard !isSwitchBlankingRows else { return }
             guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+            browseModel.applySelectionChange(change, exportRows: modelCoordinator.rowSplit.rows)
             handleSelectionChange(change, isVisible: true)
         }
         .onChange(of: exportContext.modelRequestIdentity) { _, _ in
             guard !isSwitchBlankingRows else { return }
             guard !exportContext.promptManager.isSwitchingComposeTab else { return }
             resetOrRefresh(isVisible: true)
+        }
+        .onChange(of: currentMutationRouteProof) { _, proof in
+            browseModel.updateMutationRouteProof(proof)
+        }
+        .onChange(of: isSwitchBlankingRows) { _, isBlanking in
+            if isBlanking { terminateBrowseSession() }
+        }
+        .onChange(of: modelCoordinator.model) { _, newModel in
+            guard browseModel.isActive, let newModel else { return }
+            let routeProof = agentContextFileBrowseRouteProof(
+                activeIdentity: exportContext.selectionCoordinator?.activeSelectionIdentity(),
+                sourceTabID: newModel.source.tabID,
+                lookupContext: newModel.lookupContext
+            )
+            let sessionMatchesTarget = routeProof.map {
+                browseModel.sessionMatches(identity: $0.identity, lookupContext: $0.lookupContext)
+            } ?? false
+            if agentContextFileBrowseShouldTerminateForTargetChange(
+                isBrowseActive: browseModel.isActive,
+                hasMutationTarget: routeProof != nil,
+                sessionMatchesTarget: sessionMatchesTarget
+            ) {
+                terminateBrowseSession()
+                return
+            }
+            browseModel.updateAuthoritativeSelection(newModel.source.selection, exportRows: newModel.rows)
+        }
+        .onChange(of: browseModel.isActive) { _, isActive in
+            previewCoordinator.reconcileVisibleRows(isActive ? [] : previewVisibleRows)
+        }
+        .onReceive(exportContext.promptManager.$codeMapsGloballyDisabled) { disabled in
+            browseModel.setCodeMapsGloballyDisabled(disabled)
         }
         .onChange(of: fileRows.count) { _, _ in adjustActiveSubtab() }
         .onChange(of: codemapRows.count) { _, _ in adjustActiveSubtab() }
@@ -199,6 +295,15 @@ struct AgentContextDrawerFilesTab: View {
                         .foregroundStyle(.tertiary)
                 }
                 Spacer()
+                Button {
+                    enterBrowseMode()
+                } label: {
+                    Label("Add", systemImage: "plus")
+                        .font(fontPreset.captionFont)
+                }
+                .buttonStyle(CustomButtonStyle(verticalPadding: 4, horizontalPadding: 9))
+                .disabled(!canMutateCurrentModel || currentModel == nil)
+                .hoverTooltip(canMutateCurrentModel ? "Browse workspace files" : "Selection mutation is unavailable for this Agent context")
                 Button {
                     guard let model = currentModel else { return }
                     clearSelection(for: model)
@@ -423,6 +528,32 @@ struct AgentContextDrawerFilesTab: View {
                 remove(row, from: model)
             }
         )
+    }
+
+    private func terminateBrowseSession() {
+        browseModel.end()
+    }
+
+    private func enterBrowseMode() {
+        guard canMutateCurrentModel,
+              let model = currentModel,
+              let target = exportContext.activeSelectionMutationTarget(for: model.source)
+        else { return }
+        previewCoordinator.reconcileVisibleRows([])
+        let lookupContext = model.lookupContext
+        browseModel.updateMutationRouteProof(
+            AgentContextFileBrowseRouteProof(identity: target.identity, lookupContext: lookupContext)
+        )
+        let exportRows = modelCoordinator.rowSplit.rows
+        let codeMapsGloballyDisabled = exportContext.promptManager.codeMapsGloballyDisabled
+        Task {
+            await browseModel.begin(
+                target: target,
+                lookupContext: lookupContext,
+                exportRows: exportRows,
+                codeMapsGloballyDisabled: codeMapsGloballyDisabled
+            )
+        }
     }
 
     private func refreshIfNeeded(force: Bool = false, preserveDisplayedModel: Bool = false) {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerFilesTab.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerFilesTab.swift
@@ -8,6 +8,13 @@ func presentedSelectedContextCount(
     return authoritativeRowCount
 }
 
+func agentContextFilesShouldResetModel(
+    previousIdentity: AgentSelectedFilesModelIdentity,
+    currentIdentity: AgentSelectedFilesModelIdentity
+) -> Bool {
+    !previousIdentity.hasSameMutationRoute(as: currentIdentity)
+}
+
 func agentContextFilesCanMutateCurrentModel(
     isSwitchBlankingRows: Bool,
     isSwitchingComposeTab: Bool,
@@ -55,6 +62,7 @@ struct AgentContextDrawerFilesTab: View {
     @ObservedObject var browseModel: AgentContextFileBrowseModel
     @ObservedObject private var fontScale = FontScaleManager.shared
     @StateObject private var previewCoordinator = AgentSelectedFilePreviewLoadCoordinator()
+    @State private var browseEntryTask: Task<Void, Never>?
 
     private var fontPreset: FontScalePreset {
         fontScale.preset
@@ -225,9 +233,13 @@ struct AgentContextDrawerFilesTab: View {
             browseModel.applySelectionChange(change, exportRows: modelCoordinator.rowSplit.rows)
             handleSelectionChange(change, isVisible: true)
         }
-        .onChange(of: exportContext.modelRequestIdentity) { _, _ in
+        .onChange(of: exportContext.modelRequestIdentity) { previousIdentity, currentIdentity in
             guard !isSwitchBlankingRows else { return }
             guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+            guard agentContextFilesShouldResetModel(
+                previousIdentity: previousIdentity,
+                currentIdentity: currentIdentity
+            ) else { return }
             resetOrRefresh(isVisible: true)
         }
         .onChange(of: currentMutationRouteProof) { _, proof in
@@ -531,6 +543,8 @@ struct AgentContextDrawerFilesTab: View {
     }
 
     private func terminateBrowseSession() {
+        browseEntryTask?.cancel()
+        browseEntryTask = nil
         browseModel.end()
     }
 
@@ -546,7 +560,8 @@ struct AgentContextDrawerFilesTab: View {
         )
         let exportRows = modelCoordinator.rowSplit.rows
         let codeMapsGloballyDisabled = exportContext.promptManager.codeMapsGloballyDisabled
-        Task {
+        browseEntryTask?.cancel()
+        browseEntryTask = Task {
             await browseModel.begin(
                 target: target,
                 lookupContext: lookupContext,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextFileBrowseView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextFileBrowseView.swift
@@ -1,0 +1,704 @@
+import SwiftUI
+
+func agentContextFileBrowseTreeRootTitle(_ root: AgentContextFileBrowseRoot) -> String {
+    root.scopeLabel
+}
+
+/// Inline workspace browser for the Context Composer Selections tab.
+/// Renders the browse-mode metarow, search field, scope chips, and tree/search rows
+/// over `AgentContextFileBrowseModel`; enabled checkboxes mutate the captured chat
+/// selection immediately through the model.
+struct AgentContextFileBrowseView: View {
+    @ObservedObject var model: AgentContextFileBrowseModel
+
+    @ObservedObject private var fontScale = FontScaleManager.shared
+    @FocusState private var focus: AgentContextFileBrowseFocusTarget?
+
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    private var isSearchMode: Bool {
+        !model.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var queryBinding: Binding<String> {
+        Binding(
+            get: { model.query },
+            set: { model.setQuery($0) }
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            metarow
+            searchRow
+            scopeRow
+            browseRegion
+        }
+        .onAppear {
+            focus = model.focusTarget
+        }
+        .onChange(of: model.focusTarget) { _, target in
+            guard focus != target else { return }
+            focus = target
+        }
+        .onChange(of: focus) { _, newValue in
+            guard let newValue, newValue != model.focusTarget else { return }
+            model.setFocusTarget(newValue)
+        }
+        .onChange(of: model.accessibilityAnnouncement) { _, announcement in
+            guard let announcement else { return }
+            AccessibilityNotification.Announcement(announcement.message).post()
+        }
+    }
+
+    // MARK: - Metarow
+
+    private var metarow: some View {
+        HStack(spacing: 10) {
+            Text("Add files")
+                .font(fontPreset.standardFont.weight(.semibold))
+            if let notice = model.notice {
+                Text(notice.message)
+                    .font(fontPreset.captionFont)
+                    .foregroundStyle(.orange)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            Spacer()
+            Button {
+                model.end()
+            } label: {
+                Text("Done")
+                    .font(fontPreset.captionFont)
+            }
+            .buttonStyle(CustomButtonStyle(verticalPadding: 4, horizontalPadding: 9))
+            .hoverTooltip("Return to selection review")
+        }
+    }
+
+    // MARK: - Search row
+
+    private var searchRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Search files", text: queryBinding)
+                .textFieldStyle(.plain)
+                .focused($focus, equals: .search)
+                .onKeyPress(.downArrow) {
+                    model.focusNextRow()
+                    return .handled
+                }
+                .onKeyPress(.upArrow) {
+                    model.focusPreviousRow()
+                    return .handled
+                }
+                .onExitCommand {
+                    model.clearQueryOrEnd()
+                }
+            if !model.query.isEmpty {
+                Button {
+                    model.setQuery("")
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .hoverTooltip("Clear search")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(Color(NSColor.textBackgroundColor).opacity(0.65))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.secondary.opacity(0.18), lineWidth: 0.5)
+        )
+    }
+
+    // MARK: - Scope row
+
+    private var scopeRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                scopeChip(
+                    title: "All roots",
+                    isActive: model.rootScope == .allRoots,
+                    tooltip: "Browse every workspace root"
+                ) {
+                    model.setRootScope(.allRoots)
+                }
+                ForEach(model.roots, id: \.id) { root in
+                    scopeChip(
+                        title: root.scopeLabel,
+                        isActive: model.rootScope == .root(root.id),
+                        tooltip: root.physicalPath
+                    ) {
+                        model.setRootScope(.root(root.id))
+                    }
+                }
+                Divider()
+                    .frame(height: fontPreset.scaledMetric(14))
+                codemapChip
+            }
+        }
+    }
+
+    private func scopeChip(
+        title: String,
+        isActive: Bool,
+        tooltip: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: 160)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 5)
+                .background(
+                    isActive ? Color.accentColor.opacity(0.16) : Color.clear,
+                    in: Capsule()
+                )
+                .foregroundStyle(isActive ? Color.accentColor : Color.secondary)
+        }
+        .buttonStyle(.plain)
+        .fixedSize()
+        .hoverTooltip(tooltip)
+        .accessibilityLabel(title)
+        .accessibilityValue(isActive ? "Active scope" : "Inactive scope")
+    }
+
+    private var codemapChip: some View {
+        let isActive = model.addMode == .codemapOnly
+        let isDisabled = model.codeMapsGloballyDisabled
+        return Button {
+            model.setAddMode(isActive ? .full : .codemapOnly)
+        } label: {
+            Text("Codemap")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .semibold))
+                .lineLimit(1)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 5)
+                .background(
+                    isActive ? Color.purple.opacity(0.16) : Color.clear,
+                    in: Capsule()
+                )
+                .foregroundStyle(isDisabled ? Color.secondary.opacity(0.5) : (isActive ? Color.purple : Color.secondary))
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .hoverTooltip(
+            isDisabled
+                ? "Codemaps are globally disabled in Settings"
+                : "Add newly checked files as codemap-only entries"
+        )
+        .accessibilityLabel("Codemap add mode")
+        .accessibilityValue(isDisabled ? "Unavailable, codemaps are globally disabled" : (isActive ? "On" : "Off"))
+    }
+
+    // MARK: - Browse region
+
+    private var browseRegion: some View {
+        Group {
+            switch model.phase {
+            case .inactive, .loadingRoots:
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case let .unavailable(reason):
+                unavailableState(reason)
+            case .ready:
+                if isSearchMode, model.rows.isEmpty {
+                    emptyState(
+                        icon: "magnifyingglass",
+                        title: "No matches",
+                        subtitle: "No files match this search."
+                    )
+                } else {
+                    rowsScrollView
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.16))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.secondary.opacity(0.16), lineWidth: 0.5)
+        )
+    }
+
+    private var rowsScrollView: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: true) {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(model.rows) { row in
+                        rowView(row)
+                            .id(row.id)
+                    }
+                }
+                .padding(5)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .onChange(of: model.focusTarget) { _, target in
+                guard case let .row(nodeID) = target else { return }
+                proxy.scrollTo(AgentContextFileBrowseRow.ID.node(nodeID))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rowView(_ row: AgentContextFileBrowseRow) -> some View {
+        switch row {
+        case let .root(root):
+            containerRow(
+                nodeID: .root(root.id),
+                iconName: "folder",
+                title: agentContextFileBrowseTreeRootTitle(root),
+                tooltip: root.physicalPath,
+                depth: 0
+            )
+        case let .folder(folder, depth):
+            containerRow(
+                nodeID: .folder(folder.id),
+                iconName: "folder",
+                title: folder.name,
+                tooltip: folder.standardizedFullPath,
+                depth: depth
+            )
+        case let .file(file, depth):
+            fileRow(file, depth: isSearchMode ? 1 : depth)
+        case let .searchRootHeader(group):
+            searchHeader("\(group.root.scopeLabel) · \(group.matchCount) \(group.matchCount == 1 ? "match" : "matches")")
+        case let .searchDirectoryHeader(group):
+            searchHeader(group.directoryPath)
+        case let .loading(_, depth):
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            .padding(.vertical, 4)
+            .padding(.leading, indent(for: depth) + 8)
+        case let .emptyContainer(_, depth):
+            VStack(alignment: .leading, spacing: 2) {
+                Text("No files")
+                    .font(fontPreset.captionFont.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text("This folder contains no selectable files.")
+                    .font(fontPreset.captionFont)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.vertical, 4)
+            .padding(.leading, indent(for: depth) + 8)
+        }
+    }
+
+    private func searchHeader(_ text: String) -> some View {
+        Text(text)
+            .font(fontPreset.captionFont.weight(.semibold))
+            .textCase(.uppercase)
+            .foregroundStyle(.tertiary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .padding(.horizontal, 7)
+            .padding(.top, 8)
+            .padding(.bottom, 3)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: - Container rows
+
+    private func containerRow(
+        nodeID: AgentContextFileBrowseNodeID,
+        iconName: String,
+        title: String,
+        tooltip: String,
+        depth: Int
+    ) -> some View {
+        let status = model.containerStatus(for: nodeID)
+        let isExpanded = model.expandedNodeIDs.contains(nodeID)
+        let estimate = model.tokenEstimate(for: nodeID)
+        return HStack(spacing: 8) {
+            containerCheckbox(nodeID: nodeID, title: title, status: status)
+            Button {
+                model.toggleExpansion(nodeID)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .frame(width: 14)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(isExpanded ? "Collapse" : "Expand") \(title)")
+            .accessibilityValue(isExpanded ? "Expanded" : "Collapsed")
+            Image(systemName: iconName)
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            tokenEstimateText(estimate)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 7)
+        .padding(.leading, indent(for: depth))
+        .background(focusHighlight(for: nodeID))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            model.toggleExpansion(nodeID)
+        }
+        .focusable()
+        .focused($focus, equals: .row(nodeID))
+        .onKeyPress(.upArrow) {
+            model.focusPreviousRow()
+            return .handled
+        }
+        .onKeyPress(.downArrow) {
+            model.focusNextRow()
+            return .handled
+        }
+        .onKeyPress(.leftArrow) {
+            if isExpanded { model.toggleExpansion(nodeID) }
+            return .handled
+        }
+        .onKeyPress(.rightArrow) {
+            if !isExpanded { model.toggleExpansion(nodeID) }
+            return .handled
+        }
+        .onKeyPress(.space) {
+            model.toggleContainer(nodeID) ? .handled : .ignored
+        }
+        .onKeyPress(.escape) {
+            model.clearQueryOrEnd()
+            return .handled
+        }
+        .hoverTooltip(tooltip)
+        .onAppear {
+            model.rowBecameVisible(nodeID)
+        }
+    }
+
+    private func containerCheckbox(
+        nodeID: AgentContextFileBrowseNodeID,
+        title: String,
+        status: AgentContextFileBrowseContainerStatus?
+    ) -> some View {
+        let checkboxState: CheckboxState = switch model.containerDisplayMembership(for: nodeID) {
+        case .all: .checked
+        case .mixed: .mixed
+        case .none: .unchecked
+        }
+        let isDisabled = status?.toggleEligibility.targetState == nil
+        return CheckboxView(isChecked: checkboxState) {
+            guard model.toggleContainer(nodeID) else { return }
+        }
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.4 : 1)
+        .hoverTooltip(containerCheckboxTooltip(nodeID: nodeID, title: title, status: status))
+        .accessibilityLabel(containerCheckboxLabel(nodeID: nodeID, title: title, status: status))
+        .accessibilityValue(containerCheckboxValue(nodeID: nodeID, status: status))
+    }
+
+    /// Text for a container whose descendants are not resolved yet. A collapsed folder is not
+    /// loading, so it explains that expanding it is what enables the checkbox.
+    private func unresolvedContainerDescription(
+        nodeID: AgentContextFileBrowseNodeID,
+        title: String
+    ) -> String {
+        if model.expandedNodeIDs.contains(nodeID) { return "Loading folder contents" }
+        return model.containerDisplayMembership(for: nodeID) == .mixed
+            ? "\(title) contains selected files \u{2014} expand it to change the selection"
+            : "Expand \(title) to change its selection"
+    }
+
+    private func containerCheckboxTooltip(
+        nodeID: AgentContextFileBrowseNodeID,
+        title: String,
+        status: AgentContextFileBrowseContainerStatus?
+    ) -> String {
+        guard let status else { return unresolvedContainerDescription(nodeID: nodeID, title: title) }
+        if status.totalFileCount == 0 { return "This folder contains no selectable files" }
+        if status.membership == .all {
+            return "Remove \(status.selectedFileCount) selected \(pluralFiles(status.selectedFileCount)) in \(title)"
+        }
+        var text = "Add \(status.addableFileCount) \(pluralFiles(status.addableFileCount)) in \(title)"
+        if model.addMode == .codemapOnly, status.unsupportedFileCount > 0 {
+            text += " — \(status.unsupportedFileCount) \(pluralFiles(status.unsupportedFileCount)) cannot be added as codemaps"
+        }
+        return text
+    }
+
+    private func containerCheckboxLabel(
+        nodeID: AgentContextFileBrowseNodeID,
+        title: String,
+        status: AgentContextFileBrowseContainerStatus?
+    ) -> String {
+        guard let status else { return unresolvedContainerDescription(nodeID: nodeID, title: title) }
+        if status.membership == .all {
+            return "Remove \(status.selectedFileCount) selected \(pluralFiles(status.selectedFileCount)) in \(title)"
+        }
+        return "Add \(status.addableFileCount) \(pluralFiles(status.addableFileCount)) in \(title)"
+    }
+
+    private func containerCheckboxValue(
+        nodeID: AgentContextFileBrowseNodeID,
+        status: AgentContextFileBrowseContainerStatus?
+    ) -> String {
+        guard let status else {
+            if model.expandedNodeIDs.contains(nodeID) { return "Loading" }
+            return model.containerDisplayMembership(for: nodeID) == .mixed ? "Mixed" : "Unchecked"
+        }
+        var parts = ["\(status.selectedFileCount) of \(status.selectableFileCount) selected"]
+        if model.addMode == .codemapOnly {
+            parts.append("codemap add mode")
+            if status.unsupportedFileCount > 0 {
+                parts.append("\(status.unsupportedFileCount) unsupported")
+            }
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    // MARK: - File rows
+
+    private func fileRow(_ file: AgentContextFileBrowseFile, depth: Int) -> some View {
+        let nodeID = AgentContextFileBrowseNodeID.file(file.id)
+        let status = model.fileStatus(for: file)
+        let heldMode = status.heldMode
+        let isAutoMapped = status.isAutomaticallyMapped
+        let isDisabled = status.toggleEligibility.targetState == nil
+        let estimate = model.tokenEstimate(for: nodeID)
+        return HStack(spacing: 8) {
+            CheckboxView(isChecked: heldMode == nil ? .unchecked : .checked) {
+                guard model.toggleFile(file) else { return }
+            }
+            .disabled(isDisabled)
+            .opacity(isDisabled ? 0.4 : 1)
+            .hoverTooltip(fileCheckboxTooltip(file: file, heldMode: heldMode, isCodemapBlocked: status.isCodemapBlocked))
+            .accessibilityLabel(fileCheckboxLabel(file: file, heldMode: heldMode))
+            .accessibilityValue(fileCheckboxValue(heldMode: heldMode, isAutoMapped: isAutoMapped, estimate: estimate))
+            .accessibilityHint(status.isCodemapBlocked ? codemapBlockedExplanation(file: file) : "")
+            Image(systemName: "doc.text")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(file.name)
+                .font(fontPreset.captionFont)
+                .foregroundStyle(status.isCodemapBlocked ? Color.secondary : Color.primary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 8)
+            if let heldMode {
+                heldModeBadge(heldMode)
+            } else if isAutoMapped {
+                autoMapBadge
+            }
+            tokenEstimateText(estimate)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 7)
+        .padding(.leading, indent(for: depth))
+        .background(focusHighlight(for: nodeID))
+        .contentShape(Rectangle())
+        .focusable()
+        .focused($focus, equals: .row(nodeID))
+        .onKeyPress(.upArrow) {
+            model.focusPreviousRow()
+            return .handled
+        }
+        .onKeyPress(.downArrow) {
+            model.focusNextRow()
+            return .handled
+        }
+        .onKeyPress(.space) {
+            model.toggleFile(file) ? .handled : .ignored
+        }
+        .onKeyPress(.escape) {
+            model.clearQueryOrEnd()
+            return .handled
+        }
+        .hoverTooltip(file.projectedDisplayPath)
+        .onAppear {
+            model.rowBecameVisible(nodeID)
+        }
+        .onDisappear {
+            model.rowDisappeared(nodeID)
+        }
+    }
+
+    private func fileCheckboxTooltip(
+        file: AgentContextFileBrowseFile,
+        heldMode: AgentContextFileBrowseHeldMode?,
+        isCodemapBlocked: Bool
+    ) -> String {
+        if heldMode != nil { return "Remove \(file.name) from selection" }
+        if isCodemapBlocked { return codemapBlockedExplanation(file: file) }
+        return model.addMode == .full ? "Add \(file.name) as full file" : "Add \(file.name) as codemap"
+    }
+
+    private func fileCheckboxLabel(
+        file: AgentContextFileBrowseFile,
+        heldMode: AgentContextFileBrowseHeldMode?
+    ) -> String {
+        if heldMode != nil { return "Remove \(file.name) from selection" }
+        return model.addMode == .full ? "Add \(file.name) as full file" : "Add \(file.name) as codemap"
+    }
+
+    private func fileCheckboxValue(
+        heldMode: AgentContextFileBrowseHeldMode?,
+        isAutoMapped: Bool,
+        estimate: AgentContextFileBrowseTokenEstimate
+    ) -> String {
+        var parts: [String] = []
+        switch heldMode {
+        case .full: parts.append("Selected as full file")
+        case .slice: parts.append("Selected as sliced file")
+        case .codemap: parts.append("Selected as codemap")
+        case nil: parts.append(isAutoMapped ? "Not selected, automatically codemapped" : "Not selected")
+        }
+        if case let .known(tokens) = estimate {
+            parts.append("approximately \(tokens) tokens as full file")
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    private func codemapBlockedExplanation(file: AgentContextFileBrowseFile) -> String {
+        model.codeMapsGloballyDisabled
+            ? "Codemaps are globally disabled in Settings"
+            : "\(file.name) does not support codemaps"
+    }
+
+    // MARK: - Badges and estimates
+
+    private func heldModeBadge(_ mode: AgentContextFileBrowseHeldMode) -> some View {
+        let (text, color): (String, Color) = switch mode {
+        case .full: ("Full", Color.accentColor)
+        case .slice: ("Slice", Color.orange)
+        case .codemap: ("Map", Color.purple)
+        }
+        return badge(text: text, color: color)
+    }
+
+    private var autoMapBadge: some View {
+        badge(text: "Auto Map", color: Color.purple.opacity(0.6))
+    }
+
+    private func badge(text: String, color: Color) -> some View {
+        Text(text)
+            .font(fontPreset.swiftUIFont(sizeAtNormal: 10, weight: .semibold))
+            .foregroundStyle(color)
+            .lineLimit(1)
+            .fixedSize()
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1.5)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(color.opacity(0.14))
+            )
+    }
+
+    private func tokenEstimateText(_ estimate: AgentContextFileBrowseTokenEstimate) -> some View {
+        let isCodemapMode = model.addMode == .codemapOnly
+        return Text(Self.tokenText(for: estimate))
+            .font(fontPreset.captionFont.monospacedDigit())
+            .foregroundStyle(.secondary)
+            .opacity(isCodemapMode ? 0.5 : 1)
+            .fixedSize()
+            .hoverTooltip(
+                isCodemapMode
+                    ? "Estimated full-file cost; codemap cost is available after selection"
+                    : "Approximate full-file token cost"
+            )
+    }
+
+    static func tokenText(for estimate: AgentContextFileBrowseTokenEstimate) -> String {
+        switch estimate {
+        case .notRequested, .loading, .unavailable:
+            return "—"
+        case let .known(tokens):
+            if tokens < 1000 { return "~\(tokens)" }
+            if tokens < 1_000_000 { return "~" + String(format: "%.1fk", Double(tokens) / 1000) }
+            return "~" + String(format: "%.1fM", Double(tokens) / 1_000_000)
+        }
+    }
+
+    // MARK: - Shared row chrome
+
+    private func indent(for depth: Int) -> CGFloat {
+        CGFloat(depth) * 16
+    }
+
+    @ViewBuilder
+    private func focusHighlight(for nodeID: AgentContextFileBrowseNodeID) -> some View {
+        if model.focusTarget == .row(nodeID) {
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(Color.accentColor.opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .strokeBorder(Color.accentColor.opacity(0.55), lineWidth: 1)
+                )
+        }
+    }
+
+    // MARK: - Empty states
+
+    @ViewBuilder
+    private func unavailableState(_ reason: AgentContextFileBrowseUnavailableReason) -> some View {
+        switch reason {
+        case .noRoots:
+            emptyState(
+                icon: "folder.badge.questionmark",
+                title: "No workspace roots",
+                subtitle: "Add a folder to the workspace to browse files."
+            )
+        case .sessionRootsUnavailable:
+            emptyState(
+                icon: "externaldrive.badge.questionmark",
+                title: "Workspace unavailable",
+                subtitle: "The Agent worktree roots for this chat are no longer available."
+            )
+        case .catalogChanged:
+            emptyState(
+                icon: "arrow.clockwise",
+                title: "Workspace changed",
+                subtitle: "Select Done, then browse again to refresh files."
+            )
+        case .selectionTargetUnavailable:
+            emptyState(
+                icon: "doc.text.magnifyingglass",
+                title: "Selection unavailable",
+                subtitle: "Selection is no longer available."
+            )
+        }
+    }
+
+    private func emptyState(icon: String, title: String, subtitle: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 34))
+                .foregroundStyle(.secondary.opacity(0.45))
+            Text(title)
+                .font(fontPreset.standardFont.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(subtitle)
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func pluralFiles(_ count: Int) -> String {
+        count == 1 ? "file" : "files"
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift
@@ -558,6 +558,25 @@ final class WorkspaceSelectionCoordinator {
         )
     }
 
+    /// Applies an exclusive target state to exact store-derived paths for one captured selection identity.
+    @discardableResult
+    func setPreResolvedFilePathsInSelection(
+        _ absolutePaths: [String],
+        targetState: WorkspacePreResolvedSelectionTargetState,
+        for identity: WorkspaceSelectionIdentity,
+        lookupContext: WorkspaceLookupContext
+    ) async -> TransactionResult? {
+        await transformSelection(for: identity, source: .runtimeMutation) { latestSelection in
+            let physicalSelection = lookupContext.physicalizeSelection(latestSelection)
+            let updatedPhysicalSelection = self.mutationService.setPreResolvedFilePaths(
+                base: physicalSelection,
+                absolutePaths: absolutePaths,
+                targetState: targetState
+            )
+            return lookupContext.logicalizeSelection(updatedPhysicalSelection)
+        }
+    }
+
     @discardableResult
     func persistVirtualSelection(
         _ selection: StoredSelection,

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionMutationService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionMutationService.swift
@@ -46,6 +46,12 @@ enum WorkspacePreResolvedFullFileMutationMode {
     case remove
 }
 
+enum WorkspacePreResolvedSelectionTargetState: Equatable {
+    case full
+    case codemapOnly
+    case unselected
+}
+
 struct WorkspaceCodemapAutomaticSelectionRequestPolicy: Equatable {
     static let `default` = Self()
 
@@ -353,6 +359,50 @@ struct WorkspaceSelectionMutationService {
             manualCodemapPaths: base.manualCodemapPaths.filter { !selectedSet.contains($0) },
             slices: slices,
             codemapAutoEnabled: base.codemapAutoEnabled
+        )
+    }
+
+    /// Sets store-revalidated files to one exclusive selection representation for Context Composer browse toggles.
+    /// MCP Git artifact mutations use `mutatePreResolvedFullFilePaths` because they have different representation semantics.
+    func setPreResolvedFilePaths(
+        base: StoredSelection,
+        absolutePaths: [String],
+        targetState: WorkspacePreResolvedSelectionTargetState
+    ) -> StoredSelection {
+        let identities = StoredSelectionPathNormalization.standardizedPaths(absolutePaths)
+        guard !identities.isEmpty else { return base }
+
+        let identitySet = Set(identities)
+        var selectedPaths = StoredSelectionPathNormalization.standardizedPaths(base.selectedPaths)
+        var manualCodemapPaths = StoredSelectionPathNormalization.standardizedPaths(base.manualCodemapPaths)
+        var slices = StoredSelectionPathNormalization.standardizedSlices(base.slices)
+
+        switch targetState {
+        case .full:
+            var selectedSet = Set(selectedPaths)
+            for identity in identities where selectedSet.insert(identity).inserted {
+                selectedPaths.append(identity)
+            }
+            manualCodemapPaths.removeAll { identitySet.contains($0) }
+            slices = slices.filter { !identitySet.contains($0.key) }
+        case .codemapOnly:
+            selectedPaths.removeAll { identitySet.contains($0) }
+            slices = slices.filter { !identitySet.contains($0.key) }
+            var manualCodemapSet = Set(manualCodemapPaths)
+            for identity in identities where manualCodemapSet.insert(identity).inserted {
+                manualCodemapPaths.append(identity)
+            }
+        case .unselected:
+            selectedPaths.removeAll { identitySet.contains($0) }
+            manualCodemapPaths.removeAll { identitySet.contains($0) }
+            slices = slices.filter { !identitySet.contains($0.key) }
+        }
+
+        return StoredSelection(
+            selectedPaths: selectedPaths,
+            manualCodemapPaths: manualCodemapPaths,
+            slices: slices,
+            codemapAutoEnabled: targetState == .codemapOnly ? false : base.codemapAutoEnabled
         )
     }
 
@@ -776,7 +826,7 @@ struct WorkspaceSelectionMutationService {
         for key in preflight {
             let raw = rawLookup[key] ?? key
             if let file = resolved[key] {
-                if supportsCodemap(file) {
+                if Self.supportsCodemap(file) {
                     if seen.insert(file.standardizedFullPath).inserted { candidates.append(file) }
                 } else {
                     await unavailable.append("codemap unavailable: \(displayPath(for: file, rootScope: rootScope))")
@@ -795,7 +845,7 @@ struct WorkspaceSelectionMutationService {
                         var supported = 0
                         var unsupported = 0
                         for file in folder.files {
-                            if supportsCodemap(file) {
+                            if Self.supportsCodemap(file) {
                                 if seen.insert(file.standardizedFullPath).inserted { candidates.append(file) }
                                 supported += 1
                             } else {
@@ -1272,7 +1322,7 @@ struct WorkspaceSelectionMutationService {
         return mutated
     }
 
-    private func supportsCodemap(_ file: WorkspaceFileRecord) -> Bool {
+    static func supportsCodemap(_ file: WorkspaceFileRecord) -> Bool {
         let ext = (file.name as NSString).pathExtension.lowercased()
         guard !ext.isEmpty else { return false }
         return SyntaxManager.supportsCodeMap(fileExtension: ext)

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/TokenCalculationService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/TokenCalculationService.swift
@@ -131,8 +131,14 @@ actor TokenCalculationService {
     /// Compute tokens from raw text using a cheap UTF-8 byte count plus a safety multiplier.
     @inline(__always)
     static func estimateTokens(for text: String) -> Int {
-        let bytes = text.utf8.count
-        return Int((Double(bytes) / 4.0) * 1.05)
+        estimateTokens(utf8ByteCount: text.utf8.count)
+    }
+
+    /// Compute tokens from a known nonnegative UTF-8 byte count using the canonical heuristic.
+    @inline(__always)
+    static func estimateTokens(utf8ByteCount: Int) -> Int {
+        precondition(utf8ByteCount >= 0, "UTF-8 byte count must be nonnegative")
+        return Int((Double(utf8ByteCount) / 4.0) * 1.05)
     }
 
     /// Middle-truncate text that exceeds `maxTokens`, keeping equal halves from head and tail

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootBindingProjection.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootBindingProjection.swift
@@ -327,9 +327,11 @@ struct WorkspaceRootBindingProjection: Equatable {
     }
 
     func boundRoot(containingPhysicalAbsolutePath path: String) -> BoundRoot? {
-        replacementsByLogicalRootPath.values
-            .filter { path == $0.physicalRoot.standardizedFullPath || path.hasPrefix($0.physicalRoot.standardizedFullPath + "/") }
-            .max { $0.physicalRoot.standardizedFullPath.count < $1.physicalRoot.standardizedFullPath.count }
+        let matches = boundRootsForMetadata.filter {
+            path == $0.physicalRoot.standardizedFullPath || path.hasPrefix($0.physicalRoot.standardizedFullPath + "/")
+        }
+        guard let longestRootPathLength = matches.map(\.physicalRoot.standardizedFullPath.count).max() else { return nil }
+        return matches.first { $0.physicalRoot.standardizedFullPath.count == longestRootPathLength }
     }
 
     private func pathIsUnderAnyPhysicalRoot(_ path: String) -> Bool {

--- a/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseModelTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseModelTests.swift
@@ -748,7 +748,7 @@ final class AgentContextFileBrowseModelTests: XCTestCase {
     }
 
     @MainActor
-    func testTenThousandNestedFileExpansionLatencyRemainsBounded() async throws {
+    func testTenThousandNestedFilesKeepExpansionLazyAndSelectionMembershipCorrect() async throws {
         let files = (0 ..< 10000).map { "Nested/File\($0).swift" }
         let harness = try await makeHarness(files: files)
         await harness.model.begin(
@@ -758,14 +758,11 @@ final class AgentContextFileBrowseModelTests: XCTestCase {
             codeMapsGloballyDisabled: false
         )
         let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
-        let startedAt = DispatchTime.now().uptimeNanoseconds
 
         harness.model.toggleExpansion(rootNode)
         await eventually(attempts: 100_000) { harness.model.membership(for: rootNode) != nil }
 
-        let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
         XCTAssertEqual(harness.model.rows.count, 2)
-        XCTAssertLessThan(elapsedMilliseconds, 350, "Cold large-root expansion regressed")
 
         let nestedNode = try XCTUnwrap(folderNode(in: harness, named: "Nested"))
         harness.model.toggleExpansion(nestedNode)
@@ -773,12 +770,7 @@ final class AgentContextFileBrowseModelTests: XCTestCase {
         harness.model.toggleExpansion(nestedNode)
         XCTAssertEqual(harness.model.rows.count, 2)
         let selectedPath = try XCTUnwrap(harness.paths["Nested/File9999.swift"])
-        let selectionStartedAt = DispatchTime.now().uptimeNanoseconds
         harness.model.updateAuthoritativeSelection(StoredSelection(selectedPaths: [selectedPath]), exportRows: [])
-        let selectionElapsedMilliseconds = Double(
-            DispatchTime.now().uptimeNanoseconds - selectionStartedAt
-        ) / 1_000_000
-        XCTAssertLessThan(selectionElapsedMilliseconds, 20, "Large-root selection update regressed")
         XCTAssertEqual(harness.model.membership(for: rootNode), .mixed)
         XCTAssertEqual(harness.model.membership(for: nestedNode), .mixed)
     }

--- a/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseModelTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseModelTests.swift
@@ -32,6 +32,26 @@ final class AgentContextFileBrowseModelTests: XCTestCase {
     }
 
     @MainActor
+    func testCanceledDeferredBeginDoesNotReactivateEndedSession() async throws {
+        let harness = try await makeHarness(files: ["One.swift"])
+        let deferredEntry = Task { @MainActor in
+            await harness.model.begin(
+                target: harness.target,
+                lookupContext: .visibleWorkspace,
+                exportRows: [],
+                codeMapsGloballyDisabled: false
+            )
+        }
+
+        harness.model.end()
+        deferredEntry.cancel()
+        await deferredEntry.value
+
+        XCTAssertEqual(harness.model.phase, .inactive)
+        XCTAssertNil(harness.model.capturedIdentity)
+    }
+
+    @MainActor
     func testSelectionProjectionUsesSliceFullManualPrecedenceAndExactAutoMapPredicate() async throws {
         let harness = try await makeHarness(files: ["Full.swift", "Slice.swift", "Manual.swift", "Auto.swift"])
         let paths = harness.paths
@@ -56,6 +76,9 @@ final class AgentContextFileBrowseModelTests: XCTestCase {
         )
         let files = try await loadRootFiles(harness)
 
+        XCTAssertTrue(files.values.allSatisfy {
+            StoredSelectionPathNormalization.standardizedPath($0.standardizedFullPath) == $0.standardizedFullPath
+        })
         XCTAssertEqual(try harness.model.heldMode(for: XCTUnwrap(files["Full.swift"])), .full)
         XCTAssertEqual(try harness.model.heldMode(for: XCTUnwrap(files["Slice.swift"])), .slice)
         XCTAssertEqual(try harness.model.heldMode(for: XCTUnwrap(files["Manual.swift"])), .codemap)
@@ -669,6 +692,19 @@ final class AgentContextFileBrowseModelTests: XCTestCase {
             harness.model.containerDisplayMembership(for: other),
             AgentContextFileBrowseContainerMembership.none
         )
+
+        harness.model.updateAuthoritativeSelection(StoredSelection(), exportRows: [])
+        XCTAssertEqual(
+            harness.model.membership(for: rootNode),
+            AgentContextFileBrowseContainerMembership.none
+        )
+        XCTAssertEqual(
+            harness.model.containerDisplayMembership(for: nested),
+            AgentContextFileBrowseContainerMembership.none
+        )
+        harness.model.updateAuthoritativeSelection(selection, exportRows: [])
+        XCTAssertEqual(harness.model.membership(for: rootNode), .mixed)
+        XCTAssertEqual(harness.model.containerDisplayMembership(for: nested), .mixed)
     }
 
     @MainActor
@@ -709,6 +745,42 @@ final class AgentContextFileBrowseModelTests: XCTestCase {
         )
         XCTAssertTrue(harness.model.expandedNodeIDs.isEmpty)
         XCTAssertNil(folderNode(in: harness, named: "Nested"))
+    }
+
+    @MainActor
+    func testTenThousandNestedFileExpansionLatencyRemainsBounded() async throws {
+        let files = (0 ..< 10000).map { "Nested/File\($0).swift" }
+        let harness = try await makeHarness(files: files)
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+
+        harness.model.toggleExpansion(rootNode)
+        await eventually(attempts: 100_000) { harness.model.membership(for: rootNode) != nil }
+
+        let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
+        XCTAssertEqual(harness.model.rows.count, 2)
+        XCTAssertLessThan(elapsedMilliseconds, 350, "Cold large-root expansion regressed")
+
+        let nestedNode = try XCTUnwrap(folderNode(in: harness, named: "Nested"))
+        harness.model.toggleExpansion(nestedNode)
+        await eventually(attempts: 100_000) { harness.model.membership(for: nestedNode) != nil }
+        harness.model.toggleExpansion(nestedNode)
+        XCTAssertEqual(harness.model.rows.count, 2)
+        let selectedPath = try XCTUnwrap(harness.paths["Nested/File9999.swift"])
+        let selectionStartedAt = DispatchTime.now().uptimeNanoseconds
+        harness.model.updateAuthoritativeSelection(StoredSelection(selectedPaths: [selectedPath]), exportRows: [])
+        let selectionElapsedMilliseconds = Double(
+            DispatchTime.now().uptimeNanoseconds - selectionStartedAt
+        ) / 1_000_000
+        XCTAssertLessThan(selectionElapsedMilliseconds, 20, "Large-root selection update regressed")
+        XCTAssertEqual(harness.model.membership(for: rootNode), .mixed)
+        XCTAssertEqual(harness.model.membership(for: nestedNode), .mixed)
     }
 
     @MainActor

--- a/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseModelTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseModelTests.swift
@@ -1,0 +1,926 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class AgentContextFileBrowseModelTests: XCTestCase {
+    @MainActor
+    func testBeginAndEndConstructAndResetSessionState() async throws {
+        let harness = try await makeHarness(files: ["One.swift"])
+
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+
+        XCTAssertEqual(harness.model.phase, .ready)
+        XCTAssertEqual(harness.model.capturedIdentity, harness.target.identity)
+        XCTAssertEqual(harness.model.roots.map(\.id), [harness.root.id])
+        XCTAssertEqual(harness.model.focusTarget, .search)
+        XCTAssertEqual(harness.model.addMode, .full)
+        XCTAssertEqual(harness.model.rootScope, .allRoots)
+
+        harness.model.setQuery("One")
+        harness.model.setAddMode(.codemapOnly)
+        harness.model.end()
+
+        XCTAssertEqual(harness.model.phase, .inactive)
+        XCTAssertTrue(harness.model.rows.isEmpty)
+        XCTAssertTrue(harness.model.query.isEmpty)
+        XCTAssertNil(harness.model.focusTarget)
+        XCTAssertEqual(harness.model.addMode, .full)
+    }
+
+    @MainActor
+    func testSelectionProjectionUsesSliceFullManualPrecedenceAndExactAutoMapPredicate() async throws {
+        let harness = try await makeHarness(files: ["Full.swift", "Slice.swift", "Manual.swift", "Auto.swift"])
+        let paths = harness.paths
+        let selection = try StoredSelection(
+            selectedPaths: [XCTUnwrap(paths["Full.swift"]), XCTUnwrap(paths["Slice.swift"])],
+            manualCodemapPaths: [XCTUnwrap(paths["Full.swift"]), XCTUnwrap(paths["Manual.swift"])],
+            slices: [XCTUnwrap(paths["Slice.swift"]): [LineRange(start: 2, end: 4)]],
+            codemapAutoEnabled: true
+        )
+        harness.recorder.selection = selection
+        let target = AgentContextSelectionMutationTarget(identity: harness.target.identity, expectedSelection: selection)
+        let rows = try [
+            makeCodemapRow(fileID: UUID(), rootID: harness.root.id, path: XCTUnwrap(paths["Manual.swift"])),
+            makeCodemapRow(fileID: UUID(), rootID: harness.root.id, path: XCTUnwrap(paths["Auto.swift"]))
+        ]
+
+        await harness.model.begin(
+            target: target,
+            lookupContext: .visibleWorkspace,
+            exportRows: rows,
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+
+        XCTAssertEqual(try harness.model.heldMode(for: XCTUnwrap(files["Full.swift"])), .full)
+        XCTAssertEqual(try harness.model.heldMode(for: XCTUnwrap(files["Slice.swift"])), .slice)
+        XCTAssertEqual(try harness.model.heldMode(for: XCTUnwrap(files["Manual.swift"])), .codemap)
+        XCTAssertFalse(try harness.model.isAutomaticallyMapped(XCTUnwrap(files["Manual.swift"])))
+        XCTAssertTrue(try harness.model.isAutomaticallyMapped(XCTUnwrap(files["Auto.swift"])))
+    }
+
+    @MainActor
+    func testVisibleContainerLazilyResolvesDescendantsAndComputesCodemapMembership() async throws {
+        let harness = try await makeHarness(files: ["Selected.swift", "Unsupported.txt", "Available.swift"])
+        let selectedPath = try XCTUnwrap(harness.paths["Selected.swift"])
+        let selection = StoredSelection(selectedPaths: [selectedPath])
+        harness.recorder.selection = selection
+        let target = AgentContextSelectionMutationTarget(identity: harness.target.identity, expectedSelection: selection)
+        await harness.model.begin(
+            target: target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
+
+        XCTAssertNil(harness.model.membership(for: rootNode))
+        harness.model.toggleExpansion(rootNode)
+        await eventually { harness.model.membership(for: rootNode) != nil }
+        XCTAssertEqual(harness.model.membership(for: rootNode), .mixed)
+
+        harness.model.setAddMode(.codemapOnly)
+        XCTAssertEqual(harness.model.membership(for: rootNode), .mixed)
+        XCTAssertTrue(harness.model.toggleContainer(rootNode))
+        await eventually { harness.recorder.calls.count == 1 }
+        XCTAssertEqual(Set(harness.recorder.calls[0].paths), try [
+            XCTUnwrap(harness.paths["Available.swift"])
+        ])
+        XCTAssertEqual(harness.recorder.calls[0].targetState, .codemapOnly)
+    }
+
+    @MainActor
+    func testCollapsedContainerIsDisabledUntilKnownAndPreservesFullySelectedTruth() async throws {
+        let harness = try await makeHarness(files: ["One.swift", "Two.swift"])
+        let selectedPaths = try [
+            XCTUnwrap(harness.paths["One.swift"]),
+            XCTUnwrap(harness.paths["Two.swift"])
+        ]
+        let selection = StoredSelection(selectedPaths: selectedPaths)
+        harness.recorder.selection = selection
+        let target = AgentContextSelectionMutationTarget(
+            identity: harness.target.identity,
+            expectedSelection: selection
+        )
+        await harness.model.begin(
+            target: target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
+
+        XCTAssertNil(harness.model.containerStatus(for: rootNode))
+        XCTAssertFalse(harness.model.toggleContainer(rootNode))
+        harness.model.toggleExpansion(rootNode)
+        await eventually { harness.model.membership(for: rootNode) == .all }
+        harness.model.toggleExpansion(rootNode)
+
+        XCTAssertEqual(harness.model.membership(for: rootNode), .all)
+        XCTAssertEqual(harness.model.containerStatus(for: rootNode)?.membership, .all)
+        XCTAssertTrue(harness.model.toggleContainer(rootNode))
+        await eventually { harness.recorder.calls.count == 1 }
+        XCTAssertEqual(harness.recorder.calls[0].targetState, .unselected)
+    }
+
+    @MainActor
+    func testImmediateMutationsRemainCanonicalAndExecuteInClickOrder() async throws {
+        let harness = try await makeHarness(files: ["One.swift", "Two.swift"])
+        harness.recorder.suspendMutations = true
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+        let one = try XCTUnwrap(files["One.swift"])
+        let two = try XCTUnwrap(files["Two.swift"])
+
+        XCTAssertTrue(harness.model.toggleFile(one))
+        XCTAssertTrue(harness.model.toggleFile(two))
+        XCTAssertNil(harness.model.heldMode(for: one))
+        XCTAssertNil(harness.model.heldMode(for: two))
+        XCTAssertEqual(harness.model.inFlightPaths.count, 2)
+
+        await eventually { harness.recorder.pendingMutationCount == 1 }
+        harness.recorder.resumeNextMutation()
+        await eventually { harness.recorder.pendingMutationCount == 1 && harness.recorder.calls.count == 2 }
+        harness.recorder.resumeNextMutation()
+        await eventually { harness.model.inFlightPaths.isEmpty }
+
+        XCTAssertEqual(harness.recorder.calls.map(\.paths.first), try [
+            XCTUnwrap(harness.paths["One.swift"]),
+            XCTUnwrap(harness.paths["Two.swift"])
+        ])
+        XCTAssertEqual(Set(harness.recorder.calls.map(\.identity)), [harness.target.identity])
+        XCTAssertTrue(harness.recorder.calls.allSatisfy { $0.lookupContext == .visibleWorkspace })
+        XCTAssertEqual(harness.model.heldMode(for: one), .full)
+        XCTAssertEqual(harness.model.heldMode(for: two), .full)
+    }
+
+    @MainActor
+    func testQueryScopeGenerationFencingAndFocusOrder() async throws {
+        let harness = try await makeHarness(files: ["Alpha.swift", "Beta.swift"])
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let hierarchyFiles = try await loadRootFiles(harness)
+        let staleAlpha = try XCTUnwrap(hierarchyFiles["Alpha.swift"])
+        harness.model.setQuery("Alpha")
+        XCTAssertTrue(harness.model.rows.isEmpty)
+        XCTAssertFalse(harness.model.toggleFile(staleAlpha))
+        await eventually {
+            harness.model.searchGroups.flatMap(\.rootMatches).contains { $0.file.name == "Alpha.swift" }
+        }
+        let staleSearchAlpha = try XCTUnwrap(harness.model.searchGroups.flatMap(\.rootMatches).first?.file)
+        harness.model.setRootScope(.root(harness.root.id))
+        XCTAssertTrue(harness.model.rows.isEmpty)
+        XCTAssertFalse(harness.model.toggleFile(staleSearchAlpha))
+        harness.model.setQuery("Beta")
+        await eventually {
+            harness.model.searchGroups.flatMap(\.rootMatches).contains { $0.file.name == "Beta.swift" }
+        }
+
+        let visibleNames = harness.model.rows.compactMap { row -> String? in
+            guard case let .file(file, _) = row else { return nil }
+            return file.name
+        }
+        XCTAssertEqual(visibleNames, ["Beta.swift"])
+        XCTAssertEqual(harness.model.rootScope, .root(harness.root.id))
+
+        harness.model.focusNextRow()
+        XCTAssertEqual(harness.model.focusTarget, harness.model.visibleInteractiveRowOrder.first.map {
+            .row($0)
+        })
+        harness.model.focusNextRow()
+        XCTAssertEqual(harness.model.focusTarget, harness.model.visibleInteractiveRowOrder.last.map {
+            .row($0)
+        })
+        harness.model.focusPreviousRow()
+        XCTAssertEqual(harness.model.focusTarget, harness.model.visibleInteractiveRowOrder.first.map {
+            .row($0)
+        })
+    }
+
+    @MainActor
+    func testCollapsedRootDefersTreeAndMetadataUntilExpansionAndVisibleFileDemand() async throws {
+        let harness = try await makeHarness(files: ["Tokens.swift"])
+        await harness.store.resetAppliedIndexRecordLookupDiagnosticsForTesting()
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
+        harness.model.rowBecameVisible(rootNode)
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        let collapsedDiagnostics = await harness.store.appliedIndexRecordLookupDiagnosticsForTesting()
+        let collapsedReadCount = await harness.metadataReads.count
+        XCTAssertNil(harness.model.membership(for: rootNode))
+        XCTAssertEqual(collapsedDiagnostics.rootSnapshots, 0)
+        XCTAssertEqual(collapsedReadCount, 0)
+
+        harness.model.toggleExpansion(rootNode)
+        await eventually {
+            harness.model.rows.contains { row in
+                if case .file = row { return true }
+                return false
+            }
+        }
+        let fileNode = try XCTUnwrap(harness.model.rows.compactMap(\.interactiveNodeID).first {
+            if case .file = $0 { return true }
+            return false
+        })
+        let expandedReadCountBeforeVisibility = await harness.metadataReads.count
+        XCTAssertEqual(expandedReadCountBeforeVisibility, 0)
+        harness.model.rowBecameVisible(fileNode)
+        await eventually {
+            if case .known = harness.model.tokenEstimate(for: rootNode) { return true }
+            return false
+        }
+        guard case let .known(rootTokens) = harness.model.tokenEstimate(for: rootNode) else {
+            return XCTFail("Expected known root estimate")
+        }
+        XCTAssertGreaterThan(rootTokens, 0)
+        let visibleFileReadCount = await harness.metadataReads.count
+        XCTAssertEqual(visibleFileReadCount, 1)
+    }
+
+    @MainActor
+    func testContainerTotalWaitsUntilEveryDescendantHasVisibleRowEstimate() async throws {
+        let harness = try await makeHarness(files: ["Top.swift", "Folder/Nested.swift"])
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
+        harness.model.toggleExpansion(rootNode)
+        await eventually { harness.model.membership(for: rootNode) != nil }
+        let topNode = try XCTUnwrap(harness.model.rows.compactMap(\.interactiveNodeID).first {
+            if case .file = $0 { return true }
+            return false
+        })
+        guard case let .file(topFileID) = topNode else { return XCTFail("Expected top file row") }
+        harness.model.rowBecameVisible(topNode)
+        await eventually {
+            if case .known = harness.model.tokenEstimate(for: topNode) { return true }
+            return false
+        }
+        XCTAssertEqual(harness.model.tokenEstimate(for: rootNode), .notRequested)
+
+        let folderNode = try XCTUnwrap(harness.model.rows.compactMap(\.interactiveNodeID).first {
+            if case .folder = $0 { return true }
+            return false
+        })
+        harness.model.toggleExpansion(folderNode)
+        await eventually {
+            harness.model.rows.contains { row in
+                if case let .file(file, _) = row { return file.name == "Nested.swift" }
+                return false
+            }
+        }
+        let nestedNode = try XCTUnwrap(harness.model.rows.compactMap(\.interactiveNodeID).first {
+            guard case let .file(fileID) = $0 else { return false }
+            return fileID != topFileID
+        })
+        harness.model.rowBecameVisible(nestedNode)
+        await eventually {
+            if case .known = harness.model.tokenEstimate(for: rootNode) { return true }
+            return false
+        }
+        let readCount = await harness.metadataReads.count
+        XCTAssertEqual(readCount, 2)
+    }
+
+    @MainActor
+    func testCatalogGenerationChangeFailsClosedUntilBrowseReentry() async throws {
+        let harness = try await makeHarness(files: ["Old.swift"])
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+
+        _ = try await harness.store.createFile(
+            rootID: harness.root.id,
+            relativePath: "New.swift",
+            content: "new"
+        )
+        harness.model.setQuery("New")
+        await eventually { harness.model.phase == .unavailable(.catalogChanged) }
+
+        XCTAssertTrue(harness.model.searchGroups.isEmpty)
+        XCTAssertTrue(harness.recorder.calls.isEmpty)
+    }
+
+    @MainActor
+    func testGlobalCodemapDisablementForcesFullAndPreservesMapRemoval() async throws {
+        let harness = try await makeHarness(files: ["Mapped.swift", "Unsupported.txt"])
+        let mappedPath = try XCTUnwrap(harness.paths["Mapped.swift"])
+        let selection = StoredSelection(manualCodemapPaths: [mappedPath], codemapAutoEnabled: false)
+        harness.recorder.selection = selection
+        let target = AgentContextSelectionMutationTarget(identity: harness.target.identity, expectedSelection: selection)
+        await harness.model.begin(
+            target: target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+        let unsupported = try XCTUnwrap(files["Unsupported.txt"])
+        harness.model.setAddMode(.codemapOnly)
+        XCTAssertEqual(
+            harness.model.fileStatus(for: unsupported).toggleEligibility,
+            .disabled(.unsupportedCodemap)
+        )
+        harness.model.setCodeMapsGloballyDisabled(true)
+
+        XCTAssertEqual(harness.model.addMode, .full)
+        XCTAssertTrue(harness.model.codeMapsGloballyDisabled)
+        XCTAssertTrue(try harness.model.toggleFile(XCTUnwrap(files["Mapped.swift"])))
+        await eventually { harness.recorder.calls.count == 1 }
+        XCTAssertEqual(harness.recorder.calls[0].targetState, .unselected)
+    }
+
+    @MainActor
+    func testSameTabRefreshKeepsBrowseActiveAndSessionMatchingIsPure() async throws {
+        let harness = try await makeHarness(files: ["One.swift"])
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+        let path = try XCTUnwrap(harness.paths["One.swift"])
+
+        harness.model.applySelectionChange(
+            WorkspaceSelectionCoordinator.Change(
+                tabID: UUID(),
+                selection: StoredSelection(selectedPaths: [path]),
+                source: .runtimeMutation
+            ),
+            exportRows: []
+        )
+        XCTAssertNil(try harness.model.heldMode(for: XCTUnwrap(files["One.swift"])))
+
+        harness.model.applySelectionChange(
+            WorkspaceSelectionCoordinator.Change(
+                tabID: harness.target.identity.tabID,
+                selection: StoredSelection(selectedPaths: [path]),
+                source: .runtimeMutation
+            ),
+            exportRows: []
+        )
+        XCTAssertEqual(try harness.model.heldMode(for: XCTUnwrap(files["One.swift"])), .full)
+        XCTAssertTrue(harness.model.isActive)
+        XCTAssertTrue(harness.model.sessionMatches(
+            identity: harness.target.identity,
+            lookupContext: .visibleWorkspace
+        ))
+
+        XCTAssertFalse(harness.model.sessionMatches(
+            identity: WorkspaceSelectionIdentity(workspaceID: UUID(), tabID: UUID()),
+            lookupContext: .visibleWorkspace
+        ))
+        XCTAssertEqual(harness.model.phase, .ready)
+    }
+
+    @MainActor
+    func testRetainedModelUsesLatestFilesTabRouteProof() async throws {
+        let harness = try await makeHarness(files: ["One.swift"])
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+        let file = try XCTUnwrap(files["One.swift"])
+        harness.model.updateMutationRouteProof(AgentContextFileBrowseRouteProof(
+            identity: harness.target.identity,
+            lookupContext: WorkspaceLookupContext(
+                rootScope: .visibleWorkspacePlusGitData,
+                bindingProjection: nil
+            )
+        ))
+        XCTAssertEqual(harness.model.fileStatus(for: file).toggleEligibility, .disabled(.routeUnavailable))
+        XCTAssertFalse(harness.model.toggleFile(file))
+
+        harness.model.updateMutationRouteProof(AgentContextFileBrowseRouteProof(
+            identity: WorkspaceSelectionIdentity(workspaceID: UUID(), tabID: UUID()),
+            lookupContext: .visibleWorkspace
+        ))
+        XCTAssertEqual(harness.model.phase, .ready)
+        XCTAssertEqual(harness.model.fileStatus(for: file).toggleEligibility, .disabled(.routeUnavailable))
+        XCTAssertFalse(harness.model.toggleFile(file))
+        XCTAssertTrue(harness.recorder.calls.isEmpty)
+    }
+
+    @MainActor
+    func testSearchAndRevalidationSessionScopeLossTransitionToUnavailable() async throws {
+        let searchHarness = try await makeHarness(files: ["Search.swift"], sessionScoped: true)
+        await searchHarness.model.begin(
+            target: searchHarness.target,
+            lookupContext: searchHarness.lookupContext,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        await searchHarness.store.unloadRoot(id: searchHarness.root.id)
+        searchHarness.model.setQuery("Search")
+        await eventually {
+            searchHarness.model.phase == .unavailable(.sessionRootsUnavailable)
+        }
+
+        let mutationHarness = try await makeHarness(files: ["Mutation.swift"], sessionScoped: true)
+        await mutationHarness.model.begin(
+            target: mutationHarness.target,
+            lookupContext: mutationHarness.lookupContext,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(mutationHarness)
+        await mutationHarness.store.unloadRoot(id: mutationHarness.root.id)
+        XCTAssertTrue(try mutationHarness.model.toggleFile(XCTUnwrap(files["Mutation.swift"])))
+        await eventually {
+            mutationHarness.model.phase == .unavailable(.sessionRootsUnavailable)
+        }
+        XCTAssertTrue(mutationHarness.recorder.calls.isEmpty)
+    }
+
+    @MainActor
+    func testAcceptedMutationsRemainOrderedAcrossSessionExit() async throws {
+        let harness = try await makeHarness(files: ["Old.swift", "NewOne.swift", "NewTwo.swift"])
+        harness.recorder.suspendMutations = true
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let oldFiles = try await loadRootFiles(harness)
+        XCTAssertTrue(try harness.model.toggleFile(XCTUnwrap(oldFiles["Old.swift"])))
+        await eventually { harness.recorder.pendingMutationCount == 1 }
+        XCTAssertEqual(harness.model.pendingMutationIdentities, [harness.target.identity])
+        XCTAssertTrue(agentContextFilesReviewMutationIsFenced(
+            pendingIdentities: harness.model.pendingMutationIdentities,
+            targetIdentity: harness.target.identity
+        ))
+
+        harness.model.end()
+        XCTAssertEqual(harness.model.pendingMutationIdentities, [harness.target.identity])
+        let newTarget = AgentContextSelectionMutationTarget(
+            identity: WorkspaceSelectionIdentity(workspaceID: UUID(), tabID: UUID()),
+            expectedSelection: StoredSelection()
+        )
+        XCTAssertFalse(agentContextFilesReviewMutationIsFenced(
+            pendingIdentities: harness.model.pendingMutationIdentities,
+            targetIdentity: newTarget.identity
+        ))
+        harness.model.updateMutationRouteProof(AgentContextFileBrowseRouteProof(
+            identity: newTarget.identity,
+            lookupContext: .visibleWorkspace
+        ))
+        await harness.model.begin(
+            target: newTarget,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let newFiles = try await loadRootFiles(harness)
+        XCTAssertTrue(try harness.model.toggleFile(XCTUnwrap(newFiles["NewOne.swift"])))
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        XCTAssertEqual(harness.recorder.calls.count, 1)
+        XCTAssertEqual(harness.recorder.pendingMutationCount, 1)
+
+        harness.recorder.resumeNextMutation()
+        await eventually { harness.recorder.calls.count == 2 && harness.recorder.pendingMutationCount == 1 }
+        XCTAssertTrue(try harness.model.toggleFile(XCTUnwrap(newFiles["NewTwo.swift"])))
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        XCTAssertEqual(harness.recorder.calls.count, 2)
+
+        harness.recorder.resumeNextMutation()
+        await eventually { harness.recorder.calls.count == 3 && harness.recorder.pendingMutationCount == 1 }
+        harness.recorder.resumeNextMutation()
+        await eventually { harness.model.inFlightPaths.isEmpty }
+        XCTAssertEqual(harness.recorder.calls.map(\.identity), [
+            harness.target.identity,
+            newTarget.identity,
+            newTarget.identity
+        ])
+        XCTAssertTrue(harness.recorder.calls.allSatisfy { $0.lookupContext == .visibleWorkspace })
+        await eventually { harness.model.pendingMutationIdentities.isEmpty }
+    }
+
+    @MainActor
+    func testCompletedMutationDoesNotOverwriteNewerAuthoritativeSelection() async throws {
+        let harness = try await makeHarness(files: ["Mutation.swift", "Authoritative.swift"])
+        harness.recorder.suspendMutations = true
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+        let mutationFile = try XCTUnwrap(files["Mutation.swift"])
+        let authoritativeFile = try XCTUnwrap(files["Authoritative.swift"])
+        XCTAssertTrue(harness.model.toggleFile(mutationFile))
+        await eventually { harness.recorder.pendingMutationCount == 1 }
+
+        harness.model.updateAuthoritativeSelection(
+            StoredSelection(selectedPaths: [authoritativeFile.standardizedFullPath]),
+            exportRows: []
+        )
+        harness.recorder.resumeNextMutation()
+        await eventually { harness.model.pendingMutationIdentities.isEmpty }
+
+        XCTAssertNil(harness.model.heldMode(for: mutationFile))
+        XCTAssertEqual(harness.model.heldMode(for: authoritativeFile), .full)
+    }
+
+    @MainActor
+    func testPendingMutationFenceSurvivesFilesTabRemount() async throws {
+        let harness = try await makeHarness(files: ["Pending.swift"])
+        harness.recorder.suspendMutations = true
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+        XCTAssertTrue(try harness.model.toggleFile(XCTUnwrap(files["Pending.swift"])))
+        await eventually { harness.recorder.pendingMutationCount == 1 }
+
+        harness.model.end()
+        let remountedFilesTabModel = harness.model
+        XCTAssertTrue(agentContextFilesReviewMutationIsFenced(
+            pendingIdentities: remountedFilesTabModel.pendingMutationIdentities,
+            targetIdentity: harness.target.identity
+        ))
+
+        harness.recorder.resumeNextMutation()
+        await eventually { remountedFilesTabModel.pendingMutationIdentities.isEmpty }
+    }
+
+    @MainActor
+    func testMutationFailsClosedWhenCatalogChangesBeforeRevalidation() async throws {
+        let harness = try await makeHarness(files: ["Stale.swift"])
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+        try await harness.store.deleteFile(rootID: harness.root.id, relativePath: "Stale.swift")
+
+        XCTAssertTrue(try harness.model.toggleFile(XCTUnwrap(files["Stale.swift"])))
+        await eventually { harness.model.phase == .unavailable(.catalogChanged) }
+        XCTAssertTrue(harness.recorder.calls.isEmpty)
+        XCTAssertTrue(harness.model.pendingMutationIdentities.isEmpty)
+    }
+
+    @MainActor
+    func testMissingHierarchyWithChangedCatalogRequiresBrowseReentry() async throws {
+        let harness = try await makeHarness(files: ["Missing.swift"])
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        await harness.store.unloadRoot(id: harness.root.id)
+
+        harness.model.toggleExpansion(.root(harness.root.id))
+        await eventually { harness.model.phase == .unavailable(.catalogChanged) }
+        XCTAssertTrue(harness.recorder.calls.isEmpty)
+    }
+
+    @MainActor
+    func testUnavailableMutationTargetPublishesNoticeAndUnavailablePhase() async throws {
+        let harness = try await makeHarness(files: ["One.swift"], returnsUnavailableTarget: true)
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let files = try await loadRootFiles(harness)
+        XCTAssertTrue(try harness.model.toggleFile(XCTUnwrap(files["One.swift"])))
+        await eventually { harness.model.phase == .unavailable(.selectionTargetUnavailable) }
+
+        XCTAssertEqual(harness.model.notice?.message, "Selection is no longer available")
+        XCTAssertEqual(harness.model.accessibilityAnnouncement?.message, "Selection is no longer available")
+    }
+
+    @MainActor
+    func testCollapsedAncestorShowsSelectedDescendantProvenance() async throws {
+        let harness = try await makeHarness(files: [
+            "Nested/Deep/Inner.swift",
+            "Other/Untouched.swift"
+        ])
+        let selection = try StoredSelection(
+            selectedPaths: [XCTUnwrap(harness.paths["Nested/Deep/Inner.swift"])]
+        )
+        harness.recorder.selection = selection
+        let target = AgentContextSelectionMutationTarget(
+            identity: harness.target.identity,
+            expectedSelection: selection
+        )
+        await harness.model.begin(
+            target: target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
+
+        XCTAssertNil(harness.model.membership(for: rootNode))
+        XCTAssertEqual(harness.model.containerDisplayMembership(for: rootNode), .mixed)
+
+        harness.model.toggleExpansion(rootNode)
+        await eventually { self.folderNode(in: harness, named: "Nested") != nil }
+
+        let nested = try XCTUnwrap(folderNode(in: harness, named: "Nested"))
+        let other = try XCTUnwrap(folderNode(in: harness, named: "Other"))
+        XCTAssertNil(harness.model.membership(for: nested))
+        XCTAssertEqual(harness.model.containerDisplayMembership(for: nested), .mixed)
+        XCTAssertEqual(
+            harness.model.containerDisplayMembership(for: other),
+            AgentContextFileBrowseContainerMembership.none
+        )
+    }
+
+    @MainActor
+    func testExpansionIsRestoredOnSameRouteReentryAndClearedAcrossRoutes() async throws {
+        let harness = try await makeHarness(files: ["Nested/Deep/Inner.swift"])
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
+        harness.model.toggleExpansion(rootNode)
+        await eventually { self.folderNode(in: harness, named: "Nested") != nil }
+        try harness.model.toggleExpansion(XCTUnwrap(folderNode(in: harness, named: "Nested")))
+        await eventually { self.folderNode(in: harness, named: "Deep") != nil }
+        harness.model.end()
+
+        await harness.model.begin(
+            target: harness.target,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        await eventually { self.folderNode(in: harness, named: "Deep") != nil }
+        XCTAssertTrue(harness.model.expandedNodeIDs.contains(rootNode))
+
+        harness.model.end()
+        let otherRoute = AgentContextSelectionMutationTarget(
+            identity: WorkspaceSelectionIdentity(workspaceID: UUID(), tabID: UUID()),
+            expectedSelection: StoredSelection()
+        )
+        await harness.model.begin(
+            target: otherRoute,
+            lookupContext: .visibleWorkspace,
+            exportRows: [],
+            codeMapsGloballyDisabled: false
+        )
+        XCTAssertTrue(harness.model.expandedNodeIDs.isEmpty)
+        XCTAssertNil(folderNode(in: harness, named: "Nested"))
+    }
+
+    @MainActor
+    private func folderNode(
+        in harness: Harness,
+        named name: String
+    ) -> AgentContextFileBrowseNodeID? {
+        harness.model.rows.compactMap { row -> AgentContextFileBrowseNodeID? in
+            guard case let .folder(folder, _) = row, folder.name == name else { return nil }
+            return .folder(folder.id)
+        }.first
+    }
+
+    @MainActor
+    private func makeHarness(
+        files: [String],
+        returnsUnavailableTarget: Bool = false,
+        metadataReader: AgentContextFileSizeEstimator.MetadataReader? = nil,
+        sessionScoped: Bool = false
+    ) async throws -> Harness {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseModel")
+        var paths: [String: String] = [:]
+        for file in files {
+            let url = rootURL.appendingPathComponent(file)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try "content for \(file)".write(to: url, atomically: true, encoding: .utf8)
+            paths[file] = url.path
+        }
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(
+            path: rootURL.path,
+            kind: sessionScoped ? .sessionWorktree : .primaryWorkspace
+        )
+        let lookupContext = if sessionScoped {
+            WorkspaceLookupContext(
+                rootScope: .sessionBoundWorkspace(
+                    canonicalRootPaths: [],
+                    physicalRootPaths: [root.standardizedFullPath]
+                ),
+                bindingProjection: nil
+            )
+        } else {
+            WorkspaceLookupContext.visibleWorkspace
+        }
+        let service = AgentContextFileBrowseService(store: store)
+        let metadataReads = MetadataReadCounter()
+        let estimator = AgentContextFileSizeEstimator(metadataReader: metadataReader ?? { path in
+            try await metadataReads.read(path: path)
+        })
+        let identity = WorkspaceSelectionIdentity(workspaceID: UUID(), tabID: UUID())
+        let recorder = MutationRecorder(store: store)
+        recorder.returnsUnavailableTarget = returnsUnavailableTarget
+        let model = AgentContextFileBrowseModel(
+            service: service,
+            estimator: estimator,
+            searchDebounceNanoseconds: 0,
+            noticeDurationNanoseconds: 0
+        ) { paths, targetState, identity, lookupContext in
+            await recorder.execute(
+                paths: paths,
+                targetState: targetState,
+                identity: identity,
+                lookupContext: lookupContext
+            )
+        }
+        model.updateMutationRouteProof(AgentContextFileBrowseRouteProof(
+            identity: identity,
+            lookupContext: lookupContext
+        ))
+        return Harness(
+            model: model,
+            recorder: recorder,
+            store: store,
+            root: root,
+            target: AgentContextSelectionMutationTarget(identity: identity, expectedSelection: StoredSelection()),
+            lookupContext: lookupContext,
+            paths: paths,
+            metadataReads: metadataReads
+        )
+    }
+
+    @MainActor
+    private func loadRootFiles(_ harness: Harness) async throws -> [String: AgentContextFileBrowseFile] {
+        let rootNode = AgentContextFileBrowseNodeID.root(harness.root.id)
+        harness.model.toggleExpansion(rootNode)
+        await eventually {
+            harness.model.rows.contains { row in
+                if case .file = row { return true }
+                return false
+            }
+        }
+        return Dictionary(uniqueKeysWithValues: harness.model.rows.compactMap { row in
+            guard case let .file(file, _) = row else { return nil }
+            return (file.name, file)
+        })
+    }
+
+    @MainActor
+    private func eventually(
+        attempts: Int = 2000,
+        _ predicate: @MainActor () -> Bool
+    ) async {
+        for _ in 0 ..< attempts {
+            if predicate() { return }
+            await Task.yield()
+        }
+        XCTFail("Condition did not become true")
+    }
+
+    private func makeCodemapRow(fileID: UUID, rootID: UUID, path: String) -> AgentContextExportRow {
+        AgentContextExportRow(
+            id: ResolvedPromptFileEntryID(fileID: fileID, mode: .codemap, lineRanges: nil),
+            kind: .codemap,
+            rootID: rootID,
+            relativePath: URL(fileURLWithPath: path).lastPathComponent,
+            displayPath: path,
+            displayName: URL(fileURLWithPath: path).lastPathComponent,
+            physicalPath: path,
+            directoryDisplay: nil,
+            lineRanges: nil,
+            canRemove: true
+        )
+    }
+}
+
+@MainActor
+private struct Harness {
+    let model: AgentContextFileBrowseModel
+    let recorder: MutationRecorder
+    let store: WorkspaceFileContextStore
+    let root: WorkspaceRootRecord
+    let target: AgentContextSelectionMutationTarget
+    let lookupContext: WorkspaceLookupContext
+    let paths: [String: String]
+    let metadataReads: MetadataReadCounter
+}
+
+private actor MetadataReadCounter {
+    private(set) var count = 0
+
+    func read(path: String) throws -> AgentContextFileMetadataSnapshot {
+        count += 1
+        let values = try URL(fileURLWithPath: path).resourceValues(forKeys: [
+            .contentModificationDateKey,
+            .fileSizeKey,
+            .isRegularFileKey
+        ])
+        return AgentContextFileMetadataSnapshot(
+            byteCount: values.fileSize.map(Int64.init),
+            modificationDate: values.contentModificationDate,
+            isRegularFile: values.isRegularFile == true
+        )
+    }
+}
+
+@MainActor
+private final class MutationRecorder {
+    struct Call: Equatable {
+        let paths: [String]
+        let targetState: WorkspacePreResolvedSelectionTargetState
+        let identity: WorkspaceSelectionIdentity
+        let lookupContext: WorkspaceLookupContext
+    }
+
+    var selection = StoredSelection()
+    var calls: [Call] = []
+    var suspendMutations = false
+    var returnsUnavailableTarget = false
+    private(set) var pendingMutationCount = 0
+
+    private let mutationService: WorkspaceSelectionMutationService
+    private var pendingContinuations: [CheckedContinuation<Void, Never>] = []
+
+    init(store: WorkspaceFileContextStore) {
+        mutationService = WorkspaceSelectionMutationService(store: store)
+    }
+
+    func execute(
+        paths: [String],
+        targetState: WorkspacePreResolvedSelectionTargetState,
+        identity: WorkspaceSelectionIdentity,
+        lookupContext: WorkspaceLookupContext
+    ) async -> WorkspaceSelectionCoordinator.TransactionResult? {
+        calls.append(Call(
+            paths: paths,
+            targetState: targetState,
+            identity: identity,
+            lookupContext: lookupContext
+        ))
+        if suspendMutations {
+            pendingMutationCount += 1
+            await withCheckedContinuation { continuation in
+                pendingContinuations.append(continuation)
+            }
+            pendingMutationCount -= 1
+        }
+        guard !returnsUnavailableTarget else { return nil }
+        let before = selection
+        selection = mutationService.setPreResolvedFilePaths(
+            base: selection,
+            absolutePaths: paths,
+            targetState: targetState
+        )
+        return WorkspaceSelectionCoordinator.TransactionResult(
+            identity: identity,
+            before: before,
+            after: selection,
+            revision: UInt64(calls.count)
+        )
+    }
+
+    func resumeNextMutation() {
+        pendingContinuations.removeFirst().resume()
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseServiceTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseServiceTests.swift
@@ -1,0 +1,472 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class AgentContextFileBrowseServiceTests: XCTestCase {
+    func testRootsTreeDescendantsExcludeGitDataAndProjectCodemapCapability() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseTree")
+        try write("root b", to: rootURL.appendingPathComponent("b.txt"))
+        try write("root a", to: rootURL.appendingPathComponent("a.swift"))
+        try write("nested", to: rootURL.appendingPathComponent("zFolder/Nested.swift"))
+        try write("nested", to: rootURL.appendingPathComponent("aFolder/Other.md"))
+        let gitDataParent = try makeTestDirectory(name: "ContextBrowseGitData")
+        let gitDataURL = gitDataParent.appendingPathComponent("_git_data", isDirectory: true)
+        try write("hidden", to: gitDataURL.appendingPathComponent("Hidden.swift"))
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        _ = try await store.loadRoot(path: gitDataURL.path, kind: .workspaceGitData)
+        let lookupContext = WorkspaceLookupContext(rootScope: .visibleWorkspacePlusGitData, bindingProjection: nil)
+        let service = AgentContextFileBrowseService(store: store)
+
+        let rootsResult = await service.roots(lookupContext: lookupContext)
+        let roots = try availableRoots(rootsResult)
+        let maybeHierarchy = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: lookupContext
+        )
+        let hierarchy = try XCTUnwrap(availableResult(maybeHierarchy))
+
+        XCTAssertEqual(roots.roots.map(\.id), [root.id])
+        XCTAssertEqual(hierarchy.folders.map(\.name), ["aFolder", "zFolder"])
+        XCTAssertEqual(hierarchy.files.map(\.name), ["a.swift", "b.txt"])
+        XCTAssertEqual(Set(hierarchy.descendantFiles.map(\.name)), ["a.swift", "b.txt", "Nested.swift", "Other.md"])
+        XCTAssertEqual(hierarchy.descendantFiles.count, Set(hierarchy.descendantFiles.map(\.id)).count)
+        XCTAssertTrue(hierarchy.files.allSatisfy { $0.rootGeneration == hierarchy.rootGeneration })
+        XCTAssertTrue(hierarchy.descendantFiles.allSatisfy { $0.rootGeneration == hierarchy.rootGeneration })
+        XCTAssertTrue(try XCTUnwrap(hierarchy.descendantFiles.first { $0.name == "a.swift" }).supportsCodemap)
+        XCTAssertFalse(try XCTUnwrap(hierarchy.descendantFiles.first { $0.name == "b.txt" }).supportsCodemap)
+        XCTAssertFalse(hierarchy.descendantFiles.contains { $0.standardizedFullPath.contains("_git_data") })
+    }
+
+    func testTreeIndexReusesRootSnapshotAndRebuildsAfterAppliedGenerationChanges() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseGeneration")
+        try write("one", to: rootURL.appendingPathComponent("One.swift"))
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let service = AgentContextFileBrowseService(store: store)
+        await store.resetAppliedIndexRecordLookupDiagnosticsForTesting()
+
+        let maybeInitial = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+        let initial = try XCTUnwrap(availableResult(maybeInitial))
+        _ = try await service.hierarchy(rootID: root.id, folderID: nil, lookupContext: .visibleWorkspace)
+        let reused = await store.appliedIndexRecordLookupDiagnosticsForTesting()
+
+        _ = try await store.createFile(rootID: root.id, relativePath: "Two.swift", content: "two")
+        let maybeRebuilt = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+        let rebuilt = try XCTUnwrap(availableResult(maybeRebuilt))
+        let diagnostics = await store.appliedIndexRecordLookupDiagnosticsForTesting()
+
+        XCTAssertEqual(reused.rootSnapshots, 1)
+        XCTAssertEqual(diagnostics.rootSnapshots, 2)
+        XCTAssertEqual(rebuilt.files.map(\.name), ["One.swift", "Two.swift"])
+        XCTAssertNotEqual(rebuilt.rootGeneration, initial.rootGeneration)
+        XCTAssertTrue(rebuilt.files.allSatisfy { $0.rootGeneration == rebuilt.rootGeneration })
+    }
+
+    func testPruneCachesRetainsOnlyCurrentRouteRoots() async throws {
+        let retainedURL = try makeTestDirectory(name: "ContextBrowseRetainedCache")
+        let removedURL = try makeTestDirectory(name: "ContextBrowseRemovedCache")
+        try write("retained", to: retainedURL.appendingPathComponent("Retained.swift"))
+        try write("removed", to: removedURL.appendingPathComponent("Removed.swift"))
+        let store = WorkspaceFileContextStore()
+        let retained = try await store.loadRoot(path: retainedURL.path)
+        let removed = try await store.loadRoot(path: removedURL.path)
+        let service = AgentContextFileBrowseService(store: store)
+        await store.resetAppliedIndexRecordLookupDiagnosticsForTesting()
+        _ = try await service.hierarchy(
+            rootID: retained.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+        _ = try await service.hierarchy(
+            rootID: removed.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+
+        await service.pruneCaches(
+            retainingRootIDs: [retained.id],
+            lookupContext: .visibleWorkspace
+        )
+        _ = try await service.hierarchy(
+            rootID: retained.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+        _ = try await service.hierarchy(
+            rootID: removed.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+
+        let diagnostics = await store.appliedIndexRecordLookupDiagnosticsForTesting()
+        XCTAssertEqual(diagnostics.rootSnapshots, 3)
+    }
+
+    func testIndexedSearchIsUsedOnlyForAdmissibleVisibleAllRootSearch() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseIndexed")
+        try write("target", to: rootURL.appendingPathComponent("Sources/Target.swift"))
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let snapshot = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let searchService = WorkspaceSearchService()
+        await searchService.prepareIndex(from: snapshot)
+        let service = AgentContextFileBrowseService(store: store, searchService: searchService)
+
+        let indexed = try await availableResult(service.search(
+            query: "Target",
+            scope: .allRoots,
+            lookupContext: .visibleWorkspace
+        ))
+        let rootScoped = try await availableResult(service.search(
+            query: "Target",
+            scope: .root(root.id),
+            lookupContext: .visibleWorkspace
+        ))
+        let projectedContext = makeProjectedLookupContext(physicalRoot: root, logicalRootURL: rootURL)
+        let projectedVisibleContext = WorkspaceLookupContext(
+            rootScope: .visibleWorkspace,
+            bindingProjection: projectedContext.bindingProjection
+        )
+        let projected = try await availableResult(service.search(
+            query: "Target",
+            scope: .allRoots,
+            lookupContext: projectedVisibleContext
+        ))
+
+        XCTAssertEqual(indexed.source, .indexedVisibleWorkspace)
+        XCTAssertEqual(rootScoped.source, .storeCatalog)
+        XCTAssertEqual(projected.source, .storeCatalog)
+        XCTAssertEqual(indexed.matches.map(\.file.name), ["Target.swift"])
+        XCTAssertEqual(rootScoped.matches.map(\.file.name), ["Target.swift"])
+        XCTAssertEqual(projected.matches.map(\.file.name), ["Target.swift"])
+    }
+
+    func testSelectedRootSearchFiltersBeforeCandidateCap() async throws {
+        let noisyRootURL = try makeTestDirectory(name: "ContextBrowseNoisy")
+        let selectedRootURL = try makeTestDirectory(name: "ContextBrowseSelected")
+        for index in 0 ..< 80 {
+            try write("noise", to: noisyRootURL.appendingPathComponent(String(format: "Target%03d.swift", index)))
+        }
+        try write("selected", to: selectedRootURL.appendingPathComponent("TargetSelected.swift"))
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: noisyRootURL.path)
+        let selectedRoot = try await store.loadRoot(path: selectedRootURL.path)
+        let service = AgentContextFileBrowseService(store: store)
+
+        let result = try await availableResult(service.search(
+            query: "Target",
+            scope: .root(selectedRoot.id),
+            lookupContext: .visibleWorkspace,
+            limit: 1
+        ))
+
+        XCTAssertEqual(result.source, .storeCatalog)
+        XCTAssertEqual(result.matches.map(\.file.name), ["TargetSelected.swift"])
+        XCTAssertEqual(result.groups.map(\.root.id), [selectedRoot.id])
+    }
+
+    func testWorktreeProjectionUsesLogicalRootAndGroupsDuplicateRootNamesByPhysicalIdentity() async throws {
+        let base = try makeTestDirectory(name: "ContextBrowseWorktree")
+        let logicalA = base.appendingPathComponent("A/Shared", isDirectory: true)
+        let logicalB = base.appendingPathComponent("B/Shared", isDirectory: true)
+        let physicalA = base.appendingPathComponent("worktrees/A", isDirectory: true)
+        let physicalB = base.appendingPathComponent("worktrees/B", isDirectory: true)
+        try write("a", to: physicalA.appendingPathComponent("Sources/TargetA.swift"))
+        try write("b", to: physicalB.appendingPathComponent("Sources/TargetB.swift"))
+        let store = WorkspaceFileContextStore()
+        let rootA = try await store.loadRoot(path: physicalA.path, kind: .sessionWorktree)
+        let rootB = try await store.loadRoot(path: physicalB.path, kind: .sessionWorktree)
+        let lookupContext = makeProjectedLookupContext(
+            physicalRoots: [rootA, rootB],
+            logicalRootURLs: [logicalA, logicalB]
+        )
+        let service = AgentContextFileBrowseService(store: store)
+
+        let rootsResult = await service.roots(lookupContext: lookupContext)
+        let roots = try availableRoots(rootsResult)
+        let result = try await availableResult(service.search(
+            query: "Target",
+            scope: .allRoots,
+            lookupContext: lookupContext
+        ))
+
+        XCTAssertEqual(roots.roots.map(\.displayName), ["Shared", "Shared"])
+        XCTAssertEqual(Set(roots.roots.map(\.scopeLabel)), ["A/Shared", "B/Shared"])
+        XCTAssertEqual(Set(result.groups.map(\.root.id)), [rootA.id, rootB.id])
+        XCTAssertEqual(result.groups.count, 2)
+        XCTAssertTrue(result.groups.allSatisfy { $0.directories.map(\.directoryPath) == ["Sources"] })
+        XCTAssertTrue(result.matches.allSatisfy { $0.file.projectedDisplayPath.contains("Shared/Sources/Target") })
+        XCTAssertFalse(result.matches.contains { $0.file.projectedDisplayPath.contains("worktrees") })
+        XCTAssertFalse(result.matches.contains { $0.file.standardizedFullPath == $0.file.projectedDisplayPath })
+    }
+
+    func testDuplicateRootTreeTitleUsesDisambiguatedScopeLabel() {
+        let first = AgentContextFileBrowseRoot(
+            id: UUID(),
+            physicalPath: "/worktrees/first",
+            displayName: "Shared",
+            scopeLabel: "First/Shared"
+        )
+        let second = AgentContextFileBrowseRoot(
+            id: UUID(),
+            physicalPath: "/worktrees/second",
+            displayName: "Shared",
+            scopeLabel: "Second/Shared"
+        )
+
+        XCTAssertEqual(
+            [first, second].map(agentContextFileBrowseTreeRootTitle),
+            ["First/Shared", "Second/Shared"]
+        )
+    }
+
+    func testRevalidationRejectsDeletedAndIdentityReplacedFilesWhilePreservingInputOrder() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseRevalidation")
+        try write("one", to: rootURL.appendingPathComponent("One.swift"))
+        try write("two", to: rootURL.appendingPathComponent("Two.swift"))
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let service = AgentContextFileBrowseService(store: store)
+        let maybeInitial = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+        let initial = try XCTUnwrap(availableResult(maybeInitial))
+        let one = try XCTUnwrap(initial.files.first { $0.name == "One.swift" })
+        let two = try XCTUnwrap(initial.files.first { $0.name == "Two.swift" })
+
+        try await store.deleteFile(rootID: root.id, relativePath: "One.swift")
+        _ = try await store.createFile(rootID: root.id, relativePath: "One.swift", content: "replacement")
+        let result = try await availableResult(
+            service.revalidate(files: [two, one], lookupContext: .visibleWorkspace)
+        )
+
+        XCTAssertEqual(result.files.map(\.id), [two.id])
+        XCTAssertEqual(result.rejectedCount, 1)
+        XCTAssertNotEqual(result.files.first?.rootGeneration, two.rootGeneration)
+    }
+
+    func testRootUnloadResolvesAsNormalAbsenceAcrossBrowseOperations() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseRootUnload")
+        try write("one", to: rootURL.appendingPathComponent("One.swift"))
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let service = AgentContextFileBrowseService(store: store)
+        let maybeInitial = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+        let initial = try XCTUnwrap(availableResult(maybeInitial))
+
+        await store.unloadRoot(id: root.id)
+
+        let hierarchy = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: .visibleWorkspace
+        )
+        let revalidated = try await availableResult(
+            service.revalidate(files: initial.files, lookupContext: .visibleWorkspace)
+        )
+        let search = try await availableResult(service.search(
+            query: "One",
+            scope: .allRoots,
+            lookupContext: .visibleWorkspace
+        ))
+
+        guard case let .missing(hierarchyGeneration) = hierarchy else {
+            return XCTFail("Expected missing hierarchy with catalog generation")
+        }
+        XCTAssertNotEqual(hierarchyGeneration, initial.catalogGeneration)
+        XCTAssertTrue(revalidated.files.isEmpty)
+        XCTAssertEqual(revalidated.rejectedCount, initial.files.count)
+        XCTAssertTrue(search.matches.isEmpty)
+    }
+
+    func testSessionScopeLossRemainsTypedAcrossTreeSearchAndRevalidation() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseSessionScopeLoss")
+        try write("one", to: rootURL.appendingPathComponent("One.swift"))
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path, kind: .sessionWorktree)
+        let lookupContext = WorkspaceLookupContext(
+            rootScope: .sessionBoundWorkspace(
+                canonicalRootPaths: [],
+                physicalRootPaths: [root.standardizedFullPath]
+            ),
+            bindingProjection: nil
+        )
+        let service = AgentContextFileBrowseService(store: store)
+        let initialResult = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: lookupContext
+        )
+        let initial = try XCTUnwrap(availableResult(initialResult))
+
+        await store.unloadRoot(id: root.id)
+
+        let hierarchy = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: lookupContext
+        )
+        let search = try await service.search(query: "One", scope: .allRoots, lookupContext: lookupContext)
+        let revalidated = try await service.revalidate(files: initial.files, lookupContext: lookupContext)
+
+        XCTAssertEqual(hierarchy, .sessionRootsUnavailable)
+        XCTAssertEqual(search, .sessionRootsUnavailable)
+        XCTAssertEqual(revalidated, .sessionRootsUnavailable)
+    }
+
+    func testNonMaterializedProjectionIsUnavailableAcrossBrowseOperations() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseIncompleteProjection")
+        try write("one", to: rootURL.appendingPathComponent("One.swift"))
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path, kind: .sessionWorktree)
+        let service = AgentContextFileBrowseService(store: store)
+        let materializedContext = makeProjectedLookupContext(
+            physicalRoot: root,
+            logicalRootURL: rootURL
+        )
+        let initial = try await availableResult(service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: materializedContext
+        ))
+        let lookupContext = makeProjectedLookupContext(
+            physicalRoots: [root],
+            logicalRootURLs: [rootURL],
+            lookupPhysicalRootPaths: []
+        )
+
+        let roots = await service.roots(lookupContext: lookupContext)
+        let hierarchy = try await service.hierarchy(
+            rootID: root.id,
+            folderID: nil,
+            lookupContext: lookupContext
+        )
+        let search = try await service.search(query: "One", scope: .allRoots, lookupContext: lookupContext)
+        let revalidation = try await service.revalidate(files: initial.files, lookupContext: lookupContext)
+
+        XCTAssertEqual(lookupContext.bindingProjection?.isFullyMaterialized, false)
+        XCTAssertEqual(roots, .unavailable(missingPhysicalRootPaths: []))
+        XCTAssertEqual(hierarchy, .sessionRootsUnavailable)
+        XCTAssertEqual(search, .sessionRootsUnavailable)
+        XCTAssertEqual(revalidation, .sessionRootsUnavailable)
+    }
+
+    func testSearchUsesBatchScorerOrderingAndDirectoryGrouping() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseScoring")
+        try write("exact", to: rootURL.appendingPathComponent("Target.swift"))
+        try write("nested", to: rootURL.appendingPathComponent("Sources/TargetHelper.swift"))
+        try write("weak", to: rootURL.appendingPathComponent("Sources/UnrelatedTargetName.swift"))
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: rootURL.path)
+        let service = AgentContextFileBrowseService(store: store)
+
+        let result = try await availableResult(service.search(
+            query: "Target",
+            scope: .allRoots,
+            lookupContext: .visibleWorkspace
+        ))
+        let group = try XCTUnwrap(result.groups.first)
+
+        XCTAssertEqual(result.matches.first?.file.name, "Target.swift")
+        XCTAssertEqual(group.rootMatches.map(\.file.name), ["Target.swift"])
+        XCTAssertEqual(group.directories.map(\.directoryPath), ["Sources"])
+        XCTAssertEqual(group.matchCount, result.matches.count)
+    }
+
+    private func availableResult<Value>(
+        _ result: AgentContextFileBrowseSessionScopedResult<Value>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> Value {
+        guard case let .available(value) = result else {
+            XCTFail("Expected available session roots", file: file, line: line)
+            throw TestFailure.unavailableRoots
+        }
+        return value
+    }
+
+    private func availableRoots(
+        _ result: AgentContextFileBrowseRootsResult,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> AgentContextFileBrowseRootsSnapshot {
+        guard case let .available(snapshot) = result else {
+            XCTFail("Expected available roots", file: file, line: line)
+            throw TestFailure.unavailableRoots
+        }
+        return snapshot
+    }
+
+    private func makeProjectedLookupContext(
+        physicalRoot: WorkspaceRootRecord,
+        logicalRootURL: URL
+    ) -> WorkspaceLookupContext {
+        makeProjectedLookupContext(physicalRoots: [physicalRoot], logicalRootURLs: [logicalRootURL])
+    }
+
+    private func makeProjectedLookupContext(
+        physicalRoots: [WorkspaceRootRecord],
+        logicalRootURLs: [URL],
+        lookupPhysicalRootPaths: Set<String>? = nil
+    ) -> WorkspaceLookupContext {
+        precondition(physicalRoots.count == logicalRootURLs.count)
+        let sessionID = UUID()
+        let boundRoots = zip(physicalRoots, logicalRootURLs).enumerated().map { index, pair in
+            let physical = WorkspaceRootRef(id: pair.0.id, name: pair.0.name, fullPath: pair.0.standardizedFullPath)
+            let logical = WorkspaceRootRef(id: UUID(), name: pair.1.lastPathComponent, fullPath: pair.1.path)
+            let binding = AgentSessionWorktreeBinding(
+                id: "browse-bind-\(index)",
+                repositoryID: "browse-repository-\(index)",
+                repoKey: "browse",
+                logicalRootPath: logical.standardizedFullPath,
+                logicalRootName: logical.name,
+                worktreeID: "browse-worktree-\(index)",
+                worktreeRootPath: physical.standardizedFullPath,
+                worktreeName: physical.name,
+                branch: "feature/browse",
+                head: "abcdef",
+                visualLabel: "browse",
+                visualColorHex: "#3366FF",
+                boundAt: Date(timeIntervalSinceReferenceDate: 123),
+                source: "test"
+            )
+            return WorkspaceRootBindingProjection.BoundRoot(
+                logicalRoot: logical,
+                physicalRoot: physical,
+                binding: binding
+            )
+        }
+        let projection = WorkspaceRootBindingProjection(
+            sessionID: sessionID,
+            boundRoots: boundRoots,
+            visibleLogicalRoots: boundRoots.map(\.logicalRoot),
+            lookupPhysicalRootPaths: lookupPhysicalRootPaths
+        )
+        return WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+    }
+
+    private func write(_ content: String, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private enum TestFailure: Error {
+        case unavailableRoots
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentContextFileSizeEstimatorTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextFileSizeEstimatorTests.swift
@@ -21,6 +21,35 @@ final class AgentContextFileSizeEstimatorTests: XCTestCase {
         XCTAssertEqual(snapshot.paths, [file.standardizedFullPath, file.standardizedFullPath])
     }
 
+    func testOlderGenerationDoesNotCancelNewerReadOrRollBackAuthority() async {
+        let reader = BlockingMetadataReader()
+        let file = makeFile(path: "/workspace/Generation.swift")
+        let estimator = AgentContextFileSizeEstimator { path in
+            try await reader.read(path: path)
+        }
+        let currentTask = Task {
+            await estimator.estimate(for: file, rootGeneration: 8)
+        }
+        while await reader.paths.isEmpty {
+            await Task.yield()
+        }
+
+        let staleTask = Task {
+            await estimator.estimate(for: file, rootGeneration: 7)
+        }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        await reader.release()
+        let current = await currentTask.value
+        let stale = await staleTask.value
+        let paths = await reader.paths
+
+        XCTAssertEqual(current.estimate, .known(TokenCalculationService.estimateTokens(utf8ByteCount: 100)))
+        XCTAssertEqual(stale.estimate, .notRequested)
+        XCTAssertEqual(paths, [file.standardizedFullPath])
+    }
+
     func testMissingDirectoryNegativeAndMetadataErrorAreUnavailable() async throws {
         let directory = try makeTestDirectory(name: "ContextBrowseMetadataDirectory")
         let missing = makeFile(path: directory.appendingPathComponent("Missing.swift").path)

--- a/Tests/RepoPromptTests/AgentMode/AgentContextFileSizeEstimatorTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextFileSizeEstimatorTests.swift
@@ -1,0 +1,340 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class AgentContextFileSizeEstimatorTests: XCTestCase {
+    func testEstimateUsesCanonicalFormulaCachesWithinGenerationAndInvalidatesAcrossGeneration() async {
+        let tracker = MetadataReadTracker(byteCount: 4096)
+        let file = makeFile(path: "/workspace/Cached.swift")
+        let estimator = AgentContextFileSizeEstimator { path in
+            await tracker.read(path: path, isMainThread: false)
+        }
+
+        let first = await estimator.estimate(for: file, rootGeneration: 7)
+        let cached = await estimator.estimate(for: file, rootGeneration: 7)
+        let invalidated = await estimator.estimate(for: file, rootGeneration: 8)
+        let snapshot = await tracker.snapshot()
+
+        XCTAssertEqual(first.estimate, .known(TokenCalculationService.estimateTokens(utf8ByteCount: 4096)))
+        XCTAssertEqual(cached.estimate, first.estimate)
+        XCTAssertEqual(invalidated.estimate, first.estimate)
+        XCTAssertEqual(snapshot.readCount, 2)
+        XCTAssertEqual(snapshot.paths, [file.standardizedFullPath, file.standardizedFullPath])
+    }
+
+    func testMissingDirectoryNegativeAndMetadataErrorAreUnavailable() async throws {
+        let directory = try makeTestDirectory(name: "ContextBrowseMetadataDirectory")
+        let missing = makeFile(path: directory.appendingPathComponent("Missing.swift").path)
+        let directoryFile = makeFile(path: directory.path)
+        let defaultEstimator = AgentContextFileSizeEstimator()
+        let negativeEstimator = AgentContextFileSizeEstimator { _ in
+            AgentContextFileMetadataSnapshot(byteCount: -1, modificationDate: nil, isRegularFile: true)
+        }
+        let errorEstimator = AgentContextFileSizeEstimator { _ in
+            throw MetadataError.unreadable
+        }
+
+        let missingResult = await defaultEstimator.estimate(for: missing, rootGeneration: 1)
+        let directoryResult = await defaultEstimator.estimate(for: directoryFile, rootGeneration: 1)
+        let negativeResult = await negativeEstimator.estimate(for: missing, rootGeneration: 1)
+        let errorResult = await errorEstimator.estimate(for: missing, rootGeneration: 1)
+
+        XCTAssertEqual(missingResult.estimate, .unavailable)
+        XCTAssertEqual(directoryResult.estimate, .unavailable)
+        XCTAssertEqual(negativeResult.estimate, .unavailable)
+        XCTAssertEqual(errorResult.estimate, .unavailable)
+    }
+
+    @MainActor
+    func testBatchPreservesIdentityAndRunsMetadataOffMainActorWithBoundedConcurrency() async {
+        let tracker = MetadataReadTracker(byteCount: 100)
+        let rootID = UUID()
+        let files = (0 ..< 40).map {
+            makeFile(path: "/workspace/File\($0).swift", rootID: rootID)
+        }
+        let mainQueueMarker = MainQueueMarker()
+        let estimator = AgentContextFileSizeEstimator(maximumConcurrentReads: 4) { path in
+            await tracker.beginRead(path: path, isMainThread: mainQueueMarker.isOnMainQueue())
+            for _ in 0 ..< 10 {
+                await Task.yield()
+            }
+            return await tracker.endRead()
+        }
+        let requests = files.reversed().map {
+            AgentContextFileSizeEstimateRequest(file: $0, rootGeneration: 3)
+        }
+
+        let results = await estimator.estimates(for: requests)
+        let snapshot = await tracker.snapshot()
+
+        XCTAssertEqual(results.map(\.fileID), requests.map(\.file.id))
+        XCTAssertEqual(Set(results.map(\.estimate)), [.known(TokenCalculationService.estimateTokens(utf8ByteCount: 100))])
+        XCTAssertEqual(snapshot.readCount, files.count)
+        XCTAssertLessThanOrEqual(snapshot.maximumConcurrentReads, 4)
+        XCTAssertGreaterThan(snapshot.maximumConcurrentReads, 1)
+        XCTAssertFalse(snapshot.observedMainThreadRead)
+    }
+
+    func testConcurrentSingleFileCallsShareGlobalReadBound() async {
+        let tracker = MetadataReadTracker(byteCount: 100)
+        let rootID = UUID()
+        let files = (0 ..< 40).map {
+            makeFile(path: "/workspace/Concurrent\($0).swift", rootID: rootID)
+        }
+        let estimator = AgentContextFileSizeEstimator(maximumConcurrentReads: 4) { path in
+            await tracker.beginRead(path: path, isMainThread: false)
+            for _ in 0 ..< 50 {
+                await Task.yield()
+            }
+            return await tracker.endRead()
+        }
+
+        let results = await withTaskGroup(of: AgentContextFileSizeEstimateResult.self) { group in
+            for file in files {
+                group.addTask {
+                    await estimator.estimate(for: file, rootGeneration: 3)
+                }
+            }
+            return await group.reduce(into: []) { $0.append($1) }
+        }
+        let snapshot = await tracker.snapshot()
+
+        XCTAssertEqual(results.count, files.count)
+        XCTAssertLessThanOrEqual(snapshot.maximumConcurrentReads, 4)
+        XCTAssertGreaterThan(snapshot.maximumConcurrentReads, 1)
+    }
+
+    func testConcurrentDuplicateSingleFileCallsShareOneMetadataRead() async {
+        let reader = BlockingMetadataReader()
+        let file = makeFile(path: "/workspace/ConcurrentDuplicate.swift")
+        let estimator = AgentContextFileSizeEstimator { path in
+            try await reader.read(path: path)
+        }
+        let tasks = (0 ..< 20).map { _ in
+            Task { await estimator.estimate(for: file, rootGeneration: 4) }
+        }
+        while await reader.paths.isEmpty {
+            await Task.yield()
+        }
+        await reader.release()
+        var results: [AgentContextFileSizeEstimateResult] = []
+        for task in tasks {
+            await results.append(task.value)
+        }
+
+        XCTAssertEqual(Set(results.map(\.estimate)), [.known(TokenCalculationService.estimateTokens(utf8ByteCount: 100))])
+        let paths = await reader.paths
+        XCTAssertEqual(paths, [file.standardizedFullPath])
+    }
+
+    func testCanceledQueuedSingleFileCallNeverStartsMetadataRead() async {
+        let reader = BlockingMetadataReader()
+        let first = makeFile(path: "/workspace/First.swift")
+        let queued = makeFile(path: "/workspace/Queued.swift", rootID: first.rootID)
+        let estimator = AgentContextFileSizeEstimator(maximumConcurrentReads: 1) { path in
+            try await reader.read(path: path)
+        }
+        let firstTask = Task { await estimator.estimate(for: first, rootGeneration: 1) }
+        while await reader.paths.isEmpty {
+            await Task.yield()
+        }
+        let queuedTask = Task { await estimator.estimate(for: queued, rootGeneration: 1) }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+        queuedTask.cancel()
+        let canceled = await queuedTask.value
+        await reader.release()
+        _ = await firstTask.value
+
+        XCTAssertEqual(canceled.estimate, .notRequested)
+        let paths = await reader.paths
+        XCTAssertEqual(paths, [first.standardizedFullPath])
+    }
+
+    func testPruneCachesRetainsOnlyCurrentRoots() async {
+        let tracker = MetadataReadTracker(byteCount: 100)
+        let retained = makeFile(path: "/workspace/Retained.swift")
+        let removed = makeFile(path: "/workspace/Removed.swift")
+        let estimator = AgentContextFileSizeEstimator { path in
+            await tracker.read(path: path, isMainThread: false)
+        }
+        _ = await estimator.estimate(for: retained, rootGeneration: 1)
+        _ = await estimator.estimate(for: removed, rootGeneration: 1)
+
+        await estimator.pruneCaches(retainingRootIDs: [retained.rootID])
+        _ = await estimator.estimate(for: retained, rootGeneration: 1)
+        _ = await estimator.estimate(for: removed, rootGeneration: 1)
+
+        let snapshot = await tracker.snapshot()
+        XCTAssertEqual(snapshot.paths.count(where: { $0 == retained.standardizedFullPath }), 1)
+        XCTAssertEqual(snapshot.paths.count(where: { $0 == removed.standardizedFullPath }), 2)
+    }
+
+    func testDuplicateBatchIdentityReadsMetadataOnceAndMapsEveryRequest() async {
+        let tracker = MetadataReadTracker(byteCount: 200)
+        let file = makeFile(path: "/workspace/Duplicate.swift")
+        let estimator = AgentContextFileSizeEstimator { path in
+            await tracker.read(path: path, isMainThread: false)
+        }
+        let request = AgentContextFileSizeEstimateRequest(file: file, rootGeneration: 4)
+
+        let results = await estimator.estimates(for: [request, request])
+        let snapshot = await tracker.snapshot()
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0], results[1])
+        XCTAssertEqual(snapshot.readCount, 1)
+    }
+
+    func testCanceledMetadataReadIsNotCachedAndRetriesSuccessfully() async {
+        let file = makeFile(path: "/workspace/Cancelled.swift")
+        let reader = CancellationRetryMetadataReader()
+        let estimator = AgentContextFileSizeEstimator { _ in
+            try await reader.read()
+        }
+        let task = Task {
+            await estimator.estimate(for: file, rootGeneration: 1)
+        }
+        while await reader.readCount == 0 {
+            await Task.yield()
+        }
+        task.cancel()
+
+        let canceled = await task.value
+        let retried = await estimator.estimate(for: file, rootGeneration: 1)
+        let readCount = await reader.readCount
+
+        XCTAssertEqual(canceled.estimate, .notRequested)
+        XCTAssertEqual(retried.estimate, .known(TokenCalculationService.estimateTokens(utf8ByteCount: 100)))
+        XCTAssertEqual(readCount, 2)
+    }
+
+    private func makeFile(
+        path: String,
+        id: UUID = UUID(),
+        rootID: UUID = UUID()
+    ) -> AgentContextFileBrowseFile {
+        AgentContextFileBrowseFile(
+            id: id,
+            rootID: rootID,
+            rootGeneration: 1,
+            parentFolderID: nil,
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            standardizedRelativePath: URL(fileURLWithPath: path).lastPathComponent,
+            standardizedFullPath: StandardizedPath.absolute(path),
+            projectedDisplayPath: URL(fileURLWithPath: path).lastPathComponent,
+            projectedDirectoryPath: "",
+            modificationDate: nil,
+            supportsCodemap: true
+        )
+    }
+
+    private enum MetadataError: Error {
+        case unreadable
+    }
+}
+
+private actor BlockingMetadataReader {
+    private(set) var paths: [String] = []
+    private var isReleased = false
+
+    func read(path: String) async throws -> AgentContextFileMetadataSnapshot {
+        paths.append(path)
+        while !isReleased {
+            try Task.checkCancellation()
+            await Task.yield()
+        }
+        return AgentContextFileMetadataSnapshot(byteCount: 100, modificationDate: nil, isRegularFile: true)
+    }
+
+    func release() {
+        isReleased = true
+    }
+}
+
+private actor CancellationRetryMetadataReader {
+    private(set) var readCount = 0
+
+    func read() async throws -> AgentContextFileMetadataSnapshot {
+        readCount += 1
+        if readCount == 1 {
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            throw CancellationError()
+        }
+        return AgentContextFileMetadataSnapshot(byteCount: 100, modificationDate: nil, isRegularFile: true)
+    }
+}
+
+private final class MainQueueMarker: @unchecked Sendable {
+    private let key = DispatchSpecificKey<Void>()
+
+    init() {
+        DispatchQueue.main.setSpecific(key: key, value: ())
+    }
+
+    func isOnMainQueue() -> Bool {
+        DispatchQueue.getSpecific(key: key) != nil
+    }
+}
+
+private actor MetadataReadTracker {
+    struct Snapshot {
+        let readCount: Int
+        let maximumConcurrentReads: Int
+        let observedMainThreadRead: Bool
+        let paths: [String]
+    }
+
+    private let byteCount: Int64
+    private var readCount = 0
+    private var activeReads = 0
+    private var maximumConcurrentReads = 0
+    private var observedMainThreadRead = false
+    private var paths: [String] = []
+
+    init(byteCount: Int64) {
+        self.byteCount = byteCount
+    }
+
+    func read(path: String, isMainThread: Bool) -> AgentContextFileMetadataSnapshot {
+        recordStart(path: path, isMainThread: isMainThread)
+        activeReads -= 1
+        return metadataSnapshot()
+    }
+
+    func beginRead(path: String, isMainThread: Bool) {
+        recordStart(path: path, isMainThread: isMainThread)
+    }
+
+    func endRead() -> AgentContextFileMetadataSnapshot {
+        activeReads -= 1
+        return metadataSnapshot()
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(
+            readCount: readCount,
+            maximumConcurrentReads: maximumConcurrentReads,
+            observedMainThreadRead: observedMainThreadRead,
+            paths: paths
+        )
+    }
+
+    private func recordStart(path: String, isMainThread: Bool) {
+        readCount += 1
+        activeReads += 1
+        maximumConcurrentReads = max(maximumConcurrentReads, activeReads)
+        observedMainThreadRead = observedMainThreadRead || isMainThread
+        paths.append(path)
+    }
+
+    private func metadataSnapshot() -> AgentContextFileMetadataSnapshot {
+        AgentContextFileMetadataSnapshot(
+            byteCount: byteCount,
+            modificationDate: Date(timeIntervalSinceReferenceDate: 123),
+            isRegularFile: true
+        )
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentContextFileSizeEstimatorTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextFileSizeEstimatorTests.swift
@@ -180,6 +180,30 @@ final class AgentContextFileSizeEstimatorTests: XCTestCase {
         XCTAssertEqual(paths, [first.standardizedFullPath])
     }
 
+    func testPreCanceledReadLeavesNoPermitState() async {
+        let estimator = AgentContextFileSizeEstimator(maximumConcurrentReads: 1) { _ in
+            AgentContextFileMetadataSnapshot(byteCount: 100, modificationDate: nil, isRegularFile: true)
+        }
+        let task = Task {
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            return await estimator.estimate(
+                for: self.makeFile(path: "/workspace/PreCanceled.swift"),
+                rootGeneration: 1
+            )
+        }
+
+        task.cancel()
+        _ = await task.value
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        let retainedPermitStateCount = await estimator.readPermitStateCountForTesting()
+        XCTAssertEqual(retainedPermitStateCount, 0)
+    }
+
     func testPruneCachesRetainsOnlyCurrentRoots() async {
         let tracker = MetadataReadTracker(byteCount: 100)
         let retained = makeFile(path: "/workspace/Retained.swift")

--- a/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
@@ -245,6 +245,102 @@ final class AgentModeChatSwitchActivationTests: XCTestCase {
         )
     }
 
+    func testFilesTabMutationGateRequiresStableMatchingActiveTab() {
+        let tabID = UUID()
+        XCTAssertTrue(agentContextFilesCanMutateCurrentModel(
+            isSwitchBlankingRows: false,
+            isSwitchingComposeTab: false,
+            canMutateDisplayedModel: true,
+            sourceTabID: tabID,
+            activeTabID: tabID
+        ))
+        XCTAssertFalse(agentContextFilesCanMutateCurrentModel(
+            isSwitchBlankingRows: true,
+            isSwitchingComposeTab: false,
+            canMutateDisplayedModel: true,
+            sourceTabID: tabID,
+            activeTabID: tabID
+        ))
+        XCTAssertFalse(agentContextFilesCanMutateCurrentModel(
+            isSwitchBlankingRows: false,
+            isSwitchingComposeTab: true,
+            canMutateDisplayedModel: true,
+            sourceTabID: tabID,
+            activeTabID: tabID
+        ))
+        XCTAssertFalse(agentContextFilesCanMutateCurrentModel(
+            isSwitchBlankingRows: false,
+            isSwitchingComposeTab: false,
+            canMutateDisplayedModel: false,
+            sourceTabID: tabID,
+            activeTabID: tabID
+        ))
+        XCTAssertFalse(agentContextFilesCanMutateCurrentModel(
+            isSwitchBlankingRows: false,
+            isSwitchingComposeTab: false,
+            canMutateDisplayedModel: true,
+            sourceTabID: tabID,
+            activeTabID: UUID()
+        ))
+        XCTAssertFalse(agentContextFilesCanMutateCurrentModel(
+            isSwitchBlankingRows: false,
+            isSwitchingComposeTab: false,
+            canMutateDisplayedModel: true,
+            sourceTabID: nil,
+            activeTabID: tabID
+        ))
+    }
+
+    func testFilesTabRouteProofUsesPureActiveIdentityAndDisplayedLookupContext() {
+        let identity = WorkspaceSelectionIdentity(workspaceID: UUID(), tabID: UUID())
+        let lookupContext = WorkspaceLookupContext(
+            rootScope: .visibleWorkspacePlusGitData,
+            bindingProjection: nil
+        )
+
+        XCTAssertEqual(
+            agentContextFileBrowseRouteProof(
+                activeIdentity: identity,
+                sourceTabID: identity.tabID,
+                lookupContext: lookupContext
+            ),
+            AgentContextFileBrowseRouteProof(identity: identity, lookupContext: lookupContext)
+        )
+        XCTAssertNil(agentContextFileBrowseRouteProof(
+            activeIdentity: identity,
+            sourceTabID: UUID(),
+            lookupContext: lookupContext
+        ))
+        XCTAssertNil(agentContextFileBrowseRouteProof(
+            activeIdentity: nil,
+            sourceTabID: identity.tabID,
+            lookupContext: lookupContext
+        ))
+    }
+
+    func testFilesTabBrowseTerminationDependsOnlyOnActiveTargetMatch() {
+        XCTAssertFalse(agentContextFileBrowseShouldTerminateForTargetChange(
+            isBrowseActive: false,
+            hasMutationTarget: false,
+            sessionMatchesTarget: false
+        ))
+        XCTAssertTrue(agentContextFileBrowseShouldTerminateForTargetChange(
+            isBrowseActive: true,
+            hasMutationTarget: false,
+            sessionMatchesTarget: false
+        ))
+        XCTAssertTrue(agentContextFileBrowseShouldTerminateForTargetChange(
+            isBrowseActive: true,
+            hasMutationTarget: true,
+            sessionMatchesTarget: false
+        ))
+        XCTAssertFalse(agentContextFileBrowseShouldTerminateForTargetChange(
+            isBrowseActive: true,
+            hasMutationTarget: true,
+            sessionMatchesTarget: true
+        ))
+    }
+
     func testToggleContextComposerShortcutOutsideAgentModeDoesNotArmPresentation() async throws {
         try await withFixture { fixture in
             let drawerStore = fixture.viewModel.ui.contextDrawer

--- a/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
@@ -291,6 +291,55 @@ final class AgentModeChatSwitchActivationTests: XCTestCase {
         ))
     }
 
+    func testFilesTabRequestIdentityResetSkipsSelectionOnlyChanges() {
+        let tabID = UUID()
+        func identity(
+            selection: StoredSelection,
+            tabID: UUID,
+            codeMapUsage: CodeMapUsage = .none
+        ) -> AgentSelectedFilesModelIdentity {
+            AgentSelectedFilesModelIdentity(
+                exportContextIdentity: AgentContextExportIdentity(
+                    tabID: tabID,
+                    selection: selection,
+                    activeAgentSessionID: nil,
+                    worktreeBindingFingerprint: ""
+                ),
+                filePathDisplay: .relative,
+                codeMapUsage: codeMapUsage
+            )
+        }
+
+        let previousIdentity = identity(
+            selection: StoredSelection(selectedPaths: ["Sources/Existing.swift"]),
+            tabID: tabID
+        )
+        let changedSelectionIdentity = identity(
+            selection: StoredSelection(selectedPaths: ["Sources/Existing.swift", "Sources/Added.swift"]),
+            tabID: tabID
+        )
+
+        XCTAssertFalse(agentContextFilesShouldResetModel(
+            previousIdentity: previousIdentity,
+            currentIdentity: changedSelectionIdentity
+        ))
+        XCTAssertTrue(agentContextFilesShouldResetModel(
+            previousIdentity: previousIdentity,
+            currentIdentity: identity(
+                selection: previousIdentity.exportContextIdentity.selection,
+                tabID: tabID,
+                codeMapUsage: .complete
+            )
+        ))
+        XCTAssertTrue(agentContextFilesShouldResetModel(
+            previousIdentity: previousIdentity,
+            currentIdentity: identity(
+                selection: previousIdentity.exportContextIdentity.selection,
+                tabID: UUID()
+            )
+        ))
+    }
+
     func testFilesTabRouteProofUsesPureActiveIdentityAndDisplayedLookupContext() {
         let identity = WorkspaceSelectionIdentity(workspaceID: UUID(), tabID: UUID())
         let lookupContext = WorkspaceLookupContext(

--- a/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
@@ -763,6 +763,56 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testPreservedSelectionChangeRefreshKeepsDisplayedRowsMutable() async {
+        let resolver = GatedModelResolver()
+        let coordinator = AgentSelectedFilesModelCoordinator { request in
+            await resolver.resolve(request)
+        }
+        let loadedRequest = makeRequest(name: "Selection.swift")
+        let changedSource = AgentContextExportSource(
+            tabID: loadedRequest.source.tabID,
+            promptText: loadedRequest.source.promptText,
+            selection: StoredSelection(selectedPaths: ["Sources/Selection.swift", "Sources/Added.swift"]),
+            selectedMetaPromptIDs: loadedRequest.source.selectedMetaPromptIDs,
+            tabName: loadedRequest.source.tabName,
+            activeAgentSessionID: loadedRequest.source.activeAgentSessionID,
+            worktreeBindings: loadedRequest.source.worktreeBindings
+        )
+        let changedRequest = AgentSelectedFilesModelRequest(
+            identity: AgentSelectedFilesModelIdentity(
+                exportContextIdentity: changedSource.exportContextIdentity,
+                filePathDisplay: loadedRequest.filePathDisplay,
+                codeMapUsage: loadedRequest.codeMapUsage
+            ),
+            source: changedSource,
+            store: loadedRequest.store,
+            filePathDisplay: loadedRequest.filePathDisplay,
+            codeMapUsage: loadedRequest.codeMapUsage,
+            entryMetricsSnapshot: nil
+        )
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(loadedRequest), .started)
+        let didStartInitialLoad = await resolver.waitUntilStartCount("Selection.swift", count: 1)
+        XCTAssertTrue(didStartInitialLoad)
+        await resolver.releaseNext("Selection.swift")
+        let didLoadInitialModel = await waitUntilModel(promptText: "Selection.swift", in: coordinator)
+        XCTAssertTrue(didLoadInitialModel)
+
+        XCTAssertEqual(
+            coordinator.refreshIfNeeded(changedRequest, force: true, preserveDisplayedModel: true),
+            .started
+        )
+        let didStartSelectionRefresh = await resolver.waitUntilStartCount("Selection.swift", count: 2)
+        XCTAssertTrue(didStartSelectionRefresh)
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertTrue(coordinator.canMutateDisplayedModel)
+
+        await resolver.releaseNext("Selection.swift")
+        let didLoadChangedModel = await waitUntilModel(promptText: "Selection.swift", in: coordinator)
+        XCTAssertTrue(didLoadChangedModel)
+    }
+
+    @MainActor
     func testDisplayedModelMatchesUsesFullIdentityDuringPreservedRefresh() async {
         let resolver = GatedModelResolver()
         let coordinator = AgentSelectedFilesModelCoordinator { request in

--- a/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
@@ -61,7 +61,7 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.rowSplit.fileRows.first?.metrics, .unknown)
         XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 0)
         XCTAssertTrue(coordinator.isLoading)
-        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+        XCTAssertTrue(coordinator.canMutateDisplayedModel)
 
         await resolver.releaseNext()
         let expectedMetrics = AgentContextExportRow.Metrics.known(
@@ -730,7 +730,7 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func testPreservedSameIdentityRefreshKeepsDisplayedRowsWithoutMutation() async {
+    func testPreservedSameIdentityRefreshKeepsDisplayedRowsMutable() async {
         let resolver = GatedModelResolver()
         let coordinator = AgentSelectedFilesModelCoordinator { request in
             await resolver.resolve(request)
@@ -753,7 +753,7 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.model?.source.promptText, "Stable.swift")
         XCTAssertEqual(coordinator.rowSplit.rows.count, 1)
         XCTAssertTrue(coordinator.isLoading)
-        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+        XCTAssertTrue(coordinator.canMutateDisplayedModel)
         XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
         XCTAssertFalse(coordinator.completedModelMatches(request.identity))
 

--- a/Tests/RepoPromptTests/WorkspaceContext/TokenCalculationServiceByteEstimateTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/TokenCalculationServiceByteEstimateTests.swift
@@ -1,0 +1,32 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class TokenCalculationServiceByteEstimateTests: XCTestCase {
+    func testTextAndByteCountOverloadsMatchForEmptyASCIIAndMultibyteText() {
+        let samples = [
+            "",
+            "RepoPrompt",
+            String(repeating: "a", count: 4097),
+            "Grüße 👋🏽 from RepoPrompt"
+        ]
+
+        for text in samples {
+            XCTAssertEqual(
+                TokenCalculationService.estimateTokens(for: text),
+                TokenCalculationService.estimateTokens(utf8ByteCount: text.utf8.count),
+                "Mismatch for \(text.utf8.count) UTF-8 bytes"
+            )
+        }
+    }
+
+    func testByteCountOverloadPreservesCanonicalArithmetic() {
+        let byteCounts = [0, 1, 3, 4, 5, 127, 1024, 10000, 10_000_001]
+
+        for byteCount in byteCounts {
+            XCTAssertEqual(
+                TokenCalculationService.estimateTokens(utf8ByteCount: byteCount),
+                Int((Double(byteCount) / 4.0) * 1.05)
+            )
+        }
+    }
+}

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootBindingProjectionTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootBindingProjectionTests.swift
@@ -52,6 +52,28 @@ final class WorkspaceRootBindingProjectionTests: XCTestCase {
         XCTAssertNil(projection.projectedLogicalDisplayPath(forPhysicalPath: "/repo/project/Sources/App.swift"))
     }
 
+    func testProjectedLogicalPathComponentsMapsPhysicalRootItself() throws {
+        let logicalRoot = WorkspaceRootRef(id: UUID(), name: "Project", fullPath: "/repo/project")
+        let physicalRoot = WorkspaceRootRef(id: UUID(), name: "Project", fullPath: "/tmp/worktrees/project-agent")
+        let projection = WorkspaceRootBindingProjection(
+            sessionID: UUID(),
+            boundRoots: [
+                .init(
+                    logicalRoot: logicalRoot,
+                    physicalRoot: physicalRoot,
+                    binding: Self.binding(logicalRoot: logicalRoot, physicalRoot: physicalRoot, worktreeID: "wt-1")
+                )
+            ]
+        )
+
+        let components = try XCTUnwrap(
+            projection.projectedLogicalPathComponents(forPhysicalPath: physicalRoot.standardizedFullPath)
+        )
+
+        XCTAssertEqual(components.root, logicalRoot)
+        XCTAssertEqual(components.relativePath, "")
+    }
+
     func testSingleBoundRootDoesNotStealUnboundRootAlias() {
         let logicalRoot = WorkspaceRootRef(id: UUID(), name: "Project", fullPath: "/repo/project")
         let docsRoot = WorkspaceRootRef(id: UUID(), name: "Docs", fullPath: "/repo/docs")
@@ -113,6 +135,10 @@ final class WorkspaceRootBindingProjectionTests: XCTestCase {
         XCTAssertEqual(namespace.rootBindings[0].lookupRoot.id, storeRoot.id)
         XCTAssertEqual(Set(namespace.rootBindings[0].clientRoots.map(\.id)), Set([firstLogical.id, secondLogical.id]))
         XCTAssertEqual(namespace.rootBindings[0].preferredClientRoot.id, firstLogical.id)
+        XCTAssertEqual(
+            projection.projectedLogicalPathComponents(forPhysicalPath: physicalPath + "/Sources/App.swift")?.root.id,
+            firstLogical.id
+        )
     }
 
     func testExactFileNamespaceRetainsUnavailableNestedWorktreeBinding() {

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionPreResolvedMutationTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionPreResolvedMutationTests.swift
@@ -1,0 +1,354 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class WorkspaceSelectionPreResolvedMutationTests: XCTestCase {
+    private let untouchedFull = "/workspace/UntouchedFull.swift"
+    private let untouchedMap = "/workspace/UntouchedMap.swift"
+    private let untouchedSlice = "/workspace/UntouchedSlice.swift"
+    private let existingTarget = "/workspace/Existing.swift"
+    private let newSecond = "/workspace/NewSecond.swift"
+    private let newFirst = "/workspace/NewFirst.swift"
+
+    func testFullTargetStateIsExclusiveOrderedAndIdempotent() {
+        let service = WorkspaceSelectionMutationService(store: WorkspaceFileContextStore())
+        let base = mixedBaseSelection()
+        let paths = [newSecond, existingTarget, newFirst, newSecond]
+
+        let result = service.setPreResolvedFilePaths(base: base, absolutePaths: paths, targetState: .full)
+        let repeated = service.setPreResolvedFilePaths(base: result, absolutePaths: paths, targetState: .full)
+
+        XCTAssertEqual(result.selectedPaths, [untouchedFull, existingTarget, newSecond, newFirst])
+        XCTAssertEqual(result.manualCodemapPaths, [untouchedMap])
+        XCTAssertEqual(result.slices, [untouchedSlice: [LineRange(start: 2, end: 4)]])
+        XCTAssertTrue(result.codemapAutoEnabled)
+        XCTAssertEqual(repeated, result)
+    }
+
+    func testCodemapTargetStateIsExclusiveOrderedAndIdempotent() {
+        let service = WorkspaceSelectionMutationService(store: WorkspaceFileContextStore())
+        let base = mixedBaseSelection()
+        let paths = [newSecond, existingTarget, newFirst, newSecond]
+
+        let result = service.setPreResolvedFilePaths(base: base, absolutePaths: paths, targetState: .codemapOnly)
+        let repeated = service.setPreResolvedFilePaths(base: result, absolutePaths: paths, targetState: .codemapOnly)
+
+        XCTAssertEqual(result.selectedPaths, [untouchedFull])
+        XCTAssertEqual(result.manualCodemapPaths, [untouchedMap, existingTarget, newSecond, newFirst])
+        XCTAssertEqual(result.slices, [untouchedSlice: [LineRange(start: 2, end: 4)]])
+        XCTAssertFalse(result.codemapAutoEnabled)
+        XCTAssertEqual(repeated, result)
+    }
+
+    func testUnselectedTargetStateAtomicallyRemovesEveryRepresentation() {
+        let service = WorkspaceSelectionMutationService(store: WorkspaceFileContextStore())
+        let base = mixedBaseSelection()
+        let paths = [newSecond, existingTarget, newFirst, newSecond]
+
+        let result = service.setPreResolvedFilePaths(base: base, absolutePaths: paths, targetState: .unselected)
+        let repeated = service.setPreResolvedFilePaths(base: result, absolutePaths: paths, targetState: .unselected)
+
+        XCTAssertEqual(result.selectedPaths, [untouchedFull])
+        XCTAssertEqual(result.manualCodemapPaths, [untouchedMap])
+        XCTAssertEqual(result.slices, [untouchedSlice: [LineRange(start: 2, end: 4)]])
+        XCTAssertTrue(result.codemapAutoEnabled)
+        XCTAssertEqual(repeated, result)
+    }
+
+    func testCodemapCapabilityRuleRejectsEmptyAndUnsupportedExtensions() {
+        let rootID = UUID()
+        let swift = fileRecord(name: "App.SWIFT", rootID: rootID)
+        let extensionless = fileRecord(name: "LICENSE", rootID: rootID)
+        let unsupported = fileRecord(name: "Image.png", rootID: rootID)
+
+        XCTAssertTrue(WorkspaceSelectionMutationService.supportsCodemap(swift))
+        XCTAssertFalse(WorkspaceSelectionMutationService.supportsCodemap(extensionless))
+        XCTAssertFalse(WorkspaceSelectionMutationService.supportsCodemap(unsupported))
+    }
+
+    func testTenThousandFileTargetStateTransformScale() {
+        let count = 10000
+        let paths = (0 ..< count).map { "/workspace/File\($0).swift" }
+        let slices = Dictionary(uniqueKeysWithValues: paths.map { ($0, [LineRange(start: 1, end: 1)]) })
+        let base = StoredSelection(
+            selectedPaths: paths,
+            manualCodemapPaths: paths,
+            slices: slices,
+            codemapAutoEnabled: true
+        )
+        let service = WorkspaceSelectionMutationService(store: WorkspaceFileContextStore())
+        var result = base
+
+        measure(metrics: [XCTClockMetric()]) {
+            result = service.setPreResolvedFilePaths(
+                base: base,
+                absolutePaths: paths,
+                targetState: .unselected
+            )
+        }
+
+        XCTAssertTrue(result.selectedPaths.isEmpty)
+        XCTAssertTrue(result.manualCodemapPaths.isEmpty)
+        XCTAssertTrue(result.slices.isEmpty)
+        XCTAssertTrue(result.codemapAutoEnabled)
+    }
+
+    @MainActor
+    func testCoordinatorTargetsSuppliedInactiveIdentity() async throws {
+        let activeSelection = StoredSelection(selectedPaths: ["/workspace/Active.swift"])
+        let inactiveSelection = StoredSelection(selectedPaths: ["/workspace/Inactive.swift"])
+        let harness = PreResolvedCoordinatorHarness(
+            activeSelection: activeSelection,
+            inactiveSelection: inactiveSelection
+        )
+        let added = "/workspace/Added.swift"
+
+        let transactionValue = await harness.coordinator.setPreResolvedFilePathsInSelection(
+            [added],
+            targetState: .full,
+            for: harness.inactiveIdentity,
+            lookupContext: .visibleWorkspace
+        )
+        let transaction = try XCTUnwrap(transactionValue)
+
+        XCTAssertEqual(transaction.identity, harness.inactiveIdentity)
+        XCTAssertEqual(transaction.before, inactiveSelection)
+        XCTAssertEqual(transaction.after.selectedPaths, ["/workspace/Inactive.swift", added])
+        XCTAssertEqual(harness.selection(for: harness.activeIdentity), activeSelection)
+        XCTAssertEqual(harness.selection(for: harness.inactiveIdentity), transaction.after)
+    }
+
+    @MainActor
+    func testCoordinatorSequentialTransactionsComposeAgainstLatestCanonicalSelection() async throws {
+        let harness = PreResolvedCoordinatorHarness(activeSelection: StoredSelection())
+        let first = "/workspace/First.swift"
+        let concurrent = "/workspace/Concurrent.swift"
+        let second = "/workspace/Second.swift"
+
+        let firstTransaction = await harness.coordinator.setPreResolvedFilePathsInSelection(
+            [first],
+            targetState: .full,
+            for: harness.activeIdentity,
+            lookupContext: .visibleWorkspace
+        )
+        _ = try XCTUnwrap(firstTransaction)
+        harness.replaceSelection(
+            StoredSelection(selectedPaths: [first, concurrent]),
+            for: harness.activeIdentity
+        )
+        let transactionValue = await harness.coordinator.setPreResolvedFilePathsInSelection(
+            [second],
+            targetState: .full,
+            for: harness.activeIdentity,
+            lookupContext: .visibleWorkspace
+        )
+        let transaction = try XCTUnwrap(transactionValue)
+
+        XCTAssertEqual(transaction.before.selectedPaths, [first, concurrent])
+        XCTAssertEqual(transaction.after.selectedPaths, [first, concurrent, second])
+        XCTAssertEqual(harness.selection(for: harness.activeIdentity), transaction.after)
+    }
+
+    @MainActor
+    func testCoordinatorPersistsCanonicalSelectionBeforeReturningTransaction() async throws {
+        let harness = PreResolvedCoordinatorHarness(activeSelection: StoredSelection())
+        let added = "/workspace/Added.swift"
+
+        let transactionValue = await harness.coordinator.setPreResolvedFilePathsInSelection(
+            [added],
+            targetState: .full,
+            for: harness.activeIdentity,
+            lookupContext: .visibleWorkspace
+        )
+        let transaction = try XCTUnwrap(transactionValue)
+
+        XCTAssertEqual(harness.manager.selectionStoredByPersistence, transaction.after)
+        XCTAssertEqual(harness.selection(for: harness.activeIdentity), transaction.after)
+    }
+
+    @MainActor
+    func testCoordinatorWorktreePhysicalLogicalRoundTrip() async throws {
+        let logicalRoot = WorkspaceRootRef(id: UUID(), name: "Project", fullPath: "/repo/project")
+        let physicalRoot = WorkspaceRootRef(id: UUID(), name: "Project", fullPath: "/tmp/worktrees/project-agent")
+        let binding = AgentSessionWorktreeBinding(
+            id: "binding-1",
+            repositoryID: "repo-1",
+            repoKey: "repo-key",
+            logicalRootPath: logicalRoot.fullPath,
+            logicalRootName: logicalRoot.name,
+            worktreeID: "wt-1",
+            worktreeRootPath: physicalRoot.fullPath,
+            source: "test"
+        )
+        let projection = WorkspaceRootBindingProjection(
+            sessionID: UUID(),
+            boundRoots: [.init(logicalRoot: logicalRoot, physicalRoot: physicalRoot, binding: binding)]
+        )
+        let lookupContext = WorkspaceLookupContext(
+            rootScope: projection.lookupRootScope,
+            bindingProjection: projection
+        )
+        let logicalPath = "/repo/project/Sources/App.swift"
+        let physicalPath = "/tmp/worktrees/project-agent/Sources/App.swift"
+        let harness = PreResolvedCoordinatorHarness(
+            activeSelection: StoredSelection(
+                selectedPaths: [logicalPath],
+                slices: [logicalPath: [LineRange(start: 4, end: 8)]],
+                codemapAutoEnabled: true
+            )
+        )
+
+        let transactionValue = await harness.coordinator.setPreResolvedFilePathsInSelection(
+            [physicalPath],
+            targetState: .codemapOnly,
+            for: harness.activeIdentity,
+            lookupContext: lookupContext
+        )
+        let transaction = try XCTUnwrap(transactionValue)
+
+        XCTAssertTrue(transaction.after.selectedPaths.isEmpty)
+        XCTAssertEqual(transaction.after.manualCodemapPaths, [logicalPath])
+        XCTAssertTrue(transaction.after.slices.isEmpty)
+        XCTAssertFalse(transaction.after.codemapAutoEnabled)
+        XCTAssertEqual(harness.selection(for: harness.activeIdentity), transaction.after)
+    }
+
+    @MainActor
+    func testCoordinatorReturnsNilWhenCapturedTargetNoLongerExists() async {
+        let harness = PreResolvedCoordinatorHarness(activeSelection: StoredSelection())
+        harness.removeTab(harness.activeIdentity.tabID)
+
+        let transaction = await harness.coordinator.setPreResolvedFilePathsInSelection(
+            ["/workspace/Added.swift"],
+            targetState: .full,
+            for: harness.activeIdentity,
+            lookupContext: .visibleWorkspace
+        )
+
+        XCTAssertNil(transaction)
+    }
+
+    private func mixedBaseSelection() -> StoredSelection {
+        StoredSelection(
+            selectedPaths: [untouchedFull, existingTarget],
+            manualCodemapPaths: [untouchedMap, existingTarget],
+            slices: [
+                untouchedSlice: [LineRange(start: 2, end: 4)],
+                existingTarget: [LineRange(start: 8, end: 12)]
+            ],
+            codemapAutoEnabled: true
+        )
+    }
+
+    private func fileRecord(name: String, rootID: UUID) -> WorkspaceFileRecord {
+        WorkspaceFileRecord(
+            id: UUID(),
+            rootID: rootID,
+            name: name,
+            relativePath: name,
+            fullPath: "/workspace/\(name)",
+            parentFolderID: rootID
+        )
+    }
+}
+
+@MainActor
+private final class PreResolvedCoordinatorHarness {
+    let manager: PreResolvedSelectionHost
+    let coordinator: WorkspaceSelectionCoordinator
+    let activeIdentity: WorkspaceSelectionIdentity
+    let inactiveIdentity: WorkspaceSelectionIdentity
+
+    init(
+        activeSelection: StoredSelection,
+        inactiveSelection: StoredSelection? = nil
+    ) {
+        let workspaceID = UUID()
+        let activeTabID = UUID()
+        let inactiveTabID = UUID()
+        var tabs = [ComposeTabState(id: activeTabID, name: "Active", selection: activeSelection)]
+        if let inactiveSelection {
+            tabs.append(ComposeTabState(id: inactiveTabID, name: "Inactive", selection: inactiveSelection))
+        }
+        let workspace = WorkspaceModel(
+            id: workspaceID,
+            name: "Test Workspace",
+            repoPaths: [],
+            composeTabs: tabs,
+            activeComposeTabID: activeTabID
+        )
+        manager = PreResolvedSelectionHost(workspace: workspace)
+        coordinator = WorkspaceSelectionCoordinator(
+            workspaceManager: manager,
+            store: WorkspaceFileContextStore()
+        )
+        activeIdentity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: activeTabID)
+        inactiveIdentity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: inactiveTabID)
+    }
+
+    func selection(for identity: WorkspaceSelectionIdentity) -> StoredSelection? {
+        manager.composeTab(for: identity)?.selection
+    }
+
+    func replaceSelection(_ selection: StoredSelection, for identity: WorkspaceSelectionIdentity) {
+        manager.replaceSelection(selection, for: identity)
+    }
+
+    func removeTab(_ tabID: UUID) {
+        manager.removeTab(tabID)
+    }
+}
+
+@MainActor
+private final class PreResolvedSelectionHost: WorkspaceSelectionHost {
+    var activeWorkspace: WorkspaceModel?
+    var selectionMirrorContextRevision: UInt64 = 0
+    private(set) var selectionStoredByPersistence: StoredSelection?
+
+    init(workspace: WorkspaceModel) {
+        activeWorkspace = workspace
+    }
+
+    func composeTab(with id: UUID) -> ComposeTabState? {
+        activeWorkspace?.composeTabs.first { $0.id == id }
+    }
+
+    func composeTab(for identity: WorkspaceSelectionIdentity) -> ComposeTabState? {
+        guard activeWorkspace?.id == identity.workspaceID else { return nil }
+        return composeTab(with: identity.tabID)
+    }
+
+    func publishActiveComposeTabSnapshot(commitToMemory: Bool, touchModified: Bool) {}
+
+    func updateComposeTabStoredOnly(_ tab: ComposeTabState, inWorkspaceID workspaceID: UUID) -> Bool {
+        guard var workspace = activeWorkspace,
+              workspace.id == workspaceID,
+              let index = workspace.composeTabs.firstIndex(where: { $0.id == tab.id })
+        else { return false }
+        workspace.composeTabs[index] = tab
+        activeWorkspace = workspace
+        selectionStoredByPersistence = tab.selection
+        return true
+    }
+
+    func applySelectionMirrorAttempt(
+        _ selection: StoredSelection,
+        forTabID tabID: UUID,
+        workspaceID: UUID
+    ) async {}
+
+    func replaceSelection(_ selection: StoredSelection, for identity: WorkspaceSelectionIdentity) {
+        guard var workspace = activeWorkspace,
+              workspace.id == identity.workspaceID,
+              let index = workspace.composeTabs.firstIndex(where: { $0.id == identity.tabID })
+        else { return }
+        workspace.composeTabs[index].selection = selection
+        activeWorkspace = workspace
+    }
+
+    func removeTab(_ tabID: UUID) {
+        guard var workspace = activeWorkspace else { return }
+        workspace.composeTabs.removeAll { $0.id == tabID }
+        activeWorkspace = workspace
+    }
+}

--- a/docs/architecture/context-composer.md
+++ b/docs/architecture/context-composer.md
@@ -22,6 +22,20 @@ The native macOS inspector column is resizable and adapts to preserve useful spa
 
 The **Selections** tab presents the context selected for the current agent chat, separating full and sliced files under **Files** from codemap-only entries under **Codemaps**. Users can filter by file name, path, root, or directory and sort by name or token count. Each row identifies its workspace root and selection mode, with token, context-percentage, and line-count metrics when available. Row actions support previewing, copying, removing, changing the selection mode, clearing slices, copying paths, opening files, and revealing files in Finder. **Clear** removes all displayed selections.
 
+### Browse mode
+
+**Add** in the Selections metarow swaps the tab content into an inline workspace browser; **Done** returns to selection review. Browse mode keeps the drawer header and its token pill visible, so the running budget total stays on screen while files are added.
+
+The browser has four regions: a metarow with the browse title, transient notices, and **Done**; a search field that is focused on entry; a scope row with an **All roots** chip, one chip per loaded workspace root labeled through its logical projection, and an independent **Codemap** add-mode chip; and a bordered tree region. Roots start collapsed and expand lazily from store-backed records; `_git_data` never appears. A non-empty query replaces the tree with score-ranked results grouped by logical root and projected parent directory, capped at 300 files with a 120 ms debounce.
+
+Enabled checkboxes mutate the current chat's selection immediately — one accepted click produces exactly one identity-bound selection transaction. A checked file shows a `Full`, `Slice`, or `Map` badge and unchecks to remove all of its explicit representations; an unchecked file adds in the active mode (full file, or codemap-only when the **Codemap** chip is on). Automatically inferred codemaps render an `Auto Map` badge with an unchecked, addable checkbox. Folder and root checkboxes remain loading and disabled until expansion has resolved their descendants and membership. Once known, container checkboxes are tri-state: a mixed or empty container adds only its currently unselected selectable descendants, and a fully selected container removes every descendant representation in one transaction. In codemap mode, files without codemap support are disabled with an explanation, and global codemap disablement disables the chip while keeping removal available.
+
+Visible file rows request an approximate full-file token estimate derived from on-disk byte size. A single estimator scheduler shares a 16-read bound and deduplicated cache across concurrent requests. Folder estimates appear only when every descendant estimate is already known; expanding or rendering a container never scans file metadata to manufacture a total. Estimates in codemap mode stay visible but dimmed, because codemap cost is only known after selection. The header token pill remains the single running total and updates through the existing debounced recount after each mutation.
+
+Keyboard behavior: up/down moves between interactive rows and transfers from search into the list, left/right expands or collapses a focused container, and Space toggles the focused row. When focus is in the search field or tree, Escape clears a non-empty query or exits browse mode. Checkboxes, disclosures, chips, and notices carry domain-specific accessibility labels, values, and live-region announcements.
+
+Browse mode exits on Done, Escape with an empty query, drawer close, chat or Compose-tab switches, and lookup-context or worktree-binding changes. Selection changes for the same chat update checkbox state in place.
+
 ### Prompt
 
 The **Prompt** tab combines receiving-model instructions with clipboard packaging controls: the Standard, Plan · Architect, Review, and Manual copy presets; stored prompts; and File Tree, Code Map, and Git options. Changing File Tree, Code Map, or Git selects the Manual preset. Copy Prompt uses the current prompt text and selection when clicked.
@@ -48,6 +62,12 @@ flowchart LR
     UI --> SELECTION["WorkspaceSelectionCoordinator"]
     UI --> PROMPT["PromptViewModel"]
     UI --> BUILDER["ContextBuilderAgentViewModel"]
+    UI --> BROWSE["AgentContextFileBrowseModel"]
+    BROWSE --> BSERVICE["AgentContextFileBrowseService"]
+    BROWSE --> ESTIMATOR["AgentContextFileSizeEstimator"]
+    BSERVICE --> CONTEXT
+    BSERVICE --> SEARCH["WorkspaceSearchService"]
+    BROWSE --> SELECTION
 ```
 
 `AgentModeDetailWithSidebarView` mounts the native inspector beside the chat. `AgentContextInspectorPresenter` connects its visibility to the presentation store, and `AgentContextControlDrawerView` owns the tab shell and selected-context model lifecycle.
@@ -66,6 +86,10 @@ flowchart LR
 
 **Explicit readiness.** Counts and metrics carry readiness independently. Unknown values remain pending rather than appearing as zero, and the header token estimate appears only for a complete, current selection snapshot.
 
+**Identity-bound browse mutations.** A browse session captures the chat's `WorkspaceSelectionIdentity` and `WorkspaceLookupContext` when it begins. `AgentContextInspectorPresenter` owns the retained browse model across drawer presentation and Files, Prompt, and Context Builder tab changes. The Files tab continuously updates that model with the current route proof, and an enabled checkbox click is accepted only when that proof matches the captured selection identity and lookup/worktree route. The accepted request then revalidates its store-derived records and applies one `setPreResolvedFilePathsInSelection` transaction against the captured identity. Done, Escape, drawer close, or a subsequent chat switch cancels presentation work but does not cancel that accepted transaction. Review-mode Add, Clear, and row actions for that identity remain disabled until its accepted browse mutations finish. Checkboxes derive purely from the authoritative selection projected through the captured lookup context — there is no optimistic UI state — so rejected clicks leave nothing stale, same-route selection refreshes update in place, and worktree-bound chats browse logical root names while mutating exact physical paths.
+
+**Generation-fenced browse work.** Search, hierarchy loading, and token estimates all carry session and request generations; results publish only when both still match. Each hierarchy load obtains one root tree index and returns direct children plus descendants from the same applied root generation and catalog snapshot. A catalog-generation change fails the browse session closed and asks the user to select Done and browse again, so cached hierarchy and search results are never reconciled across catalog snapshots. Search, tree loading, and mutation revalidation preserve session-root unavailability as a typed browse state instead of presenting it as empty results or stale records, including when a worktree binding projection is not fully materialized. Chat switches, drawer close, switch blanking, and lookup-context changes end the browse session, cancel presentation work, and clear accepted model generations. The next browse session prunes service and estimator caches to its current route's roots. Accepted mutation requests continue through revalidation and their captured identity-bound transaction when the catalog remains current.
+
 ## State ownership
 
 | Concern | Owner |
@@ -77,6 +101,9 @@ flowchart LR
 | Instructions, copy configuration, and token counting | `PromptViewModel` |
 | Context Builder execution and generated output | `ContextBuilderAgentViewModel` |
 | Selected-context loading, readiness, caching, and mutation gating | `AgentSelectedFilesModelCoordinator` |
+| Browse-session phase, query, scope, hierarchy, focus, notices, and mutation ordering | `AgentContextFileBrowseModel` |
+| Store-backed browse roots, lazy tree indexes, search, and record revalidation | `AgentContextFileBrowseService` |
+| File metadata reads and byte-size token estimates | `AgentContextFileSizeEstimator` |
 
 ## Selected-context model
 
@@ -101,6 +128,12 @@ make dev-test FILTER=AgentContextDrawerUIStoreTests
 make dev-test FILTER=AgentContextExportResolverTests
 make dev-test FILTER=AgentSelectedFilesModelCoordinatorTests
 make dev-test FILTER=AgentContextInspectorColumnSizingTests
+make dev-test FILTER=AgentContextFileBrowseServiceTests
+make dev-test FILTER=AgentContextFileBrowseModelTests
+make dev-test FILTER=AgentContextFileSizeEstimatorTests
+make dev-test FILTER=TokenCalculationServiceByteEstimateTests
+make dev-test FILTER=WorkspaceSelectionPreResolvedMutationTests
+make dev-test FILTER=AgentModeChatSwitchActivationTests
 ```
 
 Selection-card presentation, token accounting, Git actions, and chat-switch behavior have additional focused coverage in `AgentContextSelectedFileCardTests`, `TokenCountingViewModelTests`, `GitViewModelSelectionClearTests`, and `AgentModeChatSwitchActivationTests`. Use the contribution matrix in [`../../AGENTS.md`](../../AGENTS.md) for repository-wide lint, build, and PR-ready gates. Because Context Composer is running-app Agent Mode UI, also follow the live CE MCP smoke flow there when behavior changes.
@@ -111,6 +144,10 @@ Selection-card presentation, token accounting, Git actions, and chat-switch beha
 - `Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/` — Context Composer shell, tabs, selected-context rows, previews, and click-time export context.
 - `Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextDrawerUIStore.swift` — presentation and runtime detail state.
 - `Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift` — context-aware loading, caching, readiness, and mutation gating.
+- `Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextFileBrowseModel.swift` — browse-session lifecycle, selection projection, tri-state membership, and ordered immediate mutations.
+- `Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextFileBrowseView.swift` — browse-mode metarow, search field, scope chips, tree and search rows, keyboard, and accessibility.
+- `Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileBrowseService.swift` — store-backed root enumeration, lazy tree indexes, projected search, and mutation-time record revalidation.
+- `Sources/RepoPrompt/Features/AgentMode/Services/AgentContextFileSizeEstimator.swift` — bounded-concurrency file metadata reads and byte-size token estimates.
 - `Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift` — selection resolution, previews, metrics, and clipboard assembly.
 - `Sources/RepoPrompt/Features/AgentMode/Services/AgentSelectedFilesDiagnostics.swift` — opt-in selected-context loading and readiness diagnostics.
 - `Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift` — active-tab selection mutation.


### PR DESCRIPTION
I and a few others in the Discord have expressed interest in being able to manually add files and codemaps to the selected-set of RPCE’s Context Composer, like we can in RP Classic’s IDE mode.  So this patch adds an inline file browser to the Selections tab without introducing another window or modal.  I went with the design option `A` discussed on Discord [here](https://discord.com/channels/1262487703744675901/1537656079125844028).

## UX Notes
- The basic flow: click **Add** to replace the selection review with the browser, then click **Done** to return to the selection review
- Changes to the selected-set apply immediately
- The search field receives focus when the browser opens
- When you return to the file browser after exiting it, it recovers your prior folded/unfolded states of folders in each root
- There are also some keyboard controls added while focus is on the inline browser:
  - **Up / Down:** move between the search field and file-tree rows
  - **Left / Right:** collapse or expand the focused folder
  - **Space:** toggle the focused file, folder, or root
  - **Escape:** clear the current search; press again to return to selection review

## Summary

- Browse expandable workspace roots, folders, and files
- Fuzzy-search files across all roots or within one selected root
- Switch between adding full files and codemap-only entries
- Add or remove individual files through immediate checkboxes
- Add or remove resolved folders in bulk, with none/some/all selection states
- Preserve expanded folders when returning to the browser in the same chat
- Show existing Full, Slice, Map, and Auto Map states
- Show approximate full-file token costs while the header continues to report the current overall context size
- Keep selection controls usable while the global token estimate recalculates

## Implementation Notes

- File discovery and fuzzy matching use the existing workspace index and search infrastructure
- Selection changes remain owned by `WorkspaceSelectionCoordinator` and apply to the latest selection for the active chat
- Browse sessions remain bound to their originating chat and worktree, and stop editing when that target is no longer current
- Files are rechecked against the workspace index before mutation so deleted or replaced entries are not applied
- File-size estimates run outside the main actor and do not block selection changes

## Review Approach

- Focused maintainability and complete-patch reviews covered selection ordering, chat and worktree ownership, filesystem changes, multi-root presentation, accessibility, and SwiftUI lifecycle
- Verified findings were covered with focused regressions, and the hierarchy-loading path was simplified to avoid unnecessary concurrency machinery

## Validation

Passed locally:

- `make dev-test FILTER=AgentContextFileBrowse`
- `make dev-test FILTER=AgentSelectedFilesModelCoordinatorTests`
- `make dev-test FILTER=AgentModeChatSwitchActivationTests`
- `make dev-test FILTER=WorkspaceSelectionPreResolvedMutationTests`
- `make dev-test FILTER=WorkspaceRootBindingProjectionTests`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make guardrails`
- `make dev-smoke`
- Commit and exact one-commit outgoing-range secret scans

The full root suite was also run. Remaining failures were in unrelated Codex timing, Context Builder timeout, and Git worktree-policy tests; all feature-focused suites passed.

I also manually validated the complete flow in the live CE debug app, including:
- adding and removing files, codemaps, and entire folders, via both mouse and keyboard actions, and from multiple roots in a multi-root workspace
- repeated selection changes while the global token estimate was recalculating
- asking Context Builder to update the Prompt with descriptions of newly manually added files

## Screenshots

<p align="center">
<img width="791" height="622" alt="Screenshot 2026-08-16 at 5 23 04 AM" src="https://github.com/user-attachments/assets/1fa0a122-e9b8-4ea9-8b58-daa5cf040fde" />
<img width="787" height="1040" alt="Screenshot 2026-08-16 at 5 09 29 AM" src="https://github.com/user-attachments/assets/5c9c9a39-3acb-4436-b106-0251d3e5717a" />
<img width="788" height="1033" alt="Screenshot 2026-08-16 at 5 09 44 AM" src="https://github.com/user-attachments/assets/4a2cd027-c802-4404-99a9-8e930390e6cd" />
<img width="795" height="284" alt="Screenshot 2026-08-16 at 5 09 51 AM" src="https://github.com/user-attachments/assets/6403be4b-0170-4641-9f38-c1a80c944e88" />
</p>