### PR TITLE
Fix Grok Oracle returning progress text instead of an answer

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildCLIProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Grok Build CLI provider for non-agent use (chat, Oracle, AI queries) backed by ACP.
-/// Runs a fresh prompt-only ACP session per request without injecting RepoPrompt MCP/tools.
+/// Grok Build CLI provider for non-agent use (chat, Oracle, AI queries).
+/// Runs a fresh prompt-only one-shot process per request without injecting RepoPrompt MCP/tools.
 final class GrokBuildCLIProvider: AIProvider {
     private let activeProviders = ActiveGrokBuildCLIProviderStore()
 
@@ -31,9 +31,8 @@ final class GrokBuildCLIProvider: AIProvider {
         model: AIModel,
         maxTokens _: Int? = nil
     ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
-        let provider = GrokBuildACPHeadlessAgentProvider(
-            config: Self.makeHeadlessConfig(modelName: grokBuildModelName(for: model)),
-            workspacePath: nil
+        let provider = GrokBuildOneShotHeadlessAgentProvider(
+            config: Self.makeHeadlessConfig(modelName: grokBuildModelName(for: model))
         )
         activeProviders.insert(provider)
 
@@ -116,7 +115,7 @@ final class GrokBuildCLIProvider: AIProvider {
                 if let value = result.cost { cost = value }
             case "error":
                 throw AIProviderError.invalidConfiguration(
-                    detail: result.text ?? "Grok Build ACP reported an error"
+                    detail: result.text ?? "Grok Build reported an error"
                 )
             default:
                 continue
@@ -264,21 +263,21 @@ private extension AIStreamResult {
 
 private final class ActiveGrokBuildCLIProviderStore: @unchecked Sendable {
     private let lock = NSLock()
-    private var providers: [ObjectIdentifier: GrokBuildACPHeadlessAgentProvider] = [:]
+    private var providers: [ObjectIdentifier: GrokBuildOneShotHeadlessAgentProvider] = [:]
 
-    func insert(_ provider: GrokBuildACPHeadlessAgentProvider) {
+    func insert(_ provider: GrokBuildOneShotHeadlessAgentProvider) {
         lock.lock()
         providers[ObjectIdentifier(provider)] = provider
         lock.unlock()
     }
 
-    func remove(_ provider: GrokBuildACPHeadlessAgentProvider) {
+    func remove(_ provider: GrokBuildOneShotHeadlessAgentProvider) {
         lock.lock()
         providers.removeValue(forKey: ObjectIdentifier(provider))
         lock.unlock()
     }
 
-    func removeAll() -> [GrokBuildACPHeadlessAgentProvider] {
+    func removeAll() -> [GrokBuildOneShotHeadlessAgentProvider] {
         lock.lock()
         let current = Array(providers.values)
         providers.removeAll()

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildOneShotHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildOneShotHeadlessAgentProvider.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Agent Mode continues to use `grok agent stdio`; this adapter uses the documented
 /// one-shot JSON CLI and preserves the existing trusted Grok executable preflight.
 final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
-    typealias APIKeyProvider = @Sendable () async -> String?
+    typealias APIKeyProvider = @Sendable () async throws -> String?
 
     private let config: GrokBuildAgentConfig
     private let launchResolver: GrokBuildACPLaunchResolver
@@ -17,7 +17,7 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
         launchResolver: GrokBuildACPLaunchResolver = GrokBuildACPLaunchResolver(),
         requestTimeout: TimeInterval = 6000,
         apiKeyProvider: @escaping APIKeyProvider = {
-            try? await KeyManager().getAPIKey(for: .grok)
+            try await KeyManager().getAPIKey(for: .grok)
         }
     ) {
         self.config = config
@@ -125,7 +125,7 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
         var additionalEnvironment: [String: String] = [:]
         var apiKey = config.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
         if apiKey?.isEmpty != false {
-            apiKey = await apiKeyProvider()?.trimmingCharacters(in: .whitespacesAndNewlines)
+            apiKey = try await apiKeyProvider()?.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         if let apiKey, !apiKey.isEmpty {
             additionalEnvironment["XAI_API_KEY"] = apiKey

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildOneShotHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildOneShotHeadlessAgentProvider.swift
@@ -1,0 +1,486 @@
+import Foundation
+
+/// Prompt-only Grok Build adapter for chat, Oracle, and other non-Agent-Mode requests.
+/// Agent Mode continues to use `grok agent stdio`; this adapter uses the documented
+/// one-shot JSON CLI and preserves the existing trusted Grok executable preflight.
+final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
+    typealias APIKeyProvider = @Sendable () async -> String?
+
+    private let config: GrokBuildAgentConfig
+    private let launchResolver: GrokBuildACPLaunchResolver
+    private let requestTimeout: TimeInterval
+    private let apiKeyProvider: APIKeyProvider
+    private let activeRuns = ActiveGrokBuildOneShotRunStore()
+
+    init(
+        config: GrokBuildAgentConfig,
+        launchResolver: GrokBuildACPLaunchResolver = GrokBuildACPLaunchResolver(),
+        requestTimeout: TimeInterval = 6000,
+        apiKeyProvider: @escaping APIKeyProvider = {
+            try? await KeyManager().getAPIKey(for: .grok)
+        }
+    ) {
+        self.config = config
+        self.launchResolver = launchResolver
+        self.requestTimeout = requestTimeout
+        self.apiKeyProvider = apiKeyProvider
+    }
+
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        guard message.resumeSessionID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Grok Build one-shot requests cannot resume a previous session."
+            )
+        }
+
+        let trackedRunID = runID ?? UUID()
+        return AsyncThrowingStream { continuation in
+            let task = Task { [self] in
+                defer { activeRuns.remove(trackedRunID) }
+                do {
+                    let completion = try await runOneShot(message)
+                    for result in Self.streamResults(from: completion) {
+                        continuation.yield(result)
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            activeRuns.insert(task, for: trackedRunID)
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    func dispose() async {
+        let tasks = activeRuns.removeAll()
+        for task in tasks {
+            task.cancel()
+        }
+        for task in tasks {
+            await task.value
+        }
+    }
+
+    private func runOneShot(_ message: AgentMessage) async throws -> GrokBuildOneShotCompletion {
+        let selection = try Self.resolveModelSelection(
+            modelString: config.modelString,
+            snapshot: AgentACPModelRegistry.shared.resolvedSnapshot(for: .grokBuild)
+        )
+        try Task.checkCancellation()
+
+        let support = try await launchResolver.probeSupport(for: config)
+        guard case .supported = support else {
+            throw AIProviderError.invalidConfiguration(
+                detail: support.reason ?? "Grok Build CLI is not available."
+            )
+        }
+
+        let launch: GrokBuildACPResolvedLaunch
+        do {
+            launch = try launchResolver.resolvedLaunch(for: config)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw mapProcessError(error)
+        }
+        try Task.checkCancellation()
+
+        let promptDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rp-grok-oneshot-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: promptDirectory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        defer { try? FileManager.default.removeItem(at: promptDirectory) }
+
+        let promptURL = promptDirectory.appendingPathComponent("prompt.txt")
+        let prompt = Self.promptText(from: message)
+        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AIProviderError.invalidResponse(detail: "Grok Build prompt is empty")
+        }
+        try prompt.write(to: promptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: promptURL.path)
+
+        let processConfig = CLIProcessConfiguration(
+            command: launch.command,
+            workingDirectory: promptDirectory.path,
+            environment: launch.environment,
+            additionalPaths: [],
+            enableDebugLogging: config.enableDebugLogging,
+            resolveCandidates: [(launch.command as NSString).lastPathComponent],
+            shellLookupMode: .disabled
+        )
+        let runner = CLIProcessRunner(config: processConfig)
+
+        var additionalEnvironment: [String: String] = [:]
+        var apiKey = config.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if apiKey?.isEmpty != false {
+            apiKey = await apiKeyProvider()?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let apiKey, !apiKey.isEmpty {
+            additionalEnvironment["XAI_API_KEY"] = apiKey
+        }
+        try Task.checkCancellation()
+
+        let arguments = GrokBuildOneShotCLIOptions(
+            promptFilePath: promptURL.path,
+            model: selection.model,
+            effort: selection.effort
+        ).toTokens()
+
+        let result: CLIProcessRunner.Result
+        do {
+            // Revalidate at the final launch boundary after all async/keychain work.
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
+            result = try await runner.run(
+                args: arguments,
+                stdin: nil,
+                outputMode: .none,
+                timeout: requestTimeout,
+                additionalEnvironment: additionalEnvironment,
+                cancelChildOnTaskCancellation: true
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw mapProcessError(error)
+        }
+
+        if result.timedOut {
+            throw runtimeError(
+                code: Int(result.status),
+                message: "Grok Build timed out after \(Int(requestTimeout))s."
+            )
+        }
+
+        if result.status != 0 {
+            throw mapProcessFailure(
+                exitCode: result.status,
+                stdout: result.stdout,
+                stderr: result.stderr
+            )
+        }
+
+        if let errorMessage = Self.structuredErrorMessage(from: result.stdout) {
+            throw normalizeCLIError(message: errorMessage, exitCode: result.status)
+        }
+        guard !result.stdout.isEmpty else {
+            throw AIProviderError.invalidResponse(detail: "Grok Build CLI returned no output")
+        }
+        do {
+            return try Self.parseCompletion(result.stdout)
+        } catch let error as AIProviderError {
+            throw error
+        } catch {
+            throw AIProviderError.invalidResponse(
+                detail: "Failed to decode Grok Build CLI JSON: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func mapProcessError(_ error: Error) -> Error {
+        if error is AIProviderError {
+            return error
+        }
+        if let runnerError = error as? CLIProcessRunnerError {
+            switch runnerError {
+            case let .commandNotFound(command):
+                return AIProviderError.invalidConfiguration(
+                    detail: "Grok Build CLI was not found (`\(command)`). Install Grok Build or configure its path."
+                )
+            default:
+                return AIProviderError.apiError(source: error)
+            }
+        }
+        if error is GrokBuildACPLaunchResolutionError || error is ExecutableFileIdentityError {
+            return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
+        }
+        return AIProviderError.apiError(source: error)
+    }
+
+    private func mapProcessFailure(exitCode: Int32, stdout: Data, stderr: Data) -> Error {
+        if let message = Self.structuredErrorMessage(from: stdout) {
+            return normalizeCLIError(message: message, exitCode: exitCode)
+        }
+        let stderrMessage = String(data: stderr, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !stderrMessage.isEmpty {
+            return normalizeCLIError(message: stderrMessage, exitCode: exitCode)
+        }
+        return runtimeError(
+            code: Int(exitCode),
+            message: "Grok Build failed (exit \(exitCode))."
+        )
+    }
+
+    private func normalizeCLIError(message: String, exitCode: Int32) -> Error {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        if lower.contains("not signed in")
+            || lower.contains("not authenticated")
+            || lower.contains("unauthorized")
+            || lower.contains("authorizationrequired")
+            || lower.contains("authentication required")
+            || lower.contains("run `grok login`")
+        {
+            return AIProviderError.invalidConfiguration(detail: trimmed)
+        }
+        if lower.contains("couldn't set model")
+            || lower.contains("unknown model")
+        {
+            return AIProviderError.invalidConfiguration(detail: trimmed)
+        }
+        return runtimeError(code: Int(exitCode), message: trimmed)
+    }
+
+    private func runtimeError(code: Int, message: String) -> Error {
+        AIProviderError.apiError(
+            source: NSError(
+                domain: "GrokBuildCLI",
+                code: code,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        )
+    }
+
+    private static func promptText(from message: AgentMessage) -> String {
+        let systemPrompt = message.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let userMessage = message.userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        if systemPrompt.isEmpty {
+            return userMessage
+        }
+        if userMessage.isEmpty {
+            return systemPrompt
+        }
+        return systemPrompt + "\n\n" + userMessage
+    }
+
+    private static func resolveModelSelection(
+        modelString: String?,
+        snapshot: ACPDiscoveredSessionModels?
+    ) throws -> (model: String?, effort: String?) {
+        guard let modelString = modelString?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !modelString.isEmpty,
+              modelString.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) != .orderedSame
+        else {
+            return (nil, nil)
+        }
+        guard let snapshot, snapshot.contains(rawModel: modelString) else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Grok Build model `\(modelString)` is not in the discovered model set. Refresh Grok Build models and retry."
+            )
+        }
+        guard let decomposed = GrokBuildModelSpecifier.decompose(
+            raw: modelString,
+            options: snapshot.options
+        ) else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Grok Build model `\(modelString)` could not be resolved from the discovered model set. Refresh Grok Build models and retry."
+            )
+        }
+        return (decomposed.base.rawValue, decomposed.explicitEffort?.rawValue)
+    }
+
+    private static let successfulTerminalStopReasons: Set<String> = [
+        "end_turn",
+        "stop",
+        "stop_sequence",
+        "completed",
+        "complete"
+    ]
+
+    private static func parseCompletion(_ data: Data) throws -> GrokBuildOneShotCompletion {
+        let payload = try JSONDecoder().decode(GrokBuildOneShotJSON.self, from: data)
+        guard let stopReason = payload.stopReason?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !stopReason.isEmpty
+        else {
+            throw AIProviderError.invalidResponse(detail: "Grok Build CLI JSON omitted stopReason")
+        }
+        let text = payload.text ?? ""
+        if successfulTerminalStopReasons.contains(stopReason.lowercased()),
+           text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            throw AIProviderError.invalidResponse(detail: "Grok Build returned no completion")
+        }
+        return GrokBuildOneShotCompletion(
+            text: text,
+            thought: payload.thought,
+            stopReason: stopReason,
+            promptTokens: payload.usage?.inputTokens,
+            completionTokens: payload.usage?.outputTokens,
+            cost: payload.totalCostUsd,
+            sessionID: payload.sessionID
+        )
+    }
+
+    private static func structuredErrorMessage(from data: Data) -> String? {
+        guard let payload = try? JSONDecoder().decode(GrokBuildOneShotErrorJSON.self, from: data),
+              payload.type.caseInsensitiveCompare("error") == .orderedSame
+        else {
+            return nil
+        }
+        let message = payload.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        return message.isEmpty ? nil : message
+    }
+
+    private static func streamResults(from completion: GrokBuildOneShotCompletion) -> [AIStreamResult] {
+        var results: [AIStreamResult] = []
+        if let thought = completion.thought,
+           !thought.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            results.append(AIStreamResult(type: "reasoning", text: nil, reasoning: thought))
+        }
+        if !completion.text.isEmpty {
+            results.append(AIStreamResult(type: "content", text: completion.text))
+        }
+        results.append(
+            AIStreamResult(
+                type: "message_stop",
+                text: nil,
+                promptTokens: completion.promptTokens,
+                completionTokens: completion.completionTokens,
+                cost: completion.cost,
+                providerSessionID: completion.sessionID,
+                stopReason: completion.stopReason
+            )
+        )
+        return results
+    }
+}
+
+private struct GrokBuildOneShotCLIOptions {
+    static let disallowedTools = ["read_file", "search_tool", "use_tool"]
+
+    static let systemPromptOverride = """
+    You are a text-only assistant.
+    No tools are available.
+    Do not claim to call, inspect, read, search, or modify external resources.
+    Answer from the supplied prompt and context.
+    Provide the final answer directly without progress narration.
+    """
+
+    static let deniedPermissionRules = [
+        "Read",
+        "Grep",
+        "Edit",
+        "Write",
+        "Bash",
+        "WebFetch",
+        "MCPTool"
+    ]
+
+    var promptFilePath: String
+    var model: String?
+    var effort: String?
+
+    func toTokens() -> [String] {
+        var tokens = [
+            "--prompt-file", promptFilePath,
+            "--output-format", "json",
+            "--verbatim",
+            "--max-turns", "1",
+            "--no-subagents",
+            "--no-plan",
+            "--no-memory",
+            "--disable-web-search",
+            "--tools", "read_file",
+            "--disallowed-tools", Self.disallowedTools.joined(separator: ","),
+            "--system-prompt-override", Self.systemPromptOverride
+        ]
+        for rule in Self.deniedPermissionRules {
+            tokens += ["--deny", rule]
+        }
+        if let model {
+            tokens += ["-m", model]
+        }
+        if let effort {
+            tokens += ["--reasoning-effort", effort]
+        }
+        return tokens
+    }
+}
+
+private struct GrokBuildOneShotJSON: Decodable {
+    let text: String?
+    let thought: String?
+    let stopReason: String?
+    let sessionID: String?
+    let usage: Usage?
+    let totalCostUsd: Double?
+
+    struct Usage: Decodable {
+        let inputTokens: Int?
+        let outputTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case inputTokens = "input_tokens"
+            case outputTokens = "output_tokens"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case thought
+        case stopReason
+        case sessionID = "sessionId"
+        case usage
+        case totalCostUsd = "total_cost_usd"
+    }
+}
+
+private struct GrokBuildOneShotErrorJSON: Decodable {
+    let type: String
+    let message: String
+}
+
+private struct GrokBuildOneShotCompletion {
+    let text: String
+    let thought: String?
+    let stopReason: String
+    let promptTokens: Int?
+    let completionTokens: Int?
+    let cost: Double?
+    let sessionID: String?
+}
+
+private final class ActiveGrokBuildOneShotRunStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var acceptingRuns = true
+    private var tasks: [UUID: Task<Void, Never>] = [:]
+
+    func insert(_ task: Task<Void, Never>, for runID: UUID) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard acceptingRuns else {
+            task.cancel()
+            return
+        }
+        tasks[runID] = task
+    }
+
+    func remove(_ runID: UUID) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard acceptingRuns else { return }
+        tasks.removeValue(forKey: runID)
+    }
+
+    func removeAll() -> [Task<Void, Never>] {
+        lock.lock()
+        defer { lock.unlock() }
+        acceptingRuns = false
+        let current = Array(tasks.values)
+        tasks.removeAll()
+        return current
+    }
+}

--- a/Tests/RepoPromptTests/AI/GrokBuildCLIProviderProcessTests.swift
+++ b/Tests/RepoPromptTests/AI/GrokBuildCLIProviderProcessTests.swift
@@ -17,7 +17,7 @@ final class GrokBuildCLIProviderProcessTests: XCTestCase {
     func testOneShotUsesTrustedPathPrivatePromptAndNoToolPolicy() async throws {
         let harness = try makeHarness(scenario: "ok")
         defer { harness.cleanup() }
-        let provider = makeProvider(harness: harness, apiKey: "test-grok-key")
+        let provider = makeProvider(harness: harness, apiKeyProvider: { "test-grok-key" })
         defer { Task { await provider.dispose() } }
 
         let results = try await collect(
@@ -106,6 +106,24 @@ final class GrokBuildCLIProviderProcessTests: XCTestCase {
             XCTFail("unknown model should fail")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("not in the discovered model set"), "\(error)")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: harness.recordURL.path))
+    }
+
+    func testKeyProviderFailurePropagatesBeforeProcessLaunch() async throws {
+        let harness = try makeHarness(scenario: "ok")
+        defer { harness.cleanup() }
+        let expectedError = NSError(domain: "GrokBuildKeyProvider", code: 1)
+        let provider = makeProvider(harness: harness, apiKeyProvider: { throw expectedError })
+        defer { Task { await provider.dispose() } }
+
+        do {
+            _ = try await collect(provider: provider)
+            XCTFail("key-provider failure should propagate")
+        } catch {
+            let error = error as NSError
+            XCTAssertEqual(error.domain, expectedError.domain)
+            XCTAssertEqual(error.code, expectedError.code)
         }
         XCTAssertFalse(FileManager.default.fileExists(atPath: harness.recordURL.path))
     }
@@ -226,7 +244,7 @@ final class GrokBuildCLIProviderProcessTests: XCTestCase {
         harness: Harness,
         modelString: String = "grok-4.6",
         requestTimeout: TimeInterval = 5,
-        apiKey: String? = nil
+        apiKeyProvider: @escaping GrokBuildOneShotHeadlessAgentProvider.APIKeyProvider = { nil }
     ) -> GrokBuildOneShotHeadlessAgentProvider {
         GrokBuildOneShotHeadlessAgentProvider(
             config: GrokBuildAgentConfig(
@@ -240,7 +258,7 @@ final class GrokBuildCLIProviderProcessTests: XCTestCase {
                 ProcessInfo.processInfo.environment
             }),
             requestTimeout: requestTimeout,
-            apiKeyProvider: { apiKey }
+            apiKeyProvider: apiKeyProvider
         )
     }
 

--- a/Tests/RepoPromptTests/AI/GrokBuildCLIProviderProcessTests.swift
+++ b/Tests/RepoPromptTests/AI/GrokBuildCLIProviderProcessTests.swift
@@ -1,0 +1,358 @@
+import Foundation
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+final class GrokBuildCLIProviderProcessTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AgentACPModelRegistry.shared.test_reset(providerID: .grokBuild)
+        registerDiscoveredModels()
+    }
+
+    override func tearDown() {
+        AgentACPModelRegistry.shared.test_reset(providerID: .grokBuild)
+        super.tearDown()
+    }
+
+    func testOneShotUsesTrustedPathPrivatePromptAndNoToolPolicy() async throws {
+        let harness = try makeHarness(scenario: "ok")
+        defer { harness.cleanup() }
+        let provider = makeProvider(harness: harness, apiKey: "test-grok-key")
+        defer { Task { await provider.dispose() } }
+
+        let results = try await collect(
+            provider: provider,
+            message: AgentMessage(systemPrompt: "System rules", userMessage: "hi")
+        )
+
+        XCTAssertEqual(results.map(\.type), ["reasoning", "content", "message_stop"])
+        XCTAssertEqual(results[0].reasoning, "because")
+        XCTAssertEqual(results[1].text, "oneshot ok")
+        XCTAssertEqual(results[2].stopReason, "end_turn")
+        XCTAssertEqual(results[2].promptTokens, 3)
+        XCTAssertEqual(results[2].completionTokens, 2)
+
+        let record = try harness.record()
+        let argv = try XCTUnwrap(record["argv"] as? [String])
+        XCTAssertFalse(argv.contains("agent"))
+        XCTAssertFalse(argv.contains("stdio"))
+        XCTAssertEqual(argument(after: "--output-format", in: argv), "json")
+        XCTAssertEqual(argument(after: "--max-turns", in: argv), "1")
+        XCTAssertTrue(argv.contains("--verbatim"))
+        XCTAssertTrue(argv.contains("--no-subagents"))
+        XCTAssertTrue(argv.contains("--no-plan"))
+        XCTAssertTrue(argv.contains("--no-memory"))
+        XCTAssertTrue(argv.contains("--disable-web-search"))
+        XCTAssertEqual(argument(after: "-m", in: argv), "grok-4.6")
+
+        XCTAssertEqual(argument(after: "--tools", in: argv), "read_file")
+        XCTAssertEqual(
+            Set(
+                (argument(after: "--disallowed-tools", in: argv) ?? "")
+                    .split(separator: ",")
+                    .map(String.init)
+            ),
+            Set(["read_file", "search_tool", "use_tool"])
+        )
+        XCTAssertEqual(
+            Set(arguments(afterEach: "--deny", in: argv)),
+            Set(["Read", "Grep", "Edit", "Write", "Bash", "WebFetch", "MCPTool"])
+        )
+        XCTAssertEqual(
+            argument(after: "--system-prompt-override", in: argv),
+            "You are a text-only assistant.\nNo tools are available.\nDo not claim to call, inspect, read, search, or modify external resources.\nAnswer from the supplied prompt and context.\nProvide the final answer directly without progress narration."
+        )
+        XCTAssertFalse(argv.contains { $0.contains("System rules") })
+        XCTAssertFalse(argv.contains { $0.contains("hi") })
+
+        XCTAssertEqual(record["xai"] as? String, "test-grok-key")
+        XCTAssertEqual(record["prompt"] as? String, "System rules\n\nhi")
+        XCTAssertEqual(record["prompt_mode"] as? String, "0o600")
+        XCTAssertEqual(record["prompt_dir_mode"] as? String, "0o700")
+        XCTAssertEqual(
+            normalizedTemporaryPath(record["executable"] as? String),
+            normalizedTemporaryPath(harness.executable.path)
+        )
+
+        let promptPath = try XCTUnwrap(record["prompt_path"] as? String)
+        XCTAssertEqual(
+            normalizedTemporaryPath(record["cwd"] as? String),
+            normalizedTemporaryPath((promptPath as NSString).deletingLastPathComponent)
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: promptPath))
+    }
+
+    func testEffortVariantDecomposesOnlyAfterRegistryValidation() async throws {
+        let harness = try makeHarness(scenario: "ok")
+        defer { harness.cleanup() }
+        let provider = makeProvider(harness: harness, modelString: "grok-4.6-high")
+        defer { Task { await provider.dispose() } }
+
+        _ = try await collect(provider: provider)
+
+        let argv = try XCTUnwrap(harness.record()["argv"] as? [String])
+        XCTAssertEqual(argument(after: "-m", in: argv), "grok-4.6")
+        XCTAssertEqual(argument(after: "--reasoning-effort", in: argv), "high")
+    }
+
+    func testUnknownModelFailsBeforeProcessLaunch() async throws {
+        let harness = try makeHarness(scenario: "ok")
+        defer { harness.cleanup() }
+        let provider = makeProvider(harness: harness, modelString: "grok-does-not-exist")
+        defer { Task { await provider.dispose() } }
+
+        do {
+            _ = try await collect(provider: provider)
+            XCTFail("unknown model should fail")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("not in the discovered model set"), "\(error)")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: harness.recordURL.path))
+    }
+
+    func testStructuredStdoutErrorPreservesProviderMessage() async throws {
+        let harness = try makeHarness(scenario: "structured-error")
+        defer { harness.cleanup() }
+        let provider = makeProvider(harness: harness)
+        defer { Task { await provider.dispose() } }
+
+        do {
+            _ = try await collect(provider: provider)
+            XCTFail("structured error should fail")
+        } catch {
+            XCTAssertTrue(
+                error.localizedDescription.contains("quota exhausted {retry later}"),
+                "\(error)"
+            )
+        }
+    }
+
+    func testEmptyCompletedAnswerFails() async throws {
+        let harness = try makeHarness(scenario: "empty")
+        defer { harness.cleanup() }
+        let provider = makeProvider(harness: harness)
+        defer { Task { await provider.dispose() } }
+
+        do {
+            _ = try await collect(provider: provider)
+            XCTFail("empty completed JSON should fail")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.localizedCaseInsensitiveContains("no completion"), "\(error)")
+        }
+    }
+
+    func testCancellingReturnedStreamKillsChildAndRemovesPrompt() async throws {
+        let harness = try makeHarness(scenario: "hang")
+        defer { harness.cleanup() }
+        let provider = makeProvider(harness: harness, requestTimeout: 8)
+        defer { Task { await provider.dispose() } }
+
+        let stream = try await provider.streamAgentMessage(
+            AgentMessage(userMessage: "hi"),
+            runID: nil
+        )
+        let consumer = Task {
+            var results: [AIStreamResult] = []
+            for try await result in stream {
+                results.append(result)
+            }
+            return results
+        }
+
+        let pidDeadline = Date().addingTimeInterval(6)
+        while harness.childPID() == nil, Date() < pidDeadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        let pid = try XCTUnwrap(harness.childPID(), "fake grok never started")
+        let promptPath = try XCTUnwrap(harness.record()["prompt_path"] as? String)
+        XCTAssertEqual(kill(pid, 0), 0, "child \(pid) was not running before cancellation")
+
+        consumer.cancel()
+        _ = try? await consumer.value
+
+        let exitDeadline = Date().addingTimeInterval(2)
+        while kill(pid, 0) == 0, Date() < exitDeadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        XCTAssertNotEqual(kill(pid, 0), 0, "child \(pid) still running")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: promptPath))
+    }
+
+    func testUnsafeConfiguredExecutableIsRejected() async throws {
+        let harness = try makeHarness(scenario: "ok", executableName: "fake-grok")
+        defer { harness.cleanup() }
+        let provider = makeProvider(harness: harness)
+        defer { Task { await provider.dispose() } }
+
+        do {
+            _ = try await collect(provider: provider)
+            XCTFail("unsafe executable should fail")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.localizedCaseInsensitiveContains("unsafe"), "\(error)")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: harness.recordURL.path))
+    }
+
+    private func registerDiscoveredModels() {
+        let base = AgentModelOption(
+            rawValue: "grok-4.6",
+            displayName: "Grok 4.6",
+            description: nil,
+            isPlaceholderDefault: false,
+            isProviderDefault: true
+        )
+        let high = AgentModelOption(
+            rawValue: "grok-4.6-high",
+            displayName: "Grok 4.6 High",
+            description: nil,
+            isPlaceholderDefault: false,
+            isProviderDefault: false,
+            effortVariant: AgentModelEffortVariant(
+                baseModelRaw: "grok-4.6",
+                reasoningEffort: .high
+            )
+        )
+        _ = AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [base, high],
+                currentModelRaw: "grok-4.6"
+            ),
+            for: .grokBuild
+        )
+    }
+
+    private func makeProvider(
+        harness: Harness,
+        modelString: String = "grok-4.6",
+        requestTimeout: TimeInterval = 5,
+        apiKey: String? = nil
+    ) -> GrokBuildOneShotHeadlessAgentProvider {
+        GrokBuildOneShotHeadlessAgentProvider(
+            config: GrokBuildAgentConfig(
+                commandName: harness.executable.path,
+                additionalPathHints: [],
+                modelString: modelString,
+                includeRepoPromptMCPServer: false,
+                alwaysApproveTools: false
+            ),
+            launchResolver: GrokBuildACPLaunchResolver(environmentProvider: { _ in
+                ProcessInfo.processInfo.environment
+            }),
+            requestTimeout: requestTimeout,
+            apiKeyProvider: { apiKey }
+        )
+    }
+
+    private func collect(
+        provider: GrokBuildOneShotHeadlessAgentProvider,
+        message: AgentMessage = AgentMessage(userMessage: "hi")
+    ) async throws -> [AIStreamResult] {
+        let stream = try await provider.streamAgentMessage(message, runID: nil)
+        var results: [AIStreamResult] = []
+        for try await result in stream {
+            results.append(result)
+        }
+        return results
+    }
+
+    private func argument(after flag: String, in arguments: [String]) -> String? {
+        guard let index = arguments.firstIndex(of: flag) else { return nil }
+        let valueIndex = arguments.index(after: index)
+        guard valueIndex < arguments.endIndex else { return nil }
+        return arguments[valueIndex]
+    }
+
+    private func arguments(afterEach flag: String, in arguments: [String]) -> [String] {
+        arguments.indices.compactMap { index in
+            guard arguments[index] == flag else { return nil }
+            let valueIndex = arguments.index(after: index)
+            return valueIndex < arguments.endIndex ? arguments[valueIndex] : nil
+        }
+    }
+
+    private func normalizedTemporaryPath(_ path: String?) -> String? {
+        guard let path else { return nil }
+        return path.hasPrefix("/private/var/") ? String(path.dropFirst("/private".count)) : path
+    }
+
+    private struct Harness {
+        let directory: URL
+        let executable: URL
+        let recordURL: URL
+
+        func record() throws -> [String: Any] {
+            let data = try Data(contentsOf: recordURL)
+            return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+
+        func childPID() -> pid_t? {
+            let pidURL = directory.appendingPathComponent("pid")
+            guard let raw = try? String(contentsOf: pidURL, encoding: .utf8) else { return nil }
+            return pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    private func makeHarness(
+        scenario: String,
+        executableName: String = "grok"
+    ) throws -> Harness {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rp-grok-fake-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent(executableName)
+        let recordURL = directory.appendingPathComponent("record.json")
+        let script = """
+        #!/usr/bin/env python3
+        import json, os, sys, time
+
+        here = os.path.dirname(os.path.abspath(__file__))
+        argv = sys.argv[1:]
+        if argv == ["agent", "--help"]:
+            print("Commands:\\n  stdio", flush=True)
+            sys.exit(0)
+
+        prompt_path = None
+        if "--prompt-file" in argv:
+            prompt_path = argv[argv.index("--prompt-file") + 1]
+        record = {
+            "argv": argv,
+            "xai": os.environ.get("XAI_API_KEY"),
+            "prompt_path": prompt_path,
+            "prompt": open(prompt_path).read() if prompt_path and os.path.exists(prompt_path) else None,
+            "prompt_mode": oct(os.stat(prompt_path).st_mode & 0o777) if prompt_path else None,
+            "prompt_dir_mode": oct(os.stat(os.path.dirname(prompt_path)).st_mode & 0o777) if prompt_path else None,
+            "executable": os.path.realpath(sys.argv[0]),
+            "cwd": os.getcwd(),
+        }
+        open(os.path.join(here, "record.json"), "w").write(json.dumps(record))
+
+        scenario = "\(scenario)"
+        if scenario == "hang":
+            open(os.path.join(here, "pid"), "w").write(str(os.getpid()))
+            time.sleep(30)
+            sys.exit(0)
+        if scenario == "empty":
+            print(json.dumps({"text": "", "stopReason": "end_turn"}), flush=True)
+            sys.exit(0)
+        if scenario == "structured-error":
+            print(json.dumps({"type": "error", "message": "quota exhausted {retry later}"}), flush=True)
+            sys.exit(42)
+        print(json.dumps({
+            "text": "oneshot ok",
+            "thought": "because",
+            "stopReason": "end_turn",
+            "sessionId": "session-1",
+            "usage": {"input_tokens": 3, "output_tokens": 2}
+        }), flush=True)
+        """
+        try script.trimmingCharacters(in: .whitespacesAndNewlines).appending("\n")
+            .write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return Harness(directory: directory, executable: executable, recordURL: recordURL)
+    }
+}


### PR DESCRIPTION
## What this fixes

Grok Oracle could start a coding-agent turn instead of answering the supplied prompt. On a large review it might read files, spend its turn on tools, and return progress text such as "I'll keep reading..." as the Oracle answer.

This PR gives Grok chat and Oracle a fresh, text-only, one-shot CLI path. Grok Agent Mode stays on ACP and keeps its sessions, tools, and interactive behavior.

## The `/bro` version

Oracle already gives Grok the prompt and selected code. Grok does not need to explore the repository again.

Before this change, Grok could behave like a coding agent: look for files, announce tool work, and run out of turns before answering. Now Oracle starts a separate Grok process with no usable tools, sends the prompt through a private file, accepts one completed JSON answer, and exits.

Agent Mode is unchanged. It still uses `grok agent stdio` because that is where tools and long-lived sessions belong.

## Flow (`/show-me`)

```mermaid
flowchart LR
    A[RepoPrompt request] --> B{Request type}
    B -->|Agent Mode| C[grok agent stdio]
    C --> D[ACP session with tools]
    B -->|Chat or Oracle| E[Private prompt file]
    E --> F[grok one-shot JSON]
    F --> G[Prepared tool count: 0]
    G --> H[One completed text answer]
    H --> I[Delete prompt directory]
```

## Live Oracle proof

![Completed Grok 4.6 XHigh Oracle response over 31 selected files](https://github.com/user-attachments/assets/1f6495ad-73ab-46ae-944c-83c3a5af4934)

The debug app completed this Grok 4.6 XHigh Oracle review over 31 selected files. It returned a direct review answer with about 100k input tokens and 19k output tokens instead of stopping at tool progress text.

The code change is deliberately narrow:

```diff
 GrokBuildCLIProvider
-  GrokBuildACPHeadlessAgentProvider
+  GrokBuildOneShotHeadlessAgentProvider

 Agent Mode
   GrokBuildACPAgentProvider        # unchanged
```

## Why the tool flags look strange

The final command includes both:

```text
--tools read_file
--disallowed-tools read_file,search_tool,use_tool
```

That is intentional. The installed Grok CLI has no reliable empty-tool flag.

`read_file` is a recognized allowlist anchor. The denylist then removes it. `search_tool` and `use_tool` remove Grok's MCP meta-tools. In the validated Grok 1.0.5 build, this produced:

```text
tool_count: 0
tools: []
```

`--disallowed-tools` removes matching tools from the model schema. It is different from `--deny`, which leaves a tool visible and only blocks execution.

This policy depends on `read_file` remaining a recognized Grok tool. If Grok removes or renames it, its unresolved-allowlist behavior may fail open. A live `tool_count: 0` probe is therefore the compatibility check for future Grok releases.

## What we tried first

The final policy came from live CLI probes, not flag names alone.

### Empty allowlist

```text
--tools ''
```

This did not disable tools. Grok still exposed `read_file`, attempted a read, consumed the single tool cycle, and exited with `Error: max turns reached`.

### Unknown sentinel allowlist

```text
--tools __repoprompt_no_tools__
```

Grok treated the unknown entry as unresolved and retained the normal toolset. This also reached the max-turn failure.

### Large denylist

The first implementation denied 36 known tool names. It still prepared five dynamically injected tools, including `OpenCode:write` and four media tools. A model selected `write`; the permission rule blocked execution, but the blocked call consumed `--max-turns 1` and ended as `cancelled/max_turns_reached`.

This proved that permission denial is a safety backstop, not schema removal.

### Empty schema without a text-only prompt

The recognized allowlist and denylist intersection produced `tool_count: 0`, but Grok could still narrate a fake `<tool_call>` in plain text because it retained its coding-agent system prompt.

The final path also uses a static text-only `--system-prompt-override`. With both controls in place, the negative file-read probe returned `NO_READ_TOOL` with `end_turn` and made no tool call.

## One-shot contract

For each chat or Oracle request, RepoPrompt:

1. Resolves Grok through the trusted one-shot launch preflight and revalidates the executable identity immediately before execution.
2. Validates the selected model against the discovered Grok model snapshot.
3. Creates a `0700` temporary directory and writes the prompt to a `0600` file. Prompt text never appears on argv.
4. Sets the child working directory to that temporary directory, not the workspace.
5. Runs Grok with JSON output, verbatim input, one maximum tool cycle, no subagents, no plan mode, no memory, no web search, an empty prepared toolset, and a text-only system prompt.
6. Keeps the existing permission denials as an execution backstop.
7. Parses one final JSON object and accepts only successful terminal stop reasons.
8. Terminates the child on stream cancellation and removes the temporary directory after every outcome.

A representative invocation is:

```text
grok \
  --prompt-file <private-file> \
  --output-format json \
  --verbatim \
  --max-turns 1 \
  --tools read_file \
  --disallowed-tools read_file,search_tool,use_tool \
  --system-prompt-override <text-only-prompt> \
  --no-subagents --no-plan --no-memory --disable-web-search
```

## Model and effort handling

The one-shot path validates the selected compound model against the discovered catalog before splitting it into base model and effort.

Headless `--reasoning-effort` and ACP `_meta.reasoningEffort` are different interfaces:

- ACP must preserve the exact advertised wire value. For example, the semantic `max` option may advertise `maximum`.
- The headless CLI documents canonical effort tokens, including `max`, and resolves them after loading the model menu.

The live one-shot runs exercised `high`. They did not compare `max` and `maximum` side by side, so this PR does not claim that equivalence has been measured on the installed CLI.

## Failure behavior

The adapter rejects:

- an unknown or stale selected model;
- a failed stored-key lookup, instead of silently falling back to a different native Grok credential;
- unsafe or changed executable identity;
- resume attempts on the one-shot path;
- process timeout or nonzero exit;
- malformed, empty, or multiple JSON payloads;
- empty successful completions; and
- non-success stop reasons such as cancellation or max-token termination.

Structured Grok errors on stdout remain available when the process exits unsuccessfully. Legacy stop-reason spellings are normalized before terminal validation.

## Validation

Local checks completed against commit `6429fd41`:

- `make dev-format`
- `make dev-lint`
- `GrokBuildCLIProviderProcessTests`: 8 of 8 passed
- key-provider failure propagation test confirmed a keychain read failure prevents process launch
- `GrokBuildModelRoutingTests`: 8 of 8 passed
- `make dev-swift-build PRODUCT=RepoPrompt`
- Debug app packaged and relaunched through Conductor with explicit ad-hoc signing

Live Grok CLI checks confirmed:

- `tool_count: 0`
- `tools: []`
- no tool call
- four direct prompts returned completed text answers
- the file-read probe returned `NO_READ_TOOL/end_turn` with the final system prompt
- the rebuilt CE debug CLI routed `oracle_send` to Grok 4.6 High and returned exactly `GROK_ORACLE_CLI_SMOKE_OK` through the one-shot `--prompt-file` path
- temporary Oracle model settings were restored and no one-shot prompt directory remained

Not completed:

- The Oracle-sized prompt and its negative control both exceeded the bounded 90-second probe. That validation remains open.
- Hosted CI completed with all 8 checks passing. App shard 2 initially hit the unrelated `ContextBuilderRunLifecycleTests.testRealConnectionCleanupCannotEraseContextBeforeCommit` race, then passed on the failed-job rerun without code changes.

## Scope

This PR changes three files:

```text
Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/
├── GrokBuildCLIProvider.swift
└── GrokBuildOneShotHeadlessAgentProvider.swift

Tests/RepoPromptTests/AI/
└── GrokBuildCLIProviderProcessTests.swift
```

It does not change shared ACP draining, Agent Mode's Grok transport, or other providers. The ACP drain work remains separate in #847.
