### PR TITLE
Reject rootless working_dirs tab bindings

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1136,13 +1136,8 @@ extension MCPServerViewModel {
             throw TabBindError.tabNotFound(tabID)
         }
 
-        // Tear down any previous binding for this connection
-        if tabContextByConnectionID[connectionID] != nil {
-            releaseBinding(connectionID: connectionID)
-        }
-
-        // Explicit tab-context bindings preserve the tab's stored state unless a caller opts into
-        // active selection flushing through the snapshot helper.
+        // Build the replacement before releasing a usable binding. A stale or otherwise invalid
+        // target must not turn a failed rebind into an unbound connection.
         var context = try makeTabContextSnapshot(
             tabID: tab.id,
             workspaceID: ws.id,
@@ -1152,6 +1147,10 @@ extension MCPServerViewModel {
             captureActiveUIState: false,
             flushActiveSelection: false
         )
+
+        if tabContextByConnectionID[connectionID] != nil {
+            releaseBinding(connectionID: connectionID)
+        }
 
         activateReadFileAutoSelection(&context)
         tabContextByConnectionID[connectionID] = context
@@ -2033,6 +2032,8 @@ extension MCPServerViewModel {
     struct ProspectiveFileToolLookupResolution {
         let lookupContext: WorkspaceLookupContext
         let sourceIdentity: AgentWorkspaceLookupContextIdentity
+        fileprivate let visibleRootFingerprint: String
+        fileprivate let sessionRootLifetimeSnapshot: WorkspaceSessionRootLifetimeSnapshot?
     }
 
     @MainActor
@@ -2040,6 +2041,7 @@ extension MCPServerViewModel {
         tabID: UUID,
         workspaceID: UUID?
     ) async throws -> ProspectiveFileToolLookupResolution {
+        let visibleRootFingerprint = await fileToolVisibleRootFingerprint()
         var snapshot = try makeTabContextSnapshot(
             tabID: tabID,
             workspaceID: workspaceID,
@@ -2056,7 +2058,9 @@ extension MCPServerViewModel {
             )
             return ProspectiveFileToolLookupResolution(
                 lookupContext: AgentWorkspaceLookupContextResolver.failClosedLookupContext,
-                sourceIdentity: source.identity
+                sourceIdentity: source.identity,
+                visibleRootFingerprint: visibleRootFingerprint,
+                sessionRootLifetimeSnapshot: nil
             )
         }
 
@@ -2068,7 +2072,18 @@ extension MCPServerViewModel {
             source: source,
             store: promptVM.workspaceFileContextStore
         )
-        guard fileToolLookupSnapshotIsCurrent(snapshot, connectionID: nil),
+        let sessionRootLifetimeSnapshot: WorkspaceSessionRootLifetimeSnapshot? = if let bindingProjection = lookupContext.bindingProjection {
+            await promptVM.workspaceFileContextStore.sessionBoundRootScopeValidationSnapshot(
+                lookupContext.rootScope,
+                expectedPhysicalRoots: bindingProjection.physicalRootRefs
+            )
+        } else {
+            nil
+        }
+        let currentVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
+        guard currentVisibleRootFingerprint == visibleRootFingerprint,
+              lookupContext.bindingProjection == nil || sessionRootLifetimeSnapshot != nil,
+              fileToolLookupSnapshotIsCurrent(snapshot, connectionID: nil),
               fileToolBindingSourceIsCurrent(source, for: snapshot)
         else {
             #if DEBUG
@@ -2076,12 +2091,29 @@ extension MCPServerViewModel {
             #endif
             return ProspectiveFileToolLookupResolution(
                 lookupContext: AgentWorkspaceLookupContextResolver.failClosedLookupContext,
-                sourceIdentity: source.identity
+                sourceIdentity: source.identity,
+                visibleRootFingerprint: visibleRootFingerprint,
+                sessionRootLifetimeSnapshot: nil
             )
+        }
+        if let sessionRootLifetimeSnapshot {
+            guard await sessionRootLifetimeSnapshot.isCurrent() else {
+                #if DEBUG
+                    fileToolLookupContextStaleCompletionCount += 1
+                #endif
+                return ProspectiveFileToolLookupResolution(
+                    lookupContext: AgentWorkspaceLookupContextResolver.failClosedLookupContext,
+                    sourceIdentity: source.identity,
+                    visibleRootFingerprint: visibleRootFingerprint,
+                    sessionRootLifetimeSnapshot: nil
+                )
+            }
         }
         return ProspectiveFileToolLookupResolution(
             lookupContext: lookupContext,
-            sourceIdentity: source.identity
+            sourceIdentity: source.identity,
+            visibleRootFingerprint: visibleRootFingerprint,
+            sessionRootLifetimeSnapshot: sessionRootLifetimeSnapshot
         )
     }
 
@@ -2112,6 +2144,59 @@ extension MCPServerViewModel {
         )
         return fileToolLookupSnapshotIsCurrent(snapshot, connectionID: nil)
             && source.identity == expectedSourceIdentity
+    }
+
+    @MainActor
+    func performIfProspectiveFileToolLookupResolutionIsCurrent(
+        _ resolution: ProspectiveFileToolLookupResolution,
+        tabID: UUID,
+        workspaceID: UUID,
+        operation: @MainActor () throws -> Void
+    ) async throws -> Bool {
+        guard prospectiveFileToolLookupSourceIsCurrent(
+            tabID: tabID,
+            workspaceID: workspaceID,
+            expectedSourceIdentity: resolution.sourceIdentity
+        ) else { return false }
+
+        let currentVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
+        guard currentVisibleRootFingerprint == resolution.visibleRootFingerprint else { return false }
+        if let sessionRootLifetimeSnapshot = resolution.sessionRootLifetimeSnapshot {
+            guard await sessionRootLifetimeSnapshot.isCurrent() else { return false }
+        }
+
+        #if DEBUG
+            if let debugAfterFileToolLookupContextRootValidationForTesting {
+                await debugAfterFileToolLookupContextRootValidationForTesting()
+            }
+        #endif
+
+        let finalVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
+        guard finalVisibleRootFingerprint == resolution.visibleRootFingerprint,
+              prospectiveFileToolLookupSourceIsCurrent(
+                  tabID: tabID,
+                  workspaceID: workspaceID,
+                  expectedSourceIdentity: resolution.sourceIdentity
+              )
+        else { return false }
+
+        if let sessionRootLifetimeSnapshot = resolution.sessionRootLifetimeSnapshot {
+            var operationError: Error?
+            let didPerform = sessionRootLifetimeSnapshot.performIfGenerationCurrent {
+                do {
+                    try operation()
+                } catch {
+                    operationError = error
+                }
+            }
+            if let operationError {
+                throw operationError
+            }
+            return didPerform
+        }
+
+        try operation()
+        return true
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -2024,7 +2024,23 @@ extension MCPServerViewModel {
         tabID: UUID,
         workspaceID: UUID?
     ) async throws -> WorkspaceLookupContext {
-        let snapshot = try makeTabContextSnapshot(
+        try await resolveProspectiveFileToolLookupContext(
+            tabID: tabID,
+            workspaceID: workspaceID
+        ).lookupContext
+    }
+
+    struct ProspectiveFileToolLookupResolution {
+        let lookupContext: WorkspaceLookupContext
+        let sourceIdentity: AgentWorkspaceLookupContextIdentity
+    }
+
+    @MainActor
+    func resolveProspectiveFileToolLookupContext(
+        tabID: UUID,
+        workspaceID: UUID?
+    ) async throws -> ProspectiveFileToolLookupResolution {
+        var snapshot = try makeTabContextSnapshot(
             tabID: tabID,
             workspaceID: workspaceID,
             windowID: windowID,
@@ -2033,7 +2049,69 @@ extension MCPServerViewModel {
             captureActiveUIState: false,
             flushActiveSelection: false
         )
-        return await lookupContext(for: snapshot)
+        guard await hydrateFileToolLookupSnapshotIfNeeded(&snapshot, connectionID: nil) else {
+            let source = AgentWorkspaceLookupContextSource(
+                activeAgentSessionID: snapshot.activeAgentSessionID,
+                worktreeBindingState: snapshot.worktreeBindingState
+            )
+            return ProspectiveFileToolLookupResolution(
+                lookupContext: AgentWorkspaceLookupContextResolver.failClosedLookupContext,
+                sourceIdentity: source.identity
+            )
+        }
+
+        let source = AgentWorkspaceLookupContextSource(
+            activeAgentSessionID: snapshot.activeAgentSessionID,
+            worktreeBindingState: snapshot.worktreeBindingState
+        )
+        let lookupContext = await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
+            source: source,
+            store: promptVM.workspaceFileContextStore
+        )
+        guard fileToolLookupSnapshotIsCurrent(snapshot, connectionID: nil),
+              fileToolBindingSourceIsCurrent(source, for: snapshot)
+        else {
+            #if DEBUG
+                fileToolLookupContextStaleCompletionCount += 1
+            #endif
+            return ProspectiveFileToolLookupResolution(
+                lookupContext: AgentWorkspaceLookupContextResolver.failClosedLookupContext,
+                sourceIdentity: source.identity
+            )
+        }
+        return ProspectiveFileToolLookupResolution(
+            lookupContext: lookupContext,
+            sourceIdentity: source.identity
+        )
+    }
+
+    @MainActor
+    func prospectiveFileToolLookupSourceIsCurrent(
+        tabID: UUID,
+        workspaceID: UUID,
+        expectedSourceIdentity: AgentWorkspaceLookupContextIdentity
+    ) -> Bool {
+        guard var snapshot = try? makeTabContextSnapshot(
+            tabID: tabID,
+            workspaceID: workspaceID,
+            windowID: windowID,
+            runID: nil,
+            explicitlyBound: false,
+            captureActiveUIState: false,
+            flushActiveSelection: false
+        ) else { return false }
+
+        if let sessionID = snapshot.activeAgentSessionID {
+            snapshot.worktreeBindingState = agentWorktreeBindingStateProvider?(sessionID, snapshot.tabID) ?? .unhydrated
+        } else {
+            snapshot.worktreeBindingState = .notApplicable
+        }
+        let source = AgentWorkspaceLookupContextSource(
+            activeAgentSessionID: snapshot.activeAgentSessionID,
+            worktreeBindingState: snapshot.worktreeBindingState
+        )
+        return fileToolLookupSnapshotIsCurrent(snapshot, connectionID: nil)
+            && source.identity == expectedSourceIdentity
     }
 
     @MainActor
@@ -2069,34 +2147,11 @@ extension MCPServerViewModel {
                 }
             }
 
-            if let sessionID = snapshot.activeAgentSessionID {
-                if snapshot.runID == nil,
-                   let agentWorktreeBindingStateProvider
-                {
-                    snapshot.worktreeBindingState = agentWorktreeBindingStateProvider(sessionID, snapshot.tabID)
-                }
-                if snapshot.worktreeBindingState == .unhydrated,
-                   let agentWorktreeBindingStateResolver
-                {
-                    let bindingGeneration = snapshot.readFileAutoSelectionGeneration
-                    let hydratedState = await agentWorktreeBindingStateResolver(sessionID, snapshot.tabID)
-                    guard fileToolLookupSnapshotIsCurrent(
-                        snapshot,
-                        connectionID: metadata.connectionID,
-                        expectedBindingGeneration: bindingGeneration
-                    ),
-                        agentWorktreeBindingStateProvider?(sessionID, snapshot.tabID) == hydratedState
-                        || agentWorktreeBindingStateProvider == nil
-                    else {
-                        #if DEBUG
-                            fileToolLookupContextStaleCompletionCount += 1
-                        #endif
-                        return AgentWorkspaceLookupContextResolver.failClosedLookupContext
-                    }
-                    snapshot.worktreeBindingState = hydratedState
-                }
-            } else {
-                snapshot.worktreeBindingState = .notApplicable
+            guard await hydrateFileToolLookupSnapshotIfNeeded(
+                &snapshot,
+                connectionID: metadata.connectionID
+            ) else {
+                return AgentWorkspaceLookupContextResolver.failClosedLookupContext
             }
 
             resolved?.snapshot = snapshot
@@ -2348,6 +2403,43 @@ extension MCPServerViewModel {
             pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
         }
         return adjustedLookupContext
+    }
+
+    @MainActor
+    private func hydrateFileToolLookupSnapshotIfNeeded(
+        _ snapshot: inout TabContextSnapshot,
+        connectionID: UUID?
+    ) async -> Bool {
+        guard let sessionID = snapshot.activeAgentSessionID else {
+            snapshot.worktreeBindingState = .notApplicable
+            return true
+        }
+        if snapshot.runID == nil,
+           let agentWorktreeBindingStateProvider
+        {
+            snapshot.worktreeBindingState = agentWorktreeBindingStateProvider(sessionID, snapshot.tabID)
+        }
+        guard snapshot.worktreeBindingState == .unhydrated,
+              let agentWorktreeBindingStateResolver
+        else { return true }
+
+        let bindingGeneration = snapshot.readFileAutoSelectionGeneration
+        let hydratedState = await agentWorktreeBindingStateResolver(sessionID, snapshot.tabID)
+        guard fileToolLookupSnapshotIsCurrent(
+            snapshot,
+            connectionID: connectionID,
+            expectedBindingGeneration: bindingGeneration
+        ),
+            agentWorktreeBindingStateProvider?(sessionID, snapshot.tabID) == hydratedState
+            || agentWorktreeBindingStateProvider == nil
+        else {
+            #if DEBUG
+                fileToolLookupContextStaleCompletionCount += 1
+            #endif
+            return false
+        }
+        snapshot.worktreeBindingState = hydratedState
+        return true
     }
 
     /// Resolves mutation routing and lookup authority together so an inactive,

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
@@ -1805,19 +1805,43 @@ final class WindowRoutingService: Service {
     private func bindTarget(
         _ target: ResolvedBindTarget,
         connectionID: UUID,
-        clientName: String?
+        clientName: String?,
+        expectedWorkingDirsSourceIdentity: AgentWorkspaceLookupContextIdentity? = nil,
+        bindingAlreadyMatches: Bool = false
     ) async throws {
         guard let targetWindow = windowStates.allWindows.first(where: { $0.windowID == target.windowID }) else {
             throw MCPError.invalidParams("Window \(target.windowID) not found")
         }
-        clearNonRunScopedBindingsAcrossWindows(for: connectionID)
-        try targetWindow.mcpServer.bindTabForConnection(
-            connectionID: connectionID,
-            clientName: clientName,
-            tabID: target.tabID,
-            workspaceID: target.workspaceID,
-            windowID: target.windowID
-        )
+        if let expectedWorkingDirsSourceIdentity {
+            let currentTarget = try? resolveActiveTabBindTarget(
+                windowID: target.windowID,
+                expectedWorkspaceID: target.workspaceID,
+                matchedBy: target.matchedBy,
+                normalizedWorkingDirs: target.normalizedWorkingDirs
+            )
+            guard currentTarget?.tabID == target.tabID,
+                  targetWindow.mcpServer.prospectiveFileToolLookupSourceIsCurrent(
+                      tabID: target.tabID,
+                      workspaceID: target.workspaceID,
+                      expectedSourceIdentity: expectedWorkingDirsSourceIdentity
+                  )
+            else {
+                throw MCPError.invalidRequest(
+                    "The working_dirs target changed while its root projection was being resolved. " +
+                        "The existing MCP binding was not changed. Bind again with the same working_dirs."
+                )
+            }
+        }
+        if !bindingAlreadyMatches {
+            clearNonRunScopedBindingsAcrossWindows(for: connectionID)
+            try targetWindow.mcpServer.bindTabForConnection(
+                connectionID: connectionID,
+                clientName: clientName,
+                tabID: target.tabID,
+                workspaceID: target.workspaceID,
+                windowID: target.windowID
+            )
+        }
         try await networkMgr.setActiveWindowForCurrentConnection(target.windowID)
     }
 
@@ -1853,15 +1877,15 @@ final class WindowRoutingService: Service {
     private func ensureWorkingDirsRootProjectionIsLoaded(
         _ target: ResolvedBindTarget,
         requestedRoots: [String]
-    ) async throws {
+    ) async throws -> AgentWorkspaceLookupContextIdentity {
         let window = try resolveWindowForBinding(windowID: target.windowID)
-        let lookupContext = try await window.mcpServer.resolveFileToolLookupContext(
+        let resolution = try await window.mcpServer.resolveProspectiveFileToolLookupContext(
             tabID: target.tabID,
             workspaceID: target.workspaceID
         )
         let scopedRoots = await window.promptManager.workspaceFileContextStore
-            .rootRefs(scope: lookupContext.rootScope)
-        let loadedRoots = lookupContext.bindingProjection?.visibleLogicalRootRefs ?? scopedRoots
+            .rootRefs(scope: resolution.lookupContext.rootScope)
+        let loadedRoots = resolution.lookupContext.bindingProjection?.visibleLogicalRootRefs ?? scopedRoots
         let loadedRootPaths = Set(loadedRoots.map(\.standardizedFullPath))
         let missingRoots = WorkspaceManagerViewModel.normalizedExactWorkspaceDirectorySet(requestedRoots)
             .filter { !loadedRootPaths.contains($0) }
@@ -1874,6 +1898,7 @@ final class WindowRoutingService: Service {
                     "then bind again with the same working_dirs."
             )
         }
+        return resolution.sourceIdentity
     }
 
     private func listBindContextWindows(
@@ -2054,7 +2079,7 @@ final class WindowRoutingService: Service {
                                 normalizedWorkingDirs: target.normalizedWorkingDirs
                             )
                         }
-                        try await ensureWorkingDirsRootProjectionIsLoaded(
+                        let sourceIdentity = try await ensureWorkingDirsRootProjectionIsLoaded(
                             tabTarget,
                             requestedRoots: target.normalizedWorkingDirs
                         )
@@ -2063,11 +2088,13 @@ final class WindowRoutingService: Service {
                             && previousBinding.contextID == tabTarget.tabID
                             && previousBinding.explicit
                             && !previousBinding.runScoped
-                        if !unchanged {
-                            try await bindTarget(tabTarget, connectionID: connectionID, clientName: clientName)
-                        } else {
-                            try await networkMgr.setActiveWindowForCurrentConnection(tabTarget.windowID)
-                        }
+                        try await bindTarget(
+                            tabTarget,
+                            connectionID: connectionID,
+                            clientName: clientName,
+                            expectedWorkingDirsSourceIdentity: sourceIdentity,
+                            bindingAlreadyMatches: unchanged
+                        )
 
                         let binding = await currentBindingSummary(for: connectionID)
                         let note = await MainActor.run { self.bindContextWindowNote(windowID: binding.windowID) }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
@@ -1814,8 +1814,11 @@ final class WindowRoutingService: Service {
         throw MCPError.invalidParams("Ambiguous window choice for bind_context tab creation. Supply window_id. Available windows: \(available)")
     }
 
-    private func clearNonRunScopedBindingsAcrossWindows(for connectionID: UUID) {
-        for window in windowStates.allWindows {
+    private func clearNonRunScopedBindingsAcrossWindows(
+        for connectionID: UUID,
+        excludingWindowID: Int? = nil
+    ) {
+        for window in windowStates.allWindows where window.windowID != excludingWindowID {
             _ = window.mcpServer.clearNonRunScopedBinding(forConnection: connectionID)
         }
     }
@@ -1824,34 +1827,44 @@ final class WindowRoutingService: Service {
         _ target: ResolvedBindTarget,
         connectionID: UUID,
         clientName: String?,
-        expectedWorkingDirsSourceIdentity: AgentWorkspaceLookupContextIdentity? = nil,
+        expectedWorkingDirsResolution: MCPServerViewModel.ProspectiveFileToolLookupResolution? = nil,
         bindingAlreadyMatches: Bool = false
     ) async throws {
         guard let targetWindow = windowStates.allWindows.first(where: { $0.windowID == target.windowID }) else {
             throw MCPError.invalidParams("Window \(target.windowID) not found")
         }
-        if let expectedWorkingDirsSourceIdentity {
+        if let expectedWorkingDirsResolution {
             let currentTarget = try? resolveActiveTabBindTarget(
                 windowID: target.windowID,
                 expectedWorkspaceID: target.workspaceID,
                 matchedBy: target.matchedBy,
                 normalizedWorkingDirs: target.normalizedWorkingDirs
             )
-            guard currentTarget?.tabID == target.tabID,
-                  targetWindow.mcpServer.prospectiveFileToolLookupSourceIsCurrent(
-                      tabID: target.tabID,
-                      workspaceID: target.workspaceID,
-                      expectedSourceIdentity: expectedWorkingDirsSourceIdentity
-                  )
-            else {
-                throw MCPError.invalidRequest(
-                    "The working_dirs target changed while its root projection was being resolved. " +
-                        "The existing MCP binding was not changed. Bind again with the same working_dirs."
+            guard currentTarget?.tabID == target.tabID else {
+                throw staleWorkingDirsTargetError()
+            }
+            let didBind = try await targetWindow.mcpServer.performIfProspectiveFileToolLookupResolutionIsCurrent(
+                expectedWorkingDirsResolution,
+                tabID: target.tabID,
+                workspaceID: target.workspaceID
+            ) {
+                guard !bindingAlreadyMatches else { return }
+                try targetWindow.mcpServer.bindTabForConnection(
+                    connectionID: connectionID,
+                    clientName: clientName,
+                    tabID: target.tabID,
+                    workspaceID: target.workspaceID,
+                    windowID: target.windowID
+                )
+                clearNonRunScopedBindingsAcrossWindows(
+                    for: connectionID,
+                    excludingWindowID: target.windowID
                 )
             }
-        }
-        if !bindingAlreadyMatches {
-            clearNonRunScopedBindingsAcrossWindows(for: connectionID)
+            guard didBind else {
+                throw staleWorkingDirsTargetError()
+            }
+        } else if !bindingAlreadyMatches {
             try targetWindow.mcpServer.bindTabForConnection(
                 connectionID: connectionID,
                 clientName: clientName,
@@ -1859,8 +1872,19 @@ final class WindowRoutingService: Service {
                 workspaceID: target.workspaceID,
                 windowID: target.windowID
             )
+            clearNonRunScopedBindingsAcrossWindows(
+                for: connectionID,
+                excludingWindowID: target.windowID
+            )
         }
         try await networkMgr.setActiveWindowForCurrentConnection(target.windowID)
+    }
+
+    private func staleWorkingDirsTargetError() -> MCPError {
+        MCPError.invalidRequest(
+            "The working_dirs target changed while its root projection was being resolved. " +
+                "The existing MCP binding was not changed. Bind again with the same working_dirs."
+        )
     }
 
     private func resolveActiveTabBindTarget(
@@ -1892,10 +1916,19 @@ final class WindowRoutingService: Service {
         )
     }
 
+    nonisolated static func missingWorkingDirsRootProjectionPaths(
+        requestedRoots: [String],
+        loadedRoots: [String]
+    ) -> [String] {
+        let loadedRootKeys = Set(WorkspaceRootSetKey(paths: loadedRoots).normalizedPaths.map { $0.lowercased() })
+        return WorkspaceRootSetKey(paths: requestedRoots).normalizedPaths
+            .filter { !loadedRootKeys.contains($0.lowercased()) }
+    }
+
     private func ensureWorkingDirsRootProjectionIsLoaded(
         _ target: ResolvedBindTarget,
         requestedRoots: [String]
-    ) async throws -> AgentWorkspaceLookupContextIdentity {
+    ) async throws -> MCPServerViewModel.ProspectiveFileToolLookupResolution {
         let window = try resolveWindowForBinding(windowID: target.windowID)
         let resolution = try await window.mcpServer.resolveProspectiveFileToolLookupContext(
             tabID: target.tabID,
@@ -1904,9 +1937,10 @@ final class WindowRoutingService: Service {
         let scopedRoots = await window.promptManager.workspaceFileContextStore
             .rootRefs(scope: resolution.lookupContext.rootScope)
         let loadedRoots = resolution.lookupContext.bindingProjection?.visibleLogicalRootRefs ?? scopedRoots
-        let loadedRootPaths = Set(loadedRoots.map(\.standardizedFullPath))
-        let missingRoots = WorkspaceManagerViewModel.normalizedExactWorkspaceDirectorySet(requestedRoots)
-            .filter { !loadedRootPaths.contains($0) }
+        let missingRoots = Self.missingWorkingDirsRootProjectionPaths(
+            requestedRoots: requestedRoots,
+            loadedRoots: loadedRoots.map(\.standardizedFullPath)
+        )
         guard missingRoots.isEmpty else {
             throw MCPError.invalidRequest(
                 "working_dirs matched workspace '\(target.workspaceName)', but its active tab '\(target.tabName)' " +
@@ -1916,7 +1950,7 @@ final class WindowRoutingService: Service {
                     "then bind again with the same working_dirs."
             )
         }
-        return resolution.sourceIdentity
+        return resolution
     }
 
     private func listBindContextWindows(
@@ -2097,7 +2131,7 @@ final class WindowRoutingService: Service {
                                 normalizedWorkingDirs: target.normalizedWorkingDirs
                             )
                         }
-                        let sourceIdentity = try await ensureWorkingDirsRootProjectionIsLoaded(
+                        let prospectiveLookupResolution = try await ensureWorkingDirsRootProjectionIsLoaded(
                             tabTarget,
                             requestedRoots: target.normalizedWorkingDirs
                         )
@@ -2110,7 +2144,7 @@ final class WindowRoutingService: Service {
                             tabTarget,
                             connectionID: connectionID,
                             clientName: clientName,
-                            expectedWorkingDirsSourceIdentity: sourceIdentity,
+                            expectedWorkingDirsResolution: prospectiveLookupResolution,
                             bindingAlreadyMatches: unchanged
                         )
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
@@ -1848,6 +1848,15 @@ final class WindowRoutingService: Service {
                 tabID: target.tabID,
                 workspaceID: target.workspaceID
             ) {
+                let commitTarget = try? resolveActiveTabBindTarget(
+                    windowID: target.windowID,
+                    expectedWorkspaceID: target.workspaceID,
+                    matchedBy: target.matchedBy,
+                    normalizedWorkingDirs: target.normalizedWorkingDirs
+                )
+                guard commitTarget?.tabID == target.tabID else {
+                    throw staleWorkingDirsTargetError()
+                }
                 guard !bindingAlreadyMatches else { return }
                 try targetWindow.mcpServer.bindTabForConnection(
                     connectionID: connectionID,

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
@@ -1850,6 +1850,32 @@ final class WindowRoutingService: Service {
         )
     }
 
+    private func ensureWorkingDirsRootProjectionIsLoaded(
+        _ target: ResolvedBindTarget,
+        requestedRoots: [String]
+    ) async throws {
+        let window = try resolveWindowForBinding(windowID: target.windowID)
+        let lookupContext = try await window.mcpServer.resolveFileToolLookupContext(
+            tabID: target.tabID,
+            workspaceID: target.workspaceID
+        )
+        let scopedRoots = await window.promptManager.workspaceFileContextStore
+            .rootRefs(scope: lookupContext.rootScope)
+        let loadedRoots = lookupContext.bindingProjection?.visibleLogicalRootRefs ?? scopedRoots
+        let loadedRootPaths = Set(loadedRoots.map(\.standardizedFullPath))
+        let missingRoots = WorkspaceManagerViewModel.normalizedExactWorkspaceDirectorySet(requestedRoots)
+            .filter { !loadedRootPaths.contains($0) }
+        guard missingRoots.isEmpty else {
+            throw MCPError.invalidRequest(
+                "working_dirs matched workspace '\(target.workspaceName)', but its active tab '\(target.tabName)' " +
+                    "(context_id \(target.tabID.uuidString)) in window \(target.windowID) does not have the requested " +
+                    "root projection loaded. Missing roots: \(missingRoots.joined(separator: ", ")). " +
+                    "The existing MCP binding was not changed. Activate a tab whose file tree contains those roots, " +
+                    "then bind again with the same working_dirs."
+            )
+        }
+    }
+
     private func listBindContextWindows(
         filterWindowID: Int?,
         currentWindowID: Int?,
@@ -2028,6 +2054,10 @@ final class WindowRoutingService: Service {
                                 normalizedWorkingDirs: target.normalizedWorkingDirs
                             )
                         }
+                        try await ensureWorkingDirsRootProjectionIsLoaded(
+                            tabTarget,
+                            requestedRoots: target.normalizedWorkingDirs
+                        )
                         let unchanged = previousBinding.bindingKind == "tab_context"
                             && previousBinding.windowID == tabTarget.windowID
                             && previousBinding.contextID == tabTarget.tabID

--- a/Tests/RepoPromptTests/MCP/Control/WorkingDirsBindRootProjectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/WorkingDirsBindRootProjectionTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import MCP
+@testable import RepoPromptApp
+import XCTest
+
+final class WorkingDirsBindRootProjectionTests: XCTestCase {
+    @MainActor
+    func testWorkingDirsBindRejectsRootlessAgentTabWithoutReplacingBinding() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        addTeardownBlock { @MainActor in
+            WindowStatesManager.shared.unregisterWindowState(window)
+            await window.tearDown()
+        }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("working-dirs-root-projection-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let previousTabID = UUID()
+        let rootlessTabID = UUID()
+        let agentSessionID = UUID()
+        let workspace = WorkspaceModel(
+            name: "Working Dirs Root Projection",
+            repoPaths: [root.path],
+            customStoragePath: root.appendingPathComponent("workspace.json"),
+            composeTabs: [
+                ComposeTabState(id: previousTabID, name: "Previous"),
+                ComposeTabState(
+                    id: rootlessTabID,
+                    name: "Rootless Agent",
+                    activeAgentSessionID: agentSessionID
+                )
+            ],
+            activeComposeTabID: rootlessTabID
+        )
+        window.workspaceManager.workspaces = [workspace]
+        let switchResult = await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "workingDirsRootProjectionTest"
+        )
+        XCTAssertTrue(switchResult.didSwitch)
+        window.promptManager.loadComposeTabsFromWorkspace(workspace, syncPromptText: true)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+        let visibleRoots = await window.workspaceFileContextStore.rootRefs(scope: .visibleWorkspace)
+        XCTAssertEqual(visibleRoots.map(\.standardizedFullPath), [StandardizedPath.absolute(root.path)])
+
+        window.mcpServer.registerAgentWorktreeBindingsProvider { sessionID, tabID in
+            sessionID == agentSessionID && tabID == rootlessTabID ? .unavailable : .notApplicable
+        }
+        let prospectiveLookupContext = try await window.mcpServer.resolveFileToolLookupContext(
+            tabID: rootlessTabID,
+            workspaceID: workspace.id
+        )
+        XCTAssertEqual(prospectiveLookupContext, AgentWorkspaceLookupContextResolver.failClosedLookupContext)
+
+        let connectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "working-dirs-root-projection-test",
+            tabID: previousTabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID
+        )
+
+        let service = WindowRoutingService(
+            windowStates: WindowStatesManager.shared,
+            networkMgr: ServerNetworkManager.shared
+        )
+        await service.prepareDomainTools()
+        let tools = await service.tools
+        let bindContext = try XCTUnwrap(tools.first { $0.name == MCPGlobalToolName.bindContext })
+
+        do {
+            _ = try await ServerNetworkManager.withConnectionID(connectionID) {
+                try await bindContext([
+                    "op": .string("bind"),
+                    "working_dirs": .string(root.path),
+                    "create_if_missing": .bool(false)
+                ])
+            }
+            XCTFail("Expected rootless active tab binding to fail")
+        } catch {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("Rootless Agent"), message)
+            XCTAssertTrue(message.contains(rootlessTabID.uuidString), message)
+            XCTAssertTrue(message.contains("does not have the requested root projection loaded"), message)
+            XCTAssertTrue(message.contains("existing MCP binding was not changed"), message)
+        }
+
+        XCTAssertEqual(window.mcpServer.tabContextByConnectionID[connectionID]?.tabID, previousTabID)
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/WorkingDirsBindRootProjectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/WorkingDirsBindRootProjectionTests.swift
@@ -4,6 +4,19 @@ import MCP
 import XCTest
 
 final class WorkingDirsBindRootProjectionTests: XCTestCase {
+    func testWorkingDirsLoadedRootValidationAcceptsDifferentlyCasedEquivalentPath() {
+        let loadedRoot = "/private/tmp/RepoPrompt/WorkingRoot"
+        let differentlyCasedRequest = "/PRIVATE/TMP/repoprompt/workingroot"
+
+        XCTAssertEqual(
+            WindowRoutingService.missingWorkingDirsRootProjectionPaths(
+                requestedRoots: [differentlyCasedRequest],
+                loadedRoots: [loadedRoot]
+            ),
+            []
+        )
+    }
+
     @MainActor
     func testWorkingDirsBindHydratesAgentProjectionBeforeBinding() async throws {
         let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
@@ -187,6 +200,100 @@ final class WorkingDirsBindRootProjectionTests: XCTestCase {
         do {
             _ = try await bindTask.value
             XCTFail("Expected the stale working_dirs target to be rejected")
+        } catch {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("changed while its root projection was being resolved"), message)
+            XCTAssertTrue(message.contains("existing MCP binding was not changed"), message)
+        }
+        XCTAssertEqual(window.mcpServer.tabContextByConnectionID[connectionID]?.tabID, previousTabID)
+    }
+
+    @MainActor
+    func testWorkingDirsBindPreservesPreviousBindingWhenSessionRootLifetimeChangesAfterPreflight() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        addTeardownBlock { @MainActor in
+            WindowStatesManager.shared.unregisterWindowState(window)
+            await window.tearDown()
+        }
+
+        let logicalRootURL = try makeTemporaryDirectory(named: "working-dirs-lifetime-logical")
+        let physicalRootURL = try makeTemporaryDirectory(named: "working-dirs-lifetime-physical")
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: logicalRootURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: physicalRootURL.deletingLastPathComponent())
+        }
+
+        let previousTabID = UUID()
+        let agentTabID = UUID()
+        let agentSessionID = UUID()
+        let workspace = WorkspaceModel(
+            name: "Working Dirs Lifetime Fence",
+            repoPaths: [logicalRootURL.path],
+            customStoragePath: logicalRootURL.appendingPathComponent("workspace.json"),
+            composeTabs: [
+                ComposeTabState(id: previousTabID, name: "Previous"),
+                ComposeTabState(
+                    id: agentTabID,
+                    name: "Prospective Agent",
+                    activeAgentSessionID: agentSessionID
+                )
+            ],
+            activeComposeTabID: agentTabID
+        )
+        try await install(workspace: workspace, in: window, reason: "workingDirsLifetimeFenceTest")
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: logicalRootURL.path
+        )
+        let physicalRoot = try await window.workspaceFileContextStore.loadRoot(
+            path: physicalRootURL.path,
+            kind: .sessionWorktree
+        )
+        let binding = makeWorktreeBinding(logicalRoot: logicalRoot, physicalRoot: physicalRoot)
+        window.mcpServer.registerAgentWorktreeBindingsProvider { sessionID, tabID in
+            sessionID == agentSessionID && tabID == agentTabID ? .hydrated([binding]) : .unavailable
+        }
+
+        let connectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "working-dirs-lifetime-fence-test",
+            tabID: previousTabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID
+        )
+        window.mcpServer.setAfterFileToolLookupContextRootValidationForTesting {
+            window.mcpServer.setAfterFileToolLookupContextRootValidationForTesting(nil)
+            await window.workspaceFileContextStore.unloadRoot(id: physicalRoot.id)
+            do {
+                let replacementRoot = try await window.workspaceFileContextStore.loadRoot(
+                    path: physicalRootURL.path,
+                    kind: .sessionWorktree
+                )
+                XCTAssertNotEqual(replacementRoot.id, physicalRoot.id)
+            } catch {
+                XCTFail("Failed to reload the session root during the deterministic race: \(error)")
+            }
+        }
+        addTeardownBlock { @MainActor in
+            window.mcpServer.setAfterFileToolLookupContextRootValidationForTesting(nil)
+        }
+
+        let (service, bindContext) = try await bindContextTool(for: window)
+        defer { withExtendedLifetime(service) {} }
+        do {
+            _ = try await ServerNetworkManager.withConnectionID(connectionID) {
+                try await bindContext([
+                    "op": .string("bind"),
+                    "working_dirs": .string(logicalRootURL.path),
+                    "create_if_missing": .bool(false)
+                ])
+            }
+            XCTFail("Expected session-root lifetime churn to reject the stale working_dirs bind")
         } catch {
             let message = String(describing: error)
             XCTAssertTrue(message.contains("changed while its root projection was being resolved"), message)

--- a/Tests/RepoPromptTests/MCP/Control/WorkingDirsBindRootProjectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/WorkingDirsBindRootProjectionTests.swift
@@ -209,6 +209,82 @@ final class WorkingDirsBindRootProjectionTests: XCTestCase {
     }
 
     @MainActor
+    func testWorkingDirsBindPreservesPreviousBindingWhenActiveTabChangesAfterRootValidation() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        addTeardownBlock { @MainActor in
+            WindowStatesManager.shared.unregisterWindowState(window)
+            await window.tearDown()
+        }
+
+        let rootURL = try makeTemporaryDirectory(named: "working-dirs-commit-target")
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: rootURL.deletingLastPathComponent())
+        }
+
+        let previousTabID = UUID()
+        let prospectiveTabID = UUID()
+        let replacementTabID = UUID()
+        let workspace = WorkspaceModel(
+            name: "Working Dirs Commit Target",
+            repoPaths: [rootURL.path],
+            customStoragePath: rootURL.appendingPathComponent("workspace.json"),
+            composeTabs: [
+                ComposeTabState(id: previousTabID, name: "Previous"),
+                ComposeTabState(id: prospectiveTabID, name: "Prospective"),
+                ComposeTabState(id: replacementTabID, name: "Replacement")
+            ],
+            activeComposeTabID: prospectiveTabID
+        )
+        try await install(workspace: workspace, in: window, reason: "workingDirsCommitTargetTest")
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: rootURL.path
+        )
+
+        let connectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "working-dirs-commit-target-test",
+            tabID: previousTabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID
+        )
+        window.mcpServer.setAfterFileToolLookupContextRootValidationForTesting {
+            window.mcpServer.setAfterFileToolLookupContextRootValidationForTesting(nil)
+            guard let workspaceIndex = window.workspaceManager.workspaces.firstIndex(where: { $0.id == workspace.id }) else {
+                XCTFail("Workspace disappeared before the commit-time target change")
+                return
+            }
+            window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = replacementTabID
+        }
+        addTeardownBlock { @MainActor in
+            window.mcpServer.setAfterFileToolLookupContextRootValidationForTesting(nil)
+        }
+
+        let (service, bindContext) = try await bindContextTool(for: window)
+        defer { withExtendedLifetime(service) {} }
+        do {
+            _ = try await ServerNetworkManager.withConnectionID(connectionID) {
+                try await bindContext([
+                    "op": .string("bind"),
+                    "working_dirs": .string(rootURL.path),
+                    "create_if_missing": .bool(false)
+                ])
+            }
+            XCTFail("Expected the commit-time target change to reject the stale working_dirs bind")
+        } catch {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("changed while its root projection was being resolved"), message)
+            XCTAssertTrue(message.contains("existing MCP binding was not changed"), message)
+        }
+        XCTAssertEqual(window.mcpServer.tabContextByConnectionID[connectionID]?.tabID, previousTabID)
+    }
+
+    @MainActor
     func testWorkingDirsBindPreservesPreviousBindingWhenSessionRootLifetimeChangesAfterPreflight() async throws {
         let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
         GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)

--- a/Tests/RepoPromptTests/MCP/Control/WorkingDirsBindRootProjectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/WorkingDirsBindRootProjectionTests.swift
@@ -5,6 +5,197 @@ import XCTest
 
 final class WorkingDirsBindRootProjectionTests: XCTestCase {
     @MainActor
+    func testWorkingDirsBindHydratesAgentProjectionBeforeBinding() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        addTeardownBlock { @MainActor in
+            WindowStatesManager.shared.unregisterWindowState(window)
+            await window.tearDown()
+        }
+
+        let logicalRootURL = try makeTemporaryDirectory(named: "working-dirs-hydration-logical")
+        let physicalRootURL = try makeTemporaryDirectory(named: "working-dirs-hydration-physical")
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: logicalRootURL.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: physicalRootURL.deletingLastPathComponent())
+        }
+
+        let previousTabID = UUID()
+        let agentTabID = UUID()
+        let agentSessionID = UUID()
+        let workspace = WorkspaceModel(
+            name: "Working Dirs Hydration",
+            repoPaths: [logicalRootURL.path],
+            customStoragePath: logicalRootURL.appendingPathComponent("workspace.json"),
+            composeTabs: [
+                ComposeTabState(id: previousTabID, name: "Previous"),
+                ComposeTabState(
+                    id: agentTabID,
+                    name: "Hydrating Agent",
+                    activeAgentSessionID: agentSessionID
+                )
+            ],
+            activeComposeTabID: agentTabID
+        )
+        try await install(workspace: workspace, in: window, reason: "workingDirsHydrationTest")
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: logicalRootURL.path
+        )
+        let physicalRoot = try await window.workspaceFileContextStore.loadRoot(
+            path: physicalRootURL.path,
+            kind: .sessionWorktree
+        )
+        let binding = makeWorktreeBinding(logicalRoot: logicalRoot, physicalRoot: physicalRoot)
+
+        var bindingState = AgentSessionWorktreeBindingState.unhydrated
+        var hydrationCount = 0
+        window.mcpServer.registerAgentWorktreeBindingsProvider { sessionID, tabID in
+            guard sessionID == agentSessionID, tabID == agentTabID else { return .unavailable }
+            return bindingState
+        }
+        window.mcpServer.registerAgentWorktreeBindingsResolver { sessionID, tabID in
+            XCTAssertEqual(sessionID, agentSessionID)
+            XCTAssertEqual(tabID, agentTabID)
+            hydrationCount += 1
+            bindingState = .hydrated([binding])
+            return bindingState
+        }
+
+        let connectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "working-dirs-hydration-test",
+            tabID: previousTabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID
+        )
+        let (service, bindContext) = try await bindContextTool(for: window)
+        defer { withExtendedLifetime(service) {} }
+
+        _ = try await ServerNetworkManager.withConnectionID(connectionID) {
+            try await bindContext([
+                "op": .string("bind"),
+                "working_dirs": .string(logicalRootURL.path),
+                "create_if_missing": .bool(false)
+            ])
+        }
+
+        XCTAssertEqual(hydrationCount, 1)
+        XCTAssertEqual(window.mcpServer.tabContextByConnectionID[connectionID]?.tabID, agentTabID)
+        let lookupContext = await window.mcpServer.resolveFileToolLookupContext(from: .init(
+            connectionID: connectionID,
+            clientName: "working-dirs-hydration-test",
+            windowID: window.windowID,
+            runPurpose: .unknown
+        ))
+        XCTAssertEqual(
+            lookupContext.translateInputPath(logicalRootURL.appendingPathComponent("Sources/New.swift").path),
+            physicalRootURL.appendingPathComponent("Sources/New.swift").path
+        )
+    }
+
+    @MainActor
+    func testWorkingDirsBindPreservesPreviousBindingWhenActiveTabChangesDuringPreflight() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        addTeardownBlock { @MainActor in
+            WindowStatesManager.shared.unregisterWindowState(window)
+            await window.tearDown()
+        }
+
+        let rootURL = try makeTemporaryDirectory(named: "working-dirs-stale-target")
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: rootURL.deletingLastPathComponent())
+        }
+
+        let previousTabID = UUID()
+        let prospectiveTabID = UUID()
+        let replacementTabID = UUID()
+        let agentSessionID = UUID()
+        let workspace = WorkspaceModel(
+            name: "Working Dirs Stale Target",
+            repoPaths: [rootURL.path],
+            customStoragePath: rootURL.appendingPathComponent("workspace.json"),
+            composeTabs: [
+                ComposeTabState(id: previousTabID, name: "Previous"),
+                ComposeTabState(
+                    id: prospectiveTabID,
+                    name: "Prospective Agent",
+                    activeAgentSessionID: agentSessionID
+                ),
+                ComposeTabState(id: replacementTabID, name: "Replacement")
+            ],
+            activeComposeTabID: prospectiveTabID
+        )
+        try await install(workspace: workspace, in: window, reason: "workingDirsStaleTargetTest")
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: rootURL.path
+        )
+
+        var bindingState = AgentSessionWorktreeBindingState.unhydrated
+        let hydrationGate = WorkingDirsHydrationGate()
+        window.mcpServer.registerAgentWorktreeBindingsProvider { sessionID, tabID in
+            guard sessionID == agentSessionID, tabID == prospectiveTabID else { return .unavailable }
+            return bindingState
+        }
+        window.mcpServer.registerAgentWorktreeBindingsResolver { sessionID, tabID in
+            XCTAssertEqual(sessionID, agentSessionID)
+            XCTAssertEqual(tabID, prospectiveTabID)
+            await hydrationGate.markStartedAndWaitForRelease()
+            bindingState = .hydrated([])
+            return bindingState
+        }
+
+        let connectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "working-dirs-stale-target-test",
+            tabID: previousTabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID
+        )
+        let (service, bindContext) = try await bindContextTool(for: window)
+        defer { withExtendedLifetime(service) {} }
+        let bindTask = Task { @MainActor in
+            try await ServerNetworkManager.withConnectionID(connectionID) {
+                try await bindContext([
+                    "op": .string("bind"),
+                    "working_dirs": .string(rootURL.path),
+                    "create_if_missing": .bool(false)
+                ])
+            }
+        }
+        addTeardownBlock {
+            bindTask.cancel()
+            await hydrationGate.release()
+            _ = try? await bindTask.value
+        }
+
+        await hydrationGate.waitUntilStarted()
+        let workspaceIndex = try XCTUnwrap(window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id })
+        window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = replacementTabID
+        await hydrationGate.release()
+
+        do {
+            _ = try await bindTask.value
+            XCTFail("Expected the stale working_dirs target to be rejected")
+        } catch {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("changed while its root projection was being resolved"), message)
+            XCTAssertTrue(message.contains("existing MCP binding was not changed"), message)
+        }
+        XCTAssertEqual(window.mcpServer.tabContextByConnectionID[connectionID]?.tabID, previousTabID)
+    }
+
+    @MainActor
     func testWorkingDirsBindRejectsRootlessAgentTabWithoutReplacingBinding() async throws {
         let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
         GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
@@ -99,5 +290,85 @@ final class WorkingDirsBindRootProjectionTests: XCTestCase {
         }
 
         XCTAssertEqual(window.mcpServer.tabContextByConnectionID[connectionID]?.tabID, previousTabID)
+    }
+
+    @MainActor
+    private func install(workspace: WorkspaceModel, in window: WindowState, reason: String) async throws {
+        window.workspaceManager.workspaces = [workspace]
+        let switchResult = await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: reason
+        )
+        XCTAssertTrue(switchResult.didSwitch)
+        window.promptManager.loadComposeTabsFromWorkspace(workspace, syncPromptText: true)
+    }
+
+    @MainActor
+    private func bindContextTool(
+        for window: WindowState
+    ) async throws -> (WindowRoutingService, RepoPromptApp.Tool) {
+        let service = WindowRoutingService(
+            windowStates: WindowStatesManager.shared,
+            networkMgr: ServerNetworkManager.shared
+        )
+        await service.prepareDomainTools()
+        let tools = await service.tools
+        return try (service, XCTUnwrap(tools.first { $0.name == MCPGlobalToolName.bindContext }))
+    }
+
+    private func makeTemporaryDirectory(named name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkingDirsBindRootProjectionTests-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL
+    }
+
+    private func makeWorktreeBinding(
+        logicalRoot: WorkspaceRootRecord,
+        physicalRoot: WorkspaceRootRecord
+    ) -> AgentSessionWorktreeBinding {
+        AgentSessionWorktreeBinding(
+            id: "binding-1",
+            repositoryID: "repo-1",
+            repoKey: "repo-key",
+            logicalRootPath: logicalRoot.standardizedFullPath,
+            logicalRootName: logicalRoot.name,
+            worktreeID: "wt-1",
+            worktreeRootPath: physicalRoot.standardizedFullPath,
+            source: "test"
+        )
+    }
+}
+
+private actor WorkingDirsHydrationGate {
+    private var started = false
+    private var released = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func markStartedAndWaitForRelease() async {
+        if !started {
+            started = true
+            let pending = startWaiters
+            startWaiters.removeAll()
+            pending.forEach { $0.resume() }
+        }
+        guard !released else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitUntilStarted() async {
+        guard !started else { return }
+        await withCheckedContinuation { startWaiters.append($0) }
+    }
+
+    func release() {
+        guard !released else { return }
+        released = true
+        let pending = releaseWaiters
+        releaseWaiters.removeAll()
+        pending.forEach { $0.resume() }
     }
 }


### PR DESCRIPTION
## Summary

- validate a `working_dirs` bind against the prospective active tab's authoritative file-tool root projection before changing the connection binding
- fail closed with workspace, tab, context, window, and missing-root guidance when that tab is rootless
- preserve the previous explicit binding; do not switch or create tabs, retry, or use tab-order heuristics

## Reproduction and root cause

In RepoPrompt CE 1.3.0, `working_dirs` could select the correct saved workspace/window while retaining its active explicit Agent tab. That tab's authoritative file-tool lookup context could be fail-closed and empty, so `get_file_tree(type="roots")` returned `Roots: 0` / `No workspace loaded` while the diagnostic footer still listed the workspace's loaded root.

The binding path resolved the workspace/window and captured `activeComposeTabID`, but did not validate the prospective tab's actual `WorkspaceLookupContext`. Workspace-visible roots are diagnostic and can diverge from the bound tab's file-tool projection. Tab index/order is not involved.

## Validation

- `WorkingDirsBindRootProjectionTests`: 1 passed
- `BindContextRoutingRecoveryTests`: 6 passed
- strict SwiftFormat/SwiftLint: passed
- RepoPrompt product build: passed
- commit and push safety preflights: passed
- independent read-only review: no blockers
- full PR-ready root suite: timed out after 3600 seconds with no assertion failure while `GitWorktreeCreationReceiptTests.testConcurrentSameRepositoryCreationsKeepReceiptsSessionIsolated` was still running; the change-specific and neighboring suites above passed independently

## Relationship to open PRs

This PR is standalone on current `main`. #812 restricts `context_id` candidate windows but does not validate `working_dirs` active-tab roots. #816 handles downstream secondary-root Agent worktrees and does not touch `bind_context`. Neither PR is required.
