### PR TITLE
Restore safe Codex hook compatibility with isolated state

### DIFF
--- a/Scripts/Fixtures/codex-app-server-contract.json
+++ b/Scripts/Fixtures/codex-app-server-contract.json
@@ -1482,6 +1482,137 @@
           "cancel"
         ]
       }
+    },
+    {
+      "union": "ClientRequest.json",
+      "method": "hooks/list",
+      "alwaysSent": [
+        "cwds"
+      ],
+      "responseSchema": "v2/HooksListResponse.json",
+      "consumedResponse": [
+        { "path": "data", "presence": "required", "nullable": false },
+        { "path": "data[].cwd", "presence": "required", "nullable": false },
+        { "path": "data[].hooks", "presence": "required", "nullable": false },
+        { "path": "data[].warnings", "presence": "required", "nullable": false },
+        { "path": "data[].errors", "presence": "required", "nullable": false },
+        { "path": "data[].errors[].path", "presence": "required", "nullable": false },
+        { "path": "data[].errors[].message", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].key", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].eventName", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].handlerType", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].matcher", "presence": "optional", "nullable": true },
+        { "path": "data[].hooks[].command", "presence": "optional", "nullable": true },
+        { "path": "data[].hooks[].timeoutSec", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].statusMessage", "presence": "optional", "nullable": true },
+        { "path": "data[].hooks[].additionalContextLimit", "presence": "optional", "nullable": true },
+        { "path": "data[].hooks[].sourcePath", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].source", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].pluginId", "presence": "optional", "nullable": true },
+        { "path": "data[].hooks[].displayOrder", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].enabled", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].isManaged", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].currentHash", "presence": "required", "nullable": false },
+        { "path": "data[].hooks[].trustStatus", "presence": "required", "nullable": false }
+      ],
+      "consumedEnumValues": {
+        "data[].hooks[].eventName": ["preToolUse", "permissionRequest", "postToolUse", "preCompact", "postCompact", "sessionStart", "sessionEnd", "userPromptSubmit", "subagentStart", "subagentStop", "stop"],
+        "data[].hooks[].handlerType": ["command", "prompt", "agent"],
+        "data[].hooks[].source": ["system", "user", "project", "mdm", "sessionFlags", "plugin", "cloudRequirements", "cloudManagedConfig", "legacyManagedConfigFile", "legacyManagedConfigMdm", "unknown"],
+        "data[].hooks[].trustStatus": ["managed", "untrusted", "trusted", "modified"]
+      }
+    },
+    {
+      "union": "ClientRequest.json",
+      "method": "config/read",
+      "alwaysSent": [
+        "includeLayers",
+        "cwd"
+      ],
+      "responseSchema": "v2/ConfigReadResponse.json",
+      "consumedResponse": [
+        { "path": "layers", "presence": "optional", "nullable": true },
+        { "path": "layers[].name.type", "presence": "conditional", "nullable": false },
+        { "path": "layers[].name.file", "presence": "conditional", "nullable": false },
+        { "path": "layers[].name.profile", "presence": "optional", "nullable": true },
+        { "path": "layers[].version", "presence": "conditional", "nullable": false }
+      ],
+      "consumedEnumValues": {
+        "layers[].name.type": ["mdm", "system", "enterpriseManaged", "user", "project", "sessionFlags", "legacyManagedConfigTomlFromFile", "legacyManagedConfigTomlFromMdm"]
+      }
+    },
+    {
+      "union": "ClientRequest.json",
+      "method": "config/batchWrite",
+      "alwaysSent": [
+        "edits",
+        "edits[].keyPath",
+        "edits[].value",
+        "edits[].mergeStrategy",
+        "filePath",
+        "expectedVersion",
+        "reloadUserConfig"
+      ],
+      "enumValues": {
+        "edits[].mergeStrategy": ["upsert"]
+      },
+      "responseSchema": "v2/ConfigWriteResponse.json",
+      "consumedResponse": [
+        { "path": "status", "presence": "required", "nullable": false },
+        { "path": "version", "presence": "required", "nullable": false },
+        { "path": "filePath", "presence": "required", "nullable": false }
+      ],
+      "consumedEnumValues": {
+        "status": ["ok", "okOverridden"]
+      }
+    },
+    {
+      "union": "ServerNotification.json",
+      "method": "hook/started",
+      "consumedParams": [
+        { "path": "threadId", "presence": "required", "nullable": false },
+        { "path": "turnId", "presence": "optional", "nullable": true },
+        { "path": "run.id", "presence": "required", "nullable": false },
+        { "path": "run.eventName", "presence": "required", "nullable": false },
+        { "path": "run.handlerType", "presence": "required", "nullable": false },
+        { "path": "run.executionMode", "presence": "required", "nullable": false },
+        { "path": "run.scope", "presence": "required", "nullable": false },
+        { "path": "run.sourcePath", "presence": "required", "nullable": false },
+        { "path": "run.source", "presence": "optional", "nullable": false },
+        { "path": "run.displayOrder", "presence": "required", "nullable": false },
+        { "path": "run.status", "presence": "required", "nullable": false },
+        { "path": "run.statusMessage", "presence": "optional", "nullable": true },
+        { "path": "run.startedAt", "presence": "required", "nullable": false },
+        { "path": "run.completedAt", "presence": "optional", "nullable": true },
+        { "path": "run.durationMs", "presence": "optional", "nullable": true },
+        { "path": "run.entries", "presence": "required", "nullable": false },
+        { "path": "run.entries[].kind", "presence": "required", "nullable": false },
+        { "path": "run.entries[].text", "presence": "required", "nullable": false }
+      ]
+    },
+    {
+      "union": "ServerNotification.json",
+      "method": "hook/completed",
+      "consumedParams": [
+        { "path": "threadId", "presence": "required", "nullable": false },
+        { "path": "turnId", "presence": "optional", "nullable": true },
+        { "path": "run.id", "presence": "required", "nullable": false },
+        { "path": "run.eventName", "presence": "required", "nullable": false },
+        { "path": "run.handlerType", "presence": "required", "nullable": false },
+        { "path": "run.executionMode", "presence": "required", "nullable": false },
+        { "path": "run.scope", "presence": "required", "nullable": false },
+        { "path": "run.sourcePath", "presence": "required", "nullable": false },
+        { "path": "run.source", "presence": "optional", "nullable": false },
+        { "path": "run.displayOrder", "presence": "required", "nullable": false },
+        { "path": "run.status", "presence": "required", "nullable": false },
+        { "path": "run.statusMessage", "presence": "optional", "nullable": true },
+        { "path": "run.startedAt", "presence": "required", "nullable": false },
+        { "path": "run.completedAt", "presence": "optional", "nullable": true },
+        { "path": "run.durationMs", "presence": "optional", "nullable": true },
+        { "path": "run.entries", "presence": "required", "nullable": false },
+        { "path": "run.entries[].kind", "presence": "required", "nullable": false },
+        { "path": "run.entries[].text", "presence": "required", "nullable": false }
+      ]
     }
   ]
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/UserInteractionModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/UserInteractionModels.swift
@@ -829,6 +829,7 @@ struct AgentApprovalDetail: Identifiable, Hashable {
 enum AgentApprovalKind: String, Hashable {
     case commandExecution
     case fileChange
+    case codexHookReview
 }
 
 enum AgentApprovalDecision: Hashable {
@@ -841,6 +842,7 @@ enum AgentApprovalDecision: Hashable {
 
 enum AgentApprovalRequestID: Hashable {
     case codex(CodexAppServerRequestID)
+    case codexHookReview(UUID)
     case claudeControl(String)
     case acp(String)
 
@@ -848,6 +850,8 @@ enum AgentApprovalRequestID: Hashable {
         switch self {
         case let .codex(id):
             id.displayValue
+        case let .codexHookReview(id):
+            id.uuidString
         case let .claudeControl(id):
             id
         case let .acp(id):
@@ -995,10 +999,12 @@ struct AgentApprovalRequest: Identifiable, Hashable {
             "Command Approval"
         case .fileChange:
             "File Change Approval"
+        case .codexHookReview:
+            "Codex Project Hook Review"
         }
     }
 
     var supportsAlwaysAllow: Bool {
-        true
+        kind != .codexHookReview
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -3529,6 +3529,24 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         return true
     }
 
+    private func codexStartupStillCurrent(
+        session: AgentTabSession,
+        expectedRunID: UUID?,
+        expectedRunAttemptID: UUID?,
+        expectedController: (any CodexSessionControlling)?
+    ) -> Bool {
+        guard session.runID == expectedRunID,
+              session.activeRunAttemptID == expectedRunAttemptID,
+              let expectedController,
+              let activeController = session.codexController,
+              Self.sameCodexControllerInstance(activeController, expectedController)
+        else {
+            logCodex("[AgentModeVM][CodexStartup] ignoring stale session-start settlement for tab \(session.tabID)")
+            return false
+        }
+        return true
+    }
+
     private func applyCodexNativeSessionStartResult(
         _ startResult: CodexNativeSessionStartResult,
         to session: AgentTabSession,
@@ -5160,9 +5178,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             logCodex("[AgentModeVM][CodexReconnect] skipping repeated timed-out resume target for tab \(session.tabID) and starting a fresh thread")
         }
         let existingRef = shouldSkipTimedOutResumeTarget ? nil : resumeCandidate
+        let expectedStartupRunID = session.runID
+        let expectedStartupRunAttemptID = session.activeRunAttemptID
+        let expectedStartupController = session.codexController
         do {
             var startResult = try await startCodexNativeSession(
-                controller: session.codexController,
+                controller: expectedStartupController,
                 existingRef: existingRef,
                 baseInstructions: basePrompt,
                 model: selection.model,
@@ -5170,6 +5191,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 serviceTier: selection.serviceTier,
                 allowMissingRolloutFallback: allowMissingRolloutFallback
             )
+            guard codexStartupStillCurrent(
+                session: session,
+                expectedRunID: expectedStartupRunID,
+                expectedRunAttemptID: expectedStartupRunAttemptID,
+                expectedController: expectedStartupController
+            ) else { return }
             if shouldSkipTimedOutResumeTarget, startResult.fallbackReason == nil {
                 startResult = CodexNativeSessionStartResult(
                     sessionRef: startResult.sessionRef,
@@ -5184,6 +5211,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             )
             await ensureCodexToolTrackingForReadySessionIfNeeded(for: session, runID: runID)
         } catch {
+            guard codexStartupStillCurrent(
+                session: session,
+                expectedRunID: expectedStartupRunID,
+                expectedRunAttemptID: expectedStartupRunAttemptID,
+                expectedController: expectedStartupController
+            ) else { return }
             var effectiveError: Error = error
             if session.runState.isActive,
                let runID = session.runID,
@@ -5192,7 +5225,14 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             {
                 setRunningStatus("Refreshing Codex authentication…", source: .reconnect, session: session, urgent: true)
                 viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
-                switch await authRecovery.refreshManagedAccount() {
+                let authRecoveryResult = await authRecovery.refreshManagedAccount()
+                guard codexStartupStillCurrent(
+                    session: session,
+                    expectedRunID: expectedStartupRunID,
+                    expectedRunAttemptID: expectedStartupRunAttemptID,
+                    expectedController: expectedStartupController
+                ) else { return }
+                switch authRecoveryResult {
                 case let .requiresUserLogin(guidance):
                     _ = markCodexReconnectNeeded(for: session, source: "managed-auth-recovery-required-during-start")
                     effectiveError = AIProviderError.invalidConfiguration(detail: guidance)
@@ -5221,6 +5261,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                             serviceTier: selection.serviceTier,
                             allowMissingRolloutFallback: allowMissingRolloutFallback
                         )
+                        guard codexStartupStillCurrent(
+                            session: session,
+                            expectedRunID: expectedStartupRunID,
+                            expectedRunAttemptID: expectedStartupRunAttemptID,
+                            expectedController: recoveredController
+                        ) else { return }
                         if shouldSkipTimedOutResumeTarget, recoveredStartResult.fallbackReason == nil {
                             recoveredStartResult = CodexNativeSessionStartResult(
                                 sessionRef: recoveredStartResult.sessionRef,
@@ -5236,6 +5282,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                         await ensureCodexToolTrackingForReadySessionIfNeeded(for: session, runID: runID)
                         return
                     } catch {
+                        guard codexStartupStillCurrent(
+                            session: session,
+                            expectedRunID: expectedStartupRunID,
+                            expectedRunAttemptID: expectedStartupRunAttemptID,
+                            expectedController: recoveredController
+                        ) else { return }
                         effectiveError = error
                     }
                 }
@@ -5273,6 +5325,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                         serviceTier: selection.serviceTier,
                         allowMissingRolloutFallback: false
                     )
+                    guard codexStartupStillCurrent(
+                        session: session,
+                        expectedRunID: expectedStartupRunID,
+                        expectedRunAttemptID: expectedStartupRunAttemptID,
+                        expectedController: freshController
+                    ) else { return }
                     if retryResult.fallbackReason == nil {
                         retryResult = CodexNativeSessionStartResult(
                             sessionRef: retryResult.sessionRef,
@@ -5288,6 +5346,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     await ensureCodexToolTrackingForReadySessionIfNeeded(for: session, runID: runID)
                     return
                 } catch {
+                    guard codexStartupStillCurrent(
+                        session: session,
+                        expectedRunID: expectedStartupRunID,
+                        expectedRunAttemptID: expectedStartupRunAttemptID,
+                        expectedController: freshController
+                    ) else { return }
                     let invalidatedTimedOutController = CodexAppServerClient.isTimeoutError(error)
                         ? invalidateCodexControllerForReconnect(
                             session: session,
@@ -6674,6 +6738,8 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             (nil, payload.scope.turnID, payload.scope.itemID)
         case let .livenessActivity(activity):
             (activity.threadID, activity.turnID, activity.itemID)
+        case let .hookLifecycleDiagnostic(diagnostic):
+            (diagnostic.threadID, diagnostic.turnID, nil)
         case let .errorNotification(notification):
             (notification.threadID, notification.turnID, notification.itemID)
         default:
@@ -7215,6 +7281,26 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             }
             viewModel?.setAgentRunActive(session.tabID, isActive: true)
             viewModel?.requestUIRefresh(tabID: session.tabID, scope: .runtimeMetrics)
+        case let .hookInventoryDiagnostic(diagnostic):
+            guard session.runState.isActive else { return }
+            let status = diagnostic.isZeroInventory
+                ? "No Codex project hooks were discovered for this execution directory."
+                : "Codex inventoried \(diagnostic.hookCount) project hook definition(s)."
+            setRunningStatus(status, source: .transport, session: session, urgent: true)
+            viewModel?.requestUIRefresh(tabID: session.tabID, scope: .runtimeMetrics)
+        case let .hookLifecycleDiagnostic(diagnostic):
+            guard session.runState.isActive else { return }
+            if diagnostic.reportedRuntimeFailure {
+                let detail = diagnostic.statusMessage?.trimmingCharacters(in: .whitespacesAndNewlines)
+                let suffix = detail?.isEmpty == false ? ": \(detail!)" : ""
+                setRunningStatus(
+                    "Codex hook \(diagnostic.eventName.rawValue) reported \(diagnostic.status.rawValue)\(suffix)",
+                    source: .transport,
+                    session: session,
+                    urgent: true
+                )
+                viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true, scope: .runtimeMetrics)
+            }
         case let .errorNotification(notification):
             let willRetry: Bool
             if let structuredWillRetry = notification.willRetry {
@@ -8602,6 +8688,8 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             case .turnCompleted: "turnCompleted"
             case .contextCompacted: "contextCompacted"
             case .livenessActivity: "livenessActivity"
+            case .hookInventoryDiagnostic: "hookInventoryDiagnostic"
+            case .hookLifecycleDiagnostic: "hookLifecycleDiagnostic"
             case .errorNotification: "errorNotification"
             case .error: "error"
             case .system: "system"
@@ -8647,6 +8735,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             "contextCompacted turnID=\(turnID ?? "nil")"
         case let .livenessActivity(activity):
             "livenessActivity kind=\(activity.kind.rawValue) method=\(activity.method) activeFlags=\(activity.activeFlags.joined(separator: ","))"
+        case let .hookInventoryDiagnostic(diagnostic):
+            "hookInventoryDiagnostic hooks=\(diagnostic.hookCount) review=\(diagnostic.reviewRequiredCount)"
+        case let .hookLifecycleDiagnostic(diagnostic):
+            "hookLifecycleDiagnostic event=\(diagnostic.eventName.rawValue) status=\(diagnostic.status.rawValue)"
         case let .errorNotification(notification):
             "errorNotification willRetry=\(notification.willRetry.map(String.init(describing:)) ?? "nil") message=\(notification.message)"
         case let .error(message):
@@ -8985,11 +9077,37 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         viewModel?.reconcileInteractiveRunState(session)
         handleRunInteractionStateChange(for: session, reason: .approvalResponseSubmitted)
         viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
-        guard case let .codex(requestID) = request.requestID else {
+        switch request.requestID {
+        case let .codex(requestID):
+            Task { [controller] in
+                guard let activeController = session.codexController,
+                      Self.sameCodexControllerInstance(activeController, controller)
+                else { return }
+                await controller.respondToServerRequest(id: requestID, result: result)
+            }
+        case let .codexHookReview(interactionID):
+            let boundedDecision: AgentApprovalDecision = decision == .accept ? .accept :
+                (decision == .decline ? .decline : .cancel)
+            let expectedRunID = session.runID
+            let expectedRunAttemptID = session.activeRunAttemptID
+            Task { [controller] in
+                guard session.runID == expectedRunID,
+                      session.activeRunAttemptID == expectedRunAttemptID,
+                      let activeController = session.codexController,
+                      Self.sameCodexControllerInstance(activeController, controller)
+                else { return }
+                _ = await controller.respondToHookReview(
+                    interactionID: interactionID,
+                    decision: boundedDecision
+                )
+                guard session.runID == expectedRunID,
+                      session.activeRunAttemptID == expectedRunAttemptID,
+                      let activeController = session.codexController,
+                      Self.sameCodexControllerInstance(activeController, controller)
+                else { return }
+            }
+        default:
             return
-        }
-        Task { [controller] in
-            await controller.respondToServerRequest(id: requestID, result: result)
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -7283,10 +7283,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             viewModel?.requestUIRefresh(tabID: session.tabID, scope: .runtimeMetrics)
         case let .hookInventoryDiagnostic(diagnostic):
             guard session.runState.isActive else { return }
-            let status = diagnostic.isZeroInventory
-                ? "No Codex project hooks were discovered for this execution directory."
-                : "Codex inventoried \(diagnostic.hookCount) project hook definition(s)."
-            setRunningStatus(status, source: .transport, session: session, urgent: true)
+            setRunningStatus(
+                diagnostic.statusSummary,
+                source: .transport,
+                session: session,
+                urgent: true
+            )
             viewModel?.requestUIRefresh(tabID: session.tabID, scope: .runtimeMetrics)
         case let .hookLifecycleDiagnostic(diagnostic):
             guard session.runState.isActive else { return }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+InteractionActions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+InteractionActions.swift
@@ -9,7 +9,7 @@ extension AgentModeViewModel {
             return
         }
         switch request.requestID {
-        case .codex:
+        case .codex, .codexHookReview:
             codexCoordinator.submitApprovalDecision(session: session, decision: decision)
         case .claudeControl:
             claudeCoordinator.submitApprovalDecision(session: session, decision: decision)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1660,7 +1660,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 goalSupportEnabledProvider: { CodexGoalSupport.isEnabled },
                 reasoningSummariesEnabledProvider: { CodexReasoningSummaries.isEnabled },
                 memoriesEnabledProvider: { CodexMemories.isEnabled },
-                computerUseEnabledProvider: { computerUseEnabled }
+                computerUseEnabledProvider: { computerUseEnabled },
+                hookCompatibilityGateEnabled: true
             )
             return CodexNativeSessionController(
                 client: client,
@@ -5899,7 +5900,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     private func mcpApprovalDecisionLabels(for approval: AgentApprovalRequest, includeAliases: Bool = true) -> [String] {
-        var labels = ["accept", "accept_for_session"]
+        var labels = ["accept"]
+        if approval.supportsAlwaysAllow {
+            labels.append("accept_for_session")
+        }
         if approval.kind == .commandExecution {
             labels.append("accept_with_amendment")
         }
@@ -8488,6 +8492,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             case "accept", "approve":
                 decision = .accept
             case "accept_for_session", "always_allow", "approve_for_session":
+                guard approval.supportsAlwaysAllow else {
+                    throw MCPError.invalidParams("accept_for_session is not supported for this approval interaction.")
+                }
                 decision = .acceptForSession
             case "accept_with_amendment", "amend":
                 guard approval.kind == .commandExecution else {

--- a/Sources/RepoPrompt/Features/Diagnostics/AgentMode/Stress/AgentChatStressHarness.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/AgentMode/Stress/AgentChatStressHarness.swift
@@ -1401,7 +1401,7 @@
                 switch event {
                 case .toolCall, .commandExecutionRunning:
                     true
-                case .toolResult, .turnStarted, .turnCompleted, .assistantDelta, .canonicalAssistantDelta, .assistantCompleted, .reasoningDelta, .reasoningCompleted, .tokenUsage, .contextCompacted, .approvalRequest, .permissionsRequest, .requestUserInput, .mcpElicitationRequest, .serverRequestIssue, .livenessActivity, .errorNotification, .error, .system:
+                case .toolResult, .turnStarted, .turnCompleted, .assistantDelta, .canonicalAssistantDelta, .assistantCompleted, .reasoningDelta, .reasoningCompleted, .tokenUsage, .contextCompacted, .approvalRequest, .permissionsRequest, .requestUserInput, .mcpElicitationRequest, .serverRequestIssue, .livenessActivity, .hookInventoryDiagnostic, .hookLifecycleDiagnostic, .errorNotification, .error, .system:
                     false
                 }
             }

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/CodexManagedHomeSettingsModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/CodexManagedHomeSettingsModel.swift
@@ -1,0 +1,69 @@
+import AppKit
+import Foundation
+
+struct CodexManagedHomeSettingsSnapshot: Equatable {
+    let statePaths: CodexRuntimeAuthority.StatePaths
+    let projection: CodexManagedInstructionsProjection.Diagnostic
+
+    var managedHome: URL {
+        statePaths.codexHome
+    }
+
+    static func load(
+        applicationSupportURL: URL? = nil,
+        buildChannel: CodexRuntimeAuthority.BuildChannel = .current,
+        ordinaryHome: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true),
+        fileManager: FileManager = .default
+    ) -> CodexManagedHomeSettingsSnapshot {
+        let statePaths = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: applicationSupportURL,
+            buildChannel: buildChannel
+        )
+        return CodexManagedHomeSettingsSnapshot(
+            statePaths: statePaths,
+            projection: CodexManagedInstructionsProjection.diagnostic(
+                managedHome: statePaths.codexHome,
+                ordinaryHome: ordinaryHome,
+                fileManager: fileManager
+            )
+        )
+    }
+}
+
+struct CodexManagedHomeSettingsActions {
+    private let prepareState: (CodexRuntimeAuthority.StatePaths) throws -> Void
+    private let copyText: (String) -> Bool
+    private let openDirectory: (URL) -> Bool
+
+    init(
+        prepareState: @escaping (CodexRuntimeAuthority.StatePaths) throws -> Void,
+        copyText: @escaping (String) -> Bool,
+        openDirectory: @escaping (URL) -> Bool
+    ) {
+        self.prepareState = prepareState
+        self.copyText = copyText
+        self.openDirectory = openDirectory
+    }
+
+    func copyFullPath(_ statePaths: CodexRuntimeAuthority.StatePaths) -> Bool {
+        copyText(statePaths.codexHome.path)
+    }
+
+    func openInFinder(_ statePaths: CodexRuntimeAuthority.StatePaths) throws -> Bool {
+        try prepareState(statePaths)
+        return openDirectory(statePaths.codexHome)
+    }
+
+    static var live: CodexManagedHomeSettingsActions {
+        CodexManagedHomeSettingsActions(
+            prepareState: { try CodexRuntimeAuthority.prepareManagedState($0) },
+            copyText: { value in
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                return pasteboard.setString(value, forType: .string)
+            },
+            openDirectory: { NSWorkspace.shared.open($0) }
+        )
+    }
+}

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 
+@MainActor
 struct CLIProvidersSettingsView: View {
     @ObservedObject var viewModel: APISettingsViewModel
     @ObservedObject var promptViewModel: PromptViewModel
@@ -13,6 +14,7 @@ struct CLIProvidersSettingsView: View {
     ///
     /// SEARCH-HELPER: Open Agent Permissions, Configure in Agent Permissions, A4 progressive disclosure
     var onNavigate: ((SettingsTab) -> Void)?
+    private let codexManagedHomeActions: CodexManagedHomeSettingsActions
 
     @StateObject private var providerPermissionsVM: AgentProviderPermissionsSettingsViewModel
 
@@ -23,7 +25,8 @@ struct CLIProvidersSettingsView: View {
         providerPermissionsViewModel: @MainActor @escaping () -> AgentProviderPermissionsSettingsViewModel,
         onAPIKeyUpdated: (() -> Void)? = nil,
         closeAction: (() -> Void)? = nil,
-        onNavigate: ((SettingsTab) -> Void)? = nil
+        onNavigate: ((SettingsTab) -> Void)? = nil,
+        codexManagedHomeActions: CodexManagedHomeSettingsActions = .live
     ) {
         self.viewModel = viewModel
         self.promptViewModel = promptViewModel
@@ -31,7 +34,9 @@ struct CLIProvidersSettingsView: View {
         self.onAPIKeyUpdated = onAPIKeyUpdated
         self.closeAction = closeAction
         self.onNavigate = onNavigate
+        self.codexManagedHomeActions = codexManagedHomeActions
         _providerPermissionsVM = StateObject(wrappedValue: providerPermissionsViewModel())
+        _codexManagedHomeSnapshot = State(initialValue: .load())
     }
 
     @State private var showAlert = false
@@ -44,6 +49,8 @@ struct CLIProvidersSettingsView: View {
     @State private var codexManagedDeviceCode: CodexManagedChatgptDeviceCode?
     @State private var didCopyCodexManagedDeviceCode = false
     @State private var showCodexSignOutConfirmation = false
+    @State private var codexManagedHomeSnapshot: CodexManagedHomeSettingsSnapshot
+    @State private var codexManagedHomeActionMessage: String?
     @State private var isLoadingOpenCode = false
     @State private var isLoadingCursor = false
     @State private var isLoadingGrokBuild = false
@@ -151,6 +158,7 @@ struct CLIProvidersSettingsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
             Task {
+                refreshCodexManagedHomeSnapshot()
                 await viewModel.loadCompatibleBackendState()
                 await viewModel.refreshClaudeCodeBinaryStatus()
             }
@@ -1565,6 +1573,8 @@ struct CLIProvidersSettingsView: View {
             isExpanded: $isCodexExpanded
         ) {
             VStack(alignment: .leading, spacing: 12) {
+                codexManagedHomeSection
+
                 // KYC note
                 HStack(spacing: 4) {
                     Text("ChatGPT may require identity verification (KYC) to access Codex.")
@@ -1739,6 +1749,134 @@ struct CLIProvidersSettingsView: View {
                     }
                 }
             }
+        }
+    }
+
+    private var codexManagedHomeSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "externaldrive.fill")
+                    .foregroundColor(.secondary)
+                Text("Managed Codex Home")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            }
+
+            Text(codexManagedHomeSnapshot.managedHome.path)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundColor(.primary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(7)
+                .background(Color.secondary.opacity(0.07))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+
+            HStack(spacing: 8) {
+                Button("Copy Full Path") {
+                    codexManagedHomeActionMessage = codexManagedHomeActions.copyFullPath(
+                        codexManagedHomeSnapshot.statePaths
+                    )
+                        ? "Full managed-home path copied."
+                        : "Could not copy the managed-home path. Try selecting and copying the path above."
+                }
+                .buttonStyle(CustomButtonStyle())
+
+                Button("Open in Finder") {
+                    openManagedCodexHomeInFinder()
+                }
+                .buttonStyle(CustomButtonStyle())
+
+                Button("Refresh Status") {
+                    refreshCodexManagedHomeSnapshot()
+                    codexManagedHomeActionMessage = nil
+                }
+                .buttonStyle(CustomButtonStyle())
+
+                Spacer()
+            }
+
+            HStack(alignment: .top, spacing: 7) {
+                Image(systemName: codexProjectionStatusIcon)
+                    .foregroundColor(codexProjectionStatusColor)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(codexProjectionStatusTitle)
+                        .font(.system(size: 11, weight: .medium))
+                    Text(codexManagedHomeSnapshot.projection.message)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            if let codexManagedHomeActionMessage {
+                Text(codexManagedHomeActionMessage)
+                    .font(.caption)
+                    .foregroundColor(
+                        codexManagedHomeActionMessage.hasPrefix("Could not") ? .red : .secondary
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Text("RepoPrompt uses this isolated home. Project hooks are inventoried and reviewed before a thread starts. The effective ordinary global AGENTS.override.md or AGENTS.md is projected one-way as a RepoPrompt-owned regular file before launch.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("Not shared or imported from ordinary ~/.codex: authentication, the whole Codex home or config, sessions and history, SQLite, logs, and ordinary global executable hooks.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondary.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var codexProjectionStatusTitle: String {
+        switch codexManagedHomeSnapshot.projection.status {
+        case .current: "Global instruction projection current"
+        case .absent: "Global instruction projection absent"
+        case .conflict: "Global instruction projection needs attention"
+        case .error: "Global instruction projection inspection failed"
+        }
+    }
+
+    private var codexProjectionStatusIcon: String {
+        switch codexManagedHomeSnapshot.projection.status {
+        case .current: "checkmark.circle.fill"
+        case .absent: "minus.circle"
+        case .conflict: "exclamationmark.triangle.fill"
+        case .error: "xmark.octagon.fill"
+        }
+    }
+
+    private var codexProjectionStatusColor: Color {
+        switch codexManagedHomeSnapshot.projection.status {
+        case .current: .green
+        case .absent: .secondary
+        case .conflict: .orange
+        case .error: .red
+        }
+    }
+
+    private func refreshCodexManagedHomeSnapshot() {
+        codexManagedHomeSnapshot = .load()
+    }
+
+    private func openManagedCodexHomeInFinder() {
+        do {
+            guard try codexManagedHomeActions.openInFinder(codexManagedHomeSnapshot.statePaths) else {
+                codexManagedHomeActionMessage = "Could not open the managed Codex home in Finder. The path remains selectable above."
+                refreshCodexManagedHomeSnapshot()
+                return
+            }
+            codexManagedHomeActionMessage = nil
+            refreshCodexManagedHomeSnapshot()
+        } catch {
+            codexManagedHomeActionMessage = "Could not safely prepare the managed Codex home. Check its permissions and remove symbolic links from RepoPrompt-owned path components."
+            refreshCodexManagedHomeSnapshot()
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexOverrides.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexOverrides.swift
@@ -101,13 +101,6 @@ enum CodexOverrides {
         ]
     }
 
-    static func managedStateConfigMap(_ statePaths: CodexRuntimeAuthority.StatePaths) -> [String: Any] {
-        [
-            "sqlite_home": statePaths.sqliteHome.path,
-            "log_dir": statePaths.logDirectory.path
-        ]
-    }
-
     static func appServerConfigMap(
         toolPolicy: ToolPolicy,
         featurePolicy: FeaturePolicy = .defaultDisabled

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexOverrides.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexOverrides.swift
@@ -94,6 +94,20 @@ enum CodexOverrides {
         return args
     }
 
+    static func managedStateArgs(_ statePaths: CodexRuntimeAuthority.StatePaths) -> [String] {
+        [
+            "-c", "sqlite_home=\(tomlString(statePaths.sqliteHome.path))",
+            "-c", "log_dir=\(tomlString(statePaths.logDirectory.path))"
+        ]
+    }
+
+    static func managedStateConfigMap(_ statePaths: CodexRuntimeAuthority.StatePaths) -> [String: Any] {
+        [
+            "sqlite_home": statePaths.sqliteHome.path,
+            "log_dir": statePaths.logDirectory.path
+        ]
+    }
+
     static func appServerConfigMap(
         toolPolicy: ToolPolicy,
         featurePolicy: FeaturePolicy = .defaultDisabled
@@ -181,6 +195,22 @@ enum CodexOverrides {
             config[key] = value
         }
         return config
+    }
+
+    private static func tomlString(_ value: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(value.count + 2)
+        for character in value {
+            switch character {
+            case "\\": escaped += "\\\\"
+            case "\"": escaped += "\\\""
+            case "\n": escaped += "\\n"
+            case "\r": escaped += "\\r"
+            case "\t": escaped += "\\t"
+            default: escaped.append(character)
+            }
+        }
+        return "\"\(escaped)\""
     }
 
     private static func webSearchMode(enabled: Bool) -> String {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -1396,12 +1396,15 @@ actor CodexAppServerClient {
             ),
             featurePolicy: config.processFeaturePolicy
         )
-        let args = processOverrides + ["app-server"]
+        let args = processOverrides + CodexOverrides.managedStateArgs(runtime.statePaths) + ["app-server"]
         let launchDirectory = CLIProcessConfiguration.resolvedWorkingDirectory(
             config.processLaunchDirectory
         )
         let spawned: SpawnedProcess
         do {
+            try CodexManagedInstructionsProjection.projectBeforeLaunch(
+                managedHome: runtime.statePaths.codexHome
+            )
             try await processSpawnPreparation()
             try Task.checkCancellation()
             try ensureStartupAuthority(startupAuthority)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -202,6 +202,7 @@ actor CodexAppServerClient {
         case executableUnavailable(String)
         case transportWriteFailed(message: String, errno: Int32?)
         case transportReadSetupFailed(message: String, errno: Int32?)
+        case uncertainMutation(method: String)
 
         var errorDescription: String? {
             switch self {
@@ -221,6 +222,8 @@ actor CodexAppServerClient {
                 message
             case let .transportReadSetupFailed(message, _):
                 message
+            case let .uncertainMutation(method):
+                "Codex \(method) may have partially succeeded. RepoPrompt terminated the authoritative app-server transport and did not retry the mutation."
             }
         }
 
@@ -283,6 +286,7 @@ actor CodexAppServerClient {
     private struct PendingRequestMetadata {
         let method: String
         let transportGeneration: UInt64
+        let isMutation: Bool
     }
 
     private struct ExitObservation {
@@ -832,10 +836,15 @@ actor CodexAppServerClient {
         }
         timeoutTasks.removeAll()
         let requests = pendingRequests
+        let requestMetadata = pendingRequestMetadata
         pendingRequests.removeAll()
         pendingRequestMetadata.removeAll()
-        for continuation in requests.values {
-            continuation.resume(throwing: requestFailure)
+        for (requestID, continuation) in requests {
+            if let metadata = requestMetadata[requestID], metadata.isMutation {
+                continuation.resume(throwing: ClientError.uncertainMutation(method: metadata.method))
+            } else {
+                continuation.resume(throwing: requestFailure)
+            }
         }
 
         let notifContinuations = notificationContinuations
@@ -1025,10 +1034,15 @@ actor CodexAppServerClient {
         }
         timeoutTasks.removeAll()
         let requests = pendingRequests
+        let requestMetadata = pendingRequestMetadata
         pendingRequests.removeAll()
         pendingRequestMetadata.removeAll()
-        for continuation in requests.values {
-            continuation.resume(throwing: ClientError.processNotRunning)
+        for (requestID, continuation) in requests {
+            if let metadata = requestMetadata[requestID], metadata.isMutation {
+                continuation.resume(throwing: ClientError.uncertainMutation(method: metadata.method))
+            } else {
+                continuation.resume(throwing: ClientError.processNotRunning)
+            }
         }
         for continuation in notificationContinuations.values {
             continuation.finish()
@@ -1131,7 +1145,8 @@ actor CodexAppServerClient {
             method: method,
             params: params,
             timeout: timeout,
-            useDefaultTimeout: true
+            useDefaultTimeout: true,
+            isMutation: false
         )
     }
 
@@ -1139,7 +1154,8 @@ actor CodexAppServerClient {
         method: String,
         params: [String: Any]?,
         timeout: TimeInterval?,
-        useDefaultTimeout: Bool
+        useDefaultTimeout: Bool,
+        isMutation: Bool = false
     ) async throws -> [String: Any] {
         try Task.checkCancellation()
         guard let activeTransport, !didTerminateTransport else {
@@ -1160,13 +1176,14 @@ actor CodexAppServerClient {
                 pendingRequests[requestID] = continuation
                 pendingRequestMetadata[requestID] = PendingRequestMetadata(
                     method: method,
-                    transportGeneration: generation
+                    transportGeneration: generation,
+                    isMutation: isMutation
                 )
                 if let deadline {
                     scheduleTimeout(for: requestID, after: deadline)
                 }
                 if Task.isCancelled {
-                    cancelPendingRequestIfPresent(id: requestID)
+                    Task { await self.cancelPendingRequestIfPresent(id: requestID) }
                     return
                 }
                 do {
@@ -1178,6 +1195,20 @@ actor CodexAppServerClient {
         } onCancel: {
             Task { await self.cancelPendingRequestIfPresent(id: requestID) }
         }
+    }
+
+    func mutatingRequest(
+        method: String,
+        params: [String: Any],
+        timeout: TimeInterval?
+    ) async throws -> [String: Any] {
+        try await request(
+            method: method,
+            params: params,
+            timeout: timeout,
+            useDefaultTimeout: true,
+            isMutation: true
+        )
     }
 
     func respondToServerRequest(id: CodexAppServerRequestID, result: [String: Any]) throws {
@@ -1652,8 +1683,12 @@ actor CodexAppServerClient {
             let idString = String(describing: idValue)
             if let result = json["result"] as? [String: Any] {
                 if let continuation = pendingRequests.removeValue(forKey: idString) {
-                    pendingRequestMetadata.removeValue(forKey: idString)
+                    let metadata = pendingRequestMetadata.removeValue(forKey: idString)
                     cancelTimeout(for: idString)
+                    guard metadata?.transportGeneration == activeTransport?.generation else {
+                        continuation.resume(throwing: ClientError.invalidResponse)
+                        return
+                    }
                     if config.enableDebugLogging {
                         print("[CodexAppServer] Response for request \(idString)")
                     }
@@ -1666,6 +1701,10 @@ actor CodexAppServerClient {
             {
                 let metadata = pendingRequestMetadata.removeValue(forKey: idString)
                 cancelTimeout(for: idString)
+                guard metadata?.transportGeneration == activeTransport?.generation else {
+                    continuation.resume(throwing: ClientError.invalidResponse)
+                    return
+                }
                 guard let failure = Self.requestFailure(
                     method: metadata?.method ?? "<unknown>",
                     errorObject: error
@@ -2019,11 +2058,25 @@ actor CodexAppServerClient {
 
     private func timeoutRequest(id: String, after timeout: TimeInterval) async {
         timeoutTasks.removeValue(forKey: id)
-        guard let continuation = pendingRequests.removeValue(forKey: id) else {
+        guard let continuation = pendingRequests[id] else {
             pendingRequestMetadata.removeValue(forKey: id)
             return
         }
-        let metadata = pendingRequestMetadata.removeValue(forKey: id)
+        let metadata = pendingRequestMetadata[id]
+        if let metadata, metadata.isMutation,
+           metadata.transportGeneration == activeTransport?.generation
+        {
+            let task = beginTransportTermination(
+                flushStdout: false,
+                expectedGeneration: metadata.transportGeneration,
+                requestFailure: .uncertainMutation(method: metadata.method),
+                reason: .timeout(method: metadata.method, requestID: id)
+            )
+            await task?.value
+            return
+        }
+        pendingRequests.removeValue(forKey: id)
+        pendingRequestMetadata.removeValue(forKey: id)
         if let metadata,
            Self.shouldPoisonTransportOnTimeout(method: metadata.method)
         {
@@ -2046,8 +2099,20 @@ actor CodexAppServerClient {
         timeoutTasks.removeValue(forKey: requestID)?.cancel()
     }
 
-    private func cancelPendingRequestIfPresent(id: String) {
+    private func cancelPendingRequestIfPresent(id: String) async {
         timeoutTasks.removeValue(forKey: id)?.cancel()
+        if let metadata = pendingRequestMetadata[id], metadata.isMutation,
+           metadata.transportGeneration == activeTransport?.generation
+        {
+            let task = beginTransportTermination(
+                flushStdout: false,
+                expectedGeneration: metadata.transportGeneration,
+                requestFailure: .uncertainMutation(method: metadata.method),
+                reason: .livenessCheckFailed(method: metadata.method)
+            )
+            await task?.value
+            return
+        }
         pendingRequestMetadata.removeValue(forKey: id)
         if let continuation = pendingRequests.removeValue(forKey: id) {
             continuation.resume(throwing: CancellationError())

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookCompatibilityGate.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookCompatibilityGate.swift
@@ -1,0 +1,515 @@
+import CryptoKit
+import Foundation
+
+enum CodexHookGateError: LocalizedError, Equatable {
+    case malformedInventory(String)
+    case inventoryError(cwd: String, details: String)
+    case unsupportedUntrustedSource(String)
+    case reviewDeclined
+    case reviewCancelled
+    case inventoryDrift
+    case invalidManagedConfig(String)
+    case uncertainWrite(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .malformedInventory(message): message
+        case let .inventoryError(cwd, details): "Codex could not inventory project hooks for \(cwd): \(details)"
+        case let .unsupportedUntrustedSource(source):
+            "Codex reported an enabled unmanaged \(source) hook that RepoPrompt cannot safely trust. Disable or manage that hook before starting the agent."
+        case .reviewDeclined: "Project hook review was declined; Codex was not started."
+        case .reviewCancelled: "Project hook review was cancelled; Codex was not started."
+        case .inventoryDrift: "Project hooks changed during review. Start again to review the refreshed definitions."
+        case let .invalidManagedConfig(message): message
+        case let .uncertainWrite(message): message
+        }
+    }
+}
+
+struct CodexHookInventory: Equatable {
+    enum EventName: String, Codable, CaseIterable {
+        case preToolUse, permissionRequest, postToolUse, preCompact, postCompact
+        case sessionStart, sessionEnd, userPromptSubmit, subagentStart, subagentStop, stop
+    }
+
+    enum HandlerType: String, Codable { case command, prompt, agent }
+    enum Source: String, Codable {
+        case system, user, project, mdm, sessionFlags, plugin, cloudRequirements
+        case cloudManagedConfig, legacyManagedConfigFile, legacyManagedConfigMdm, unknown
+    }
+
+    enum TrustStatus: String, Codable { case managed, untrusted, trusted, modified }
+
+    struct HookError: Codable, Equatable {
+        let path: String
+        let message: String
+    }
+
+    struct Hook: Codable, Equatable {
+        let key: String
+        let eventName: EventName
+        let handlerType: HandlerType
+        let matcher: String?
+        let command: String?
+        let timeoutSec: UInt64
+        let statusMessage: String?
+        let additionalContextLimit: UInt64?
+        let sourcePath: String
+        let source: Source
+        let pluginId: String?
+        let displayOrder: Int64
+        let enabled: Bool
+        let isManaged: Bool
+        let currentHash: String
+        let trustStatus: TrustStatus
+
+        var needsProjectReview: Bool {
+            enabled && !isManaged && source == .project && (trustStatus == .untrusted || trustStatus == .modified)
+        }
+
+        var hasUnsupportedUntrustedSource: Bool {
+            enabled && !isManaged && source != .project && (trustStatus == .untrusted || trustStatus == .modified)
+        }
+    }
+
+    struct Record: Codable, Equatable {
+        let cwd: String
+        let hooks: [Hook]
+        let warnings: [String]
+        let errors: [HookError]
+    }
+
+    private struct Response: Codable { let data: [Record] }
+
+    let records: [Record]
+
+    var hookCount: Int {
+        records.reduce(0) { $0 + $1.hooks.count }
+    }
+
+    var reviewHooks: [Hook] {
+        records.flatMap(\.hooks).filter(\.needsProjectReview)
+    }
+
+    var reviewFingerprint: String {
+        let material = records.flatMap { record in
+            record.hooks.map { [record.cwd, $0.key, $0.currentHash, $0.trustStatus.rawValue].joined(separator: "\u{0}") }
+        }.joined(separator: "\u{1}")
+        return SHA256.hash(data: Data(material.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Definition fingerprint deliberately excludes trust status so post-write verification
+    /// permits only the expected trust transition while still detecting definition drift.
+    var definitionFingerprint: String {
+        let material = records.flatMap { record in
+            record.hooks.map { hook in
+                [
+                    record.cwd, hook.key, hook.eventName.rawValue, hook.handlerType.rawValue,
+                    hook.matcher ?? "", hook.command ?? "", String(hook.timeoutSec),
+                    hook.sourcePath, hook.source.rawValue, String(hook.enabled),
+                    String(hook.isManaged), hook.currentHash
+                ].joined(separator: "\u{0}")
+            }
+        }.joined(separator: "\u{1}")
+        return SHA256.hash(data: Data(material.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func decode(_ result: [String: Any], expectedCWDs: [String]) throws -> CodexHookInventory {
+        guard JSONSerialization.isValidJSONObject(result) else {
+            throw CodexHookGateError.malformedInventory("hooks/list returned non-JSON data.")
+        }
+        let response: Response
+        do {
+            let data = try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys])
+            response = try JSONDecoder().decode(Response.self, from: data)
+        } catch {
+            throw CodexHookGateError.malformedInventory("hooks/list did not match the pinned Codex 0.147 schema.")
+        }
+
+        let expected = expectedCWDs.map { URL(fileURLWithPath: $0).standardized.path }
+        guard Set(expected).count == expected.count, response.data.count == expected.count else {
+            throw CodexHookGateError.malformedInventory("hooks/list returned a missing or duplicate cwd record.")
+        }
+        var seenCWDs = Set<String>()
+        let expectedSet = Set(expected)
+        var normalizedRecords: [Record] = []
+        for record in response.data {
+            guard record.cwd.hasPrefix("/") else {
+                throw CodexHookGateError.malformedInventory("hooks/list returned a non-absolute cwd.")
+            }
+            let cwd = URL(fileURLWithPath: record.cwd).standardized.path
+            guard record.cwd == cwd,
+                  !record.cwd.utf8.contains(0),
+                  expectedSet.contains(cwd),
+                  seenCWDs.insert(cwd).inserted
+            else {
+                throw CodexHookGateError.malformedInventory("hooks/list returned an unexpected or duplicate cwd record.")
+            }
+            if !record.errors.isEmpty {
+                let details = record.errors.map { "\($0.path): \($0.message)" }.joined(separator: "; ")
+                throw CodexHookGateError.inventoryError(cwd: cwd, details: details)
+            }
+            var keys = Set<String>()
+            var hooks: [Hook] = []
+            for hook in record.hooks {
+                let key = hook.key.trimmingCharacters(in: .whitespacesAndNewlines)
+                let sourcePath = URL(fileURLWithPath: hook.sourcePath).standardized.path
+                guard hook.key == key,
+                      !key.isEmpty, key.count <= 4096, !key.utf8.contains(0), keys.insert(key).inserted,
+                      hook.sourcePath.hasPrefix("/"), hook.sourcePath == sourcePath,
+                      !hook.sourcePath.utf8.contains(0),
+                      isCodexSHA256Version(hook.currentHash)
+                else {
+                    throw CodexHookGateError.malformedInventory("hooks/list returned an invalid or duplicate hook key, hash, or path.")
+                }
+                if hook.hasUnsupportedUntrustedSource {
+                    throw CodexHookGateError.unsupportedUntrustedSource(hook.source.rawValue)
+                }
+                hooks.append(Hook(
+                    key: key,
+                    eventName: hook.eventName,
+                    handlerType: hook.handlerType,
+                    matcher: hook.matcher,
+                    command: hook.command,
+                    timeoutSec: hook.timeoutSec,
+                    statusMessage: hook.statusMessage,
+                    additionalContextLimit: hook.additionalContextLimit,
+                    sourcePath: sourcePath,
+                    source: hook.source,
+                    pluginId: hook.pluginId,
+                    displayOrder: hook.displayOrder,
+                    enabled: hook.enabled,
+                    isManaged: hook.isManaged,
+                    currentHash: hook.currentHash.lowercased(),
+                    trustStatus: hook.trustStatus
+                ))
+            }
+            normalizedRecords.append(Record(cwd: cwd, hooks: hooks, warnings: record.warnings, errors: []))
+        }
+        guard seenCWDs == expectedSet else {
+            throw CodexHookGateError.malformedInventory("hooks/list omitted an execution cwd record.")
+        }
+        normalizedRecords.sort { $0.cwd < $1.cwd }
+        return CodexHookInventory(records: normalizedRecords)
+    }
+
+    private static func isCodexSHA256Version(_ value: String) -> Bool {
+        let prefix = "sha256:"
+        guard value.hasPrefix(prefix) else { return false }
+        let bytes = value.dropFirst(prefix.count).utf8
+        return bytes.count == 64 && bytes.allSatisfy { byte in
+            (48 ... 57).contains(byte) || (65 ... 70).contains(byte) || (97 ... 102).contains(byte)
+        }
+    }
+}
+
+struct CodexHookReview: Equatable {
+    let interactionID: UUID
+    let cwd: String
+    let hooks: [CodexHookInventory.Hook]
+    let inventoryFingerprint: String
+}
+
+enum CodexHookReviewDecision: Equatable { case trustAll, decline, cancel }
+
+struct CodexHookGateDependencies {
+    let read: @Sendable (_ method: String, _ params: [String: Any], _ timeout: TimeInterval?) async throws -> [String: Any]
+    let write: @Sendable (_ method: String, _ params: [String: Any], _ timeout: TimeInterval?) async throws -> [String: Any]
+    let review: @Sendable (CodexHookReview) async -> CodexHookReviewDecision
+    let emitInventory: @Sendable (CodexHookInventoryDiagnostic) async -> Void
+    let terminateUncertainWrite: @Sendable () async throws -> Void
+    let assertAuthority: @Sendable () throws -> Void
+}
+
+enum CodexHookCompatibilityGate {
+    static func run(
+        cwd: String,
+        managedConfigURL: URL,
+        timeout: TimeInterval?,
+        dependencies: CodexHookGateDependencies
+    ) async throws {
+        let normalizedCWD = URL(fileURLWithPath: cwd).standardized.path
+        let initial = try await inventory(cwd: normalizedCWD, timeout: timeout, dependencies: dependencies)
+        try dependencies.assertAuthority()
+        await dependencies.emitInventory(.init(
+            cwds: initial.records.map(\.cwd),
+            hookCount: initial.hookCount,
+            warningCount: initial.records.reduce(0) { $0 + $1.warnings.count },
+            reviewRequiredCount: initial.reviewHooks.count
+        ))
+        try dependencies.assertAuthority()
+        guard !initial.reviewHooks.isEmpty else { return }
+
+        let review = CodexHookReview(
+            interactionID: UUID(),
+            cwd: normalizedCWD,
+            hooks: initial.reviewHooks,
+            inventoryFingerprint: initial.reviewFingerprint
+        )
+        let decision = await dependencies.review(review)
+        try dependencies.assertAuthority()
+        switch decision {
+        case .decline: throw CodexHookGateError.reviewDeclined
+        case .cancel: throw CodexHookGateError.reviewCancelled
+        case .trustAll: break
+        }
+
+        // Snapshot the exact all-or-nothing policy before any config read or mutation.
+        let approvedHashes = Dictionary(uniqueKeysWithValues: review.hooks.map { ($0.key, $0.currentHash) })
+        let refreshed = try await inventory(cwd: normalizedCWD, timeout: timeout, dependencies: dependencies)
+        try dependencies.assertAuthority()
+        guard refreshed.reviewFingerprint == review.inventoryFingerprint else {
+            throw CodexHookGateError.inventoryDrift
+        }
+
+        let configResult = try await dependencies.read(
+            "config/read",
+            ["includeLayers": true, "cwd": normalizedCWD],
+            timeout
+        )
+        try dependencies.assertAuthority()
+        let config = try decodeManagedConfig(result: configResult, expectedFile: managedConfigURL)
+
+        let trustState: [String: Any] = approvedHashes.reduce(into: [:]) { result, pair in
+            result[pair.key] = ["trusted_hash": pair.value]
+        }
+        let writeParams: [String: Any] = [
+            "edits": [[
+                "keyPath": "hooks.state",
+                "value": trustState,
+                "mergeStrategy": "upsert"
+            ]],
+            "filePath": config.filePath,
+            "expectedVersion": config.version,
+            "reloadUserConfig": true
+        ]
+
+        let writeResult: [String: Any]
+        do {
+            writeResult = try await dependencies.write("config/batchWrite", writeParams, timeout)
+        } catch {
+            try await dependencies.terminateUncertainWrite()
+            throw uncertainWriteError(underlying: error)
+        }
+        try dependencies.assertAuthority()
+        do {
+            try validateWriteResponse(writeResult, expectedFile: managedConfigURL)
+        } catch {
+            try await dependencies.terminateUncertainWrite()
+            throw uncertainWriteError(underlying: error)
+        }
+
+        let verified = try await inventory(cwd: normalizedCWD, timeout: timeout, dependencies: dependencies)
+        try dependencies.assertAuthority()
+        guard verified.definitionFingerprint == initial.definitionFingerprint else {
+            throw CodexHookGateError.inventoryDrift
+        }
+        let verifiedByKey = Dictionary(uniqueKeysWithValues: verified.records.flatMap(\.hooks).map { ($0.key, $0) })
+        guard approvedHashes.allSatisfy({ key, hash in
+            guard let hook = verifiedByKey[key] else { return false }
+            return hook.currentHash == hash && hook.trustStatus == .trusted
+        }) else {
+            throw CodexHookGateError.invalidManagedConfig(
+                "Codex did not report the reviewed project hooks as trusted after writing managed-home config."
+            )
+        }
+    }
+
+    private struct ManagedConfigLayer {
+        let filePath: String
+        let version: String
+    }
+
+    private static func inventory(
+        cwd: String,
+        timeout: TimeInterval?,
+        dependencies: CodexHookGateDependencies
+    ) async throws -> CodexHookInventory {
+        let result = try await dependencies.read("hooks/list", ["cwds": [cwd]], timeout)
+        try dependencies.assertAuthority()
+        return try CodexHookInventory.decode(result, expectedCWDs: [cwd])
+    }
+
+    private static func decodeManagedConfig(
+        result: [String: Any],
+        expectedFile: URL
+    ) throws -> ManagedConfigLayer {
+        guard let layers = result["layers"] as? [[String: Any]] else {
+            throw CodexHookGateError.invalidManagedConfig("config/read omitted pinned user-config layers.")
+        }
+        let expected = expectedFile.standardized.path
+        let matches = layers.compactMap { layer -> ManagedConfigLayer? in
+            guard let name = layer["name"] as? [String: Any],
+                  name["type"] as? String == "user",
+                  name["profile"] == nil || name["profile"] is NSNull,
+                  let file = name["file"] as? String,
+                  file == expected,
+                  let version = layer["version"] as? String,
+                  !version.isEmpty
+            else { return nil }
+            return ManagedConfigLayer(filePath: expected, version: version)
+        }
+        guard matches.count == 1, let match = matches.first else {
+            throw CodexHookGateError.invalidManagedConfig(
+                "config/read did not return exactly one versioned RPCE-managed user config layer."
+            )
+        }
+        return match
+    }
+
+    private static func uncertainWriteError(underlying error: Error) -> CodexHookGateError {
+        .uncertainWrite(
+            "Codex hook trust may have been partially written. RepoPrompt terminated the authoritative app-server transport and did not retry. Restart the agent to re-inventory current hook trust. Underlying error: \(error.localizedDescription)"
+        )
+    }
+
+    private static func validateWriteResponse(_ result: [String: Any], expectedFile: URL) throws {
+        guard let status = result["status"] as? String,
+              status == "ok" || status == "okOverridden",
+              let version = result["version"] as? String, !version.isEmpty,
+              let filePath = result["filePath"] as? String,
+              filePath == expectedFile.standardized.path
+        else {
+            throw CodexHookGateError.invalidManagedConfig(
+                "config/batchWrite returned an invalid status, version, or managed file path."
+            )
+        }
+    }
+}
+
+struct CodexHookInventoryDiagnostic: Equatable {
+    let cwds: [String]
+    let hookCount: Int
+    let warningCount: Int
+    let reviewRequiredCount: Int
+
+    var isZeroInventory: Bool {
+        hookCount == 0
+    }
+}
+
+struct CodexHookLifecycleDiagnostic: Equatable {
+    enum Status: String, Codable { case running, completed, failed, blocked, stopped }
+    enum ExecutionMode: String, Codable { case sync, async }
+    enum Scope: String, Codable { case thread, turn }
+    enum EntryKind: String, Codable { case warning, stop, feedback, context, error }
+    struct Entry: Codable, Equatable { let kind: EntryKind
+        let text: String
+    }
+
+    struct Run: Decodable, Equatable {
+        let id: String
+        let eventName: CodexHookInventory.EventName
+        let handlerType: CodexHookInventory.HandlerType
+        let executionMode: ExecutionMode
+        let scope: Scope
+        let sourcePath: String
+        let source: CodexHookInventory.Source
+        let displayOrder: Int64
+        let status: Status
+        let statusMessage: String?
+        let startedAt: Int64
+        let completedAt: Int64?
+        let durationMs: Int64?
+        let entries: [Entry]
+
+        private enum CodingKeys: String, CodingKey {
+            case id, eventName, handlerType, executionMode, scope, sourcePath, source
+            case displayOrder, status, statusMessage, startedAt, completedAt, durationMs, entries
+        }
+
+        init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+            id = try values.decode(String.self, forKey: .id)
+            eventName = try values.decode(CodexHookInventory.EventName.self, forKey: .eventName)
+            handlerType = try values.decode(CodexHookInventory.HandlerType.self, forKey: .handlerType)
+            executionMode = try values.decode(ExecutionMode.self, forKey: .executionMode)
+            scope = try values.decode(Scope.self, forKey: .scope)
+            sourcePath = try values.decode(String.self, forKey: .sourcePath)
+            source = try values.decodeIfPresent(CodexHookInventory.Source.self, forKey: .source) ?? .unknown
+            displayOrder = try values.decode(Int64.self, forKey: .displayOrder)
+            status = try values.decode(Status.self, forKey: .status)
+            statusMessage = try values.decodeIfPresent(String.self, forKey: .statusMessage)
+            startedAt = try values.decode(Int64.self, forKey: .startedAt)
+            completedAt = try values.decodeIfPresent(Int64.self, forKey: .completedAt)
+            durationMs = try values.decodeIfPresent(Int64.self, forKey: .durationMs)
+            entries = try values.decode([Entry].self, forKey: .entries)
+        }
+    }
+
+    private struct Payload: Decodable {
+        let threadId: String
+        let turnId: String?
+        let run: Run
+    }
+
+    let method: String
+    let threadID: String
+    let turnID: String?
+    let run: Run
+
+    var runID: String {
+        run.id
+    }
+
+    var eventName: CodexHookInventory.EventName {
+        run.eventName
+    }
+
+    var handlerType: CodexHookInventory.HandlerType {
+        run.handlerType
+    }
+
+    var sourcePath: String {
+        run.sourcePath
+    }
+
+    var status: Status {
+        run.status
+    }
+
+    var statusMessage: String? {
+        run.statusMessage
+    }
+
+    var reportedRuntimeFailure: Bool {
+        status == .failed || status == .blocked || status == .stopped
+    }
+
+    static func decode(method: String, params: [String: Any]) throws -> CodexHookLifecycleDiagnostic {
+        guard method == "hook/started" || method == "hook/completed",
+              JSONSerialization.isValidJSONObject(params)
+        else { throw CodexHookGateError.malformedInventory("Invalid hook lifecycle notification method or payload.") }
+        let payload: Payload
+        do {
+            payload = try JSONDecoder().decode(
+                Payload.self,
+                from: JSONSerialization.data(withJSONObject: params, options: [.sortedKeys])
+            )
+        } catch {
+            throw CodexHookGateError.malformedInventory("Hook lifecycle notification did not match the pinned Codex 0.147 schema.")
+        }
+        let normalizedSourcePath = URL(fileURLWithPath: payload.run.sourcePath).standardized.path
+        guard !payload.threadId.isEmpty,
+              !payload.threadId.utf8.contains(0),
+              !payload.run.id.isEmpty,
+              !payload.run.id.utf8.contains(0),
+              payload.run.sourcePath.hasPrefix("/"),
+              payload.run.sourcePath == normalizedSourcePath,
+              !payload.run.sourcePath.utf8.contains(0)
+        else {
+            throw CodexHookGateError.malformedInventory("Hook lifecycle notification contained an invalid identity or path.")
+        }
+        guard (method == "hook/started" && payload.run.status == .running)
+            || (method == "hook/completed" && payload.run.status != .running)
+        else {
+            throw CodexHookGateError.malformedInventory("Hook lifecycle notification contained an invalid method/status pairing.")
+        }
+        return .init(
+            method: method,
+            threadID: payload.threadId,
+            turnID: payload.turnId,
+            run: payload.run
+        )
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookCompatibilityGate.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookCompatibilityGate.swift
@@ -33,7 +33,7 @@ struct CodexHookInventory: Equatable {
     }
 
     enum HandlerType: String, Codable { case command, prompt, agent }
-    enum Source: String, Codable {
+    enum Source: String, Codable, Hashable {
         case system, user, project, mdm, sessionFlags, plugin, cloudRequirements
         case cloudManagedConfig, legacyManagedConfigFile, legacyManagedConfigMdm, unknown
     }
@@ -231,11 +231,17 @@ enum CodexHookCompatibilityGate {
         let normalizedCWD = URL(fileURLWithPath: cwd).standardized.path
         let initial = try await inventory(cwd: normalizedCWD, timeout: timeout, dependencies: dependencies)
         try dependencies.assertAuthority()
+        let sourceCounts = initial.records
+            .flatMap(\.hooks)
+            .reduce(into: [CodexHookInventory.Source: Int]()) { counts, hook in
+                counts[hook.source, default: 0] += 1
+            }
         await dependencies.emitInventory(.init(
             cwds: initial.records.map(\.cwd),
             hookCount: initial.hookCount,
             warningCount: initial.records.reduce(0) { $0 + $1.warnings.count },
-            reviewRequiredCount: initial.reviewHooks.count
+            reviewRequiredCount: initial.reviewHooks.count,
+            sourceCounts: sourceCounts
         ))
         try dependencies.assertAuthority()
         guard !initial.reviewHooks.isEmpty else { return }
@@ -382,9 +388,26 @@ struct CodexHookInventoryDiagnostic: Equatable {
     let hookCount: Int
     let warningCount: Int
     let reviewRequiredCount: Int
+    let sourceCounts: [CodexHookInventory.Source: Int]
 
     var isZeroInventory: Bool {
         hookCount == 0
+    }
+
+    var statusSummary: String {
+        if isZeroInventory {
+            if warningCount == 0 {
+                return "No Codex hook definitions were discovered for this execution directory."
+            }
+            return "Codex discovered no hook definitions and reported \(warningCount) inventory warning(s); review the Codex configuration before relying on hooks."
+        }
+        let sources = sourceCounts
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+            .map { "\($0.key.rawValue)=\($0.value)" }
+            .joined(separator: ", ")
+        let sourceSuffix = sources.isEmpty ? "" : " (\(sources))"
+        let warningSuffix = warningCount == 0 ? "" : " Codex also reported \(warningCount) inventory warning(s)."
+        return "Codex inventoried \(hookCount) hook definition(s)\(sourceSuffix).\(warningSuffix)"
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -110,11 +110,16 @@ protocol CodexSessionControlling: AnyObject {
     func cleanupConversation(_ handle: ProviderConversationCleanupHandle, action: ProviderConversationCleanupAction) async -> ProviderConversationCleanupOutcome
     func shutdown() async
     func respondToServerRequest(id: CodexAppServerRequestID, result: [String: Any]) async
+    func respondToHookReview(interactionID: UUID, decision: AgentApprovalDecision) async -> Bool
 }
 
 extension CodexSessionControlling {
     func cleanupConversation(_ handle: ProviderConversationCleanupHandle, action: ProviderConversationCleanupAction) async -> ProviderConversationCleanupOutcome {
         .unsupported(message: "Codex runtime has no local API for \(action.rawValue) cleanup of conversations.")
+    }
+
+    func respondToHookReview(interactionID _: UUID, decision _: AgentApprovalDecision) async -> Bool {
+        false
     }
 }
 
@@ -416,6 +421,8 @@ final class CodexNativeSessionController {
         case toolResult(name: String, invocationID: UUID?, argsJSON: String?, resultJSON: String, isError: Bool?)
         case commandExecutionRunning(CommandExecutionRunningUpdate)
         case livenessActivity(LivenessActivity)
+        case hookInventoryDiagnostic(CodexHookInventoryDiagnostic)
+        case hookLifecycleDiagnostic(CodexHookLifecycleDiagnostic)
         case errorNotification(ErrorNotification)
         case error(String)
         case system(String)
@@ -568,6 +575,7 @@ final class CodexNativeSessionController {
         var memoriesEnabledProvider: (@MainActor () -> Bool)?
         var computerUseEnabledProvider: @MainActor () -> Bool = { false }
         var skillExtraRootsProvider: () -> [URL] = { [] }
+        var hookCompatibilityGateEnabled = false
 
         /// Fail-closed RepoPrompt MCP provisioning validator, applied by `startOrResume` only for a
         /// child that expects RepoPrompt MCP tools; throwing aborts the start before any process
@@ -597,7 +605,8 @@ final class CodexNativeSessionController {
             goalSupportEnabledProvider: @escaping @MainActor () -> Bool = { CodexGoalSupport.isEnabled },
             reasoningSummariesEnabledProvider: @escaping @MainActor () -> Bool = { false },
             memoriesEnabledProvider: @escaping @MainActor () -> Bool = { false },
-            computerUseEnabledProvider: @escaping @MainActor () -> Bool = { false }
+            computerUseEnabledProvider: @escaping @MainActor () -> Bool = { false },
+            hookCompatibilityGateEnabled: Bool = false
         ) -> Options {
             Options(
                 requestTimeout: 120,
@@ -630,7 +639,8 @@ final class CodexNativeSessionController {
                 computerUseEnabledProvider: computerUseEnabledProvider,
                 skillExtraRootsProvider: {
                     [AgentSupportDirectoryCatalog.globalRootURLs().agentsSkills]
-                }
+                },
+                hookCompatibilityGateEnabled: hookCompatibilityGateEnabled
             )
         }
     }
@@ -676,6 +686,11 @@ final class CodexNativeSessionController {
     private struct LifecycleAuthorityObservation: Equatable {
         let lineage: LifecycleAuthorityReconciliationLineage
         let kind: LifecycleAuthorityObservationKind
+    }
+
+    private struct PendingHookReview {
+        let interactionID: UUID
+        let continuation: AsyncStream<CodexHookReviewDecision>.Continuation
     }
 
     private let client: CodexAppServerClient
@@ -729,6 +744,9 @@ final class CodexNativeSessionController {
     private var serverRequestTask: Task<Void, Never>?
     private var eventsContinuation: AsyncStream<Event>.Continuation?
     private let eventsContinuationLock = NSLock()
+    private let hookGateLock = NSLock()
+    private var activeHookGateID: UUID?
+    private var pendingHookReview: PendingHookReview?
     private let eventHandlingMutex = AsyncMutex()
     private let eventsStream: AsyncStream<Event>
     /// Protected by `eventsContinuationLock`.
@@ -853,6 +871,17 @@ final class CodexNativeSessionController {
             timeout: timeout,
             useDefaultTimeout: useDefaultTimeout
         )
+    }
+
+    private func performMutatingRequest(
+        method: String,
+        params: [String: Any],
+        timeout: TimeInterval?
+    ) async throws -> [String: Any] {
+        if let requestExecutor {
+            return try await requestExecutor(method, params, timeout)
+        }
+        return try await client.mutatingRequest(method: method, params: params, timeout: timeout)
     }
 
     func cleanupConversation(
@@ -1302,6 +1331,11 @@ final class CodexNativeSessionController {
                 )
             }
 
+            if options.hookCompatibilityGateEnabled {
+                try await performHookCompatibilityGate(runtime: runtime)
+                try Task.checkCancellation()
+            }
+
             if let resumeThreadID {
                 let desiredMemoryMode: ThreadMemoryMode? = await MainActor.run {
                     guard let memoriesEnabledProvider = options.memoriesEnabledProvider else { return nil }
@@ -1417,6 +1451,166 @@ final class CodexNativeSessionController {
             }
             throw error
         }
+    }
+
+    private func performHookCompatibilityGate(runtime: CodexRuntimeAuthority.Runtime) async throws {
+        let cwd = try exactHookInventoryCWD()
+        let gateID = UUID()
+        let installedGate = hookGateLock.withLock {
+            guard activeHookGateID == nil else { return false }
+            activeHookGateID = gateID
+            return true
+        }
+        guard installedGate else {
+            throw CodexSessionControllerError.invalidLifecycleState("already running a hook compatibility gate")
+        }
+        defer { retireHookGate(gateID) }
+
+        let dependencies = CodexHookGateDependencies(
+            read: { [weak self] method, params, timeout in
+                guard let self else { throw CodexSessionControllerError.invalidLifecycleState("no longer active") }
+                return try await performRequest(method: method, params: params, timeout: timeout)
+            },
+            write: { [weak self] method, params, timeout in
+                guard let self else { throw CodexSessionControllerError.invalidLifecycleState("no longer active") }
+                return try await performMutatingRequest(method: method, params: params, timeout: timeout)
+            },
+            review: { [weak self] review in
+                guard let self else { return .cancel }
+                return await requestHookReview(review, gateID: gateID)
+            },
+            emitInventory: { [weak self] diagnostic in
+                await self?.emit(.hookInventoryDiagnostic(diagnostic))
+            },
+            terminateUncertainWrite: { [weak self] in
+                guard let self else { throw CodexSessionControllerError.invalidLifecycleState("no longer active") }
+                await client.stop()
+                try ensureHookGateIdentity(gateID)
+            },
+            assertAuthority: { [weak self] in
+                guard let self else { throw CodexSessionControllerError.invalidLifecycleState("no longer active") }
+                try ensureHookGateAuthority(gateID)
+            }
+        )
+        try await CodexHookCompatibilityGate.run(
+            cwd: cwd,
+            managedConfigURL: runtime.statePaths.codexHome.appendingPathComponent("config.toml"),
+            timeout: options.requestTimeout,
+            dependencies: dependencies
+        )
+        try ensureHookGateAuthority(gateID)
+    }
+
+    private func exactHookInventoryCWD() throws -> String {
+        let candidate = workspacePaths.executionDirectory
+            ?? workspacePaths.processLaunchDirectory
+            ?? CLIProcessConfiguration.resolvedWorkingDirectory(nil)
+        let path = URL(fileURLWithPath: candidate).standardized.path
+        var isDirectory: ObjCBool = false
+        guard path.hasPrefix("/"),
+              FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw CodexHookGateError.malformedInventory("Codex hook inventory requires one existing absolute execution cwd.")
+        }
+        return path
+    }
+
+    private func ensureHookGateIdentity(_ gateID: UUID) throws {
+        let ownsGate = hookGateLock.withLock { activeHookGateID == gateID }
+        guard ownsGate else {
+            throw CodexSessionControllerError.invalidLifecycleState("superseded during hook review")
+        }
+    }
+
+    private func ensureHookGateAuthority(_ gateID: UUID) throws {
+        try ensureHookGateIdentity(gateID)
+        let isBinding = withEventsStateLock { lifecycleState == .binding }
+        guard isBinding else {
+            throw CodexSessionControllerError.invalidLifecycleState("superseded during hook review")
+        }
+        // Identity is checked before cancellation so a stale controller cannot finalize a newer run.
+        try Task.checkCancellation()
+    }
+
+    private func retireHookGate(_ gateID: UUID) {
+        let pending = hookGateLock.withLock { () -> PendingHookReview? in
+            if activeHookGateID == gateID { activeHookGateID = nil }
+            let pending = pendingHookReview
+            if pending != nil { pendingHookReview = nil }
+            return pending
+        }
+        pending?.continuation.yield(.cancel)
+        pending?.continuation.finish()
+    }
+
+    private func requestHookReview(
+        _ review: CodexHookReview,
+        gateID: UUID
+    ) async -> CodexHookReviewDecision {
+        do { try ensureHookGateAuthority(gateID) } catch { return .cancel }
+        let pair = AsyncStream<CodexHookReviewDecision>.makeStream()
+        let installedReview = hookGateLock.withLock {
+            guard activeHookGateID == gateID, pendingHookReview == nil else { return false }
+            pendingHookReview = PendingHookReview(
+                interactionID: review.interactionID,
+                continuation: pair.continuation
+            )
+            return true
+        }
+        guard installedReview else {
+            pair.continuation.finish()
+            return .cancel
+        }
+
+        let details = review.hooks.enumerated().map { index, hook in
+            let matcher = hook.matcher?.prefix(512) ?? "all matching events"
+            let command = hook.command?.prefix(1024) ?? "<non-command handler>"
+            return AgentApprovalDetail(
+                label: "Hook \(index + 1): \(hook.eventName.rawValue)",
+                value: "source: \(hook.sourcePath)\nhandler: \(hook.handlerType.rawValue)\nmatcher: \(matcher)\ncommand: \(command)\nhash: \(hook.currentHash)",
+                isCode: true
+            )
+        }
+        await emit(.approvalRequest(.init(
+            id: review.interactionID,
+            requestID: .codexHookReview(review.interactionID),
+            method: "hooks/review",
+            kind: .codexHookReview,
+            threadID: "",
+            turnID: "",
+            itemID: review.inventoryFingerprint,
+            reason: "Trust all \(review.hooks.count) current enabled project hook definitions for \(review.cwd), or cancel this agent start.",
+            cwd: review.cwd,
+            details: details
+        )))
+
+        return await withTaskCancellationHandler {
+            var iterator = pair.stream.makeAsyncIterator()
+            return await iterator.next() ?? .cancel
+        } onCancel: {
+            Task { [weak self] in
+                _ = await self?.respondToHookReview(interactionID: review.interactionID, decision: .cancel)
+            }
+        }
+    }
+
+    func respondToHookReview(interactionID: UUID, decision: AgentApprovalDecision) async -> Bool {
+        let resolved: CodexHookReviewDecision = switch decision {
+        case .accept: .trustAll
+        case .decline: .decline
+        case .cancel, .acceptForSession, .acceptWithExecpolicyAmendment: .cancel
+        }
+        guard let pending = hookGateLock.withLock({ () -> PendingHookReview? in
+            guard let pending = pendingHookReview, pending.interactionID == interactionID else { return nil }
+            pendingHookReview = nil
+            return pending
+        }) else {
+            return false
+        }
+        pending.continuation.yield(resolved)
+        pending.continuation.finish()
+        return true
     }
 
     private func setThreadMemoryMode(_ mode: ThreadMemoryMode, threadID: String) async throws {
@@ -1970,6 +2164,10 @@ final class CodexNativeSessionController {
             if lifecycleState != .terminated {
                 lifecycleState = .shuttingDown
             }
+        }
+        let pendingHookReviewID = hookGateLock.withLock { pendingHookReview?.interactionID }
+        if let pendingHookReviewID {
+            _ = await respondToHookReview(interactionID: pendingHookReviewID, decision: .cancel)
         }
         notificationTask?.cancel()
         notificationTask = nil
@@ -3112,6 +3310,21 @@ final class CodexNativeSessionController {
         case "thread/tokenUsage/updated":
             if let usage = parseTokenUsage(from: params) {
                 await emit(.tokenUsage(usage))
+            }
+        case "hook/started", "hook/completed":
+            do {
+                let diagnostic = try CodexHookLifecycleDiagnostic.decode(
+                    method: notification.method,
+                    params: params
+                )
+                await emit(.hookLifecycleDiagnostic(diagnostic))
+            } catch {
+                await emit(.errorNotification(.init(
+                    message: error.localizedDescription,
+                    willRetry: false,
+                    threadID: Self.notificationThreadID(from: params),
+                    turnID: Self.notificationTurnID(from: params)
+                )))
             }
         case "error":
             if let errorNotification = Self.parseErrorNotification(from: params) {
@@ -4989,6 +5202,10 @@ final class CodexNativeSessionController {
             "tokenUsage modelContextWindow=\(usage.modelContextWindow.map(String.init(describing:)) ?? "nil") lastTotalTokens=\(usage.lastTotalTokens.map(String.init(describing:)) ?? "nil") totalTotalTokens=\(usage.totalTotalTokens.map(String.init(describing:)) ?? "nil")"
         case let .livenessActivity(activity):
             "livenessActivity kind=\(activity.kind.rawValue) method=\(activity.method) threadID=\(activity.threadID ?? "nil") turnID=\(activity.turnID ?? "nil") itemID=\(activity.itemID ?? "nil")"
+        case let .hookInventoryDiagnostic(diagnostic):
+            "hookInventoryDiagnostic cwds=\(diagnostic.cwds.count) hooks=\(diagnostic.hookCount) review=\(diagnostic.reviewRequiredCount)"
+        case let .hookLifecycleDiagnostic(diagnostic):
+            "hookLifecycleDiagnostic runID=\(diagnostic.runID) status=\(diagnostic.status.rawValue)"
         case let .errorNotification(notification):
             "errorNotification willRetry=\(notification.willRetry.map(String.init(describing:)) ?? "nil") message=\(debugPreview(notification.message))"
         case let .error(message):

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -1473,6 +1473,8 @@ final class CodexNativeSessionController {
             },
             write: { [weak self] method, params, timeout in
                 guard let self else { throw CodexSessionControllerError.invalidLifecycleState("no longer active") }
+                try CodexRuntimeAuthority.validateManagedState(runtime.statePaths)
+                try ensureHookGateAuthority(gateID)
                 return try await performMutatingRequest(method: method, params: params, timeout: timeout)
             },
             review: { [weak self] review in

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
@@ -586,7 +586,8 @@ final class CodexCLIProvider: AIProvider {
                     case .toolCall, .toolResult, .commandExecutionRunning:
                         throw AIProviderError.invalidConfiguration(detail: "Codex app-server emitted tool events while interactive chat tools are disabled.")
 
-                    case .reasoningCompleted, .tokenUsage, .turnStarted(turnID: _), .system:
+                    case .reasoningCompleted, .tokenUsage, .turnStarted(turnID: _), .system,
+                         .hookInventoryDiagnostic, .hookLifecycleDiagnostic:
                         continue
                     }
                 }
@@ -762,7 +763,8 @@ final class CodexCLIProvider: AIProvider {
                     case .toolCall, .toolResult, .commandExecutionRunning:
                         throw AIProviderError.invalidConfiguration(detail: "Codex app-server emitted tool events while interactive chat tools are disabled.")
 
-                    case .reasoningDelta, .reasoningCompleted, .tokenUsage, .turnStarted(turnID: _), .system:
+                    case .reasoningDelta, .reasoningCompleted, .tokenUsage, .turnStarted(turnID: _), .system,
+                         .hookInventoryDiagnostic, .hookLifecycleDiagnostic:
                         continue
                     }
                 }
@@ -1161,6 +1163,8 @@ final class CodexCLIProvider: AIProvider {
                 return "Codex app-server returned an invalid response."
             case .jsonDecodeFailed:
                 return "Failed to decode Codex app-server JSON response."
+            case .uncertainMutation:
+                return clientError.localizedDescription
             }
         }
         let localized = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
@@ -14,6 +14,7 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
     private let configService = MCPConfigExportService.shared
     private let toolTracking = AgentToolTrackingController()
     private var streamTask: Task<Void, Never>?
+    private var preparedRuntime: CodexRuntimeAuthority.Runtime?
     private var codexItemInvocationIDs: [String: UUID] = [:]
 
     private var enableDebugLogging: Bool {
@@ -42,7 +43,8 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
         selectedModelString: String?,
         serverEntries: [MCPIntegrationHelper.CodexServerEntry],
         brokenServers: Set<String>,
-        fullAccess: Bool = false
+        fullAccess: Bool = false,
+        statePaths: CodexRuntimeAuthority.StatePaths = CodexRuntimeAuthority.statePaths()
     ) -> (args: [String], modelSpecifier: CodexModelSpecifier) {
         var args: [String] = []
         let modelCLIArgs = codexModelCLIArgs(selectedModelString: selectedModelString)
@@ -71,6 +73,7 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
 
         // Add exec subcommand and its arguments.
         args.append("exec")
+        args.append(contentsOf: CodexOverrides.managedStateArgs(statePaths))
         args.append(contentsOf: modelCLIArgs.configArgs)
         args.append(contentsOf: toolOverrideArgs)
         args.append(contentsOf: serverOverrideArgs)
@@ -120,6 +123,9 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
         }
         do {
             try runtime.prepareState()
+            try CodexManagedInstructionsProjection.projectBeforeLaunch(
+                managedHome: runtime.statePaths.codexHome
+            )
         } catch {
             throw AIProviderError.invalidConfiguration(
                 detail: "RepoPrompt could not start Codex: unable to prepare its isolated state directories (\(error.localizedDescription))."
@@ -132,6 +138,7 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
         )
         processConfig.ensureAdditionalPaths(config.additionalPathHints)
         runner = CLIProcessRunner(config: processConfig)
+        preparedRuntime = runtime
 
         // Verify MCP server is running
         if enableDebugLogging {
@@ -267,6 +274,20 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
                                     }
 
                                     let expectedPIDRunID = context.runID
+                                    guard let runtime = self.preparedRuntime else {
+                                        throw AIProviderError.invalidConfiguration(
+                                            detail: "RepoPrompt could not start Codex: its runtime launch authority expired."
+                                        )
+                                    }
+                                    do {
+                                        try CodexManagedInstructionsProjection.projectBeforeLaunch(
+                                            managedHome: runtime.statePaths.codexHome
+                                        )
+                                    } catch {
+                                        throw AIProviderError.invalidConfiguration(
+                                            detail: "RepoPrompt could not project ordinary global Codex instructions safely (\(error.localizedDescription))."
+                                        )
+                                    }
                                     let stream = try await runner.runStreaming(
                                         args: args,
                                         stdin: combinedPrompt,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexManagedInstructionsProjection.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexManagedInstructionsProjection.swift
@@ -1,0 +1,272 @@
+import CryptoKit
+import Foundation
+
+/// Projects Codex's effective ordinary user-global instructions into RepoPrompt's isolated home.
+/// The projection is one-way and only replaces or removes files whose ownership is proven by the sidecar.
+enum CodexManagedInstructionsProjection {
+    static let overrideName = "AGENTS.override.md"
+    static let fallbackName = "AGENTS.md"
+    static let sidecarName = ".repoprompt-global-instructions.json"
+    private static let lock = NSLock()
+
+    enum ProjectionError: LocalizedError, Equatable {
+        case invalidSource(String)
+        case foreignTarget(String)
+        case invalidSidecar(String)
+        case modifiedProjection(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .invalidSource(message), let .foreignTarget(message),
+                 let .invalidSidecar(message), let .modifiedProjection(message):
+                message
+            }
+        }
+    }
+
+    enum State: Equatable {
+        case projected(source: URL, target: URL)
+        case absent(managedHome: URL)
+        case conflict(message: String)
+    }
+
+    private struct Receipt: Codable, Equatable {
+        enum Phase: String, Codable { case pending, committed }
+
+        let schemaVersion: Int
+        let owner: String
+        let sourceName: String
+        let targetName: String
+        let previousTargetHash: String?
+        let projectedHash: String
+        let phase: Phase
+    }
+
+    static func projectBeforeLaunch(
+        managedHome: URL,
+        ordinaryHome: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true),
+        fileManager: FileManager = .default
+    ) throws -> State {
+        lock.lock()
+        defer { lock.unlock() }
+
+        try fileManager.createDirectory(at: managedHome, withIntermediateDirectories: true)
+        try requireDirectoryWithoutSymbolicLink(managedHome, label: "managed Codex home", fileManager: fileManager)
+        try requireDirectoryWithoutSymbolicLink(ordinaryHome, label: "ordinary Codex home", allowMissing: true, fileManager: fileManager)
+
+        let selection = try effectiveSource(in: ordinaryHome, fileManager: fileManager)
+        let sidecar = managedHome.appendingPathComponent(sidecarName, isDirectory: false)
+        let existingReceipt = try loadReceipt(at: sidecar, fileManager: fileManager)
+
+        guard let selection else {
+            try removeOwnedProjectionIfPresent(
+                managedHome: managedHome,
+                sidecar: sidecar,
+                receipt: existingReceipt,
+                fileManager: fileManager
+            )
+            return .absent(managedHome: managedHome)
+        }
+
+        let target = managedHome.appendingPathComponent(selection.name, isDirectory: false)
+        let otherName = selection.name == overrideName ? fallbackName : overrideName
+        let otherTarget = managedHome.appendingPathComponent(otherName, isDirectory: false)
+        try removeOwnedTargetIfNeeded(otherTarget, sidecar: sidecar, receipt: existingReceipt, fileManager: fileManager)
+
+        let sourceData = try Data(contentsOf: selection.url, options: .mappedIfSafe)
+        let sourceHash = digest(sourceData)
+        let previousHash = try verifyOwnershipForReplacement(
+            target: target,
+            sidecar: sidecar,
+            receipt: existingReceipt,
+            nextHash: sourceHash,
+            fileManager: fileManager
+        )
+
+        let pending = Receipt(
+            schemaVersion: 1,
+            owner: "com.repoprompt.ce.codex-global-instructions",
+            sourceName: selection.name,
+            targetName: selection.name,
+            previousTargetHash: previousHash,
+            projectedHash: sourceHash,
+            phase: .pending
+        )
+        try writeReceipt(pending, to: sidecar)
+        try sourceData.write(to: target, options: .atomic)
+        try requireRegularFile(target, label: "managed instruction projection", fileManager: fileManager)
+        try writeReceipt(
+            Receipt(
+                schemaVersion: pending.schemaVersion,
+                owner: pending.owner,
+                sourceName: pending.sourceName,
+                targetName: pending.targetName,
+                previousTargetHash: nil,
+                projectedHash: pending.projectedHash,
+                phase: .committed
+            ),
+            to: sidecar
+        )
+        return .projected(source: selection.url, target: target)
+    }
+
+    static func inspect(
+        managedHome: URL,
+        ordinaryHome: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true),
+        fileManager: FileManager = .default
+    ) -> State {
+        do {
+            let selection = try effectiveSource(in: ordinaryHome, fileManager: fileManager)
+            let receipt = try loadReceipt(
+                at: managedHome.appendingPathComponent(sidecarName),
+                fileManager: fileManager
+            )
+            guard let selection else { return .absent(managedHome: managedHome) }
+            let target = managedHome.appendingPathComponent(selection.name)
+            guard let receipt, receipt.phase == .committed,
+                  receipt.sourceName == selection.name,
+                  receipt.targetName == selection.name,
+                  try hashOfRegularFile(target, fileManager: fileManager) == receipt.projectedHash
+            else {
+                return .conflict(message: "Global instruction projection is not current.")
+            }
+            return .projected(source: selection.url, target: target)
+        } catch {
+            return .conflict(message: error.localizedDescription)
+        }
+    }
+
+    private static func effectiveSource(
+        in ordinaryHome: URL,
+        fileManager: FileManager
+    ) throws -> (name: String, url: URL)? {
+        for name in [overrideName, fallbackName] {
+            let candidate = ordinaryHome.appendingPathComponent(name, isDirectory: false)
+            guard fileManager.fileExists(atPath: candidate.path) else { continue }
+            try requireRegularFile(candidate, label: "ordinary \(name)", fileManager: fileManager)
+            return (name, candidate)
+        }
+        return nil
+    }
+
+    private static func verifyOwnershipForReplacement(
+        target: URL,
+        sidecar: URL,
+        receipt: Receipt?,
+        nextHash: String,
+        fileManager: FileManager
+    ) throws -> String? {
+        guard fileManager.fileExists(atPath: target.path) else {
+            if let receipt, receipt.targetName == target.lastPathComponent,
+               receipt.phase == .pending, receipt.previousTargetHash != nil
+            {
+                throw ProjectionError.modifiedProjection("Owned projection disappeared during an interrupted update: \(target.path)")
+            }
+            return nil
+        }
+        guard let receipt else {
+            throw ProjectionError.foreignTarget("Preserving foreign managed-home file without RepoPrompt ownership receipt: \(target.path)")
+        }
+        guard receipt.targetName == target.lastPathComponent else {
+            throw ProjectionError.foreignTarget("Projection receipt does not own \(target.path)")
+        }
+        let actual = try hashOfRegularFile(target, fileManager: fileManager)
+        let allowed = receipt.phase == .committed
+            ? [receipt.projectedHash]
+            : [receipt.previousTargetHash, receipt.projectedHash].compactMap(\.self)
+        guard allowed.contains(actual) else {
+            throw ProjectionError.modifiedProjection("Preserving modified managed instruction projection: \(target.path)")
+        }
+        _ = sidecar
+        return actual == nextHash ? actual : actual
+    }
+
+    private static func removeOwnedProjectionIfPresent(
+        managedHome: URL,
+        sidecar: URL,
+        receipt: Receipt?,
+        fileManager: FileManager
+    ) throws {
+        guard let receipt else { return }
+        let target = managedHome.appendingPathComponent(receipt.targetName)
+        try removeOwnedTargetIfNeeded(target, sidecar: sidecar, receipt: receipt, fileManager: fileManager)
+        if fileManager.fileExists(atPath: sidecar.path) { try fileManager.removeItem(at: sidecar) }
+    }
+
+    private static func removeOwnedTargetIfNeeded(
+        _ target: URL,
+        sidecar: URL,
+        receipt: Receipt?,
+        fileManager: FileManager
+    ) throws {
+        guard fileManager.fileExists(atPath: target.path) else { return }
+        guard let receipt, receipt.targetName == target.lastPathComponent else {
+            throw ProjectionError.foreignTarget("Preserving foreign managed-home file: \(target.path)")
+        }
+        let actual = try hashOfRegularFile(target, fileManager: fileManager)
+        let allowed = receipt.phase == .committed
+            ? [receipt.projectedHash]
+            : [receipt.previousTargetHash, receipt.projectedHash].compactMap(\.self)
+        guard allowed.contains(actual) else {
+            throw ProjectionError.modifiedProjection("Preserving modified managed instruction projection: \(target.path)")
+        }
+        try fileManager.removeItem(at: target)
+        _ = sidecar
+    }
+
+    private static func loadReceipt(at url: URL, fileManager: FileManager) throws -> Receipt? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        try requireRegularFile(url, label: "projection receipt", fileManager: fileManager)
+        let receipt: Receipt
+        do { receipt = try JSONDecoder().decode(Receipt.self, from: Data(contentsOf: url)) }
+        catch { throw ProjectionError.invalidSidecar("Invalid RepoPrompt projection receipt at \(url.path)") }
+        guard receipt.schemaVersion == 1,
+              receipt.owner == "com.repoprompt.ce.codex-global-instructions",
+              [overrideName, fallbackName].contains(receipt.sourceName),
+              receipt.sourceName == receipt.targetName,
+              receipt.projectedHash.count == 64,
+              receipt.projectedHash.allSatisfy(\.isHexDigit)
+        else { throw ProjectionError.invalidSidecar("Unrecognized RepoPrompt projection receipt at \(url.path)") }
+        return receipt
+    }
+
+    private static func writeReceipt(_ receipt: Receipt, to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(receipt).write(to: url, options: .atomic)
+    }
+
+    private static func hashOfRegularFile(_ url: URL, fileManager: FileManager) throws -> String {
+        try requireRegularFile(url, label: "managed instruction projection", fileManager: fileManager)
+        return try digest(Data(contentsOf: url, options: .mappedIfSafe))
+    }
+
+    private static func digest(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func requireRegularFile(_ url: URL, label: String, fileManager: FileManager) throws {
+        let attributes = try fileManager.attributesOfItem(atPath: url.path)
+        guard attributes[.type] as? FileAttributeType == .typeRegular else {
+            throw ProjectionError.invalidSource("The \(label) must be a regular file: \(url.path)")
+        }
+    }
+
+    private static func requireDirectoryWithoutSymbolicLink(
+        _ url: URL,
+        label: String,
+        allowMissing: Bool = false,
+        fileManager: FileManager
+    ) throws {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            if allowMissing { return }
+            throw ProjectionError.invalidSource("Missing \(label): \(url.path)")
+        }
+        guard isDirectory.boolValue,
+              try (fileManager.attributesOfItem(atPath: url.path)[.type] as? FileAttributeType) == .typeDirectory
+        else { throw ProjectionError.invalidSource("The \(label) must be a real directory: \(url.path)") }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexManagedInstructionsProjection.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexManagedInstructionsProjection.swift
@@ -1,12 +1,16 @@
 import CryptoKit
+import Darwin
 import Foundation
 
 /// Projects Codex's effective ordinary user-global instructions into RepoPrompt's isolated home.
-/// The projection is one-way and only replaces or removes files whose ownership is proven by the sidecar.
+/// The projection is one-way and only replaces or removes regular files whose ownership is
+/// proven by the sidecar. A pending receipt makes interrupted updates recoverable without
+/// deleting the last known-good owned projection before every conflict has been validated.
 enum CodexManagedInstructionsProjection {
     static let overrideName = "AGENTS.override.md"
     static let fallbackName = "AGENTS.md"
     static let sidecarName = ".repoprompt-global-instructions.json"
+    private static let owner = "com.repoprompt.ce.codex-global-instructions"
     private static let lock = NSLock()
 
     enum ProjectionError: LocalizedError, Equatable {
@@ -22,6 +26,19 @@ enum CodexManagedInstructionsProjection {
                 message
             }
         }
+
+        var privacyBoundedDiagnostic: String {
+            switch self {
+            case .invalidSource:
+                "Projection is blocked because an instruction path is missing, unreadable, non-regular, or uses a symbolic link. RepoPrompt preserved all files."
+            case .foreignTarget:
+                "Projection is blocked by a managed-home instruction file that RepoPrompt does not own. Move or rename that file, then reconnect Codex."
+            case .invalidSidecar:
+                "Projection ownership metadata is foreign, modified, malformed, or uses a symbolic link. RepoPrompt preserved it; remove it only after reviewing the managed home."
+            case .modifiedProjection:
+                "A RepoPrompt-owned instruction projection was modified outside RepoPrompt. It was preserved; review the managed home before reconnecting Codex."
+            }
+        }
     }
 
     enum State: Equatable {
@@ -30,84 +47,177 @@ enum CodexManagedInstructionsProjection {
         case conflict(message: String)
     }
 
+    struct Diagnostic: Equatable {
+        enum Status: Equatable {
+            case current(sourceName: String)
+            case absent
+            case conflict
+            case error
+        }
+
+        let status: Status
+        let message: String
+    }
+
+    enum MutationCheckpoint: Equatable {
+        case afterPendingReceipt
+        case afterTargetWrite
+        case afterPreviousTargetRemoval
+        case afterOwnedTargetRemoval
+    }
+
     private struct Receipt: Codable, Equatable {
         enum Phase: String, Codable { case pending, committed }
+        enum Operation: String, Codable { case project, remove }
 
         let schemaVersion: Int
         let owner: String
         let sourceName: String
         let targetName: String
+        let previousTargetName: String?
         let previousTargetHash: String?
         let projectedHash: String
         let phase: Phase
+        let operation: Operation?
+
+        var effectiveOperation: Operation {
+            operation ?? .project
+        }
+    }
+
+    private struct FileIdentity: Equatable {
+        let device: UInt64
+        let inode: UInt64
+        let size: Int64
+        let modificationSeconds: Int
+        let modificationNanoseconds: Int
+
+        init(_ status: stat) {
+            device = UInt64(status.st_dev)
+            inode = UInt64(status.st_ino)
+            size = status.st_size
+            modificationSeconds = status.st_mtimespec.tv_sec
+            modificationNanoseconds = status.st_mtimespec.tv_nsec
+        }
     }
 
     static func projectBeforeLaunch(
         managedHome: URL,
         ordinaryHome: URL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".codex", isDirectory: true),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        checkpoint: ((MutationCheckpoint) throws -> Void)? = nil
     ) throws -> State {
         lock.lock()
         defer { lock.unlock() }
 
-        try fileManager.createDirectory(at: managedHome, withIntermediateDirectories: true)
-        try requireDirectoryWithoutSymbolicLink(managedHome, label: "managed Codex home", fileManager: fileManager)
-        try requireDirectoryWithoutSymbolicLink(ordinaryHome, label: "ordinary Codex home", allowMissing: true, fileManager: fileManager)
+        try prepareManagedHome(managedHome, fileManager: fileManager)
+        try requireDirectoryChainWithoutSymbolicLink(
+            ordinaryHome,
+            label: "ordinary Codex home",
+            allowMissing: true,
+            ancestorDepth: 1
+        )
 
-        let selection = try effectiveSource(in: ordinaryHome, fileManager: fileManager)
         let sidecar = managedHome.appendingPathComponent(sidecarName, isDirectory: false)
-        let existingReceipt = try loadReceipt(at: sidecar, fileManager: fileManager)
-
-        guard let selection else {
-            try removeOwnedProjectionIfPresent(
+        var receipt = try loadReceipt(at: sidecar)
+        if let pending = receipt, pending.phase == .pending {
+            receipt = try recoverInterruptedProjection(
+                pending,
                 managedHome: managedHome,
                 sidecar: sidecar,
-                receipt: existingReceipt,
                 fileManager: fileManager
             )
+        }
+
+        let selection = try effectiveSource(in: ordinaryHome)
+        let hashes = try targetHashes(in: managedHome)
+        if let receipt {
+            try validateCommittedReceipt(receipt, hashes: hashes)
+        } else if !hashes.isEmpty {
+            throw ProjectionError.foreignTarget(
+                "Preserving managed-home instruction files without a RepoPrompt ownership receipt."
+            )
+        }
+
+        guard let selection else {
+            if let receipt {
+                let pendingRemoval = Receipt(
+                    schemaVersion: 2,
+                    owner: owner,
+                    sourceName: receipt.sourceName,
+                    targetName: receipt.targetName,
+                    previousTargetName: receipt.targetName,
+                    previousTargetHash: receipt.projectedHash,
+                    projectedHash: receipt.projectedHash,
+                    phase: .pending,
+                    operation: .remove
+                )
+                try writeReceipt(pendingRemoval, to: sidecar)
+                let target = managedHome.appendingPathComponent(receipt.targetName)
+                try removeRegularFile(target, expectedHash: receipt.projectedHash, fileManager: fileManager)
+                try checkpoint?(.afterOwnedTargetRemoval)
+                try removeRegularSidecarIfPresent(sidecar, fileManager: fileManager)
+            }
             return .absent(managedHome: managedHome)
         }
 
-        let target = managedHome.appendingPathComponent(selection.name, isDirectory: false)
-        let otherName = selection.name == overrideName ? fallbackName : overrideName
-        let otherTarget = managedHome.appendingPathComponent(otherName, isDirectory: false)
-        try removeOwnedTargetIfNeeded(otherTarget, sidecar: sidecar, receipt: existingReceipt, fileManager: fileManager)
-
-        let sourceData = try Data(contentsOf: selection.url, options: .mappedIfSafe)
+        let sourceData = try readStableRegularFile(selection.url, label: "ordinary \(selection.name)")
         let sourceHash = digest(sourceData)
-        let previousHash = try verifyOwnershipForReplacement(
-            target: target,
-            sidecar: sidecar,
-            receipt: existingReceipt,
-            nextHash: sourceHash,
-            fileManager: fileManager
-        )
+        let target = managedHome.appendingPathComponent(selection.name, isDirectory: false)
+
+        if let receipt,
+           receipt.targetName == selection.name,
+           receipt.projectedHash == sourceHash
+        {
+            return .projected(source: selection.url, target: target)
+        }
+
+        let previousTargetName = receipt?.targetName
+        let previousTargetHash = receipt?.projectedHash
+        if previousTargetName != selection.name, hashes[selection.name] != nil {
+            throw ProjectionError.foreignTarget(
+                "Preserving a managed-home instruction target that is not owned by the current receipt."
+            )
+        }
 
         let pending = Receipt(
-            schemaVersion: 1,
-            owner: "com.repoprompt.ce.codex-global-instructions",
+            schemaVersion: 2,
+            owner: owner,
             sourceName: selection.name,
             targetName: selection.name,
-            previousTargetHash: previousHash,
+            previousTargetName: previousTargetName,
+            previousTargetHash: previousTargetHash,
             projectedHash: sourceHash,
-            phase: .pending
+            phase: .pending,
+            operation: .project
         )
         try writeReceipt(pending, to: sidecar)
+        try checkpoint?(.afterPendingReceipt)
+
         try sourceData.write(to: target, options: .atomic)
-        try requireRegularFile(target, label: "managed instruction projection", fileManager: fileManager)
-        try writeReceipt(
-            Receipt(
-                schemaVersion: pending.schemaVersion,
-                owner: pending.owner,
-                sourceName: pending.sourceName,
-                targetName: pending.targetName,
-                previousTargetHash: nil,
-                projectedHash: pending.projectedHash,
-                phase: .committed
-            ),
-            to: sidecar
-        )
+        try requireRegularFile(target, label: "managed instruction projection")
+        guard try hashOfRegularFile(target) == sourceHash else {
+            throw ProjectionError.modifiedProjection(
+                "Managed instruction projection changed while it was being written."
+            )
+        }
+        try checkpoint?(.afterTargetWrite)
+
+        if let previousTargetName,
+           previousTargetName != selection.name,
+           let previousTargetHash
+        {
+            let previousTarget = managedHome.appendingPathComponent(previousTargetName)
+            try removeRegularFile(
+                previousTarget,
+                expectedHash: previousTargetHash,
+                fileManager: fileManager
+            )
+            try checkpoint?(.afterPreviousTargetRemoval)
+        }
+
+        try writeReceipt(committedReceipt(name: selection.name, hash: sourceHash), to: sidecar)
         return .projected(source: selection.url, target: target)
     }
 
@@ -117,156 +227,459 @@ enum CodexManagedInstructionsProjection {
             .appendingPathComponent(".codex", isDirectory: true),
         fileManager: FileManager = .default
     ) -> State {
-        do {
-            let selection = try effectiveSource(in: ordinaryHome, fileManager: fileManager)
-            let receipt = try loadReceipt(
-                at: managedHome.appendingPathComponent(sidecarName),
-                fileManager: fileManager
+        let diagnostic = diagnostic(
+            managedHome: managedHome,
+            ordinaryHome: ordinaryHome,
+            fileManager: fileManager
+        )
+        switch diagnostic.status {
+        case let .current(sourceName):
+            return .projected(
+                source: ordinaryHome.appendingPathComponent(sourceName),
+                target: managedHome.appendingPathComponent(sourceName)
             )
-            guard let selection else { return .absent(managedHome: managedHome) }
-            let target = managedHome.appendingPathComponent(selection.name)
-            guard let receipt, receipt.phase == .committed,
-                  receipt.sourceName == selection.name,
-                  receipt.targetName == selection.name,
-                  try hashOfRegularFile(target, fileManager: fileManager) == receipt.projectedHash
-            else {
-                return .conflict(message: "Global instruction projection is not current.")
-            }
-            return .projected(source: selection.url, target: target)
-        } catch {
-            return .conflict(message: error.localizedDescription)
+        case .absent:
+            return .absent(managedHome: managedHome)
+        case .conflict, .error:
+            return .conflict(message: diagnostic.message)
         }
     }
 
-    private static func effectiveSource(
-        in ordinaryHome: URL,
-        fileManager: FileManager
-    ) throws -> (name: String, url: URL)? {
+    static func diagnostic(
+        managedHome: URL,
+        ordinaryHome: URL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true),
+        fileManager: FileManager = .default
+    ) -> Diagnostic {
+        do {
+            try requireDirectoryChainWithoutSymbolicLink(
+                ordinaryHome,
+                label: "ordinary Codex home",
+                allowMissing: true,
+                ancestorDepth: 1
+            )
+            let selection = try effectiveSource(in: ordinaryHome)
+            if try nodeType(at: managedHome) == nil {
+                try requireDirectoryChainWithoutSymbolicLink(
+                    managedHome,
+                    label: "managed Codex home",
+                    allowMissing: true,
+                    ancestorDepth: 3
+                )
+                return Diagnostic(
+                    status: .absent,
+                    message: selection == nil
+                        ? "No ordinary global Codex instruction file is present."
+                        : "Global instructions are available and will be projected before the next Codex launch."
+                )
+            }
+            try requireDirectoryChainWithoutSymbolicLink(
+                managedHome,
+                label: "managed Codex home",
+                ancestorDepth: 3
+            )
+
+            let sidecar = managedHome.appendingPathComponent(sidecarName)
+            let receipt = try loadReceipt(at: sidecar)
+            let hashes = try targetHashes(in: managedHome)
+            if let receipt, receipt.phase == .pending {
+                return Diagnostic(
+                    status: .conflict,
+                    message: "A previous instruction projection was interrupted. RepoPrompt preserved its recoverable state and will reconcile it before the next Codex launch."
+                )
+            }
+
+            guard let selection else {
+                if receipt == nil, hashes.isEmpty {
+                    return Diagnostic(
+                        status: .absent,
+                        message: "No ordinary global Codex instruction file is present."
+                    )
+                }
+                return Diagnostic(
+                    status: .conflict,
+                    message: "No ordinary global instruction source is present, but projection state remains in the managed home. RepoPrompt will reconcile it before launch."
+                )
+            }
+
+            guard let receipt else {
+                return Diagnostic(
+                    status: hashes.isEmpty ? .absent : .conflict,
+                    message: hashes.isEmpty
+                        ? "Global instructions are available and will be projected before the next Codex launch."
+                        : "A managed-home instruction file is not owned by RepoPrompt and was preserved."
+                )
+            }
+            try validateCommittedReceipt(receipt, hashes: hashes)
+            let sourceData = try readStableRegularFile(selection.url, label: "ordinary \(selection.name)")
+            guard receipt.sourceName == selection.name,
+                  receipt.targetName == selection.name,
+                  receipt.projectedHash == digest(sourceData)
+            else {
+                return Diagnostic(
+                    status: .conflict,
+                    message: "The ordinary global instruction source changed after the last projection. RepoPrompt will refresh it before the next Codex launch."
+                )
+            }
+            return Diagnostic(
+                status: .current(sourceName: selection.name),
+                message: "The effective ordinary global \(selection.name) is currently projected as a RepoPrompt-owned regular file."
+            )
+        } catch {
+            return diagnostic(for: error)
+        }
+    }
+
+    static func diagnostic(for error: Error) -> Diagnostic {
+        if let projectionError = error as? ProjectionError {
+            return Diagnostic(status: .conflict, message: projectionError.privacyBoundedDiagnostic)
+        }
+        return Diagnostic(
+            status: .error,
+            message: "RepoPrompt could not inspect the global-instruction projection. Check managed-home permissions, then reconnect Codex."
+        )
+    }
+
+    private static func effectiveSource(in ordinaryHome: URL) throws -> (name: String, url: URL)? {
+        guard try nodeType(at: ordinaryHome) != nil else { return nil }
         for name in [overrideName, fallbackName] {
             let candidate = ordinaryHome.appendingPathComponent(name, isDirectory: false)
-            guard fileManager.fileExists(atPath: candidate.path) else { continue }
-            try requireRegularFile(candidate, label: "ordinary \(name)", fileManager: fileManager)
+            guard try nodeType(at: candidate) != nil else { continue }
+            try requireRegularFile(candidate, label: "ordinary \(name)")
             return (name, candidate)
         }
         return nil
     }
 
-    private static func verifyOwnershipForReplacement(
-        target: URL,
-        sidecar: URL,
-        receipt: Receipt?,
-        nextHash: String,
-        fileManager: FileManager
-    ) throws -> String? {
-        guard fileManager.fileExists(atPath: target.path) else {
-            if let receipt, receipt.targetName == target.lastPathComponent,
-               receipt.phase == .pending, receipt.previousTargetHash != nil
-            {
-                throw ProjectionError.modifiedProjection("Owned projection disappeared during an interrupted update: \(target.path)")
-            }
-            return nil
-        }
-        guard let receipt else {
-            throw ProjectionError.foreignTarget("Preserving foreign managed-home file without RepoPrompt ownership receipt: \(target.path)")
-        }
-        guard receipt.targetName == target.lastPathComponent else {
-            throw ProjectionError.foreignTarget("Projection receipt does not own \(target.path)")
-        }
-        let actual = try hashOfRegularFile(target, fileManager: fileManager)
-        let allowed = receipt.phase == .committed
-            ? [receipt.projectedHash]
-            : [receipt.previousTargetHash, receipt.projectedHash].compactMap(\.self)
-        guard allowed.contains(actual) else {
-            throw ProjectionError.modifiedProjection("Preserving modified managed instruction projection: \(target.path)")
-        }
-        _ = sidecar
-        return actual == nextHash ? actual : actual
-    }
-
-    private static func removeOwnedProjectionIfPresent(
+    private static func recoverInterruptedProjection(
+        _ receipt: Receipt,
         managedHome: URL,
         sidecar: URL,
-        receipt: Receipt?,
         fileManager: FileManager
-    ) throws {
-        guard let receipt else { return }
-        let target = managedHome.appendingPathComponent(receipt.targetName)
-        try removeOwnedTargetIfNeeded(target, sidecar: sidecar, receipt: receipt, fileManager: fileManager)
-        if fileManager.fileExists(atPath: sidecar.path) { try fileManager.removeItem(at: sidecar) }
+    ) throws -> Receipt? {
+        let hashes = try targetHashes(in: managedHome)
+        if receipt.effectiveOperation == .remove {
+            guard Set(hashes.keys).isSubset(of: Set([receipt.targetName])) else {
+                throw ProjectionError.foreignTarget(
+                    "Preserving an instruction file outside the interrupted removal receipt."
+                )
+            }
+            if let actualHash = hashes[receipt.targetName] {
+                guard actualHash == receipt.projectedHash else {
+                    throw ProjectionError.modifiedProjection(
+                        "The projection changed during interrupted removal."
+                    )
+                }
+                try removeRegularFile(
+                    managedHome.appendingPathComponent(receipt.targetName),
+                    expectedHash: receipt.projectedHash,
+                    fileManager: fileManager
+                )
+            }
+            try removeRegularSidecarIfPresent(sidecar, fileManager: fileManager)
+            return nil
+        }
+
+        let previousName = receipt.previousTargetName
+            ?? (receipt.previousTargetHash == nil ? nil : receipt.targetName)
+        let ownedNames = Set([receipt.targetName, previousName].compactMap(\.self))
+        guard Set(hashes.keys).isSubset(of: ownedNames) else {
+            throw ProjectionError.foreignTarget(
+                "Preserving an instruction file outside the interrupted projection receipt."
+            )
+        }
+
+        let currentHash = hashes[receipt.targetName]
+        if currentHash == receipt.projectedHash {
+            if let previousName,
+               previousName != receipt.targetName,
+               let previousHash = receipt.previousTargetHash,
+               let actualPreviousHash = hashes[previousName]
+            {
+                guard actualPreviousHash == previousHash else {
+                    throw ProjectionError.modifiedProjection(
+                        "The previous projection changed during interrupted source switching."
+                    )
+                }
+                try removeRegularFile(
+                    managedHome.appendingPathComponent(previousName),
+                    expectedHash: previousHash,
+                    fileManager: fileManager
+                )
+            }
+            let committed = committedReceipt(name: receipt.targetName, hash: receipt.projectedHash)
+            try writeReceipt(committed, to: sidecar)
+            return committed
+        }
+
+        if previousName == receipt.targetName,
+           let previousHash = receipt.previousTargetHash,
+           currentHash == previousHash
+        {
+            let committed = committedReceipt(name: receipt.targetName, hash: previousHash)
+            try writeReceipt(committed, to: sidecar)
+            return committed
+        }
+
+        if let previousName,
+           previousName != receipt.targetName,
+           let previousHash = receipt.previousTargetHash,
+           currentHash == nil,
+           hashes[previousName] == previousHash
+        {
+            let committed = committedReceipt(name: previousName, hash: previousHash)
+            try writeReceipt(committed, to: sidecar)
+            return committed
+        }
+
+        if previousName == nil, currentHash == nil, hashes.isEmpty {
+            try removeRegularSidecarIfPresent(sidecar, fileManager: fileManager)
+            return nil
+        }
+
+        throw ProjectionError.modifiedProjection(
+            "The interrupted instruction projection no longer matches its ownership receipt."
+        )
     }
 
-    private static func removeOwnedTargetIfNeeded(
-        _ target: URL,
-        sidecar: URL,
-        receipt: Receipt?,
-        fileManager: FileManager
+    private static func validateCommittedReceipt(
+        _ receipt: Receipt,
+        hashes: [String: String]
     ) throws {
-        guard fileManager.fileExists(atPath: target.path) else { return }
-        guard let receipt, receipt.targetName == target.lastPathComponent else {
-            throw ProjectionError.foreignTarget("Preserving foreign managed-home file: \(target.path)")
+        guard receipt.phase == .committed else {
+            throw ProjectionError.invalidSidecar("Expected a committed projection receipt.")
         }
-        let actual = try hashOfRegularFile(target, fileManager: fileManager)
-        let allowed = receipt.phase == .committed
-            ? [receipt.projectedHash]
-            : [receipt.previousTargetHash, receipt.projectedHash].compactMap(\.self)
-        guard allowed.contains(actual) else {
-            throw ProjectionError.modifiedProjection("Preserving modified managed instruction projection: \(target.path)")
+        guard hashes[receipt.targetName] == receipt.projectedHash else {
+            throw ProjectionError.modifiedProjection(
+                "The owned instruction projection is missing or modified."
+            )
         }
-        try fileManager.removeItem(at: target)
-        _ = sidecar
+        guard Set(hashes.keys) == Set([receipt.targetName]) else {
+            throw ProjectionError.foreignTarget(
+                "Preserving an additional managed-home instruction file not owned by the receipt."
+            )
+        }
     }
 
-    private static func loadReceipt(at url: URL, fileManager: FileManager) throws -> Receipt? {
-        guard fileManager.fileExists(atPath: url.path) else { return nil }
-        try requireRegularFile(url, label: "projection receipt", fileManager: fileManager)
+    private static func targetHashes(in managedHome: URL) throws -> [String: String] {
+        var hashes: [String: String] = [:]
+        for name in [overrideName, fallbackName] {
+            let target = managedHome.appendingPathComponent(name)
+            guard try nodeType(at: target) != nil else { continue }
+            do {
+                hashes[name] = try hashOfRegularFile(target)
+            } catch {
+                throw ProjectionError.foreignTarget(
+                    "Preserving a non-regular or symbolic-link managed-home instruction target."
+                )
+            }
+        }
+        return hashes
+    }
+
+    private static func committedReceipt(name: String, hash: String) -> Receipt {
+        Receipt(
+            schemaVersion: 2,
+            owner: owner,
+            sourceName: name,
+            targetName: name,
+            previousTargetName: nil,
+            previousTargetHash: nil,
+            projectedHash: hash,
+            phase: .committed,
+            operation: .project
+        )
+    }
+
+    private static func loadReceipt(at url: URL) throws -> Receipt? {
+        guard try nodeType(at: url) != nil else { return nil }
+        do {
+            try requireRegularFile(url, label: "projection receipt")
+        } catch {
+            throw ProjectionError.invalidSidecar(
+                "The RepoPrompt projection receipt is not a regular file."
+            )
+        }
         let receipt: Receipt
-        do { receipt = try JSONDecoder().decode(Receipt.self, from: Data(contentsOf: url)) }
-        catch { throw ProjectionError.invalidSidecar("Invalid RepoPrompt projection receipt at \(url.path)") }
-        guard receipt.schemaVersion == 1,
-              receipt.owner == "com.repoprompt.ce.codex-global-instructions",
+        do {
+            receipt = try JSONDecoder().decode(
+                Receipt.self,
+                from: readStableRegularFile(url, label: "projection receipt")
+            )
+        } catch let error as ProjectionError {
+            throw error
+        } catch {
+            throw ProjectionError.invalidSidecar("Invalid RepoPrompt projection receipt.")
+        }
+        let validPreviousName = receipt.previousTargetName.map {
+            [overrideName, fallbackName].contains($0)
+        } ?? true
+        let validPreviousHash = receipt.previousTargetHash.map(isValidHash) ?? true
+        guard [1, 2].contains(receipt.schemaVersion),
+              receipt.owner == owner,
               [overrideName, fallbackName].contains(receipt.sourceName),
               receipt.sourceName == receipt.targetName,
-              receipt.projectedHash.count == 64,
-              receipt.projectedHash.allSatisfy(\.isHexDigit)
-        else { throw ProjectionError.invalidSidecar("Unrecognized RepoPrompt projection receipt at \(url.path)") }
+              validPreviousName,
+              validPreviousHash,
+              isValidHash(receipt.projectedHash),
+              receipt.phase == .pending || (receipt.previousTargetName == nil && receipt.previousTargetHash == nil),
+              receipt.phase == .pending || receipt.effectiveOperation == .project
+        else {
+            throw ProjectionError.invalidSidecar("Unrecognized RepoPrompt projection receipt.")
+        }
         return receipt
     }
 
     private static func writeReceipt(_ receipt: Receipt, to url: URL) throws {
+        if try nodeType(at: url) != nil {
+            do {
+                try requireRegularFile(url, label: "projection receipt")
+            } catch {
+                throw ProjectionError.invalidSidecar(
+                    "Preserving a non-regular or symbolic-link projection receipt."
+                )
+            }
+        }
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         try encoder.encode(receipt).write(to: url, options: .atomic)
+        do {
+            try requireRegularFile(url, label: "projection receipt")
+        } catch {
+            throw ProjectionError.invalidSidecar("Projection receipt write did not produce a regular file.")
+        }
     }
 
-    private static func hashOfRegularFile(_ url: URL, fileManager: FileManager) throws -> String {
-        try requireRegularFile(url, label: "managed instruction projection", fileManager: fileManager)
-        return try digest(Data(contentsOf: url, options: .mappedIfSafe))
+    private static func prepareManagedHome(_ managedHome: URL, fileManager: FileManager) throws {
+        let parent = managedHome.deletingLastPathComponent()
+        try requireDirectoryChainWithoutSymbolicLink(
+            parent,
+            label: "managed Codex state parent",
+            ancestorDepth: 2
+        )
+        switch try nodeType(at: managedHome) {
+        case nil:
+            try fileManager.createDirectory(at: managedHome, withIntermediateDirectories: false)
+        case mode_t(S_IFDIR):
+            break
+        default:
+            throw ProjectionError.invalidSource(
+                "The managed Codex home must be a real directory."
+            )
+        }
+        try requireDirectoryChainWithoutSymbolicLink(
+            managedHome,
+            label: "managed Codex home",
+            ancestorDepth: 3
+        )
+    }
+
+    private static func removeRegularFile(
+        _ url: URL,
+        expectedHash: String,
+        fileManager: FileManager
+    ) throws {
+        guard try hashOfRegularFile(url) == expectedHash else {
+            throw ProjectionError.modifiedProjection(
+                "Preserving a modified managed instruction projection."
+            )
+        }
+        try fileManager.removeItem(at: url)
+    }
+
+    private static func removeRegularSidecarIfPresent(
+        _ sidecar: URL,
+        fileManager: FileManager
+    ) throws {
+        guard try nodeType(at: sidecar) != nil else { return }
+        do {
+            try requireRegularFile(sidecar, label: "projection receipt")
+        } catch {
+            throw ProjectionError.invalidSidecar(
+                "Preserving a non-regular or symbolic-link projection receipt."
+            )
+        }
+        try fileManager.removeItem(at: sidecar)
+    }
+
+    private static func hashOfRegularFile(_ url: URL) throws -> String {
+        try digest(readStableRegularFile(url, label: "managed instruction projection"))
+    }
+
+    private static func readStableRegularFile(_ url: URL, label: String) throws -> Data {
+        let before = try requireRegularFile(url, label: label)
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        let after = try requireRegularFile(url, label: label)
+        guard FileIdentity(before) == FileIdentity(after), Int64(data.count) == after.st_size else {
+            throw ProjectionError.invalidSource(
+                "The \(label) changed while RepoPrompt was reading it."
+            )
+        }
+        return data
     }
 
     private static func digest(_ data: Data) -> String {
         SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
-    private static func requireRegularFile(_ url: URL, label: String, fileManager: FileManager) throws {
-        let attributes = try fileManager.attributesOfItem(atPath: url.path)
-        guard attributes[.type] as? FileAttributeType == .typeRegular else {
-            throw ProjectionError.invalidSource("The \(label) must be a regular file: \(url.path)")
+    private static func isValidHash(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy { character in
+            character.isNumber || (character >= "a" && character <= "f")
         }
     }
 
-    private static func requireDirectoryWithoutSymbolicLink(
+    @discardableResult
+    private static func requireRegularFile(_ url: URL, label: String) throws -> stat {
+        guard let status = try lstatStatus(at: url),
+              status.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG)
+        else {
+            throw ProjectionError.invalidSource(
+                "The \(label) must be a regular file and not a symbolic link."
+            )
+        }
+        return status
+    }
+
+    private static func requireDirectoryChainWithoutSymbolicLink(
         _ url: URL,
         label: String,
         allowMissing: Bool = false,
-        fileManager: FileManager
+        ancestorDepth: Int
     ) throws {
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
-            if allowMissing { return }
-            throw ProjectionError.invalidSource("Missing \(label): \(url.path)")
+        var candidate = url.standardizedFileURL
+        for depth in 0 ... ancestorDepth {
+            guard let status = try lstatStatus(at: candidate) else {
+                if allowMissing {
+                    candidate.deleteLastPathComponent()
+                    continue
+                }
+                throw ProjectionError.invalidSource("Missing \(label).")
+            }
+            guard status.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR) else {
+                throw ProjectionError.invalidSource(
+                    "The \(label) and its RepoPrompt-owned ancestors must be real directories."
+                )
+            }
+            candidate.deleteLastPathComponent()
         }
-        guard isDirectory.boolValue,
-              try (fileManager.attributesOfItem(atPath: url.path)[.type] as? FileAttributeType) == .typeDirectory
-        else { throw ProjectionError.invalidSource("The \(label) must be a real directory: \(url.path)") }
+    }
+
+    private static func nodeType(at url: URL) throws -> mode_t? {
+        try lstatStatus(at: url)?.st_mode.mapType
+    }
+
+    private static func lstatStatus(at url: URL) throws -> stat? {
+        var status = stat()
+        if lstat(url.path, &status) == 0 { return status }
+        guard errno == ENOENT else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return nil
+    }
+}
+
+private extension mode_t {
+    var mapType: mode_t {
+        self & mode_t(S_IFMT)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
@@ -18,6 +18,7 @@ enum CodexRuntimeAuthority {
     struct StatePaths: Equatable {
         let codexHome: URL
         let sqliteHome: URL
+        let logDirectory: URL
 
         var environment: [String: String] {
             [
@@ -36,6 +37,8 @@ enum CodexRuntimeAuthority {
         func prepareState(fileManager: FileManager = .default) throws {
             try fileManager.createDirectory(at: statePaths.codexHome, withIntermediateDirectories: true)
             try fileManager.createDirectory(at: statePaths.sqliteHome, withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: statePaths.logDirectory, withIntermediateDirectories: true)
+            try CodexRuntimeAuthority.validateManagedStatePaths(statePaths, fileManager: fileManager)
         }
 
         var redactedDiagnosticSummary: String {
@@ -219,8 +222,37 @@ enum CodexRuntimeAuthority {
             .appendingPathComponent(buildChannel, isDirectory: true)
         return StatePaths(
             codexHome: root.appendingPathComponent("home", isDirectory: true),
-            sqliteHome: root.appendingPathComponent("sqlite", isDirectory: true)
+            sqliteHome: root.appendingPathComponent("sqlite", isDirectory: true),
+            logDirectory: root.appendingPathComponent("log", isDirectory: true)
         )
+    }
+
+    private static func validateManagedStatePaths(
+        _ paths: StatePaths,
+        fileManager: FileManager
+    ) throws {
+        let root = paths.codexHome.deletingLastPathComponent().standardizedFileURL
+        let ownedAncestors = [
+            root.deletingLastPathComponent().deletingLastPathComponent(),
+            root.deletingLastPathComponent(),
+            root
+        ]
+        for directory in ownedAncestors {
+            let attributes = try fileManager.attributesOfItem(atPath: directory.path)
+            guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+                throw CocoaError(.fileReadInvalidFileName)
+            }
+        }
+        for candidate in [paths.codexHome, paths.sqliteHome, paths.logDirectory] {
+            let standardized = candidate.standardizedFileURL
+            guard standardized.deletingLastPathComponent() == root else {
+                throw CocoaError(.fileReadInvalidFileName)
+            }
+            let attributes = try fileManager.attributesOfItem(atPath: standardized.path)
+            guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+                throw CocoaError(.fileReadInvalidFileName)
+            }
+        }
     }
 
     static func resolve(
@@ -421,6 +453,6 @@ enum CodexRuntimeAuthority {
         func redact(_ path: String) -> String {
             path.hasPrefix(home + "/") ? "~" + path.dropFirst(home.count) : "<application-support>/" + URL(fileURLWithPath: path).lastPathComponent
         }
-        return "CODEX_HOME=\(redact(paths.codexHome.path)), CODEX_SQLITE_HOME=\(redact(paths.sqliteHome.path))"
+        return "CODEX_HOME=\(redact(paths.codexHome.path)), CODEX_SQLITE_HOME=\(redact(paths.sqliteHome.path)), log_dir=\(redact(paths.logDirectory.path))"
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
@@ -258,7 +258,7 @@ enum CodexRuntimeAuthority {
                 throw CocoaError(.fileReadInvalidFileName)
             }
         }
-        try validateManagedStatePaths(paths)
+        try validateManagedState(paths, fileManager: fileManager)
     }
 
     private static func managedStateDirectories(_ paths: StatePaths) throws -> [URL] {
@@ -291,10 +291,68 @@ enum CodexRuntimeAuthority {
         return [repoPromptRoot, codexRoot, channelRoot, codexHome, sqliteHome, logDirectory]
     }
 
-    private static func validateManagedStatePaths(_ paths: StatePaths) throws {
+    static func validateManagedState(
+        _ paths: StatePaths,
+        fileManager: FileManager = .default
+    ) throws {
         for directory in try managedStateDirectories(paths) {
             guard try nodeType(at: directory) == mode_t(S_IFDIR) else {
                 throw CocoaError(.fileReadInvalidFileName)
+            }
+        }
+        let sensitiveFiles = [
+            paths.codexHome.appendingPathComponent("auth.json"),
+            paths.codexHome.appendingPathComponent("config.toml"),
+            paths.codexHome.appendingPathComponent("session_index.jsonl")
+        ]
+        for file in sensitiveFiles {
+            guard try nodeType(at: file) != mode_t(S_IFLNK) else {
+                throw CocoaError(.fileReadInvalidFileName)
+            }
+        }
+
+        let sensitiveTrees = [
+            paths.codexHome.appendingPathComponent("sessions", isDirectory: true),
+            paths.codexHome.appendingPathComponent("shell_snapshots", isDirectory: true),
+            paths.sqliteHome,
+            paths.logDirectory
+        ]
+        for root in sensitiveTrees {
+            try rejectSymbolicLinks(in: root, fileManager: fileManager)
+        }
+    }
+
+    private static func rejectSymbolicLinks(
+        in root: URL,
+        fileManager: FileManager
+    ) throws {
+        switch try nodeType(at: root) {
+        case nil:
+            return
+        case mode_t(S_IFDIR):
+            break
+        default:
+            throw CocoaError(.fileReadInvalidFileName)
+        }
+
+        var pendingDirectories = [root]
+        while let directory = pendingDirectories.popLast() {
+            let children = try fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil,
+                options: []
+            )
+            for child in children {
+                switch try nodeType(at: child) {
+                case mode_t(S_IFLNK):
+                    throw CocoaError(.fileReadInvalidFileName)
+                case mode_t(S_IFDIR):
+                    pendingDirectories.append(child)
+                case nil:
+                    continue
+                default:
+                    break
+                }
             }
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// The single source of truth for RepoPrompt-managed Codex runtime selection and state.
@@ -9,6 +10,19 @@ enum CodexRuntimeAuthority {
     static let bundledVersion = Version(major: 0, minor: 147, patch: 0)
     static let minimumExternalVersion = bundledVersion
     static let externalExecutableOverrideEnvironmentKey = "REPOPROMPT_CODEX_EXECUTABLE"
+
+    enum BuildChannel: String, CaseIterable {
+        case debug = "Debug"
+        case release = "Release"
+
+        static var current: BuildChannel {
+            #if DEBUG
+                .debug
+            #else
+                .release
+            #endif
+        }
+    }
 
     enum Source: Equatable {
         case bundled(target: String)
@@ -35,10 +49,7 @@ enum CodexRuntimeAuthority {
         let statePaths: StatePaths
 
         func prepareState(fileManager: FileManager = .default) throws {
-            try fileManager.createDirectory(at: statePaths.codexHome, withIntermediateDirectories: true)
-            try fileManager.createDirectory(at: statePaths.sqliteHome, withIntermediateDirectories: true)
-            try fileManager.createDirectory(at: statePaths.logDirectory, withIntermediateDirectories: true)
-            try CodexRuntimeAuthority.validateManagedStatePaths(statePaths, fileManager: fileManager)
+            try CodexRuntimeAuthority.prepareManagedState(statePaths, fileManager: fileManager)
         }
 
         var redactedDiagnosticSummary: String {
@@ -209,17 +220,15 @@ enum CodexRuntimeAuthority {
         #endif
     }
 
-    static func statePaths(applicationSupportURL: URL? = nil) -> StatePaths {
+    static func statePaths(
+        applicationSupportURL: URL? = nil,
+        buildChannel: BuildChannel = .current
+    ) -> StatePaths {
         let support = applicationSupportURL ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        #if DEBUG
-            let buildChannel = "Debug"
-        #else
-            let buildChannel = "Release"
-        #endif
         let root = support
             .appendingPathComponent("RepoPrompt CE", isDirectory: true)
             .appendingPathComponent("Codex", isDirectory: true)
-            .appendingPathComponent(buildChannel, isDirectory: true)
+            .appendingPathComponent(buildChannel.rawValue, isDirectory: true)
         return StatePaths(
             codexHome: root.appendingPathComponent("home", isDirectory: true),
             sqliteHome: root.appendingPathComponent("sqlite", isDirectory: true),
@@ -227,32 +236,78 @@ enum CodexRuntimeAuthority {
         )
     }
 
-    private static func validateManagedStatePaths(
+    static func prepareManagedState(
         _ paths: StatePaths,
-        fileManager: FileManager
+        fileManager: FileManager = .default
     ) throws {
-        let root = paths.codexHome.deletingLastPathComponent().standardizedFileURL
-        let ownedAncestors = [
-            root.deletingLastPathComponent().deletingLastPathComponent(),
-            root.deletingLastPathComponent(),
-            root
-        ]
-        for directory in ownedAncestors {
-            let attributes = try fileManager.attributesOfItem(atPath: directory.path)
-            guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+        let directories = try managedStateDirectories(paths)
+        for directory in directories {
+            switch try nodeType(at: directory) {
+            case nil:
+                let parent = directory.deletingLastPathComponent()
+                guard try nodeType(at: parent) == mode_t(S_IFDIR) else {
+                    throw CocoaError(.fileReadInvalidFileName)
+                }
+                try fileManager.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: false
+                )
+            case mode_t(S_IFDIR):
+                break
+            default:
                 throw CocoaError(.fileReadInvalidFileName)
             }
         }
-        for candidate in [paths.codexHome, paths.sqliteHome, paths.logDirectory] {
-            let standardized = candidate.standardizedFileURL
-            guard standardized.deletingLastPathComponent() == root else {
-                throw CocoaError(.fileReadInvalidFileName)
-            }
-            let attributes = try fileManager.attributesOfItem(atPath: standardized.path)
-            guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+        try validateManagedStatePaths(paths)
+    }
+
+    private static func managedStateDirectories(_ paths: StatePaths) throws -> [URL] {
+        let codexHome = paths.codexHome.standardizedFileURL
+        let sqliteHome = paths.sqliteHome.standardizedFileURL
+        let logDirectory = paths.logDirectory.standardizedFileURL
+        guard codexHome == paths.codexHome,
+              sqliteHome == paths.sqliteHome,
+              logDirectory == paths.logDirectory,
+              codexHome.isFileURL,
+              codexHome.path.hasPrefix("/")
+        else {
+            throw CocoaError(.fileReadInvalidFileName)
+        }
+
+        let channelRoot = codexHome.deletingLastPathComponent()
+        guard codexHome == channelRoot.appendingPathComponent("home", isDirectory: true),
+              sqliteHome == channelRoot.appendingPathComponent("sqlite", isDirectory: true),
+              logDirectory == channelRoot.appendingPathComponent("log", isDirectory: true),
+              channelRoot.lastPathComponent == BuildChannel.debug.rawValue
+              || channelRoot.lastPathComponent == BuildChannel.release.rawValue,
+              channelRoot.deletingLastPathComponent().lastPathComponent == "Codex",
+              channelRoot.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent == "RepoPrompt CE"
+        else {
+            throw CocoaError(.fileReadInvalidFileName)
+        }
+
+        let codexRoot = channelRoot.deletingLastPathComponent()
+        let repoPromptRoot = codexRoot.deletingLastPathComponent()
+        return [repoPromptRoot, codexRoot, channelRoot, codexHome, sqliteHome, logDirectory]
+    }
+
+    private static func validateManagedStatePaths(_ paths: StatePaths) throws {
+        for directory in try managedStateDirectories(paths) {
+            guard try nodeType(at: directory) == mode_t(S_IFDIR) else {
                 throw CocoaError(.fileReadInvalidFileName)
             }
         }
+    }
+
+    private static func nodeType(at url: URL) throws -> mode_t? {
+        var status = stat()
+        if lstat(url.path, &status) == 0 {
+            return status.st_mode & mode_t(S_IFMT)
+        }
+        guard errno == ENOENT else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return nil
     }
 
     static func resolve(

--- a/Tests/RepoPromptTests/AI/CodexManagedInstructionsProjectionTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexManagedInstructionsProjectionTests.swift
@@ -3,6 +3,8 @@ import Foundation
 import XCTest
 
 final class CodexManagedInstructionsProjectionTests: XCTestCase {
+    private enum InjectedFailure: Error { case stop }
+
     private var root: URL!
     private var ordinaryHome: URL!
     private var managedHome: URL!
@@ -20,88 +22,328 @@ final class CodexManagedInstructionsProjectionTests: XCTestCase {
     }
 
     func testOverrideWinsAndProjectionIsARegularFile() throws {
-        try "fallback".write(
-            to: ordinaryHome.appendingPathComponent("AGENTS.md"),
-            atomically: true,
-            encoding: .utf8
-        )
+        try write("fallback", to: ordinaryHome.appendingPathComponent("AGENTS.md"))
         let source = ordinaryHome.appendingPathComponent("AGENTS.override.md")
-        try "override".write(to: source, atomically: true, encoding: .utf8)
+        try write("override", to: source)
 
-        let state = try CodexManagedInstructionsProjection.projectBeforeLaunch(
-            managedHome: managedHome,
-            ordinaryHome: ordinaryHome
-        )
+        let state = try project()
 
         XCTAssertEqual(
             state,
             .projected(source: source, target: managedHome.appendingPathComponent("AGENTS.override.md"))
         )
-        XCTAssertEqual(
-            try String(contentsOf: managedHome.appendingPathComponent("AGENTS.override.md")),
-            "override"
-        )
+        XCTAssertEqual(try read(managedHome.appendingPathComponent("AGENTS.override.md")), "override")
         let attributes = try FileManager.default.attributesOfItem(
             atPath: managedHome.appendingPathComponent("AGENTS.override.md").path
         )
         XCTAssertEqual(attributes[.type] as? FileAttributeType, .typeRegular)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managedHome.appendingPathComponent("AGENTS.md").path))
     }
 
     func testForeignManagedFileIsPreservedAndReported() throws {
         try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
         let target = managedHome.appendingPathComponent("AGENTS.md")
-        try "foreign".write(to: target, atomically: true, encoding: .utf8)
-        try "ordinary".write(
-            to: ordinaryHome.appendingPathComponent("AGENTS.md"),
-            atomically: true,
-            encoding: .utf8
-        )
+        try write("foreign", to: target)
+        try write("ordinary", to: ordinaryHome.appendingPathComponent("AGENTS.md"))
 
-        XCTAssertThrowsError(
-            try CodexManagedInstructionsProjection.projectBeforeLaunch(
+        XCTAssertThrowsError(try project())
+        XCTAssertEqual(try read(target), "foreign")
+        XCTAssertEqual(
+            CodexManagedInstructionsProjection.diagnostic(
                 managedHome: managedHome,
                 ordinaryHome: ordinaryHome
-            )
+            ).status,
+            .conflict
         )
-        XCTAssertEqual(try String(contentsOf: target), "foreign")
     }
 
-    func testModifiedProjectionIsPreservedAndFailsClosed() throws {
+    func testModifiedProjectionAndSidecarArePreservedAndFailClosed() throws {
         let source = ordinaryHome.appendingPathComponent("AGENTS.md")
-        try "first".write(to: source, atomically: true, encoding: .utf8)
-        _ = try CodexManagedInstructionsProjection.projectBeforeLaunch(
-            managedHome: managedHome,
-            ordinaryHome: ordinaryHome
-        )
+        try write("first", to: source)
+        _ = try project()
         let target = managedHome.appendingPathComponent("AGENTS.md")
-        try "user edit".write(to: target, atomically: true, encoding: .utf8)
-        try "second".write(to: source, atomically: true, encoding: .utf8)
+        try write("user edit", to: target)
+        try write("second", to: source)
 
-        XCTAssertThrowsError(
-            try CodexManagedInstructionsProjection.projectBeforeLaunch(
-                managedHome: managedHome,
-                ordinaryHome: ordinaryHome
-            )
+        XCTAssertThrowsError(try project())
+        XCTAssertEqual(try read(target), "user edit")
+
+        try write("first", to: target)
+        let sidecar = managedHome.appendingPathComponent(
+            CodexManagedInstructionsProjection.sidecarName
         )
-        XCTAssertEqual(try String(contentsOf: target), "user edit")
+        try write("foreign receipt", to: sidecar)
+        XCTAssertThrowsError(try project())
+        XCTAssertEqual(try read(target), "first")
+        XCTAssertEqual(try read(sidecar), "foreign receipt")
     }
 
     func testOwnedProjectionIsRemovedWhenOrdinarySourceDisappears() throws {
         let source = ordinaryHome.appendingPathComponent("AGENTS.md")
-        try "ordinary".write(to: source, atomically: true, encoding: .utf8)
-        _ = try CodexManagedInstructionsProjection.projectBeforeLaunch(
+        try write("ordinary", to: source)
+        _ = try project()
+        try FileManager.default.removeItem(at: source)
+
+        XCTAssertEqual(try project(), .absent(managedHome: managedHome))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managedHome.appendingPathComponent("AGENTS.md").path))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: managedHome.appendingPathComponent(
+                    CodexManagedInstructionsProjection.sidecarName
+                ).path
+            )
+        )
+    }
+
+    func testSymlinkSourceTargetSidecarAndManagedAncestorAreRejectedWithoutFollowingThem() throws {
+        let externalSource = root.appendingPathComponent("external-source")
+        try write("external", to: externalSource)
+        let sourceLink = ordinaryHome.appendingPathComponent("AGENTS.md")
+        try FileManager.default.createSymbolicLink(at: sourceLink, withDestinationURL: externalSource)
+        XCTAssertThrowsError(try project())
+        XCTAssertEqual(try read(externalSource), "external")
+        try FileManager.default.removeItem(at: sourceLink)
+
+        let externalOrdinaryHome = root.appendingPathComponent("external-ordinary", isDirectory: true)
+        try FileManager.default.createDirectory(at: externalOrdinaryHome, withIntermediateDirectories: true)
+        try write("ancestor source", to: externalOrdinaryHome.appendingPathComponent("AGENTS.md"))
+        let ordinaryHomeLink = root.appendingPathComponent("ordinary-link")
+        try FileManager.default.createSymbolicLink(
+            at: ordinaryHomeLink,
+            withDestinationURL: externalOrdinaryHome
+        )
+        XCTAssertThrowsError(
+            try CodexManagedInstructionsProjection.projectBeforeLaunch(
+                managedHome: managedHome,
+                ordinaryHome: ordinaryHomeLink
+            )
+        )
+        XCTAssertEqual(
+            try read(externalOrdinaryHome.appendingPathComponent("AGENTS.md")),
+            "ancestor source"
+        )
+
+        try write("ordinary", to: ordinaryHome.appendingPathComponent("AGENTS.md"))
+        try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
+        let externalTarget = root.appendingPathComponent("external-target")
+        try write("preserve target", to: externalTarget)
+        let targetLink = managedHome.appendingPathComponent("AGENTS.md")
+        try FileManager.default.createSymbolicLink(at: targetLink, withDestinationURL: externalTarget)
+        XCTAssertThrowsError(try project())
+        XCTAssertEqual(try read(externalTarget), "preserve target")
+        try FileManager.default.removeItem(at: targetLink)
+
+        _ = try project()
+        let target = managedHome.appendingPathComponent("AGENTS.md")
+        let sidecar = managedHome.appendingPathComponent(
+            CodexManagedInstructionsProjection.sidecarName
+        )
+        let externalSidecar = root.appendingPathComponent("external-sidecar")
+        try write("preserve sidecar", to: externalSidecar)
+        try FileManager.default.removeItem(at: sidecar)
+        try FileManager.default.createSymbolicLink(at: sidecar, withDestinationURL: externalSidecar)
+        XCTAssertThrowsError(try project())
+        XCTAssertEqual(try read(target), "ordinary")
+        XCTAssertEqual(try read(externalSidecar), "preserve sidecar")
+
+        let externalDirectory = root.appendingPathComponent("external-directory")
+        try FileManager.default.createDirectory(at: externalDirectory, withIntermediateDirectories: true)
+        let linkedParent = root.appendingPathComponent("linked-parent")
+        try FileManager.default.createSymbolicLink(at: linkedParent, withDestinationURL: externalDirectory)
+        XCTAssertThrowsError(
+            try CodexManagedInstructionsProjection.projectBeforeLaunch(
+                managedHome: linkedParent.appendingPathComponent("managed"),
+                ordinaryHome: ordinaryHome
+            )
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: externalDirectory.appendingPathComponent("managed").path))
+        XCTAssertEqual(
+            CodexManagedInstructionsProjection.diagnostic(
+                managedHome: linkedParent.appendingPathComponent("managed"),
+                ordinaryHome: ordinaryHome
+            ).status,
+            .conflict
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: externalDirectory.appendingPathComponent("managed").path))
+    }
+
+    func testInterruptedSourceSwitchPreservesLastKnownGoodAndRecoversDeterministically() throws {
+        let fallbackSource = ordinaryHome.appendingPathComponent("AGENTS.md")
+        try write("fallback", to: fallbackSource)
+        _ = try project()
+        let fallbackTarget = managedHome.appendingPathComponent("AGENTS.md")
+        try write("override", to: ordinaryHome.appendingPathComponent("AGENTS.override.md"))
+
+        XCTAssertThrowsError(
+            try project { checkpoint in
+                if checkpoint == .afterPendingReceipt { throw InjectedFailure.stop }
+            }
+        )
+        XCTAssertEqual(try read(fallbackTarget), "fallback")
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: managedHome.appendingPathComponent("AGENTS.override.md").path
+            )
+        )
+        XCTAssertEqual(
+            CodexManagedInstructionsProjection.diagnostic(
+                managedHome: managedHome,
+                ordinaryHome: ordinaryHome
+            ).status,
+            .conflict
+        )
+
+        _ = try project()
+        XCTAssertEqual(try read(managedHome.appendingPathComponent("AGENTS.override.md")), "override")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fallbackTarget.path))
+    }
+
+    func testInterruptedSwitchAfterNewTargetWriteRecoversWithoutStaleFallback() throws {
+        try write("fallback", to: ordinaryHome.appendingPathComponent("AGENTS.md"))
+        _ = try project()
+        try write("override", to: ordinaryHome.appendingPathComponent("AGENTS.override.md"))
+
+        XCTAssertThrowsError(
+            try project { checkpoint in
+                if checkpoint == .afterTargetWrite { throw InjectedFailure.stop }
+            }
+        )
+        XCTAssertEqual(try read(managedHome.appendingPathComponent("AGENTS.md")), "fallback")
+        XCTAssertEqual(try read(managedHome.appendingPathComponent("AGENTS.override.md")), "override")
+
+        _ = try project()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managedHome.appendingPathComponent("AGENTS.md").path))
+        XCTAssertEqual(try read(managedHome.appendingPathComponent("AGENTS.override.md")), "override")
+        XCTAssertEqual(
+            CodexManagedInstructionsProjection.diagnostic(
+                managedHome: managedHome,
+                ordinaryHome: ordinaryHome
+            ).status,
+            .current(sourceName: "AGENTS.override.md")
+        )
+    }
+
+    func testInterruptedSwitchAfterPreviousRemovalCommitsNewProjectionOnRecovery() throws {
+        try write("fallback", to: ordinaryHome.appendingPathComponent("AGENTS.md"))
+        _ = try project()
+        try write("override", to: ordinaryHome.appendingPathComponent("AGENTS.override.md"))
+
+        XCTAssertThrowsError(
+            try project { checkpoint in
+                if checkpoint == .afterPreviousTargetRemoval { throw InjectedFailure.stop }
+            }
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managedHome.appendingPathComponent("AGENTS.md").path))
+        XCTAssertEqual(try read(managedHome.appendingPathComponent("AGENTS.override.md")), "override")
+
+        _ = try project()
+        XCTAssertEqual(
+            CodexManagedInstructionsProjection.diagnostic(
+                managedHome: managedHome,
+                ordinaryHome: ordinaryHome
+            ).status,
+            .current(sourceName: "AGENTS.override.md")
+        )
+    }
+
+    func testInterruptedOwnedRemovalFinishesWithoutPermanentConflict() throws {
+        let source = ordinaryHome.appendingPathComponent("AGENTS.md")
+        try write("ordinary", to: source)
+        _ = try project()
+        try FileManager.default.removeItem(at: source)
+
+        XCTAssertThrowsError(
+            try project { checkpoint in
+                if checkpoint == .afterOwnedTargetRemoval { throw InjectedFailure.stop }
+            }
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managedHome.appendingPathComponent("AGENTS.md").path))
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: managedHome.appendingPathComponent(
+                    CodexManagedInstructionsProjection.sidecarName
+                ).path
+            )
+        )
+
+        XCTAssertEqual(try project(), .absent(managedHome: managedHome))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: managedHome.appendingPathComponent(
+                    CodexManagedInstructionsProjection.sidecarName
+                ).path
+            )
+        )
+    }
+
+    func testSourceSwitchDetectsForeignNewTargetBeforeRemovingOwnedProjection() throws {
+        try write("fallback", to: ordinaryHome.appendingPathComponent("AGENTS.md"))
+        _ = try project()
+        let fallbackTarget = managedHome.appendingPathComponent("AGENTS.md")
+        let overrideTarget = managedHome.appendingPathComponent("AGENTS.override.md")
+        try write("foreign override", to: overrideTarget)
+        try write("ordinary override", to: ordinaryHome.appendingPathComponent("AGENTS.override.md"))
+
+        XCTAssertThrowsError(try project())
+        XCTAssertEqual(try read(fallbackTarget), "fallback")
+        XCTAssertEqual(try read(overrideTarget), "foreign override")
+    }
+
+    func testDiagnosticsCoverAbsentCurrentConflictAndErrorWithoutSourceContents() throws {
+        var diagnostic = CodexManagedInstructionsProjection.diagnostic(
             managedHome: managedHome,
             ordinaryHome: ordinaryHome
         )
-        try FileManager.default.removeItem(at: source)
+        XCTAssertEqual(diagnostic.status, .absent)
 
-        XCTAssertEqual(
-            try CodexManagedInstructionsProjection.projectBeforeLaunch(
-                managedHome: managedHome,
-                ordinaryHome: ordinaryHome
-            ),
-            .absent(managedHome: managedHome)
+        let secretMarker = "do-not-leak-secret-instruction"
+        try write(secretMarker, to: ordinaryHome.appendingPathComponent("AGENTS.md"))
+        diagnostic = CodexManagedInstructionsProjection.diagnostic(
+            managedHome: managedHome,
+            ordinaryHome: ordinaryHome
         )
-        XCTAssertFalse(FileManager.default.fileExists(atPath: managedHome.appendingPathComponent("AGENTS.md").path))
+        XCTAssertEqual(diagnostic.status, .absent)
+        XCTAssertFalse(diagnostic.message.contains(secretMarker))
+
+        _ = try project()
+        diagnostic = CodexManagedInstructionsProjection.diagnostic(
+            managedHome: managedHome,
+            ordinaryHome: ordinaryHome
+        )
+        XCTAssertEqual(diagnostic.status, .current(sourceName: "AGENTS.md"))
+        XCTAssertFalse(diagnostic.message.contains(secretMarker))
+
+        try write("modified", to: managedHome.appendingPathComponent("AGENTS.md"))
+        diagnostic = CodexManagedInstructionsProjection.diagnostic(
+            managedHome: managedHome,
+            ordinaryHome: ordinaryHome
+        )
+        XCTAssertEqual(diagnostic.status, .conflict)
+        XCTAssertFalse(diagnostic.message.contains(secretMarker))
+
+        diagnostic = CodexManagedInstructionsProjection.diagnostic(
+            for: CocoaError(.fileReadNoPermission)
+        )
+        XCTAssertEqual(diagnostic.status, .error)
+        XCTAssertFalse(diagnostic.message.contains(secretMarker))
+    }
+
+    @discardableResult
+    private func project(
+        checkpoint: ((CodexManagedInstructionsProjection.MutationCheckpoint) throws -> Void)? = nil
+    ) throws -> CodexManagedInstructionsProjection.State {
+        try CodexManagedInstructionsProjection.projectBeforeLaunch(
+            managedHome: managedHome,
+            ordinaryHome: ordinaryHome,
+            checkpoint: checkpoint
+        )
+    }
+
+    private func write(_ value: String, to url: URL) throws {
+        try value.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func read(_ url: URL) throws -> String {
+        try String(contentsOf: url, encoding: .utf8)
     }
 }

--- a/Tests/RepoPromptTests/AI/CodexManagedInstructionsProjectionTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexManagedInstructionsProjectionTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class CodexManagedInstructionsProjectionTests: XCTestCase {
+    private var root: URL!
+    private var ordinaryHome: URL!
+    private var managedHome: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexManagedInstructionsProjectionTests-\(UUID().uuidString)")
+        ordinaryHome = root.appendingPathComponent("ordinary")
+        managedHome = root.appendingPathComponent("managed")
+        try FileManager.default.createDirectory(at: ordinaryHome, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func testOverrideWinsAndProjectionIsARegularFile() throws {
+        try "fallback".write(
+            to: ordinaryHome.appendingPathComponent("AGENTS.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let source = ordinaryHome.appendingPathComponent("AGENTS.override.md")
+        try "override".write(to: source, atomically: true, encoding: .utf8)
+
+        let state = try CodexManagedInstructionsProjection.projectBeforeLaunch(
+            managedHome: managedHome,
+            ordinaryHome: ordinaryHome
+        )
+
+        XCTAssertEqual(
+            state,
+            .projected(source: source, target: managedHome.appendingPathComponent("AGENTS.override.md"))
+        )
+        XCTAssertEqual(
+            try String(contentsOf: managedHome.appendingPathComponent("AGENTS.override.md")),
+            "override"
+        )
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: managedHome.appendingPathComponent("AGENTS.override.md").path
+        )
+        XCTAssertEqual(attributes[.type] as? FileAttributeType, .typeRegular)
+    }
+
+    func testForeignManagedFileIsPreservedAndReported() throws {
+        try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
+        let target = managedHome.appendingPathComponent("AGENTS.md")
+        try "foreign".write(to: target, atomically: true, encoding: .utf8)
+        try "ordinary".write(
+            to: ordinaryHome.appendingPathComponent("AGENTS.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        XCTAssertThrowsError(
+            try CodexManagedInstructionsProjection.projectBeforeLaunch(
+                managedHome: managedHome,
+                ordinaryHome: ordinaryHome
+            )
+        )
+        XCTAssertEqual(try String(contentsOf: target), "foreign")
+    }
+
+    func testModifiedProjectionIsPreservedAndFailsClosed() throws {
+        let source = ordinaryHome.appendingPathComponent("AGENTS.md")
+        try "first".write(to: source, atomically: true, encoding: .utf8)
+        _ = try CodexManagedInstructionsProjection.projectBeforeLaunch(
+            managedHome: managedHome,
+            ordinaryHome: ordinaryHome
+        )
+        let target = managedHome.appendingPathComponent("AGENTS.md")
+        try "user edit".write(to: target, atomically: true, encoding: .utf8)
+        try "second".write(to: source, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(
+            try CodexManagedInstructionsProjection.projectBeforeLaunch(
+                managedHome: managedHome,
+                ordinaryHome: ordinaryHome
+            )
+        )
+        XCTAssertEqual(try String(contentsOf: target), "user edit")
+    }
+
+    func testOwnedProjectionIsRemovedWhenOrdinarySourceDisappears() throws {
+        let source = ordinaryHome.appendingPathComponent("AGENTS.md")
+        try "ordinary".write(to: source, atomically: true, encoding: .utf8)
+        _ = try CodexManagedInstructionsProjection.projectBeforeLaunch(
+            managedHome: managedHome,
+            ordinaryHome: ordinaryHome
+        )
+        try FileManager.default.removeItem(at: source)
+
+        XCTAssertEqual(
+            try CodexManagedInstructionsProjection.projectBeforeLaunch(
+                managedHome: managedHome,
+                ordinaryHome: ordinaryHome
+            ),
+            .absent(managedHome: managedHome)
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managedHome.appendingPathComponent("AGENTS.md").path))
+    }
+}

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -123,6 +123,44 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         )
     }
 
+    func testManagedStateValidationRejectsSymlinkedSensitiveLeavesAndPreservesDestinations() throws {
+        let support = temporaryDirectory.appendingPathComponent("Support", isDirectory: true)
+        try FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
+        let paths = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: support,
+            buildChannel: .debug
+        )
+        try CodexRuntimeAuthority.prepareManagedState(paths)
+        let sessions = paths.codexHome.appendingPathComponent("sessions", isDirectory: true)
+        let shellSnapshots = paths.codexHome.appendingPathComponent("shell_snapshots", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: shellSnapshots, withIntermediateDirectories: true)
+        let foreign = temporaryDirectory.appendingPathComponent("ForeignState", isDirectory: true)
+        try FileManager.default.createDirectory(at: foreign, withIntermediateDirectories: true)
+
+        let sensitiveLeaves = [
+            paths.codexHome.appendingPathComponent("auth.json"),
+            paths.codexHome.appendingPathComponent("config.toml"),
+            paths.codexHome.appendingPathComponent("session_index.jsonl"),
+            sessions.appendingPathComponent("rollout.jsonl"),
+            shellSnapshots.appendingPathComponent("snapshot.sh"),
+            paths.sqliteHome.appendingPathComponent("state.sqlite"),
+            paths.logDirectory.appendingPathComponent("codex.log")
+        ]
+        for (index, leaf) in sensitiveLeaves.enumerated() {
+            let destination = foreign.appendingPathComponent("state-\(index)")
+            try "preserve-\(index)".write(to: destination, atomically: true, encoding: .utf8)
+            try FileManager.default.createSymbolicLink(at: leaf, withDestinationURL: destination)
+
+            XCTAssertThrowsError(try CodexRuntimeAuthority.validateManagedState(paths))
+            XCTAssertEqual(
+                try String(contentsOf: destination, encoding: .utf8),
+                "preserve-\(index)"
+            )
+            try FileManager.default.removeItem(at: leaf)
+        }
+    }
+
     func testBundledRuntimeResolvesIntelPackageIndependently() throws {
         let resources = temporaryDirectory.appendingPathComponent("Resources", isDirectory: true)
         _ = try makePackage(in: resources, target: "aarch64-apple-darwin")

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -36,14 +36,17 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         XCTAssertEqual(runtime.source, .bundled(target: "aarch64-apple-darwin"))
         XCTAssertTrue(runtime.statePaths.codexHome.path.hasPrefix(support.path))
         XCTAssertTrue(runtime.statePaths.sqliteHome.path.hasPrefix(support.path))
+        XCTAssertTrue(runtime.statePaths.logDirectory.path.hasPrefix(support.path))
         XCTAssertNotEqual(runtime.statePaths.codexHome.path, ("~/.codex" as NSString).expandingTildeInPath)
         XCTAssertEqual(runtime.statePaths.environment["CODEX_HOME"], runtime.statePaths.codexHome.path)
         XCTAssertEqual(runtime.statePaths.environment["CODEX_SQLITE_HOME"], runtime.statePaths.sqliteHome.path)
         try runtime.prepareState()
         XCTAssertTrue(FileManager.default.fileExists(atPath: runtime.statePaths.codexHome.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: runtime.statePaths.sqliteHome.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: runtime.statePaths.logDirectory.path))
         XCTAssertTrue(runtime.redactedDiagnosticSummary.contains("provenance=bundled:aarch64-apple-darwin"))
         XCTAssertTrue(runtime.redactedDiagnosticSummary.contains("version=0.147.0"))
+        XCTAssertTrue(runtime.redactedDiagnosticSummary.contains("log_dir="))
         XCTAssertFalse(runtime.redactedDiagnosticSummary.contains(temporaryDirectory.path))
     }
 

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -21,6 +21,7 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
     func testBundledRuntimeResolvesRequestedArchitectureAndOwnedState() throws {
         let resources = temporaryDirectory.appendingPathComponent("Resources", isDirectory: true)
         let support = temporaryDirectory.appendingPathComponent("Support", isDirectory: true)
+        try FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
         let armExecutable = try makePackage(in: resources, target: "aarch64-apple-darwin")
         _ = try makePackage(in: resources, target: "x86_64-apple-darwin")
 
@@ -48,6 +49,78 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         XCTAssertTrue(runtime.redactedDiagnosticSummary.contains("version=0.147.0"))
         XCTAssertTrue(runtime.redactedDiagnosticSummary.contains("log_dir="))
         XCTAssertFalse(runtime.redactedDiagnosticSummary.contains(temporaryDirectory.path))
+    }
+
+    func testManagedStatePathsDifferentiateDebugAndReleaseChannels() {
+        let support = temporaryDirectory.appendingPathComponent("Support", isDirectory: true)
+        let debug = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: support,
+            buildChannel: .debug
+        )
+        let release = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: support,
+            buildChannel: .release
+        )
+
+        XCTAssertEqual(
+            debug.codexHome.path,
+            support.appendingPathComponent("RepoPrompt CE/Codex/Debug/home").path
+        )
+        XCTAssertEqual(
+            release.codexHome.path,
+            support.appendingPathComponent("RepoPrompt CE/Codex/Release/home").path
+        )
+        XCTAssertNotEqual(debug.codexHome, release.codexHome)
+        XCTAssertEqual(
+            CodexRuntimeAuthority.statePaths(applicationSupportURL: support).codexHome,
+            CodexRuntimeAuthority.statePaths(
+                applicationSupportURL: support,
+                buildChannel: .current
+            ).codexHome
+        )
+    }
+
+    func testManagedStatePreparationRejectsSymlinkedOwnedAncestorWithoutWritingOutside() throws {
+        let support = temporaryDirectory.appendingPathComponent("Support", isDirectory: true)
+        let foreign = temporaryDirectory.appendingPathComponent("Foreign", isDirectory: true)
+        try FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: foreign, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: support.appendingPathComponent("RepoPrompt CE"),
+            withDestinationURL: foreign
+        )
+        let paths = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: support,
+            buildChannel: .debug
+        )
+
+        XCTAssertThrowsError(try CodexRuntimeAuthority.prepareManagedState(paths))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: foreign.appendingPathComponent("Codex").path))
+    }
+
+    func testManagedStatePreparationRejectsSymlinkedStateDirectoryAndPreservesDestination() throws {
+        let support = temporaryDirectory.appendingPathComponent("Support", isDirectory: true)
+        try FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
+        let paths = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: support,
+            buildChannel: .debug
+        )
+        try CodexRuntimeAuthority.prepareManagedState(paths)
+        try FileManager.default.removeItem(at: paths.codexHome)
+        let foreign = temporaryDirectory.appendingPathComponent("ForeignHome", isDirectory: true)
+        try FileManager.default.createDirectory(at: foreign, withIntermediateDirectories: true)
+        try "preserve".write(
+            to: foreign.appendingPathComponent("sentinel"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.createSymbolicLink(at: paths.codexHome, withDestinationURL: foreign)
+
+        XCTAssertThrowsError(try CodexRuntimeAuthority.prepareManagedState(paths))
+        XCTAssertEqual(
+            try String(contentsOf: foreign.appendingPathComponent("sentinel"), encoding: .utf8),
+            "preserve"
+        )
     }
 
     func testBundledRuntimeResolvesIntelPackageIndependently() throws {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -439,6 +439,89 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         await client.stop()
     }
 
+    func testMutatingRequestTimeoutTerminatesTransportAndIsUncertainWithoutRetry() async throws {
+        let directory = try makeTemporaryDirectory()
+        let recordURL = directory.appendingPathComponent("requests.jsonl")
+        let executable = try makePersistentServer(
+            in: directory,
+            recordURL: recordURL,
+            ignoredMethods: ["config/batchWrite"]
+        )
+        let client = try await makeClient(executable: executable, launchDirectory: directory, timeout: 5)
+        try await client.startIfNeeded()
+
+        do {
+            _ = try await client.mutatingRequest(
+                method: "config/batchWrite",
+                params: ["edits": []],
+                timeout: 0.05
+            )
+            XCTFail("The ignored mutation must be uncertain")
+        } catch let CodexAppServerClient.ClientError.uncertainMutation(method) {
+            XCTAssertEqual(method, "config/batchWrite")
+        }
+        let isRunning = await client.debugIsProcessRunning()
+        XCTAssertFalse(isRunning)
+        await client.stop()
+    }
+
+    func testMutatingRequestCancellationTerminatesTransportAndIsUncertain() async throws {
+        let directory = try makeTemporaryDirectory()
+        let recordURL = directory.appendingPathComponent("requests.jsonl")
+        let executable = try makePersistentServer(
+            in: directory,
+            recordURL: recordURL,
+            ignoredMethods: ["config/batchWrite"]
+        )
+        let client = try await makeClient(executable: executable, launchDirectory: directory, timeout: 5)
+        try await client.startIfNeeded()
+        let request = Task {
+            try await client.mutatingRequest(
+                method: "config/batchWrite",
+                params: ["edits": []],
+                timeout: 5
+            )
+        }
+        try await waitForRecordedMethod("config/batchWrite", at: recordURL)
+        request.cancel()
+        do {
+            _ = try await request.value
+            XCTFail("Cancelled mutation must be uncertain")
+        } catch let CodexAppServerClient.ClientError.uncertainMutation(method) {
+            XCTAssertEqual(method, "config/batchWrite")
+        }
+        let isRunning = await client.debugIsProcessRunning()
+        XCTAssertFalse(isRunning)
+        await client.stop()
+    }
+
+    func testTransportLossSettlesPendingMutationAsUncertain() async throws {
+        let directory = try makeTemporaryDirectory()
+        let recordURL = directory.appendingPathComponent("requests.jsonl")
+        let executable = try makePersistentServer(
+            in: directory,
+            recordURL: recordURL,
+            ignoredMethods: ["config/batchWrite"]
+        )
+        let client = try await makeClient(executable: executable, launchDirectory: directory, timeout: 5)
+        try await client.startIfNeeded()
+        let request = Task {
+            try await client.mutatingRequest(
+                method: "config/batchWrite",
+                params: ["edits": []],
+                timeout: 5
+            )
+        }
+        try await waitForRecordedMethod("config/batchWrite", at: recordURL)
+        await client.stop()
+        do {
+            _ = try await request.value
+            XCTFail("Transport loss must make the mutation uncertain")
+        } catch let CodexAppServerClient.ClientError.uncertainMutation(method) {
+            XCTAssertEqual(method, "config/batchWrite")
+        }
+    }
+
     func testStaleObservedExitCannotMutateReplacementGeneration() async throws {
         let directory = try makeTemporaryDirectory()
         let recordURL = directory.appendingPathComponent("requests.jsonl")

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexHookCompatibilityGateTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexHookCompatibilityGateTests.swift
@@ -1,0 +1,416 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class CodexHookCompatibilityGateTests: XCTestCase {
+    private let cwd = "/tmp/codex-hook-project"
+    private let configURL = URL(fileURLWithPath: "/tmp/rpce-codex-home/config.toml")
+    private let hashA = "sha256:" + String(repeating: "a", count: 64)
+    private let hashB = "sha256:" + String(repeating: "b", count: 64)
+
+    func testZeroInventoryIsValidAndEmitsTypedDiagnostic() async throws {
+        let diagnostics = LockedValues<CodexHookInventoryDiagnostic>()
+        let dependencies = dependencies(
+            read: { method, _, _ in
+                XCTAssertEqual(method, "hooks/list")
+                return self.inventory(hooks: [])
+            },
+            review: { _ in XCTFail("zero inventory must not review")
+                return .cancel
+            },
+            emit: { diagnostics.append($0) }
+        )
+
+        try await CodexHookCompatibilityGate.run(
+            cwd: cwd,
+            managedConfigURL: configURL,
+            timeout: 1,
+            dependencies: dependencies
+        )
+
+        XCTAssertEqual(diagnostics.values.count, 1)
+        XCTAssertEqual(diagnostics.values.first?.isZeroInventory, true)
+    }
+
+    func testPinnedSchemaRejectsUnknownTrustAndPerCwdErrors() throws {
+        var unknown = projectHook(hash: hashA, trust: "futureStatus")
+        XCTAssertThrowsError(try CodexHookInventory.decode(
+            inventory(hooks: [unknown]),
+            expectedCWDs: [cwd]
+        ))
+        unknown["trustStatus"] = "untrusted"
+        unknown["currentHash"] = String(repeating: "a", count: 64)
+        XCTAssertThrowsError(try CodexHookInventory.decode(
+            inventory(hooks: [unknown]),
+            expectedCWDs: [cwd]
+        ))
+        unknown["currentHash"] = hashA
+        XCTAssertThrowsError(try CodexHookInventory.decode(
+            inventory(hooks: [unknown], errors: [["path": "/tmp/.codex/hooks.json", "message": "invalid"]]),
+            expectedCWDs: [cwd]
+        )) { error in
+            guard case CodexHookGateError.inventoryError = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testPinnedSchemaRequiresExactlyOneRecordPerCwd() throws {
+        let duplicated: [String: Any] = [
+            "data": [
+                inventoryRecord(hooks: []),
+                inventoryRecord(hooks: [])
+            ]
+        ]
+        XCTAssertThrowsError(try CodexHookInventory.decode(duplicated, expectedCWDs: [cwd]))
+        XCTAssertThrowsError(try CodexHookInventory.decode(["data": []], expectedCWDs: [cwd]))
+    }
+
+    func testTrustAllUsesVersionFencedManagedWriteAndReinventories() async throws {
+        let calls = LockedValues<String>()
+        let hookReads = LockedCounter()
+        let writes = LockedValues<[String: Any]>()
+        let dependencies = dependencies(
+            read: { method, _, _ in
+                calls.append(method)
+                switch method {
+                case "hooks/list":
+                    let count = hookReads.increment()
+                    return self.inventory(hooks: [
+                        self.projectHook(hash: self.hashA, trust: count == 3 ? "trusted" : "untrusted")
+                    ])
+                case "config/read":
+                    return self.configRead()
+                default:
+                    XCTFail("Unexpected read \(method)")
+                    return [:]
+                }
+            },
+            write: { method, params, _ in
+                calls.append(method)
+                writes.append(params)
+                return ["status": "ok", "version": "v2", "filePath": self.configURL.path]
+            },
+            review: { _ in .trustAll }
+        )
+
+        try await CodexHookCompatibilityGate.run(
+            cwd: cwd,
+            managedConfigURL: configURL,
+            timeout: 1,
+            dependencies: dependencies
+        )
+
+        XCTAssertEqual(calls.values, ["hooks/list", "hooks/list", "config/read", "config/batchWrite", "hooks/list"])
+        let write = try XCTUnwrap(writes.values.first)
+        XCTAssertEqual(write["filePath"] as? String, configURL.path)
+        XCTAssertEqual(write["expectedVersion"] as? String, "v1")
+        let edits = try XCTUnwrap(write["edits"] as? [[String: Any]])
+        XCTAssertEqual(edits.first?["keyPath"] as? String, "hooks.state")
+        XCTAssertEqual(edits.first?["mergeStrategy"] as? String, "upsert")
+    }
+
+    func testDeclineAndCancelDoNotWrite() async throws {
+        for (decision, expected) in [
+            (CodexHookReviewDecision.decline, CodexHookGateError.reviewDeclined),
+            (.cancel, .reviewCancelled)
+        ] {
+            let writes = LockedCounter()
+            let dependencies = dependencies(
+                read: { _, _, _ in self.inventory(hooks: [self.projectHook(hash: self.hashA, trust: "untrusted")]) },
+                write: { _, _, _ in _ = writes.increment()
+                    return [:]
+                },
+                review: { _ in decision }
+            )
+            do {
+                try await CodexHookCompatibilityGate.run(
+                    cwd: cwd,
+                    managedConfigURL: configURL,
+                    timeout: 1,
+                    dependencies: dependencies
+                )
+                XCTFail("Expected review rejection")
+            } catch let error as CodexHookGateError {
+                XCTAssertEqual(error, expected)
+            }
+            XCTAssertEqual(writes.value, 0)
+        }
+    }
+
+    func testInventoryDriftRequiresFreshDecisionBeforeWrite() async throws {
+        let reads = LockedCounter()
+        let writes = LockedCounter()
+        let dependencies = dependencies(
+            read: { _, _, _ in
+                let hash = reads.increment() == 1 ? self.hashA : self.hashB
+                return self.inventory(hooks: [self.projectHook(hash: hash, trust: "untrusted")])
+            },
+            write: { _, _, _ in _ = writes.increment()
+                return [:]
+            },
+            review: { _ in .trustAll }
+        )
+        do {
+            try await CodexHookCompatibilityGate.run(
+                cwd: cwd,
+                managedConfigURL: configURL,
+                timeout: 1,
+                dependencies: dependencies
+            )
+            XCTFail("Expected drift")
+        } catch let error as CodexHookGateError {
+            XCTAssertEqual(error, .inventoryDrift)
+        }
+        XCTAssertEqual(writes.value, 0)
+    }
+
+    func testAmbiguousWriteIsNotRetriedAndReturnsActionableError() async throws {
+        struct SimulatedTransportLoss: LocalizedError { var errorDescription: String? {
+            "transport lost"
+        } }
+        let reads = LockedCounter()
+        let writes = LockedCounter()
+        let terminations = LockedCounter()
+        let dependencies = dependencies(
+            read: { method, _, _ in
+                if method == "config/read" { return self.configRead() }
+                _ = reads.increment()
+                return self.inventory(hooks: [self.projectHook(hash: self.hashA, trust: "untrusted")])
+            },
+            write: { _, _, _ in _ = writes.increment()
+                throw SimulatedTransportLoss()
+            },
+            review: { _ in .trustAll },
+            terminateUncertainWrite: { _ = terminations.increment() }
+        )
+        do {
+            try await CodexHookCompatibilityGate.run(
+                cwd: cwd,
+                managedConfigURL: configURL,
+                timeout: 1,
+                dependencies: dependencies
+            )
+            XCTFail("Expected uncertain write")
+        } catch let error as CodexHookGateError {
+            guard case let .uncertainWrite(message) = error else { return XCTFail("Unexpected \(error)") }
+            XCTAssertTrue(message.contains("did not retry"))
+        }
+        XCTAssertEqual(writes.value, 1)
+        XCTAssertEqual(terminations.value, 1)
+    }
+
+    func testMalformedWriteSuccessIsQuarantinedAsUncertain() async {
+        let terminations = LockedCounter()
+        let dependencies = dependencies(
+            read: { method, _, _ in
+                method == "config/read"
+                    ? self.configRead()
+                    : self.inventory(hooks: [self.projectHook(hash: self.hashA, trust: "untrusted")])
+            },
+            write: { _, _, _ in ["status": "futureStatus"] },
+            review: { _ in .trustAll },
+            terminateUncertainWrite: { _ = terminations.increment() }
+        )
+
+        do {
+            try await CodexHookCompatibilityGate.run(
+                cwd: cwd,
+                managedConfigURL: configURL,
+                timeout: 1,
+                dependencies: dependencies
+            )
+            XCTFail("Expected uncertain write")
+        } catch let error as CodexHookGateError {
+            guard case .uncertainWrite = error else { return XCTFail("Unexpected \(error)") }
+        } catch {
+            XCTFail("Unexpected \(error)")
+        }
+        XCTAssertEqual(terminations.value, 1)
+    }
+
+    func testStaleAuthorityStopsAfterAwait() async {
+        let authorityChecks = LockedCounter()
+        let dependencies = dependencies(
+            read: { _, _, _ in self.inventory(hooks: []) },
+            assertAuthority: {
+                if authorityChecks.increment() >= 1 {
+                    throw CodexSessionControllerError.invalidLifecycleState("stale test controller")
+                }
+            }
+        )
+        await XCTAssertThrowsErrorAsync {
+            try await CodexHookCompatibilityGate.run(
+                cwd: self.cwd,
+                managedConfigURL: self.configURL,
+                timeout: 1,
+                dependencies: dependencies
+            )
+        }
+    }
+
+    func testTypedLifecycleStartedAndExplicitFailure() throws {
+        let started = try CodexHookLifecycleDiagnostic.decode(
+            method: "hook/started",
+            params: lifecyclePayload(status: "running")
+        )
+        XCTAssertFalse(started.reportedRuntimeFailure)
+
+        let failed = try CodexHookLifecycleDiagnostic.decode(
+            method: "hook/completed",
+            params: lifecyclePayload(status: "failed")
+        )
+        XCTAssertTrue(failed.reportedRuntimeFailure)
+        XCTAssertEqual(failed.statusMessage, "exit 1")
+
+        var defaultSourcePayload = lifecyclePayload(status: "running")
+        var defaultSourceRun = try XCTUnwrap(defaultSourcePayload["run"] as? [String: Any])
+        defaultSourceRun.removeValue(forKey: "source")
+        defaultSourcePayload["run"] = defaultSourceRun
+        let defaultSource = try CodexHookLifecycleDiagnostic.decode(
+            method: "hook/started",
+            params: defaultSourcePayload
+        )
+        XCTAssertEqual(defaultSource.run.source, .unknown)
+
+        XCTAssertThrowsError(try CodexHookLifecycleDiagnostic.decode(
+            method: "hook/completed",
+            params: lifecyclePayload(status: "running")
+        ))
+    }
+
+    func testHookReviewApprovalHasNoAlwaysAllow() {
+        let request = AgentApprovalRequest(
+            requestID: .codexHookReview(UUID()),
+            method: "hooks/review",
+            kind: .codexHookReview,
+            threadID: "",
+            turnID: "",
+            itemID: "fingerprint"
+        )
+        XCTAssertFalse(request.supportsAlwaysAllow)
+    }
+
+    private func dependencies(
+        read: @escaping @Sendable (String, [String: Any], TimeInterval?) async throws -> [String: Any],
+        write: @escaping @Sendable (String, [String: Any], TimeInterval?) async throws -> [String: Any] = { _, _, _ in XCTFail("Unexpected write")
+            return [:]
+        },
+        review: @escaping @Sendable (CodexHookReview) async -> CodexHookReviewDecision = { _ in XCTFail("Unexpected review")
+            return .cancel
+        },
+        emit: @escaping @Sendable (CodexHookInventoryDiagnostic) async -> Void = { _ in },
+        terminateUncertainWrite: @escaping @Sendable () async throws -> Void = {},
+        assertAuthority: @escaping @Sendable () throws -> Void = {}
+    ) -> CodexHookGateDependencies {
+        .init(
+            read: read,
+            write: write,
+            review: review,
+            emitInventory: emit,
+            terminateUncertainWrite: terminateUncertainWrite,
+            assertAuthority: assertAuthority
+        )
+    }
+
+    private func inventory(hooks: [[String: Any]], errors: [[String: Any]] = []) -> [String: Any] {
+        ["data": [inventoryRecord(hooks: hooks, errors: errors)]]
+    }
+
+    private func inventoryRecord(hooks: [[String: Any]], errors: [[String: Any]] = []) -> [String: Any] {
+        ["cwd": cwd, "hooks": hooks, "warnings": [], "errors": errors]
+    }
+
+    private func projectHook(hash: String, trust: String) -> [String: Any] {
+        [
+            "key": "project-hook-key",
+            "eventName": "sessionStart",
+            "handlerType": "command",
+            "matcher": NSNull(),
+            "command": "./hooks/session-start.sh",
+            "timeoutSec": 10,
+            "statusMessage": NSNull(),
+            "additionalContextLimit": NSNull(),
+            "sourcePath": "\(cwd)/.codex/hooks.json",
+            "source": "project",
+            "pluginId": NSNull(),
+            "displayOrder": 0,
+            "enabled": true,
+            "isManaged": false,
+            "currentHash": hash,
+            "trustStatus": trust
+        ]
+    }
+
+    private func configRead() -> [String: Any] {
+        [
+            "config": [:],
+            "origins": [:],
+            "layers": [[
+                "name": ["type": "user", "file": configURL.path, "profile": NSNull()],
+                "version": "v1",
+                "config": [:]
+            ]]
+        ]
+    }
+
+    private func lifecyclePayload(status: String) -> [String: Any] {
+        [
+            "threadId": "thread-1",
+            "turnId": NSNull(),
+            "run": [
+                "id": "run-1",
+                "eventName": "sessionStart",
+                "handlerType": "command",
+                "executionMode": "sync",
+                "scope": "thread",
+                "sourcePath": "\(cwd)/.codex/hooks.json",
+                "source": "project",
+                "displayOrder": 0,
+                "status": status,
+                "statusMessage": status == "failed" ? "exit 1" : NSNull(),
+                "startedAt": 1,
+                "completedAt": status == "running" ? NSNull() : 2,
+                "durationMs": status == "running" ? NSNull() : 1,
+                "entries": status == "failed" ? [["kind": "error", "text": "exit 1"]] : []
+            ]
+        ]
+    }
+}
+
+private final class LockedValues<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Value] = []
+    var values: [Value] {
+        lock.withLock { storage }
+    }
+
+    func append(_ value: Value) {
+        lock.withLock { storage.append(value) }
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+    var value: Int {
+        lock.withLock { storage }
+    }
+
+    @discardableResult func increment() -> Int {
+        lock.withLock { storage += 1
+            return storage
+        }
+    }
+}
+
+private func XCTAssertThrowsErrorAsync(
+    _ expression: () async throws -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        try await expression()
+        XCTFail("Expected expression to throw", file: file, line: line)
+    } catch {}
+}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexHookCompatibilityGateTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexHookCompatibilityGateTests.swift
@@ -30,6 +30,33 @@ final class CodexHookCompatibilityGateTests: XCTestCase {
 
         XCTAssertEqual(diagnostics.values.count, 1)
         XCTAssertEqual(diagnostics.values.first?.isZeroInventory, true)
+        XCTAssertEqual(diagnostics.values.first?.warningCount, 0)
+        XCTAssertEqual(diagnostics.values.first?.sourceCounts, [:])
+        XCTAssertEqual(
+            diagnostics.values.first?.statusSummary,
+            "No Codex hook definitions were discovered for this execution directory."
+        )
+    }
+
+    func testZeroInventoryWarningsRemainVisibleWithoutLeakingRawDetails() async throws {
+        let diagnostics = LockedValues<CodexHookInventoryDiagnostic>()
+        let dependencies = dependencies(
+            read: { _, _, _ in self.inventory(hooks: [], warnings: ["private warning contents"]) },
+            review: { _ in .cancel },
+            emit: { diagnostics.append($0) }
+        )
+
+        try await CodexHookCompatibilityGate.run(
+            cwd: cwd,
+            managedConfigURL: configURL,
+            timeout: 1,
+            dependencies: dependencies
+        )
+
+        let diagnostic = try XCTUnwrap(diagnostics.values.first)
+        XCTAssertEqual(diagnostic.warningCount, 1)
+        XCTAssertTrue(diagnostic.statusSummary.contains("1 inventory warning"))
+        XCTAssertFalse(diagnostic.statusSummary.contains("private warning contents"))
     }
 
     func testPinnedSchemaRejectsUnknownTrustAndPerCwdErrors() throws {
@@ -313,12 +340,20 @@ final class CodexHookCompatibilityGateTests: XCTestCase {
         )
     }
 
-    private func inventory(hooks: [[String: Any]], errors: [[String: Any]] = []) -> [String: Any] {
-        ["data": [inventoryRecord(hooks: hooks, errors: errors)]]
+    private func inventory(
+        hooks: [[String: Any]],
+        warnings: [String] = [],
+        errors: [[String: Any]] = []
+    ) -> [String: Any] {
+        ["data": [inventoryRecord(hooks: hooks, warnings: warnings, errors: errors)]]
     }
 
-    private func inventoryRecord(hooks: [[String: Any]], errors: [[String: Any]] = []) -> [String: Any] {
-        ["cwd": cwd, "hooks": hooks, "warnings": [], "errors": errors]
+    private func inventoryRecord(
+        hooks: [[String: Any]],
+        warnings: [String] = [],
+        errors: [[String: Any]] = []
+    ) -> [String: Any] {
+        ["cwd": cwd, "hooks": hooks, "warnings": warnings, "errors": errors]
     }
 
     private func projectHook(hash: String, trust: String) -> [String: Any] {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
@@ -100,6 +100,50 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
         )
     }
 
+    func testHookInventoryGatePrecedesFreshAndResumeThreadMutations() async throws {
+        let options = CodexNativeSessionController.Options.agentModeDefault(
+            approvalPolicyProvider: { .never },
+            sandboxModeProvider: { .readOnly },
+            approvalReviewerProvider: { .user },
+            memoriesEnabledProvider: { true },
+            hookCompatibilityGateEnabled: true
+        )
+
+        let (startController, startRecordURL) = try await makeController(options: options)
+        addTeardownBlock { await startController.shutdown() }
+        _ = try await startController.startOrResume(existing: nil, baseInstructions: "Agent")
+        try assertRequestOrder(
+            first: "hooks/list",
+            second: "thread/start",
+            at: startRecordURL,
+            label: "fresh pre-thread hook gate"
+        )
+
+        let (resumeController, resumeRecordURL) = try await makeController(options: options)
+        addTeardownBlock { await resumeController.shutdown() }
+        _ = try await resumeController.startOrResume(
+            existing: .init(
+                conversationID: "existing-thread",
+                rolloutPath: nil,
+                model: nil,
+                reasoningEffort: nil
+            ),
+            baseInstructions: "Agent"
+        )
+        try assertRequestOrder(
+            first: "hooks/list",
+            second: "thread/memoryMode/set",
+            at: resumeRecordURL,
+            label: "resume hook gate before memory mutation"
+        )
+        try assertRequestOrder(
+            first: "hooks/list",
+            second: "thread/resume",
+            at: resumeRecordURL,
+            label: "resume pre-thread hook gate"
+        )
+    }
+
     func testResumeFailsClosedWhenMemoryModeReconciliationIsRejected() async throws {
         let options = CodexNativeSessionController.Options.agentModeDefault(
             approvalPolicyProvider: { .never },
@@ -1192,6 +1236,9 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
                 continue
             if method == "thread/memoryMode/set" and reject_memory_mode_requests:
                 reject(request["id"], "memory mode rejected")
+            elif method == "hooks/list":
+                cwds = params.get("cwds") or []
+                respond(request["id"], {"data": [{"cwd": cwd, "hooks": [], "warnings": [], "errors": []} for cwd in cwds]})
             elif method == "thread/start":
                 respond(request["id"], {"thread": {"id": "fresh-thread", "status": "idle", "turns": []}})
             elif method == "thread/resume":

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceRespondDiagnosticsTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceRespondDiagnosticsTests.swift
@@ -72,6 +72,11 @@ final class AgentRunMCPToolServiceRespondDiagnosticsTests: XCTestCase {
                 "provider file change",
                 { fixture.installProviderApproval(kind: .fileChange) },
                 "response must be one of: accept, accept_for_session, decline, cancel."
+            ),
+            (
+                "Codex hook review",
+                { fixture.installCodexHookReview() },
+                "response must be one of: accept, decline, cancel."
             )
         ]
 
@@ -88,6 +93,23 @@ final class AgentRunMCPToolServiceRespondDiagnosticsTests: XCTestCase {
             )
             XCTAssertEqual(fixture.currentPendingInteractionID, interactionID, label)
         }
+    }
+
+    func testCodexHookReviewRejectsSessionWideApprovalWithoutMutation() async throws {
+        let fixture = try await ControlledApprovalSessionFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let interactionID = fixture.installCodexHookReview()
+        let pendingApproval = try XCTUnwrap(fixture.session.pendingApproval)
+
+        await assertInvalidParams(
+            service: fixture.service,
+            sessionID: fixture.sessionID,
+            interactionID: interactionID,
+            arguments: ["response": .string("accept_for_session")],
+            expectedMessage: "accept_for_session is not supported for this approval interaction.",
+            label: "Codex hook review"
+        )
+        XCTAssertEqual(fixture.session.pendingApproval, pendingApproval)
     }
 
     func testApprovalRespondWithStaleInteractionIDReportsCurrentSafeIdentityWithoutMutation() async throws {
@@ -251,6 +273,21 @@ final class AgentRunMCPToolServiceRespondDiagnosticsTests: XCTestCase {
                 grantRoot: privacySentinels ? "SCOPE_SENTINEL" : nil,
                 proposedExecpolicyAmendmentJSON: privacySentinels ? "AMENDMENT_SENTINEL" : nil,
                 details: privacySentinels ? [.init(label: "OPTION_SENTINEL", value: "RESPONSE_SENTINEL")] : []
+            )
+            return id
+        }
+
+        @discardableResult
+        func installCodexHookReview() -> UUID {
+            let id = UUID()
+            session.pendingApproval = AgentApprovalRequest(
+                id: id,
+                requestID: .codexHookReview(id),
+                method: "hooks/review",
+                kind: .codexHookReview,
+                threadID: "",
+                turnID: "",
+                itemID: "fingerprint"
             )
             return id
         }

--- a/Tests/RepoPromptTests/MCP/CodexIntegration/CodexIntegrationConfigurationTests.swift
+++ b/Tests/RepoPromptTests/MCP/CodexIntegration/CodexIntegrationConfigurationTests.swift
@@ -82,8 +82,6 @@ final class CodexIntegrationConfigurationTests: XCTestCase {
             "-c",
             "log_dir=\"/tmp/managed log\""
         ])
-        XCTAssertEqual(CodexOverrides.managedStateConfigMap(statePaths)["sqlite_home"] as? String, "/tmp/managed sqlite")
-        XCTAssertEqual(CodexOverrides.managedStateConfigMap(statePaths)["log_dir"] as? String, "/tmp/managed log")
     }
 
     func testManagedStateOverridesEscapeTOMLStrings() {

--- a/Tests/RepoPromptTests/MCP/CodexIntegration/CodexIntegrationConfigurationTests.swift
+++ b/Tests/RepoPromptTests/MCP/CodexIntegration/CodexIntegrationConfigurationTests.swift
@@ -61,6 +61,43 @@ final class CodexIntegrationConfigurationTests: XCTestCase {
         XCTAssertTrue(arguments.contains("--dangerously-bypass-approvals-and-sandbox"))
     }
 
+    func testManagedStateOverridesPinExecSQLiteAndLogPaths() {
+        let statePaths = CodexRuntimeAuthority.StatePaths(
+            codexHome: URL(fileURLWithPath: "/tmp/managed home"),
+            sqliteHome: URL(fileURLWithPath: "/tmp/managed sqlite"),
+            logDirectory: URL(fileURLWithPath: "/tmp/managed log")
+        )
+
+        let arguments = CodexExecAgentProvider.buildCodexExecArguments(
+            selectedModelString: nil,
+            serverEntries: [],
+            brokenServers: [],
+            statePaths: statePaths
+        ).args
+
+        XCTAssertEqual(Array(arguments.prefix(5)), [
+            "exec",
+            "-c",
+            "sqlite_home=\"/tmp/managed sqlite\"",
+            "-c",
+            "log_dir=\"/tmp/managed log\""
+        ])
+        XCTAssertEqual(CodexOverrides.managedStateConfigMap(statePaths)["sqlite_home"] as? String, "/tmp/managed sqlite")
+        XCTAssertEqual(CodexOverrides.managedStateConfigMap(statePaths)["log_dir"] as? String, "/tmp/managed log")
+    }
+
+    func testManagedStateOverridesEscapeTOMLStrings() {
+        let statePaths = CodexRuntimeAuthority.StatePaths(
+            codexHome: URL(fileURLWithPath: "/tmp/home"),
+            sqliteHome: URL(fileURLWithPath: "/tmp/sqlite\\\"value"),
+            logDirectory: URL(fileURLWithPath: "/tmp/log")
+        )
+        XCTAssertEqual(
+            CodexOverrides.managedStateArgs(statePaths)[1],
+            "sqlite_home=\"/tmp/sqlite\\\\\\\"value\""
+        )
+    }
+
     private func occurrences(of needle: String, in haystack: String) -> Int {
         guard !needle.isEmpty else { return 0 }
         return haystack.components(separatedBy: needle).count - 1

--- a/Tests/RepoPromptTests/Settings/CodexManagedHomeSettingsTests.swift
+++ b/Tests/RepoPromptTests/Settings/CodexManagedHomeSettingsTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class CodexManagedHomeSettingsTests: XCTestCase {
+    func testSnapshotUsesRuntimeAuthorityChannelSpecificFullPath() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexManagedHomeSettingsTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let support = root.appendingPathComponent("Support", isDirectory: true)
+        let ordinary = root.appendingPathComponent("ordinary", isDirectory: true)
+        try FileManager.default.createDirectory(at: support, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: ordinary, withIntermediateDirectories: true)
+
+        let debug = CodexManagedHomeSettingsSnapshot.load(
+            applicationSupportURL: support,
+            buildChannel: .debug,
+            ordinaryHome: ordinary
+        )
+        let release = CodexManagedHomeSettingsSnapshot.load(
+            applicationSupportURL: support,
+            buildChannel: .release,
+            ordinaryHome: ordinary
+        )
+
+        XCTAssertEqual(
+            debug.managedHome.path,
+            support.appendingPathComponent("RepoPrompt CE/Codex/Debug/home").path
+        )
+        XCTAssertEqual(
+            release.managedHome.path,
+            support.appendingPathComponent("RepoPrompt CE/Codex/Release/home").path
+        )
+        XCTAssertEqual(debug.projection.status, .absent)
+        XCTAssertEqual(release.projection.status, .absent)
+    }
+
+    func testCopyAndOpenActionsReceiveExactAuthoritativePathWithoutLaunchingFinder() throws {
+        let paths = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: URL(fileURLWithPath: "/tmp/settings-action-support"),
+            buildChannel: .debug
+        )
+        var prepared: CodexRuntimeAuthority.StatePaths?
+        var copied: String?
+        var opened: URL?
+        let actions = CodexManagedHomeSettingsActions(
+            prepareState: { prepared = $0 },
+            copyText: {
+                copied = $0
+                return true
+            },
+            openDirectory: {
+                opened = $0
+                return true
+            }
+        )
+
+        XCTAssertTrue(actions.copyFullPath(paths))
+        XCTAssertTrue(try actions.openInFinder(paths))
+
+        XCTAssertEqual(copied, paths.codexHome.path)
+        XCTAssertEqual(prepared, paths)
+        XCTAssertEqual(opened, paths.codexHome)
+    }
+
+    func testOpenActionDoesNotInvokeFinderWhenSafePreparationFails() {
+        struct PreparationFailure: Error {}
+        let paths = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: URL(fileURLWithPath: "/tmp/settings-action-failure"),
+            buildChannel: .release
+        )
+        var opened: URL?
+        let actions = CodexManagedHomeSettingsActions(
+            prepareState: { _ in throw PreparationFailure() },
+            copyText: { _ in true },
+            openDirectory: {
+                opened = $0
+                return true
+            }
+        )
+
+        XCTAssertThrowsError(try actions.openInFinder(paths))
+        XCTAssertNil(opened)
+    }
+
+    func testPlatformActionFailuresAreReportedToCaller() throws {
+        let paths = CodexRuntimeAuthority.statePaths(
+            applicationSupportURL: URL(fileURLWithPath: "/tmp/settings-platform-failure"),
+            buildChannel: .debug
+        )
+        let actions = CodexManagedHomeSettingsActions(
+            prepareState: { _ in },
+            copyText: { _ in false },
+            openDirectory: { _ in false }
+        )
+
+        XCTAssertFalse(actions.copyFullPath(paths))
+        XCTAssertFalse(try actions.openInFinder(paths))
+    }
+}

--- a/docs/architecture/codex-app-server-schema-gate.md
+++ b/docs/architecture/codex-app-server-schema-gate.md
@@ -41,8 +41,10 @@ The initial projection covers:
   variants, sandbox-policy variants, and detection of newly required upstream fields;
 - incoming parameter and response paths RPCE reads, with explicit required, optional, conditional,
   and nullable semantics, including adopted discriminated item variants;
-- core lifecycle, transcript, progress, plan, diff, status, usage, and canonical command-execution
-  notifications, including terminal interaction;
+- core lifecycle, transcript, progress, plan, diff, status, usage, canonical command-execution,
+  and typed hook lifecycle notifications, including terminal interaction;
+- project-hook inventory plus exact-file, version-fenced user-config reads and batch writes used by
+  the pre-thread compatibility gate;
 - canonical v2 server requests for user input, auth refresh, MCP elicitation, permissions, dynamic
   tools, and command/file approvals;
 - server-response fields and enum values RPCE emits for those canonical requests;
@@ -52,7 +54,7 @@ The versioned contract is fail-closed: missing or unknown keys are errors. Metho
 local `$ref`, `allOf`, `oneOf`, and `anyOf` composition and accepts both single-value `enum`
 and `const` discriminators, so upstream organizational refactors do not create false removals.
 
-The hardened 0.147.0 baseline checks 42 methods, 186 parameter paths, and 78 response paths. A failure names
+The hardened 0.147.0 baseline checks 48 methods, 233 parameter paths, and 109 response paths. A failure names
 the union, method, and exact missing field, required field, response path, or enum value.
 
 This is intentionally not a complete protocol mirror. New upstream methods do not fail the gate


### PR DESCRIPTION
Fixes #665.

Supersedes #678 with a current-main implementation built around RepoPrompt CE's isolated Codex runtime authority. Thank you to @mplibunao for the original hook-approval investigation and design work in #678.

## Summary

RepoPrompt CE intentionally runs bundled Codex with an app-managed `CODEX_HOME` so Agent Mode does not pollute or depend on the user's ordinary Codex sessions and mutable runtime state. That isolation also removed compatibility that users reasonably expect from Codex: repository hook approval/execution and global `AGENTS` instructions.

This PR keeps the isolation boundary and adds only the compatibility bridges that can be made explicit and safe:

- project-hook inventory, approval, persistence, and verification through the pinned app-server contract;
- headless `agent_run` approval parity;
- one-way projection of the user's global `AGENTS.override.md` / `AGENTS.md` instructions into the managed home;
- explicit managed SQLite and log locations for both app-server and exec launch paths;
- typed hook inventory/lifecycle diagnostics;
- settings UI for the actual Debug/Release managed Codex home, including selectable path text, **Copy Full Path**, and **Open in Finder**.

## Hook compatibility gate

Before `thread/start` or `thread/resume`, CE calls the pinned Codex 0.147 `hooks/list` contract for the execution directory.

- Enabled, unmanaged project hooks reported as `untrusted` or `modified` block thread creation behind an approval interaction.
- The same interaction is available in Agent Mode UI and through headless `agent_run` response handling.
- There is no "continue without hooks" bypass in this implementation: decline/cancel leaves the gate closed.
- Approval uses version-fenced `config/read` + `config/batchWrite`, then re-runs `hooks/list` and verifies the definition/trust transition before allowing the thread mutation.
- Inventory drift, unsupported untrusted sources, per-cwd errors, malformed pinned-schema responses, stale authority, and ambiguous writes fail closed.
- Ambiguous mutating-RPC completion terminates the affected transport rather than retrying a write whose outcome is unknown.
- Inventory diagnostics retain counts by hook source and surface warning-only zero inventories without exposing raw warning content. Hook lifecycle events use typed, privacy-bounded diagnostics.

## Managed Codex state and instructions

All CE Codex launch paths use the same runtime authority and provide:

- app-managed `CODEX_HOME`;
- app-managed `CODEX_SQLITE_HOME`;
- app-managed `log_dir`;
- a verified bundled runtime by default, with the existing explicit absolute executable override as the only external-runtime path.

Managed state creation validates the owned directory chain and rejects symlink escapes for auth/config/session-index state and recursively within session, shell-snapshot, SQLite, and log storage. Codex's own temporary command-wrapper symlinks remain supported.

Global instructions use a one-way, receipt-backed projection from `~/.codex/AGENTS.override.md` or `~/.codex/AGENTS.md` into CE's managed home. The projection preserves foreign or locally modified destination state and reports current / absent / conflict / error diagnostics instead of overwriting it silently.

## Settings UX

Settings now shows the exact managed Codex home for the running Debug or Release channel and explains the isolation boundary. Users can:

- select the complete path;
- copy it with **Copy Full Path**;
- reveal it with **Open in Finder**;
- refresh the projection/status display.

The UI derives the path from the same runtime authority used at launch, rather than reconstructing a potentially different path.

## What it does and doesn't solve

### Solved here

- Repository-declared project hooks can be reviewed, trusted, verified, and run when CE launches Codex through app server.
- Direct Agent Mode and headless `agent_run` use the same gate and interaction authority.
- Global Codex `AGENTS` instructions can follow the user into CE without sharing the rest of the Codex home.
- SQLite, logs, sessions, and runtime configuration remain under explicit CE-owned paths.
- Hook discovery and lifecycle outcomes are visible instead of silently appearing hook-free.
- Users can locate and inspect the exact managed home from Settings.

### Explicitly excluded

These are isolation boundaries, not missing follow-up work in this PR:

- **No shared, copied, or symlinked auth state.** CE does not import `~/.codex/auth.json`.
- **No shared whole config or home.** CE does not copy or point at the user's `config.toml`, skills, plugins, caches, or entire `~/.codex` directory.
- **No shared sessions/history/SQLite/log state.** CE sessions do not appear in the user's ordinary Codex history/database/logs, and ordinary Codex sessions do not populate CE's managed state.
- **No global hook bridge.** Hooks declared only in the user's global Codex configuration are not imported or executed by CE. This PR supports project hooks discovered by the pinned app server for the execution directory.
- **No claim to detect upstream-silent malformed hooks.** If the pinned app server returns a clean zero inventory with no warning/error for an invalid declaration, CE cannot distinguish it from a hook-free repository. CE surfaces the zero inventory; fixing silent upstream omission is outside this bridge.
- **No unrelated app-server feature expansion.** This PR adds the config/hook RPC and diagnostics required for the compatibility model, not general parity with every Codex CLI/TUI feature.

## Validation

Post-merge with current `origin/main` (`059d35a1`):

- `make dev-test FILTER=CodexRuntimeAuthorityTests` — 12 passed
- `make dev-test FILTER=CodexHookCompatibilityGateTests` — 12 passed
- `make dev-test FILTER=CodexNativeSessionControllerGoalConfigTests` — 27 passed
- `make dev-test FILTER=CodexNativeSessionControllerEventRecoveryTests` — 39 passed
- `make dev-test FILTER=CodexAgentModeCoordinatorLivenessTests` — 73 passed
- `make dev-test FILTER=CodemapBindingEngineRootLeaseTests` — 3 passed
- `make dev-lint` — passed
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `make dev-codex-schema-check` — passed against the pinned contract
- contribution `commit` and `push` safety preflights — passed

The full PR-ready root test lane was attempted. It hit one load-sensitive failure in `CodemapBindingEngineRootLeaseTests.testSequentialRootsRetainGlobalAdoptionLeaseBudgetUntilUnloadThenRecover` and then the repository's one-hour conductor timeout. That suite passed focused 3/3 with no related source changes. Hosted PR CI remains authoritative for the full-suite result.

Not run: live app/Finder canary, because this change was validated without launching or relaunching the user's visible app.
