### PR TITLE
Fix Codex wait-agent watchdog liveness

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -3885,6 +3885,33 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     return .skipped
                 }
 
+                let blockingNativeToolNames = await probeController.outstandingBlockingNativeToolCallNames()
+                guard codexWatchdogAttemptRemainsCurrent(
+                    session: session,
+                    controller: probeController,
+                    expectedRunID: expectedRunID,
+                    expectedRunAttemptID: expectedRunAttemptID,
+                    expectedProgressGeneration: expectedProgressGeneration,
+                    checkpoint: "after-blocking-native-tool-probe"
+                ) else {
+                    return .skipped
+                }
+                if !blockingNativeToolNames.isEmpty {
+                    recordCodexWatchdogProgress(for: session)
+                    recordCodexWatchdogTransition(
+                        "toolExempt",
+                        session: session,
+                        fields: [
+                            "reasonCount": String(blockingNativeToolNames.count),
+                            "source": "persisted-native-call"
+                        ]
+                    )
+                    logCodex(
+                        "[AgentModeVM][CodexWatchdog] suppressing watchdog for tab \(session.tabID) while blocking native tool calls remain active names=\(blockingNativeToolNames.joined(separator: ","))"
+                    )
+                    return .skipped
+                }
+
                 reconcileTerminalNativeToolItems(snapshot, session: session)
                 if probeCorroboratesOpenNativeTool(snapshot, session: session) {
                     recordCodexWatchdogProgress(for: session)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -77,6 +77,7 @@ protocol CodexSessionControlling: AnyObject {
         includeTurns: Bool,
         timeout: TimeInterval?
     ) async throws -> CodexNativeSessionController.ThreadSnapshot
+    func outstandingBlockingNativeToolCallNames() async -> [String]
     func setThreadName(_ name: String, threadID: String?) async throws
     func startUserTurn(
         text: String,
@@ -113,6 +114,10 @@ protocol CodexSessionControlling: AnyObject {
 }
 
 extension CodexSessionControlling {
+    func outstandingBlockingNativeToolCallNames() async -> [String] {
+        []
+    }
+
     func cleanupConversation(_ handle: ProviderConversationCleanupHandle, action: ProviderConversationCleanupAction) async -> ProviderConversationCleanupOutcome {
         .unsupported(message: "Codex runtime has no local API for \(action.rawValue) cleanup of conversations.")
     }
@@ -1448,6 +1453,17 @@ final class CodexNativeSessionController {
             timeout: timeout
         )
         return Self.parseThreadSnapshot(from: result, fallbackEffort: nil)
+    }
+
+    func outstandingBlockingNativeToolCallNames() async -> [String] {
+        guard let path = threadPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty
+        else {
+            return []
+        }
+        return await Task.detached(priority: .utility) {
+            Self.persistedOutstandingBlockingNativeToolCallNames(fromRolloutPath: path)
+        }.value
     }
 
     func setThreadName(_ name: String, threadID explicitThreadID: String?) async throws {
@@ -3726,6 +3742,12 @@ final class CodexNativeSessionController {
             parseThreadSnapshot(from: result, fallbackEffort: fallbackEffort)
         }
 
+        static func test_persistedOutstandingBlockingNativeToolCallNames(
+            fromRolloutPath path: String
+        ) -> [String] {
+            persistedOutstandingBlockingNativeToolCallNames(fromRolloutPath: path)
+        }
+
         static func test_toolItemCandidatesCount(from params: [String: Any]) -> Int {
             toolItemCandidates(fromParams: params).count
         }
@@ -5263,7 +5285,10 @@ final class CodexNativeSessionController {
         var terminalCallIDs: Set<String> = []
         var outputByProcessID: [String: String] = [:]
         var outputByCallID: [String: String] = [:]
+        var outstandingBlockingNativeToolNameByCallID: [String: String] = [:]
     }
+
+    private static let blockingNativeToolNames: Set<String> = ["wait_agent"]
 
     static func commandExecutionRunningUpdate(
         fromToolName toolName: String,
@@ -6784,6 +6809,10 @@ final class CodexNativeSessionController {
                 continue
             }
 
+            if root["type"] as? String == "session_meta" {
+                signals.outstandingBlockingNativeToolNameByCallID.removeAll()
+            }
+
             if let type = root["type"] as? String,
                type == "response_item",
                let payload = root["payload"] as? [String: Any],
@@ -6795,6 +6824,9 @@ final class CodexNativeSessionController {
                     let normalizedName = normalizedExternalToolName(dictString(payload, key: "name"))
                     if let normalizedName {
                         toolNameByCallID[callID] = normalizedName
+                        if blockingNativeToolNames.contains(normalizedName) {
+                            signals.outstandingBlockingNativeToolNameByCallID[callID] = normalizedName
+                        }
                     }
                     if normalizedName == "write_stdin",
                        let argsJSON = dictString(payload, key: "arguments"),
@@ -6805,6 +6837,7 @@ final class CodexNativeSessionController {
 
                 case "function_call_output":
                     guard let callID = dictString(payload, key: "call_id"), !callID.isEmpty else { continue }
+                    signals.outstandingBlockingNativeToolNameByCallID.removeValue(forKey: callID)
                     guard let output = dictString(payload, key: "output"), !output.isEmpty else { continue }
                     guard let normalizedName = toolNameByCallID[callID] else { continue }
 
@@ -7151,6 +7184,13 @@ final class CodexNativeSessionController {
             }
         }
         return signals
+    }
+
+    private static func persistedOutstandingBlockingNativeToolCallNames(
+        fromRolloutPath path: String
+    ) -> [String] {
+        let signals = loadPersistedCommandSignals(fromRolloutPath: path)
+        return Array(Set(signals.outstandingBlockingNativeToolNameByCallID.values)).sorted()
     }
 
     private static func appendPersistedCommandOutput(

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -1935,6 +1935,72 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         XCTAssertNotNil(session.lastTerminalCommitRevision)
     }
 
+    func testOutstandingNativeWaitAgentCallSuppressesIdleRecovery() async {
+        let controller = LivenessFakeCodexController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            outstandingBlockingNativeToolNames: ["wait_agent"]
+        )
+        let viewModel = makeViewModel(
+            controller: controller,
+            watchdogProbeThreshold: 10,
+            watchdogRecoveryThreshold: 10
+        )
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        let originalProgressGeneration = session.codexWatchdogState.progressGeneration
+
+        let attemptedTerminalSettlement = await viewModel.test_codexCoordinator
+            .test_attemptCodexStallRecovery(session: session)
+
+        XCTAssertFalse(attemptedTerminalSettlement)
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertEqual(controller.shutdownCountSync(), 0)
+        XCTAssertEqual(controller.startOrResumeCountSync(), 0)
+        XCTAssertGreaterThan(session.codexWatchdogState.progressGeneration, originalProgressGeneration)
+        XCTAssertNil(session.codexWatchdogState.lastAmbiguousProbeKind)
+
+        session.pendingUserInputRequest = makeUserInputRequest(id: "stop-watchdog")
+    }
+
+    func testProgressDuringBlockingNativeToolProbeSupersedesStaleResult() async throws {
+        let blockingToolProbeGate = LivenessSnapshotReadGate()
+        let controller = LivenessFakeCodexController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            outstandingBlockingNativeToolNames: ["wait_agent"],
+            blockingNativeToolReadGate: blockingToolProbeGate
+        )
+        let viewModel = makeViewModel(
+            controller: controller,
+            watchdogProbeThreshold: 10,
+            watchdogRecoveryThreshold: 10
+        )
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+
+        let recoveryTask = Task {
+            await viewModel.test_codexCoordinator.test_attemptCodexStallRecovery(session: session)
+        }
+        try await waitUntil {
+            blockingToolProbeGate.isWaitingSync()
+        }
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .assistantDelta("fresh provider progress"),
+            session: session
+        )
+        let progressGenerationAfterEvent = session.codexWatchdogState.progressGeneration
+        blockingToolProbeGate.release()
+
+        let attemptedTerminalSettlement = await recoveryTask.value
+        XCTAssertFalse(attemptedTerminalSettlement)
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertEqual(controller.shutdownCountSync(), 0)
+        XCTAssertEqual(controller.startOrResumeCountSync(), 0)
+        XCTAssertEqual(session.codexWatchdogState.progressGeneration, progressGenerationAfterEvent)
+
+        session.pendingUserInputRequest = makeUserInputRequest(id: "stop-watchdog")
+    }
+
     func testWatchdogFlushesCachedExplicitErrorWhenProbeFindsNoActiveTurn() async throws {
         let controller = LivenessFakeCodexController(
             snapshot: .idle,
@@ -3277,6 +3343,8 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
     private let snapshotReadGate: LivenessSnapshotReadGate?
     private let postReattachSnapshotReadGate: LivenessSnapshotReadGate?
     private let shutdownGate: LivenessSnapshotReadGate?
+    private let outstandingBlockingNativeToolNames: [String]
+    private let blockingNativeToolReadGate: LivenessSnapshotReadGate?
     private var pendingTurnFailure: CodexNativeSessionController.TurnFailure?
 
     init(
@@ -3298,6 +3366,8 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
         snapshotReadGate: LivenessSnapshotReadGate? = nil,
         postReattachSnapshotReadGate: LivenessSnapshotReadGate? = nil,
         shutdownGate: LivenessSnapshotReadGate? = nil,
+        outstandingBlockingNativeToolNames: [String] = [],
+        blockingNativeToolReadGate: LivenessSnapshotReadGate? = nil,
         pendingTurnFailure: CodexNativeSessionController.TurnFailure? = nil
     ) {
         snapshotStatuses = if let snapshotSequence, !snapshotSequence.isEmpty {
@@ -3321,6 +3391,8 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
         self.snapshotReadGate = snapshotReadGate
         self.postReattachSnapshotReadGate = postReattachSnapshotReadGate
         self.shutdownGate = shutdownGate
+        self.outstandingBlockingNativeToolNames = outstandingBlockingNativeToolNames
+        self.blockingNativeToolReadGate = blockingNativeToolReadGate
         self.pendingTurnFailure = pendingTurnFailure
     }
 
@@ -3433,6 +3505,13 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
             activeToolItems: includeTurns ? activeToolItems : [],
             hasAuthoritativeActiveTurnItems: includeTurns && hasAuthoritativeActiveTurnItems
         )
+    }
+
+    func outstandingBlockingNativeToolCallNames() async -> [String] {
+        if let blockingNativeToolReadGate {
+            await blockingNativeToolReadGate.wait()
+        }
+        return outstandingBlockingNativeToolNames
     }
 
     func setThreadName(_ name: String, threadID: String?) async throws {}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
@@ -5,6 +5,50 @@ import XCTest
 final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
     private static let webSearchAliases = ["search", "web_search", "web_search_request", "google_web_search", "search_web"]
 
+    func testPersistedWaitAgentCallRemainsBlockingUntilOutputOrNewSession() throws {
+        let rolloutURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-wait-agent-liveness-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: rolloutURL) }
+
+        let sessionMeta = #"{"type":"session_meta","payload":{}}"#
+        let waitCall = #"{"type":"response_item","payload":{"type":"function_call","name":"wait_agent","call_id":"call-1","arguments":"{}"}}"#
+        let waitOutput = #"{"type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":""}}"#
+
+        try ([sessionMeta, waitCall].joined(separator: "\n") + "\n").write(
+            to: rolloutURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        XCTAssertEqual(
+            CodexNativeSessionController.test_persistedOutstandingBlockingNativeToolCallNames(
+                fromRolloutPath: rolloutURL.path
+            ),
+            ["wait_agent"]
+        )
+
+        try ([sessionMeta, waitCall, waitOutput].joined(separator: "\n") + "\n").write(
+            to: rolloutURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        XCTAssertTrue(
+            CodexNativeSessionController.test_persistedOutstandingBlockingNativeToolCallNames(
+                fromRolloutPath: rolloutURL.path
+            ).isEmpty
+        )
+
+        try ([sessionMeta, waitCall, sessionMeta].joined(separator: "\n") + "\n").write(
+            to: rolloutURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        XCTAssertTrue(
+            CodexNativeSessionController.test_persistedOutstandingBlockingNativeToolCallNames(
+                fromRolloutPath: rolloutURL.path
+            ).isEmpty
+        )
+    }
+
     func testExternalToolNameNormalizationRejectsOversizedInputBeforeCanonicalization() {
         let oversizedName = String(repeating: "x", count: AgentToolNamePolicy.maximumUTF8Length + 1)
 


### PR DESCRIPTION
## Summary
- detect unmatched Codex-native `wait_agent` calls from the current rollout session segment
- exempt legitimate collaboration waits from idle recovery without changing watchdog deadlines
- fence asynchronous persisted-liveness results against superseded runs and add regressions

## Root cause
RepoPrompt's watchdog only saw the thread/read snapshot return idle while Codex was blocked in a native collaboration wait that never appeared in the app transcript. After 300 seconds it treated the run as abandoned and cancelled it.

This is separate from the `manage_worktree` partial-success/session-binding issue addressed by #826.

## Validation
- `make dev-test FILTER=CodexAgentModeCoordinatorLivenessTests` (73 tests, 0 failures)
- `make dev-test FILTER=CodexNativeSessionControllerEventRecoveryTests` (39 tests, 0 failures)
- `make dev-format`
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`
  - full root suite passed
  - RepoPrompt product build passed
- integrated review: no must-fix findings