### PR TITLE
Harden Apple identity migration bridge

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -11,6 +11,14 @@ on:
         description: Commit SHA on protected main to publish as tip
         required: false
         type: string
+      identity_migration_phase:
+        description: Apple identity migration mode for a manual Tip publish
+        required: true
+        default: disabled
+        type: choice
+        options:
+          - disabled
+          - legacy-preparer
 
 concurrency:
   group: >-
@@ -158,6 +166,7 @@ jobs:
           TIP_TAG: ${{ needs.setup.outputs.tag }}
           REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
           REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase || 'disabled' }}
           # Link Sentry and preserve dSYMs without exposing DSN or auth in this stage.
           REPOPROMPT_ENABLE_SENTRY: "1"
         run: ./trusted-control-plane/Scripts/main_tip_release.sh stage
@@ -208,6 +217,7 @@ jobs:
         env:
           RELEASE_COMMIT: ${{ needs.setup.outputs.commit }}
           REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE: ${{ needs.setup.outputs.build-number }}
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase || 'disabled' }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -242,6 +252,45 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
           echo "SIGN_IDENTITY=${CONFIGURED_SIGN_IDENTITY:-Developer ID Application: Eric Provencher (648A27MST5)}" >> "$GITHUB_ENV"
+
+      - name: Prepare successor identity migration anchor
+        if: github.event_name == 'workflow_dispatch' && inputs.identity_migration_phase == 'legacy-preparer'
+        env:
+          SUCCESSOR_CERTIFICATE_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          SUCCESSOR_CERTIFICATE_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}
+          CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          umask 077
+          : "${SUCCESSOR_CERTIFICATE_P12_BASE64:?Successor Developer ID Application certificate is not configured}"
+          : "${SUCCESSOR_CERTIFICATE_P12_PASSWORD:?Successor Developer ID Application password is not configured}"
+          expected_identity="Developer ID Application: Samuel Baron (69N6K965SF)"
+          [[ "$SUCCESSOR_SIGN_IDENTITY" == "$expected_identity" ]] || {
+            echo "Successor signing identity must be $expected_identity" >&2
+            exit 1
+          }
+          successor_certificate="$RUNNER_TEMP/repoprompt-tip-successor.p12"
+          anchor_source="tip-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt"
+          anchor="$RUNNER_TEMP/repoprompt-tip-successor-identity-anchor"
+          [[ -f "$anchor_source" && -x "$anchor_source" ]] || {
+            echo "Missing staged executable for successor identity anchor: $anchor_source" >&2
+            exit 1
+          }
+          printf '%s' "$SUCCESSOR_CERTIFICATE_P12_BASE64" | base64 --decode > "$successor_certificate"
+          security import "$successor_certificate" -k "$KEYCHAIN_PATH" \
+            -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          ditto "$anchor_source" "$anchor"
+          chmod 755 "$anchor"
+          codesign --force --sign "$SUCCESSOR_SIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" \
+            --identifier com.repoprompt.ce --timestamp --options runtime "$anchor"
+          codesign --verify --strict --verbose=2 "$anchor"
+          signature_details="$(codesign -dv --verbose=4 "$anchor" 2>&1)"
+          grep -Fx 'Identifier=com.repoprompt.ce' <<< "$signature_details" >/dev/null
+          grep -Fx 'TeamIdentifier=69N6K965SF' <<< "$signature_details" >/dev/null
+          echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"
 
       - name: Prepare provisioning profile and notarization key
         env:
@@ -289,6 +338,7 @@ jobs:
           REPOPROMPT_APPROVED_SOURCE_ROOT: ${{ github.workspace }}/approved-source
           REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE: ${{ needs.setup.outputs.build-number }}
           REPOPROMPT_ENABLE_SENTRY: "1"
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase || 'disabled' }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           REPOPROMPT_SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
@@ -304,6 +354,8 @@ jobs:
           security delete-keychain "$RUNNER_TEMP/repoprompt-tip.keychain-db" || true
           rm -rf "$RUNNER_TEMP/repoprompt-tip-secrets"
           rm -f "$RUNNER_TEMP/repoprompt-tip.p12"
+          rm -f "$RUNNER_TEMP/repoprompt-tip-successor.p12"
+          rm -f "$RUNNER_TEMP/repoprompt-tip-successor-identity-anchor"
 
       - name: Upload signed tip assets for smoke and publish
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -11,14 +11,6 @@ on:
         description: Commit SHA on protected main to publish as tip
         required: false
         type: string
-      identity_migration_phase:
-        description: Apple identity migration mode for a manual Tip publish
-        required: true
-        default: disabled
-        type: choice
-        options:
-          - disabled
-          - legacy-preparer
 
 concurrency:
   group: >-
@@ -166,7 +158,9 @@ jobs:
           TIP_TAG: ${{ needs.setup.outputs.tag }}
           REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
           REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
-          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase || 'disabled' }}
+          # Tip is rolling and cannot preserve a migration phase across automatic
+          # workflow_run publishes. Preparers are Stable-only release artifacts.
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled
           # Link Sentry and preserve dSYMs without exposing DSN or auth in this stage.
           REPOPROMPT_ENABLE_SENTRY: "1"
         run: ./trusted-control-plane/Scripts/main_tip_release.sh stage
@@ -217,7 +211,7 @@ jobs:
         env:
           RELEASE_COMMIT: ${{ needs.setup.outputs.commit }}
           REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE: ${{ needs.setup.outputs.build-number }}
-          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase || 'disabled' }}
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -252,45 +246,6 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
           echo "SIGN_IDENTITY=${CONFIGURED_SIGN_IDENTITY:-Developer ID Application: Eric Provencher (648A27MST5)}" >> "$GITHUB_ENV"
-
-      - name: Prepare successor identity migration anchor
-        if: github.event_name == 'workflow_dispatch' && inputs.identity_migration_phase == 'legacy-preparer'
-        env:
-          SUCCESSOR_CERTIFICATE_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
-          SUCCESSOR_CERTIFICATE_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
-          SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}
-          CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
-        run: |
-          set -euo pipefail
-          umask 077
-          : "${SUCCESSOR_CERTIFICATE_P12_BASE64:?Successor Developer ID Application certificate is not configured}"
-          : "${SUCCESSOR_CERTIFICATE_P12_PASSWORD:?Successor Developer ID Application password is not configured}"
-          expected_identity="Developer ID Application: Samuel Baron (69N6K965SF)"
-          [[ "$SUCCESSOR_SIGN_IDENTITY" == "$expected_identity" ]] || {
-            echo "Successor signing identity must be $expected_identity" >&2
-            exit 1
-          }
-          successor_certificate="$RUNNER_TEMP/repoprompt-tip-successor.p12"
-          anchor_source="tip-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt"
-          anchor="$RUNNER_TEMP/repoprompt-tip-successor-identity-anchor"
-          [[ -f "$anchor_source" && -x "$anchor_source" ]] || {
-            echo "Missing staged executable for successor identity anchor: $anchor_source" >&2
-            exit 1
-          }
-          printf '%s' "$SUCCESSOR_CERTIFICATE_P12_BASE64" | base64 --decode > "$successor_certificate"
-          security import "$successor_certificate" -k "$KEYCHAIN_PATH" \
-            -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          ditto "$anchor_source" "$anchor"
-          chmod 755 "$anchor"
-          codesign --force --sign "$SUCCESSOR_SIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" \
-            --identifier com.repoprompt.ce --timestamp --options runtime "$anchor"
-          codesign --verify --strict --verbose=2 "$anchor"
-          signature_details="$(codesign -dv --verbose=4 "$anchor" 2>&1)"
-          grep -Fx 'Identifier=com.repoprompt.ce' <<< "$signature_details" >/dev/null
-          grep -Fx 'TeamIdentifier=69N6K965SF' <<< "$signature_details" >/dev/null
-          echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"
 
       - name: Prepare provisioning profile and notarization key
         env:
@@ -338,7 +293,7 @@ jobs:
           REPOPROMPT_APPROVED_SOURCE_ROOT: ${{ github.workspace }}/approved-source
           REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE: ${{ needs.setup.outputs.build-number }}
           REPOPROMPT_ENABLE_SENTRY: "1"
-          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase || 'disabled' }}
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           REPOPROMPT_SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
@@ -354,8 +309,6 @@ jobs:
           security delete-keychain "$RUNNER_TEMP/repoprompt-tip.keychain-db" || true
           rm -rf "$RUNNER_TEMP/repoprompt-tip-secrets"
           rm -f "$RUNNER_TEMP/repoprompt-tip.p12"
-          rm -f "$RUNNER_TEMP/repoprompt-tip-successor.p12"
-          rm -f "$RUNNER_TEMP/repoprompt-tip-successor-identity-anchor"
 
       - name: Upload signed tip assets for smoke and publish
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,14 @@ on:
         description: Existing release tag to publish
         required: true
         type: string
+      identity_migration_phase:
+        description: Apple identity migration mode for this release
+        required: true
+        default: disabled
+        type: choice
+        options:
+          - disabled
+          - legacy-preparer
 
 concurrency:
   group: release-draft-creation
@@ -72,6 +80,7 @@ jobs:
           SOURCE_GITHUB_REPOSITORY: ${{ github.repository }}
           REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
           REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase }}
           # Link the Sentry SDK into the official release binary. The protected DSN is
           # injected later in the signing job, so the secret-free stage stays inert.
           REPOPROMPT_ENABLE_SENTRY: "1"
@@ -123,6 +132,7 @@ jobs:
       - name: Verify and expand staged release source
         env:
           RELEASE_COMMIT: ${{ needs.validate-ref.outputs.commit }}
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase }}
         run: |
           set -euo pipefail
           cd staged-release
@@ -169,6 +179,45 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
           echo "SIGN_IDENTITY=${CONFIGURED_SIGN_IDENTITY:-Developer ID Application: Eric Provencher (648A27MST5)}" >> "$GITHUB_ENV"
+
+      - name: Prepare successor identity migration anchor
+        if: inputs.identity_migration_phase == 'legacy-preparer'
+        env:
+          SUCCESSOR_CERTIFICATE_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          SUCCESSOR_CERTIFICATE_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}
+          CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          umask 077
+          : "${SUCCESSOR_CERTIFICATE_P12_BASE64:?Successor Developer ID Application certificate is not configured}"
+          : "${SUCCESSOR_CERTIFICATE_P12_PASSWORD:?Successor Developer ID Application password is not configured}"
+          expected_identity="Developer ID Application: Samuel Baron (69N6K965SF)"
+          [[ "$SUCCESSOR_SIGN_IDENTITY" == "$expected_identity" ]] || {
+            echo "Successor signing identity must be $expected_identity" >&2
+            exit 1
+          }
+          successor_certificate="$RUNNER_TEMP/repoprompt-release-successor.p12"
+          anchor_source="release-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt"
+          anchor="$RUNNER_TEMP/repoprompt-successor-identity-anchor"
+          [[ -f "$anchor_source" && -x "$anchor_source" ]] || {
+            echo "Missing staged executable for successor identity anchor: $anchor_source" >&2
+            exit 1
+          }
+          printf '%s' "$SUCCESSOR_CERTIFICATE_P12_BASE64" | base64 --decode > "$successor_certificate"
+          security import "$successor_certificate" -k "$KEYCHAIN_PATH" \
+            -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          ditto "$anchor_source" "$anchor"
+          chmod 755 "$anchor"
+          codesign --force --sign "$SUCCESSOR_SIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" \
+            --identifier com.repoprompt.ce --timestamp --options runtime "$anchor"
+          codesign --verify --strict --verbose=2 "$anchor"
+          signature_details="$(codesign -dv --verbose=4 "$anchor" 2>&1)"
+          grep -Fx 'Identifier=com.repoprompt.ce' <<< "$signature_details" >/dev/null
+          grep -Fx 'TeamIdentifier=69N6K965SF' <<< "$signature_details" >/dev/null
+          echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"
 
       - name: Prepare provisioning profile and notarization key
         env:
@@ -217,6 +266,7 @@ jobs:
           REPOPROMPT_APPROVED_SOURCE_ROOT: ${{ github.workspace }}/approved-source
           REPOPROMPT_REQUIRE_HEAD_MATCH: 0
           REPOPROMPT_ENABLE_SENTRY: "1"
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase }}
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
           NOTARYTOOL_ISSUER_ID: ${{ secrets.NOTARYTOOL_ISSUER_ID }}
@@ -235,6 +285,8 @@ jobs:
           CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-release.p12"
           security delete-keychain "$KEYCHAIN_PATH" || true
           rm -f "$CERTIFICATE_PATH"
+          rm -f "$RUNNER_TEMP/repoprompt-release-successor.p12"
+          rm -f "$RUNNER_TEMP/repoprompt-successor-identity-anchor"
           rm -rf "$RUNNER_TEMP/repoprompt-release-secrets"
 
       - name: Upload signed release ZIP for secret-free smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,10 +198,15 @@ jobs:
             exit 1
           }
           successor_certificate="$RUNNER_TEMP/repoprompt-release-successor.p12"
-          anchor_source="release-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt"
+          anchor_source="trusted-control-plane/Scripts/identity_migration_anchor.c"
           anchor="$RUNNER_TEMP/repoprompt-successor-identity-anchor"
-          [[ -f "$anchor_source" && -x "$anchor_source" ]] || {
-            echo "Missing staged executable for successor identity anchor: $anchor_source" >&2
+          [[ -f "$anchor_source" ]] || {
+            echo "Missing trusted successor identity anchor source: $anchor_source" >&2
+            exit 1
+          }
+          xcrun clang -arch arm64 -arch x86_64 -Os -Wl,-dead_strip -o "$anchor" "$anchor_source"
+          [[ -f "$anchor" && -x "$anchor" ]] || {
+            echo "Failed to build successor identity anchor" >&2
             exit 1
           }
           printf '%s' "$SUCCESSOR_CERTIFICATE_P12_BASE64" | base64 --decode > "$successor_certificate"
@@ -209,11 +214,10 @@ jobs:
             -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          ditto "$anchor_source" "$anchor"
-          chmod 755 "$anchor"
           codesign --force --sign "$SUCCESSOR_SIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" \
             --identifier com.repoprompt.ce --timestamp --options runtime "$anchor"
-          codesign --verify --strict --verbose=2 "$anchor"
+          successor_requirement='anchor apple generic and identifier "com.repoprompt.ce" and certificate leaf[subject.OU] = "69N6K965SF" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists'
+          codesign --verify --strict --verbose=2 -R="$successor_requirement" "$anchor"
           signature_details="$(codesign -dv --verbose=4 "$anchor" 2>&1)"
           grep -Fx 'Identifier=com.repoprompt.ce' <<< "$signature_details" >/dev/null
           grep -Fx 'TeamIdentifier=69N6K965SF' <<< "$signature_details" >/dev/null

--- a/AppBundle/Info.plist.template
+++ b/AppBundle/Info.plist.template
@@ -18,6 +18,8 @@
   <key>RepoPromptSigningMode</key><string>__SIGNING_MODE__</string>
   <key>RepoPromptLocalSigningCertificateSHA256</key><string>__LOCAL_SIGNING_CERTIFICATE_SHA256__</string>
   <key>RepoPromptLocalSecureStorageGeneration</key><string>__LOCAL_SECURE_STORAGE_GENERATION__</string>
+  <key>RepoPromptIdentityMigrationPhase</key><string>__IDENTITY_MIGRATION_PHASE__</string>
+  <key>RepoPromptIdentityMigrationAnchorRelativePath</key><string>IdentityMigration/RepoPromptIdentityAnchor</string>
   <key>RepoPromptSentryDSN</key><string></string>
   <key>LSEnvironment</key><dict><key>REPOPROMPT_LAUNCH_SOURCE</key><string>launchservices</string></dict>
   <key>CFBundleURLTypes</key><array><dict><key>CFBundleTypeRole</key><string>Viewer</string><key>CFBundleURLName</key><string>com.pvncher.repoprompt.ce</string><key>CFBundleURLSchemes</key><array><string>repoprompt-ce</string></array><key>CFBundleURLIconFile</key><string>AppIcon</string></dict></array>

--- a/Scripts/identity_migration_anchor.c
+++ b/Scripts/identity_migration_anchor.c
@@ -1,0 +1,5 @@
+// Minimal executable used only to derive the successor identity's Keychain ACL requirement.
+// It is never launched by RepoPrompt CE.
+int main(void) {
+    return 0;
+}

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -94,6 +94,11 @@ if [[ -n "$RELEASE_BUILD_NUMBER_OVERRIDE" ]]; then
     BUILD_NUMBER="$RELEASE_BUILD_NUMBER_OVERRIDE"
 fi
 APP_NAME="${APP_NAME:-RepoPrompt}"; DISPLAY_NAME="${DISPLAY_NAME:-RepoPrompt CE}"; BASE_BUNDLE_ID="${BUNDLE_ID:-com.pvncher.repoprompt.ce}"; MARKETING_VERSION="${MARKETING_VERSION:-0.1.0}"; BUILD_NUMBER="${BUILD_NUMBER:-1}"; SIGNING_TEAM_ID="${SIGNING_TEAM_ID:-648A27MST5}"
+IDENTITY_MIGRATION_PHASE="${REPOPROMPT_IDENTITY_MIGRATION_PHASE:-disabled}"
+case "$IDENTITY_MIGRATION_PHASE" in
+disabled | legacy-preparer) ;;
+*) fail "REPOPROMPT_IDENTITY_MIGRATION_PHASE must be disabled or legacy-preparer" ;;
+esac
 ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
 SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/$CONF"
 
@@ -103,6 +108,12 @@ if (( IS_RELEASE )); then
     BUNDLE_ID="${BUNDLE_ID_OVERRIDE:-$BASE_BUNDLE_ID}"
 else
     BUNDLE_ID="${BUNDLE_ID_OVERRIDE:-${DEBUG_BUNDLE_ID:-$BASE_BUNDLE_ID.debug}}"
+fi
+if [[ "$IDENTITY_MIGRATION_PHASE" == "legacy-preparer" ]]; then
+    [[ "$BUNDLE_ID" == "com.pvncher.repoprompt.ce" ]] ||
+        fail "legacy-preparer requires bundle identifier com.pvncher.repoprompt.ce"
+    [[ "$SIGNING_TEAM_ID" == "648A27MST5" ]] ||
+        fail "legacy-preparer requires signing Team ID 648A27MST5"
 fi
 
 phase "Checking build environment"
@@ -320,10 +331,16 @@ phase "Writing Info.plist"
 run python3 - <<PY
 from pathlib import Path
 s=Path('AppBundle/Info.plist.template').read_text()
-for k,v in {'__APP_NAME__':'$APP_NAME','__DISPLAY_NAME__':'$DISPLAY_NAME','__BUNDLE_ID__':'$BUNDLE_ID','__MARKETING_VERSION__':'$MARKETING_VERSION','__BUILD_NUMBER__':'$BUILD_NUMBER','__DEBUG_SECURE_STORAGE_BACKEND__':'$DEBUG_STORAGE_BACKEND_MARKER','__SIGNING_MODE__':'$SIGNING_MODE_MARKER','__LOCAL_SIGNING_CERTIFICATE_SHA256__':'$LOCAL_SIGNING_CERTIFICATE_SHA256','__LOCAL_SECURE_STORAGE_GENERATION__':'$LOCAL_SIGNING_SERVICE_GENERATION'}.items(): s=s.replace(k,v)
+for k,v in {'__APP_NAME__':'$APP_NAME','__DISPLAY_NAME__':'$DISPLAY_NAME','__BUNDLE_ID__':'$BUNDLE_ID','__MARKETING_VERSION__':'$MARKETING_VERSION','__BUILD_NUMBER__':'$BUILD_NUMBER','__DEBUG_SECURE_STORAGE_BACKEND__':'$DEBUG_STORAGE_BACKEND_MARKER','__SIGNING_MODE__':'$SIGNING_MODE_MARKER','__LOCAL_SIGNING_CERTIFICATE_SHA256__':'$LOCAL_SIGNING_CERTIFICATE_SHA256','__LOCAL_SECURE_STORAGE_GENERATION__':'$LOCAL_SIGNING_SERVICE_GENERATION','__IDENTITY_MIGRATION_PHASE__':'$IDENTITY_MIGRATION_PHASE'}.items(): s=s.replace(k,v)
 Path('$APP_BUNDLE/Contents/Info.plist').write_text(s)
 PY
 run plutil -lint "$APP_BUNDLE/Contents/Info.plist"
+PACKAGED_IDENTITY_MIGRATION_PHASE="$(
+    plutil -extract RepoPromptIdentityMigrationPhase raw "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null ||
+        printf 'disabled\n'
+)"
+[[ "$PACKAGED_IDENTITY_MIGRATION_PHASE" == "$IDENTITY_MIGRATION_PHASE" ]] ||
+    fail "Packaged identity migration phase mismatch: requested $IDENTITY_MIGRATION_PHASE, got $PACKAGED_IDENTITY_MIGRATION_PHASE"
 
 if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
     phase "Rendering local self-signed entitlements"

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -16,6 +16,9 @@ TRUSTED_SPARKLE_FRAMEWORK="$TRUSTED_ROOT/Vendor/Sparkle/Sparkle.xcframework/maco
 STAGED_SPARKLE_FRAMEWORK="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
 CODEX_BUNDLE="$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex"
 ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
+IDENTITY_MIGRATION_ANCHOR_DESTINATION="$APP_BUNDLE/Contents/Resources/IdentityMigration/RepoPromptIdentityAnchor"
+IDENTITY_MIGRATION_TARGET_IDENTIFIER="com.repoprompt.ce"
+IDENTITY_MIGRATION_TARGET_TEAM_ID="69N6K965SF"
 
 fail() {
     printf 'ERROR: %s\n' "$*" >&2
@@ -74,6 +77,43 @@ plutil -lint "$app_entitlements"
 plutil -lint "$CODEX_V8_ENTITLEMENTS"
 plutil -replace RepoPromptDebugSecureStorageBackend -string keychain "$APP_BUNDLE/Contents/Info.plist"
 plutil -replace RepoPromptSigningMode -string developer-id "$APP_BUNDLE/Contents/Info.plist"
+
+identity_migration_phase="$(
+    plutil -extract RepoPromptIdentityMigrationPhase raw "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null ||
+        printf 'disabled\n'
+)"
+expected_identity_migration_phase="${REPOPROMPT_IDENTITY_MIGRATION_PHASE:-disabled}"
+[[ "$identity_migration_phase" == "$expected_identity_migration_phase" ]] ||
+    fail "Staged identity migration phase mismatch: expected $expected_identity_migration_phase, got $identity_migration_phase"
+case "$identity_migration_phase" in
+disabled)
+    ;;
+legacy-preparer)
+    [[ "$BUNDLE_ID" == "com.pvncher.repoprompt.ce" ]] ||
+        fail "Legacy identity preparer must retain bundle identifier com.pvncher.repoprompt.ce"
+    [[ "$SIGNING_TEAM_ID" == "648A27MST5" ]] ||
+        fail "Legacy identity preparer must retain signing Team ID 648A27MST5"
+    identity_migration_anchor="${REPOPROMPT_IDENTITY_MIGRATION_ANCHOR:-}"
+    [[ -n "$identity_migration_anchor" ]] ||
+        fail "Legacy identity preparer signing requires REPOPROMPT_IDENTITY_MIGRATION_ANCHOR"
+    [[ -f "$identity_migration_anchor" && ! -L "$identity_migration_anchor" ]] ||
+        fail "Identity migration anchor must be a regular, non-symlink file"
+    codesign --verify --strict --verbose=2 "$identity_migration_anchor"
+    anchor_signature_details="$(codesign -dv --verbose=4 "$identity_migration_anchor" 2>&1)"
+    anchor_identifier="$(printf '%s\n' "$anchor_signature_details" | awk -F= '/^Identifier=/{print $2; exit}')"
+    anchor_team="$(printf '%s\n' "$anchor_signature_details" | awk -F= '/^TeamIdentifier=/{print $2; exit}')"
+    [[ "$anchor_identifier" == "$IDENTITY_MIGRATION_TARGET_IDENTIFIER" ]] ||
+        fail "Identity migration anchor identifier mismatch: expected $IDENTITY_MIGRATION_TARGET_IDENTIFIER, got ${anchor_identifier:-<missing>}"
+    [[ "$anchor_team" == "$IDENTITY_MIGRATION_TARGET_TEAM_ID" ]] ||
+        fail "Identity migration anchor team mismatch: expected $IDENTITY_MIGRATION_TARGET_TEAM_ID, got ${anchor_team:-<missing>}"
+    mkdir -p "$(dirname "$IDENTITY_MIGRATION_ANCHOR_DESTINATION")"
+    ditto "$identity_migration_anchor" "$IDENTITY_MIGRATION_ANCHOR_DESTINATION"
+    chmod 755 "$IDENTITY_MIGRATION_ANCHOR_DESTINATION"
+    ;;
+*)
+    fail "Unsupported RepoPromptIdentityMigrationPhase: $identity_migration_phase"
+    ;;
+esac
 
 # Telemetry is gated on DSN presence: only the official Developer ID publish job receives the
 # protected SENTRY_DSN secret, and only here is it baked into the signed bundle. The value is never

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -19,6 +19,7 @@ ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
 IDENTITY_MIGRATION_ANCHOR_DESTINATION="$APP_BUNDLE/Contents/Resources/IdentityMigration/RepoPromptIdentityAnchor"
 IDENTITY_MIGRATION_TARGET_IDENTIFIER="com.repoprompt.ce"
 IDENTITY_MIGRATION_TARGET_TEAM_ID="69N6K965SF"
+IDENTITY_MIGRATION_TARGET_REQUIREMENT='anchor apple generic and identifier "com.repoprompt.ce" and certificate leaf[subject.OU] = "69N6K965SF" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists'
 
 fail() {
     printf 'ERROR: %s\n' "$*" >&2
@@ -98,7 +99,8 @@ legacy-preparer)
         fail "Legacy identity preparer signing requires REPOPROMPT_IDENTITY_MIGRATION_ANCHOR"
     [[ -f "$identity_migration_anchor" && ! -L "$identity_migration_anchor" ]] ||
         fail "Identity migration anchor must be a regular, non-symlink file"
-    codesign --verify --strict --verbose=2 "$identity_migration_anchor"
+    codesign --verify --strict --verbose=2 \
+        -R="$IDENTITY_MIGRATION_TARGET_REQUIREMENT" "$identity_migration_anchor"
     anchor_signature_details="$(codesign -dv --verbose=4 "$identity_migration_anchor" 2>&1)"
     anchor_identifier="$(printf '%s\n' "$anchor_signature_details" | awk -F= '/^Identifier=/{print $2; exit}')"
     anchor_team="$(printf '%s\n' "$anchor_signature_details" | awk -F= '/^TeamIdentifier=/{print $2; exit}')"
@@ -109,6 +111,10 @@ legacy-preparer)
     mkdir -p "$(dirname "$IDENTITY_MIGRATION_ANCHOR_DESTINATION")"
     ditto "$identity_migration_anchor" "$IDENTITY_MIGRATION_ANCHOR_DESTINATION"
     chmod 755 "$IDENTITY_MIGRATION_ANCHOR_DESTINATION"
+    [[ -f "$IDENTITY_MIGRATION_ANCHOR_DESTINATION" && ! -L "$IDENTITY_MIGRATION_ANCHOR_DESTINATION" ]] ||
+        fail "Embedded identity migration anchor must be a regular, non-symlink file"
+    codesign --verify --strict --verbose=2 \
+        -R="$IDENTITY_MIGRATION_TARGET_REQUIREMENT" "$IDENTITY_MIGRATION_ANCHOR_DESTINATION"
     ;;
 *)
     fail "Unsupported RepoPromptIdentityMigrationPhase: $identity_migration_phase"

--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -769,6 +769,7 @@ print_matches \
 # 8. Agent-authored reports and working notes stay local unless explicitly
 # promoted into the contributor-facing documentation set.
 allowed_tracked_docs=(
+  "docs/architecture/apple-identity-migration.md"
   "docs/architecture/codex-app-server-schema-gate.md"
   "docs/architecture/context-composer.md"
   "docs/architecture/headless-mcp-runtime.md"

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -100,6 +100,11 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("RepoPromptDebugSecureStorageBackend", info_plist)
         self.assertIn("RepoPromptLocalSigningCertificateSHA256", info_plist)
         self.assertIn("RepoPromptLocalSecureStorageGeneration", info_plist)
+        self.assertEqual(info_plist["RepoPromptIdentityMigrationPhase"], "__IDENTITY_MIGRATION_PHASE__")
+        self.assertEqual(
+            info_plist["RepoPromptIdentityMigrationAnchorRelativePath"],
+            "IdentityMigration/RepoPromptIdentityAnchor",
+        )
         self.assertIn("RepoPromptSentryDSN", info_plist)
         self.assertEqual(info_plist["RepoPromptSentryDSN"], "")
         self.assertIn(
@@ -233,6 +238,95 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertLess(mcp_sign, app_sign)
         self.assertLess(app_sign, outer_sign)
         self.assertNotIn('sign_path "$CODEX_BUNDLE"', source)
+
+    def test_legacy_preparer_requires_verified_future_identity_anchor(self) -> None:
+        package_source = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        source = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
+
+        self.assertIn('[[ "$BUNDLE_ID" == "com.pvncher.repoprompt.ce" ]]', package_source)
+        self.assertIn('[[ "$SIGNING_TEAM_ID" == "648A27MST5" ]]', package_source)
+        self.assertIn('[[ "$PACKAGED_IDENTITY_MIGRATION_PHASE" == "$IDENTITY_MIGRATION_PHASE" ]]', package_source)
+        self.assertIn('plutil -extract RepoPromptIdentityMigrationPhase raw', source)
+        self.assertIn("printf 'disabled\\n'", source)
+        self.assertIn('[[ "$identity_migration_phase" == "$expected_identity_migration_phase" ]]', source)
+        self.assertIn('REPOPROMPT_IDENTITY_MIGRATION_ANCHOR', source)
+        self.assertIn('[[ "$BUNDLE_ID" == "com.pvncher.repoprompt.ce" ]]', source)
+        self.assertIn('[[ "$SIGNING_TEAM_ID" == "648A27MST5" ]]', source)
+        self.assertIn('IDENTITY_MIGRATION_TARGET_IDENTIFIER="com.repoprompt.ce"', source)
+        self.assertIn('IDENTITY_MIGRATION_TARGET_TEAM_ID="69N6K965SF"', source)
+        self.assertIn('codesign --verify --strict --verbose=2 "$identity_migration_anchor"', source)
+        self.assertIn('[[ "$anchor_identifier" == "$IDENTITY_MIGRATION_TARGET_IDENTIFIER" ]]', source)
+        self.assertIn('[[ "$anchor_team" == "$IDENTITY_MIGRATION_TARGET_TEAM_ID" ]]', source)
+        self.assertNotIn('codesign --force --sign "$SIGN_IDENTITY"', source.split(
+            'ditto "$identity_migration_anchor" "$IDENTITY_MIGRATION_ANCHOR_DESTINATION"',
+            1,
+        )[0].split("legacy-preparer)", 1)[1])
+        self.assertLess(
+            source.index('ditto "$identity_migration_anchor" "$IDENTITY_MIGRATION_ANCHOR_DESTINATION"'),
+            source.index('sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"'),
+        )
+
+    def test_release_workflows_gate_legacy_preparer_and_keep_automatic_tip_disabled(self) -> None:
+        workflows = SCRIPT_DIR.parent / ".github" / "workflows"
+        release_workflow = (workflows / "release.yml").read_text(encoding="utf-8")
+        tip_workflow = (workflows / "main-tip.yml").read_text(encoding="utf-8")
+
+        for workflow in (release_workflow, tip_workflow):
+            self.assertIn("identity_migration_phase:", workflow)
+            self.assertIn("default: disabled", workflow)
+            self.assertIn("- legacy-preparer", workflow)
+            self.assertEqual(workflow.count("SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64"), 1)
+            self.assertEqual(workflow.count("SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD"), 1)
+            self.assertEqual(workflow.count("SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}"), 1)
+            self.assertNotIn("SUCCESSOR_DEVELOPER_ID_INSTALLER", workflow)
+            self.assertNotIn("SUCCESSOR_NOTARYTOOL", workflow)
+            self.assertIn("--identifier com.repoprompt.ce", workflow)
+            self.assertIn("grep -Fx 'Identifier=com.repoprompt.ce'", workflow)
+            self.assertIn("grep -Fx 'TeamIdentifier=69N6K965SF'", workflow)
+            self.assertIn('echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"', workflow)
+
+        release_stage = release_workflow.split("\n  stage:", 1)[1].split("\n  publish:", 1)[0]
+        release_publish = release_workflow.split("\n  publish:", 1)[1].split("\n  smoke-signed-helper:", 1)[0]
+        release_anchor = release_publish.split("      - name: Prepare successor identity migration anchor", 1)[1].split(
+            "      - name: Prepare provisioning profile and notarization key", 1
+        )[0]
+        self.assertNotIn("SUCCESSOR_", release_stage)
+        self.assertIn("if: inputs.identity_migration_phase == 'legacy-preparer'", release_anchor)
+        self.assertIn('anchor_source="release-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt"', release_anchor)
+        self.assertEqual(
+            release_workflow.count("REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase }}"),
+            3,
+        )
+        self.assertLess(
+            release_publish.index("Prepare successor identity migration anchor"),
+            release_publish.index("Sign, notarize, and create draft release"),
+        )
+        self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-release-successor.p12"', release_publish)
+        self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-successor-identity-anchor"', release_publish)
+
+        tip_stage = tip_workflow.split("\n  stage:", 1)[1].split("\n  sign:", 1)[0]
+        tip_sign = tip_workflow.split("\n  sign:", 1)[1].split("\n  smoke-no-secrets:", 1)[0]
+        tip_anchor = tip_sign.split("      - name: Prepare successor identity migration anchor", 1)[1].split(
+            "      - name: Prepare provisioning profile and notarization key", 1
+        )[0]
+        self.assertNotIn("SUCCESSOR_", tip_stage)
+        self.assertIn(
+            "if: github.event_name == 'workflow_dispatch' && inputs.identity_migration_phase == 'legacy-preparer'",
+            tip_anchor,
+        )
+        self.assertIn('anchor_source="tip-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt"', tip_anchor)
+        self.assertEqual(
+            tip_workflow.count(
+                "REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase || 'disabled' }}"
+            ),
+            3,
+        )
+        self.assertLess(
+            tip_sign.index("Prepare successor identity migration anchor"),
+            tip_sign.index("Sign and notarize staged tip"),
+        )
+        self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-tip-successor.p12"', tip_sign)
+        self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-tip-successor-identity-anchor"', tip_sign)
 
     def test_codex_v8_entitlement_allowlist_matches_pinned_manifest_policy(self) -> None:
         v8_profile = {
@@ -2513,6 +2607,34 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("OK: staged release payload matches approved source", result.stdout)
 
+    def test_staged_release_validator_rejects_requested_preparer_for_historical_template(self) -> None:
+        approved, staged, scripts = self.make_staged_release_fixture()
+        template_path = approved / "AppBundle" / "Info.plist.template"
+        historical_template = "\n".join(
+            line
+            for line in template_path.read_text(encoding="utf-8").splitlines()
+            if "RepoPromptIdentityMigration" not in line
+        )
+        template_path.write_text(historical_template + "\n", encoding="utf-8")
+        info_path = staged / ".build" / "release" / "RepoPrompt.app" / "Contents" / "Info.plist"
+        info = plistlib.loads(info_path.read_bytes())
+        info.pop("RepoPromptIdentityMigrationPhase")
+        info.pop("RepoPromptIdentityMigrationAnchorRelativePath")
+        info_path.write_bytes(plistlib.dumps(info))
+
+        result = self.run_staged_validation(
+            approved,
+            staged,
+            scripts,
+            identity_migration_phase="legacy-preparer",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "staged identity migration phase mismatch: expected legacy-preparer, got disabled",
+            result.stderr,
+        )
+
     def test_public_app_validation_uses_approved_manifest_from_extracted_stage_layout(self) -> None:
         for script_name in ("release.sh", "main_tip_release.sh"):
             with self.subTest(script=script_name):
@@ -4365,6 +4487,7 @@ SIGNING_TEAM_ID=648A27MST5
             "__SIGNING_MODE__": "release-candidate-adhoc",
             "__LOCAL_SIGNING_CERTIFICATE_SHA256__": "",
             "__LOCAL_SECURE_STORAGE_GENERATION__": "",
+            "__IDENTITY_MIGRATION_PHASE__": "disabled",
         }.items():
             template = template.replace(key, value)
         (app / "Contents" / "Info.plist").write_text(template, encoding="utf-8")
@@ -4456,6 +4579,7 @@ esac
         approved: Path,
         staged: Path,
         scripts: Path,
+        identity_migration_phase: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -4468,6 +4592,8 @@ esac
                 **cls.codex_fixture_environment(approved, staged),
             }
         )
+        if identity_migration_phase is not None:
+            env["REPOPROMPT_IDENTITY_MIGRATION_PHASE"] = identity_migration_phase
         return subprocess.run(
             [str(scripts / "validate_staged_release.sh")],
             env=env,

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2813,7 +2813,8 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
             "\n    func startUpdater()", 1
         )[0]
         self.assertNotIn("updaterController.startUpdater()", manager_init)
-        self.assertIn("guard sparkleConfigurationValid, !updaterStarted else { return }", sparkle_manager)
+        self.assertIn("switch Self.startDecision(", sparkle_manager)
+        self.assertIn("guard sparkleConfigurationValid, !updaterStarted else { return .ignore }", sparkle_manager)
         self.assertIn(
             "guard updaterStarted, sparkleConfigurationValid, userInitiatedObserverState.activeRequest == nil else {",
             sparkle_manager,

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -243,6 +243,7 @@ APP_SIGN_ARGS=(){app_signing_body}
         package_source = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
         source = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
 
+        self.assertTrue((SCRIPT_DIR / "identity_migration_anchor.c").is_file())
         self.assertIn('[[ "$BUNDLE_ID" == "com.pvncher.repoprompt.ce" ]]', package_source)
         self.assertIn('[[ "$SIGNING_TEAM_ID" == "648A27MST5" ]]', package_source)
         self.assertIn('[[ "$PACKAGED_IDENTITY_MIGRATION_PHASE" == "$IDENTITY_MIGRATION_PHASE" ]]', package_source)
@@ -254,7 +255,9 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn('[[ "$SIGNING_TEAM_ID" == "648A27MST5" ]]', source)
         self.assertIn('IDENTITY_MIGRATION_TARGET_IDENTIFIER="com.repoprompt.ce"', source)
         self.assertIn('IDENTITY_MIGRATION_TARGET_TEAM_ID="69N6K965SF"', source)
-        self.assertIn('codesign --verify --strict --verbose=2 "$identity_migration_anchor"', source)
+        self.assertIn('IDENTITY_MIGRATION_TARGET_REQUIREMENT=', source)
+        self.assertIn('-R="$IDENTITY_MIGRATION_TARGET_REQUIREMENT" "$identity_migration_anchor"', source)
+        self.assertIn('-R="$IDENTITY_MIGRATION_TARGET_REQUIREMENT" "$IDENTITY_MIGRATION_ANCHOR_DESTINATION"', source)
         self.assertIn('[[ "$anchor_identifier" == "$IDENTITY_MIGRATION_TARGET_IDENTIFIER" ]]', source)
         self.assertIn('[[ "$anchor_team" == "$IDENTITY_MIGRATION_TARGET_TEAM_ID" ]]', source)
         self.assertNotIn('codesign --force --sign "$SIGN_IDENTITY"', source.split(
@@ -271,19 +274,20 @@ APP_SIGN_ARGS=(){app_signing_body}
         release_workflow = (workflows / "release.yml").read_text(encoding="utf-8")
         tip_workflow = (workflows / "main-tip.yml").read_text(encoding="utf-8")
 
-        for workflow in (release_workflow, tip_workflow):
-            self.assertIn("identity_migration_phase:", workflow)
-            self.assertIn("default: disabled", workflow)
-            self.assertIn("- legacy-preparer", workflow)
-            self.assertEqual(workflow.count("SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64"), 1)
-            self.assertEqual(workflow.count("SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD"), 1)
-            self.assertEqual(workflow.count("SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}"), 1)
-            self.assertNotIn("SUCCESSOR_DEVELOPER_ID_INSTALLER", workflow)
-            self.assertNotIn("SUCCESSOR_NOTARYTOOL", workflow)
-            self.assertIn("--identifier com.repoprompt.ce", workflow)
-            self.assertIn("grep -Fx 'Identifier=com.repoprompt.ce'", workflow)
-            self.assertIn("grep -Fx 'TeamIdentifier=69N6K965SF'", workflow)
-            self.assertIn('echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"', workflow)
+        self.assertIn("identity_migration_phase:", release_workflow)
+        self.assertIn("default: disabled", release_workflow)
+        self.assertIn("- legacy-preparer", release_workflow)
+        self.assertEqual(release_workflow.count("SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64"), 1)
+        self.assertEqual(release_workflow.count("SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD"), 1)
+        self.assertEqual(release_workflow.count("SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}"), 1)
+        self.assertNotIn("SUCCESSOR_DEVELOPER_ID_INSTALLER", release_workflow)
+        self.assertNotIn("SUCCESSOR_NOTARYTOOL", release_workflow)
+        self.assertIn("--identifier com.repoprompt.ce", release_workflow)
+        self.assertIn("grep -Fx 'Identifier=com.repoprompt.ce'", release_workflow)
+        self.assertIn("grep -Fx 'TeamIdentifier=69N6K965SF'", release_workflow)
+        self.assertIn('successor_requirement=', release_workflow)
+        self.assertIn('-R="$successor_requirement" "$anchor"', release_workflow)
+        self.assertIn('echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"', release_workflow)
 
         release_stage = release_workflow.split("\n  stage:", 1)[1].split("\n  publish:", 1)[0]
         release_publish = release_workflow.split("\n  publish:", 1)[1].split("\n  smoke-signed-helper:", 1)[0]
@@ -292,7 +296,12 @@ APP_SIGN_ARGS=(){app_signing_body}
         )[0]
         self.assertNotIn("SUCCESSOR_", release_stage)
         self.assertIn("if: inputs.identity_migration_phase == 'legacy-preparer'", release_anchor)
-        self.assertIn('anchor_source="release-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt"', release_anchor)
+        self.assertIn('anchor_source="trusted-control-plane/Scripts/identity_migration_anchor.c"', release_anchor)
+        self.assertIn(
+            'xcrun clang -arch arm64 -arch x86_64 -Os -Wl,-dead_strip -o "$anchor" "$anchor_source"',
+            release_anchor,
+        )
+        self.assertNotIn('release-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt', release_anchor)
         self.assertEqual(
             release_workflow.count("REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase }}"),
             3,
@@ -304,29 +313,14 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-release-successor.p12"', release_publish)
         self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-successor-identity-anchor"', release_publish)
 
-        tip_stage = tip_workflow.split("\n  stage:", 1)[1].split("\n  sign:", 1)[0]
-        tip_sign = tip_workflow.split("\n  sign:", 1)[1].split("\n  smoke-no-secrets:", 1)[0]
-        tip_anchor = tip_sign.split("      - name: Prepare successor identity migration anchor", 1)[1].split(
-            "      - name: Prepare provisioning profile and notarization key", 1
-        )[0]
-        self.assertNotIn("SUCCESSOR_", tip_stage)
-        self.assertIn(
-            "if: github.event_name == 'workflow_dispatch' && inputs.identity_migration_phase == 'legacy-preparer'",
-            tip_anchor,
-        )
-        self.assertIn('anchor_source="tip-source/.build/release/RepoPrompt.app/Contents/MacOS/RepoPrompt"', tip_anchor)
+        self.assertNotIn("identity_migration_phase:", tip_workflow)
+        self.assertNotIn("legacy-preparer", tip_workflow)
+        self.assertNotIn("SUCCESSOR_", tip_workflow)
+        self.assertNotIn("Prepare successor identity migration anchor", tip_workflow)
         self.assertEqual(
-            tip_workflow.count(
-                "REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ inputs.identity_migration_phase || 'disabled' }}"
-            ),
+            tip_workflow.count("REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled"),
             3,
         )
-        self.assertLess(
-            tip_sign.index("Prepare successor identity migration anchor"),
-            tip_sign.index("Sign and notarize staged tip"),
-        )
-        self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-tip-successor.p12"', tip_sign)
-        self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-tip-successor-identity-anchor"', tip_sign)
 
     def test_codex_v8_entitlement_allowlist_matches_pinned_manifest_policy(self) -> None:
         v8_profile = {

--- a/Scripts/validate_staged_release.sh
+++ b/Scripts/validate_staged_release.sh
@@ -164,12 +164,13 @@ REPOPROMPT_RELEASE_SOURCE_ROOT="$APPROVED_SOURCE_ROOT" \
     "$SCRIPT_DIR/validate_packaged_legal.sh" "$APP_BUNDLE"
 
 python3 - "$APPROVED_SOURCE_ROOT/AppBundle/Info.plist.template" "$APP_BUNDLE/Contents/Info.plist" \
-    "$APP_NAME" "$DISPLAY_NAME" "$BUNDLE_ID" "$MARKETING_VERSION" "$BUILD_NUMBER" <<'PYTHON'
+    "$APP_NAME" "$DISPLAY_NAME" "$BUNDLE_ID" "$MARKETING_VERSION" "$BUILD_NUMBER" \
+    "${REPOPROMPT_IDENTITY_MIGRATION_PHASE:-disabled}" <<'PYTHON'
 import plistlib
 import sys
 from pathlib import Path
 
-template, actual, app_name, display_name, bundle_id, version, build = sys.argv[1:]
+template, actual, app_name, display_name, bundle_id, version, build, identity_migration_phase = sys.argv[1:]
 text = Path(template).read_text(encoding="utf-8")
 for key, value in {
     "__APP_NAME__": app_name,
@@ -181,10 +182,19 @@ for key, value in {
     "__SIGNING_MODE__": "release-candidate-adhoc",
     "__LOCAL_SIGNING_CERTIFICATE_SHA256__": "",
     "__LOCAL_SECURE_STORAGE_GENERATION__": "",
+    "__IDENTITY_MIGRATION_PHASE__": identity_migration_phase,
 }.items():
     text = text.replace(key, value)
-if plistlib.loads(text.encode("utf-8")) != plistlib.loads(Path(actual).read_bytes()):
+expected_plist = plistlib.loads(text.encode("utf-8"))
+actual_plist = plistlib.loads(Path(actual).read_bytes())
+if expected_plist != actual_plist:
     raise SystemExit("ERROR: staged Info.plist does not match the approved release candidate")
+actual_identity_migration_phase = actual_plist.get("RepoPromptIdentityMigrationPhase", "disabled")
+if actual_identity_migration_phase != identity_migration_phase:
+    raise SystemExit(
+        "ERROR: staged identity migration phase mismatch: "
+        f"expected {identity_migration_phase}, got {actual_identity_migration_phase}"
+    )
 PYTHON
 
 printf 'OK: staged release payload matches approved source and confined path policy.\n'

--- a/Sources/RepoPrompt/App/RepoPromptApp.swift
+++ b/Sources/RepoPrompt/App/RepoPromptApp.swift
@@ -183,6 +183,7 @@ struct RepoPromptSwiftUIApp: App {
 @MainActor
 public enum RepoPromptApplication {
     public static func main() {
+        SecureStorageIdentityMigrationBootstrap.prepareIfConfigured()
         RepoPromptSwiftUIApp.main()
     }
 }

--- a/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
+++ b/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
@@ -9,6 +9,12 @@ import Combine
 import Sparkle
 import SwiftUI
 
+enum SparkleUpdaterStartDecision: Equatable {
+    case ignore
+    case blocked(String)
+    case start
+}
+
 #if DEBUG
     private var sparkleUpdaterManagerDebugLoggingEnabled = false
     private func sparkleUpdaterManagerDebugLog(_ message: @autoclosure () -> String) {
@@ -166,11 +172,19 @@ final class SparkleUpdaterManager: ObservableObject {
     }
 
     func startUpdater() {
-        guard sparkleConfigurationValid, !updaterStarted else { return }
-        if let blockedMessage = IdentityMigrationRuntimeState.shared.updatesBlockedMessage() {
+        switch Self.startDecision(
+            sparkleConfigurationValid: sparkleConfigurationValid,
+            updaterStarted: updaterStarted,
+            identityMigrationBlockedMessage: IdentityMigrationRuntimeState.shared.updatesBlockedMessage()
+        ) {
+        case .ignore:
+            return
+        case let .blocked(blockedMessage):
             updatesDisabledMessage = blockedMessage
             canCheckForUpdates = false
             return
+        case .start:
+            break
         }
 
         // Install observers before activation so no Sparkle event can race registration.
@@ -187,6 +201,18 @@ final class SparkleUpdaterManager: ObservableObject {
 
         // Setup periodic passive update checking if enabled.
         setupPeriodicUpdateCheck()
+    }
+
+    static func startDecision(
+        sparkleConfigurationValid: Bool,
+        updaterStarted: Bool,
+        identityMigrationBlockedMessage: String?
+    ) -> SparkleUpdaterStartDecision {
+        guard sparkleConfigurationValid, !updaterStarted else { return .ignore }
+        if let identityMigrationBlockedMessage {
+            return .blocked(identityMigrationBlockedMessage)
+        }
+        return .start
     }
 
     private static func loadPassiveAppcastChecksPreference(defaultingTo sparkleAutomaticChecks: Bool) -> Bool {

--- a/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
+++ b/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
@@ -167,6 +167,11 @@ final class SparkleUpdaterManager: ObservableObject {
 
     func startUpdater() {
         guard sparkleConfigurationValid, !updaterStarted else { return }
+        if let blockedMessage = IdentityMigrationRuntimeState.shared.updatesBlockedMessage() {
+            updatesDisabledMessage = blockedMessage
+            canCheckForUpdates = false
+            return
+        }
 
         // Install observers before activation so no Sparkle event can race registration.
         setupObservers()

--- a/Sources/RepoPrompt/Features/Settings/Views/General/LicenseUpdatesSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/General/LicenseUpdatesSettingsView.swift
@@ -34,6 +34,13 @@ struct LicenseUpdatesSettingsView: View {
                                 closeAction?()
                             }
                             .buttonStyle(.bordered)
+                            .disabled(!sparkleManager.canCheckForUpdates)
+                        }
+
+                        if let message = sparkleManager.updatesDisabledMessage {
+                            Label(message, systemImage: "exclamationmark.triangle.fill")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
                         }
 
                         if let availableUpdate = sparkleManager.availableUpdate {

--- a/Sources/RepoPrompt/Features/Settings/Views/GeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/GeneralSettingsView.swift
@@ -101,6 +101,13 @@ struct GeneralSettingsView: View {
                                 closeAction?()
                             }
                             .buttonStyle(.bordered)
+                            .disabled(!sparkleManager.canCheckForUpdates)
+                        }
+
+                        if let message = sparkleManager.updatesDisabledMessage {
+                            Label(message, systemImage: "exclamationmark.triangle.fill")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
                         }
 
                         // Install button (only when update is available)

--- a/Sources/RepoPrompt/Features/Settings/Views/SystemSettings.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/SystemSettings.swift
@@ -68,6 +68,13 @@ struct SystemSettingsView: View {
                                 closeAction?()
                             }
                             .buttonStyle(.bordered)
+                            .disabled(!sparkleManager.canCheckForUpdates)
+                        }
+
+                        if let message = sparkleManager.updatesDisabledMessage {
+                            Label(message, systemImage: "exclamationmark.triangle.fill")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
                         }
 
                         // Install button (only when update is available)

--- a/Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift
@@ -59,6 +59,43 @@ protocol KeychainItemCreationAttributeProvider {
     func attributesForNewItem() throws -> [String: Any]
 }
 
+protocol KeychainItemAccessValidator {
+    func validate(_ access: AnyObject) throws
+}
+
+protocol SecKeychainItemAccessProvider {
+    func copyAccess(from result: AnyObject) throws -> AnyObject
+}
+
+enum KeychainItemAccessProviderError: Error, LocalizedError, Equatable {
+    case invalidItemReference
+    case accessCopyFailed(status: OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidItemReference:
+            "The Keychain item reference is invalid"
+        case let .accessCopyFailed(status):
+            "Could not copy the Keychain access policy (status \(status))"
+        }
+    }
+}
+
+struct SystemSecKeychainItemAccessProvider: SecKeychainItemAccessProvider {
+    func copyAccess(from result: AnyObject) throws -> AnyObject {
+        guard CFGetTypeID(result as CFTypeRef) == SecKeychainItemGetTypeID() else {
+            throw KeychainItemAccessProviderError.invalidItemReference
+        }
+        let item = unsafeBitCast(result, to: SecKeychainItem.self)
+        var access: SecAccess?
+        let status = SecKeychainItemCopyAccess(item, &access)
+        guard status == errSecSuccess, let access else {
+            throw KeychainItemAccessProviderError.accessCopyFailed(status: status)
+        }
+        return access
+    }
+}
+
 enum KeychainItemCreationAttributeError: Error, LocalizedError, Equatable {
     case trustedApplicationCreationFailed(path: String, status: OSStatus)
     case trustedApplicationValidationFailed(path: String)
@@ -85,14 +122,247 @@ enum KeychainItemCreationAttributeError: Error, LocalizedError, Equatable {
     }
 }
 
-/// Builds a classic macOS Keychain ACL from signed executables. The migration preparer
-/// supplies its current executable plus an embedded executable signed for the successor
-/// identity. Security.framework derives the designated requirements; no credential data
-/// or authorization prompt is involved in constructing this policy.
+/// Builds a classic macOS Keychain ACL from exact code requirements after validating
+/// the corresponding signed executables. The migration preparer supplies its current
+/// executable plus an embedded executable signed for the successor identity; no
+/// credential data or authorization prompt is involved in constructing this policy.
 struct TrustedApplicationCodeRequirement {
     let trustedApplicationPath: String
     let codeURL: URL
     let requirementSource: String
+}
+
+enum KeychainACLPrincipal: Equatable {
+    case requirement(Data)
+    case wildcard
+    case malformed
+}
+
+enum KeychainACLValidationError: Error, LocalizedError, Equatable {
+    case invalidExpectedPrincipalPolicy
+    case invalidAccess
+    case decryptACLListMissing
+    case unexpectedDecryptACLCount(Int)
+    case accessACLTypeInvalid
+    case accessACLContentsCopyFailed(status: OSStatus)
+    case wildcardPrincipal
+    case missingPrincipal
+    case extraPrincipal
+    case duplicatePrincipal
+    case malformedPrincipal
+    case trustedApplicationRequirementCopyFailed(status: OSStatus)
+    case trustedApplicationRequirementMissing
+    case requirementDataCopyFailed(status: OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidExpectedPrincipalPolicy:
+            "The Keychain ACL principal policy is invalid"
+        case .invalidAccess:
+            "The Keychain access policy is invalid"
+        case .decryptACLListMissing:
+            "The Keychain access policy has no decrypt ACL"
+        case let .unexpectedDecryptACLCount(count):
+            "The Keychain access policy has an unexpected number of decrypt ACLs (\(count))"
+        case .accessACLTypeInvalid:
+            "The Keychain access-control list contains an invalid ACL"
+        case let .accessACLContentsCopyFailed(status):
+            "Could not inspect Keychain ACL contents (status \(status))"
+        case .wildcardPrincipal:
+            "The Keychain access policy contains a wildcard principal"
+        case .missingPrincipal:
+            "The Keychain access policy is missing an expected principal"
+        case .extraPrincipal:
+            "The Keychain access policy contains an unexpected principal"
+        case .duplicatePrincipal:
+            "The Keychain access policy contains a duplicate principal"
+        case .malformedPrincipal:
+            "The Keychain access policy contains a malformed principal"
+        case let .trustedApplicationRequirementCopyFailed(status):
+            "Could not inspect a Keychain trusted-application requirement (status \(status))"
+        case .trustedApplicationRequirementMissing:
+            "The Keychain trusted application has no code requirement"
+        case let .requirementDataCopyFailed(status):
+            "Could not serialize a Keychain trusted-application requirement (status \(status))"
+        }
+    }
+}
+
+/// Security.framework exports these SPIs on macOS, and its implementation is the
+/// only API that creates and exposes the code requirement carried by a
+/// SecTrustedApplication.
+/// SecTrustedApplicationCopyData is deliberately not used: Apple documents that
+/// payload as opaque, and current Security sources return the principal description
+/// (normally a path), not the requirement that grants access.
+@_silgen_name("SecTrustedApplicationCopyRequirement")
+private func SecTrustedApplicationCopyRequirementSPI(
+    _ application: SecTrustedApplication,
+    _ requirement: UnsafeMutablePointer<SecRequirement?>
+) -> OSStatus
+
+@_silgen_name("SecTrustedApplicationCreateFromRequirement")
+private func SecTrustedApplicationCreateFromRequirementSPI(
+    _ description: UnsafePointer<CChar>?,
+    _ requirement: SecRequirement,
+    _ application: UnsafeMutablePointer<SecTrustedApplication?>
+) -> OSStatus
+
+/// Authenticates the one ACL that can decrypt a classic Keychain item. Every
+/// trusted application in that ACL must carry one of the exact expected designated
+/// requirements, with no wildcard, duplicate, missing, or additional principal.
+struct ClassicKeychainACLValidator: KeychainItemAccessValidator {
+    private let expectedPrincipalData: [Data]
+
+    init(requirementSources: [String]) throws {
+        guard !requirementSources.isEmpty else {
+            throw KeychainACLValidationError.invalidExpectedPrincipalPolicy
+        }
+        let principalData = requirementSources.compactMap(RuntimeCodeSigningDetector.requirementData(from:))
+        guard principalData.count == requirementSources.count,
+              Set(principalData).count == principalData.count
+        else {
+            throw KeychainACLValidationError.invalidExpectedPrincipalPolicy
+        }
+        expectedPrincipalData = principalData
+    }
+
+    func validate(_ access: AnyObject) throws {
+        guard CFGetTypeID(access as CFTypeRef) == SecAccessGetTypeID() else {
+            throw KeychainACLValidationError.invalidAccess
+        }
+        let access = unsafeBitCast(access, to: SecAccess.self)
+        guard let aclList = SecAccessCopyMatchingACLList(
+            access,
+            kSecACLAuthorizationDecrypt
+        ) else {
+            throw KeychainACLValidationError.decryptACLListMissing
+        }
+        let aclCount = CFArrayGetCount(aclList)
+        guard aclCount == 1 else {
+            throw KeychainACLValidationError.unexpectedDecryptACLCount(aclCount)
+        }
+
+        var principals: [KeychainACLPrincipal] = []
+        let aclValue = CFArrayGetValueAtIndex(aclList, 0)
+        let aclObject: CFTypeRef = unsafeBitCast(aclValue, to: CFTypeRef.self)
+        guard CFGetTypeID(aclObject) == SecACLGetTypeID() else {
+            throw KeychainACLValidationError.accessACLTypeInvalid
+        }
+        let acl = unsafeBitCast(aclValue, to: SecACL.self)
+        var applications: CFArray?
+        var description: CFString?
+        var promptSelector = SecKeychainPromptSelector(rawValue: 0)
+        let contentsStatus = SecACLCopyContents(
+            acl,
+            &applications,
+            &description,
+            &promptSelector
+        )
+        guard contentsStatus == errSecSuccess else {
+            throw KeychainACLValidationError.accessACLContentsCopyFailed(status: contentsStatus)
+        }
+        guard let applications else {
+            throw KeychainACLValidationError.wildcardPrincipal
+        }
+        guard CFArrayGetCount(applications) > 0 else {
+            throw KeychainACLValidationError.missingPrincipal
+        }
+        for applicationIndex in 0 ..< CFArrayGetCount(applications) {
+            let applicationValue = CFArrayGetValueAtIndex(applications, applicationIndex)
+            let applicationObject: CFTypeRef = unsafeBitCast(
+                applicationValue,
+                to: CFTypeRef.self
+            )
+            guard CFGetTypeID(applicationObject) == SecTrustedApplicationGetTypeID() else {
+                principals.append(.malformed)
+                continue
+            }
+            let application = unsafeBitCast(
+                applicationValue,
+                to: SecTrustedApplication.self
+            )
+            var requirement: SecRequirement?
+            let requirementStatus = SecTrustedApplicationCopyRequirementSPI(
+                application,
+                &requirement
+            )
+            guard requirementStatus == errSecSuccess else {
+                throw KeychainACLValidationError.trustedApplicationRequirementCopyFailed(
+                    status: requirementStatus
+                )
+            }
+            guard let requirement else {
+                throw KeychainACLValidationError.trustedApplicationRequirementMissing
+            }
+            var data: CFData?
+            let dataStatus = SecRequirementCopyData(requirement, [], &data)
+            guard dataStatus == errSecSuccess else {
+                throw KeychainACLValidationError.requirementDataCopyFailed(status: dataStatus)
+            }
+            guard let data, CFDataGetLength(data) > 0 else {
+                principals.append(.malformed)
+                continue
+            }
+            principals.append(.requirement(data as Data))
+        }
+
+        try Self.validate(principals: principals, expected: expectedPrincipalData)
+    }
+
+    static func validate(
+        principals: [KeychainACLPrincipal],
+        expected: [Data]
+    ) throws {
+        guard !expected.isEmpty,
+              Set(expected).count == expected.count
+        else {
+            throw KeychainACLValidationError.invalidExpectedPrincipalPolicy
+        }
+
+        var seen: Set<Data> = []
+        for principal in principals {
+            switch principal {
+            case .wildcard:
+                throw KeychainACLValidationError.wildcardPrincipal
+            case .malformed:
+                throw KeychainACLValidationError.malformedPrincipal
+            case let .requirement(data):
+                guard !data.isEmpty else {
+                    throw KeychainACLValidationError.malformedPrincipal
+                }
+                guard expected.contains(data) else {
+                    throw KeychainACLValidationError.extraPrincipal
+                }
+                guard seen.insert(data).inserted else {
+                    throw KeychainACLValidationError.duplicatePrincipal
+                }
+            }
+        }
+        guard seen == Set(expected) else {
+            throw KeychainACLValidationError.missingPrincipal
+        }
+    }
+}
+
+struct KeychainAccessAuthority {
+    let creationAttributeProvider: TrustedApplicationsKeychainAttributeProvider
+    let accessValidator: ClassicKeychainACLValidator
+
+    init(
+        descriptor: String,
+        applications: [TrustedApplicationCodeRequirement]
+    ) throws {
+        guard applications.count == 2 else {
+            throw KeychainACLValidationError.invalidExpectedPrincipalPolicy
+        }
+        creationAttributeProvider = TrustedApplicationsKeychainAttributeProvider(
+            descriptor: descriptor,
+            applications: applications
+        )
+        accessValidator = try ClassicKeychainACLValidator(
+            requirementSources: applications.map(\.requirementSource)
+        )
+    }
 }
 
 final class TrustedApplicationsKeychainAttributeProvider: KeychainItemCreationAttributeProvider {
@@ -124,11 +394,19 @@ final class TrustedApplicationsKeychainAttributeProvider: KeychainItemCreationAt
                     path: application.trustedApplicationPath
                 )
             }
+            guard let requirement = RuntimeCodeSigningDetector.requirement(
+                from: application.requirementSource
+            ) else {
+                throw KeychainACLValidationError.invalidExpectedPrincipalPolicy
+            }
             var trustedApplication: SecTrustedApplication?
-            let status = SecTrustedApplicationCreateFromPath(
-                application.trustedApplicationPath,
-                &trustedApplication
-            )
+            let status = application.trustedApplicationPath.withCString { description in
+                SecTrustedApplicationCreateFromRequirementSPI(
+                    description,
+                    requirement,
+                    &trustedApplication
+                )
+            }
             guard status == errSecSuccess, let trustedApplication else {
                 throw KeychainItemCreationAttributeError.trustedApplicationCreationFailed(
                     path: application.trustedApplicationPath,
@@ -164,6 +442,25 @@ struct ExistingKeychainItemAccessAttributeProvider: KeychainItemCreationAttribut
     let serviceName: String
     let account: String
     let itemIdentityAttributes: [String: Any]
+    let accessValidator: KeychainItemAccessValidator
+    let itemAccessProvider: SecKeychainItemAccessProvider
+    let secItemClient: SecItemClient
+
+    init(
+        serviceName: String,
+        account: String,
+        itemIdentityAttributes: [String: Any] = [:],
+        accessValidator: KeychainItemAccessValidator,
+        itemAccessProvider: SecKeychainItemAccessProvider = SystemSecKeychainItemAccessProvider(),
+        secItemClient: SecItemClient = SystemSecItemClient()
+    ) {
+        self.serviceName = serviceName
+        self.account = account
+        self.itemIdentityAttributes = itemIdentityAttributes
+        self.accessValidator = accessValidator
+        self.itemAccessProvider = itemAccessProvider
+        self.secItemClient = secItemClient
+    }
 
     func attributesForNewItem() throws -> [String: Any] {
         var query: [String: Any] = [
@@ -176,23 +473,17 @@ struct ExistingKeychainItemAccessAttributeProvider: KeychainItemCreationAttribut
         ]
         query.merge(itemIdentityAttributes) { _, replacement in replacement }
 
-        var result: CFTypeRef?
-        let lookupStatus = SecItemCopyMatching(query as CFDictionary, &result)
+        var result: AnyObject?
+        let lookupStatus = secItemClient.copyMatching(query as CFDictionary, &result)
         guard lookupStatus == errSecSuccess else {
             throw KeychainItemCreationAttributeError.referenceItemLookupFailed(status: lookupStatus)
         }
-        guard let result,
-              CFGetTypeID(result) == SecKeychainItemGetTypeID()
-        else {
+        guard let result else {
             throw KeychainItemCreationAttributeError.referenceItemInvalid
         }
 
-        let item = unsafeBitCast(result, to: SecKeychainItem.self)
-        var access: SecAccess?
-        let accessStatus = SecKeychainItemCopyAccess(item, &access)
-        guard accessStatus == errSecSuccess, let access else {
-            throw KeychainItemCreationAttributeError.referenceItemAccessFailed(status: accessStatus)
-        }
+        let access = try itemAccessProvider.copyAccess(from: result)
+        try accessValidator.validate(access)
         return [kSecAttrAccess as String: access]
     }
 }
@@ -201,7 +492,7 @@ struct ExistingKeychainItemAccessAttributeProvider: KeychainItemCreationAttribut
 final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
     static let legacyCanonicalServiceName = "com.pvncher.repoprompt.ce.keychain"
     static let officialV2ServiceName = "com.pvncher.repoprompt.ce.developer-id.keychain.v2"
-    static let identityMigrationBridgeServiceName = "com.repoprompt.ce.identity-migration.keychain.v1"
+    static let identityMigrationBridgeServiceNamePrefix = "com.repoprompt.ce.identity-migration.keychain.v1."
     static let identityMigrationLegacyStateServiceName = "com.pvncher.repoprompt.ce.identity-migration.state.v2"
     static let localSelfSignedServiceNamePrefix = "com.pvncher.repoprompt.ce.local-self-signed."
     static let debugServiceName = "com.pvncher.repoprompt.ce.debug.keychain"
@@ -224,10 +515,21 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
         KeychainService(serviceName: legacyCanonicalServiceName, secItemClient: secItemClient)
     }
 
+    static func identityMigrationBridgeServiceName(for attemptIdentifier: String) -> String? {
+        guard let uuid = UUID(uuidString: attemptIdentifier),
+              uuid.uuidString.lowercased() == attemptIdentifier
+        else {
+            return nil
+        }
+        return "\(identityMigrationBridgeServiceNamePrefix)\(attemptIdentifier)"
+    }
+
     let serviceName: String
     private let secItemClient: SecItemClient
     private let itemCreationAttributeProvider: KeychainItemCreationAttributeProvider?
     private let itemIdentityAttributes: [String: Any]
+    private let itemAccessValidator: KeychainItemAccessValidator?
+    private let itemAccessProvider: SecKeychainItemAccessProvider
     private let operationLock = NSRecursiveLock()
 
     let persistsValuesAcrossLaunches = true
@@ -236,12 +538,16 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
         serviceName: String = KeychainService.officialV2ServiceName,
         secItemClient: SecItemClient = SystemSecItemClient(),
         itemCreationAttributeProvider: KeychainItemCreationAttributeProvider? = nil,
-        itemIdentityAttributes: [String: Any] = [:]
+        itemIdentityAttributes: [String: Any] = [:],
+        itemAccessValidator: KeychainItemAccessValidator? = nil,
+        itemAccessProvider: SecKeychainItemAccessProvider = SystemSecKeychainItemAccessProvider()
     ) {
         self.serviceName = serviceName
         self.secItemClient = secItemClient
         self.itemCreationAttributeProvider = itemCreationAttributeProvider
         self.itemIdentityAttributes = itemIdentityAttributes
+        self.itemAccessValidator = itemAccessValidator
+        self.itemAccessProvider = itemAccessProvider
     }
 
     private func withLock<T>(_ body: () throws -> T) rethrows -> T {
@@ -257,6 +563,30 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
             query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
         }
         return query
+    }
+
+    private func validateExistingItem(
+        for key: String,
+        accessMode: KeychainAccessMode
+    ) throws {
+        guard let itemAccessValidator else { return }
+        let referenceQuery = query([
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key,
+            kSecReturnRef as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ], accessMode: accessMode)
+        var result: AnyObject?
+        let status = secItemClient.copyMatching(referenceQuery as CFDictionary, &result)
+        guard status == errSecSuccess else {
+            throw keychainError(for: status)
+        }
+        guard let result else {
+            throw KeychainItemAccessProviderError.invalidItemReference
+        }
+        let access = try itemAccessProvider.copyAccess(from: result)
+        try itemAccessValidator.validate(access)
     }
 
     private func keychainError(for status: OSStatus) -> KeychainError {
@@ -318,6 +648,14 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
                 throw KeychainError.invalidData
             }
 
+            if itemAccessValidator != nil {
+                do {
+                    try validateExistingItem(for: key, accessMode: accessMode)
+                } catch KeychainError.itemNotFound {
+                    // The atomic add below establishes the ACL for a new item.
+                }
+            }
+
             let itemQuery = query([
                 kSecClass as String: kSecClassGenericPassword,
                 kSecAttrService as String: serviceName,
@@ -331,6 +669,9 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
             let updateStatus = secItemClient.update(itemQuery as CFDictionary, attributes as CFDictionary)
             switch updateStatus {
             case errSecSuccess:
+                if itemAccessValidator != nil {
+                    try validateExistingItem(for: key, accessMode: accessMode)
+                }
                 return
             case errSecItemNotFound:
                 break
@@ -383,6 +724,9 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
         guard addStatus == errSecSuccess else {
             throw keychainError(for: addStatus)
         }
+        if itemAccessValidator != nil {
+            try validateExistingItem(for: key, accessMode: accessMode)
+        }
     }
 
     // MARK: - Retrieve from Keychain
@@ -393,6 +737,7 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
         accessMode: KeychainAccessMode = .interactive
     ) throws -> String {
         let data = try withLock {
+            try validateExistingItem(for: key, accessMode: accessMode)
             let itemQuery = query([
                 kSecClass as String: kSecClassGenericPassword,
                 kSecAttrService as String: serviceName,
@@ -424,6 +769,13 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
     /// Delete an item from this service only.
     func delete(for key: String, accessMode: KeychainAccessMode = .interactive) throws {
         try withLock {
+            if itemAccessValidator != nil {
+                do {
+                    try validateExistingItem(for: key, accessMode: accessMode)
+                } catch KeychainError.itemNotFound {
+                    return
+                }
+            }
             let itemQuery = query([
                 kSecClass as String: kSecClassGenericPassword,
                 kSecAttrService as String: serviceName,

--- a/Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift
@@ -61,14 +61,26 @@ protocol KeychainItemCreationAttributeProvider {
 
 enum KeychainItemCreationAttributeError: Error, LocalizedError, Equatable {
     case trustedApplicationCreationFailed(path: String, status: OSStatus)
+    case trustedApplicationValidationFailed(path: String)
     case accessCreationFailed(status: OSStatus)
+    case referenceItemLookupFailed(status: OSStatus)
+    case referenceItemInvalid
+    case referenceItemAccessFailed(status: OSStatus)
 
     var errorDescription: String? {
         switch self {
         case let .trustedApplicationCreationFailed(path, status):
             "Could not create a Keychain trusted-application requirement for \(path) (status \(status))"
+        case let .trustedApplicationValidationFailed(path):
+            "The Keychain trusted application failed code-signing validation: \(path)"
         case let .accessCreationFailed(status):
             "Could not create the Keychain access policy (status \(status))"
+        case let .referenceItemLookupFailed(status):
+            "Could not find the Keychain access-policy reference item (status \(status))"
+        case .referenceItemInvalid:
+            "The Keychain access-policy reference item is invalid"
+        case let .referenceItemAccessFailed(status):
+            "Could not copy the Keychain access policy from the reference item (status \(status))"
         }
     }
 }
@@ -77,21 +89,58 @@ enum KeychainItemCreationAttributeError: Error, LocalizedError, Equatable {
 /// supplies its current executable plus an embedded executable signed for the successor
 /// identity. Security.framework derives the designated requirements; no credential data
 /// or authorization prompt is involved in constructing this policy.
-struct TrustedApplicationsKeychainAttributeProvider: KeychainItemCreationAttributeProvider {
+struct TrustedApplicationCodeRequirement {
+    let trustedApplicationPath: String
+    let codeURL: URL
+    let requirementSource: String
+}
+
+final class TrustedApplicationsKeychainAttributeProvider: KeychainItemCreationAttributeProvider {
     let descriptor: String
-    let executablePaths: [String]
+    let applications: [TrustedApplicationCodeRequirement]
+
+    private let lock = NSRecursiveLock()
+    private var cachedAttributes: [String: Any]?
+
+    init(descriptor: String, applications: [TrustedApplicationCodeRequirement]) {
+        self.descriptor = descriptor
+        self.applications = applications
+    }
 
     func attributesForNewItem() throws -> [String: Any] {
-        var trustedApplications: [SecTrustedApplication] = []
-        trustedApplications.reserveCapacity(executablePaths.count)
+        lock.lock()
+        defer { lock.unlock() }
+        if let cachedAttributes { return cachedAttributes }
 
-        for path in executablePaths {
+        var trustedApplications: [SecTrustedApplication] = []
+        trustedApplications.reserveCapacity(applications.count)
+
+        for application in applications {
+            guard RuntimeCodeSigningDetector.validatesStaticCode(
+                at: application.codeURL,
+                requirementSource: application.requirementSource
+            ) else {
+                throw KeychainItemCreationAttributeError.trustedApplicationValidationFailed(
+                    path: application.trustedApplicationPath
+                )
+            }
             var trustedApplication: SecTrustedApplication?
-            let status = SecTrustedApplicationCreateFromPath(path, &trustedApplication)
+            let status = SecTrustedApplicationCreateFromPath(
+                application.trustedApplicationPath,
+                &trustedApplication
+            )
             guard status == errSecSuccess, let trustedApplication else {
                 throw KeychainItemCreationAttributeError.trustedApplicationCreationFailed(
-                    path: path,
+                    path: application.trustedApplicationPath,
                     status: status
+                )
+            }
+            guard RuntimeCodeSigningDetector.validatesStaticCode(
+                at: application.codeURL,
+                requirementSource: application.requirementSource
+            ) else {
+                throw KeychainItemCreationAttributeError.trustedApplicationValidationFailed(
+                    path: application.trustedApplicationPath
                 )
             }
             trustedApplications.append(trustedApplication)
@@ -102,6 +151,48 @@ struct TrustedApplicationsKeychainAttributeProvider: KeychainItemCreationAttribu
         guard status == errSecSuccess, let access else {
             throw KeychainItemCreationAttributeError.accessCreationFailed(status: status)
         }
+        let attributes = [kSecAttrAccess as String: access]
+        cachedAttributes = attributes
+        return attributes
+    }
+}
+
+/// Reuses the ACL from a bridge manifest whose creation was committed by the legacy
+/// preparer. This lets later legacy builds create additional bridge records without
+/// carrying a new successor-signed anchor in every package.
+struct ExistingKeychainItemAccessAttributeProvider: KeychainItemCreationAttributeProvider {
+    let serviceName: String
+    let account: String
+    let itemIdentityAttributes: [String: Any]
+
+    func attributesForNewItem() throws -> [String: Any] {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: account,
+            kSecReturnRef as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecUseAuthenticationUI as String: kSecUseAuthenticationUISkip
+        ]
+        query.merge(itemIdentityAttributes) { _, replacement in replacement }
+
+        var result: CFTypeRef?
+        let lookupStatus = SecItemCopyMatching(query as CFDictionary, &result)
+        guard lookupStatus == errSecSuccess else {
+            throw KeychainItemCreationAttributeError.referenceItemLookupFailed(status: lookupStatus)
+        }
+        guard let result,
+              CFGetTypeID(result) == SecKeychainItemGetTypeID()
+        else {
+            throw KeychainItemCreationAttributeError.referenceItemInvalid
+        }
+
+        let item = unsafeBitCast(result, to: SecKeychainItem.self)
+        var access: SecAccess?
+        let accessStatus = SecKeychainItemCopyAccess(item, &access)
+        guard accessStatus == errSecSuccess, let access else {
+            throw KeychainItemCreationAttributeError.referenceItemAccessFailed(status: accessStatus)
+        }
         return [kSecAttrAccess as String: access]
     }
 }
@@ -111,6 +202,7 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
     static let legacyCanonicalServiceName = "com.pvncher.repoprompt.ce.keychain"
     static let officialV2ServiceName = "com.pvncher.repoprompt.ce.developer-id.keychain.v2"
     static let identityMigrationBridgeServiceName = "com.repoprompt.ce.identity-migration.keychain.v1"
+    static let identityMigrationLegacyStateServiceName = "com.pvncher.repoprompt.ce.identity-migration.state.v2"
     static let localSelfSignedServiceNamePrefix = "com.pvncher.repoprompt.ce.local-self-signed."
     static let debugServiceName = "com.pvncher.repoprompt.ce.debug.keychain"
 
@@ -135,6 +227,7 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
     let serviceName: String
     private let secItemClient: SecItemClient
     private let itemCreationAttributeProvider: KeychainItemCreationAttributeProvider?
+    private let itemIdentityAttributes: [String: Any]
     private let operationLock = NSRecursiveLock()
 
     let persistsValuesAcrossLaunches = true
@@ -142,11 +235,13 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
     init(
         serviceName: String = KeychainService.officialV2ServiceName,
         secItemClient: SecItemClient = SystemSecItemClient(),
-        itemCreationAttributeProvider: KeychainItemCreationAttributeProvider? = nil
+        itemCreationAttributeProvider: KeychainItemCreationAttributeProvider? = nil,
+        itemIdentityAttributes: [String: Any] = [:]
     ) {
         self.serviceName = serviceName
         self.secItemClient = secItemClient
         self.itemCreationAttributeProvider = itemCreationAttributeProvider
+        self.itemIdentityAttributes = itemIdentityAttributes
     }
 
     private func withLock<T>(_ body: () throws -> T) rethrows -> T {
@@ -156,12 +251,11 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
     }
 
     private func query(_ values: [String: Any], accessMode: KeychainAccessMode) -> [String: Any] {
-        guard accessMode.isNonInteractive else {
-            return values
-        }
-
         var query = values
-        query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        query.merge(itemIdentityAttributes) { _, replacement in replacement }
+        if accessMode.isNonInteractive {
+            query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUISkip
+        }
         return query
     }
 
@@ -244,25 +338,50 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
                 throw keychainError(for: updateStatus)
             }
 
-            var newItem: [String: Any] = [
-                kSecClass as String: kSecClassGenericPassword,
-                kSecAttrService as String: serviceName,
-                kSecAttrAccount as String: key,
-                kSecValueData as String: data,
-                kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
-                kSecAttrSynchronizable as String: false
-            ]
-            if let itemCreationAttributeProvider {
-                try newItem.merge(itemCreationAttributeProvider.attributesForNewItem()) { _, replacement in
-                    replacement
-                }
-            }
-            let addQuery = query(newItem, accessMode: accessMode)
+            try add(data, for: key, accessMode: accessMode)
+        }
+    }
 
-            let addStatus = secItemClient.add(addQuery as CFDictionary, nil)
-            guard addStatus == errSecSuccess else {
-                throw keychainError(for: addStatus)
+    /// Atomically creates a UTF-8 value without falling back to an update. The
+    /// migration bridge uses this to avoid retaining an unproven existing ACL.
+    func create(
+        _ value: String,
+        for key: String,
+        accessMode: KeychainAccessMode = .interactive
+    ) throws {
+        try withLock {
+            guard let data = value.data(using: .utf8) else {
+                throw KeychainError.invalidData
             }
+            try add(data, for: key, accessMode: accessMode)
+        }
+    }
+
+    private func add(
+        _ data: Data,
+        for key: String,
+        accessMode: KeychainAccessMode
+    ) throws {
+        // kSecAttrAccess is the classic file-based Keychain ACL. Apple documents
+        // kSecAttrAccessible as a data-protection-Keychain-only attribute on macOS.
+        // A login Keychain may ignore kSecAttrAccessible here, but omitting an
+        // inapplicable attribute keeps the item model explicit and portable.
+        var newItem: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+        if let itemCreationAttributeProvider {
+            try newItem.merge(itemCreationAttributeProvider.attributesForNewItem()) { _, replacement in
+                replacement
+            }
+        }
+        let addQuery = query(newItem, accessMode: accessMode)
+
+        let addStatus = secItemClient.add(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw keychainError(for: addStatus)
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift
@@ -55,10 +55,62 @@ struct SystemSecItemClient: SecItemClient {
     }
 }
 
+protocol KeychainItemCreationAttributeProvider {
+    func attributesForNewItem() throws -> [String: Any]
+}
+
+enum KeychainItemCreationAttributeError: Error, LocalizedError, Equatable {
+    case trustedApplicationCreationFailed(path: String, status: OSStatus)
+    case accessCreationFailed(status: OSStatus)
+
+    var errorDescription: String? {
+        switch self {
+        case let .trustedApplicationCreationFailed(path, status):
+            "Could not create a Keychain trusted-application requirement for \(path) (status \(status))"
+        case let .accessCreationFailed(status):
+            "Could not create the Keychain access policy (status \(status))"
+        }
+    }
+}
+
+/// Builds a classic macOS Keychain ACL from signed executables. The migration preparer
+/// supplies its current executable plus an embedded executable signed for the successor
+/// identity. Security.framework derives the designated requirements; no credential data
+/// or authorization prompt is involved in constructing this policy.
+struct TrustedApplicationsKeychainAttributeProvider: KeychainItemCreationAttributeProvider {
+    let descriptor: String
+    let executablePaths: [String]
+
+    func attributesForNewItem() throws -> [String: Any] {
+        var trustedApplications: [SecTrustedApplication] = []
+        trustedApplications.reserveCapacity(executablePaths.count)
+
+        for path in executablePaths {
+            var trustedApplication: SecTrustedApplication?
+            let status = SecTrustedApplicationCreateFromPath(path, &trustedApplication)
+            guard status == errSecSuccess, let trustedApplication else {
+                throw KeychainItemCreationAttributeError.trustedApplicationCreationFailed(
+                    path: path,
+                    status: status
+                )
+            }
+            trustedApplications.append(trustedApplication)
+        }
+
+        var access: SecAccess?
+        let status = SecAccessCreate(descriptor as CFString, trustedApplications as CFArray, &access)
+        guard status == errSecSuccess, let access else {
+            throw KeychainItemCreationAttributeError.accessCreationFailed(status: status)
+        }
+        return [kSecAttrAccess as String: access]
+    }
+}
+
 /// Secure storage service for one explicitly selected CE macOS Keychain domain.
 final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
     static let legacyCanonicalServiceName = "com.pvncher.repoprompt.ce.keychain"
     static let officialV2ServiceName = "com.pvncher.repoprompt.ce.developer-id.keychain.v2"
+    static let identityMigrationBridgeServiceName = "com.repoprompt.ce.identity-migration.keychain.v1"
     static let localSelfSignedServiceNamePrefix = "com.pvncher.repoprompt.ce.local-self-signed."
     static let debugServiceName = "com.pvncher.repoprompt.ce.debug.keychain"
 
@@ -82,16 +134,19 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
 
     let serviceName: String
     private let secItemClient: SecItemClient
+    private let itemCreationAttributeProvider: KeychainItemCreationAttributeProvider?
     private let operationLock = NSRecursiveLock()
 
     let persistsValuesAcrossLaunches = true
 
     init(
         serviceName: String = KeychainService.officialV2ServiceName,
-        secItemClient: SecItemClient = SystemSecItemClient()
+        secItemClient: SecItemClient = SystemSecItemClient(),
+        itemCreationAttributeProvider: KeychainItemCreationAttributeProvider? = nil
     ) {
         self.serviceName = serviceName
         self.secItemClient = secItemClient
+        self.itemCreationAttributeProvider = itemCreationAttributeProvider
     }
 
     private func withLock<T>(_ body: () throws -> T) rethrows -> T {
@@ -189,14 +244,20 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
                 throw keychainError(for: updateStatus)
             }
 
-            let addQuery = query([
+            var newItem: [String: Any] = [
                 kSecClass as String: kSecClassGenericPassword,
                 kSecAttrService as String: serviceName,
                 kSecAttrAccount as String: key,
                 kSecValueData as String: data,
                 kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
                 kSecAttrSynchronizable as String: false
-            ], accessMode: accessMode)
+            ]
+            if let itemCreationAttributeProvider {
+                try newItem.merge(itemCreationAttributeProvider.attributesForNewItem()) { _, replacement in
+                    replacement
+                }
+            }
+            let addQuery = query(newItem, accessMode: accessMode)
 
             let addStatus = secItemClient.add(addQuery as CFDictionary, nil)
             guard addStatus == errSecSuccess else {

--- a/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningDetector.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningDetector.swift
@@ -138,6 +138,17 @@ enum RuntimeCodeSigningDetector {
         return requirement
     }
 
+    static func requirementData(from source: String) -> Data? {
+        guard let requirement = requirement(from: source) else { return nil }
+        var data: CFData?
+        guard SecRequirementCopyData(requirement, [], &data) == errSecSuccess,
+              let data
+        else {
+            return nil
+        }
+        return data as Data
+    }
+
     private static func leafCertificateFingerprint(from dictionary: [String: Any]) -> String? {
         guard let certificates = dictionary[kSecCodeInfoCertificates as String] as? [SecCertificate],
               let leafCertificate = certificates.first

--- a/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningDetector.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningDetector.swift
@@ -35,6 +35,22 @@ struct RuntimeLocalSigningExpectation: Equatable {
 }
 
 enum RuntimeCodeSigningDetector {
+    static func validatesStaticCode(at executableURL: URL, requirementSource: String) -> Bool {
+        var staticCode: SecStaticCode?
+        let createStatus = SecStaticCodeCreateWithPath(executableURL as CFURL, [], &staticCode)
+        guard createStatus == errSecSuccess,
+              let staticCode,
+              let requirement = requirement(from: requirementSource)
+        else {
+            return false
+        }
+        return SecStaticCodeCheckValidity(
+            staticCode,
+            SecCSFlags(rawValue: kSecCSStrictValidate),
+            requirement
+        ) == errSecSuccess
+    }
+
     static func currentProcessSigningInfo(
         localSigningExpectation: RuntimeLocalSigningExpectation? = nil
     ) -> RuntimeCodeSigningInfo {
@@ -115,7 +131,7 @@ enum RuntimeCodeSigningDetector {
         )
     }
 
-    private static func requirement(from source: String) -> SecRequirement? {
+    static func requirement(from source: String) -> SecRequirement? {
         var requirement: SecRequirement?
         let status = SecRequirementCreateWithString(source as CFString, [], &requirement)
         guard status == errSecSuccess else { return nil }

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift
@@ -26,6 +26,25 @@ struct SecureKeyValueStorageSelection {
 }
 
 enum SecureKeyValueStorageFactory {
+    private final class State: @unchecked Sendable {
+        static let shared = State()
+
+        private let lock = NSLock()
+        private var officialBackendOverride: SecureKeyValueStorageBackend?
+
+        func installOfficialBackendOverride(_ backend: SecureKeyValueStorageBackend) {
+            lock.lock()
+            officialBackendOverride = backend
+            lock.unlock()
+        }
+
+        func officialBackend(fallback: SecureKeyValueStorageBackend) -> SecureKeyValueStorageBackend {
+            lock.lock()
+            defer { lock.unlock() }
+            return officialBackendOverride ?? fallback
+        }
+    }
+
     private static let cachedSelection: SecureKeyValueStorageSelection = {
         let localSigningContext = RuntimeCodeSigningPolicy.currentLocalSigningContext()
         let signingInfo = RuntimeCodeSigningDetector.currentProcessSigningInfo(
@@ -40,11 +59,19 @@ enum SecureKeyValueStorageFactory {
     }()
 
     static func defaultBackend() -> SecureKeyValueStorageBackend {
-        cachedSelection.backend
+        guard cachedSelection.decision.domain == .officialDeveloperID else {
+            return cachedSelection.backend
+        }
+        return State.shared.officialBackend(fallback: cachedSelection.backend)
     }
 
     static func currentDecision() -> RuntimeSecureStorageDecision {
         cachedSelection.decision
+    }
+
+    /// Must be called during process bootstrap, before services capture the default backend.
+    static func installOfficialBackendOverride(_ backend: SecureKeyValueStorageBackend) {
+        State.shared.installOfficialBackendOverride(backend)
     }
 
     static func selection(for decision: RuntimeSecureStorageDecision) -> SecureKeyValueStorageSelection {

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift
@@ -9,6 +9,14 @@ protocol SecureKeyValueStorageBackend: AnyObject, Sendable {
         accessMode: KeychainAccessMode
     ) throws
 
+    /// Creates a value only when no item with this backend's identity already exists.
+    /// Migration code uses this to avoid rewriting an unproven pre-existing Keychain ACL.
+    func create(
+        _ value: String,
+        for key: String,
+        accessMode: KeychainAccessMode
+    ) throws
+
     func get(
         for key: String,
         accessMode: KeychainAccessMode
@@ -18,6 +26,21 @@ protocol SecureKeyValueStorageBackend: AnyObject, Sendable {
         for key: String,
         accessMode: KeychainAccessMode
     ) throws
+}
+
+extension SecureKeyValueStorageBackend {
+    func create(
+        _ value: String,
+        for key: String,
+        accessMode: KeychainAccessMode
+    ) throws {
+        do {
+            _ = try get(for: key, accessMode: accessMode)
+            throw KeychainService.KeychainError.duplicateItem
+        } catch KeychainService.KeychainError.itemNotFound {
+            try save(value, for: key, accessMode: accessMode)
+        }
+    }
 }
 
 struct SecureKeyValueStorageSelection {

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureStorageAccountCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureStorageAccountCatalog.swift
@@ -144,6 +144,37 @@ enum SecureStorageAccount: CaseIterable, Hashable, Identifiable {
 }
 
 enum SecureStorageAccountCatalog {
+    /// Frozen inventory copied by the version-2 Apple identity migration preparer.
+    /// New secure-storage accounts must not expand this list: once a bridge is
+    /// committed, that bridge remains the canonical backend and creates later
+    /// accounts with the committed manifest's authenticated ACL.
+    static let identityMigrationV2Accounts: [SecureStorageAccount] = [
+        .anthropicAPI,
+        .openAIAPI,
+        .geminiAPI,
+        .openRouterAPI,
+        .ollamaURL,
+        .azureAPI,
+        .deepSeekAPI,
+        .customProviderAPI,
+        .fireworksAPI,
+        .grokAPI,
+        .groqAPI,
+        .claudeCodeAPI,
+        .codexCLIAPI,
+        .openCodeCLIAPI,
+        .cursorCLIAPI,
+        .zAIAPI,
+        .claudeCompatibleKimiAPIKey,
+        .claudeCompatibleCustomAPIKey,
+        .agentPermissionSubagentDocument,
+        .agentPermissionCodexDocument,
+        .agentPermissionClaudeDocument,
+        .agentPermissionOpenCodeDocument,
+        .agentPermissionCursorDocument,
+        .agentPermissionGrokBuildDocument
+    ]
+
     static let providerAndCLIAccounts: [SecureStorageAccount] = [
         .anthropicAPI,
         .openAIAPI,

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
@@ -155,9 +155,10 @@ struct KeychainSecureStorageIdentityMigrationStateStore: SecureStorageIdentityMi
 
 /// Copies the closed secure-storage inventory into a new service whose item ACL trusts
 /// both signing identities. A legacy-Keychain journal is committed before mutation, so
-/// interrupted attempts can reconcile only items carrying that attempt's random marker.
+/// interrupted attempts can reconcile only items in that attempt's random service.
 final class SecureStorageIdentityMigrationCoordinator {
-    typealias BridgeStoreFactory = (String) -> SecureKeyValueStorageBackend
+    typealias BridgeStoreFactory = (String) throws -> SecureKeyValueStorageBackend
+    typealias AttemptIdentifierGenerator = () -> String
 
     private enum CoordinatorError: Error {
         case manifestEncodingFailed
@@ -171,18 +172,23 @@ final class SecureStorageIdentityMigrationCoordinator {
     private let sourceStore: SecureKeyValueStorageBackend
     private let bridgeStoreFactory: BridgeStoreFactory
     private let stateStore: SecureStorageIdentityMigrationStateStore
+    private let attemptIdentifierGenerator: AttemptIdentifierGenerator
     private let accessMode = KeychainAccessMode.nonInteractive(reason: .launch)
 
     init(
-        accounts: [SecureStorageAccount] = SecureStorageAccountCatalog.allAccounts,
+        accounts: [SecureStorageAccount] = SecureStorageAccountCatalog.identityMigrationV2Accounts,
         sourceStore: SecureKeyValueStorageBackend,
         bridgeStoreFactory: @escaping BridgeStoreFactory,
-        stateStore: SecureStorageIdentityMigrationStateStore
+        stateStore: SecureStorageIdentityMigrationStateStore,
+        attemptIdentifierGenerator: @escaping AttemptIdentifierGenerator = {
+            UUID().uuidString.lowercased()
+        }
     ) {
         self.accounts = accounts
         self.sourceStore = sourceStore
         self.bridgeStoreFactory = bridgeStoreFactory
         self.stateStore = stateStore
+        self.attemptIdentifierGenerator = attemptIdentifierGenerator
     }
 
     func prepareBridge() -> SecureStorageIdentityMigrationReport {
@@ -216,10 +222,17 @@ final class SecureStorageIdentityMigrationCoordinator {
             return failedReport(records: preflightRecords)
         }
 
+        let attemptIdentifier = attemptIdentifierGenerator()
+        guard KeychainService.identityMigrationBridgeServiceName(for: attemptIdentifier) != nil else {
+            return failedReport(
+                records: preflightRecords,
+                error: KeychainACLValidationError.invalidExpectedPrincipalPolicy
+            )
+        }
         let manifest = SecureStorageIdentityMigrationManifest(
             version: SecureStorageIdentityMigrationManifest.currentVersion,
             status: .preparing,
-            attemptIdentifier: UUID().uuidString.lowercased(),
+            attemptIdentifier: attemptIdentifier,
             catalogIdentifiers: expectedCatalogIdentifiers
         )
         do {
@@ -240,9 +253,19 @@ final class SecureStorageIdentityMigrationCoordinator {
     }
 
     private func isStructurallyValid(_ manifest: SecureStorageIdentityMigrationManifest) -> Bool {
+        Self.isStructurallyValid(
+            manifest,
+            expectedCatalogIdentifiers: expectedCatalogIdentifiers
+        )
+    }
+
+    static func isStructurallyValid(
+        _ manifest: SecureStorageIdentityMigrationManifest,
+        expectedCatalogIdentifiers: [String]
+    ) -> Bool {
         manifest.version == SecureStorageIdentityMigrationManifest.currentVersion
-            && !manifest.attemptIdentifier.isEmpty
-            && manifest.catalogIdentifiers == expectedCatalogIdentifiers
+            && KeychainService.identityMigrationBridgeServiceName(for: manifest.attemptIdentifier) != nil
+            && manifest.catalogIdentifiers == expectedCatalogIdentifiers.sorted()
     }
 
     private func readAll(from store: SecureKeyValueStorageBackend) -> [SecureStorageAccount: ReadResult] {
@@ -286,7 +309,12 @@ final class SecureStorageIdentityMigrationCoordinator {
         _ manifest: SecureStorageIdentityMigrationManifest,
         sourceResults suppliedSourceResults: [SecureStorageAccount: ReadResult]? = nil
     ) -> SecureStorageIdentityMigrationReport {
-        let bridgeStore = bridgeStoreFactory(manifest.attemptIdentifier)
+        let bridgeStore: SecureKeyValueStorageBackend
+        do {
+            bridgeStore = try bridgeStoreFactory(manifest.attemptIdentifier)
+        } catch {
+            return blockedReport(error: error)
+        }
         let sourceResults = suppliedSourceResults ?? readAll(from: sourceStore)
         let bridgeResults = readAll(from: bridgeStore)
         let preflightRecords = zipResults(source: sourceResults, bridge: bridgeResults)
@@ -369,8 +397,9 @@ final class SecureStorageIdentityMigrationCoordinator {
                 if sourceValue == bridgeValue {
                     return SecureStorageIdentityMigrationRecord(account: account, state: .verified)
                 }
-                // The random item marker and preparing journal prove this is an
-                // interrupted attempt. The source remains authoritative until commit.
+                // The random attempt-specific service and preparing journal prove
+                // this is an interrupted attempt. The source remains authoritative
+                // until commit.
                 try bridgeStore.save(sourceValue, for: account.identifier, accessMode: accessMode)
                 let verified = try bridgeStore.get(for: account.identifier, accessMode: accessMode)
                 return SecureStorageIdentityMigrationRecord(
@@ -442,7 +471,12 @@ final class SecureStorageIdentityMigrationCoordinator {
     private func verifyCommittedBridge(
         _ manifest: SecureStorageIdentityMigrationManifest
     ) -> SecureStorageIdentityMigrationReport {
-        let bridgeStore = bridgeStoreFactory(manifest.attemptIdentifier)
+        let bridgeStore: SecureKeyValueStorageBackend
+        do {
+            bridgeStore = try bridgeStoreFactory(manifest.attemptIdentifier)
+        } catch {
+            return blockedReport(error: error)
+        }
         guard let encoded = Self.encodeManifest(manifest) else {
             return blockedReport()
         }
@@ -489,6 +523,51 @@ final class SecureStorageIdentityMigrationCoordinator {
     }
 }
 
+enum SecureStorageIdentityMigrationActivationError: Error {
+    case invalidJournal
+    case invalidBridgeManifest
+}
+
+struct SecureStorageIdentityMigrationCommittedBridge {
+    let manifest: SecureStorageIdentityMigrationManifest
+    let store: SecureKeyValueStorageBackend
+}
+
+/// Resolves the committed bridge from authenticated storage. Production stores
+/// validate each item's decrypt ACL before returning its JSON, so structural
+/// equality is only considered after the journal and bridge-manifest authorities
+/// have both been proven.
+struct SecureStorageIdentityMigrationCommittedBridgeResolver {
+    let accounts: [SecureStorageAccount]
+    let stateStore: SecureStorageIdentityMigrationStateStore
+    let bridgeStoreFactory: SecureStorageIdentityMigrationCoordinator.BridgeStoreFactory
+
+    func resolve() throws -> SecureStorageIdentityMigrationCommittedBridge? {
+        guard let manifest = try stateStore.load() else { return nil }
+        guard manifest.status == .committed,
+              SecureStorageIdentityMigrationCoordinator.isStructurallyValid(
+                  manifest,
+                  expectedCatalogIdentifiers: accounts.map(\.identifier)
+              ),
+              let encoded = SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest)
+        else {
+            throw SecureStorageIdentityMigrationActivationError.invalidJournal
+        }
+
+        let bridgeStore = try bridgeStoreFactory(manifest.attemptIdentifier)
+        guard try bridgeStore.get(
+            for: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
+            accessMode: .nonInteractive(reason: .launch)
+        ) == encoded else {
+            throw SecureStorageIdentityMigrationActivationError.invalidBridgeManifest
+        }
+        return SecureStorageIdentityMigrationCommittedBridge(
+            manifest: manifest,
+            store: bridgeStore
+        )
+    }
+}
+
 final class IdentityMigrationRuntimeState: @unchecked Sendable {
     static let shared = IdentityMigrationRuntimeState()
 
@@ -526,6 +605,13 @@ enum SecureStorageIdentityMigrationBootstrap {
         return Phase(rawValue: rawPhase)
     }
 
+    static func preparerCatalogMatchesFrozenCatalog(
+        currentAccounts: [SecureStorageAccount] = SecureStorageAccountCatalog.allAccounts,
+        migrationAccounts: [SecureStorageAccount] = SecureStorageAccountCatalog.identityMigrationV2Accounts
+    ) -> Bool {
+        currentAccounts.map(\.identifier) == migrationAccounts.map(\.identifier)
+    }
+
     static func prepareIfConfigured(bundle: Bundle = .main) {
         IdentityMigrationRuntimeState.shared.setBlockedMessage(nil)
         guard SecureKeyValueStorageFactory.currentDecision().domain == .officialDeveloperID else { return }
@@ -544,7 +630,8 @@ enum SecureStorageIdentityMigrationBootstrap {
     }
 
     private static func prepareLegacyBridge(bundle: Bundle) {
-        guard bundle.bundleIdentifier == RuntimeCodeSigningPolicy.developerIDBundleIdentifier,
+        guard preparerCatalogMatchesFrozenCatalog(),
+              bundle.bundleIdentifier == RuntimeCodeSigningPolicy.developerIDBundleIdentifier,
               let executableURL = bundle.executableURL,
               let resourceURL = bundle.resourceURL,
               let relativeAnchorPath = bundle.object(forInfoDictionaryKey: anchorRelativePathInfoKey) as? String,
@@ -559,123 +646,161 @@ enum SecureStorageIdentityMigrationBootstrap {
                   requirementSource: successorDeveloperIDRequirement
               )
         else {
-            blockUpdates("Updates are paused because the secure credential migration package is incomplete or has an invalid identity anchor.")
+            blockUpdates("Updates are paused because the secure credential migration package is incomplete, its account catalog changed, or it has an invalid identity anchor.")
             return
         }
 
-        let attributeProvider = TrustedApplicationsKeychainAttributeProvider(
-            descriptor: "RepoPrompt CE identity migration bridge",
-            applications: [
-                TrustedApplicationCodeRequirement(
-                    trustedApplicationPath: executableURL.path,
-                    codeURL: bundle.bundleURL,
-                    requirementSource: RuntimeCodeSigningPolicy.developerIDRequirement
-                ),
-                TrustedApplicationCodeRequirement(
-                    trustedApplicationPath: anchorURL.path,
-                    codeURL: anchorURL,
-                    requirementSource: successorDeveloperIDRequirement
-                )
-            ]
-        )
+        let authority: KeychainAccessAuthority
+        do {
+            authority = try KeychainAccessAuthority(
+                descriptor: "RepoPrompt CE identity migration bridge",
+                applications: [
+                    TrustedApplicationCodeRequirement(
+                        trustedApplicationPath: executableURL.path,
+                        codeURL: bundle.bundleURL,
+                        requirementSource: RuntimeCodeSigningPolicy.developerIDRequirement
+                    ),
+                    TrustedApplicationCodeRequirement(
+                        trustedApplicationPath: anchorURL.path,
+                        codeURL: anchorURL,
+                        requirementSource: successorDeveloperIDRequirement
+                    )
+                ]
+            )
+        } catch {
+            blockUpdates(for: error)
+            return
+        }
+        let attributeProvider = authority.creationAttributeProvider
         let stateStore = KeychainSecureStorageIdentityMigrationStateStore(
             store: KeychainService(
                 serviceName: KeychainService.identityMigrationLegacyStateServiceName,
-                itemCreationAttributeProvider: attributeProvider
+                itemCreationAttributeProvider: attributeProvider,
+                itemAccessValidator: authority.accessValidator
             )
         )
         let coordinator = SecureStorageIdentityMigrationCoordinator(
             sourceStore: KeychainService.officialV2Shared,
             bridgeStoreFactory: { attemptIdentifier in
-                bridgeStore(
+                try bridgeStore(
                     attemptIdentifier: attemptIdentifier,
-                    itemCreationAttributeProvider: attributeProvider
+                    itemCreationAttributeProvider: attributeProvider,
+                    itemAccessValidator: authority.accessValidator
                 )
             },
             stateStore: stateStore
         )
         let report = coordinator.prepareBridge()
-        guard report.bridgeReady,
-              let manifest = try? stateStore.load(),
-              manifest.status == .committed
-        else {
+        guard report.bridgeReady else {
             blockUpdates(report.blockedUpdateMessage)
             return
         }
-
-        SecureKeyValueStorageFactory.installOfficialBackendOverride(
-            bridgeStore(
-                attemptIdentifier: manifest.attemptIdentifier,
-                itemCreationAttributeProvider: attributeProvider
-            )
-        )
-    }
-
-    private static func activateCommittedBridgeIfPresent() {
-        let stateStore = KeychainSecureStorageIdentityMigrationStateStore()
-        let manifest: SecureStorageIdentityMigrationManifest?
+        let manifest: SecureStorageIdentityMigrationManifest
         do {
-            manifest = try stateStore.load()
+            guard let loadedManifest = try stateStore.load(),
+                  loadedManifest.status == .committed
+            else {
+                blockUpdates("Updates are paused because the secure credential migration journal is incomplete.")
+                return
+            }
+            manifest = loadedManifest
         } catch {
             blockUpdates(for: error)
             return
         }
-        guard let manifest else { return }
-        guard manifest.version == SecureStorageIdentityMigrationManifest.currentVersion,
-              manifest.status == .committed,
-              !manifest.attemptIdentifier.isEmpty,
-              manifest.catalogIdentifiers == SecureStorageAccountCatalog.allAccounts.map(\.identifier).sorted(),
-              let encoded = SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest)
-        else {
+
+        do {
+            let bridge = try bridgeStore(
+                attemptIdentifier: manifest.attemptIdentifier,
+                itemCreationAttributeProvider: attributeProvider,
+                itemAccessValidator: authority.accessValidator
+            )
+            SecureKeyValueStorageFactory.installOfficialBackendOverride(bridge)
+        } catch {
+            blockUpdates(for: error)
+        }
+    }
+
+    private static func activateCommittedBridgeIfPresent() {
+        let accessValidator: ClassicKeychainACLValidator
+        do {
+            accessValidator = try ClassicKeychainACLValidator(
+                requirementSources: [
+                    RuntimeCodeSigningPolicy.developerIDRequirement,
+                    successorDeveloperIDRequirement
+                ]
+            )
+        } catch {
+            blockUpdates(for: error)
+            return
+        }
+        let stateStore = KeychainSecureStorageIdentityMigrationStateStore(
+            store: KeychainService(
+                serviceName: KeychainService.identityMigrationLegacyStateServiceName,
+                itemAccessValidator: accessValidator
+            )
+        )
+        let resolution: SecureStorageIdentityMigrationCommittedBridge?
+        do {
+            resolution = try SecureStorageIdentityMigrationCommittedBridgeResolver(
+                accounts: SecureStorageAccountCatalog.identityMigrationV2Accounts,
+                stateStore: stateStore,
+                bridgeStoreFactory: { attemptIdentifier in
+                    guard let serviceName = KeychainService.identityMigrationBridgeServiceName(
+                        for: attemptIdentifier
+                    ) else {
+                        throw SecureStorageIdentityMigrationActivationError.invalidJournal
+                    }
+                    return KeychainService(
+                        serviceName: serviceName,
+                        itemAccessValidator: accessValidator
+                    )
+                }
+            ).resolve()
+        } catch {
+            blockUpdates(for: error)
+            return
+        }
+        guard let resolution else { return }
+        let manifest = resolution.manifest
+
+        guard let bridgeServiceName = KeychainService.identityMigrationBridgeServiceName(
+            for: manifest.attemptIdentifier
+        ) else {
             blockUpdates("Updates are paused because the secure credential migration journal is incomplete.")
             return
         }
 
-        let itemIdentityAttributes = bridgeItemIdentityAttributes(manifest.attemptIdentifier)
-        let readOnlyBridge = KeychainService(
-            serviceName: KeychainService.identityMigrationBridgeServiceName,
-            itemIdentityAttributes: itemIdentityAttributes
+        let accessProvider = ExistingKeychainItemAccessAttributeProvider(
+            serviceName: bridgeServiceName,
+            account: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
+            accessValidator: accessValidator
         )
         do {
-            guard try readOnlyBridge.get(
-                for: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
-                accessMode: .nonInteractive(reason: .launch)
-            ) == encoded
-            else {
-                blockUpdates("Updates are paused because the secure credential migration bridge could not be verified.")
-                return
-            }
+            let bridge = try bridgeStore(
+                attemptIdentifier: manifest.attemptIdentifier,
+                itemCreationAttributeProvider: accessProvider,
+                itemAccessValidator: accessValidator
+            )
+            SecureKeyValueStorageFactory.installOfficialBackendOverride(bridge)
         } catch {
             blockUpdates(for: error)
-            return
         }
-
-        let accessProvider = ExistingKeychainItemAccessAttributeProvider(
-            serviceName: KeychainService.identityMigrationBridgeServiceName,
-            account: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
-            itemIdentityAttributes: itemIdentityAttributes
-        )
-        SecureKeyValueStorageFactory.installOfficialBackendOverride(
-            bridgeStore(
-                attemptIdentifier: manifest.attemptIdentifier,
-                itemCreationAttributeProvider: accessProvider
-            )
-        )
     }
 
     private static func bridgeStore(
         attemptIdentifier: String,
-        itemCreationAttributeProvider: KeychainItemCreationAttributeProvider
-    ) -> KeychainService {
-        KeychainService(
-            serviceName: KeychainService.identityMigrationBridgeServiceName,
+        itemCreationAttributeProvider: KeychainItemCreationAttributeProvider,
+        itemAccessValidator: KeychainItemAccessValidator
+    ) throws -> KeychainService {
+        guard let serviceName = KeychainService.identityMigrationBridgeServiceName(for: attemptIdentifier) else {
+            throw KeychainACLValidationError.invalidExpectedPrincipalPolicy
+        }
+        return KeychainService(
+            serviceName: serviceName,
             itemCreationAttributeProvider: itemCreationAttributeProvider,
-            itemIdentityAttributes: bridgeItemIdentityAttributes(attemptIdentifier)
+            itemAccessValidator: itemAccessValidator
         )
-    }
-
-    private static func bridgeItemIdentityAttributes(_ attemptIdentifier: String) -> [String: Any] {
-        [kSecAttrGeneric as String: Data(attemptIdentifier.utf8)]
     }
 
     static func validatedAnchorURL(relativePath: String, resourceURL: URL) -> URL? {

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
@@ -1,0 +1,355 @@
+import Foundation
+
+enum SecureStorageIdentityMigrationRecordState: Equatable {
+    case absent
+    case copied
+    case verified
+    case conflict
+    case interactionRequired
+    case failed
+
+    var isReady: Bool {
+        switch self {
+        case .absent, .copied, .verified:
+            true
+        case .conflict, .interactionRequired, .failed:
+            false
+        }
+    }
+}
+
+struct SecureStorageIdentityMigrationRecord: Equatable, Identifiable {
+    let account: SecureStorageAccount
+    let state: SecureStorageIdentityMigrationRecordState
+
+    var id: String {
+        account.identifier
+    }
+}
+
+struct SecureStorageIdentityMigrationReport: Equatable {
+    let records: [SecureStorageIdentityMigrationRecord]
+    let bridgeReady: Bool
+    let completionPersisted: Bool
+
+    var blockedUpdateMessage: String? {
+        guard !bridgeReady else { return nil }
+        return "Updates are paused because secure credential migration could not be verified. Your existing credentials were not deleted or replaced."
+    }
+}
+
+struct SecureStorageIdentityMigrationManifest: Codable, Equatable {
+    static let currentVersion = 1
+
+    let version: Int
+    let migratedAccountIdentifiers: [String]
+}
+
+protocol SecureStorageIdentityMigrationStateStore {
+    func load() throws -> SecureStorageIdentityMigrationManifest?
+    func save(_ manifest: SecureStorageIdentityMigrationManifest) throws
+}
+
+struct UserDefaultsSecureStorageIdentityMigrationStateStore: SecureStorageIdentityMigrationStateStore {
+    static let suiteName = "com.repoprompt.ce.identity-migration"
+    static let manifestKey = "secure-storage-bridge-v1-manifest"
+
+    enum StoreError: Error {
+        case unavailable
+        case invalidManifest
+    }
+
+    private let defaults: UserDefaults
+
+    init?() {
+        guard let defaults = UserDefaults(suiteName: Self.suiteName) else { return nil }
+        self.defaults = defaults
+    }
+
+    func load() throws -> SecureStorageIdentityMigrationManifest? {
+        guard let data = defaults.data(forKey: Self.manifestKey) else { return nil }
+        guard let manifest = try? JSONDecoder().decode(SecureStorageIdentityMigrationManifest.self, from: data),
+              manifest.version == SecureStorageIdentityMigrationManifest.currentVersion
+        else {
+            throw StoreError.invalidManifest
+        }
+        return manifest
+    }
+
+    func save(_ manifest: SecureStorageIdentityMigrationManifest) throws {
+        let data = try JSONEncoder().encode(manifest)
+        defaults.set(data, forKey: Self.manifestKey)
+        guard defaults.synchronize() else { throw StoreError.unavailable }
+    }
+}
+
+/// Copies the closed secure-storage inventory into a new service whose item ACL trusts
+/// both signing identities. All operations are noninteractive. Source items are never
+/// changed or deleted, and the bridge is not selected until every present value has been
+/// read back byte-for-byte and the completion manifest has been persisted.
+final class SecureStorageIdentityMigrationCoordinator {
+    private let accounts: [SecureStorageAccount]
+    private let sourceStore: SecureKeyValueStorageBackend
+    private let bridgeStore: SecureKeyValueStorageBackend
+    private let stateStore: SecureStorageIdentityMigrationStateStore
+    private let accessMode = KeychainAccessMode.nonInteractive(reason: .launch)
+
+    init(
+        accounts: [SecureStorageAccount] = SecureStorageAccountCatalog.allAccounts,
+        sourceStore: SecureKeyValueStorageBackend,
+        bridgeStore: SecureKeyValueStorageBackend,
+        stateStore: SecureStorageIdentityMigrationStateStore
+    ) {
+        self.accounts = accounts
+        self.sourceStore = sourceStore
+        self.bridgeStore = bridgeStore
+        self.stateStore = stateStore
+    }
+
+    func prepareBridge() -> SecureStorageIdentityMigrationReport {
+        do {
+            if let manifest = try stateStore.load() {
+                return verifyCommittedBridge(manifest)
+            }
+        } catch {
+            return blockedReport()
+        }
+
+        var records: [SecureStorageIdentityMigrationRecord] = []
+        var migratedAccountIdentifiers: [String] = []
+
+        for account in accounts {
+            let source = read(account, from: sourceStore)
+            let bridge = read(account, from: bridgeStore)
+            let record = prepare(account, source: source, bridge: bridge)
+            records.append(record)
+            if source.value != nil {
+                migratedAccountIdentifiers.append(account.identifier)
+            }
+        }
+
+        guard records.allSatisfy(\.state.isReady) else {
+            return SecureStorageIdentityMigrationReport(
+                records: records,
+                bridgeReady: false,
+                completionPersisted: false
+            )
+        }
+
+        let manifest = SecureStorageIdentityMigrationManifest(
+            version: SecureStorageIdentityMigrationManifest.currentVersion,
+            migratedAccountIdentifiers: migratedAccountIdentifiers.sorted()
+        )
+        do {
+            try stateStore.save(manifest)
+        } catch {
+            return SecureStorageIdentityMigrationReport(
+                records: records,
+                bridgeReady: false,
+                completionPersisted: false
+            )
+        }
+
+        return SecureStorageIdentityMigrationReport(
+            records: records,
+            bridgeReady: true,
+            completionPersisted: true
+        )
+    }
+
+    private struct ReadResult {
+        let value: String?
+        let failureState: SecureStorageIdentityMigrationRecordState?
+    }
+
+    private func read(
+        _ account: SecureStorageAccount,
+        from store: SecureKeyValueStorageBackend
+    ) -> ReadResult {
+        do {
+            return try ReadResult(
+                value: store.get(for: account.identifier, accessMode: accessMode),
+                failureState: nil
+            )
+        } catch KeychainService.KeychainError.itemNotFound {
+            return ReadResult(value: nil, failureState: nil)
+        } catch KeychainService.KeychainError.interactionNotAllowed {
+            return ReadResult(value: nil, failureState: .interactionRequired)
+        } catch {
+            return ReadResult(value: nil, failureState: .failed)
+        }
+    }
+
+    private func prepare(
+        _ account: SecureStorageAccount,
+        source: ReadResult,
+        bridge: ReadResult
+    ) -> SecureStorageIdentityMigrationRecord {
+        if let failureState = source.failureState ?? bridge.failureState {
+            return SecureStorageIdentityMigrationRecord(account: account, state: failureState)
+        }
+
+        switch (source.value, bridge.value) {
+        case (nil, nil):
+            return SecureStorageIdentityMigrationRecord(account: account, state: .absent)
+        case let (sourceValue?, nil):
+            do {
+                try bridgeStore.save(sourceValue, for: account.identifier, accessMode: accessMode)
+                let verified = try bridgeStore.get(for: account.identifier, accessMode: accessMode)
+                return SecureStorageIdentityMigrationRecord(
+                    account: account,
+                    state: verified == sourceValue ? .copied : .failed
+                )
+            } catch KeychainService.KeychainError.interactionNotAllowed {
+                return SecureStorageIdentityMigrationRecord(account: account, state: .interactionRequired)
+            } catch {
+                return SecureStorageIdentityMigrationRecord(account: account, state: .failed)
+            }
+        case let (sourceValue?, bridgeValue?):
+            return SecureStorageIdentityMigrationRecord(
+                account: account,
+                state: sourceValue == bridgeValue ? .verified : .conflict
+            )
+        case (nil, _?):
+            // Before the manifest is committed, a target-only value has no proven origin.
+            return SecureStorageIdentityMigrationRecord(account: account, state: .conflict)
+        }
+    }
+
+    private func verifyCommittedBridge(
+        _ manifest: SecureStorageIdentityMigrationManifest
+    ) -> SecureStorageIdentityMigrationReport {
+        let migrated = Set(manifest.migratedAccountIdentifiers)
+        let known = Set(accounts.map(\.identifier))
+        guard manifest.version == SecureStorageIdentityMigrationManifest.currentVersion,
+              migrated.count == manifest.migratedAccountIdentifiers.count,
+              migrated.isSubset(of: known)
+        else {
+            return blockedReport()
+        }
+        var records: [SecureStorageIdentityMigrationRecord] = []
+        var ready = true
+
+        for account in accounts {
+            guard migrated.contains(account.identifier) else {
+                records.append(SecureStorageIdentityMigrationRecord(account: account, state: .absent))
+                continue
+            }
+            let result = read(account, from: bridgeStore)
+            let state: SecureStorageIdentityMigrationRecordState = if result.value != nil {
+                .verified
+            } else if let failureState = result.failureState {
+                failureState
+            } else {
+                .failed
+            }
+            ready = ready && state.isReady
+            records.append(SecureStorageIdentityMigrationRecord(account: account, state: state))
+        }
+
+        return SecureStorageIdentityMigrationReport(
+            records: records,
+            bridgeReady: ready,
+            completionPersisted: true
+        )
+    }
+
+    private func blockedReport() -> SecureStorageIdentityMigrationReport {
+        SecureStorageIdentityMigrationReport(
+            records: accounts.map {
+                SecureStorageIdentityMigrationRecord(account: $0, state: .failed)
+            },
+            bridgeReady: false,
+            completionPersisted: false
+        )
+    }
+}
+
+final class IdentityMigrationRuntimeState: @unchecked Sendable {
+    static let shared = IdentityMigrationRuntimeState()
+
+    private let lock = NSLock()
+    private var blockedMessage: String?
+
+    func setBlockedMessage(_ message: String?) {
+        lock.lock()
+        blockedMessage = message
+        lock.unlock()
+    }
+
+    func updatesBlockedMessage() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return blockedMessage
+    }
+}
+
+enum SecureStorageIdentityMigrationBootstrap {
+    static let legacyBundleIdentifier = "com.pvncher.repoprompt.ce"
+    static let phaseInfoKey = "RepoPromptIdentityMigrationPhase"
+    static let anchorRelativePathInfoKey = "RepoPromptIdentityMigrationAnchorRelativePath"
+
+    enum Phase: String {
+        case disabled
+        case legacyPreparer = "legacy-preparer"
+    }
+
+    static func prepareIfConfigured(bundle: Bundle = .main) {
+        guard let rawPhase = bundle.object(forInfoDictionaryKey: phaseInfoKey) as? String,
+              let phase = Phase(rawValue: rawPhase),
+              phase != .disabled
+        else {
+            return
+        }
+
+        guard phase == .legacyPreparer,
+              bundle.bundleIdentifier == legacyBundleIdentifier,
+              SecureKeyValueStorageFactory.currentDecision().domain == .officialDeveloperID,
+              let executableURL = bundle.executableURL,
+              let resourceURL = bundle.resourceURL,
+              let relativeAnchorPath = bundle.object(forInfoDictionaryKey: anchorRelativePathInfoKey) as? String,
+              !relativeAnchorPath.isEmpty
+        else {
+            blockUpdates()
+            return
+        }
+
+        let anchorURL = resourceURL.appendingPathComponent(relativeAnchorPath).standardizedFileURL
+        let resourcePath = resourceURL.standardizedFileURL.path
+        guard anchorURL.path.hasPrefix(resourcePath + "/"),
+              FileManager.default.isExecutableFile(atPath: anchorURL.path),
+              let stateStore = UserDefaultsSecureStorageIdentityMigrationStateStore()
+        else {
+            blockUpdates()
+            return
+        }
+
+        let attributeProvider = TrustedApplicationsKeychainAttributeProvider(
+            descriptor: "RepoPrompt CE identity migration bridge",
+            executablePaths: [executableURL.path, anchorURL.path]
+        )
+        let bridgeStore = KeychainService(
+            serviceName: KeychainService.identityMigrationBridgeServiceName,
+            itemCreationAttributeProvider: attributeProvider
+        )
+        let coordinator = SecureStorageIdentityMigrationCoordinator(
+            sourceStore: KeychainService.officialV2Shared,
+            bridgeStore: bridgeStore,
+            stateStore: stateStore
+        )
+        let report = coordinator.prepareBridge()
+        guard report.bridgeReady else {
+            IdentityMigrationRuntimeState.shared.setBlockedMessage(report.blockedUpdateMessage)
+            return
+        }
+
+        SecureKeyValueStorageFactory.installOfficialBackendOverride(bridgeStore)
+        IdentityMigrationRuntimeState.shared.setBlockedMessage(nil)
+    }
+
+    private static func blockUpdates() {
+        IdentityMigrationRuntimeState.shared.setBlockedMessage(
+            "Updates are paused because the secure credential migration package is incomplete."
+        )
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
@@ -4,16 +4,30 @@ enum SecureStorageIdentityMigrationRecordState: Equatable {
     case absent
     case copied
     case verified
-    case conflict
     case interactionRequired
+    case userInteractionCancelled
+    case authenticationFailed
     case failed
 
     var isReady: Bool {
         switch self {
         case .absent, .copied, .verified:
             true
-        case .conflict, .interactionRequired, .failed:
+        case .interactionRequired, .userInteractionCancelled, .authenticationFailed, .failed:
             false
+        }
+    }
+
+    static func failureState(for error: Error) -> SecureStorageIdentityMigrationRecordState {
+        switch error {
+        case KeychainService.KeychainError.interactionNotAllowed:
+            .interactionRequired
+        case KeychainService.KeychainError.userInteractionCancelled:
+            .userInteractionCancelled
+        case KeychainService.KeychainError.authenticationFailed:
+            .authenticationFailed
+        default:
+            .failed
         }
     }
 }
@@ -30,46 +44,85 @@ struct SecureStorageIdentityMigrationRecord: Equatable, Identifiable {
 struct SecureStorageIdentityMigrationReport: Equatable {
     let records: [SecureStorageIdentityMigrationRecord]
     let bridgeReady: Bool
-    let completionPersisted: Bool
+    let blockingState: SecureStorageIdentityMigrationRecordState?
 
     var blockedUpdateMessage: String? {
         guard !bridgeReady else { return nil }
-        return "Updates are paused because secure credential migration could not be verified. Your existing credentials were not deleted or replaced."
+        let states = records.map(\.state) + [blockingState].compactMap(\.self)
+        if states.contains(.userInteractionCancelled) {
+            return "Updates are paused because Keychain access was cancelled. Quit and reopen RepoPrompt CE to retry, then approve Keychain access if prompted. Your existing credentials were not deleted."
+        }
+        if states.contains(.authenticationFailed) {
+            return "Updates are paused because Keychain authentication failed. Unlock your login Keychain, then quit and reopen RepoPrompt CE to retry. Your existing credentials were not deleted."
+        }
+        if states.contains(.interactionRequired) {
+            return "Updates are paused because the login Keychain is locked or unavailable. Unlock it, then quit and reopen RepoPrompt CE to retry. Your existing credentials were not deleted."
+        }
+        return "Updates are paused because secure credential migration could not be verified. Quit and reopen RepoPrompt CE to retry. Your existing credentials were not deleted."
     }
 }
 
 struct SecureStorageIdentityMigrationManifest: Codable, Equatable {
-    static let currentVersion = 1
+    static let currentVersion = 2
+
+    enum Status: String, Codable {
+        case preparing
+        case committed
+    }
 
     let version: Int
-    let migratedAccountIdentifiers: [String]
+    let status: Status
+    let attemptIdentifier: String
+    let catalogIdentifiers: [String]
+
+    func changingStatus(to status: Status) -> SecureStorageIdentityMigrationManifest {
+        SecureStorageIdentityMigrationManifest(
+            version: version,
+            status: status,
+            attemptIdentifier: attemptIdentifier,
+            catalogIdentifiers: catalogIdentifiers
+        )
+    }
 }
 
 protocol SecureStorageIdentityMigrationStateStore {
     func load() throws -> SecureStorageIdentityMigrationManifest?
     func save(_ manifest: SecureStorageIdentityMigrationManifest) throws
+    func reset() throws
 }
 
-struct UserDefaultsSecureStorageIdentityMigrationStateStore: SecureStorageIdentityMigrationStateStore {
-    static let suiteName = "com.repoprompt.ce.identity-migration"
-    static let manifestKey = "secure-storage-bridge-v1-manifest"
+/// A Keychain item is the durable migration journal and authority. Production preparers
+/// create it with the same validated dual-identity ACL as the bridge so the successor can
+/// discover the committed bridge marker. Unlike preferences, another same-user process
+/// cannot silently rewrite it without satisfying that Keychain ACL.
+struct KeychainSecureStorageIdentityMigrationStateStore: SecureStorageIdentityMigrationStateStore {
+    static let account = "RepoPromptIdentityMigrationStateV2"
 
     enum StoreError: Error {
-        case unavailable
         case invalidManifest
+        case verificationFailed
     }
 
-    private let defaults: UserDefaults
+    private let store: SecureKeyValueStorageBackend
+    private let accessMode = KeychainAccessMode.nonInteractive(reason: .launch)
 
-    init?() {
-        guard let defaults = UserDefaults(suiteName: Self.suiteName) else { return nil }
-        self.defaults = defaults
+    init(
+        store: SecureKeyValueStorageBackend = KeychainService(
+            serviceName: KeychainService.identityMigrationLegacyStateServiceName
+        )
+    ) {
+        self.store = store
     }
 
     func load() throws -> SecureStorageIdentityMigrationManifest? {
-        guard let data = defaults.data(forKey: Self.manifestKey) else { return nil }
-        guard let manifest = try? JSONDecoder().decode(SecureStorageIdentityMigrationManifest.self, from: data),
-              manifest.version == SecureStorageIdentityMigrationManifest.currentVersion
+        let value: String
+        do {
+            value = try store.get(for: Self.account, accessMode: accessMode)
+        } catch KeychainService.KeychainError.itemNotFound {
+            return nil
+        }
+        guard let data = value.data(using: .utf8),
+              let manifest = try? JSONDecoder().decode(SecureStorageIdentityMigrationManifest.self, from: data)
         else {
             throw StoreError.invalidManifest
         }
@@ -77,84 +130,104 @@ struct UserDefaultsSecureStorageIdentityMigrationStateStore: SecureStorageIdenti
     }
 
     func save(_ manifest: SecureStorageIdentityMigrationManifest) throws {
-        let data = try JSONEncoder().encode(manifest)
-        defaults.set(data, forKey: Self.manifestKey)
-        guard defaults.synchronize() else { throw StoreError.unavailable }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(manifest)
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw StoreError.invalidManifest
+        }
+        try store.save(value, for: Self.account, accessMode: accessMode)
+        guard try store.get(for: Self.account, accessMode: accessMode) == value else {
+            throw StoreError.verificationFailed
+        }
+    }
+
+    func reset() throws {
+        try store.delete(for: Self.account, accessMode: accessMode)
+        do {
+            _ = try store.get(for: Self.account, accessMode: accessMode)
+            throw StoreError.verificationFailed
+        } catch KeychainService.KeychainError.itemNotFound {
+            return
+        }
     }
 }
 
 /// Copies the closed secure-storage inventory into a new service whose item ACL trusts
-/// both signing identities. All operations are noninteractive. Source items are never
-/// changed or deleted, and the bridge is not selected until every present value has been
-/// read back byte-for-byte and the completion manifest has been persisted.
+/// both signing identities. A legacy-Keychain journal is committed before mutation, so
+/// interrupted attempts can reconcile only items carrying that attempt's random marker.
 final class SecureStorageIdentityMigrationCoordinator {
+    typealias BridgeStoreFactory = (String) -> SecureKeyValueStorageBackend
+
+    private enum CoordinatorError: Error {
+        case manifestEncodingFailed
+        case manifestConflict
+        case manifestVerificationFailed
+    }
+
+    static let bridgeManifestAccount = "RepoPromptIdentityMigrationBridgeManifestV2"
+
     private let accounts: [SecureStorageAccount]
     private let sourceStore: SecureKeyValueStorageBackend
-    private let bridgeStore: SecureKeyValueStorageBackend
+    private let bridgeStoreFactory: BridgeStoreFactory
     private let stateStore: SecureStorageIdentityMigrationStateStore
     private let accessMode = KeychainAccessMode.nonInteractive(reason: .launch)
 
     init(
         accounts: [SecureStorageAccount] = SecureStorageAccountCatalog.allAccounts,
         sourceStore: SecureKeyValueStorageBackend,
-        bridgeStore: SecureKeyValueStorageBackend,
+        bridgeStoreFactory: @escaping BridgeStoreFactory,
         stateStore: SecureStorageIdentityMigrationStateStore
     ) {
         self.accounts = accounts
         self.sourceStore = sourceStore
-        self.bridgeStore = bridgeStore
+        self.bridgeStoreFactory = bridgeStoreFactory
         self.stateStore = stateStore
     }
 
     func prepareBridge() -> SecureStorageIdentityMigrationReport {
+        let existingManifest: SecureStorageIdentityMigrationManifest?
         do {
-            if let manifest = try stateStore.load() {
-                return verifyCommittedBridge(manifest)
+            existingManifest = try stateStore.load()
+        } catch KeychainSecureStorageIdentityMigrationStateStore.StoreError.invalidManifest {
+            do {
+                try stateStore.reset()
+            } catch {
+                return blockedReport(error: error)
             }
+            return prepareBridge()
         } catch {
-            return blockedReport()
+            return blockedReport(error: error)
         }
 
-        var records: [SecureStorageIdentityMigrationRecord] = []
-        var migratedAccountIdentifiers: [String] = []
-
-        for account in accounts {
-            let source = read(account, from: sourceStore)
-            let bridge = read(account, from: bridgeStore)
-            let record = prepare(account, source: source, bridge: bridge)
-            records.append(record)
-            if source.value != nil {
-                migratedAccountIdentifiers.append(account.identifier)
+        if let existingManifest {
+            guard isStructurallyValid(existingManifest) else { return blockedReport() }
+            switch existingManifest.status {
+            case .preparing:
+                return resumePreparation(existingManifest)
+            case .committed:
+                return verifyCommittedBridge(existingManifest)
             }
         }
 
-        guard records.allSatisfy(\.state.isReady) else {
-            return SecureStorageIdentityMigrationReport(
-                records: records,
-                bridgeReady: false,
-                completionPersisted: false
-            )
+        let sourceResults = readAll(from: sourceStore)
+        let preflightRecords = recordsForReadFailures(sourceResults)
+        guard preflightRecords.allSatisfy(\.state.isReady) else {
+            return failedReport(records: preflightRecords)
         }
 
         let manifest = SecureStorageIdentityMigrationManifest(
             version: SecureStorageIdentityMigrationManifest.currentVersion,
-            migratedAccountIdentifiers: migratedAccountIdentifiers.sorted()
+            status: .preparing,
+            attemptIdentifier: UUID().uuidString.lowercased(),
+            catalogIdentifiers: expectedCatalogIdentifiers
         )
         do {
             try stateStore.save(manifest)
         } catch {
-            return SecureStorageIdentityMigrationReport(
-                records: records,
-                bridgeReady: false,
-                completionPersisted: false
-            )
+            return failedReport(records: preflightRecords, error: error)
         }
-
-        return SecureStorageIdentityMigrationReport(
-            records: records,
-            bridgeReady: true,
-            completionPersisted: true
-        )
+        return resumePreparation(manifest, sourceResults: sourceResults)
     }
 
     private struct ReadResult {
@@ -162,106 +235,257 @@ final class SecureStorageIdentityMigrationCoordinator {
         let failureState: SecureStorageIdentityMigrationRecordState?
     }
 
-    private func read(
-        _ account: SecureStorageAccount,
-        from store: SecureKeyValueStorageBackend
-    ) -> ReadResult {
+    private var expectedCatalogIdentifiers: [String] {
+        accounts.map(\.identifier).sorted()
+    }
+
+    private func isStructurallyValid(_ manifest: SecureStorageIdentityMigrationManifest) -> Bool {
+        manifest.version == SecureStorageIdentityMigrationManifest.currentVersion
+            && !manifest.attemptIdentifier.isEmpty
+            && manifest.catalogIdentifiers == expectedCatalogIdentifiers
+    }
+
+    private func readAll(from store: SecureKeyValueStorageBackend) -> [SecureStorageAccount: ReadResult] {
+        Dictionary(uniqueKeysWithValues: accounts.map { account in
+            (account, read(account.identifier, from: store))
+        })
+    }
+
+    private func read(_ key: String, from store: SecureKeyValueStorageBackend) -> ReadResult {
         do {
             return try ReadResult(
-                value: store.get(for: account.identifier, accessMode: accessMode),
+                value: store.get(for: key, accessMode: accessMode),
                 failureState: nil
             )
         } catch KeychainService.KeychainError.itemNotFound {
             return ReadResult(value: nil, failureState: nil)
         } catch KeychainService.KeychainError.interactionNotAllowed {
             return ReadResult(value: nil, failureState: .interactionRequired)
+        } catch KeychainService.KeychainError.userInteractionCancelled {
+            return ReadResult(value: nil, failureState: .userInteractionCancelled)
+        } catch KeychainService.KeychainError.authenticationFailed {
+            return ReadResult(value: nil, failureState: .authenticationFailed)
         } catch {
             return ReadResult(value: nil, failureState: .failed)
         }
     }
 
-    private func prepare(
-        _ account: SecureStorageAccount,
-        source: ReadResult,
-        bridge: ReadResult
-    ) -> SecureStorageIdentityMigrationRecord {
-        if let failureState = source.failureState ?? bridge.failureState {
-            return SecureStorageIdentityMigrationRecord(account: account, state: failureState)
+    private func recordsForReadFailures(
+        _ results: [SecureStorageAccount: ReadResult]
+    ) -> [SecureStorageIdentityMigrationRecord] {
+        accounts.map { account in
+            let result = results[account]
+            return SecureStorageIdentityMigrationRecord(
+                account: account,
+                state: result?.failureState ?? (result?.value == nil ? .absent : .verified)
+            )
+        }
+    }
+
+    private func resumePreparation(
+        _ manifest: SecureStorageIdentityMigrationManifest,
+        sourceResults suppliedSourceResults: [SecureStorageAccount: ReadResult]? = nil
+    ) -> SecureStorageIdentityMigrationReport {
+        let bridgeStore = bridgeStoreFactory(manifest.attemptIdentifier)
+        let sourceResults = suppliedSourceResults ?? readAll(from: sourceStore)
+        let bridgeResults = readAll(from: bridgeStore)
+        let preflightRecords = zipResults(source: sourceResults, bridge: bridgeResults)
+        guard preflightRecords.allSatisfy(\.state.isReady) else {
+            return failedReport(records: preflightRecords)
         }
 
-        switch (source.value, bridge.value) {
-        case (nil, nil):
-            return SecureStorageIdentityMigrationRecord(account: account, state: .absent)
-        case let (sourceValue?, nil):
-            do {
+        var records: [SecureStorageIdentityMigrationRecord] = []
+        for account in accounts {
+            guard let source = sourceResults[account], let bridge = bridgeResults[account] else {
+                records.append(SecureStorageIdentityMigrationRecord(account: account, state: .failed))
+                continue
+            }
+            records.append(reconcile(account, source: source, bridge: bridge, bridgeStore: bridgeStore))
+        }
+        guard records.allSatisfy(\.state.isReady) else {
+            return failedReport(records: records)
+        }
+
+        if let verificationFailure = verifyValuesMatch(bridgeStore: bridgeStore) {
+            return failedReport(records: records, blockingState: verificationFailure)
+        }
+
+        let committedManifest = manifest.changingStatus(to: .committed)
+        do {
+            try persistBridgeManifest(committedManifest, bridgeStore: bridgeStore)
+        } catch {
+            return failedReport(records: records, error: error)
+        }
+        do {
+            try stateStore.save(committedManifest)
+        } catch {
+            return failedReport(records: records, error: error)
+        }
+        return SecureStorageIdentityMigrationReport(
+            records: records,
+            bridgeReady: true,
+            blockingState: nil
+        )
+    }
+
+    private func zipResults(
+        source: [SecureStorageAccount: ReadResult],
+        bridge: [SecureStorageAccount: ReadResult]
+    ) -> [SecureStorageIdentityMigrationRecord] {
+        accounts.map { account in
+            let failure = source[account]?.failureState ?? bridge[account]?.failureState
+            return SecureStorageIdentityMigrationRecord(
+                account: account,
+                state: failure ?? .verified
+            )
+        }
+    }
+
+    private func reconcile(
+        _ account: SecureStorageAccount,
+        source: ReadResult,
+        bridge: ReadResult,
+        bridgeStore: SecureKeyValueStorageBackend
+    ) -> SecureStorageIdentityMigrationRecord {
+        guard source.failureState == nil, bridge.failureState == nil else {
+            return SecureStorageIdentityMigrationRecord(
+                account: account,
+                state: source.failureState ?? bridge.failureState ?? .failed
+            )
+        }
+
+        do {
+            switch (source.value, bridge.value) {
+            case (nil, nil):
+                return SecureStorageIdentityMigrationRecord(account: account, state: .absent)
+            case let (sourceValue?, nil):
+                try bridgeStore.create(sourceValue, for: account.identifier, accessMode: accessMode)
+                let verified = try bridgeStore.get(for: account.identifier, accessMode: accessMode)
+                return SecureStorageIdentityMigrationRecord(
+                    account: account,
+                    state: verified == sourceValue ? .copied : .failed
+                )
+            case let (sourceValue?, bridgeValue?):
+                if sourceValue == bridgeValue {
+                    return SecureStorageIdentityMigrationRecord(account: account, state: .verified)
+                }
+                // The random item marker and preparing journal prove this is an
+                // interrupted attempt. The source remains authoritative until commit.
                 try bridgeStore.save(sourceValue, for: account.identifier, accessMode: accessMode)
                 let verified = try bridgeStore.get(for: account.identifier, accessMode: accessMode)
                 return SecureStorageIdentityMigrationRecord(
                     account: account,
                     state: verified == sourceValue ? .copied : .failed
                 )
-            } catch KeychainService.KeychainError.interactionNotAllowed {
-                return SecureStorageIdentityMigrationRecord(account: account, state: .interactionRequired)
-            } catch {
-                return SecureStorageIdentityMigrationRecord(account: account, state: .failed)
+            case (nil, _?):
+                try bridgeStore.delete(for: account.identifier, accessMode: accessMode)
+                do {
+                    _ = try bridgeStore.get(for: account.identifier, accessMode: accessMode)
+                    return SecureStorageIdentityMigrationRecord(account: account, state: .failed)
+                } catch KeychainService.KeychainError.itemNotFound {
+                    return SecureStorageIdentityMigrationRecord(account: account, state: .absent)
+                }
             }
-        case let (sourceValue?, bridgeValue?):
+        } catch {
             return SecureStorageIdentityMigrationRecord(
                 account: account,
-                state: sourceValue == bridgeValue ? .verified : .conflict
+                state: SecureStorageIdentityMigrationRecordState.failureState(for: error)
             )
-        case (nil, _?):
-            // Before the manifest is committed, a target-only value has no proven origin.
-            return SecureStorageIdentityMigrationRecord(account: account, state: .conflict)
+        }
+    }
+
+    private func verifyValuesMatch(
+        bridgeStore: SecureKeyValueStorageBackend
+    ) -> SecureStorageIdentityMigrationRecordState? {
+        let sourceResults = readAll(from: sourceStore)
+        let bridgeResults = readAll(from: bridgeStore)
+        for account in accounts {
+            guard let source = sourceResults[account],
+                  let bridge = bridgeResults[account]
+            else {
+                return .failed
+            }
+            if let failureState = source.failureState ?? bridge.failureState {
+                return failureState
+            }
+            guard source.value == bridge.value else { return .failed }
+        }
+        return nil
+    }
+
+    private func persistBridgeManifest(
+        _ manifest: SecureStorageIdentityMigrationManifest,
+        bridgeStore: SecureKeyValueStorageBackend
+    ) throws {
+        guard let encoded = Self.encodeManifest(manifest) else {
+            throw CoordinatorError.manifestEncodingFailed
+        }
+        let existingValue: String?
+        do {
+            existingValue = try bridgeStore.get(for: Self.bridgeManifestAccount, accessMode: accessMode)
+        } catch KeychainService.KeychainError.itemNotFound {
+            existingValue = nil
+        }
+        if let existingValue {
+            guard existingValue == encoded else { throw CoordinatorError.manifestConflict }
+        } else {
+            try bridgeStore.create(encoded, for: Self.bridgeManifestAccount, accessMode: accessMode)
+        }
+        guard try bridgeStore.get(
+            for: Self.bridgeManifestAccount,
+            accessMode: accessMode
+        ) == encoded else {
+            throw CoordinatorError.manifestVerificationFailed
         }
     }
 
     private func verifyCommittedBridge(
         _ manifest: SecureStorageIdentityMigrationManifest
     ) -> SecureStorageIdentityMigrationReport {
-        let migrated = Set(manifest.migratedAccountIdentifiers)
-        let known = Set(accounts.map(\.identifier))
-        guard manifest.version == SecureStorageIdentityMigrationManifest.currentVersion,
-              migrated.count == manifest.migratedAccountIdentifiers.count,
-              migrated.isSubset(of: known)
-        else {
+        let bridgeStore = bridgeStoreFactory(manifest.attemptIdentifier)
+        guard let encoded = Self.encodeManifest(manifest) else {
             return blockedReport()
         }
-        var records: [SecureStorageIdentityMigrationRecord] = []
-        var ready = true
-
-        for account in accounts {
-            guard migrated.contains(account.identifier) else {
-                records.append(SecureStorageIdentityMigrationRecord(account: account, state: .absent))
-                continue
+        do {
+            guard try bridgeStore.get(
+                for: Self.bridgeManifestAccount,
+                accessMode: accessMode
+            ) == encoded else {
+                return blockedReport()
             }
-            let result = read(account, from: bridgeStore)
-            let state: SecureStorageIdentityMigrationRecordState = if result.value != nil {
-                .verified
-            } else if let failureState = result.failureState {
-                failureState
-            } else {
-                .failed
-            }
-            ready = ready && state.isReady
-            records.append(SecureStorageIdentityMigrationRecord(account: account, state: state))
+        } catch {
+            return blockedReport(error: error)
         }
-
         return SecureStorageIdentityMigrationReport(
-            records: records,
-            bridgeReady: ready,
-            completionPersisted: true
+            records: [],
+            bridgeReady: true,
+            blockingState: nil
         )
     }
 
-    private func blockedReport() -> SecureStorageIdentityMigrationReport {
+    static func encodeManifest(_ manifest: SecureStorageIdentityMigrationManifest) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(manifest) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func failedReport(
+        records: [SecureStorageIdentityMigrationRecord],
+        error: Error? = nil,
+        blockingState: SecureStorageIdentityMigrationRecordState? = nil
+    ) -> SecureStorageIdentityMigrationReport {
         SecureStorageIdentityMigrationReport(
-            records: accounts.map {
-                SecureStorageIdentityMigrationRecord(account: $0, state: .failed)
-            },
+            records: records,
             bridgeReady: false,
-            completionPersisted: false
+            blockingState: error.map {
+                SecureStorageIdentityMigrationRecordState.failureState(for: $0)
+            } ?? blockingState
         )
+    }
+
+    private func blockedReport(error: Error? = nil) -> SecureStorageIdentityMigrationReport {
+        failedReport(records: [], error: error)
     }
 }
 
@@ -285,71 +509,209 @@ final class IdentityMigrationRuntimeState: @unchecked Sendable {
 }
 
 enum SecureStorageIdentityMigrationBootstrap {
-    static let legacyBundleIdentifier = "com.pvncher.repoprompt.ce"
     static let phaseInfoKey = "RepoPromptIdentityMigrationPhase"
     static let anchorRelativePathInfoKey = "RepoPromptIdentityMigrationAnchorRelativePath"
+    static let successorBundleIdentifier = "com.repoprompt.ce"
+    static let successorTeamIdentifier = "69N6K965SF"
+    static let successorDeveloperIDRequirement =
+        "anchor apple generic and identifier \"\(successorBundleIdentifier)\" and certificate leaf[subject.OU] = \"\(successorTeamIdentifier)\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
 
     enum Phase: String {
         case disabled
         case legacyPreparer = "legacy-preparer"
     }
 
+    static func configuredPhase(from value: Any?) -> Phase? {
+        guard let rawPhase = value as? String else { return nil }
+        return Phase(rawValue: rawPhase)
+    }
+
     static func prepareIfConfigured(bundle: Bundle = .main) {
-        guard let rawPhase = bundle.object(forInfoDictionaryKey: phaseInfoKey) as? String,
-              let phase = Phase(rawValue: rawPhase),
-              phase != .disabled
+        IdentityMigrationRuntimeState.shared.setBlockedMessage(nil)
+        guard SecureKeyValueStorageFactory.currentDecision().domain == .officialDeveloperID else { return }
+        guard let phase = configuredPhase(from: bundle.object(forInfoDictionaryKey: phaseInfoKey))
         else {
+            blockUpdates("Updates are paused because this build has an unrecognized secure credential migration configuration.")
             return
         }
 
-        guard phase == .legacyPreparer,
-              bundle.bundleIdentifier == legacyBundleIdentifier,
-              SecureKeyValueStorageFactory.currentDecision().domain == .officialDeveloperID,
+        switch phase {
+        case .disabled:
+            activateCommittedBridgeIfPresent()
+        case .legacyPreparer:
+            prepareLegacyBridge(bundle: bundle)
+        }
+    }
+
+    private static func prepareLegacyBridge(bundle: Bundle) {
+        guard bundle.bundleIdentifier == RuntimeCodeSigningPolicy.developerIDBundleIdentifier,
               let executableURL = bundle.executableURL,
               let resourceURL = bundle.resourceURL,
               let relativeAnchorPath = bundle.object(forInfoDictionaryKey: anchorRelativePathInfoKey) as? String,
-              !relativeAnchorPath.isEmpty
+              !relativeAnchorPath.isEmpty,
+              let anchorURL = validatedAnchorURL(relativePath: relativeAnchorPath, resourceURL: resourceURL),
+              RuntimeCodeSigningDetector.validatesStaticCode(
+                  at: bundle.bundleURL,
+                  requirementSource: RuntimeCodeSigningPolicy.developerIDRequirement
+              ),
+              RuntimeCodeSigningDetector.validatesStaticCode(
+                  at: anchorURL,
+                  requirementSource: successorDeveloperIDRequirement
+              )
         else {
-            blockUpdates()
-            return
-        }
-
-        let anchorURL = resourceURL.appendingPathComponent(relativeAnchorPath).standardizedFileURL
-        let resourcePath = resourceURL.standardizedFileURL.path
-        guard anchorURL.path.hasPrefix(resourcePath + "/"),
-              FileManager.default.isExecutableFile(atPath: anchorURL.path),
-              let stateStore = UserDefaultsSecureStorageIdentityMigrationStateStore()
-        else {
-            blockUpdates()
+            blockUpdates("Updates are paused because the secure credential migration package is incomplete or has an invalid identity anchor.")
             return
         }
 
         let attributeProvider = TrustedApplicationsKeychainAttributeProvider(
             descriptor: "RepoPrompt CE identity migration bridge",
-            executablePaths: [executableURL.path, anchorURL.path]
+            applications: [
+                TrustedApplicationCodeRequirement(
+                    trustedApplicationPath: executableURL.path,
+                    codeURL: bundle.bundleURL,
+                    requirementSource: RuntimeCodeSigningPolicy.developerIDRequirement
+                ),
+                TrustedApplicationCodeRequirement(
+                    trustedApplicationPath: anchorURL.path,
+                    codeURL: anchorURL,
+                    requirementSource: successorDeveloperIDRequirement
+                )
+            ]
         )
-        let bridgeStore = KeychainService(
-            serviceName: KeychainService.identityMigrationBridgeServiceName,
-            itemCreationAttributeProvider: attributeProvider
+        let stateStore = KeychainSecureStorageIdentityMigrationStateStore(
+            store: KeychainService(
+                serviceName: KeychainService.identityMigrationLegacyStateServiceName,
+                itemCreationAttributeProvider: attributeProvider
+            )
         )
         let coordinator = SecureStorageIdentityMigrationCoordinator(
             sourceStore: KeychainService.officialV2Shared,
-            bridgeStore: bridgeStore,
+            bridgeStoreFactory: { attemptIdentifier in
+                bridgeStore(
+                    attemptIdentifier: attemptIdentifier,
+                    itemCreationAttributeProvider: attributeProvider
+                )
+            },
             stateStore: stateStore
         )
         let report = coordinator.prepareBridge()
-        guard report.bridgeReady else {
-            IdentityMigrationRuntimeState.shared.setBlockedMessage(report.blockedUpdateMessage)
+        guard report.bridgeReady,
+              let manifest = try? stateStore.load(),
+              manifest.status == .committed
+        else {
+            blockUpdates(report.blockedUpdateMessage)
             return
         }
 
-        SecureKeyValueStorageFactory.installOfficialBackendOverride(bridgeStore)
-        IdentityMigrationRuntimeState.shared.setBlockedMessage(nil)
+        SecureKeyValueStorageFactory.installOfficialBackendOverride(
+            bridgeStore(
+                attemptIdentifier: manifest.attemptIdentifier,
+                itemCreationAttributeProvider: attributeProvider
+            )
+        )
     }
 
-    private static func blockUpdates() {
-        IdentityMigrationRuntimeState.shared.setBlockedMessage(
-            "Updates are paused because the secure credential migration package is incomplete."
+    private static func activateCommittedBridgeIfPresent() {
+        let stateStore = KeychainSecureStorageIdentityMigrationStateStore()
+        let manifest: SecureStorageIdentityMigrationManifest?
+        do {
+            manifest = try stateStore.load()
+        } catch {
+            blockUpdates(for: error)
+            return
+        }
+        guard let manifest else { return }
+        guard manifest.version == SecureStorageIdentityMigrationManifest.currentVersion,
+              manifest.status == .committed,
+              !manifest.attemptIdentifier.isEmpty,
+              manifest.catalogIdentifiers == SecureStorageAccountCatalog.allAccounts.map(\.identifier).sorted(),
+              let encoded = SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest)
+        else {
+            blockUpdates("Updates are paused because the secure credential migration journal is incomplete.")
+            return
+        }
+
+        let itemIdentityAttributes = bridgeItemIdentityAttributes(manifest.attemptIdentifier)
+        let readOnlyBridge = KeychainService(
+            serviceName: KeychainService.identityMigrationBridgeServiceName,
+            itemIdentityAttributes: itemIdentityAttributes
         )
+        do {
+            guard try readOnlyBridge.get(
+                for: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
+                accessMode: .nonInteractive(reason: .launch)
+            ) == encoded
+            else {
+                blockUpdates("Updates are paused because the secure credential migration bridge could not be verified.")
+                return
+            }
+        } catch {
+            blockUpdates(for: error)
+            return
+        }
+
+        let accessProvider = ExistingKeychainItemAccessAttributeProvider(
+            serviceName: KeychainService.identityMigrationBridgeServiceName,
+            account: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
+            itemIdentityAttributes: itemIdentityAttributes
+        )
+        SecureKeyValueStorageFactory.installOfficialBackendOverride(
+            bridgeStore(
+                attemptIdentifier: manifest.attemptIdentifier,
+                itemCreationAttributeProvider: accessProvider
+            )
+        )
+    }
+
+    private static func bridgeStore(
+        attemptIdentifier: String,
+        itemCreationAttributeProvider: KeychainItemCreationAttributeProvider
+    ) -> KeychainService {
+        KeychainService(
+            serviceName: KeychainService.identityMigrationBridgeServiceName,
+            itemCreationAttributeProvider: itemCreationAttributeProvider,
+            itemIdentityAttributes: bridgeItemIdentityAttributes(attemptIdentifier)
+        )
+    }
+
+    private static func bridgeItemIdentityAttributes(_ attemptIdentifier: String) -> [String: Any] {
+        [kSecAttrGeneric as String: Data(attemptIdentifier.utf8)]
+    }
+
+    static func validatedAnchorURL(relativePath: String, resourceURL: URL) -> URL? {
+        let resolvedResources = resourceURL.resolvingSymlinksInPath().standardizedFileURL
+        let unresolvedCandidate = resolvedResources
+            .appendingPathComponent(relativePath)
+            .standardizedFileURL
+        let resolvedCandidate = unresolvedCandidate.resolvingSymlinksInPath().standardizedFileURL
+        guard unresolvedCandidate.path.hasPrefix(resolvedResources.path + "/"),
+              resolvedCandidate == unresolvedCandidate,
+              let values = try? unresolvedCandidate.resourceValues(forKeys: [
+                  .isRegularFileKey,
+                  .isSymbolicLinkKey,
+                  .isExecutableKey
+              ]),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true,
+              values.isExecutable == true
+        else {
+            return nil
+        }
+        return unresolvedCandidate
+    }
+
+    private static func blockUpdates(_ message: String?) {
+        IdentityMigrationRuntimeState.shared.setBlockedMessage(
+            message ?? "Updates are paused because secure credential migration could not be verified."
+        )
+    }
+
+    private static func blockUpdates(for error: Error) {
+        let report = SecureStorageIdentityMigrationReport(
+            records: [],
+            bridgeReady: false,
+            blockingState: SecureStorageIdentityMigrationRecordState.failureState(for: error)
+        )
+        blockUpdates(report.blockedUpdateMessage)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureStorageRepairService.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureStorageRepairService.swift
@@ -53,13 +53,20 @@ actor SecureStorageRepairService {
     }
 
     static func makeForCurrentRuntime() -> SecureStorageRepairService? {
-        guard SecureKeyValueStorageFactory.currentDecision().domain == .officialDeveloperID else {
-            return nil
-        }
-        return SecureStorageRepairService(
+        makeForRuntime(
+            decision: SecureKeyValueStorageFactory.currentDecision(),
             legacyStore: KeychainService.legacyRepairSource(),
-            targetStore: KeychainService.officialV2Shared
+            targetStore: SecureKeyValueStorageFactory.defaultBackend()
         )
+    }
+
+    static func makeForRuntime(
+        decision: RuntimeSecureStorageDecision,
+        legacyStore: SecureKeyValueStorageBackend,
+        targetStore: SecureKeyValueStorageBackend
+    ) -> SecureStorageRepairService? {
+        guard decision.domain == .officialDeveloperID else { return nil }
+        return SecureStorageRepairService(legacyStore: legacyStore, targetStore: targetStore)
     }
 
     func scan() -> [SecureStorageRepairRecord] {

--- a/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
+++ b/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
@@ -2,6 +2,41 @@
 import XCTest
 
 final class AppPlatformUtilityRecoveryTests: XCTestCase {
+    func testSparkleUpdaterStartDecisionFailsClosedForIdentityMigration() {
+        XCTAssertEqual(
+            SparkleUpdaterManager.startDecision(
+                sparkleConfigurationValid: true,
+                updaterStarted: false,
+                identityMigrationBlockedMessage: "migration blocked"
+            ),
+            .blocked("migration blocked")
+        )
+        XCTAssertEqual(
+            SparkleUpdaterManager.startDecision(
+                sparkleConfigurationValid: true,
+                updaterStarted: false,
+                identityMigrationBlockedMessage: nil
+            ),
+            .start
+        )
+        XCTAssertEqual(
+            SparkleUpdaterManager.startDecision(
+                sparkleConfigurationValid: false,
+                updaterStarted: false,
+                identityMigrationBlockedMessage: "migration blocked"
+            ),
+            .ignore
+        )
+        XCTAssertEqual(
+            SparkleUpdaterManager.startDecision(
+                sparkleConfigurationValid: true,
+                updaterStarted: true,
+                identityMigrationBlockedMessage: "migration blocked"
+            ),
+            .ignore
+        )
+    }
+
     func testAgentSessionDeepLinkURLRoundTripsAndRejectsInvalidScopedRoutes() throws {
         let route = try AgentSessionDeepLinkRoute(
             windowID: 7,

--- a/Tests/RepoPromptTests/Security/KeychainServiceTests.swift
+++ b/Tests/RepoPromptTests/Security/KeychainServiceTests.swift
@@ -161,7 +161,7 @@ final class KeychainServiceTests: XCTestCase {
         )
         let provider = FakeItemCreationAttributeProvider()
         let service = KeychainService(
-            serviceName: KeychainService.identityMigrationBridgeServiceName,
+            serviceName: KeychainService.identityMigrationBridgeServiceNamePrefix,
             secItemClient: fake,
             itemCreationAttributeProvider: provider
         )
@@ -175,18 +175,20 @@ final class KeychainServiceTests: XCTestCase {
         XCTAssertNil(fake.updateAttributes.first?.stringValue(for: kSecAttrAccess))
     }
 
-    func testCreateAddsWithoutUpdatingAndIncludesFixedIdentityAttributes() throws {
-        let marker = Data("attempt-123".utf8)
+    func testCreateUsesAttemptScopedServiceIdentityWithoutGenericMarker() throws {
+        let attemptIdentifier = "123e4567-e89b-12d3-a456-426614174000"
+        let serviceName = try XCTUnwrap(
+            KeychainService.identityMigrationBridgeServiceName(for: attemptIdentifier)
+        )
         let fake = FakeSecItemClient(
             copyHandler: { _, _ in errSecItemNotFound },
             addHandler: { _, _ in errSecSuccess }
         )
         let provider = FakeItemCreationAttributeProvider()
         let service = KeychainService(
-            serviceName: KeychainService.identityMigrationBridgeServiceName,
+            serviceName: serviceName,
             secItemClient: fake,
-            itemCreationAttributeProvider: provider,
-            itemIdentityAttributes: [kSecAttrGeneric as String: marker]
+            itemCreationAttributeProvider: provider
         )
 
         try service.create("stored-value", for: "api-key", accessMode: .nonInteractive(reason: .test))
@@ -194,10 +196,98 @@ final class KeychainServiceTests: XCTestCase {
         XCTAssertEqual(fake.operationLog, ["add"])
         XCTAssertTrue(fake.updateQueries.isEmpty)
         let addQuery = try XCTUnwrap(fake.addQueries.first)
-        XCTAssertEqual(addQuery.dataValue(for: kSecAttrGeneric), marker)
+        XCTAssertEqual(addQuery.stringValue(for: kSecAttrService), serviceName)
+        XCTAssertNil(addQuery.dataValue(for: kSecAttrGeneric))
         XCTAssertEqual(addQuery.stringValue(for: kSecAttrAccess), "test-access-policy")
         XCTAssertNil(addQuery.stringValue(for: kSecAttrAccessible))
         XCTAssertNil(addQuery.boolValue(for: kSecAttrSynchronizable))
+    }
+
+    func testAttemptScopedServiceIdentityRequiresCanonicalUUIDAndIsDistinct() throws {
+        let first = "123e4567-e89b-12d3-a456-426614174000"
+        let second = "123e4567-e89b-12d3-a456-426614174001"
+        let firstService = try XCTUnwrap(KeychainService.identityMigrationBridgeServiceName(for: first))
+        let secondService = try XCTUnwrap(KeychainService.identityMigrationBridgeServiceName(for: second))
+
+        XCTAssertNotEqual(firstService, secondService)
+        XCTAssertTrue(firstService.hasSuffix(first))
+        XCTAssertNil(KeychainService.identityMigrationBridgeServiceName(for: first.uppercased()))
+        XCTAssertNil(KeychainService.identityMigrationBridgeServiceName(for: "attempt-123"))
+    }
+
+    func testACLPrincipalValidationRequiresExactDesignatedRequirements() throws {
+        let legacyRequirement = Data("legacy-requirement".utf8)
+        let successorRequirement = Data("successor-requirement".utf8)
+        let expected = [legacyRequirement, successorRequirement]
+
+        XCTAssertNoThrow(try ClassicKeychainACLValidator.validate(
+            principals: [.requirement(successorRequirement), .requirement(legacyRequirement)],
+            expected: expected
+        ))
+        XCTAssertThrowsError(try ClassicKeychainACLValidator.validate(
+            principals: [.requirement(legacyRequirement)],
+            expected: expected
+        )) { error in
+            XCTAssertEqual(error as? KeychainACLValidationError, .missingPrincipal)
+        }
+        XCTAssertThrowsError(try ClassicKeychainACLValidator.validate(
+            principals: [.requirement(legacyRequirement), .wildcard],
+            expected: expected
+        )) { error in
+            XCTAssertEqual(error as? KeychainACLValidationError, .wildcardPrincipal)
+        }
+        XCTAssertThrowsError(try ClassicKeychainACLValidator.validate(
+            principals: [.requirement(legacyRequirement), .requirement(Data("attacker".utf8))],
+            expected: expected
+        )) { error in
+            XCTAssertEqual(error as? KeychainACLValidationError, .extraPrincipal)
+        }
+    }
+
+    func testReadRejectsForgedItemACLBeforeReturningCredentialValue() {
+        let fake = FakeSecItemClient { query, result in
+            if query.boolValue(for: kSecReturnRef) == true {
+                result?.pointee = NSObject()
+            } else {
+                result?.pointee = Data("attacker-value".utf8) as NSData
+            }
+            return errSecSuccess
+        }
+        let validator = FakeItemAccessValidator(error: KeychainACLValidationError.extraPrincipal)
+        let service = KeychainService(
+            serviceName: KeychainService.identityMigrationLegacyStateServiceName,
+            secItemClient: fake,
+            itemAccessValidator: validator,
+            itemAccessProvider: FakeSecKeychainItemAccessProvider()
+        )
+
+        XCTAssertThrowsError(
+            try service.get(for: "migration-journal", accessMode: .nonInteractive(reason: .test))
+        ) { error in
+            XCTAssertEqual(error as? KeychainACLValidationError, .extraPrincipal)
+        }
+        XCTAssertEqual(fake.copyQueries.count, 1)
+        XCTAssertEqual(fake.copyQueries.first?.boolValue(for: kSecReturnRef), true)
+    }
+
+    func testCopiedBridgeManifestACLIsValidatedBeforeReuse() {
+        let fake = FakeSecItemClient { _, result in
+            result?.pointee = NSObject()
+            return errSecSuccess
+        }
+        let validator = FakeItemAccessValidator(error: KeychainACLValidationError.extraPrincipal)
+        let provider = ExistingKeychainItemAccessAttributeProvider(
+            serviceName: "attempt-service",
+            account: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
+            accessValidator: validator,
+            itemAccessProvider: FakeSecKeychainItemAccessProvider(),
+            secItemClient: fake
+        )
+
+        XCTAssertThrowsError(try provider.attributesForNewItem()) { error in
+            XCTAssertEqual(error as? KeychainACLValidationError, .extraPrincipal)
+        }
+        XCTAssertEqual(validator.validationCount, 1)
     }
 
     func testPersistentServiceNamesAreIsolatedAndLegacyIsRepairOnly() throws {
@@ -206,7 +296,7 @@ final class KeychainServiceTests: XCTestCase {
         let names = Set([
             KeychainService.legacyCanonicalServiceName,
             KeychainService.officialV2ServiceName,
-            KeychainService.identityMigrationBridgeServiceName,
+            KeychainService.identityMigrationBridgeServiceNamePrefix,
             KeychainService.identityMigrationLegacyStateServiceName,
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintA, generation: 1),
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintA, generation: 2),
@@ -241,6 +331,26 @@ private final class FakeItemCreationAttributeProvider: KeychainItemCreationAttri
     func attributesForNewItem() throws -> [String: Any] {
         callCount += 1
         return [kSecAttrAccess as String: "test-access-policy"]
+    }
+}
+
+private final class FakeItemAccessValidator: KeychainItemAccessValidator {
+    private let error: Error?
+    private(set) var validationCount = 0
+
+    init(error: Error? = nil) {
+        self.error = error
+    }
+
+    func validate(_: AnyObject) throws {
+        validationCount += 1
+        if let error { throw error }
+    }
+}
+
+private struct FakeSecKeychainItemAccessProvider: SecKeychainItemAccessProvider {
+    func copyAccess(from _: AnyObject) throws -> AnyObject {
+        NSObject()
     }
 }
 

--- a/Tests/RepoPromptTests/Security/KeychainServiceTests.swift
+++ b/Tests/RepoPromptTests/Security/KeychainServiceTests.swift
@@ -153,18 +153,39 @@ final class KeychainServiceTests: XCTestCase {
         XCTAssertEqual(addQuery.boolValue(for: kSecAttrSynchronizable), false)
     }
 
+    func testSaveAddsCreationAttributesOnlyWhenCreatingItem() throws {
+        let fake = FakeSecItemClient(
+            copyHandler: { _, _ in errSecItemNotFound },
+            addHandler: { _, _ in errSecSuccess },
+            updateHandler: { _, _ in errSecItemNotFound }
+        )
+        let provider = FakeItemCreationAttributeProvider()
+        let service = KeychainService(
+            serviceName: KeychainService.identityMigrationBridgeServiceName,
+            secItemClient: fake,
+            itemCreationAttributeProvider: provider
+        )
+
+        try service.save("stored-value", for: "api-key", accessMode: .nonInteractive(reason: .test))
+
+        XCTAssertEqual(provider.callCount, 1)
+        XCTAssertEqual(fake.addQueries.first?.stringValue(for: kSecAttrAccess), "test-access-policy")
+        XCTAssertNil(fake.updateAttributes.first?.stringValue(for: kSecAttrAccess))
+    }
+
     func testPersistentServiceNamesAreIsolatedAndLegacyIsRepairOnly() throws {
         let fingerprintA = String(repeating: "A", count: 64)
         let fingerprintB = String(repeating: "B", count: 64)
         let names = Set([
             KeychainService.legacyCanonicalServiceName,
             KeychainService.officialV2ServiceName,
+            KeychainService.identityMigrationBridgeServiceName,
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintA, generation: 1),
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintA, generation: 2),
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintB, generation: 1),
             KeychainService.debugServiceName
         ])
-        XCTAssertEqual(names.count, 6)
+        XCTAssertEqual(names.count, 7)
 
         let fake = FakeSecItemClient { _, _ in errSecItemNotFound }
         let legacy = KeychainService.legacyRepairSource(secItemClient: fake)
@@ -183,6 +204,15 @@ final class KeychainServiceTests: XCTestCase {
             serviceName: serviceName,
             secItemClient: secItemClient
         )
+    }
+}
+
+private final class FakeItemCreationAttributeProvider: KeychainItemCreationAttributeProvider {
+    private(set) var callCount = 0
+
+    func attributesForNewItem() throws -> [String: Any] {
+        callCount += 1
+        return [kSecAttrAccess as String: "test-access-policy"]
     }
 }
 

--- a/Tests/RepoPromptTests/Security/KeychainServiceTests.swift
+++ b/Tests/RepoPromptTests/Security/KeychainServiceTests.swift
@@ -149,8 +149,8 @@ final class KeychainServiceTests: XCTestCase {
         XCTAssertEqual(addQuery.stringValue(for: kSecAttrAccount), "api-key")
         XCTAssertEqual(addQuery.stringValue(for: kSecUseAuthenticationUI), kSecUseAuthenticationUISkip as String)
         XCTAssertEqual(addQuery.dataValue(for: kSecValueData), Data("stored-value".utf8))
-        XCTAssertEqual(addQuery.stringValue(for: kSecAttrAccessible), kSecAttrAccessibleAfterFirstUnlock as String)
-        XCTAssertEqual(addQuery.boolValue(for: kSecAttrSynchronizable), false)
+        XCTAssertNil(addQuery.stringValue(for: kSecAttrAccessible))
+        XCTAssertNil(addQuery.boolValue(for: kSecAttrSynchronizable))
     }
 
     func testSaveAddsCreationAttributesOnlyWhenCreatingItem() throws {
@@ -170,7 +170,34 @@ final class KeychainServiceTests: XCTestCase {
 
         XCTAssertEqual(provider.callCount, 1)
         XCTAssertEqual(fake.addQueries.first?.stringValue(for: kSecAttrAccess), "test-access-policy")
+        XCTAssertNil(fake.addQueries.first?.stringValue(for: kSecAttrAccessible))
+        XCTAssertNil(fake.addQueries.first?.boolValue(for: kSecAttrSynchronizable))
         XCTAssertNil(fake.updateAttributes.first?.stringValue(for: kSecAttrAccess))
+    }
+
+    func testCreateAddsWithoutUpdatingAndIncludesFixedIdentityAttributes() throws {
+        let marker = Data("attempt-123".utf8)
+        let fake = FakeSecItemClient(
+            copyHandler: { _, _ in errSecItemNotFound },
+            addHandler: { _, _ in errSecSuccess }
+        )
+        let provider = FakeItemCreationAttributeProvider()
+        let service = KeychainService(
+            serviceName: KeychainService.identityMigrationBridgeServiceName,
+            secItemClient: fake,
+            itemCreationAttributeProvider: provider,
+            itemIdentityAttributes: [kSecAttrGeneric as String: marker]
+        )
+
+        try service.create("stored-value", for: "api-key", accessMode: .nonInteractive(reason: .test))
+
+        XCTAssertEqual(fake.operationLog, ["add"])
+        XCTAssertTrue(fake.updateQueries.isEmpty)
+        let addQuery = try XCTUnwrap(fake.addQueries.first)
+        XCTAssertEqual(addQuery.dataValue(for: kSecAttrGeneric), marker)
+        XCTAssertEqual(addQuery.stringValue(for: kSecAttrAccess), "test-access-policy")
+        XCTAssertNil(addQuery.stringValue(for: kSecAttrAccessible))
+        XCTAssertNil(addQuery.boolValue(for: kSecAttrSynchronizable))
     }
 
     func testPersistentServiceNamesAreIsolatedAndLegacyIsRepairOnly() throws {
@@ -180,12 +207,13 @@ final class KeychainServiceTests: XCTestCase {
             KeychainService.legacyCanonicalServiceName,
             KeychainService.officialV2ServiceName,
             KeychainService.identityMigrationBridgeServiceName,
+            KeychainService.identityMigrationLegacyStateServiceName,
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintA, generation: 1),
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintA, generation: 2),
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintB, generation: 1),
             KeychainService.debugServiceName
         ])
-        XCTAssertEqual(names.count, 7)
+        XCTAssertEqual(names.count, 8)
 
         let fake = FakeSecItemClient { _, _ in errSecItemNotFound }
         let legacy = KeychainService.legacyRepairSource(secItemClient: fake)

--- a/Tests/RepoPromptTests/Security/SecureStorageAccountCatalogTests.swift
+++ b/Tests/RepoPromptTests/Security/SecureStorageAccountCatalogTests.swift
@@ -36,6 +36,38 @@ final class SecureStorageAccountCatalogTests: XCTestCase {
         XCTAssertEqual(Set(SecureStorageAccountCatalog.allAccounts.map(\.identifier)).count, 24)
     }
 
+    func testIdentityMigrationV2CatalogRemainsFrozen() {
+        XCTAssertEqual(
+            SecureStorageAccountCatalog.identityMigrationV2Accounts.map(\.identifier),
+            [
+                "AnthropicAPI",
+                "OpenAIAPI",
+                "GeminiAPI",
+                "OpenRouterAPI",
+                "OllamaURL",
+                "AzureAPI",
+                "DeepSeekAPI",
+                "CustomProviderAPI",
+                "FireworksAPI",
+                "GrokAPI",
+                "GroqAPI",
+                "ClaudeCodeAPI",
+                "CodexCLIAPI",
+                "OpenCodeCLIAPI",
+                "CursorCLIAPI",
+                "ZAIAPI",
+                "ClaudeCompatibleBackend.kimi.apiKey",
+                "ClaudeCompatibleBackend.custom.apiKey",
+                "rp.agent.permissions.subagent.v1",
+                "rp.agent.permissions.codex.v1",
+                "rp.agent.permissions.claude.v1",
+                "rp.agent.permissions.openCode.v1",
+                "rp.agent.permissions.cursor.v1",
+                "rp.agent.permissions.grokBuild.v1"
+            ]
+        )
+    }
+
     func testProviderMappingsUseCatalogAccounts() {
         let mappings: [(AIProviderType, SecureStorageAccount)] = [
             (.anthropic, .anthropicAPI),
@@ -82,6 +114,7 @@ final class SecureStorageAccountCatalogTests: XCTestCase {
             "Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift",
             "Sources/RepoPrompt/Infrastructure/Security/SecureKeyService.swift",
             "Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift",
+            "Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift",
             "Sources/RepoPrompt/Infrastructure/Security/SecureStorageRepairService.swift"
         ]
 

--- a/Tests/RepoPromptTests/Security/SecureStorageIdentityMigrationTests.swift
+++ b/Tests/RepoPromptTests/Security/SecureStorageIdentityMigrationTests.swift
@@ -1,0 +1,211 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class SecureStorageIdentityMigrationTests: XCTestCase {
+    func testCopiesPresentValuesVerifiesThemAndPreservesSource() {
+        let source = TestSecureStorageBackend(values: [.openAIAPI: "secret"])
+        let bridge = TestSecureStorageBackend()
+        let state = TestIdentityMigrationStateStore()
+        let coordinator = makeCoordinator(source: source, bridge: bridge, state: state)
+
+        let report = coordinator.prepareBridge()
+
+        XCTAssertTrue(report.bridgeReady)
+        XCTAssertTrue(report.completionPersisted)
+        XCTAssertEqual(report.records.map(\.state), [.copied, .absent])
+        XCTAssertEqual(source.value(for: .openAIAPI), "secret")
+        XCTAssertEqual(bridge.value(for: .openAIAPI), "secret")
+        XCTAssertFalse(source.calls.contains { $0.operation == .delete })
+        XCTAssertFalse(bridge.calls.contains { $0.operation == .delete })
+        XCTAssertEqual(
+            state.manifest?.migratedAccountIdentifiers,
+            [SecureStorageAccount.openAIAPI.identifier]
+        )
+        XCTAssertTrue((source.calls + bridge.calls).allSatisfy {
+            $0.accessMode == .nonInteractive(reason: .launch)
+        })
+    }
+
+    func testMatchingExistingBridgeValueIsVerifiedWithoutRewrite() {
+        let source = TestSecureStorageBackend(values: [.openAIAPI: "secret"])
+        let bridge = TestSecureStorageBackend(values: [.openAIAPI: "secret"])
+        let coordinator = makeCoordinator(
+            source: source,
+            bridge: bridge,
+            state: TestIdentityMigrationStateStore()
+        )
+
+        let report = coordinator.prepareBridge()
+
+        XCTAssertTrue(report.bridgeReady)
+        XCTAssertEqual(report.records.first?.state, .verified)
+        XCTAssertFalse(bridge.calls.contains { $0.operation == .save })
+    }
+
+    func testConflictFailsClosedAndPreservesBothValues() {
+        let source = TestSecureStorageBackend(values: [.openAIAPI: "source"])
+        let bridge = TestSecureStorageBackend(values: [.openAIAPI: "bridge"])
+        let state = TestIdentityMigrationStateStore()
+        let coordinator = makeCoordinator(source: source, bridge: bridge, state: state)
+
+        let report = coordinator.prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(report.records.first?.state, .conflict)
+        XCTAssertEqual(source.value(for: .openAIAPI), "source")
+        XCTAssertEqual(bridge.value(for: .openAIAPI), "bridge")
+        XCTAssertNil(state.manifest)
+        XCTAssertFalse((source.calls + bridge.calls).contains { $0.operation == .delete })
+    }
+
+    func testTargetOnlyValueBeforeCommitFailsClosed() {
+        let source = TestSecureStorageBackend()
+        let bridge = TestSecureStorageBackend(values: [.openAIAPI: "unproven"])
+
+        let report = makeCoordinator(
+            source: source,
+            bridge: bridge,
+            state: TestIdentityMigrationStateStore()
+        ).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(report.records.first?.state, .conflict)
+    }
+
+    func testInteractionRequirementFailsClosedWithoutPromptingOrWriting() {
+        let source = TestSecureStorageBackend()
+        source.getErrors[.openAIAPI] = .interactionNotAllowed
+        let bridge = TestSecureStorageBackend()
+
+        let report = makeCoordinator(
+            source: source,
+            bridge: bridge,
+            state: TestIdentityMigrationStateStore()
+        ).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(report.records.first?.state, .interactionRequired)
+        XCTAssertFalse(bridge.calls.contains { $0.operation == .save })
+        XCTAssertTrue((source.calls + bridge.calls).allSatisfy {
+            $0.accessMode == .nonInteractive(reason: .launch)
+        })
+    }
+
+    func testReadBackMismatchDoesNotCommit() {
+        let source = TestSecureStorageBackend(values: [.openAIAPI: "source"])
+        let bridge = TestSecureStorageBackend()
+        bridge.savedValueOverride = "different"
+        let state = TestIdentityMigrationStateStore()
+
+        let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(report.records.first?.state, .failed)
+        XCTAssertNil(state.manifest)
+        XCTAssertEqual(source.value(for: .openAIAPI), "source")
+    }
+
+    func testCommittedManifestVerifiesOnlyMigratedBridgeAccounts() {
+        let source = TestSecureStorageBackend()
+        let bridge = TestSecureStorageBackend(values: [.openAIAPI: "secret"])
+        let state = TestIdentityMigrationStateStore(
+            manifest: SecureStorageIdentityMigrationManifest(
+                version: SecureStorageIdentityMigrationManifest.currentVersion,
+                migratedAccountIdentifiers: [SecureStorageAccount.openAIAPI.identifier]
+            )
+        )
+
+        let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
+
+        XCTAssertTrue(report.bridgeReady)
+        XCTAssertTrue(source.calls.isEmpty)
+        XCTAssertEqual(report.records.map(\.state), [.verified, .absent])
+    }
+
+    func testCommittedManifestWithMissingBridgeValueBlocks() {
+        let state = TestIdentityMigrationStateStore(
+            manifest: SecureStorageIdentityMigrationManifest(
+                version: SecureStorageIdentityMigrationManifest.currentVersion,
+                migratedAccountIdentifiers: [SecureStorageAccount.openAIAPI.identifier]
+            )
+        )
+
+        let report = makeCoordinator(
+            source: TestSecureStorageBackend(),
+            bridge: TestSecureStorageBackend(),
+            state: state
+        ).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(report.records.first?.state, .failed)
+    }
+
+    func testCommittedManifestWithUnknownAccountBlocks() {
+        let state = TestIdentityMigrationStateStore(
+            manifest: SecureStorageIdentityMigrationManifest(
+                version: SecureStorageIdentityMigrationManifest.currentVersion,
+                migratedAccountIdentifiers: ["unknown-account"]
+            )
+        )
+
+        let report = makeCoordinator(
+            source: TestSecureStorageBackend(),
+            bridge: TestSecureStorageBackend(),
+            state: state
+        ).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertTrue(report.records.allSatisfy { $0.state == .failed })
+    }
+
+    func testManifestPersistenceFailureLeavesBridgeUnselected() {
+        let state = TestIdentityMigrationStateStore(saveError: TestStateError.failed)
+        let report = makeCoordinator(
+            source: TestSecureStorageBackend(values: [.openAIAPI: "secret"]),
+            bridge: TestSecureStorageBackend(),
+            state: state
+        ).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertFalse(report.completionPersisted)
+    }
+
+    private func makeCoordinator(
+        source: SecureKeyValueStorageBackend,
+        bridge: SecureKeyValueStorageBackend,
+        state: SecureStorageIdentityMigrationStateStore
+    ) -> SecureStorageIdentityMigrationCoordinator {
+        SecureStorageIdentityMigrationCoordinator(
+            accounts: [.openAIAPI, .anthropicAPI],
+            sourceStore: source,
+            bridgeStore: bridge,
+            stateStore: state
+        )
+    }
+}
+
+private enum TestStateError: Error {
+    case failed
+}
+
+private final class TestIdentityMigrationStateStore: SecureStorageIdentityMigrationStateStore {
+    private(set) var manifest: SecureStorageIdentityMigrationManifest?
+    private let saveError: Error?
+
+    init(
+        manifest: SecureStorageIdentityMigrationManifest? = nil,
+        saveError: Error? = nil
+    ) {
+        self.manifest = manifest
+        self.saveError = saveError
+    }
+
+    func load() throws -> SecureStorageIdentityMigrationManifest? {
+        manifest
+    }
+
+    func save(_ manifest: SecureStorageIdentityMigrationManifest) throws {
+        if let saveError { throw saveError }
+        self.manifest = manifest
+    }
+}

--- a/Tests/RepoPromptTests/Security/SecureStorageIdentityMigrationTests.swift
+++ b/Tests/RepoPromptTests/Security/SecureStorageIdentityMigrationTests.swift
@@ -1,173 +1,317 @@
+import Foundation
 @testable import RepoPromptApp
 import XCTest
 
 final class SecureStorageIdentityMigrationTests: XCTestCase {
-    func testCopiesPresentValuesVerifiesThemAndPreservesSource() {
-        let source = TestSecureStorageBackend(values: [.openAIAPI: "secret"])
-        let bridge = TestSecureStorageBackend()
+    private let accounts: [SecureStorageAccount] = [.openAIAPI, .anthropicAPI]
+
+    func testPreparationCopiesValuesCommitsBothManifestsAndPreservesSource() throws {
+        let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
+        let bridge = MigrationTestBackend()
         let state = TestIdentityMigrationStateStore()
-        let coordinator = makeCoordinator(source: source, bridge: bridge, state: state)
+        var attemptIdentifiers: [String] = []
+        let coordinator = makeCoordinator(source: source, state: state) { attemptIdentifier in
+            attemptIdentifiers.append(attemptIdentifier)
+            return bridge
+        }
 
         let report = coordinator.prepareBridge()
 
         XCTAssertTrue(report.bridgeReady)
-        XCTAssertTrue(report.completionPersisted)
         XCTAssertEqual(report.records.map(\.state), [.copied, .absent])
-        XCTAssertEqual(source.value(for: .openAIAPI), "secret")
-        XCTAssertEqual(bridge.value(for: .openAIAPI), "secret")
+        XCTAssertEqual(source.value(for: SecureStorageAccount.openAIAPI.identifier), "secret")
+        XCTAssertEqual(bridge.value(for: SecureStorageAccount.openAIAPI.identifier), "secret")
         XCTAssertFalse(source.calls.contains { $0.operation == .delete })
-        XCTAssertFalse(bridge.calls.contains { $0.operation == .delete })
+        XCTAssertEqual(state.savedManifests.map(\.status), [.preparing, .committed])
+
+        let committed = try XCTUnwrap(state.manifest)
+        XCTAssertEqual(committed.version, SecureStorageIdentityMigrationManifest.currentVersion)
+        XCTAssertEqual(committed.status, .committed)
+        XCTAssertEqual(committed.catalogIdentifiers, accounts.map(\.identifier).sorted())
+        XCTAssertEqual(attemptIdentifiers, [committed.attemptIdentifier])
         XCTAssertEqual(
-            state.manifest?.migratedAccountIdentifiers,
-            [SecureStorageAccount.openAIAPI.identifier]
+            bridge.value(for: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount),
+            SecureStorageIdentityMigrationCoordinator.encodeManifest(committed)
         )
         XCTAssertTrue((source.calls + bridge.calls).allSatisfy {
             $0.accessMode == .nonInteractive(reason: .launch)
         })
     }
 
-    func testMatchingExistingBridgeValueIsVerifiedWithoutRewrite() {
-        let source = TestSecureStorageBackend(values: [.openAIAPI: "secret"])
-        let bridge = TestSecureStorageBackend(values: [.openAIAPI: "secret"])
-        let coordinator = makeCoordinator(
-            source: source,
-            bridge: bridge,
-            state: TestIdentityMigrationStateStore()
-        )
-
-        let report = coordinator.prepareBridge()
-
-        XCTAssertTrue(report.bridgeReady)
-        XCTAssertEqual(report.records.first?.state, .verified)
-        XCTAssertFalse(bridge.calls.contains { $0.operation == .save })
-    }
-
-    func testConflictFailsClosedAndPreservesBothValues() {
-        let source = TestSecureStorageBackend(values: [.openAIAPI: "source"])
-        let bridge = TestSecureStorageBackend(values: [.openAIAPI: "bridge"])
+    func testPreflightReadFailureWritesNeitherJournalNorBridge() {
+        let source = MigrationTestBackend()
+        source.getErrors[SecureStorageAccount.openAIAPI.identifier] = .interactionNotAllowed
+        let bridge = MigrationTestBackend()
         let state = TestIdentityMigrationStateStore()
-        let coordinator = makeCoordinator(source: source, bridge: bridge, state: state)
+        var factoryCallCount = 0
+        let coordinator = makeCoordinator(source: source, state: state) { _ in
+            factoryCallCount += 1
+            return bridge
+        }
 
         let report = coordinator.prepareBridge()
-
-        XCTAssertFalse(report.bridgeReady)
-        XCTAssertEqual(report.records.first?.state, .conflict)
-        XCTAssertEqual(source.value(for: .openAIAPI), "source")
-        XCTAssertEqual(bridge.value(for: .openAIAPI), "bridge")
-        XCTAssertNil(state.manifest)
-        XCTAssertFalse((source.calls + bridge.calls).contains { $0.operation == .delete })
-    }
-
-    func testTargetOnlyValueBeforeCommitFailsClosed() {
-        let source = TestSecureStorageBackend()
-        let bridge = TestSecureStorageBackend(values: [.openAIAPI: "unproven"])
-
-        let report = makeCoordinator(
-            source: source,
-            bridge: bridge,
-            state: TestIdentityMigrationStateStore()
-        ).prepareBridge()
-
-        XCTAssertFalse(report.bridgeReady)
-        XCTAssertEqual(report.records.first?.state, .conflict)
-    }
-
-    func testInteractionRequirementFailsClosedWithoutPromptingOrWriting() {
-        let source = TestSecureStorageBackend()
-        source.getErrors[.openAIAPI] = .interactionNotAllowed
-        let bridge = TestSecureStorageBackend()
-
-        let report = makeCoordinator(
-            source: source,
-            bridge: bridge,
-            state: TestIdentityMigrationStateStore()
-        ).prepareBridge()
 
         XCTAssertFalse(report.bridgeReady)
         XCTAssertEqual(report.records.first?.state, .interactionRequired)
-        XCTAssertFalse(bridge.calls.contains { $0.operation == .save })
-        XCTAssertTrue((source.calls + bridge.calls).allSatisfy {
-            $0.accessMode == .nonInteractive(reason: .launch)
+        XCTAssertTrue(report.blockedUpdateMessage?.contains("login Keychain is locked or unavailable") == true)
+        XCTAssertTrue(state.savedManifests.isEmpty)
+        XCTAssertEqual(factoryCallCount, 0)
+        XCTAssertTrue(bridge.calls.isEmpty)
+    }
+
+    func testPreflightPreservesCancelledAndAuthenticationFailures() {
+        let cancellationSource = MigrationTestBackend()
+        cancellationSource.getErrors[SecureStorageAccount.openAIAPI.identifier] = .userInteractionCancelled
+
+        let cancellationReport = makeCoordinator(
+            source: cancellationSource,
+            bridge: MigrationTestBackend(),
+            state: TestIdentityMigrationStateStore()
+        ).prepareBridge()
+
+        XCTAssertEqual(cancellationReport.records.first?.state, .userInteractionCancelled)
+        XCTAssertTrue(cancellationReport.blockedUpdateMessage?.contains("Keychain access was cancelled") == true)
+
+        let authenticationSource = MigrationTestBackend()
+        authenticationSource.getErrors[SecureStorageAccount.openAIAPI.identifier] = .authenticationFailed
+
+        let authenticationReport = makeCoordinator(
+            source: authenticationSource,
+            bridge: MigrationTestBackend(),
+            state: TestIdentityMigrationStateStore()
+        ).prepareBridge()
+
+        XCTAssertEqual(authenticationReport.records.first?.state, .authenticationFailed)
+        XCTAssertTrue(authenticationReport.blockedUpdateMessage?.contains("Keychain authentication failed") == true)
+    }
+
+    func testInterruptedPreparationResumesFromSourceAndCommits() throws {
+        let source = MigrationTestBackend(values: [
+            SecureStorageAccount.openAIAPI.identifier: "openai-v1",
+            SecureStorageAccount.anthropicAPI.identifier: "anthropic"
+        ])
+        let bridge = MigrationTestBackend()
+        bridge.createErrors[SecureStorageAccount.anthropicAPI.identifier] = .unexpectedStatus(-1)
+        let state = TestIdentityMigrationStateStore()
+        let coordinator = makeCoordinator(source: source, bridge: bridge, state: state)
+
+        let firstReport = coordinator.prepareBridge()
+
+        XCTAssertFalse(firstReport.bridgeReady)
+        XCTAssertEqual(firstReport.records.map(\.state), [.copied, .failed])
+        XCTAssertEqual(state.manifest?.status, .preparing)
+        XCTAssertEqual(bridge.value(for: SecureStorageAccount.openAIAPI.identifier), "openai-v1")
+
+        source.setValue("openai-v2", for: SecureStorageAccount.openAIAPI.identifier)
+        bridge.createErrors.removeValue(forKey: SecureStorageAccount.anthropicAPI.identifier)
+
+        let resumedReport = coordinator.prepareBridge()
+
+        XCTAssertTrue(resumedReport.bridgeReady)
+        XCTAssertEqual(resumedReport.records.map(\.state), [.copied, .copied])
+        XCTAssertEqual(bridge.value(for: SecureStorageAccount.openAIAPI.identifier), "openai-v2")
+        XCTAssertEqual(bridge.value(for: SecureStorageAccount.anthropicAPI.identifier), "anthropic")
+        XCTAssertEqual(try XCTUnwrap(state.manifest).status, .committed)
+    }
+
+    func testPreparingJournalRemovesAttemptScopedValueWhenSourceWasDeleted() {
+        let manifest = makeManifest(status: .preparing)
+        let source = MigrationTestBackend()
+        let bridge = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "stale"])
+        let state = TestIdentityMigrationStateStore(manifest: manifest)
+
+        let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
+
+        XCTAssertTrue(report.bridgeReady)
+        XCTAssertNil(bridge.value(for: SecureStorageAccount.openAIAPI.identifier))
+        XCTAssertTrue(bridge.calls.contains {
+            $0.operation == .delete && $0.key == SecureStorageAccount.openAIAPI.identifier
         })
     }
 
-    func testReadBackMismatchDoesNotCommit() {
-        let source = TestSecureStorageBackend(values: [.openAIAPI: "source"])
-        let bridge = TestSecureStorageBackend()
-        bridge.savedValueOverride = "different"
+    func testCommittedManifestUsesSingleBridgeManifestRead() throws {
+        let manifest = makeManifest(status: .committed)
+        let encoded = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest))
+        XCTAssertEqual(
+            encoded,
+            #"{"attemptIdentifier":"attempt-123","catalogIdentifiers":["AnthropicAPI","OpenAIAPI"],"status":"committed","version":2}"#
+        )
+        let source = MigrationTestBackend()
+        let bridge = MigrationTestBackend(values: [
+            SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount: encoded
+        ])
+        let state = TestIdentityMigrationStateStore(manifest: manifest)
+
+        let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
+
+        XCTAssertTrue(report.bridgeReady)
+        XCTAssertTrue(report.records.isEmpty)
+        XCTAssertTrue(source.calls.isEmpty)
+        XCTAssertEqual(bridge.calls.map(\.key), [SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount])
+    }
+
+    func testCommittedJournalWithoutMatchingBridgeManifestBlocks() {
+        let manifest = makeManifest(status: .committed)
+
+        let report = makeCoordinator(
+            source: MigrationTestBackend(),
+            bridge: MigrationTestBackend(),
+            state: TestIdentityMigrationStateStore(manifest: manifest)
+        ).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertTrue(report.records.isEmpty)
+        XCTAssertEqual(report.blockingState, .failed)
+    }
+
+    func testInvalidJournalBlocksWithoutReadingCredentials() {
+        let invalidManifest = SecureStorageIdentityMigrationManifest(
+            version: SecureStorageIdentityMigrationManifest.currentVersion,
+            status: .committed,
+            attemptIdentifier: "",
+            catalogIdentifiers: accounts.map(\.identifier).sorted()
+        )
+        let source = MigrationTestBackend()
+        let bridge = MigrationTestBackend()
+
+        let report = makeCoordinator(
+            source: source,
+            bridge: bridge,
+            state: TestIdentityMigrationStateStore(manifest: invalidManifest)
+        ).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertTrue(source.calls.isEmpty)
+        XCTAssertTrue(bridge.calls.isEmpty)
+    }
+
+    func testJournalAuthenticationFailureKeepsSpecificBlockedReason() {
+        let source = MigrationTestBackend()
+        let state = TestIdentityMigrationStateStore(loadError: KeychainService.KeychainError.authenticationFailed)
+
+        let report = makeCoordinator(
+            source: source,
+            bridge: MigrationTestBackend(),
+            state: state
+        ).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertTrue(report.records.isEmpty)
+        XCTAssertEqual(report.blockingState, .authenticationFailed)
+        XCTAssertTrue(report.blockedUpdateMessage?.contains("Keychain authentication failed") == true)
+        XCTAssertTrue(source.calls.isEmpty)
+    }
+
+    func testPreparingJournalPersistenceFailureLeavesBridgeUntouched() {
+        let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
+        let bridge = MigrationTestBackend()
+        let state = TestIdentityMigrationStateStore(saveFailuresRemaining: 1)
+        var factoryCallCount = 0
+        let coordinator = makeCoordinator(source: source, state: state) { _ in
+            factoryCallCount += 1
+            return bridge
+        }
+
+        let report = coordinator.prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(factoryCallCount, 0)
+        XCTAssertTrue(bridge.calls.isEmpty)
+    }
+
+    func testCorruptJournalIsResetAndMigrationRetriesFromIntactSource() {
+        let journalBackend = MigrationTestBackend(values: [
+            KeychainSecureStorageIdentityMigrationStateStore.account: "not-json"
+        ])
+        let state = KeychainSecureStorageIdentityMigrationStateStore(store: journalBackend)
+        let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
+        let bridge = MigrationTestBackend()
+
+        let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
+
+        XCTAssertTrue(report.bridgeReady)
+        XCTAssertEqual(bridge.value(for: SecureStorageAccount.openAIAPI.identifier), "secret")
+        XCTAssertTrue(journalBackend.calls.contains {
+            $0.operation == .delete && $0.key == KeychainSecureStorageIdentityMigrationStateStore.account
+        })
+    }
+
+    func testBridgeManifestPersistenceFailureLeavesJournalPreparing() {
+        let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
+        let bridge = MigrationTestBackend()
+        bridge.createErrors[SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount] = .unexpectedStatus(-1)
         let state = TestIdentityMigrationStateStore()
 
         let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
 
         XCTAssertFalse(report.bridgeReady)
-        XCTAssertEqual(report.records.first?.state, .failed)
-        XCTAssertNil(state.manifest)
-        XCTAssertEqual(source.value(for: .openAIAPI), "source")
+        XCTAssertEqual(state.manifest?.status, .preparing)
+        XCTAssertEqual(state.savedManifests.map(\.status), [.preparing])
     }
 
-    func testCommittedManifestVerifiesOnlyMigratedBridgeAccounts() {
-        let source = TestSecureStorageBackend()
-        let bridge = TestSecureStorageBackend(values: [.openAIAPI: "secret"])
-        let state = TestIdentityMigrationStateStore(
-            manifest: SecureStorageIdentityMigrationManifest(
-                version: SecureStorageIdentityMigrationManifest.currentVersion,
-                migratedAccountIdentifiers: [SecureStorageAccount.openAIAPI.identifier]
-            )
-        )
+    func testBridgeManifestAuthenticationFailureKeepsSpecificBlockedReason() {
+        let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
+        let bridge = MigrationTestBackend()
+        bridge.createErrors[SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount] = .authenticationFailed
+        let state = TestIdentityMigrationStateStore()
 
         let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
 
-        XCTAssertTrue(report.bridgeReady)
-        XCTAssertTrue(source.calls.isEmpty)
-        XCTAssertEqual(report.records.map(\.state), [.verified, .absent])
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(report.blockingState, .authenticationFailed)
+        XCTAssertTrue(report.blockedUpdateMessage?.contains("Keychain authentication failed") == true)
+        XCTAssertEqual(state.manifest?.status, .preparing)
     }
 
-    func testCommittedManifestWithMissingBridgeValueBlocks() {
-        let state = TestIdentityMigrationStateStore(
-            manifest: SecureStorageIdentityMigrationManifest(
-                version: SecureStorageIdentityMigrationManifest.currentVersion,
-                migratedAccountIdentifiers: [SecureStorageAccount.openAIAPI.identifier]
-            )
+    func testAnchorValidationAcceptsOnlyExecutableRegularFileInsideResources() throws {
+        let fixture = try makeAnchorFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        XCTAssertEqual(
+            SecureStorageIdentityMigrationBootstrap.validatedAnchorURL(
+                relativePath: "IdentityMigration/anchor",
+                resourceURL: fixture.resources
+            ),
+            fixture.anchor.standardizedFileURL
         )
-
-        let report = makeCoordinator(
-            source: TestSecureStorageBackend(),
-            bridge: TestSecureStorageBackend(),
-            state: state
-        ).prepareBridge()
-
-        XCTAssertFalse(report.bridgeReady)
-        XCTAssertEqual(report.records.first?.state, .failed)
     }
 
-    func testCommittedManifestWithUnknownAccountBlocks() {
-        let state = TestIdentityMigrationStateStore(
-            manifest: SecureStorageIdentityMigrationManifest(
-                version: SecureStorageIdentityMigrationManifest.currentVersion,
-                migratedAccountIdentifiers: ["unknown-account"]
-            )
+    func testConfiguredPhaseAcceptsOnlyKnownLiteralValues() {
+        XCTAssertEqual(SecureStorageIdentityMigrationBootstrap.configuredPhase(from: "disabled"), .disabled)
+        XCTAssertEqual(
+            SecureStorageIdentityMigrationBootstrap.configuredPhase(from: "legacy-preparer"),
+            .legacyPreparer
         )
-
-        let report = makeCoordinator(
-            source: TestSecureStorageBackend(),
-            bridge: TestSecureStorageBackend(),
-            state: state
-        ).prepareBridge()
-
-        XCTAssertFalse(report.bridgeReady)
-        XCTAssertTrue(report.records.allSatisfy { $0.state == .failed })
+        XCTAssertNil(SecureStorageIdentityMigrationBootstrap.configuredPhase(from: "legacy_preparer"))
+        XCTAssertNil(SecureStorageIdentityMigrationBootstrap.configuredPhase(from: nil))
+        XCTAssertNil(SecureStorageIdentityMigrationBootstrap.configuredPhase(from: 1))
     }
 
-    func testManifestPersistenceFailureLeavesBridgeUnselected() {
-        let state = TestIdentityMigrationStateStore(saveError: TestStateError.failed)
-        let report = makeCoordinator(
-            source: TestSecureStorageBackend(values: [.openAIAPI: "secret"]),
-            bridge: TestSecureStorageBackend(),
-            state: state
-        ).prepareBridge()
+    func testAnchorValidationRejectsSymlinkAndPathEscape() throws {
+        let fixture = try makeAnchorFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let symlink = fixture.resources.appendingPathComponent("IdentityMigration/anchor-link")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: fixture.anchor)
 
-        XCTAssertFalse(report.bridgeReady)
-        XCTAssertFalse(report.completionPersisted)
+        XCTAssertNil(SecureStorageIdentityMigrationBootstrap.validatedAnchorURL(
+            relativePath: "IdentityMigration/anchor-link",
+            resourceURL: fixture.resources
+        ))
+        XCTAssertNil(SecureStorageIdentityMigrationBootstrap.validatedAnchorURL(
+            relativePath: "../outside-anchor",
+            resourceURL: fixture.resources
+        ))
+    }
+
+    private func makeManifest(
+        status: SecureStorageIdentityMigrationManifest.Status
+    ) -> SecureStorageIdentityMigrationManifest {
+        SecureStorageIdentityMigrationManifest(
+            version: SecureStorageIdentityMigrationManifest.currentVersion,
+            status: status,
+            attemptIdentifier: "attempt-123",
+            catalogIdentifiers: accounts.map(\.identifier).sorted()
+        )
     }
 
     private func makeCoordinator(
@@ -175,12 +319,32 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         bridge: SecureKeyValueStorageBackend,
         state: SecureStorageIdentityMigrationStateStore
     ) -> SecureStorageIdentityMigrationCoordinator {
+        makeCoordinator(source: source, state: state) { _ in bridge }
+    }
+
+    private func makeCoordinator(
+        source: SecureKeyValueStorageBackend,
+        state: SecureStorageIdentityMigrationStateStore,
+        bridgeFactory: @escaping SecureStorageIdentityMigrationCoordinator.BridgeStoreFactory
+    ) -> SecureStorageIdentityMigrationCoordinator {
         SecureStorageIdentityMigrationCoordinator(
-            accounts: [.openAIAPI, .anthropicAPI],
+            accounts: accounts,
             sourceStore: source,
-            bridgeStore: bridge,
+            bridgeStoreFactory: bridgeFactory,
             stateStore: state
         )
+    }
+
+    private func makeAnchorFixture() throws -> (root: URL, resources: URL, anchor: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rpce-identity-migration-tests-\(UUID().uuidString)")
+        let resources = root.appendingPathComponent("Resources")
+        let anchorDirectory = resources.appendingPathComponent("IdentityMigration")
+        try FileManager.default.createDirectory(at: anchorDirectory, withIntermediateDirectories: true)
+        let anchor = anchorDirectory.appendingPathComponent("anchor")
+        try Data("anchor".utf8).write(to: anchor)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: anchor.path)
+        return (root, resources, anchor)
     }
 }
 
@@ -190,22 +354,112 @@ private enum TestStateError: Error {
 
 private final class TestIdentityMigrationStateStore: SecureStorageIdentityMigrationStateStore {
     private(set) var manifest: SecureStorageIdentityMigrationManifest?
-    private let saveError: Error?
+    private(set) var savedManifests: [SecureStorageIdentityMigrationManifest] = []
+    var loadError: Error?
+    var saveFailuresRemaining: Int
 
     init(
         manifest: SecureStorageIdentityMigrationManifest? = nil,
-        saveError: Error? = nil
+        loadError: Error? = nil,
+        saveFailuresRemaining: Int = 0
     ) {
         self.manifest = manifest
-        self.saveError = saveError
+        self.loadError = loadError
+        self.saveFailuresRemaining = saveFailuresRemaining
     }
 
     func load() throws -> SecureStorageIdentityMigrationManifest? {
-        manifest
+        if let loadError { throw loadError }
+        return manifest
     }
 
     func save(_ manifest: SecureStorageIdentityMigrationManifest) throws {
-        if let saveError { throw saveError }
+        if saveFailuresRemaining > 0 {
+            saveFailuresRemaining -= 1
+            throw TestStateError.failed
+        }
+        savedManifests.append(manifest)
         self.manifest = manifest
+    }
+
+    func reset() throws {
+        manifest = nil
+    }
+}
+
+private final class MigrationTestBackend: SecureKeyValueStorageBackend, @unchecked Sendable {
+    enum Operation: Equatable {
+        case get
+        case save
+        case create
+        case delete
+    }
+
+    struct Call: Equatable {
+        let operation: Operation
+        let key: String
+        let accessMode: KeychainAccessMode
+    }
+
+    let persistsValuesAcrossLaunches = true
+    var getErrors: [String: KeychainService.KeychainError] = [:]
+    var saveErrors: [String: KeychainService.KeychainError] = [:]
+    var createErrors: [String: KeychainService.KeychainError] = [:]
+    var deleteErrors: [String: KeychainService.KeychainError] = [:]
+
+    private var values: [String: String]
+    private(set) var calls: [Call] = []
+    private let lock = NSRecursiveLock()
+
+    init(values: [String: String] = [:]) {
+        self.values = values
+    }
+
+    func save(_ value: String, for key: String, accessMode: KeychainAccessMode) throws {
+        try withLock {
+            calls.append(Call(operation: .save, key: key, accessMode: accessMode))
+            if let error = saveErrors[key] { throw error }
+            values[key] = value
+        }
+    }
+
+    func create(_ value: String, for key: String, accessMode: KeychainAccessMode) throws {
+        try withLock {
+            calls.append(Call(operation: .create, key: key, accessMode: accessMode))
+            if let error = createErrors[key] { throw error }
+            guard values[key] == nil else { throw KeychainService.KeychainError.duplicateItem }
+            values[key] = value
+        }
+    }
+
+    func get(for key: String, accessMode: KeychainAccessMode) throws -> String {
+        try withLock {
+            calls.append(Call(operation: .get, key: key, accessMode: accessMode))
+            if let error = getErrors[key] { throw error }
+            guard let value = values[key] else { throw KeychainService.KeychainError.itemNotFound }
+            return value
+        }
+    }
+
+    func delete(for key: String, accessMode: KeychainAccessMode) throws {
+        try withLock {
+            calls.append(Call(operation: .delete, key: key, accessMode: accessMode))
+            if let error = deleteErrors[key] { throw error }
+            values.removeValue(forKey: key)
+        }
+    }
+
+    func setValue(_ value: String?, for key: String) {
+        withLock { values[key] = value }
+    }
+
+    func value(for key: String) -> String? {
+        withLock { values[key] }
+    }
+
+    private func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body()
     }
 }

--- a/Tests/RepoPromptTests/Security/SecureStorageIdentityMigrationTests.swift
+++ b/Tests/RepoPromptTests/Security/SecureStorageIdentityMigrationTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 final class SecureStorageIdentityMigrationTests: XCTestCase {
     private let accounts: [SecureStorageAccount] = [.openAIAPI, .anthropicAPI]
+    private let firstAttemptIdentifier = "123e4567-e89b-12d3-a456-426614174000"
+    private let secondAttemptIdentifier = "123e4567-e89b-12d3-a456-426614174001"
 
     func testPreparationCopiesValuesCommitsBothManifestsAndPreservesSource() throws {
         let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
@@ -40,7 +42,8 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
 
     func testPreflightReadFailureWritesNeitherJournalNorBridge() {
         let source = MigrationTestBackend()
-        source.getErrors[SecureStorageAccount.openAIAPI.identifier] = .interactionNotAllowed
+        source.getErrors[SecureStorageAccount.openAIAPI.identifier] =
+            KeychainService.KeychainError.interactionNotAllowed
         let bridge = MigrationTestBackend()
         let state = TestIdentityMigrationStateStore()
         var factoryCallCount = 0
@@ -61,7 +64,8 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
 
     func testPreflightPreservesCancelledAndAuthenticationFailures() {
         let cancellationSource = MigrationTestBackend()
-        cancellationSource.getErrors[SecureStorageAccount.openAIAPI.identifier] = .userInteractionCancelled
+        cancellationSource.getErrors[SecureStorageAccount.openAIAPI.identifier] =
+            KeychainService.KeychainError.userInteractionCancelled
 
         let cancellationReport = makeCoordinator(
             source: cancellationSource,
@@ -73,7 +77,8 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         XCTAssertTrue(cancellationReport.blockedUpdateMessage?.contains("Keychain access was cancelled") == true)
 
         let authenticationSource = MigrationTestBackend()
-        authenticationSource.getErrors[SecureStorageAccount.openAIAPI.identifier] = .authenticationFailed
+        authenticationSource.getErrors[SecureStorageAccount.openAIAPI.identifier] =
+            KeychainService.KeychainError.authenticationFailed
 
         let authenticationReport = makeCoordinator(
             source: authenticationSource,
@@ -91,7 +96,8 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
             SecureStorageAccount.anthropicAPI.identifier: "anthropic"
         ])
         let bridge = MigrationTestBackend()
-        bridge.createErrors[SecureStorageAccount.anthropicAPI.identifier] = .unexpectedStatus(-1)
+        bridge.createErrors[SecureStorageAccount.anthropicAPI.identifier] =
+            KeychainService.KeychainError.unexpectedStatus(-1)
         let state = TestIdentityMigrationStateStore()
         let coordinator = makeCoordinator(source: source, bridge: bridge, state: state)
 
@@ -114,6 +120,47 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(state.manifest).status, .committed)
     }
 
+    func testLostJournalStartsNewServiceAndIgnoresOrphanedAttemptItems() throws {
+        let source = MigrationTestBackend(values: [
+            SecureStorageAccount.openAIAPI.identifier: "openai",
+            SecureStorageAccount.anthropicAPI.identifier: "anthropic"
+        ])
+        let firstBridge = MigrationTestBackend()
+        firstBridge.createErrors[SecureStorageAccount.anthropicAPI.identifier] =
+            KeychainService.KeychainError.unexpectedStatus(-1)
+        let secondBridge = MigrationTestBackend()
+        let state = TestIdentityMigrationStateStore()
+        var generatedAttempts = [firstAttemptIdentifier, secondAttemptIdentifier]
+        let coordinator = makeCoordinator(
+            source: source,
+            state: state,
+            attemptIdentifierGenerator: { generatedAttempts.removeFirst() }
+        ) { attemptIdentifier in
+            switch attemptIdentifier {
+            case self.firstAttemptIdentifier:
+                firstBridge
+            case self.secondAttemptIdentifier:
+                secondBridge
+            default:
+                throw TestStateError.failed
+            }
+        }
+
+        XCTAssertFalse(coordinator.prepareBridge().bridgeReady)
+        XCTAssertEqual(
+            firstBridge.value(for: SecureStorageAccount.openAIAPI.identifier),
+            "openai"
+        )
+        try state.reset()
+
+        let recoveredReport = coordinator.prepareBridge()
+
+        XCTAssertTrue(recoveredReport.bridgeReady)
+        XCTAssertEqual(secondBridge.value(for: SecureStorageAccount.openAIAPI.identifier), "openai")
+        XCTAssertEqual(secondBridge.value(for: SecureStorageAccount.anthropicAPI.identifier), "anthropic")
+        XCTAssertEqual(state.manifest?.attemptIdentifier, secondAttemptIdentifier)
+    }
+
     func testPreparingJournalRemovesAttemptScopedValueWhenSourceWasDeleted() {
         let manifest = makeManifest(status: .preparing)
         let source = MigrationTestBackend()
@@ -134,7 +181,7 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         let encoded = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest))
         XCTAssertEqual(
             encoded,
-            #"{"attemptIdentifier":"attempt-123","catalogIdentifiers":["AnthropicAPI","OpenAIAPI"],"status":"committed","version":2}"#
+            #"{"attemptIdentifier":"123e4567-e89b-12d3-a456-426614174000","catalogIdentifiers":["AnthropicAPI","OpenAIAPI"],"status":"committed","version":2}"#
         )
         let source = MigrationTestBackend()
         let bridge = MigrationTestBackend(values: [
@@ -202,6 +249,75 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         XCTAssertTrue(source.calls.isEmpty)
     }
 
+    func testForgedJournalACLBlocksBeforeBridgeOrCredentialReads() {
+        let source = MigrationTestBackend()
+        let journalBackend = MigrationTestBackend()
+        journalBackend.getErrors[KeychainSecureStorageIdentityMigrationStateStore.account] =
+            KeychainACLValidationError.extraPrincipal
+        var bridgeFactoryCalled = false
+        let coordinator = makeCoordinator(
+            source: source,
+            state: KeychainSecureStorageIdentityMigrationStateStore(store: journalBackend)
+        ) { _ in
+            bridgeFactoryCalled = true
+            return MigrationTestBackend()
+        }
+
+        let report = coordinator.prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertFalse(bridgeFactoryCalled)
+        XCTAssertTrue(source.calls.isEmpty)
+    }
+
+    func testForgedBridgeManifestACLBlocksCommittedActivation() throws {
+        let manifest = makeManifest(status: .committed)
+        let encoded = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest))
+        let bridge = MigrationTestBackend(values: [
+            SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount: encoded
+        ])
+        bridge.getErrors[SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount] =
+            KeychainACLValidationError.extraPrincipal
+        let resolver = SecureStorageIdentityMigrationCommittedBridgeResolver(
+            accounts: accounts,
+            stateStore: TestIdentityMigrationStateStore(manifest: manifest),
+            bridgeStoreFactory: { _ in bridge }
+        )
+
+        XCTAssertThrowsError(try resolver.resolve()) { error in
+            XCTAssertEqual(error as? KeychainACLValidationError, .extraPrincipal)
+        }
+    }
+
+    func testCommittedBridgeRemainsAuthorityWhenRuntimeCatalogAddsAccount() throws {
+        let frozenMigrationAccounts: [SecureStorageAccount] = [.openAIAPI]
+        let futureRuntimeAccount = SecureStorageAccount.anthropicAPI
+        let manifest = SecureStorageIdentityMigrationManifest(
+            version: SecureStorageIdentityMigrationManifest.currentVersion,
+            status: .committed,
+            attemptIdentifier: firstAttemptIdentifier,
+            catalogIdentifiers: frozenMigrationAccounts.map(\.identifier)
+        )
+        let encoded = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest))
+        let bridge = MigrationTestBackend(values: [
+            SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount: encoded
+        ])
+        let resolution = try XCTUnwrap(SecureStorageIdentityMigrationCommittedBridgeResolver(
+            accounts: frozenMigrationAccounts,
+            stateStore: TestIdentityMigrationStateStore(manifest: manifest),
+            bridgeStoreFactory: { _ in bridge }
+        ).resolve())
+
+        try resolution.store.save(
+            "future-value",
+            for: futureRuntimeAccount.identifier,
+            accessMode: .nonInteractive(reason: .test)
+        )
+
+        XCTAssertEqual(bridge.value(for: futureRuntimeAccount.identifier), "future-value")
+        XCTAssertEqual(resolution.manifest.catalogIdentifiers, [SecureStorageAccount.openAIAPI.identifier])
+    }
+
     func testPreparingJournalPersistenceFailureLeavesBridgeUntouched() {
         let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
         let bridge = MigrationTestBackend()
@@ -239,7 +355,8 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
     func testBridgeManifestPersistenceFailureLeavesJournalPreparing() {
         let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
         let bridge = MigrationTestBackend()
-        bridge.createErrors[SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount] = .unexpectedStatus(-1)
+        bridge.createErrors[SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount] =
+            KeychainService.KeychainError.unexpectedStatus(-1)
         let state = TestIdentityMigrationStateStore()
 
         let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
@@ -252,7 +369,8 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
     func testBridgeManifestAuthenticationFailureKeepsSpecificBlockedReason() {
         let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
         let bridge = MigrationTestBackend()
-        bridge.createErrors[SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount] = .authenticationFailed
+        bridge.createErrors[SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount] =
+            KeychainService.KeychainError.authenticationFailed
         let state = TestIdentityMigrationStateStore()
 
         let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
@@ -287,6 +405,17 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         XCTAssertNil(SecureStorageIdentityMigrationBootstrap.configuredPhase(from: 1))
     }
 
+    func testPreparerCatalogGateRejectsDriftFromFrozenMigrationCatalog() {
+        XCTAssertTrue(SecureStorageIdentityMigrationBootstrap.preparerCatalogMatchesFrozenCatalog(
+            currentAccounts: [.openAIAPI],
+            migrationAccounts: [.openAIAPI]
+        ))
+        XCTAssertFalse(SecureStorageIdentityMigrationBootstrap.preparerCatalogMatchesFrozenCatalog(
+            currentAccounts: [.openAIAPI, .anthropicAPI],
+            migrationAccounts: [.openAIAPI]
+        ))
+    }
+
     func testAnchorValidationRejectsSymlinkAndPathEscape() throws {
         let fixture = try makeAnchorFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
@@ -309,7 +438,7 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         SecureStorageIdentityMigrationManifest(
             version: SecureStorageIdentityMigrationManifest.currentVersion,
             status: status,
-            attemptIdentifier: "attempt-123",
+            attemptIdentifier: firstAttemptIdentifier,
             catalogIdentifiers: accounts.map(\.identifier).sorted()
         )
     }
@@ -325,13 +454,17 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
     private func makeCoordinator(
         source: SecureKeyValueStorageBackend,
         state: SecureStorageIdentityMigrationStateStore,
+        attemptIdentifierGenerator: @escaping SecureStorageIdentityMigrationCoordinator.AttemptIdentifierGenerator = {
+            UUID().uuidString.lowercased()
+        },
         bridgeFactory: @escaping SecureStorageIdentityMigrationCoordinator.BridgeStoreFactory
     ) -> SecureStorageIdentityMigrationCoordinator {
         SecureStorageIdentityMigrationCoordinator(
             accounts: accounts,
             sourceStore: source,
             bridgeStoreFactory: bridgeFactory,
-            stateStore: state
+            stateStore: state,
+            attemptIdentifierGenerator: attemptIdentifierGenerator
         )
     }
 
@@ -402,10 +535,10 @@ private final class MigrationTestBackend: SecureKeyValueStorageBackend, @uncheck
     }
 
     let persistsValuesAcrossLaunches = true
-    var getErrors: [String: KeychainService.KeychainError] = [:]
-    var saveErrors: [String: KeychainService.KeychainError] = [:]
-    var createErrors: [String: KeychainService.KeychainError] = [:]
-    var deleteErrors: [String: KeychainService.KeychainError] = [:]
+    var getErrors: [String: Error] = [:]
+    var saveErrors: [String: Error] = [:]
+    var createErrors: [String: Error] = [:]
+    var deleteErrors: [String: Error] = [:]
 
     private var values: [String: String]
     private(set) var calls: [Call] = []

--- a/Tests/RepoPromptTests/Security/SecureStorageRepairServiceTests.swift
+++ b/Tests/RepoPromptTests/Security/SecureStorageRepairServiceTests.swift
@@ -3,6 +3,26 @@ import Foundation
 import XCTest
 
 final class SecureStorageRepairServiceTests: XCTestCase {
+    func testOfficialRuntimeFactoryRepairsIntoSelectedRuntimeBackend() async throws {
+        let legacy = TestSecureStorageBackend(values: [.openAIAPI: "legacy-secret"])
+        let selectedRuntimeBackend = TestSecureStorageBackend()
+        let decision = RuntimeSecureStorageDecision(
+            domain: .officialDeveloperID,
+            rejectionReason: nil
+        )
+        let service = try XCTUnwrap(SecureStorageRepairService.makeForRuntime(
+            decision: decision,
+            legacyStore: legacy,
+            targetStore: selectedRuntimeBackend
+        ))
+
+        let result = await service.importAccount(.openAIAPI)
+
+        XCTAssertEqual(result.state, .imported)
+        XCTAssertEqual(selectedRuntimeBackend.value(for: .openAIAPI), "legacy-secret")
+        XCTAssertEqual(legacy.value(for: .openAIAPI), "legacy-secret")
+    }
+
     func testScanClassifiesKnownAccountsNoninteractivelyAndContinuesAfterFailures() async {
         let accounts: [SecureStorageAccount] = [
             .anthropicAPI,

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -17,16 +17,30 @@ contain multiple update items during the transition; this does not require extra
 ## Release ladder
 
 1. Ship a legacy-signed preparer (`P`) through the existing Sparkle path.
-2. `P` copies every present account in `SecureStorageAccountCatalog` from the current Developer ID
-   Keychain service into the identity-migration bridge service.
-3. Each new bridge item receives a classic macOS Keychain ACL derived from the running legacy-signed
-   executable and an embedded executable signed for the successor identity.
-4. `P` reads back every copied value byte-for-byte. It never deletes or rewrites the source items.
-5. Only after every record is absent, copied, or verified does `P` persist the completion manifest and
-   select the bridge as the canonical secure-storage backend.
-6. If any read needs interaction, any values conflict, read-back fails, or the completion manifest
-   cannot be persisted, the old secure-storage service remains canonical and Sparkle is paused.
-7. After the bridge has been proven under both real signing identities, publish a notarized transition
+2. Before mutating bridge records, `P` writes a `preparing` journal to a dedicated Keychain service
+   using the same validated dual-identity ACL as the bridge. The journal contains a random attempt
+   identifier and the exact closed account catalog, allowing the successor to discover the committed
+   bridge without relying on mutable preferences.
+3. `P` copies every present account in `SecureStorageAccountCatalog` from the current Developer ID
+   Keychain service into bridge items scoped by that attempt identifier. New records use create-only
+   writes so an unproven pre-existing ACL cannot be retained.
+4. Each new bridge item receives a classic macOS Keychain ACL derived from the running legacy-signed
+   executable and an embedded executable signed for the successor identity. Before creating that ACL,
+   runtime code validates both executables against their exact identifiers, Team IDs, and Developer ID
+   certificate requirements.
+5. `P` reads back every copied value byte-for-byte. It never deletes or rewrites source items. If an
+   attempt is interrupted, the next launch resumes the same journal: the source remains authoritative,
+   changed source values are recopied, and attempt-scoped bridge values whose source disappeared are
+   removed.
+6. Only after every source and bridge value matches does `P` create and verify a committed bridge
+   manifest, commit the dual-identity Keychain journal, and select the bridge as the canonical backend.
+7. Later launches verify the committed bridge manifest instead of decrypting the full credential
+   catalog. Later legacy builds copy its committed ACL when they need to create a new bridge item.
+8. If any read needs interaction, validation or read-back fails, or either manifest cannot be persisted,
+   the old secure-storage service remains canonical and Sparkle is paused. Settings surfaces distinguish
+   a locked Keychain, cancelled access, authentication failure, and generic verification failure, then
+   provide the corresponding relaunch guidance.
+9. After the bridge has been proven under both real signing identities, publish a notarized transition
    package (`T`) that installs the successor app. Feeds must keep `P` and `T` available long enough for
    slow-upgrading clients; use Sparkle item eligibility/version constraints instead of new feeds.
 
@@ -37,9 +51,18 @@ contain multiple update items during the transition; this does not require extra
 `REPOPROMPT_IDENTITY_MIGRATION_ANCHOR`, pointing to a regular executable already signed with identifier
 `com.repoprompt.ce` and Team ID `69N6K965SF`.
 
-`Scripts/sign_staged_release.sh` verifies that signature and identity before copying the anchor into
-`Contents/Resources/IdentityMigration/RepoPromptIdentityAnchor`. It does not re-sign the anchor with
-the legacy certificate. The outer legacy app signature then seals the embedded file as a resource.
+`Scripts/sign_staged_release.sh` validates the exact successor Developer ID requirement before copying
+the anchor into `Contents/Resources/IdentityMigration/RepoPromptIdentityAnchor`, then validates the
+embedded copy again. It does not re-sign the anchor with the legacy certificate. The outer legacy app
+signature then seals the embedded file as a resource.
+
+The protected release job builds a universal anchor from `Scripts/identity_migration_anchor.c` in the
+trusted control-plane checkout. The minimal executable is never launched; it avoids embedding a second
+copy of the main app binary while still giving Security.framework a successor-signed designated
+requirement on both supported architectures.
+
+Preparers are Stable-only artifacts. The rolling Tip workflow always packages, validates, and signs
+with phase `disabled`; it has no migration-phase input or access to successor signing secrets.
 
 ## Required proof gate
 
@@ -49,7 +72,10 @@ for the full account catalog. It must demonstrate:
 
 - the legacy app can create, read, and update bridge items without authorization UI;
 - the successor app can read and update the same items without authorization UI;
-- mismatches, target-only values before commit, inaccessible records, and missing anchors fail closed;
+- interrupted writes resume from the dual-identity Keychain journal without losing a newer source value;
+- inaccessible records, forged or missing manifests, invalid runtime anchors, and unknown phase values
+  fail closed;
+- a locked Keychain pauses updates visibly and a later unlocked relaunch retries successfully;
 - originals remain intact after preparation and after a failed transition;
 - rollback to the preparer can still read the bridge for the supported rollback window; and
 - the preparer, transition package, and successor artifacts pass signature, notarization, and

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -1,0 +1,66 @@
+# Apple Identity Migration
+
+RepoPrompt CE cannot treat a Developer ID and bundle-identifier replacement as an ordinary in-place
+Sparkle update. The migration must preserve the legacy signing anchor long enough to prepare secure
+storage, then use a notarized transition installer to cross the application identity boundary.
+
+## Fixed identities
+
+| Phase | Bundle identifier | Team identifier |
+| --- | --- | --- |
+| Legacy and preparer | `com.pvncher.repoprompt.ce` | `648A27MST5` |
+| Successor | `com.repoprompt.ce` | `69N6K965SF` |
+
+The existing Sparkle EdDSA key and the Stable and Tip feed URLs remain unchanged. Each channel may
+contain multiple update items during the transition; this does not require extra feeds.
+
+## Release ladder
+
+1. Ship a legacy-signed preparer (`P`) through the existing Sparkle path.
+2. `P` copies every present account in `SecureStorageAccountCatalog` from the current Developer ID
+   Keychain service into the identity-migration bridge service.
+3. Each new bridge item receives a classic macOS Keychain ACL derived from the running legacy-signed
+   executable and an embedded executable signed for the successor identity.
+4. `P` reads back every copied value byte-for-byte. It never deletes or rewrites the source items.
+5. Only after every record is absent, copied, or verified does `P` persist the completion manifest and
+   select the bridge as the canonical secure-storage backend.
+6. If any read needs interaction, any values conflict, read-back fails, or the completion manifest
+   cannot be persisted, the old secure-storage service remains canonical and Sparkle is paused.
+7. After the bridge has been proven under both real signing identities, publish a notarized transition
+   package (`T`) that installs the successor app. Feeds must keep `P` and `T` available long enough for
+   slow-upgrading clients; use Sparkle item eligibility/version constraints instead of new feeds.
+
+## Packaging contract
+
+`REPOPROMPT_IDENTITY_MIGRATION_PHASE` is `disabled` by default. A protected preparer build sets it to
+`legacy-preparer` for both staging and validation. The protected signing step must also provide
+`REPOPROMPT_IDENTITY_MIGRATION_ANCHOR`, pointing to a regular executable already signed with identifier
+`com.repoprompt.ce` and Team ID `69N6K965SF`.
+
+`Scripts/sign_staged_release.sh` verifies that signature and identity before copying the anchor into
+`Contents/Resources/IdentityMigration/RepoPromptIdentityAnchor`. It does not re-sign the anchor with
+the legacy certificate. The outer legacy app signature then seals the embedded file as a resource.
+
+## Required proof gate
+
+Do not exercise the bridge against a maintainer's login Keychain. The final go/no-go proof must run in
+an isolated macOS CI runner or disposable VM/account with a disposable Keychain and synthetic values
+for the full account catalog. It must demonstrate:
+
+- the legacy app can create, read, and update bridge items without authorization UI;
+- the successor app can read and update the same items without authorization UI;
+- mismatches, target-only values before commit, inaccessible records, and missing anchors fail closed;
+- originals remain intact after preparation and after a failed transition;
+- rollback to the preparer can still read the bridge for the supported rollback window; and
+- the preparer, transition package, and successor artifacts pass signature, notarization, and
+  Sparkle EdDSA verification.
+
+Certificate files, passwords, temporary Keychains, and synthetic credential values must remain in the
+isolated environment and must never be committed, logged, or copied into a developer's login Keychain.
+
+## Rollback
+
+Before the transition package is published, rollback is simply removal of the eligible transition
+item: clients remain on the legacy app, source Keychain items remain untouched, and a successfully
+prepared client can continue using the bridge. After the successor is published, keep the preparer
+and its signing material available until the supported migration window closes.

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -21,9 +21,11 @@ contain multiple update items during the transition; this does not require extra
    using the same validated dual-identity ACL as the bridge. The journal contains a random attempt
    identifier and the exact closed account catalog, allowing the successor to discover the committed
    bridge without relying on mutable preferences.
-3. `P` copies every present account in `SecureStorageAccountCatalog` from the current Developer ID
-   Keychain service into bridge items scoped by that attempt identifier. New records use create-only
-   writes so an unproven pre-existing ACL cannot be retained.
+3. `P` copies every present account in the frozen version-2 migration catalog from the current
+   Developer ID Keychain service into a bridge service whose name includes that attempt identifier.
+   Service and account are generic-password primary-key attributes, so an orphaned earlier attempt
+   cannot collide with a later attempt. New records use create-only writes so an unproven
+   pre-existing ACL cannot be retained.
 4. Each new bridge item receives a classic macOS Keychain ACL derived from the running legacy-signed
    executable and an embedded executable signed for the successor identity. Before creating that ACL,
    runtime code validates both executables against their exact identifiers, Team IDs, and Developer ID
@@ -34,8 +36,10 @@ contain multiple update items during the transition; this does not require extra
    removed.
 6. Only after every source and bridge value matches does `P` create and verify a committed bridge
    manifest, commit the dual-identity Keychain journal, and select the bridge as the canonical backend.
-7. Later launches verify the committed bridge manifest instead of decrypting the full credential
-   catalog. Later legacy builds copy its committed ACL when they need to create a new bridge item.
+7. Later launches authenticate the journal and bridge manifest by inspecting their decrypt ACLs and
+   requiring exactly the legacy and successor designated requirements before accepting the JSON.
+   Later builds validate that ACL again before copying it to a new bridge item. The version-2 catalog
+   remains frozen; accounts added to the app later are created in the already-authoritative bridge.
 8. If any read needs interaction, validation or read-back fails, or either manifest cannot be persisted,
    the old secure-storage service remains canonical and Sparkle is paused. Settings surfaces distinguish
    a locked Keychain, cancelled access, authentication failure, and generic verification failure, then
@@ -73,6 +77,8 @@ for the full account catalog. It must demonstrate:
 - the legacy app can create, read, and update bridge items without authorization UI;
 - the successor app can read and update the same items without authorization UI;
 - interrupted writes resume from the dual-identity Keychain journal without losing a newer source value;
+- a lost journal starts a collision-free attempt even when orphaned bridge records remain;
+- forged journal or bridge-manifest ACLs fail closed and are never propagated to new credentials;
 - inaccessible records, forged or missing manifests, invalid runtime anchors, and unknown phase values
   fail closed;
 - a locked Keychain pauses updates visibly and a later unlocked relaunch retries successfully;


### PR DESCRIPTION
## Summary

- move migration authority from mutable UserDefaults into a dual-identity Keychain journal with resumable bridge records
- authenticate the journal and bridge-manifest decrypt ACLs against exactly the legacy and successor designated requirements before accepting or propagating them
- scope each migration attempt with a unique generic-password service name, avoiding orphan collisions on the actual Keychain primary key
- freeze the version-2 migration catalog while retaining an authenticated committed bridge as the authority for accounts added later
- validate the embedded successor anchor at runtime and build a minimal universal signed anchor instead of copying the main executable
- repair credentials into the selected runtime backend, fail closed on invalid migration state, and surface blocked-update guidance in Settings
- keep Tip builds migration-disabled and tighten release signing and post-copy anchor validation

## Validation

Review-fix pass:

- `swift test --filter KeychainServiceTests` — 15 passed
- `swift test --skip-build --filter SecureStorageIdentityMigrationTests` — 21 passed
- `swift test --filter SecureStorageAccountCatalogTests` — 6 passed
- targeted release-tooling source-contract test — passed
- `make dev-lint`
- `make guardrails`
- mandatory contribution commit and push preflights, including staged/outgoing secret scans

Earlier implementation pass:

- focused Sparkle startup-gating and secure-storage repair tests
- targeted release-tooling Python tests
- bash syntax check for `Scripts/sign_staged_release.sh`
- universal anchor compile and architecture verification

No live Keychain mutation probe, visible app launch, release build, or redundant full test suite was run for this follow-up.
