### PR TITLE
Add Grok Build CLI to Oracle and built-in chat models

### DIFF
--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -5641,6 +5641,8 @@ class PromptViewModel: ObservableObject {
             return api.isOpenCodeConnected
         case .cursor:
             return api.isCursorConnected
+        case .grokBuild:
+            return api.isGrokBuildConnected
         }
     }
 
@@ -5662,7 +5664,7 @@ class PromptViewModel: ObservableObject {
             // Custom models are always valid (user explicitly configured them)
             if model.isCustom { return true }
             switch model.providerType {
-            case .claudeCode, .codex, .openCode, .cursor:
+            case .claudeCode, .codex, .openCode, .cursor, .grokBuild:
                 return true
             default:
                 // Check if the model's provider has an API key configured

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -1859,6 +1859,10 @@ public class APISettingsViewModel: ObservableObject {
             modelSet.formUnion(AIModel.modelsForProvider(.cursor))
         }
 
+        if isGrokBuildConnected {
+            modelSet.formUnion(AIModel.modelsForProvider(.grokBuild))
+        }
+
         // ── Custom provider (OpenAI compatible) ────────────────────────────────
         if isCustomProviderValid,
            let config = try? CustomProviderConfiguration.load()
@@ -1923,6 +1927,7 @@ public class APISettingsViewModel: ObservableObject {
         case .customProvider: "custom"
         case .azure: "azure"
         case .cursor: "cursor"
+        case .grokBuild: "grok_build"
         case .ollama: "ollama"
         case .claudeCode: "claude_code"
         case .codex: "codex"
@@ -2001,6 +2006,8 @@ public class APISettingsViewModel: ObservableObject {
                 break
             case .cursor:
                 break
+            case .grokBuild:
+                break
             }
 
             await updateAvailableModels()
@@ -2060,6 +2067,8 @@ public class APISettingsViewModel: ObservableObject {
         case .openCode:
             break
         case .cursor:
+            break
+        case .grokBuild:
             break
         }
         await updateAvailableModels()

--- a/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
@@ -179,6 +179,7 @@ public enum AIModel: Equatable, Hashable {
     case codexCustom(name: String)
     case openCodeCustom(name: String)
     case cursorCustom(name: String)
+    case grokBuildCustom(name: String)
 
     // Custom Provider Models
     case customProvider(name: String, provider: String, model: String)
@@ -236,6 +237,7 @@ public enum AIModel: Equatable, Hashable {
         static let codex = 11
         static let openCode = 12
         static let cursor = 13
+        static let grokBuild = 14
         static let special = -1
     }
 
@@ -451,7 +453,7 @@ public enum AIModel: Equatable, Hashable {
     }()
 
     private static let modelGroups: [Set<AIModel>] = {
-        var groups: [Set<AIModel>] = Array(repeating: [], count: 14) // Includes CLI provider groups through Cursor
+        var groups: [Set<AIModel>] = Array(repeating: [], count: 15) // Includes CLI provider groups through Grok Build
         for info in modelDefinitions where info.provider >= 0 {
             groups[info.provider].insert(info.model)
         }
@@ -535,6 +537,8 @@ public enum AIModel: Equatable, Hashable {
             return "opencode_custom_\(n)"
         case let .cursorCustom(n):
             return "cursor_custom_\(n)"
+        case let .grokBuildCustom(n):
+            return "grokbuild_custom_\(n)"
         case let .customProvider(_, _, model):
             return "custom_provider_\(model)"
         case let .customProviderUser(name):
@@ -602,6 +606,9 @@ public enum AIModel: Equatable, Hashable {
             }
             return n
         }
+        if case let .grokBuildCustom(n) = self {
+            return ACPAIModelCatalog.grokBuildModelOption(for: n)?.displayName ?? n
+        }
         if case let .customProviderUser(name) = self { return "Custom/\(name)" }
         if case .ollama = self {
             return "local/" + modelName
@@ -630,6 +637,7 @@ public enum AIModel: Equatable, Hashable {
         case .codex: CodexCLIProvider.self
         case .openCode: OpenCodeCLIProvider.self
         case .cursor: CursorCLIProvider.self
+        case .grokBuild: GrokBuildCLIProvider.self
         }
     }
 
@@ -658,6 +666,7 @@ public enum AIModel: Equatable, Hashable {
         case .codexCustom: return .codex
         case .openCodeCustom: return .openCode
         case .cursorCustom: return .cursor
+        case .grokBuildCustom: return .grokBuild
         case .customProviderUser: return .customProvider
         // or, if you prefer the old modelGroups approach:
         default:
@@ -674,6 +683,7 @@ public enum AIModel: Equatable, Hashable {
             if Self.modelGroups[ProviderIndex.codex].contains(self) { return .codex }
             if Self.modelGroups[ProviderIndex.openCode].contains(self) { return .openCode }
             if Self.modelGroups[ProviderIndex.cursor].contains(self) { return .cursor }
+            if Self.modelGroups[ProviderIndex.grokBuild].contains(self) { return .grokBuild }
             // fallback
             return .azure
         }
@@ -711,7 +721,8 @@ public enum AIModel: Equatable, Hashable {
              let .zaiCustom(n),
              let .codexCustom(n),
              let .openCodeCustom(n),
-             let .cursorCustom(n):
+             let .cursorCustom(n),
+             let .grokBuildCustom(n):
             return n
         case let .customProviderUser(name):
             return name
@@ -1152,7 +1163,7 @@ public enum AIModel: Equatable, Hashable {
             return SwiftOpenAI.Model.custom(modelName)
         case .anthropic:
             return SwiftAnthropic.Model.other(modelName)
-        case .azure, .openRouter, .customProvider, .claudeCode, .codex, .openCode, .cursor:
+        case .azure, .openRouter, .customProvider, .claudeCode, .codex, .openCode, .cursor, .grokBuild:
             // For these providers, use the actual model name when available
             if let modelInfo = Self.modelDefinitions.first(where: { $0.model == self }),
                let actualName = modelInfo.actualName
@@ -1243,6 +1254,9 @@ public enum AIModel: Equatable, Hashable {
         }
         if normalizedRawValue.hasPrefix("cursor_custom_") {
             return .cursorCustom(name: String(normalizedRawValue.dropFirst("cursor_custom_".count)))
+        }
+        if normalizedRawValue.hasPrefix("grokbuild_custom_") {
+            return .grokBuildCustom(name: String(normalizedRawValue.dropFirst("grokbuild_custom_".count)))
         }
 
         if normalizedRawValue.hasPrefix("openai_custom_reasoning_") {
@@ -1356,6 +1370,8 @@ public enum AIModel: Equatable, Hashable {
             models = ACPAIModelCatalog.openCodeModelsFromStore()
         case .cursor:
             models = ACPAIModelCatalog.cursorModelsFromStore()
+        case .grokBuild:
+            models = ACPAIModelCatalog.grokBuildModelsFromStore()
         }
 
         // Filter out models that are not yet available based on their release date
@@ -1936,6 +1952,8 @@ public enum AIModel: Equatable, Hashable {
                 models.append(contentsOf: ACPAIModelCatalog.openCodeModelsFromStore())
             } else if providerIndex == ProviderIndex.cursor {
                 models.append(contentsOf: ACPAIModelCatalog.cursorModelsFromStore())
+            } else if providerIndex == ProviderIndex.grokBuild {
+                models.append(contentsOf: ACPAIModelCatalog.grokBuildModelsFromStore())
             } else {
                 models.append(contentsOf: group)
             }
@@ -1962,6 +1980,7 @@ public enum AIModel: Equatable, Hashable {
         case codexCustom(name: String)
         case openCodeCustom(name: String)
         case cursorCustom(name: String)
+        case grokBuildCustom(name: String)
         case customProvider(name: String, provider: String, model: String)
         case customProviderUser(name: String)
         case claudeCodeModel(normalizedSpecifier: String)
@@ -2116,6 +2135,8 @@ public enum AIModel: Equatable, Hashable {
             .openCodeCustom(name: name)
         case let .cursorCustom(name):
             .cursorCustom(name: name)
+        case let .grokBuildCustom(name):
+            .grokBuildCustom(name: name)
         case let .customProvider(name, provider, model):
             .customProvider(name: name, provider: provider, model: model)
         case let .customProviderUser(name):

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ACPAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ACPAIModelCatalog.swift
@@ -319,6 +319,10 @@ enum ACPAIModelCatalog {
         cursorModelOptionsFromStore().map { .cursorCustom(name: $0.rawValue) }
     }
 
+    static func grokBuildModelsFromStore() -> [AIModel] {
+        grokBuildModelOptionsFromStore().map { .grokBuildCustom(name: $0.rawValue) }
+    }
+
     static func openCodeModelOption(for rawValue: String) -> AgentModelOption? {
         let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else { return nil }
@@ -335,6 +339,13 @@ enum ACPAIModelCatalog {
             return discovered
         }
         return cursorModelOptionsFromStore()
+            .first { $0.rawValue.caseInsensitiveCompare(normalized) == .orderedSame }
+    }
+
+    static func grokBuildModelOption(for rawValue: String) -> AgentModelOption? {
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+        return grokBuildModelOptionsFromStore()
             .first { $0.rawValue.caseInsensitiveCompare(normalized) == .orderedSame }
     }
 
@@ -362,6 +373,13 @@ enum ACPAIModelCatalog {
         let discovered = AgentACPModelRegistry.shared.resolvedSnapshot(for: .cursor)?.options ?? []
         guard !discovered.isEmpty else { return [fallback] }
         return [fallback] + discovered.filter { !isCursorAutoOption($0) }
+    }
+
+    private static func grokBuildModelOptionsFromStore() -> [AgentModelOption] {
+        AgentModelCatalog.options(
+            for: .grokBuild,
+            availability: AgentModelCatalog.AvailabilityContext(grokBuildAvailable: true)
+        )
     }
 
     private static func isCursorAutoOption(_ option: AgentModelOption) -> Bool {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AIProviderFactory.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AIProviderFactory.swift
@@ -18,7 +18,7 @@ class AIProviderFactory {
         }
 
         // CLI providers don't need API keys - they leverage existing authentication
-        if providerType == .claudeCode || providerType == .codex || providerType == .openCode || providerType == .cursor {
+        if providerType == .claudeCode || providerType == .codex || providerType == .openCode || providerType == .cursor || providerType == .grokBuild {
             return try await createProvider(
                 for: providerType,
                 key: "",
@@ -87,6 +87,8 @@ class AIProviderFactory {
             return OpenCodeCLIProvider()
         case .cursor:
             return CursorCLIProvider()
+        case .grokBuild:
+            return GrokBuildCLIProvider()
         case .customProvider:
             let config = try CustomProviderConfiguration.load()
 
@@ -178,6 +180,7 @@ enum AIProviderType: Codable, Equatable {
     case codex // <-- New Codex CLI provider case
     case openCode // OpenCode CLI provider case
     case cursor // Cursor CLI provider case
+    case grokBuild // Grok Build CLI provider case
 }
 
 extension AIProviderType {
@@ -199,6 +202,7 @@ extension AIProviderType {
         case .codex: "Codex CLI"
         case .openCode: "OpenCode"
         case .cursor: "Cursor CLI"
+        case .grokBuild: "Grok Build"
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildCLIProvider.swift
@@ -13,6 +13,17 @@ final class GrokBuildCLIProvider: AIProvider {
         static func test_makeAgentMessage(from aiMessage: AIMessage) -> AgentMessage {
             GrokBuildCLIProvider().makeAgentMessage(from: aiMessage)
         }
+
+        static func test_normalizedTerminalResult(_ result: AIStreamResult) -> AIStreamResult {
+            normalizedTerminalResult(result)
+        }
+
+        static func test_resolvedCompletionText(
+            streamedParts: [String],
+            finalContent: String?
+        ) -> String {
+            resolvedCompletionText(streamedParts: streamedParts, finalContent: finalContent)
+        }
     #endif
 
     func streamMessage(
@@ -39,7 +50,7 @@ final class GrokBuildCLIProvider: AIProvider {
             let bridgeTask = Task {
                 do {
                     for try await result in upstream {
-                        continuation.yield(result)
+                        continuation.yield(Self.normalizedTerminalResult(result))
                     }
                     continuation.finish()
                 } catch {
@@ -74,7 +85,7 @@ final class GrokBuildCLIProvider: AIProvider {
         var promptTokens: Int?
         var completionTokens: Int?
         var cost: Double?
-        var sawMessageStop = false
+        var completionOutcome: AIProviderCompletionOutcome?
 
         for try await result in stream {
             switch result.type {
@@ -87,7 +98,19 @@ final class GrokBuildCLIProvider: AIProvider {
                     finalContent = text
                 }
             case "message_stop":
-                sawMessageStop = true
+                completionOutcome = .completed
+                if let value = result.promptTokens { promptTokens = value }
+                if let value = result.completionTokens { completionTokens = value }
+                if let value = result.cost { cost = value }
+            case AIStreamResult.incompleteType:
+                guard let reason = result.stopReason?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !reason.isEmpty
+                else {
+                    throw AIProviderError.invalidResponse(
+                        detail: "Grok Build reported incomplete termination without a reason"
+                    )
+                }
+                completionOutcome = .incomplete(reason: reason)
                 if let value = result.promptTokens { promptTokens = value }
                 if let value = result.completionTokens { completionTokens = value }
                 if let value = result.cost { cost = value }
@@ -100,16 +123,26 @@ final class GrokBuildCLIProvider: AIProvider {
             }
         }
 
-        let text = textParts.isEmpty ? (finalContent ?? "") : textParts.joined()
-        guard sawMessageStop || !text.isEmpty else {
-            throw AIProviderError.invalidResponse(detail: "Grok Build returned no completion")
+        let text = Self.resolvedCompletionText(
+            streamedParts: textParts,
+            finalContent: finalContent
+        )
+        let resolvedOutcome: AIProviderCompletionOutcome
+        if let completionOutcome {
+            resolvedOutcome = completionOutcome
+        } else {
+            guard !text.isEmpty else {
+                throw AIProviderError.invalidResponse(detail: "Grok Build returned no completion")
+            }
+            resolvedOutcome = .incomplete(reason: "stream_ended_without_terminal")
         }
 
         return AICompletionResult(
             text: text,
             promptTokens: promptTokens,
             completionTokens: completionTokens,
-            cost: cost
+            cost: cost,
+            completionOutcome: resolvedOutcome
         )
     }
 
@@ -118,6 +151,35 @@ final class GrokBuildCLIProvider: AIProvider {
         for provider in providers {
             await provider.dispose()
         }
+    }
+
+    private static let successfulTerminalStopReasons: Set<String> = [
+        "end_turn",
+        "stop",
+        "stop_sequence",
+        "completed",
+        "complete"
+    ]
+
+    private static func normalizedTerminalResult(_ result: AIStreamResult) -> AIStreamResult {
+        guard result.type == "message_stop",
+              let stopReason = result.stopReason?
+              .trimmingCharacters(in: .whitespacesAndNewlines)
+              .lowercased(),
+              !stopReason.isEmpty,
+              !successfulTerminalStopReasons.contains(stopReason)
+        else {
+            return result
+        }
+
+        return result.replacingType(AIStreamResult.incompleteType)
+    }
+
+    private static func resolvedCompletionText(
+        streamedParts: [String],
+        finalContent: String?
+    ) -> String {
+        finalContent ?? streamedParts.joined()
     }
 
     private static func makeHeadlessConfig(modelName: String?) -> GrokBuildAgentConfig {
@@ -171,6 +233,32 @@ final class GrokBuildCLIProvider: AIProvider {
         guard model.providerType == .grokBuild else { return nil }
         let trimmed = model.modelName.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+private extension AIStreamResult {
+    func replacingType(_ type: String) -> AIStreamResult {
+        AIStreamResult(
+            type: type,
+            text: text,
+            reasoning: reasoning,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            cost: cost,
+            toolName: toolName,
+            toolArgs: toolArgs,
+            toolOutput: toolOutput,
+            toolInvocationID: toolInvocationID,
+            toolResultJSON: toolResultJSON,
+            toolArgsJSON: toolArgsJSON,
+            toolIsError: toolIsError,
+            providerSessionID: providerSessionID,
+            stopReason: stopReason,
+            modelContextWindow: modelContextWindow,
+            contextUsedTokens: contextUsedTokens,
+            contentMessageID: contentMessageID,
+            cleanupHandle: cleanupHandle
+        )
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildCLIProvider.swift
@@ -1,0 +1,200 @@
+import Foundation
+
+/// Grok Build CLI provider for non-agent use (chat, Oracle, AI queries) backed by ACP.
+/// Runs a fresh prompt-only ACP session per request without injecting RepoPrompt MCP/tools.
+final class GrokBuildCLIProvider: AIProvider {
+    private let activeProviders = ActiveGrokBuildCLIProviderStore()
+
+    #if DEBUG
+        static func test_makeHeadlessConfig(modelName: String?) -> GrokBuildAgentConfig {
+            makeHeadlessConfig(modelName: modelName)
+        }
+
+        static func test_makeAgentMessage(from aiMessage: AIMessage) -> AgentMessage {
+            GrokBuildCLIProvider().makeAgentMessage(from: aiMessage)
+        }
+    #endif
+
+    func streamMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens _: Int? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        let provider = GrokBuildACPHeadlessAgentProvider(
+            config: Self.makeHeadlessConfig(modelName: grokBuildModelName(for: model)),
+            workspacePath: nil
+        )
+        activeProviders.insert(provider)
+
+        let upstream: AsyncThrowingStream<AIStreamResult, Error>
+        do {
+            upstream = try await provider.streamAgentMessage(makeAgentMessage(from: aiMessage), runID: nil)
+        } catch {
+            activeProviders.remove(provider)
+            await provider.dispose()
+            throw error
+        }
+
+        return AsyncThrowingStream { continuation in
+            let bridgeTask = Task {
+                do {
+                    for try await result in upstream {
+                        continuation.yield(result)
+                    }
+                    continuation.finish()
+                } catch {
+                    if Task.isCancelled {
+                        continuation.finish()
+                    } else {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                await provider.dispose()
+                self.activeProviders.remove(provider)
+            }
+
+            continuation.onTermination = { _ in
+                bridgeTask.cancel()
+                Task {
+                    await provider.dispose()
+                    self.activeProviders.remove(provider)
+                }
+            }
+        }
+    }
+
+    func completeMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AICompletionResult {
+        let stream = try await streamMessage(aiMessage, model: model, maxTokens: maxTokens)
+        var textParts: [String] = []
+        var finalContent: String?
+        var promptTokens: Int?
+        var completionTokens: Int?
+        var cost: Double?
+        var sawMessageStop = false
+
+        for try await result in stream {
+            switch result.type {
+            case "content":
+                if let text = result.text, !text.isEmpty {
+                    textParts.append(text)
+                }
+            case "final_content":
+                if let text = result.text, !text.isEmpty {
+                    finalContent = text
+                }
+            case "message_stop":
+                sawMessageStop = true
+                if let value = result.promptTokens { promptTokens = value }
+                if let value = result.completionTokens { completionTokens = value }
+                if let value = result.cost { cost = value }
+            case "error":
+                throw AIProviderError.invalidConfiguration(
+                    detail: result.text ?? "Grok Build ACP reported an error"
+                )
+            default:
+                continue
+            }
+        }
+
+        let text = textParts.isEmpty ? (finalContent ?? "") : textParts.joined()
+        guard sawMessageStop || !text.isEmpty else {
+            throw AIProviderError.invalidResponse(detail: "Grok Build returned no completion")
+        }
+
+        return AICompletionResult(
+            text: text,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            cost: cost
+        )
+    }
+
+    func dispose() async {
+        let providers = activeProviders.removeAll()
+        for provider in providers {
+            await provider.dispose()
+        }
+    }
+
+    private static func makeHeadlessConfig(modelName: String?) -> GrokBuildAgentConfig {
+        GrokBuildAgentConfig(
+            enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
+            modelString: modelName,
+            includeRepoPromptMCPServer: false,
+            alwaysApproveTools: false
+        )
+    }
+
+    private static let noToolsInstruction = "IMPORTANT: Do not use any tools, function calls, or external commands. Respond with text only. Any tool invocation will cause task failure."
+
+    private func makeAgentMessage(from aiMessage: AIMessage) -> AgentMessage {
+        let systemPrompt = aiMessage.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let nonAgentSystemPrompt = systemPrompt.isEmpty
+            ? Self.noToolsInstruction
+            : "\(systemPrompt)\n\n\(Self.noToolsInstruction)"
+        return AgentMessage(
+            systemPrompt: nonAgentSystemPrompt,
+            userMessage: buildPrompt(from: aiMessage),
+            resumeSessionID: nil
+        )
+    }
+
+    private func buildPrompt(from aiMessage: AIMessage) -> String {
+        let tail = aiMessage.buildTail(embedSystemPrompt: false)
+        var conversation = ""
+        let lastUserIndex = aiMessage.conversationMessages.lastIndex { $0.role == .user }
+        for (index, message) in aiMessage.conversationMessages.enumerated() {
+            var text = message.content
+            if message.role == .user,
+               index == lastUserIndex,
+               !tail.isEmpty
+            {
+                text = tail + "\n\n" + text
+            }
+            let prefix = message.role == .user ? "User" : "Assistant"
+            if !conversation.isEmpty {
+                conversation += "\n\n"
+            }
+            conversation += "\(prefix): \(text)"
+        }
+        if aiMessage.conversationMessages.isEmpty, !tail.isEmpty {
+            conversation = "User: \(tail)"
+        }
+        return conversation
+    }
+
+    private func grokBuildModelName(for model: AIModel) -> String? {
+        guard model.providerType == .grokBuild else { return nil }
+        let trimmed = model.modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+private final class ActiveGrokBuildCLIProviderStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var providers: [ObjectIdentifier: GrokBuildACPHeadlessAgentProvider] = [:]
+
+    func insert(_ provider: GrokBuildACPHeadlessAgentProvider) {
+        lock.lock()
+        providers[ObjectIdentifier(provider)] = provider
+        lock.unlock()
+    }
+
+    func remove(_ provider: GrokBuildACPHeadlessAgentProvider) {
+        lock.lock()
+        providers.removeValue(forKey: ObjectIdentifier(provider))
+        lock.unlock()
+    }
+
+    func removeAll() -> [GrokBuildACPHeadlessAgentProvider] {
+        lock.lock()
+        let current = Array(providers.values)
+        providers.removeAll()
+        lock.unlock()
+        return current
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
@@ -1336,9 +1336,7 @@ private enum AppSettingsMCPRegistry {
         case .cursor:
             .cursor
         case .grokBuild:
-            // Grok Build is an Agent Mode ACP provider only; `AIProviderType.grok` is the
-            // HTTP chat provider and does not describe Agent Mode models.
-            nil
+            .grokBuild
         }
     }
 
@@ -1360,6 +1358,7 @@ private enum AppSettingsMCPRegistry {
         case .codex: "codex"
         case .openCode: "openCode"
         case .cursor: "cursor"
+        case .grokBuild: "grokBuild"
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/Security/KeyManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/KeyManager.swift
@@ -70,6 +70,7 @@ extension AIProviderType {
         case .codex: .codexCLIAPI
         case .openCode: .openCodeCLIAPI
         case .cursor: .cursorCLIAPI
+        case .grokBuild: .grokAPI
         case .zAI: .zAIAPI
         }
     }

--- a/Tests/RepoPromptTests/AI/GrokBuildModelRoutingTests.swift
+++ b/Tests/RepoPromptTests/AI/GrokBuildModelRoutingTests.swift
@@ -82,6 +82,80 @@ final class GrokBuildModelRoutingTests: XCTestCase {
         XCTAssertTrue(message.systemPrompt.contains("Do not use any tools"))
     }
 
+    func testNonAgentAdapterMapsNonSuccessfulStopsToIncomplete() {
+        let incompleteStopReasons = [
+            "max_tokens",
+            "max_turn_requests",
+            "cancelled",
+            "refusal",
+            "future_reason"
+        ]
+        for stopReason in incompleteStopReasons {
+            let normalized = GrokBuildCLIProvider.test_normalizedTerminalResult(
+                AIStreamResult(
+                    type: "message_stop",
+                    text: nil,
+                    promptTokens: 11,
+                    completionTokens: 7,
+                    providerSessionID: "session-1",
+                    stopReason: stopReason,
+                    contextUsedTokens: 13
+                )
+            )
+
+            XCTAssertEqual(normalized.type, AIStreamResult.incompleteType, stopReason)
+            XCTAssertEqual(normalized.stopReason, stopReason, stopReason)
+            XCTAssertEqual(normalized.promptTokens, 11, stopReason)
+            XCTAssertEqual(normalized.completionTokens, 7, stopReason)
+            XCTAssertEqual(normalized.providerSessionID, "session-1", stopReason)
+            XCTAssertEqual(normalized.contextUsedTokens, 13, stopReason)
+        }
+    }
+
+    func testNonAgentAdapterKeepsSuccessfulStopsCompleted() {
+        let successfulStopReasons = [
+            "end_turn",
+            "stop",
+            "stop_sequence",
+            "completed",
+            "complete"
+        ]
+        for stopReason in successfulStopReasons {
+            let normalized = GrokBuildCLIProvider.test_normalizedTerminalResult(
+                AIStreamResult(
+                    type: "message_stop",
+                    text: nil,
+                    stopReason: stopReason
+                )
+            )
+
+            XCTAssertEqual(normalized.type, "message_stop", stopReason)
+            XCTAssertEqual(normalized.stopReason, stopReason, stopReason)
+        }
+
+        let missingReason = GrokBuildCLIProvider.test_normalizedTerminalResult(
+            AIStreamResult(type: "message_stop", text: nil)
+        )
+        XCTAssertEqual(missingReason.type, "message_stop")
+    }
+
+    func testNonAgentCompletionPrefersAuthoritativeFinalContent() {
+        XCTAssertEqual(
+            GrokBuildCLIProvider.test_resolvedCompletionText(
+                streamedParts: ["draft ", "answer"],
+                finalContent: "final answer"
+            ),
+            "final answer"
+        )
+        XCTAssertEqual(
+            GrokBuildCLIProvider.test_resolvedCompletionText(
+                streamedParts: ["streamed ", "answer"],
+                finalContent: nil
+            ),
+            "streamed answer"
+        )
+    }
+
     @MainActor
     func testDropdownDisplaysGrokBuildCatalogName() {
         let model = AIModel.grokBuildCustom(name: "grok-4.6")

--- a/Tests/RepoPromptTests/AI/GrokBuildModelRoutingTests.swift
+++ b/Tests/RepoPromptTests/AI/GrokBuildModelRoutingTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+final class GrokBuildModelRoutingTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AgentACPModelRegistry.shared.test_reset(providerID: .grokBuild)
+    }
+
+    override func tearDown() {
+        AgentACPModelRegistry.shared.test_reset(providerID: .grokBuild)
+        super.tearDown()
+    }
+
+    func testModelIdentityRoundTripsToGrokBuildProvider() {
+        let model = AIModel.grokBuildCustom(name: "grok-4.6-high")
+
+        XCTAssertEqual(model.rawValue, "grokbuild_custom_grok-4.6-high")
+        XCTAssertEqual(AIModel.fromModelName(model.rawValue), model)
+        XCTAssertEqual(model.modelName, "grok-4.6-high")
+        XCTAssertEqual(model.providerType, .grokBuild)
+        XCTAssertEqual(AIProviderType.displayName(for: model.providerType), "Grok Build")
+        XCTAssertEqual(ObjectIdentifier(model.provider), ObjectIdentifier(GrokBuildCLIProvider.self))
+    }
+
+    func testCatalogUsesDefaultAndDiscoveredGrokBuildModels() {
+        XCTAssertEqual(
+            AIModel.modelsForProvider(.grokBuild),
+            [.grokBuildCustom(name: AgentModel.defaultModel.rawValue)]
+        )
+
+        _ = AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [
+                    AgentModelOption(
+                        rawValue: "grok-4.6",
+                        displayName: "Grok 4.6",
+                        description: nil,
+                        isPlaceholderDefault: false,
+                        isProviderDefault: false
+                    )
+                ],
+                currentModelRaw: "grok-4.6"
+            ),
+            for: .grokBuild
+        )
+
+        let models = AIModel.modelsForProvider(.grokBuild)
+        XCTAssertEqual(Set(models), [
+            .grokBuildCustom(name: AgentModel.defaultModel.rawValue),
+            .grokBuildCustom(name: "grok-4.6")
+        ])
+        XCTAssertEqual(
+            models.first { $0.modelName == "grok-4.6" }?.displayName,
+            "Grok 4.6"
+        )
+    }
+
+    func testFactoryCreatesGrokBuildProviderWithoutStoredAPIKey() async throws {
+        let keyManager = KeyManager(
+            secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+        )
+
+        let provider = try await AIProviderFactory.createProvider(
+            for: .grokBuild,
+            keyManager: keyManager
+        )
+        XCTAssertTrue(provider is GrokBuildCLIProvider)
+        await provider.dispose()
+    }
+
+    func testNonAgentAdapterDisablesRepoPromptToolsAndPreservesModel() {
+        let config = GrokBuildCLIProvider.test_makeHeadlessConfig(modelName: "grok-4.6")
+        let message = GrokBuildCLIProvider.test_makeAgentMessage(
+            from: AIMessage(systemPrompt: "", userMessage: "Hello")
+        )
+
+        XCTAssertEqual(config.modelString, "grok-4.6")
+        XCTAssertFalse(config.includeRepoPromptMCPServer)
+        XCTAssertFalse(config.alwaysApproveTools)
+        XCTAssertTrue(message.systemPrompt.contains("Do not use any tools"))
+    }
+
+    @MainActor
+    func testDropdownDisplaysGrokBuildCatalogName() {
+        let model = AIModel.grokBuildCustom(name: "grok-4.6")
+        _ = AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [
+                    AgentModelOption(
+                        rawValue: model.modelName,
+                        displayName: "Grok 4.6",
+                        description: nil,
+                        isPlaceholderDefault: false,
+                        isProviderDefault: false
+                    )
+                ],
+                currentModelRaw: model.modelName
+            ),
+            for: .grokBuild
+        )
+
+        XCTAssertEqual(
+            AIModelDropdown.displayName(
+                forRawValue: model.rawValue,
+                destinationID: "planningModel",
+                availableModels: [model],
+                customOpenRouterModels: []
+            ),
+            "Grok 4.6"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a thin non-agent `GrokBuildCLIProvider` over the existing Grok Build ACP headless runtime
- add provider-qualified model identity, catalog, factory, and availability routing for Oracle and built-in chat
- keep Oracle UI, profiles, recommendations, and Grok Build process ownership unchanged

## Validation
- `make dev-test FILTER=GrokBuildModelRoutingTests`
- `make dev-test FILTER=GrokBuildACPHeadlessAgentProviderTests`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- contribution commit and push preflights

Live app smoke was not run.