### PR TITLE
Add session ID copying to Agent Mode sidebar menus

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -25,6 +25,7 @@ extension AgentModeViewModel {
         let filteredTabs: [StashedTab]
         let sortedTabs: [StashedTab]
         let dateInfoByStashedTabID: [UUID: SidebarSessionDateInfo]
+        let sessionIDByStashedTabID: [UUID: UUID]
     }
 
     struct ArchivedHUDSessionDescriptor {
@@ -32,6 +33,11 @@ extension AgentModeViewModel {
         let entry: AgentSessionIndexEntry?
         let dateInfo: SidebarSessionDateInfo
         let searchFields: AgentSessionSearchFields
+    }
+
+    private struct ArchivedSidebarSessionMetadata {
+        let dateInfoByStashedTabID: [UUID: SidebarSessionDateInfo]
+        let sessionIDByStashedTabID: [UUID: UUID]
     }
 
     private struct ArchivedSidebarSessionLookup {
@@ -172,12 +178,40 @@ extension AgentModeViewModel {
         for stashedTab: StashedTab,
         lookup: ArchivedSidebarSessionLookup
     ) -> SidebarSessionDateInfo {
-        let entry = lookup.explicitEntry(for: stashedTab.tab.activeAgentSessionID)
-            ?? preferredArchivedSidebarEntry(for: stashedTab.tab.id, tabName: stashedTab.tab.name, lookup: lookup)
+        archivedSessionDateInfo(
+            for: stashedTab,
+            entry: archivedSidebarEntry(for: stashedTab, lookup: lookup)
+        )
+    }
 
-        return SidebarSessionDateInfo(
+    private func archivedSessionDateInfo(
+        for stashedTab: StashedTab,
+        entry: AgentSessionIndexEntry?
+    ) -> SidebarSessionDateInfo {
+        SidebarSessionDateInfo(
             lastEngagementAt: entry?.lastUserMessageAt,
             activityDate: entry.map(AgentSessionRestoreSupport.sidebarActivityDate(for:)) ?? stashedTab.tab.lastModified
+        )
+    }
+
+    private func archivedSidebarSessionMetadata(
+        for stashedTabs: [StashedTab],
+        lookup: ArchivedSidebarSessionLookup
+    ) -> ArchivedSidebarSessionMetadata {
+        var dateInfoByStashedTabID: [UUID: SidebarSessionDateInfo] = [:]
+        var sessionIDByStashedTabID: [UUID: UUID] = [:]
+        dateInfoByStashedTabID.reserveCapacity(stashedTabs.count)
+        sessionIDByStashedTabID.reserveCapacity(stashedTabs.count)
+
+        for stashedTab in stashedTabs {
+            let entry = archivedSidebarEntry(for: stashedTab, lookup: lookup)
+            dateInfoByStashedTabID[stashedTab.id] = archivedSessionDateInfo(for: stashedTab, entry: entry)
+            sessionIDByStashedTabID[stashedTab.id] = stashedTab.tab.activeAgentSessionID ?? entry?.id
+        }
+
+        return ArchivedSidebarSessionMetadata(
+            dateInfoByStashedTabID: dateInfoByStashedTabID,
+            sessionIDByStashedTabID: sessionIDByStashedTabID
         )
     }
 
@@ -197,20 +231,22 @@ extension AgentModeViewModel {
             return ArchivedSidebarSessionTabsSnapshot(
                 filteredTabs: filteredTabs,
                 sortedTabs: [],
-                dateInfoByStashedTabID: [:]
+                dateInfoByStashedTabID: [:],
+                sessionIDByStashedTabID: [:]
             )
         }
-        let dateInfoByID = archivedSessionDateInfoByID(for: filteredTabs, lookup: lookup)
+        let metadata = archivedSidebarSessionMetadata(for: filteredTabs, lookup: lookup)
         let sortedTabs = sortedFilteredArchivedSessionTabs(
             filteredTabs,
             diagnosticInputStashedCount: stashedTabs.count,
             diagnosticSearchActive: !trimmedSearch.isEmpty,
-            dateInfoByID: dateInfoByID
+            dateInfoByID: metadata.dateInfoByStashedTabID
         )
         return ArchivedSidebarSessionTabsSnapshot(
             filteredTabs: filteredTabs,
             sortedTabs: sortedTabs,
-            dateInfoByStashedTabID: dateInfoByID
+            dateInfoByStashedTabID: metadata.dateInfoByStashedTabID,
+            sessionIDByStashedTabID: metadata.sessionIDByStashedTabID
         )
     }
 
@@ -599,6 +635,7 @@ extension AgentModeViewModel {
             archivedSessionTabsForHeader: archivedSessionTabs.filteredTabs,
             pagedArchivedSessionTabsForRows: pagedArchivedTabs,
             archivedDateInfoByStashedTabID: archivedSessionTabs.dateInfoByStashedTabID,
+            archivedSessionIDByStashedTabID: archivedSessionTabs.sessionIDByStashedTabID,
             defaultCollapseSeedKeys: defaultCollapsedSidebarThreadKeys(
                 in: canonicalRows,
                 searchText: sidebarSnapshot.searchText

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -207,6 +207,7 @@ extension AgentModeViewModel {
         let archivedSessionTabsForHeader: [StashedTab]
         let pagedArchivedSessionTabsForRows: [StashedTab]
         let archivedDateInfoByStashedTabID: [UUID: SidebarSessionDateInfo]
+        let archivedSessionIDByStashedTabID: [UUID: UUID]
         let defaultCollapseSeedKeys: [AgentSidebarThreadKey]
         let renderedSelectionOrder: [AgentSidebarSelectionIdentity]
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -42,6 +42,7 @@ struct AgentSessionRow: View {
     let onDelete: () -> Void
     let onRename: (String) -> Void
     var onDismissAttention: (() -> Void)?
+    let sessionIDCopyAction: AgentSidebarSessionIDCopyAction
 
     @State private var isHovered = false
     @State private var isPinHovered = false
@@ -311,6 +312,11 @@ struct AgentSessionRow: View {
                 Button(pinActionLabel, action: onTogglePin)
 
                 Button(renameActionLabel, action: beginRename)
+
+                Button(AgentSidebarSessionIDCopyAction.menuTitle) {
+                    sessionIDCopyAction.perform()
+                }
+                .disabled(!sessionIDCopyAction.isEnabled)
 
                 if let onStash {
                     Button(stashActionLabel, action: onStash)
@@ -752,6 +758,7 @@ struct AgentStashedSessionRow: View {
     let onSelectionGesture: (AgentSidebarSelectionGesture) -> AgentSidebarSelectionGestureDisposition
     let onRestore: () -> Void
     let onDelete: () -> Void
+    let sessionIDCopyAction: AgentSidebarSessionIDCopyAction
 
     @State private var isHovered = false
     @State private var isRestoreHovered = false
@@ -897,6 +904,10 @@ struct AgentStashedSessionRow: View {
                 Button("Select chat", action: toggleSelection)
                 Divider()
                 Button(restoreActionLabel, action: onRestore)
+                Button(AgentSidebarSessionIDCopyAction.menuTitle) {
+                    sessionIDCopyAction.perform()
+                }
+                .disabled(!sessionIDCopyAction.isEnabled)
                 Divider()
                 Button(deleteActionLabel, role: .destructive, action: onDelete)
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -525,7 +525,8 @@ struct AgentModeSessionsListView: View {
                                         guard agentModeVM.workspaceManager?.activeWorkspaceID == snapshot.workspaceID else { return }
                                         agentModeVM.renameSession(tabID: session.tabID, to: newName)
                                     },
-                                    onDismissAttention: dismissAttentionAction
+                                    onDismissAttention: dismissAttentionAction,
+                                    sessionIDCopyAction: .systemClipboard(sessionID: session.sessionID)
                                 )
                             }
                         }
@@ -1148,7 +1149,10 @@ struct ArchivedSessionsList: View {
                                 await promptManager.unstashTab(stashed.id)
                             }
                         },
-                        onDelete: { deleteArchived(stashed) }
+                        onDelete: { deleteArchived(stashed) },
+                        sessionIDCopyAction: .systemClipboard(
+                            sessionID: stashed.tab.activeAgentSessionID
+                        )
                     )
                 }
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -631,6 +631,7 @@ struct AgentModeSessionsListView: View {
                                     hasMore: snapshot.hasMoreArchivedSessions,
                                     remainingCount: snapshot.remainingArchivedSessionCount,
                                     dateInfoByStashedTabID: snapshot.archivedDateInfoByStashedTabID,
+                                    sessionIDByStashedTabID: snapshot.archivedSessionIDByStashedTabID,
                                     workspaceID: snapshot.workspaceID,
                                     selectionState: selectionState,
                                     renderedOrder: snapshot.renderedSelectionOrder,
@@ -1085,6 +1086,7 @@ struct ArchivedSessionsList: View {
     let hasMore: Bool
     let remainingCount: Int
     let dateInfoByStashedTabID: [UUID: AgentModeViewModel.SidebarSessionDateInfo]
+    let sessionIDByStashedTabID: [UUID: UUID]
     let workspaceID: UUID?
     let selectionState: AgentSidebarSelectionState
     let renderedOrder: [AgentSidebarSelectionIdentity]
@@ -1151,7 +1153,7 @@ struct ArchivedSessionsList: View {
                         },
                         onDelete: { deleteArchived(stashed) },
                         sessionIDCopyAction: .systemClipboard(
-                            sessionID: stashed.tab.activeAgentSessionID
+                            sessionID: sessionIDByStashedTabID[stashed.id]
                         )
                     )
                 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSidebarSessionIDCopyAction.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSidebarSessionIDCopyAction.swift
@@ -1,0 +1,43 @@
+import AppKit
+
+/// Sidebar row action that copies a persistent Agent Mode session UUID to the clipboard.
+///
+/// Owns optional-UUID enablement and exact single-write clipboard semantics for the
+/// `Copy session ID` command in active, sub-agent, and archived sidebar row context menus.
+@MainActor
+struct AgentSidebarSessionIDCopyAction {
+    typealias ClipboardWriter = @MainActor (String) -> Void
+
+    static let menuTitle = "Copy session ID"
+
+    private let sessionID: UUID?
+    private let clipboardWriter: ClipboardWriter
+
+    init(
+        sessionID: UUID?,
+        clipboardWriter: @escaping ClipboardWriter
+    ) {
+        self.sessionID = sessionID
+        self.clipboardWriter = clipboardWriter
+    }
+
+    var isEnabled: Bool {
+        sessionID != nil
+    }
+
+    func perform() {
+        guard let sessionID else { return }
+        clipboardWriter(sessionID.uuidString)
+    }
+
+    static func systemClipboard(sessionID: UUID?) -> Self {
+        AgentSidebarSessionIDCopyAction(
+            sessionID: sessionID,
+            clipboardWriter: { value in
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(value, forType: .string)
+            }
+        )
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -821,6 +821,72 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertEqual(searched.renderedSelectionOrder.count, 25)
     }
 
+    func testArchivedCopyUsesIndexSessionIDWhenStoredBindingIsMissing() {
+        let viewModel = makeViewModel()
+        let activeTab = ComposeTabState(id: UUID(), name: "Active")
+        let archivedTabID = UUID()
+        let stashedTab = StashedTab(
+            tab: ComposeTabState(
+                id: archivedTabID,
+                name: "Archived",
+                activeAgentSessionID: nil
+            )
+        )
+        var workspace = makeWorkspace(name: "Archived copy", tabs: [activeTab], activeTabID: activeTab.id)
+        workspace.stashedTabs = [stashedTab]
+        let manager = makeWorkspaceManager(workspaces: [workspace])
+        manager.activeWorkspace = workspace
+        viewModel.workspaceManager = manager
+
+        let indexSessionID = UUID()
+        let entry = makeIndexEntry(
+            id: indexSessionID,
+            tabID: archivedTabID,
+            lastUserMessageAt: Date(timeIntervalSince1970: 1)
+        )
+        let owner = AgentModeViewModel.SessionIndexOwner(workspaceID: workspace.id, activationEpoch: 1)
+        viewModel.test_installSessionIndexSnapshot(
+            [entry.id: entry],
+            owner: owner,
+            latestOwner: owner,
+            activeWorkspace: workspace
+        )
+
+        let collapsedProjection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: [activeTab],
+            stashedTabs: [stashedTab],
+            currentTabID: activeTab.id,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: false,
+            showComposeTabsWithoutAgentSessions: false
+        )
+        XCTAssertTrue(collapsedProjection.pagedArchivedSessionTabsForRows.isEmpty)
+        XCTAssertTrue(collapsedProjection.archivedSessionIDByStashedTabID.isEmpty)
+
+        let projection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: [activeTab],
+            stashedTabs: [stashedTab],
+            currentTabID: activeTab.id,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
+        )
+        var writtenValues: [String] = []
+        let action = AgentSidebarSessionIDCopyAction(
+            sessionID: projection.archivedSessionIDByStashedTabID[stashedTab.id],
+            clipboardWriter: { writtenValues.append($0) }
+        )
+
+        XCTAssertEqual(projection.pagedArchivedSessionTabsForRows.map(\.id), [stashedTab.id])
+        XCTAssertTrue(action.isEnabled)
+
+        action.perform()
+
+        XCTAssertEqual(writtenValues, [indexSessionID.uuidString])
+    }
+
     func testSidebarListProjectionMemoizesWithinExplicitRenderGeneration() throws {
         let viewModel = makeViewModel()
         let composeTabs = (0 ..< 400).map { index in

--- a/Tests/RepoPromptTests/AgentMode/AgentSidebarSessionIDCopyActionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSidebarSessionIDCopyActionTests.swift
@@ -1,0 +1,116 @@
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class AgentSidebarSessionIDCopyActionTests: XCTestCase {
+    func testIsEnabledWhenSessionIDIsPresent() throws {
+        let sessionID = try XCTUnwrap(UUID(uuidString: "12345678-1234-1234-1234-123456789ABC"))
+        let action = AgentSidebarSessionIDCopyAction(
+            sessionID: sessionID,
+            clipboardWriter: { _ in }
+        )
+
+        XCTAssertTrue(action.isEnabled)
+    }
+
+    func testPerformWritesExactRawUUIDOnceWithoutPrefixOrWhitespace() throws {
+        let sessionID = try XCTUnwrap(UUID(uuidString: "0A1B2C3D-4E5F-6071-8293-A4B5C6D7E8F9"))
+        var writtenValues: [String] = []
+        let action = AgentSidebarSessionIDCopyAction(
+            sessionID: sessionID,
+            clipboardWriter: { writtenValues.append($0) }
+        )
+
+        action.perform()
+
+        XCTAssertEqual(writtenValues, [sessionID.uuidString])
+    }
+
+    func testNilSessionIDIsDisabledAndPerformsNoWrite() {
+        var writtenValues = ["sentinel"]
+        let action = AgentSidebarSessionIDCopyAction(
+            sessionID: nil,
+            clipboardWriter: { writtenValues.append($0) }
+        )
+
+        XCTAssertFalse(action.isEnabled)
+
+        action.perform()
+
+        XCTAssertEqual(writtenValues, ["sentinel"])
+    }
+
+    func testActiveArchivedAndSubagentRowsUseSharedSessionIDCopyAction() throws {
+        let rootSessionID = try XCTUnwrap(UUID(uuidString: "11111111-1111-1111-1111-111111111111"))
+        let subagentSessionID = try XCTUnwrap(UUID(uuidString: "22222222-2222-2222-2222-222222222222"))
+        let archivedSessionID = try XCTUnwrap(UUID(uuidString: "33333333-3333-3333-3333-333333333333"))
+        var rootWrites: [String] = []
+        var subagentWrites: [String] = []
+        var archivedWrites: [String] = []
+
+        let rootRow = makeActiveRow(
+            threadDepth: 0,
+            sessionIDCopyAction: AgentSidebarSessionIDCopyAction(
+                sessionID: rootSessionID,
+                clipboardWriter: { rootWrites.append($0) }
+            )
+        )
+        let subagentRow = makeActiveRow(
+            threadDepth: 1,
+            sessionIDCopyAction: AgentSidebarSessionIDCopyAction(
+                sessionID: subagentSessionID,
+                clipboardWriter: { subagentWrites.append($0) }
+            )
+        )
+        let archivedRow = makeArchivedRow(
+            sessionID: archivedSessionID,
+            sessionIDCopyAction: AgentSidebarSessionIDCopyAction(
+                sessionID: archivedSessionID,
+                clipboardWriter: { archivedWrites.append($0) }
+            )
+        )
+
+        rootRow.sessionIDCopyAction.perform()
+        subagentRow.sessionIDCopyAction.perform()
+        archivedRow.sessionIDCopyAction.perform()
+
+        XCTAssertEqual(rootWrites, ["11111111-1111-1111-1111-111111111111"])
+        XCTAssertEqual(subagentWrites, ["22222222-2222-2222-2222-222222222222"])
+        XCTAssertEqual(archivedWrites, ["33333333-3333-3333-3333-333333333333"])
+    }
+
+    private func makeActiveRow(
+        threadDepth: Int,
+        sessionIDCopyAction: AgentSidebarSessionIDCopyAction
+    ) -> AgentSessionRow {
+        AgentSessionRow(
+            title: "Session",
+            isActive: false,
+            isPinned: false,
+            isMCPControlled: false,
+            runState: .idle,
+            threadDepth: threadDepth,
+            onSelectionGesture: { _ in .ignored },
+            onSelect: {},
+            onTogglePin: {},
+            onDelete: {},
+            onRename: { _ in },
+            sessionIDCopyAction: sessionIDCopyAction
+        )
+    }
+
+    private func makeArchivedRow(
+        sessionID: UUID,
+        sessionIDCopyAction: AgentSidebarSessionIDCopyAction
+    ) -> AgentStashedSessionRow {
+        AgentStashedSessionRow(
+            stashed: StashedTab(
+                tab: ComposeTabState(activeAgentSessionID: sessionID)
+            ),
+            onSelectionGesture: { _ in .ignored },
+            onRestore: {},
+            onDelete: {},
+            sessionIDCopyAction: sessionIDCopyAction
+        )
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentSidebarSessionIDCopyActionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSidebarSessionIDCopyActionTests.swift
@@ -40,7 +40,7 @@ final class AgentSidebarSessionIDCopyActionTests: XCTestCase {
         XCTAssertEqual(writtenValues, ["sentinel"])
     }
 
-    func testActiveArchivedAndSubagentRowsUseSharedSessionIDCopyAction() throws {
+    func testRowsExposeInjectedSessionIDCopyAction() throws {
         let rootSessionID = try XCTUnwrap(UUID(uuidString: "11111111-1111-1111-1111-111111111111"))
         let subagentSessionID = try XCTUnwrap(UUID(uuidString: "22222222-2222-2222-2222-222222222222"))
         let archivedSessionID = try XCTUnwrap(UUID(uuidString: "33333333-3333-3333-3333-333333333333"))


### PR DESCRIPTION
## Summary

Agent Mode sidebar context menus can now copy the raw persistent session UUID for active, archived, and sub-agent chats. The command stays visible but disabled when a row has no persistent session ID.

## Changes

- Add one shared clipboard action that owns enablement and writes the exact UUID once.
- Place `Copy session ID` after rename for active and sub-agent chats, and after restore for archived chats.
- Cover raw clipboard output, missing IDs, and reuse across all three row types.

## Testing

- `./conductor test --filter AgentSidebarSessionIDCopyActionTests`
- `./conductor lint`
- `./conductor guardrails`
- `./conductor swift-build --product RepoPrompt`

The full `./conductor test` run did not complete cleanly. It reported failures outside this feature in Codex managed-auth and configuration tests and Context Builder tests, then stopped producing output in `WorkspaceSwitchRecoveryTests`. The job was canceled after 18 minutes so the focused test and product build could run.

Closes #842

## Screenshot

<img width="400" height="386" alt="image" src="https://github.com/user-attachments/assets/259a9887-9ba9-420b-9b9c-9cb114482eda" />

