### PR TITLE
Drain leftover Grok ACP stdout after session/prompt, Grok-only

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -239,6 +239,7 @@ actor ACPAgentSessionController {
     private var stdoutConsumerTask: Task<Void, Never>?
     private var stderrConsumerTask: Task<Void, Never>?
     private var processWaitTask: Task<Void, Never>?
+    private var isDrainingTransport = false
     private var stdoutFramer = LineFramer()
     private var stderrFramer = LineFramer()
     private var launchDescription: String?
@@ -1172,31 +1173,80 @@ actor ACPAgentSessionController {
         }
     }
 
+    func prepareForPromptTransportDrain() {
+        isDrainingTransport = true
+    }
+
     func shutdown() async {
+        _ = await shutdown(drainTransport: false)
+    }
+
+    /// Shuts down a completed one-shot prompt without discarding bytes that become
+    /// readable while the ACP process responds to stdin closure.
+    ///
+    /// Returns `true` only when the process and its transport settle cooperatively
+    /// before the bounded timeout. Forced termination discards bytes still buffered
+    /// in the pipes and cannot prove that the provider finished writing the response.
+    func shutdownAfterPromptTransportDrain() async -> Bool {
+        await shutdown(drainTransport: true)
+    }
+
+    private func shutdown(drainTransport: Bool) async -> Bool {
         #if DEBUG
             debugResumeConfigurationMutationPostcheck()
         #endif
-        guard state != .closed, state != .closing else { return }
+        guard state != .closed, state != .closing else { return false }
         state = .closing
+        isDrainingTransport = drainTransport
         log("Shutting down ACP controller")
 
         await cancelPrompt()
         failAllPromptSettlementWaiters(with: ControllerError.transportClosed)
         failPendingRequests(with: ControllerError.transportClosed)
 
-        stdoutChannel?.finish()
-        stderrChannel?.finish()
-        stdoutConsumerTask?.cancel()
-        stderrConsumerTask?.cancel()
-        processWaitTask?.cancel()
-
-        if let process {
-            process.stdout.readabilityHandler = nil
-            process.stderr.readabilityHandler = nil
+        var transportSettled = !drainTransport
+        if drainTransport, let process {
             process.stdin?.closeFile()
-            _ = await ProcessTermination.terminateAndReap(pid: process.pid, processGroupID: process.processGroupID)
+            transportSettled = await waitForTransportSettlementDuringDrain()
+            if transportSettled {
+                stdoutFramer.flush { lineData in
+                    handleJSONLine(lineData)
+                }
+                stderrFramer.flush { lineData in
+                    handleStderrLine(lineData)
+                }
+            } else {
+                process.stdout.readabilityHandler = nil
+                process.stderr.readabilityHandler = nil
+                stdoutChannel?.finish()
+                stderrChannel?.finish()
+                stdoutConsumerTask?.cancel()
+                stderrConsumerTask?.cancel()
+                processWaitTask?.cancel()
+                _ = await ProcessTermination.terminateAndReap(
+                    pid: process.pid,
+                    processGroupID: process.processGroupID
+                )
+            }
+        } else {
+            stdoutChannel?.finish()
+            stderrChannel?.finish()
+            stdoutConsumerTask?.cancel()
+            stderrConsumerTask?.cancel()
+            processWaitTask?.cancel()
+
+            if let process {
+                process.stdout.readabilityHandler = nil
+                process.stderr.readabilityHandler = nil
+                process.stdin?.closeFile()
+                _ = await ProcessTermination.terminateAndReap(
+                    pid: process.pid,
+                    processGroupID: process.processGroupID
+                )
+            }
         }
 
+        isDrainingTransport = false
         await clearExpectedAgentPIDIfNeeded()
         await cleanupLaunchArtifacts()
 
@@ -1219,6 +1269,39 @@ actor ACPAgentSessionController {
         suppressSessionLoadReplayUpdates = false
         state = .closed
         finishEventsIfNeeded()
+        return transportSettled
+    }
+
+    private func waitForTransportSettlementDuringDrain() async -> Bool {
+        guard let processWaitTask,
+              let stdoutConsumerTask,
+              let stderrConsumerTask
+        else { return false }
+        let timeout = ProcessTermination.cooperativeCancellationWaitTimeout()
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await processWaitTask.value
+                await stdoutConsumerTask.value
+                await stderrConsumerTask.value
+                return true
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                } catch {
+                    return false
+                }
+                return false
+            }
+            let settled = await group.next() ?? false
+            if !settled {
+                processWaitTask.cancel()
+                stdoutConsumerTask.cancel()
+                stderrConsumerTask.cancel()
+            }
+            group.cancelAll()
+            return settled
+        }
     }
 
     // MARK: - Transport
@@ -1284,20 +1367,24 @@ actor ACPAgentSessionController {
 
     private func handleStderrChunk(_ data: Data) {
         stderrFramer.feed(data) { lineData in
-            guard
-                let trimmed = trimmedASCIIWhitespace(lineData),
-                let rawText = String(data: trimmed, encoding: .utf8),
-                !rawText.isEmpty
-            else { return }
-            let text = Self.strippingANSIEscapeSequences(from: rawText)
-            guard !text.isEmpty else { return }
-            stderrLineCount += 1
-            lastStderrPreview = Self.truncatedDiagnosticPreview(text)
-            recordActivePromptStderrLine(text)
-            diagnose(.stderrLine(text))
-            guard provider.shouldEmitStderrLine(text) else { return }
-            emit(.stream(AIStreamResult(type: "system", text: text)))
+            handleStderrLine(lineData)
         }
+    }
+
+    private func handleStderrLine(_ lineData: Data) {
+        guard
+            let trimmed = trimmedASCIIWhitespace(lineData),
+            let rawText = String(data: trimmed, encoding: .utf8),
+            !rawText.isEmpty
+        else { return }
+        let text = Self.strippingANSIEscapeSequences(from: rawText)
+        guard !text.isEmpty else { return }
+        stderrLineCount += 1
+        lastStderrPreview = Self.truncatedDiagnosticPreview(text)
+        recordActivePromptStderrLine(text)
+        diagnose(.stderrLine(text))
+        guard provider.shouldEmitStderrLine(text) else { return }
+        emit(.stream(AIStreamResult(type: "system", text: text)))
     }
 
     /// CLI providers log with terminal colors; ANSI escape sequences would render as raw
@@ -1555,8 +1642,13 @@ actor ACPAgentSessionController {
     }
 
     private func handleProcessExit(_ exitCode: Int32, timedOut: Bool) async {
+        if isDrainingTransport, didEmitTerminal {
+            return
+        }
         guard state != .closing, state != .closed else {
-            finishEventsIfNeeded()
+            if !isDrainingTransport {
+                finishEventsIfNeeded()
+            }
             return
         }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/AIQueriesService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIQueriesService.swift
@@ -330,6 +330,16 @@ public class AIQueriesService {
         return trimmed.hasPrefix("**") || trimmed.contains("****")
     }
 
+    static func assistantText(for result: AIStreamResult) -> String? {
+        guard result.type == "content" || result.type == "final_content",
+              let text = result.text,
+              !text.isEmpty
+        else {
+            return nil
+        }
+        return text
+    }
+
     static func transportActivityOutput(for result: AIStreamResult) -> ChatStreamOutput? {
         guard result.type == AIStreamResult.transportActivityType else { return nil }
         return ChatStreamOutput(
@@ -454,7 +464,7 @@ public class AIQueriesService {
 
                             var shouldYield = false
 
-                            if let text = result.text, !text.isEmpty {
+                            if let text = Self.assistantText(for: result) {
                                 let yieldText = await self.taskManager.bufferChunk(
                                     text,
                                     for: taskId,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ACPHeadlessAgentProviderBridge.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ACPHeadlessAgentProviderBridge.swift
@@ -12,6 +12,11 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
         case acceptForSession
     }
 
+    enum PromptCompletion {
+        case shutdownImmediately
+        case drainTransportBeforeShutdown
+    }
+
     typealias ProviderFactory = () async throws -> any ACPAgentProvider
     typealias RequestFactory = (_ message: AgentMessage, _ runID: UUID) -> ACPRunRequest
     typealias ControllerFactory = (
@@ -27,6 +32,7 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
     private let makeController: ControllerFactory
     private let beforePrompt: BeforePrompt
     private let approvalPolicy: ApprovalPolicy
+    private let promptCompletion: PromptCompletion
     private let lifecycle = ACPHeadlessProviderLifecycle()
 
     init(
@@ -35,7 +41,8 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
         makeRequest: @escaping RequestFactory,
         makeController: @escaping ControllerFactory,
         beforePrompt: @escaping BeforePrompt = { _, _ in },
-        approvalPolicy: ApprovalPolicy
+        approvalPolicy: ApprovalPolicy,
+        promptCompletion: PromptCompletion = .shutdownImmediately
     ) {
         self.providerName = providerName
         self.makeProvider = makeProvider
@@ -43,6 +50,7 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
         self.makeController = makeController
         self.beforePrompt = beforePrompt
         self.approvalPolicy = approvalPolicy
+        self.promptCompletion = promptCompletion
     }
 
     func streamAgentMessage(
@@ -122,12 +130,14 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
 
             await controller.setExpectedMCPRunID(runID)
             let events = await controller.currentEventsStream()
+            let transportSettlement = ACPHeadlessTransportSettlement()
             let forwardTask = Task {
                 await Self.forwardEvents(
                     events,
                     controller: controller,
                     providerName: providerName,
                     approvalPolicy: approvalPolicy,
+                    transportSettlement: transportSettlement,
                     to: continuation
                 )
             }
@@ -135,11 +145,22 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
             do {
                 _ = try await controller.bootstrap()
                 try await beforePrompt(controller, request)
-                try await controller.prompt(message, request: request)
-                await controller.shutdown()
+                let transportSettled: Bool
+                switch promptCompletion {
+                case .shutdownImmediately:
+                    try await controller.prompt(message, request: request)
+                    await controller.shutdown()
+                    transportSettled = true
+                case .drainTransportBeforeShutdown:
+                    await controller.prepareForPromptTransportDrain()
+                    try await controller.prompt(message, request: request)
+                    transportSettled = await controller.shutdownAfterPromptTransportDrain()
+                }
+                await transportSettlement.publish(transportSettled)
                 await forwardTask.value
             } catch {
                 forwardTask.cancel()
+                await transportSettlement.publish(false)
                 await controller.shutdown()
                 throw await controller.normalizeError(error)
             }
@@ -155,13 +176,23 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
         controller: ACPAgentSessionController,
         providerName: String,
         approvalPolicy: ApprovalPolicy,
+        transportSettlement: ACPHeadlessTransportSettlement,
         to continuation: AsyncThrowingStream<AIStreamResult, Error>.Continuation
     ) async {
+        var terminalResult: AIStreamResult?
         var terminalError: String?
         for await event in events {
             switch event {
             case let .stream(result):
-                continuation.yield(result)
+                if result.type == "message_stop" || result.type == AIStreamResult.incompleteType {
+                    if terminalResult == nil {
+                        terminalResult = result
+                    } else {
+                        terminalError = "\(providerName) ACP emitted more than one terminal result."
+                    }
+                } else {
+                    continuation.yield(result)
+                }
             case let .terminal(state, errorText):
                 if state == .failed {
                     terminalError = errorText ?? "\(providerName) ACP run failed."
@@ -191,10 +222,74 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
         if Task.isCancelled {
             return
         }
+        let transportSettled = await transportSettlement.wait()
         if let terminalError {
             continuation.finish(throwing: AIProviderError.invalidConfiguration(detail: terminalError))
-        } else {
-            continuation.finish()
+            return
+        }
+        if let terminalResult {
+            continuation.yield(
+                transportSettled || terminalResult.type == AIStreamResult.incompleteType
+                    ? terminalResult
+                    : incompleteTransportTerminal(from: terminalResult)
+            )
+        } else if !transportSettled {
+            continuation.yield(
+                AIStreamResult(
+                    type: AIStreamResult.incompleteType,
+                    text: nil,
+                    stopReason: "transport_did_not_settle_before_shutdown"
+                )
+            )
+        }
+        continuation.finish()
+    }
+
+    private static func incompleteTransportTerminal(from result: AIStreamResult) -> AIStreamResult {
+        AIStreamResult(
+            type: AIStreamResult.incompleteType,
+            text: result.text,
+            reasoning: result.reasoning,
+            promptTokens: result.promptTokens,
+            completionTokens: result.completionTokens,
+            cost: result.cost,
+            toolName: result.toolName,
+            toolArgs: result.toolArgs,
+            toolOutput: result.toolOutput,
+            toolInvocationID: result.toolInvocationID,
+            toolResultJSON: result.toolResultJSON,
+            toolArgsJSON: result.toolArgsJSON,
+            toolIsError: result.toolIsError,
+            providerSessionID: result.providerSessionID,
+            stopReason: "transport_did_not_settle_before_shutdown",
+            modelContextWindow: result.modelContextWindow,
+            contextUsedTokens: result.contextUsedTokens,
+            contentMessageID: result.contentMessageID,
+            cleanupHandle: result.cleanupHandle
+        )
+    }
+}
+
+private actor ACPHeadlessTransportSettlement {
+    private var value: Bool?
+    private var waiters: [CheckedContinuation<Bool, Never>] = []
+
+    func publish(_ value: Bool) {
+        guard self.value == nil else { return }
+        self.value = value
+        let waiters = waiters
+        self.waiters.removeAll()
+        for waiter in waiters {
+            waiter.resume(returning: value)
+        }
+    }
+
+    func wait() async -> Bool {
+        if let value {
+            return value
+        }
+        return await withCheckedContinuation { continuation in
+            waiters.append(continuation)
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildACPHeadlessAgentProvider.swift
@@ -67,7 +67,8 @@ final class GrokBuildACPHeadlessAgentProvider: HeadlessAgentProvider {
             beforePrompt: { controller, _ in
                 try await Self.applySelectedModelIfNeeded(config: config, controller: controller)
             },
-            approvalPolicy: .declineUnsupported
+            approvalPolicy: .declineUnsupported,
+            promptCompletion: .drainTransportBeforeShutdown
         )
     }
 

--- a/Tests/RepoPromptTests/AI/ProviderStreamCompletionTests.swift
+++ b/Tests/RepoPromptTests/AI/ProviderStreamCompletionTests.swift
@@ -23,6 +23,28 @@ final class ProviderStreamCompletionTests: XCTestCase {
         XCTAssertFalse(AnthropicProvider.isSuccessfulCompletionStopReason("tool_use"))
     }
 
+    func testAIQueriesBuffersOnlySemanticAssistantText() {
+        XCTAssertEqual(
+            AIQueriesService.assistantText(for: AIStreamResult(type: "content", text: "No.")),
+            "No."
+        )
+        XCTAssertEqual(
+            AIQueriesService.assistantText(for: AIStreamResult(type: "final_content", text: "Final answer")),
+            "Final answer"
+        )
+        XCTAssertNil(
+            AIQueriesService.assistantText(
+                for: AIStreamResult(type: "status", text: "RepoPrompt Agent File Tools Plan")
+            )
+        )
+        XCTAssertNil(
+            AIQueriesService.assistantText(for: AIStreamResult(type: "system", text: "provider diagnostic"))
+        )
+        XCTAssertNil(
+            AIQueriesService.assistantText(for: AIStreamResult(type: "unknown", text: "not assistant text"))
+        )
+    }
+
     func testAIQueriesNormalizesIncompleteTerminationWithoutMarkingSuccess() throws {
         let result = AIStreamResult(
             type: AIStreamResult.incompleteType,

--- a/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
@@ -53,13 +53,88 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
         XCTAssertTrue(requestConfig.alwaysApproveTools)
     }
 
+    func testStatusRemainsDistinctFromValidShortAssistantContent() async throws {
+        let harness = try makeHarness()
+        let provider = harness.makeHeadlessProvider(modelString: nil, scenario: .statusAndShortContent)
+
+        let results = try await collect(provider, message: "hi")
+
+        XCTAssertEqual(results.filter { $0.type == "status" }.compactMap(\.text), ["RepoPrompt Agent File Tools Plan"])
+        XCTAssertEqual(results.filter { $0.type == "content" }.compactMap(\.text), ["No."])
+        XCTAssertEqual(results.last?.type, "message_stop")
+    }
+
+    func testCleanPreTerminalFragmentsRemainComplete() async throws {
+        let harness = try makeHarness()
+        let provider = harness.makeHeadlessProvider(modelString: nil, scenario: .preTerminalFragments)
+
+        let results = try await collect(provider, message: "hi")
+
+        XCTAssertEqual(results.filter { $0.type == "content" }.compactMap(\.text).joined(), "Clean answer.")
+        XCTAssertEqual(results.last?.type, "message_stop")
+    }
+
+    func testPostResponseContentIsDrainedBeforeTerminal() async throws {
+        let harness = try makeHarness()
+        let provider = harness.makeHeadlessProvider(modelString: nil, scenario: .postResponseContent)
+
+        let results = try await collect(provider, message: "hi")
+
+        XCTAssertEqual(results.filter { $0.type == "content" }.compactMap(\.text).joined(), "Full response.")
+        XCTAssertEqual(results.map(\.type), ["content", "content", "message_stop"])
+    }
+
+    func testDescendantLateContentHoldingInheritedPipesIsBounded() async throws {
+        let harness = try makeHarness()
+        let provider = harness.makeHeadlessProvider(
+            modelString: nil,
+            scenario: .descendantLateContentHoldingInheritedPipes
+        )
+        let startedAt = ProcessInfo.processInfo.systemUptime
+
+        let results = try await collect(provider, message: "hi")
+
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+        XCTAssertEqual(results.filter { $0.type == "content" }.compactMap(\.text).joined(), "Full response.")
+        let terminals = results.filter { $0.type == "message_stop" || $0.type == AIStreamResult.incompleteType }
+        XCTAssertEqual(terminals.count, 1)
+        let terminal = try XCTUnwrap(terminals.first)
+        XCTAssertEqual(terminal.type, AIStreamResult.incompleteType)
+        XCTAssertEqual(terminal.stopReason, "transport_did_not_settle_before_shutdown")
+        XCTAssertFalse(results.contains { $0.type == "message_stop" })
+        XCTAssertLessThan(elapsed, 15)
+    }
+
+    func testForcedShutdownMarksPartialContentIncomplete() async throws {
+        let harness = try makeHarness()
+        let provider = harness.makeHeadlessProvider(modelString: nil, scenario: .unsettledTransport)
+
+        let results = try await collect(provider, message: "hi")
+
+        XCTAssertEqual(results.filter { $0.type == "content" }.compactMap(\.text), ["No."])
+        XCTAssertEqual(results.last?.type, AIStreamResult.incompleteType)
+        XCTAssertEqual(results.last?.stopReason, "transport_did_not_settle_before_shutdown")
+    }
+
     // MARK: - Harness
+
+    private enum Scenario: String {
+        case standard
+        case statusAndShortContent = "status_and_short_content"
+        case preTerminalFragments = "pre_terminal_fragments"
+        case postResponseContent = "post_response_content"
+        case unsettledTransport = "unsettled_transport"
+        case descendantLateContentHoldingInheritedPipes = "descendant_late_content_holding_pipes"
+    }
 
     private struct Harness {
         let workspace: URL
         let recordURL: URL
 
-        func makeHeadlessProvider(modelString: String?) -> GrokBuildACPHeadlessAgentProvider {
+        func makeHeadlessProvider(
+            modelString: String?,
+            scenario: Scenario = .standard
+        ) -> GrokBuildACPHeadlessAgentProvider {
             let recordPath = recordURL.path
             return GrokBuildACPHeadlessAgentProvider(
                 config: GrokBuildAgentConfig(
@@ -72,7 +147,10 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
                 providerFactory: { config in
                     EnvForwardingGrokProvider(
                         config: config,
-                        extraEnvironment: ["ACP_RECORD_PATH": recordPath]
+                        extraEnvironment: [
+                            "ACP_RECORD_PATH": recordPath,
+                            "ACP_SCENARIO": scenario.rawValue
+                        ]
                     )
                 }
             )
@@ -115,9 +193,20 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
     }
 
     private func drain(_ provider: GrokBuildACPHeadlessAgentProvider, message: String) async throws {
+        _ = try await collect(provider, message: message)
+    }
+
+    private func collect(
+        _ provider: GrokBuildACPHeadlessAgentProvider,
+        message: String
+    ) async throws -> [AIStreamResult] {
         let stream = try await provider.streamAgentMessage(AgentMessage(userMessage: message))
-        for try await _ in stream {}
+        var results: [AIStreamResult] = []
+        for try await result in stream {
+            results.append(result)
+        }
         await provider.dispose()
+        return results
     }
 
     private func makeHarness() throws -> Harness {
@@ -128,8 +217,10 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
         import json
         import os
         import sys
+        import time
 
         record_path = os.environ.get("ACP_RECORD_PATH")
+        scenario = os.environ.get("ACP_SCENARIO", "standard")
         session_id = "grok-headless-session"
 
         if "--help" in sys.argv:
@@ -144,6 +235,18 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
 
         def respond(request_id, result=None):
             print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result or {}}), flush=True)
+
+        def emit_update(update):
+            print(json.dumps({
+                "jsonrpc": "2.0", "method": "session/update",
+                "params": {"sessionId": session_id, "update": update}
+            }), flush=True)
+
+        def emit_content(text):
+            emit_update({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": text}
+            })
 
         for line in sys.stdin:
             line = line.strip()
@@ -176,13 +279,43 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
             elif method == "session/set_model":
                 respond(request_id, {"_meta": {"model": {"Ok": params.get("modelId")}}})
             elif method == "session/prompt":
-                print(json.dumps({
-                    "jsonrpc": "2.0", "method": "session/update",
-                    "params": {"sessionId": session_id, "update": {
-                        "sessionUpdate": "agent_message_chunk",
-                        "content": {"type": "text", "text": "pong"}}}
-                }), flush=True)
-                respond(request_id, {"stopReason": "end_turn"})
+                if scenario == "status_and_short_content":
+                    emit_update({
+                        "sessionUpdate": "session_info_update",
+                        "title": "RepoPrompt Agent File Tools Plan"
+                    })
+                    emit_content("No.")
+                    respond(request_id, {"stopReason": "end_turn"})
+                elif scenario == "pre_terminal_fragments":
+                    emit_content("Clean ")
+                    emit_content("answer.")
+                    respond(request_id, {"stopReason": "end_turn"})
+                    sys.exit(0)
+                elif scenario == "post_response_content":
+                    emit_content("Full ")
+                    respond(request_id, {"stopReason": "end_turn"})
+                    for _ in sys.stdin:
+                        pass
+                    emit_content("response.")
+                    sys.exit(0)
+                elif scenario == "descendant_late_content_holding_pipes":
+                    emit_content("Full ")
+                    respond(request_id, {"stopReason": "end_turn"})
+                    child_pid = os.fork()
+                    if child_pid == 0:
+                        time.sleep(0.2)
+                        emit_content("response.")
+                        time.sleep(30)
+                        os._exit(0)
+                    os._exit(0)
+                elif scenario == "unsettled_transport":
+                    emit_content("No.")
+                    respond(request_id, {"stopReason": "end_turn"})
+                    while True:
+                        time.sleep(1)
+                else:
+                    emit_content("pong")
+                    respond(request_id, {"stopReason": "end_turn"})
             elif request_id is not None:
                 respond(request_id, {})
         """# + "\n"


### PR DESCRIPTION
## Why

Grok CLI can still write `session/update` chunks after `session/prompt` returns `end_turn`. The old one-shot path shut down immediately and dropped those bytes, so short Oracle answers could be truncated. OpenCode and Cursor use the same bridge but do not opt into this drain path.

## What changed

- Grok remains the only provider that opts into transport draining.
- Cooperative settlement now waits for the root process and both existing stdout and stderr consumer tasks under one bounded deadline. This proves that pipe EOF was observed and queued chunks reached the framers.
- Successful settlement flushes partial lines after the consumers finish, then publishes the terminal event.
- Timeout or cancellation removes handlers, closes the channels, terminates the saved process group, and publishes `message_incomplete` with `transport_did_not_settle_before_shutdown`.
- OpenCode and Cursor retain the existing prompt-then-shutdown path.

```mermaid
sequenceDiagram
    participant Oracle
    participant Bridge
    participant ACP
    participant CLI as Grok stdio

    Oracle->>Bridge: execute prompt
    Bridge->>ACP: session/prompt
    CLI-->>ACP: end_turn
    CLI-->>ACP: late session/update chunks
    ACP->>ACP: await root exit and both pipe consumers
    alt transport settles before deadline
        ACP->>ACP: flush framers
        ACP-->>Bridge: content then message_stop
        Bridge-->>Oracle: complete response
    else deadline or cancellation
        ACP->>ACP: cancel consumers and terminate process group
        ACP-->>Bridge: message_incomplete
        Bridge-->>Oracle: bounded incomplete response
    end
```

The regression test forks a descendant that retains inherited stdout and stderr after the root exits. It verifies that late content remains ordered, the response does not hang, and exactly one incomplete terminal is emitted when transport settlement misses the deadline.

This supersedes the extra work from #844.

## Verification

- `make dev-test FILTER=GrokBuildACPHeadlessAgentProviderTests` passed 9 tests.
- `make dev-test FILTER=ProviderStreamCompletionTests` passed 6 tests.
- `make dev-lint` passed.
- `make dev-swift-build PRODUCT=RepoPrompt` passed.
- `make dev-format` reported 0 of 1517 files formatted.

## Files

- `Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift` changed.
- `Sources/RepoPrompt/Infrastructure/AI/AIQueriesService.swift` changed.
- `Sources/RepoPrompt/Infrastructure/AI/Providers/ACPHeadlessAgentProviderBridge.swift` changed.
- `Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildACPHeadlessAgentProvider.swift` changed.
- `Tests/RepoPromptTests/AI/ProviderStreamCompletionTests.swift` changed.
- `Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift` changed.
