### PR TITLE
Fix Codex session disconnect during worktree rebinding

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -950,6 +950,15 @@ extension AgentModeViewModel {
         case blocked(String)
     }
 
+    /// Exact routed provider request that initiated an external binding mutation.
+    /// This is transient execution identity, never durable binding authority.
+    struct WorktreeBindingMutationInvocationIdentity: Equatable {
+        let connectionID: UUID
+        let sessionID: UUID
+        let runID: UUID
+        let provider: AgentProviderKind
+    }
+
     enum WorktreeBindingTransitionIntent {
         case initialSend
         case userExecutionLocationChange(confirmation: ExecutionLocationChangeConfirmation?)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -6636,6 +6636,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         _ desiredBindings: [AgentSessionWorktreeBinding],
         forSessionID sessionID: UUID,
         intent: WorktreeBindingTransitionIntent,
+        invocation: WorktreeBindingMutationInvocationIdentity? = nil,
         startupContext: WorktreeStartupContext? = nil,
         initializationHintsByBindingID: [String: WorkspaceRootMaterializationHint] = [:]
     ) async throws -> [AgentSessionWorktreeBinding] {
@@ -6654,6 +6655,12 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         let previousDestination = executionDestinationIdentity(in: previousBindings)
         let nextDestination = executionDestinationIdentity(in: desiredBindings)
         let changedDuringActiveRun = session.runState.isActive
+        let preservesInvokingCodexController = shouldPreserveInvokingCodexController(
+            for: session,
+            intent: intent,
+            invocation: invocation,
+            destinationChanged: previousDestination != nextDestination
+        )
 
         if changedDuringActiveRun, previousDestination != nextDestination {
             switch intent {
@@ -6728,7 +6735,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 if !changedDuringActiveRun {
                     await stageResumeRecoveryHandoffIfNeeded(for: session)
                 }
-                await invalidateProviderContextForExecutionLocationChange(session)
+                if !preservesInvokingCodexController {
+                    await invalidateProviderContextForExecutionLocationChange(session)
+                }
                 guard sessions[session.tabID] === session,
                       session.activeAgentSessionID == sessionID,
                       session.worktreeBindings == previousBindings,
@@ -6876,6 +6885,29 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             }
             throw error
         }
+    }
+
+    /// Preserves only the exact Codex process currently executing an externally routed
+    /// binding mutation. The existing controller workspace-path key forces replacement
+    /// before the next turn can run at the newly committed execution destination.
+    private func shouldPreserveInvokingCodexController(
+        for session: TabSession,
+        intent: WorktreeBindingTransitionIntent,
+        invocation: WorktreeBindingMutationInvocationIdentity?,
+        destinationChanged: Bool
+    ) -> Bool {
+        guard destinationChanged,
+              case .externalManagement = intent,
+              let invocation,
+              invocation.provider == .codexExec,
+              invocation.sessionID == session.activeAgentSessionID,
+              invocation.runID == session.runID,
+              session.selectedAgent == .codexExec,
+              session.codexController != nil
+        else {
+            return false
+        }
+        return true
     }
 
     private func invalidateProviderContextForExecutionLocationChange(_ session: TabSession) async {

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWorktreeToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWorktreeToolProvider.swift
@@ -221,7 +221,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
     private func executeCreate(args: [String: Value]) async throws -> ToolResultDTOs.ManageWorktreeReplyDTO {
         let context = try await resolveRepositoryContext(args: args)
         let bindAfterCreate = parseBool(args["bind"]) ?? false
-        let sessionID = bindAfterCreate ? try await resolveBindingSessionID(args: args) : nil
+        let bindingRequest = bindAfterCreate ? try await resolveBindingRequest(args: args) : nil
+        let sessionID = bindingRequest?.sessionID
 
         if let sessionID {
             try validateLiveSession(sessionID, in: dependencies.execution.requireTargetWindow())
@@ -304,7 +305,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
                     context: context,
                     visualIdentity: identity,
                     args: args,
-                    source: "manage_worktree.create"
+                    source: "manage_worktree.create",
+                    invocation: bindingRequest?.invocation
                 )
                 bindingDTO = bindingResult.binding
                 previousDTO = bindingResult.previous
@@ -339,7 +341,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
             visibleRoots: context.visibleRoots,
             requireExplicit: true
         )
-        let sessionID = try await resolveBindingSessionID(args: args)
+        let bindingRequest = try await resolveBindingRequest(args: args)
+        let sessionID = bindingRequest.sessionID
         try validateLiveSession(sessionID, in: dependencies.execution.requireTargetWindow())
         let repositoryRoot = try await logicalRoot(for: context)
         let worktreeRoot = try await logicalRoot(for: worktree, context: context)
@@ -355,7 +358,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
             context: context,
             visualIdentity: identity,
             args: args,
-            source: op == .select ? "manage_worktree.select" : "manage_worktree.bind"
+            source: op == .select ? "manage_worktree.select" : "manage_worktree.bind",
+            invocation: bindingRequest.invocation
         )
         let dto = try await worktreeDTO(worktree, visualIdentity: identity, includeStatus: parseBool(args["include_status"]) ?? false)
         return ToolResultDTOs.ManageWorktreeReplyDTO(
@@ -369,7 +373,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
     }
 
     private func executeUnbind(args: [String: Value]) async throws -> ToolResultDTOs.ManageWorktreeReplyDTO {
-        let sessionID = try await resolveBindingSessionID(args: args)
+        let bindingRequest = try await resolveBindingRequest(args: args)
+        let sessionID = bindingRequest.sessionID
         let targetWindow = try dependencies.execution.requireTargetWindow()
         let agentModeVM = targetWindow.agentModeViewModel
         let existing = agentModeVM.worktreeBindings(forAgentSessionID: sessionID)
@@ -412,7 +417,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
             _ = try await agentModeVM.transitionWorktreeBindings(
                 remaining,
                 forSessionID: sessionID,
-                intent: .externalManagement
+                intent: .externalManagement,
+                invocation: bindingRequest.invocation
             )
         }
 
@@ -432,7 +438,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
         context: RepositoryContext,
         visualIdentity: WorktreeVisualIdentity,
         args: [String: Value],
-        source: String
+        source: String,
+        invocation: AgentModeViewModel.WorktreeBindingMutationInvocationIdentity?
     ) async throws -> (binding: ToolResultDTOs.ManageWorktreeReplyDTO.BindingDTO, previous: ToolResultDTOs.ManageWorktreeReplyDTO.BindingDTO?) {
         let targetWindow = try dependencies.execution.requireTargetWindow()
         let agentModeVM = targetWindow.agentModeViewModel
@@ -471,7 +478,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
         _ = try await agentModeVM.transitionWorktreeBindings(
             desiredBindings,
             forSessionID: sessionID,
-            intent: .externalManagement
+            intent: .externalManagement,
+            invocation: invocation
         )
         let previousDTO = previous.flatMap { $0.worktreeID == binding.worktreeID ? nil : bindingDTO($0) }
         return (bindingDTO(binding), previousDTO)
@@ -482,23 +490,57 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
         try agentModeVM.requireLiveAgentSession(sessionID)
     }
 
-    private func resolveBindingSessionID(args: [String: Value]) async throws -> UUID {
+    private struct BindingRequest {
+        let sessionID: UUID
+        let invocation: AgentModeViewModel.WorktreeBindingMutationInvocationIdentity?
+    }
+
+    private func resolveBindingRequest(args: [String: Value]) async throws -> BindingRequest {
+        let metadata = await dependencies.context.captureRequestMetadata()
+        let explicitSessionID: UUID?
         if let raw = trimmedString(args["session_id"]) {
             guard let uuid = UUID(uuidString: raw) else {
                 throw MCPError.invalidParams("session_id must be a UUID. Received: \(raw)")
             }
-            return uuid
+            explicitSessionID = uuid
+        } else {
+            explicitSessionID = nil
         }
 
-        let metadata = await dependencies.context.captureRequestMetadata()
-        let resolved = try dependencies.context.resolveTabContextSnapshot(
-            metadata,
-            MCPWindowToolName.manageWorktree
-        )
-        guard let sessionID = resolved.snapshot.activeAgentSessionID else {
+        let resolved: MCPServerViewModel.ResolvedTabContextSnapshot? = if explicitSessionID == nil {
+            try dependencies.context.resolveTabContextSnapshot(
+                metadata,
+                MCPWindowToolName.manageWorktree
+            )
+        } else {
+            try? dependencies.context.resolveTabContextSnapshot(
+                metadata,
+                MCPWindowToolName.manageWorktree
+            )
+        }
+        guard let sessionID = explicitSessionID ?? resolved?.snapshot.activeAgentSessionID else {
             throw MCPError.invalidParams("session_id is required because current MCP routing does not resolve an active Agent session.")
         }
-        return sessionID
+
+        let invocation: AgentModeViewModel.WorktreeBindingMutationInvocationIdentity? = if metadata.runPurpose == .agentModeRun,
+                                                                                           MCPClientIdentity.matches(
+                                                                                               metadata.clientName,
+                                                                                               AgentProviderKind.codexMCPClientID
+                                                                                           ),
+                                                                                           let connectionID = metadata.connectionID,
+                                                                                           let invokingSessionID = resolved?.snapshot.activeAgentSessionID,
+                                                                                           let runID = resolved?.snapshot.runID
+        {
+            .init(
+                connectionID: connectionID,
+                sessionID: invokingSessionID,
+                runID: runID,
+                provider: .codexExec
+            )
+        } else {
+            nil
+        }
+        return BindingRequest(sessionID: sessionID, invocation: invocation)
     }
 
     // MARK: - Repository and worktree resolution

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -2719,6 +2719,99 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         XCTAssertEqual(session.providerSessionID, "managed-old-identity")
     }
 
+    func testCodexOriginatedExternalUnbindPreservesInvokingControllerUntilNextSessionPreparation() async throws {
+        let root = try makeTemporaryDirectory(named: "managed-codex-origin-root")
+        let worktree = try makeTemporaryDirectory(named: "managed-codex-origin-worktree")
+        var createdPaths: [CodexRuntimeWorkspacePaths] = []
+        let viewModel = AgentModeViewModel(
+            testWorkspacePath: root.path,
+            codexControllerFactory: { _, _, _, workspacePaths, _, _ in
+                createdPaths.append(workspacePaths)
+                return ReplacementIdentityFakeCodexController()
+            }
+        )
+        viewModel.test_initializeRunService()
+        let session = viewModel.session(for: UUID())
+        let sessionID = UUID()
+        session.testInstallPersistentSessionBinding(sessionID: sessionID)
+        session.selectedAgent = .codexExec
+        session.worktreeBindings = [makeBinding(logicalRoot: root.path, worktreeRoot: worktree.path)]
+
+        await viewModel.test_codexCoordinator.ensureCodexNativeSession(session: session)
+        let invokingRunID = try XCTUnwrap(session.runID)
+        let invokingController = try XCTUnwrap(
+            session.codexController as? ReplacementIdentityFakeCodexController
+        )
+        session.runState = .completed
+
+        _ = try await viewModel.transitionWorktreeBindings(
+            [],
+            forSessionID: sessionID,
+            intent: .externalManagement,
+            invocation: .init(
+                connectionID: UUID(),
+                sessionID: sessionID,
+                runID: invokingRunID,
+                provider: .codexExec
+            )
+        )
+
+        XCTAssertTrue(session.worktreeBindings.isEmpty)
+        XCTAssertEqual(controllerIdentity(in: session), ObjectIdentifier(invokingController))
+        XCTAssertEqual(invokingController.shutdownCallCount, 0)
+
+        await viewModel.test_codexCoordinator.ensureCodexNativeSession(session: session)
+        XCTAssertEqual(invokingController.shutdownCallCount, 1)
+        XCTAssertEqual(createdPaths.count, 2)
+        XCTAssertEqual(createdPaths.last, .uniform(root.path))
+        XCTAssertNotEqual(controllerIdentity(in: session), ObjectIdentifier(invokingController))
+        await viewModel.test_codexCoordinator.shutdownCodexSession(session)
+    }
+
+    func testCodexOriginatedExternalMutationDoesNotDeferInvalidationForUnrelatedSession() async throws {
+        let root = try makeTemporaryDirectory(named: "managed-unrelated-root")
+        let worktree = try makeTemporaryDirectory(named: "managed-unrelated-worktree")
+        let viewModel = makeViewModel(workspacePath: root.path)
+        viewModel.test_initializeRunService()
+        let invokingSession = viewModel.session(for: UUID())
+        let invokingSessionID = UUID()
+        let invokingRunID = UUID()
+        invokingSession.testInstallPersistentSessionBinding(sessionID: invokingSessionID)
+        invokingSession.selectedAgent = .codexExec
+        invokingSession.installRunID(invokingRunID)
+
+        let targetSession = viewModel.session(for: UUID())
+        let targetSessionID = UUID()
+        let targetRunID = UUID()
+        let targetController = ReplacementIdentityFakeCodexController()
+        targetSession.testInstallPersistentSessionBinding(sessionID: targetSessionID)
+        targetSession.selectedAgent = .codexExec
+        targetSession.installRunID(targetRunID)
+        targetSession.codexController = targetController
+        targetSession.codexControllerWorkspacePaths = .worktreeBound(
+            logicalRootPath: root.path,
+            validatedWorktreeRootPath: worktree.path
+        )
+        targetSession.worktreeBindings = [makeBinding(logicalRoot: root.path, worktreeRoot: worktree.path)]
+        targetSession.runState = .completed
+
+        _ = try await viewModel.transitionWorktreeBindings(
+            [],
+            forSessionID: targetSessionID,
+            intent: .externalManagement,
+            invocation: .init(
+                connectionID: UUID(),
+                sessionID: invokingSessionID,
+                runID: invokingRunID,
+                provider: .codexExec
+            )
+        )
+
+        XCTAssertTrue(targetSession.worktreeBindings.isEmpty)
+        XCTAssertNil(targetSession.codexController)
+        XCTAssertEqual(targetController.shutdownCallCount, 1)
+    }
+
     func testAgentStartExplicitWorktreeIDOverridesInheritedBindingAcrossRunExploreAndExplicitTab() async throws {
         let fixture = try makeGitFixture()
         let parentWorktree = fixture.sandbox.appendingPathComponent("parent-worktree", isDirectory: true)


### PR DESCRIPTION
## Summary

- capture the exact routed Codex invocation identity for external `manage_worktree` binding mutations
- preserve only the invoking Codex controller long enough for the mutation reply to settle
- rely on the existing workspace-path identity check to retire and recreate that controller before the next turn
- retain immediate provider invalidation for unrelated sessions and non-Codex callers
- add regression coverage for both invoking-session continuity and unrelated-session invalidation

## Root cause

`manage_worktree select`, `bind`, and `unbind` could synchronously invalidate the provider context for the session issuing the MCP request. For Codex-originated calls, that shut down the same controller carrying the tool invocation before the reply settled, producing post-commit partial success and leaving the run idle/disconnected.

## Validation

- contribution commit and push preflights: passed
- staged and outgoing-range secret scans: passed
- repository guardrails: passed
- strict Swift lint: passed
- focused Codex worktree continuity regression tests: passed
- `swift build --product RepoPrompt`: passed
- full root suite: completed with two unrelated transient failures:
  - `CodemapBindingEngineWarmManifestTests/testSourceAuthorityDemandSurvivesOrdinaryGitChurnAfterRegistration`
  - `ContextBuilderMCPProgressTimelineTests/testContextBuilderToolProviderUsesCallerPromptWithoutMutatingDiscoveryFallback`
- both unrelated failures passed on exact isolated rerun

Live patched-app smoke was not run because it requires an explicitly approved visible app launch/relaunch.
