### PR TITLE
Server upstreaming (PR 1/6): Restore Desktop Agent Mode authority boundary

### DIFF
--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -772,6 +772,7 @@ allowed_tracked_docs=(
   "docs/architecture/apple-identity-migration.md"
   "docs/architecture/codex-app-server-schema-gate.md"
   "docs/architecture/context-composer.md"
+  "docs/architecture/desktop-agent-authority.md"
   "docs/architecture/headless-mcp-runtime.md"
   "docs/architecture/provider-plugins.md"
   "docs/architecture/settings-persistence.md"

--- a/Sources/RepoPrompt/App/AppDomainRuntimeComposition.swift
+++ b/Sources/RepoPrompt/App/AppDomainRuntimeComposition.swift
@@ -1,5 +1,8 @@
 import Foundation
+import Logging
 import RepoPromptDomainRuntime
+
+private let appDomainRuntimeLog = Logger(label: "com.repoprompt.app.domain-runtime")
 
 private enum AppDomainRuntimeMetrics {
     static let editFlowSink = DomainRuntimeMetricsSink { metric in
@@ -36,6 +39,33 @@ final class AppDomainRuntimeComposition: Sendable {
 
     let runtime: MCPDomainRuntime
 
+    static func prototypeAuthorityDatabaseURL(applicationSupportRoot: URL) -> URL {
+        applicationSupportRoot
+            .appendingPathComponent("AgentAuthority", isDirectory: true)
+            .appendingPathComponent("repoprompt.sqlite", isDirectory: false)
+    }
+
+    /// Reports the intentionally orphaned Desktop authority prototype without opening,
+    /// migrating, moving, or deleting it. Production calls this once from the process-wide
+    /// composition initializer; the return value keeps the preservation contract testable.
+    @discardableResult
+    static func reportUnusedPrototypeAuthorityStoreIfPresent(
+        applicationSupportRoot: URL,
+        fileManager: FileManager = .default,
+        log: (String) -> Void
+    ) -> Bool {
+        let databaseURL = prototypeAuthorityDatabaseURL(applicationSupportRoot: applicationSupportRoot)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: databaseURL.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue
+        else {
+            return false
+        }
+
+        log("Unused Desktop AgentAuthority prototype store preserved at \(databaseURL.path); it will not be opened or migrated.")
+        return true
+    }
+
     static func collectLegacyRuntimeDefaults(from defaults: UserDefaults) -> [String: Data] {
         var collected: [String: Data] = [:]
         for key in legacyRuntimeDefaultKeys {
@@ -60,6 +90,9 @@ final class AppDomainRuntimeComposition: Sendable {
             in: .userDomainMask
         ).first ?? FileManager.default.temporaryDirectory
         let root = applicationSupport.appendingPathComponent("RepoPrompt CE", isDirectory: true)
+        Self.reportUnusedPrototypeAuthorityStoreIfPresent(applicationSupportRoot: root) { message in
+            appDomainRuntimeLog.notice("\(message)")
+        }
         let defaults = UserDefaults.standard
         let customStoragePath = defaults.string(forKey: "GlobalCustomStorageURL")
         var legacyRuntimeDefaults = Self.collectLegacyRuntimeDefaults(from: defaults)

--- a/Tests/RepoPromptTests/AI/ModelPickerStringOrderingTests.swift
+++ b/Tests/RepoPromptTests/AI/ModelPickerStringOrderingTests.swift
@@ -3,6 +3,58 @@ import XCTest
 @_spi(TestSupport) @testable import RepoPromptApp
 
 final class ModelPickerStringOrderingTests: XCTestCase {
+    func testDesktopProviderAndModelIdentitySnapshot() throws {
+        XCTAssertEqual(
+            AgentProviderKind.allCases.map { provider in
+                [
+                    provider.rawValue,
+                    provider.commandName,
+                    provider.mcpClientNameHint ?? "",
+                    String(provider.usesClaudeNativeRuntime),
+                    String(provider.requiresPrePromptAgentModeMCPRouting)
+                ].joined(separator: "|")
+            },
+            [
+                "claudeCode|claude|claude-code|true|true",
+                "codexExec|codex|codex-mcp-client|false|true",
+                "openCode|opencode|opencode|false|true",
+                "cursor|cursor-agent|cursor|false|false",
+                "grokBuild|grok|grok-shell-RepoPromptCE|false|false",
+                "claudeCodeGLM|claude|claude-code|true|true",
+                "kimiCode|claude|claude-code|true|true",
+                "customClaudeCompatible|claude|claude-code|true|true"
+            ]
+        )
+
+        let expectedRawValues = [
+            "gpt-5.1-codex-mini",
+            "gpt-5.6-sol-low", "gpt-5.6-sol-medium", "gpt-5.6-sol-high", "gpt-5.6-sol-xhigh", "gpt-5.6-sol-max", "gpt-5.6-sol-ultra",
+            "gpt-5.6-terra-low", "gpt-5.6-terra-medium", "gpt-5.6-terra-high", "gpt-5.6-terra-xhigh", "gpt-5.6-terra-max", "gpt-5.6-terra-ultra",
+            "gpt-5.6-luna-low", "gpt-5.6-luna-medium", "gpt-5.6-luna-high", "gpt-5.6-luna-xhigh", "gpt-5.6-luna-max",
+            "gpt-5.5-low", "gpt-5.5-medium", "gpt-5.5-high", "gpt-5.5-xhigh",
+            "gpt-5.3-codex-low", "gpt-5.3-codex-medium", "gpt-5.3-codex-high", "gpt-5.3-codex-xhigh",
+            "gpt-5.2-low", "gpt-5.2-medium", "gpt-5.2-high", "gpt-5.2-xhigh",
+            "gpt-5.4-low", "gpt-5.4-medium", "gpt-5.4-high", "gpt-5.4-xhigh",
+            "gpt-5.4-mini-low", "gpt-5.4-mini-medium", "gpt-5.4-mini-high",
+            "sonnet", "opus", "haiku", "opus[1m]",
+            "claude-fable-5", "claude-sonnet-5", "claude-sonnet-4-6", "claude-sonnet-4-5",
+            "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5", "claude-haiku-4-5",
+            "glm-4.5-air", "glm-4.7", "glm-5.2", "glm-5.2[1m]", "glm-5-turbo", "glm-5.1",
+            "kimi-code", "custom-claude-compatible", "auto", "composer-2", "default"
+        ]
+        XCTAssertEqual(AgentModel.allCases.map(\.rawValue), expectedRawValues)
+        XCTAssertEqual(AgentModel.defaultModel.rawValue, "default")
+        XCTAssertEqual(
+            AgentModelDiscoveryTag.displayOrder.map(\.rawValue),
+            ["fast", "exploration", "balanced", "engineering", "complex", "pair", "extended_context"]
+        )
+
+        for model in AgentModel.allCases {
+            let encoded = try JSONEncoder().encode(model)
+            XCTAssertEqual(try JSONDecoder().decode(AgentModel.self, from: encoded), model, model.rawValue)
+        }
+    }
+
     func testScalarOrderingUsesAsciiFoldThenRawScalarTieBreak() {
         XCTAssertEqual(
             ModelPickerStringOrdering.compare("GPT-5", "gpt-5", caseInsensitiveASCII: true),

--- a/Tests/RepoPromptTests/App/AppDomainRuntimeCompositionTests.swift
+++ b/Tests/RepoPromptTests/App/AppDomainRuntimeCompositionTests.swift
@@ -2,6 +2,49 @@
 import XCTest
 
 final class AppDomainRuntimeCompositionTests: XCTestCase {
+    func testDesktopSettingsContractSnapshotAndRawValueRoundTrip() throws {
+        XCTAssertEqual(GlobalSettingsDocument.baselineSchemaVersion, 2)
+        XCTAssertEqual(GlobalSettingsDocument.workspaceAgentModelsSchemaVersion, 4)
+        XCTAssertEqual(GlobalSettingsDocument.currentSchemaVersion, 4)
+        XCTAssertEqual(GlobalSettingsDocument.schemaLineage, "repoprompt-ce.global-settings")
+        XCTAssertEqual(GlobalSettingsDocument.legacyUnlineagedSchemaVersionCeiling, 2)
+        XCTAssertEqual(AgentModelsInheritanceMode.useGlobalSettings.rawValue, "useGlobalSettings")
+        XCTAssertEqual(AgentModelsInheritanceMode.useWorkspaceOverrides.rawValue, "useWorkspaceOverrides")
+        XCTAssertEqual(WorktreeVisualMarkerStyle.dot.rawValue, "dot")
+        XCTAssertEqual(WorktreeVisualMarkerStyle.ring.rawValue, "ring")
+        XCTAssertEqual(WorktreeVisualMarkerStyle.capsule.rawValue, "capsule")
+
+        let behavior = ContextBuilderDefaults.behaviorSettings
+        XCTAssertEqual(behavior.contextTokenBudget, 160_000)
+        XCTAssertEqual(behavior.analysisTokenBudget, 120_000)
+        XCTAssertEqual(behavior.enhancementMode, .fullRewrite)
+        XCTAssertEqual(behavior.questionTimeoutSeconds, 300)
+        XCTAssertTrue(behavior.allowUIClarifyingQuestions)
+        XCTAssertFalse(behavior.allowMCPClarifyingQuestions)
+        XCTAssertFalse(behavior.followUpAnalysisEnabled)
+
+        let stored = AgentModelsSettingsProfile(
+            planningModelRaw: "legacy_oracle_raw",
+            preferredComposeModelRaw: "legacy_compose_raw",
+            syncChatModelWithOracle: true,
+            contextBuilderAgentRaw: "legacy_agent_raw",
+            contextBuilderModelsByAgent: ["legacy_agent_raw": "legacy_model_raw"],
+            mcpAgentRoleOverrides: ["engineer": "legacy_agent_raw:legacy_model_raw"],
+            restrictMCPAgentDiscoveryToRoleLabels: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let encoded = try encoder.encode(stored)
+        let decoded = try JSONDecoder().decode(AgentModelsSettingsProfile.self, from: encoded)
+
+        XCTAssertEqual(decoded, stored)
+        XCTAssertEqual(try encoder.encode(decoded), encoded)
+        XCTAssertEqual(
+            String(decoding: encoded, as: UTF8.self),
+            #"{"contextBuilderAgentRaw":"legacy_agent_raw","contextBuilderModelsByAgent":{"legacy_agent_raw":"legacy_model_raw"},"mcpAgentRoleOverrides":{"engineer":"legacy_agent_raw:legacy_model_raw"},"planningModelRaw":"legacy_oracle_raw","preferredComposeModelRaw":"legacy_compose_raw","restrictMCPAgentDiscoveryToRoleLabels":true,"syncChatModelWithOracle":true}"#
+        )
+    }
+
     func testCollectLegacyRuntimeDefaultsSerializesBooleanScalarFragments() throws {
         for value in [true, false] {
             let (defaults, suiteName) = try makeIsolatedDefaults()

--- a/Tests/RepoPromptTests/App/DesktopAgentAuthorityRestorationTests.swift
+++ b/Tests/RepoPromptTests/App/DesktopAgentAuthorityRestorationTests.swift
@@ -1,0 +1,106 @@
+import Darwin
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class DesktopAgentAuthorityRestorationTests: XCTestCase {
+    func testMissingPrototypeStoreIsNeitherReportedNorCreated() throws {
+        let temporaryRoot = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+        let supportRoot = temporaryRoot.appendingPathComponent("RepoPrompt CE", isDirectory: true)
+        var messages: [String] = []
+
+        let observed = AppDomainRuntimeComposition.reportUnusedPrototypeAuthorityStoreIfPresent(
+            applicationSupportRoot: supportRoot,
+            log: { messages.append($0) }
+        )
+
+        XCTAssertFalse(observed)
+        XCTAssertTrue(messages.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: supportRoot.path))
+    }
+
+    func testExistingPrototypeStoreIsReportedWithoutOpeningOrMutatingIt() throws {
+        let temporaryRoot = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+        let supportRoot = temporaryRoot.appendingPathComponent("RepoPrompt CE", isDirectory: true)
+        let databaseURL = AppDomainRuntimeComposition.prototypeAuthorityDatabaseURL(
+            applicationSupportRoot: supportRoot
+        )
+        try FileManager.default.createDirectory(
+            at: databaseURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let sentinel = Data("prototype-authority-sentinel\u{0}not-a-database".utf8)
+        try sentinel.write(to: databaseURL, options: .withoutOverwriting)
+        let expectedMetadata = try metadata(at: databaseURL)
+        var messages: [String] = []
+
+        let observed = AppDomainRuntimeComposition.reportUnusedPrototypeAuthorityStoreIfPresent(
+            applicationSupportRoot: supportRoot,
+            log: { messages.append($0) }
+        )
+        let actualMetadata = try metadata(at: databaseURL)
+
+        XCTAssertTrue(observed)
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertTrue(messages[0].contains("will not be opened or migrated"))
+        XCTAssertEqual(actualMetadata, expectedMetadata)
+        XCTAssertEqual(try Data(contentsOf: databaseURL), sentinel)
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: databaseURL.deletingLastPathComponent().appendingPathComponent("repoprompt.sqlite-wal").path
+        ))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: databaseURL.deletingLastPathComponent().appendingPathComponent("repoprompt.sqlite-shm").path
+        ))
+    }
+
+    private func makeTemporaryRoot() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DesktopAgentAuthorityRestorationTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func metadata(at url: URL) throws -> FileMetadata {
+        var value = stat()
+        guard lstat(url.path, &value) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return FileMetadata(
+            device: value.st_dev,
+            inode: value.st_ino,
+            mode: value.st_mode,
+            links: value.st_nlink,
+            user: value.st_uid,
+            group: value.st_gid,
+            size: value.st_size,
+            blocks: value.st_blocks,
+            blockSize: value.st_blksize,
+            accessSeconds: value.st_atimespec.tv_sec,
+            accessNanoseconds: value.st_atimespec.tv_nsec,
+            modificationSeconds: value.st_mtimespec.tv_sec,
+            modificationNanoseconds: value.st_mtimespec.tv_nsec,
+            statusSeconds: value.st_ctimespec.tv_sec,
+            statusNanoseconds: value.st_ctimespec.tv_nsec
+        )
+    }
+
+    private struct FileMetadata: Equatable {
+        let device: dev_t
+        let inode: ino_t
+        let mode: mode_t
+        let links: nlink_t
+        let user: uid_t
+        let group: gid_t
+        let size: off_t
+        let blocks: blkcnt_t
+        let blockSize: blksize_t
+        let accessSeconds: Int
+        let accessNanoseconds: Int
+        let modificationSeconds: Int
+        let modificationNanoseconds: Int
+        let statusSeconds: Int
+        let statusNanoseconds: Int
+    }
+}

--- a/Tests/RepoPromptTests/Prompt/WorkflowPromptCatalogTests.swift
+++ b/Tests/RepoPromptTests/Prompt/WorkflowPromptCatalogTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 @testable import RepoPromptApp
 @testable import RepoPromptShared
 import XCTest
@@ -33,6 +34,97 @@ final class WorkflowPromptCatalogTests: XCTestCase {
             ]
         )
         XCTAssertEqual(RepoPromptWorkflowID.allCases.count, 9)
+    }
+
+    func testCanonicalWorkflowIdentityAndMetadataSnapshot() {
+        XCTAssertEqual(
+            RepoPromptWorkflowID.allCases.map { "\($0.rawValue)|\($0.commandName)" },
+            [
+                "build|rp-build",
+                "investigate|rp-investigate",
+                "deepPlan|rp-deep-plan",
+                "reminder|rp-reminder",
+                "oracleExport|rp-oracle-export",
+                "review|rp-review",
+                "refactor|rp-refactor",
+                "orchestrate|rp-orchestrate",
+                "optimize|rp-optimize"
+            ]
+        )
+        XCTAssertEqual(
+            RepoPromptBuiltInAgentWorkflow.allCases.map { workflow in
+                let metadata = workflow.metadata
+                return [
+                    workflow.rawValue,
+                    workflow.canonicalID,
+                    metadata.id,
+                    metadata.displayName,
+                    metadata.iconName,
+                    metadata.tooltipText,
+                    metadata.descriptionText
+                ].joined(separator: "|")
+            },
+            [
+                "build|builtin-build|builtin-build|Plan & Build|hammer.fill|Deep-research, plan, and implement complex tasks|Researches the code, makes a plan, and implements the change step by step.",
+                "review|builtin-review|builtin-review|Review|eye.fill|Thorough code review across branches and diffs|Deeply reviews the code for subtle bugs, regressions, risks, and missed edge cases.",
+                "refactor|builtin-refactor|builtin-refactor|Refactor|arrow.triangle.2.circlepath|Analyze and improve code organization|Cleans up code structure while keeping behavior the same.",
+                "investigate|builtin-investigate|builtin-investigate|Investigate|magnifyingglass|Hypothesis-driven research with evidence gathering|Digs into bugs, crashes, security concerns, or research questions and reports the evidence.",
+                "oracleExport|builtin-oracleExport|builtin-oracleExport|ChatGPT Export|square.and.arrow.up|Export codebase context for ChatGPT analysis|Packages the right code and context into a prompt you can send to ChatGPT.",
+                "orchestrate|builtin-orchestrate|builtin-orchestrate|Orchestrate|arrow.triangle.branch|Plan, decompose, and delegate tasks across multiple agents|Breaks a complex request into smaller tasks, sends agents to do the work, and checks each result.",
+                "optimize|builtin-optimize|builtin-optimize|Optimize|speedometer|Instrument, baseline, and iteratively optimize a target metric|Finds what to measure, adds metrics, tries improvements, and uses evidence to keep iterating.",
+                "deepPlan|builtin-deepPlan|builtin-deepPlan|Deep Plan|text.book.closed.fill|Deeply research and shape a polished plan document|Researches the code, asks how hands-on you want to be, and writes a clear implementation plan."
+            ]
+        )
+    }
+
+    func testRenderedWorkflowPromptHashesStayStable() {
+        let variants: [(name: String, value: WorkflowPromptVariant)] = [
+            ("mcp", .mcp),
+            ("cli", .cli),
+            ("agent", .agent)
+        ]
+        let actual = variants.flatMap { variant in
+            RepoPromptWorkflowID.allCases.map { id in
+                let prompt = RepoPromptWorkflowPrompts.render(id: id, variant: variant.value)
+                let hash = SHA256.hash(data: Data(prompt.utf8))
+                    .map { String(format: "%02x", $0) }
+                    .joined()
+                return "\(variant.name)|\(id.rawValue)|\(hash)"
+            }
+        }
+
+        XCTAssertEqual(
+            actual,
+            [
+                "mcp|build|4ee7d6c30ed78693d06d6bb30daa6f637246fbb6f07751705ec8fefe4e506ea4",
+                "mcp|investigate|98d70868c950d4f5843fe4a5fb3c7c7c6a61b1c18bedb0dd1e1147af45f531f7",
+                "mcp|deepPlan|f6f72bb8873ebb032e98eb424690be05a1d00a1b58fd1152459c74c05f4897d1",
+                "mcp|reminder|a14a016e035ed958cadfa65a9bb6f8c1d5967c542e5c5b30b253064163c64d26",
+                "mcp|oracleExport|93481eee50e79ef13cf1abc0a004741555ac33e1a5573bbac2054d7f8754180f",
+                "mcp|review|23c727c32604a1020a4d505134cb72a56fa5ad1ed1f49ef94a0bfde8da32bb78",
+                "mcp|refactor|f86326cf57a8906e944f94a086786fedbe8b0a17f252be0094ac3ca75f63e900",
+                "mcp|orchestrate|5d596e445dd6ce25c96d816ea1f277b815f1100686ae7d1d26ab9bd31ca721c1",
+                "mcp|optimize|362c8ac7014271ccabca7dff1fb669df9e03aa0d64c981fd028e02414b069655",
+                "cli|build|f0ac0a053268851aff51052972cd6404f77fb0c186cb47cee2a758fbcf391c80",
+                "cli|investigate|d4e9b590132b2ccf00d5a4d795d83313d16a33c66395719af463fb8035e18252",
+                "cli|deepPlan|0ecd7922dbaef2e7aa9aa4de036c82b5c5e18fde70bff1f5a0bdf9afd9953d37",
+                "cli|reminder|6e615c32cbdfcd61026f3fdca48ac554f9c73c3b017cc04724f669014ae536a4",
+                "cli|oracleExport|f4a8e8d75f90c7bf4873d6323af4a545f8422f2dd204b499ec218d33f8f608ed",
+                "cli|review|1c7ecffeb88adeeb598cc5da35138745280830b7040708908b85900f79bf5240",
+                "cli|refactor|293fe063a4d48fccacc9df59c6a626f0dafe48dfe90f2fbc400f5addc66c9bab",
+                "cli|orchestrate|ae7c6e3bc9da37295dabb9cb5db1144072e7c31d2d4e93a4e003f680b9cd45b9",
+                "cli|optimize|31fb5586e559c2f13f585c1bb9060baf2044f1abc20d748e3aac525baa220463",
+                "agent|build|d2e6ca699d75f5a39050cb48be741c75512d00f4ffa7461d8bb0fb3c568f6307",
+                "agent|investigate|f03aa1a084b00ce71073d8bd1b859e790a625a7f5865949bc65ba11195885d13",
+                "agent|deepPlan|70c4017281caa13c0a5aac4914da80d6fc91bd8e859982faf6c3ded1e07888ed",
+                "agent|reminder|da0b1656bb1b27addf0aaddfb06322fcb91a302261bfeec14b81868676d5977d",
+                "agent|oracleExport|a750d5ac89793b7a6fad9c2c6d44673d43ea43a37f97aa3aa64cdc9aedabc4bb",
+                "agent|review|121322a42f19768b79d30e1a88103b9220cf5f93e7f52585187869d3f2cf0e3e",
+                "agent|refactor|c931e3e71f80c2af12ed98ea70968c6571b69b787860d133015f1a0639a09db8",
+                "agent|orchestrate|03660b79b7a807da6541e10f45ed6d85168f800e27836c16faa01c337b04991a",
+                "agent|optimize|9977840e1013fc91e829b6e75f5690204c56a253d63fedb808c72e08cebba022"
+            ]
+        )
     }
 
     func testCatalogMetadataMatchesWorkflowIDs() {

--- a/docs/architecture/desktop-agent-authority.md
+++ b/docs/architecture/desktop-agent-authority.md
@@ -1,0 +1,76 @@
+# Desktop Agent Mode authority boundary
+
+**Status:** Accepted
+**Date:** 2026-08-19
+
+## Context
+
+The Server prototype experimented with constructing a durable headless authority and SQLite store inside the macOS app. That cutover created a second owner for Desktop Agent Mode lifecycle and app-backed MCP state without a supported Desktop migration, recovery, or operational contract.
+
+The established Desktop implementation already has complete owners for these responsibilities:
+
+- `AgentModeViewModel` delegates run control to `AgentModeRunService`.
+- The integrated Codex, Claude-compatible, ACP, and headless runners own provider launch and cancellation.
+- `AgentRunTerminalCommitBarrier` settles terminal session-local lifecycle state.
+- `AgentTabSession.runLifecycle` identifies the active Desktop run attempt.
+- `AppGlobalMCPServiceComposition`, `MCPServerViewModel`, `ServerController`, `AgentManageMCPToolService`, and `AgentRunSessionStore` project live and persisted Desktop sessions to app-backed MCP.
+
+The Server work is being reconstructed from current upstream in later boundary-focused changes. Prototype code is evidence, not a commit sequence or an authority over Desktop behavior.
+
+## Decision
+
+Desktop remains a non-durable, app-owned Agent Mode authority.
+
+Desktop production code must not:
+
+- construct `RepoPromptHeadlessAuthority`;
+- open a Server or direct-headless SQLite authority store;
+- route provider control through an authority snapshot/provider closure;
+- project Server authority epochs into app-backed MCP wait identity; or
+- write both Desktop session state and a Server authority store.
+
+Provider start, steer, follow-up, interaction, permission, worktree, cancellation, and terminal settlement continue through their existing integrated Desktop owners. App-backed MCP continues resolving live Desktop sessions first and persisted Desktop sessions second. The public direct-headless MCP behavior is unchanged by this decision.
+
+## Prototype store preservation
+
+The removed prototype used:
+
+```text
+~/Library/Application Support/RepoPrompt CE/AgentAuthority/repoprompt.sqlite
+```
+
+If that file exists, Desktop emits one process-start diagnostic stating that the unused store was preserved. Desktop does not open, migrate, import, move, truncate, or delete the file, and does not create the directory when it is absent. There is no automatic Desktop-to-Server state adoption path.
+
+This preserves potential recovery evidence without making an unsupported prototype store authoritative for either product.
+
+## Contract freeze
+
+The restoration baseline freezes:
+
+- the canonical 27-tool MCP fixture;
+- workflow raw IDs, command names, MCP/install order, built-in canonical IDs, metadata, and rendered prompt hashes;
+- Desktop provider and model raw values/order plus stored-value round trips; and
+- Desktop settings schema identity, defaults, and stored Agent Models raw-value round trips.
+
+A package move or Server extraction must have zero semantic diff at these boundaries. An intentional MCP fixture change requires a human-readable compatibility diff and the repository's designated Desktop/MCP approvals.
+
+## Consequences
+
+- Desktop preserves the established integrated runner and app-backed MCP behavior.
+- Existing Desktop workspace, compose-tab, selection, prompt, provider/model, and settings state is not migrated.
+- The prototype SQLite file may remain orphaned on disk by design.
+- Later Server work must establish its own compile-isolated host, namespace ownership, persistence, recovery, and operational contracts without importing those choices into Desktop.
+- A future Desktop durability proposal requires a separate migration and product decision; it is not an incidental consequence of Server extraction.
+
+## Validation boundary
+
+The owning validation is the smallest coordinated Desktop/MCP batch covering:
+
+- Desktop app and public MCP product builds;
+- representative integrated-runner lifecycle and terminal-barrier behavior;
+- app-backed MCP registration/wait identity;
+- prototype-store non-creation and sentinel immutability;
+- canonical MCP fixture parity; and
+- workflow, provider/model, and settings snapshots.
+
+Visible app launch or shutdown is not required for this boundary.


### PR DESCRIPTION
## Scope

Implements PR 1 only from the Server upstreaming plan: freeze the current Desktop/MCP contracts and preserve the established non-durable Desktop Agent Mode authority boundary before any Server extraction.

- Keeps provider start/cancel/terminal settlement on `AgentModeRunService`, the integrated Codex/Claude-compatible/ACP/headless runners, and `AgentRunTerminalCommitBarrier`.
- Keeps app-backed MCP on live/persisted Desktop sessions and the existing `AgentRunSessionStore` wait identity.
- Adds a read-only startup diagnostic for the orphaned prototype store at `~/Library/Application Support/RepoPrompt CE/AgentAuthority/repoprompt.sqlite` without opening, creating, migrating, moving, or deleting it.
- Adds sentinel byte/metadata preservation coverage.
- Freezes workflow IDs/order/metadata and all rendered prompt variants, Desktop provider/model identities and raw-value round trips, and Desktop settings schema/default/raw-value contracts.
- Records the Desktop deferral and later Server reconstruction boundary in an architecture decision record.
- Adds the durable ADR to the repository documentation allowlist.

No Server package extraction, packaging change, SQLite authority change, direct-headless behavior change, or Desktop state migration is included.

## Contract result

- Canonical `Tests/Fixtures/AgentParity/v1` diff: **empty**.
- Forbidden Desktop authority-symbol grep under `Sources/RepoPrompt`: **empty**.
- No `RepoPromptHeadlessAuthority` construction or Server SQLite owner exists under Desktop production sources.

## Validation

- `make dev-format` — passed (0 files required formatting)
- `make dev-lint` — passed
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `make dev-swift-build PRODUCT=repoprompt-mcp` — passed
- Coordinated focused batch — passed:
  - `AppDomainRuntimeCompositionTests`
  - `DesktopAgentAuthorityRestorationTests`
  - `AgentModeRunServiceLifecycleTests`
  - `AgentRunSessionStoreRegistrationTests`
  - `HeadlessMCPDomainRuntimeM0ContractTests`
  - `DirectHeadlessCompositionTests`
  - `WorkflowPromptCatalogTests`
  - `ModelPickerStringOrderingTests`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit` — passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` — passed; outgoing range `upstream/main..HEAD`, one commit, no leaks

The visible app was not launched, stopped, or relaunched.

## Publication sequence

This is the first of six planned draft PRs. Later draft PRs will be based on their predecessor and will therefore be cumulative until earlier PRs merge; each later Server-upstreaming slice remains separate work.
