### PR TITLE
Fix: expose global skills to Codex agents

### DIFF
--- a/Scripts/Fixtures/codex-app-server-contract.json
+++ b/Scripts/Fixtures/codex-app-server-contract.json
@@ -133,6 +133,14 @@
     },
     {
       "union": "ClientRequest.json",
+      "method": "skills/extraRoots/set",
+      "alwaysSent": [
+        "extraRoots"
+      ],
+      "responseSchema": "v2/SkillsExtraRootsSetResponse.json"
+    },
+    {
+      "union": "ClientRequest.json",
       "method": "thread/start",
       "alwaysSent": [
         "approvalPolicy",

--- a/Scripts/test_codex_app_server_schema.py
+++ b/Scripts/test_codex_app_server_schema.py
@@ -88,6 +88,7 @@ class CodexAppServerSchemaGateTests(unittest.TestCase):
             ("ClientRequest.json", "account/login/start"),
             ("ClientRequest.json", "account/login/cancel"),
             ("ClientRequest.json", "model/list"),
+            ("ClientRequest.json", "skills/extraRoots/set"),
             ("ClientRequest.json", "thread/start"),
             ("ClientRequest.json", "thread/resume"),
             ("ClientRequest.json", "thread/memoryMode/set"),
@@ -128,7 +129,7 @@ class CodexAppServerSchemaGateTests(unittest.TestCase):
             ("ServerRequest.json", "item/fileChange/requestApproval"),
         }
 
-        self.assertEqual(len(checks), 42)
+        self.assertEqual(len(checks), 43)
         self.assertEqual({(check["union"], check["method"]) for check in checks}, expected)
 
     def test_bundle_validation_accepts_declared_fields_nested_paths_and_enum(self) -> None:

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -567,6 +567,9 @@ final class CodexNativeSessionController {
         var reasoningSummariesEnabledProvider: @MainActor () -> Bool = { false }
         var memoriesEnabledProvider: (@MainActor () -> Bool)?
         var computerUseEnabledProvider: @MainActor () -> Bool = { false }
+        var skillExtraRootsProvider: () -> [URL] = {
+            [AgentSupportDirectoryCatalog.globalRootURLs().agentsSkills]
+        }
 
         /// Fail-closed RepoPrompt MCP provisioning validator, applied by `startOrResume` only for a
         /// child that expects RepoPrompt MCP tools; throwing aborts the start before any process
@@ -1288,6 +1291,13 @@ final class CodexNativeSessionController {
                 throw error
             }
             await ensureInboundStreamsStarted()
+
+            let skillExtraRoots = options.skillExtraRootsProvider().map(\.standardizedFileURL.path)
+            _ = try await performRequest(
+                method: "skills/extraRoots/set",
+                params: ["extraRoots": skillExtraRoots],
+                timeout: options.requestTimeout
+            )
 
             if let resumeThreadID {
                 let desiredMemoryMode: ThreadMemoryMode? = await MainActor.run {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -567,9 +567,7 @@ final class CodexNativeSessionController {
         var reasoningSummariesEnabledProvider: @MainActor () -> Bool = { false }
         var memoriesEnabledProvider: (@MainActor () -> Bool)?
         var computerUseEnabledProvider: @MainActor () -> Bool = { false }
-        var skillExtraRootsProvider: () -> [URL] = {
-            [AgentSupportDirectoryCatalog.globalRootURLs().agentsSkills]
-        }
+        var skillExtraRootsProvider: () -> [URL] = { [] }
 
         /// Fail-closed RepoPrompt MCP provisioning validator, applied by `startOrResume` only for a
         /// child that expects RepoPrompt MCP tools; throwing aborts the start before any process
@@ -629,7 +627,10 @@ final class CodexNativeSessionController {
                 goalSupportEnabledProvider: goalSupportEnabledProvider,
                 reasoningSummariesEnabledProvider: reasoningSummariesEnabledProvider,
                 memoriesEnabledProvider: memoriesEnabledProvider,
-                computerUseEnabledProvider: computerUseEnabledProvider
+                computerUseEnabledProvider: computerUseEnabledProvider,
+                skillExtraRootsProvider: {
+                    [AgentSupportDirectoryCatalog.globalRootURLs().agentsSkills]
+                }
             )
         }
     }
@@ -1293,11 +1294,13 @@ final class CodexNativeSessionController {
             await ensureInboundStreamsStarted()
 
             let skillExtraRoots = options.skillExtraRootsProvider().map(\.standardizedFileURL.path)
-            _ = try await performRequest(
-                method: "skills/extraRoots/set",
-                params: ["extraRoots": skillExtraRoots],
-                timeout: options.requestTimeout
-            )
+            if !skillExtraRoots.isEmpty {
+                _ = try await performRequest(
+                    method: "skills/extraRoots/set",
+                    params: ["extraRoots": skillExtraRoots],
+                    timeout: options.requestTimeout
+                )
+            }
 
             if let resumeThreadID {
                 let desiredMemoryMode: ThreadMemoryMode? = await MainActor.run {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
@@ -911,18 +911,9 @@ final class CodexCLIProvider: AIProvider {
             preconditionFailure("CodexCLIProvider requires an app-server client when no custom session controller factory is provided.")
         }
 
-        let interactiveConfigOverrides = interactiveConfigOverrides(excludeServers: excludeServers)
-        let options = CodexNativeSessionController.Options(
-            requestTimeout: requestTimeout,
-            configOverridesProvider: { interactiveConfigOverrides },
-            approvalPolicyProvider: { .never },
-            sandboxModeProvider: { .readOnly },
-            approvalReviewerProvider: { .user },
-            authTokensRefreshHandler: nil,
-            goalSupportEnabledProvider: { false },
-            reasoningSummariesEnabledProvider: { false },
-            memoriesEnabledProvider: { false },
-            computerUseEnabledProvider: { false }
+        let options = interactiveSessionOptions(
+            excludeServers: excludeServers,
+            requestTimeout: requestTimeout
         )
 
         return CodexNativeSessionController(
@@ -993,6 +984,25 @@ final class CodexCLIProvider: AIProvider {
             overrides[key] = value
         }
         return overrides
+    }
+
+    func interactiveSessionOptions(
+        excludeServers: Set<String>,
+        requestTimeout: TimeInterval
+    ) -> CodexNativeSessionController.Options {
+        let configOverrides = interactiveConfigOverrides(excludeServers: excludeServers)
+        return CodexNativeSessionController.Options(
+            requestTimeout: requestTimeout,
+            configOverridesProvider: { configOverrides },
+            approvalPolicyProvider: { .never },
+            sandboxModeProvider: { .readOnly },
+            approvalReviewerProvider: { .user },
+            authTokensRefreshHandler: nil,
+            goalSupportEnabledProvider: { false },
+            reasoningSummariesEnabledProvider: { false },
+            memoriesEnabledProvider: { false },
+            computerUseEnabledProvider: { false }
+        )
     }
 
     private func appServerSelection(

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPBootstrapReadinessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPBootstrapReadinessTests.swift
@@ -192,7 +192,9 @@ final class CodexMCPBootstrapReadinessTests: XCTestCase {
         ])
         let gate = ProvisionerSuspensionGate()
         let provisionedRuntime = ProvisionedRuntimeRecorder()
+        let expectedSkillRoot = directory.appendingPathComponent("global-skills", isDirectory: true)
         var options = makeAgentModeOptions()
+        options.skillExtraRootsProvider = { [expectedSkillRoot] }
         // Park the provisioner so the ordering can be observed: nothing downstream may happen while
         // it is suspended.
         options.repoPromptMCPProvisioner = { runtime in
@@ -229,7 +231,13 @@ final class CodexMCPBootstrapReadinessTests: XCTestCase {
         let processRunning = await client.debugIsProcessRunning()
         XCTAssertTrue(processRunning, "a successful provisioner lets the app-server process start")
         XCTAssertEqual(registrar.registeredClientNames, [expectedClientName], "the launched process registers its expected-agent PID")
-        XCTAssertEqual(requests.methods, ["thread/start"], "the only controller request after a successful start is thread/start")
+        XCTAssertEqual(
+            requests.methods,
+            ["skills/extraRoots/set", "thread/start"],
+            "global skill roots must be registered before the thread starts"
+        )
+        let skillRootParams = try XCTUnwrap(requests.params(for: "skills/extraRoots/set"))
+        XCTAssertEqual(skillRootParams["extraRoots"] as? [String], [expectedSkillRoot.path])
 
         let runtime = try XCTUnwrap(provisionedRuntime.runtime)
         XCTAssertEqual(runtime.source, .externalOverride)
@@ -343,7 +351,7 @@ private final class CallCounter: @unchecked Sendable {
 /// returns a canned `thread/start` result so a session can bind without a real app-server response.
 private final class RecordedRequests: @unchecked Sendable {
     private let lock = NSLock()
-    private var recorded: [String] = []
+    private var recorded: [(method: String, params: [String: Any]?)] = []
     private let threadStartResult: [String: Any]
 
     init(threadStartResult: [String: Any] = [:]) {
@@ -351,9 +359,9 @@ private final class RecordedRequests: @unchecked Sendable {
     }
 
     var executor: @Sendable (String, [String: Any]?, TimeInterval?) async throws -> [String: Any] {
-        { [self] method, _, _ in
+        { [self] method, params, _ in
             lock.lock()
-            recorded.append(method)
+            recorded.append((method: method, params: params))
             lock.unlock()
             return method == "thread/start" ? threadStartResult : [:]
         }
@@ -362,7 +370,13 @@ private final class RecordedRequests: @unchecked Sendable {
     var methods: [String] {
         lock.lock()
         defer { lock.unlock() }
-        return recorded
+        return recorded.map(\.method)
+    }
+
+    func params(for method: String) -> [String: Any]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded.first { $0.method == method }?.params
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPBootstrapReadinessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPBootstrapReadinessTests.swift
@@ -192,9 +192,8 @@ final class CodexMCPBootstrapReadinessTests: XCTestCase {
         ])
         let gate = ProvisionerSuspensionGate()
         let provisionedRuntime = ProvisionedRuntimeRecorder()
-        let expectedSkillRoot = directory.appendingPathComponent("global-skills", isDirectory: true)
+        let expectedSkillRoot = AgentSupportDirectoryCatalog.globalRootURLs().agentsSkills
         var options = makeAgentModeOptions()
-        options.skillExtraRootsProvider = { [expectedSkillRoot] }
         // Park the provisioner so the ordering can be observed: nothing downstream may happen while
         // it is suspended.
         options.repoPromptMCPProvisioner = { runtime in

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
@@ -776,6 +776,23 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
         }
     }
 
+    func testStandardCodexProviderDoesNotRegisterAgentModeSkillRoots() async throws {
+        let provider = CodexCLIProvider(
+            defaultRequestTimeout: 5,
+            testRequestTimeout: 5,
+            maxRetries: 0,
+            appServerReadyHook: {}
+        )
+        let options = provider.interactiveSessionOptions(excludeServers: [], requestTimeout: 5)
+        let (controller, recordURL) = try await makeController(options: options)
+
+        _ = try await controller.startOrResume(existing: nil, baseInstructions: "Chat")
+        await controller.shutdown()
+
+        XCTAssertEqual(try recordedRequests(for: "skills/extraRoots/set", at: recordURL).count, 0)
+        XCTAssertEqual(try recordedRequests(for: "thread/start", at: recordURL).count, 1)
+    }
+
     func testSchemaAlignedThreadRequestsOmitUndeclaredFieldsAndAcceptMissingGoal() async throws {
         let (startController, startRecordURL) = try await makeController(options: makeOptions())
         _ = try await startController.startOrResume(


### PR DESCRIPTION
Fixes https://github.com/repoprompt/repoprompt-ce/issues/821.  Codex Agent Mode now registers RepoPrompt CE's global skill directory with the Codex app-server before starting or resuming a thread.  Fresh Codex agents can discover and load enabled skills from `~/.agents/skills` without users needing to add that directory as a workspace root.  Existing `/skill-name` invocation continues to work.

## Validation

- Focused Codex bootstrap tests
- Codex app-server schema check
- Swift lint and debug build
- Push safety and outgoing-range secret scans

I also manually validated the full flow in a fresh Codex Agent Mode thread, confirming that it's now able to discover my global skills and could read them directly from `~/.agents/skills` without that directory being a workspace root.

The full root suite was also run.  Remaining failures were in unrelated Agent-run, Codex liveness, and Git-policy tests.