### PR TITLE
test: stabilize worktree API smoke and agent-run startup

### DIFF
--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -4392,7 +4392,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
                         initialDelayNanoseconds: 10_000_000,
                         maximumDelayNanoseconds: 100_000_000
                     ) {
-                        trackedSession.agentTask != nil
+                        trackedSession.agentTask != nil || trackedSession.runState != .idle
                     }
                 } catch is AsyncTestConditionTimeout {
                     throw FixtureError.trackedAgentTaskDidNotStart

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -7,6 +7,17 @@ import XCTest
 @MainActor
 final class WorktreeAPISmokeHarnessTests: XCTestCase {
     func testManageWorktreeAndAgentRunAPISmokeFlow() async throws {
+        let defaults = UserDefaults.standard
+        let previousServe = defaults.object(forKey: WorktreeStartupFeatureFlags.serveDefaultsKey)
+        defaults.set(false, forKey: WorktreeStartupFeatureFlags.serveDefaultsKey)
+        defer {
+            if let previousServe {
+                defaults.set(previousServe, forKey: WorktreeStartupFeatureFlags.serveDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: WorktreeStartupFeatureFlags.serveDefaultsKey)
+            }
+        }
+
         #if DEBUG
             let startupTrace = WorktreeStartupEventTraceSink()
             let startupTraceToken = WorktreeStartupInstrumentation.addEventObserverForTesting { event, sequence in


### PR DESCRIPTION
Split the two CI test-stability commits out of PR #796 (Oracle groups) so the maturing Oracle feature ships only its scoped changes.

- test(agent-run): observe durable startup state (AgentRunWorktreeStartTests)
- test(worktree): avoid seeded startup in API smoke (WorktreeAPISmokeHarnessTests)

Both address pre-existing host-runner flakes, neither is Oracle-scope. Cherry-picked onto upstream/main. See docs/investigations/oracle-group-branch-scope-audit.md.