### PR TITLE
Harden identity rollover runtime safety

### DIFF
--- a/Sources/RepoPrompt/App/Sparkle/AppcastParser.swift
+++ b/Sources/RepoPrompt/App/Sparkle/AppcastParser.swift
@@ -36,6 +36,12 @@ enum AppcastItemEligibility {
     static let supportedInstallationTypes: Set<String> = ["application", "package"]
 
     static func isEligible(_ item: AppcastVersion, context: AppcastEligibilityContext) -> Bool {
+        // A passively advertised update must have a downloadable enclosure.
+        guard hasValidEnclosureURL(item) else { return false }
+        // A present but malformed Sparkle build cannot be ordered deterministically.
+        if let buildNumber = item.buildNumber {
+            guard SparkleBuildVersion(buildNumber) != nil else { return false }
+        }
         if let installationType = item.installationType {
             guard supportedInstallationTypes.contains(installationType) else { return false }
         }
@@ -50,6 +56,16 @@ enum AppcastItemEligibility {
                   currentBuild >= required
             else { return false }
         }
+        return true
+    }
+
+    static func hasValidEnclosureURL(_ item: AppcastVersion) -> Bool {
+        guard let rawURL = item.downloadURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawURL.isEmpty,
+              let url = URL(string: rawURL),
+              url.scheme != nil,
+              url.host != nil
+        else { return false }
         return true
     }
 }
@@ -101,24 +117,25 @@ final class AppcastParser: NSObject, XMLParserDelegate {
         return versions
     }
 
-    /// Filters items for eligibility first, then returns the update with the
-    /// highest numeric Sparkle build, falling back to marketing-version
-    /// comparison for legacy appcasts.
+    /// Filters items for eligibility first, then selects deterministically:
+    /// when any eligible item carries a valid numeric Sparkle build, the
+    /// greatest valid build wins; marketing-version comparison is used only
+    /// when every eligible legacy item omits a build number.
     static func select(
         from items: [AppcastVersion],
         context: AppcastEligibilityContext
     ) -> AppcastVersion? {
-        items
-            .filter { AppcastItemEligibility.isEligible($0, context: context) }
-            .max { lhs, rhs in
-                if let lhsBuild = lhs.buildNumber.flatMap(SparkleBuildVersion.init),
-                   let rhsBuild = rhs.buildNumber.flatMap(SparkleBuildVersion.init)
-                {
-                    return lhsBuild < rhsBuild
-                }
-                if SparkleVersionComparison.isVersion(lhs.version, newerThan: rhs.version) { return false }
-                return SparkleVersionComparison.isVersion(rhs.version, newerThan: lhs.version)
-            }
+        let eligible = items.filter { AppcastItemEligibility.isEligible($0, context: context) }
+        let numbered = eligible.compactMap { item in
+            item.buildNumber.flatMap(SparkleBuildVersion.init).map { (item: item, build: $0) }
+        }
+        if !numbered.isEmpty {
+            return numbered.max { $0.build < $1.build }?.item
+        }
+        return eligible.max { lhs, rhs in
+            if SparkleVersionComparison.isVersion(lhs.version, newerThan: rhs.version) { return false }
+            return SparkleVersionComparison.isVersion(rhs.version, newerThan: lhs.version)
+        }
     }
 
     // MARK: - Private Helpers

--- a/Sources/RepoPrompt/App/Sparkle/AppcastParser.swift
+++ b/Sources/RepoPrompt/App/Sparkle/AppcastParser.swift
@@ -17,6 +17,41 @@ struct AppcastVersion {
     let releaseNotesURL: String?
     let downloadURL: String?
     let minimumSystemVersion: String?
+    let minimumAutoupdateVersion: String?
+    let installationType: String?
+}
+
+/// Immutable client state captured before detached appcast parsing so sibling
+/// transition items can be filtered for eligibility off the main actor.
+struct AppcastEligibilityContext: Equatable {
+    let currentBuildNumber: String
+    let osVersion: SparkleBuildVersion
+}
+
+/// Eligibility rules for a single appcast item. Constraints that are absent keep
+/// the historical single-item feed behavior; constraints that are present but
+/// malformed or unknown fail closed so a legacy client never advertises an
+/// update it must not take.
+enum AppcastItemEligibility {
+    static let supportedInstallationTypes: Set<String> = ["application", "package"]
+
+    static func isEligible(_ item: AppcastVersion, context: AppcastEligibilityContext) -> Bool {
+        if let installationType = item.installationType {
+            guard supportedInstallationTypes.contains(installationType) else { return false }
+        }
+        if let minimumSystemVersion = item.minimumSystemVersion {
+            guard let required = SparkleBuildVersion(minimumSystemVersion),
+                  required <= context.osVersion
+            else { return false }
+        }
+        if let minimumAutoupdateVersion = item.minimumAutoupdateVersion {
+            guard let required = SparkleBuildVersion(minimumAutoupdateVersion),
+                  let currentBuild = SparkleBuildVersion(context.currentBuildNumber),
+                  currentBuild >= required
+            else { return false }
+        }
+        return true
+    }
 }
 
 /// Parses Sparkle appcast.xml feeds to extract version information
@@ -32,6 +67,8 @@ final class AppcastParser: NSObject, XMLParserDelegate {
     private var currentReleaseNotesURL: String?
     private var currentDownloadURL: String?
     private var currentMinimumSystemVersion: String?
+    private var currentMinimumAutoupdateVersion: String?
+    private var currentInstallationType: String?
     private var currentText: String = ""
     private var inItem = false
 
@@ -45,27 +82,43 @@ final class AppcastParser: NSObject, XMLParserDelegate {
 
     // MARK: - Public API
 
-    /// Parses appcast XML data and returns the latest version, or nil if parsing fails
-    func parse(data: Data) -> AppcastVersion? {
+    /// Parses appcast XML data and returns the newest version the client is
+    /// eligible for, or nil if parsing fails or no item is eligible.
+    func parse(data: Data, context: AppcastEligibilityContext) -> AppcastVersion? {
+        Self.select(from: parseItems(data: data), context: context)
+    }
+
+    /// Parses every appcast item. Malformed XML fails the entire parse rather
+    /// than returning a partial item list.
+    func parseItems(data: Data) -> [AppcastVersion] {
         versions.removeAll()
         resetCurrentItem()
 
         let parser = XMLParser(data: data)
         parser.delegate = self
         parser.shouldProcessNamespaces = false // Keep prefixes like "sparkle:"
-        parser.parse()
+        guard parser.parse() else { return [] }
+        return versions
+    }
 
-        // Return the update with the highest numeric Sparkle build when present,
-        // falling back to marketing-version comparison for legacy appcasts.
-        return versions.max { lhs, rhs in
-            if let lhsBuild = lhs.buildNumber.flatMap(SparkleBuildVersion.init),
-               let rhsBuild = rhs.buildNumber.flatMap(SparkleBuildVersion.init)
-            {
-                return lhsBuild < rhsBuild
+    /// Filters items for eligibility first, then returns the update with the
+    /// highest numeric Sparkle build, falling back to marketing-version
+    /// comparison for legacy appcasts.
+    static func select(
+        from items: [AppcastVersion],
+        context: AppcastEligibilityContext
+    ) -> AppcastVersion? {
+        items
+            .filter { AppcastItemEligibility.isEligible($0, context: context) }
+            .max { lhs, rhs in
+                if let lhsBuild = lhs.buildNumber.flatMap(SparkleBuildVersion.init),
+                   let rhsBuild = rhs.buildNumber.flatMap(SparkleBuildVersion.init)
+                {
+                    return lhsBuild < rhsBuild
+                }
+                if SparkleVersionComparison.isVersion(lhs.version, newerThan: rhs.version) { return false }
+                return SparkleVersionComparison.isVersion(rhs.version, newerThan: lhs.version)
             }
-            if isVersion(lhs.version, newerThan: rhs.version) { return false }
-            return isVersion(rhs.version, newerThan: lhs.version)
-        }
     }
 
     // MARK: - Private Helpers
@@ -78,24 +131,10 @@ final class AppcastParser: NSObject, XMLParserDelegate {
         currentReleaseNotesURL = nil
         currentDownloadURL = nil
         currentMinimumSystemVersion = nil
+        currentMinimumAutoupdateVersion = nil
+        currentInstallationType = nil
         currentText = ""
         inItem = false
-    }
-
-    private func isVersion(_ v1: String, newerThan v2: String) -> Bool {
-        let v1Components = v1.split(separator: ".").compactMap { Int($0) }
-        let v2Components = v2.split(separator: ".").compactMap { Int($0) }
-
-        let maxLength = max(v1Components.count, v2Components.count)
-
-        for i in 0 ..< maxLength {
-            let v1Part = i < v1Components.count ? v1Components[i] : 0
-            let v2Part = i < v2Components.count ? v2Components[i] : 0
-
-            if v1Part > v2Part { return true }
-            if v1Part < v2Part { return false }
-        }
-        return false
     }
 
     // MARK: - XMLParserDelegate
@@ -115,11 +154,14 @@ final class AppcastParser: NSObject, XMLParserDelegate {
             currentReleaseNotesURL = nil
             currentDownloadURL = nil
             currentMinimumSystemVersion = nil
+            currentMinimumAutoupdateVersion = nil
+            currentInstallationType = nil
 
         case "enclosure":
-            // Extract download URL from enclosure
+            // Extract download URL and installation type from enclosure
             if inItem {
                 currentDownloadURL = attributeDict["url"]
+                currentInstallationType = attributeDict["sparkle:installationType"]
             }
 
         default:
@@ -145,7 +187,9 @@ final class AppcastParser: NSObject, XMLParserDelegate {
                     description: nil,
                     releaseNotesURL: currentReleaseNotesURL,
                     downloadURL: currentDownloadURL,
-                    minimumSystemVersion: currentMinimumSystemVersion
+                    minimumSystemVersion: currentMinimumSystemVersion,
+                    minimumAutoupdateVersion: currentMinimumAutoupdateVersion,
+                    installationType: currentInstallationType
                 )
                 versions.append(appcastVersion)
             }
@@ -183,6 +227,11 @@ final class AppcastParser: NSObject, XMLParserDelegate {
         case "sparkle:minimumSystemVersion":
             if inItem, !trimmedText.isEmpty {
                 currentMinimumSystemVersion = trimmedText
+            }
+
+        case "sparkle:minimumAutoupdateVersion":
+            if inItem, !trimmedText.isEmpty {
+                currentMinimumAutoupdateVersion = trimmedText
             }
 
         default:

--- a/Sources/RepoPrompt/App/Sparkle/SparkleBuildVersion.swift
+++ b/Sources/RepoPrompt/App/Sparkle/SparkleBuildVersion.swift
@@ -17,7 +17,31 @@ struct SparkleBuildVersion: Comparable {
         components = parsed
     }
 
+    init(major: Int, minor: Int, patch: Int) {
+        components = [major, minor, patch]
+    }
+
     static func < (lhs: SparkleBuildVersion, rhs: SparkleBuildVersion) -> Bool {
         lhs.components.lexicographicallyPrecedes(rhs.components)
+    }
+}
+
+/// Single authority for comparing dotted marketing-version strings. Non-numeric
+/// components are ignored, matching the historical passive-update comparison.
+enum SparkleVersionComparison {
+    static func isVersion(_ v1: String, newerThan v2: String) -> Bool {
+        let v1Components = v1.split(separator: ".").compactMap { Int($0) }
+        let v2Components = v2.split(separator: ".").compactMap { Int($0) }
+
+        let maxLength = max(v1Components.count, v2Components.count)
+
+        for index in 0 ..< maxLength {
+            let v1Part = index < v1Components.count ? v1Components[index] : 0
+            let v2Part = index < v2Components.count ? v2Components[index] : 0
+
+            if v1Part > v2Part { return true }
+            if v1Part < v2Part { return false }
+        }
+        return false
     }
 }

--- a/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
+++ b/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
@@ -300,11 +300,14 @@ final class SparkleUpdaterManager: ObservableObject {
 
         let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
         let currentBuildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        let eligibilityContext = Self.currentEligibilityContext(
+            currentBuildNumber: currentBuildNumber
+        )
         let client = httpClient
         invalidateActiveAppcastCheck()
         activeAppcastCheckRequest = requestIdentity
         let task = Task.detached(priority: .utility) {
-            await Self.fetchAndParseAppcast(feedURL: url, httpClient: client)
+            await Self.fetchAndParseAppcast(feedURL: url, httpClient: client, context: eligibilityContext)
         }
         appcastCheckTask = task
         let appcastInfo = await task.value
@@ -381,10 +384,33 @@ final class SparkleUpdaterManager: ObservableObject {
     }
 
     static func testFetchAndParseAppcastVersion(feedURL: URL, httpClient: HTTPClient) async -> String? {
-        await fetchAndParseAppcast(feedURL: feedURL, httpClient: httpClient)?.latestVersion
+        let currentBuildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+        return await fetchAndParseAppcast(
+            feedURL: feedURL,
+            httpClient: httpClient,
+            context: currentEligibilityContext(currentBuildNumber: currentBuildNumber)
+        )?.latestVersion
     }
 
-    private static func fetchAndParseAppcast(feedURL: URL, httpClient: HTTPClient) async -> AppcastUpdateInfo? {
+    static func currentEligibilityContext(
+        currentBuildNumber: String
+    ) -> AppcastEligibilityContext {
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+        return AppcastEligibilityContext(
+            currentBuildNumber: currentBuildNumber,
+            osVersion: SparkleBuildVersion(
+                major: osVersion.majorVersion,
+                minor: osVersion.minorVersion,
+                patch: osVersion.patchVersion
+            )
+        )
+    }
+
+    private static func fetchAndParseAppcast(
+        feedURL: URL,
+        httpClient: HTTPClient,
+        context: AppcastEligibilityContext
+    ) async -> AppcastUpdateInfo? {
         let request = makePassiveAppcastRequest(feedURL: feedURL)
 
         do {
@@ -398,8 +424,8 @@ final class SparkleUpdaterManager: ObservableObject {
             let data = response.data
             return await Task.detached(priority: .utility) {
                 let parser = AppcastParser()
-                guard let latestVersion = parser.parse(data: data) else {
-                    sparkleUpdaterManagerDebugLog("Failed to parse appcast - no versions found")
+                guard let latestVersion = parser.parse(data: data, context: context) else {
+                    sparkleUpdaterManagerDebugLog("Failed to parse appcast - no eligible versions found")
                     return nil
                 }
                 return AppcastUpdateInfo(
@@ -430,7 +456,7 @@ final class SparkleUpdaterManager: ObservableObject {
 
         let isNewer = appcastInfo.latestBuildNumber.flatMap { latestBuild in
             isBuildNumber(latestBuild, newerThan: currentBuildNumber)
-        } ?? isVersion(appcastInfo.latestVersion, newerThan: currentVersion)
+        } ?? SparkleVersionComparison.isVersion(appcastInfo.latestVersion, newerThan: currentVersion)
 
         if isNewer {
             let presentationVersion = Self.presentationVersion(
@@ -451,23 +477,6 @@ final class SparkleUpdaterManager: ObservableObject {
             clearUpdateState()
             sparkleUpdaterManagerDebugLog("No update available. Current: \(currentVersion) build \(currentBuildNumber), Latest: \(appcastInfo.latestVersion) build \(appcastInfo.latestBuildNumber ?? "<missing>")")
         }
-    }
-
-    /// Compares two version strings to determine if the first is newer than the second
-    private func isVersion(_ v1: String, newerThan v2: String) -> Bool {
-        let v1Components = v1.split(separator: ".").compactMap { Int($0) }
-        let v2Components = v2.split(separator: ".").compactMap { Int($0) }
-
-        let maxLength = max(v1Components.count, v2Components.count)
-
-        for i in 0 ..< maxLength {
-            let v1Part = i < v1Components.count ? v1Components[i] : 0
-            let v2Part = i < v2Components.count ? v2Components[i] : 0
-
-            if v1Part > v2Part { return true }
-            if v1Part < v2Part { return false }
-        }
-        return false
     }
 
     private func isBuildNumber(_ lhs: String, newerThan rhs: String) -> Bool? {
@@ -764,17 +773,7 @@ final class SparkleUpdaterManager: ObservableObject {
         }
 
         static func debugIsVersion(_ lhs: String, newerThan rhs: String) -> Bool {
-            let lhsComponents = lhs.split(separator: ".").compactMap { Int($0) }
-            let rhsComponents = rhs.split(separator: ".").compactMap { Int($0) }
-            let maxLength = max(lhsComponents.count, rhsComponents.count)
-
-            for index in 0 ..< maxLength {
-                let lhsPart = index < lhsComponents.count ? lhsComponents[index] : 0
-                let rhsPart = index < rhsComponents.count ? rhsComponents[index] : 0
-                if lhsPart > rhsPart { return true }
-                if lhsPart < rhsPart { return false }
-            }
-            return false
+            SparkleVersionComparison.isVersion(lhs, newerThan: rhs)
         }
 
         @MainActor

--- a/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningDetector.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningDetector.swift
@@ -93,6 +93,9 @@ enum RuntimeCodeSigningDetector {
         let leafCertificateSHA256 = leafCertificateFingerprint(from: dictionary)
 
         guard let developerIDRequirement = requirement(from: RuntimeCodeSigningPolicy.developerIDRequirement),
+              let successorDeveloperIDRequirement = requirement(
+                  from: RuntimeCodeSigningPolicy.successorDeveloperIDRequirement
+              ),
               let debugRequirement = requirement(from: RuntimeCodeSigningPolicy.appleDevelopmentDebugRequirement)
         else {
             return RuntimeCodeSigningInfo(
@@ -108,6 +111,13 @@ enum RuntimeCodeSigningDetector {
         var validatedDomains: Set<RuntimeCodeSigningDomain> = []
         if SecCodeCheckValidity(code, SecCSFlags(rawValue: kSecCSStrictValidate), developerIDRequirement) == errSecSuccess {
             validatedDomains.insert(.developerID)
+        }
+        if SecCodeCheckValidity(
+            code,
+            SecCSFlags(rawValue: kSecCSStrictValidate),
+            successorDeveloperIDRequirement
+        ) == errSecSuccess {
+            validatedDomains.insert(.successorDeveloperID)
         }
         if SecCodeCheckValidity(code, SecCSFlags(rawValue: kSecCSStrictValidate), debugRequirement) == errSecSuccess {
             validatedDomains.insert(.appleDevelopmentDebug)

--- a/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningPolicy.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum RuntimeCodeSigningDomain: Hashable {
     case developerID
+    case successorDeveloperID
     case appleDevelopmentDebug
     case localSelfSigned
 }
@@ -53,6 +54,7 @@ struct RuntimeCodeSigningInfo: Equatable {
 
 enum RuntimeSecureStorageDomain: Equatable {
     case officialDeveloperID
+    case successorOfficialDeveloperID
     case localSelfSigned
     case appleDevelopmentDebug
     case ephemeral
@@ -106,6 +108,8 @@ enum RuntimeCodeSigningPolicy {
     static let developerIDBundleIdentifier = "com.pvncher.repoprompt.ce"
     static let appleDevelopmentDebugBundleIdentifier = "com.pvncher.repoprompt.ce.debug"
     static let signingTeamIdentifier = "648A27MST5"
+    static let successorDeveloperIDBundleIdentifier = "com.repoprompt.ce"
+    static let successorSigningTeamIdentifier = "69N6K965SF"
     static let localSelfSignedCertificateName = "RepoPrompt CE Local Self-Signed Code Signing"
 
     static let developerIDRequirement =
@@ -113,6 +117,9 @@ enum RuntimeCodeSigningPolicy {
 
     static let appleDevelopmentDebugRequirement =
         "anchor apple generic and identifier \"\(appleDevelopmentDebugBundleIdentifier)\" and certificate leaf[subject.OU] = \"\(signingTeamIdentifier)\" and certificate leaf[field.1.2.840.113635.100.6.1.12] exists"
+
+    static let successorDeveloperIDRequirement =
+        "anchor apple generic and identifier \"\(successorDeveloperIDBundleIdentifier)\" and certificate leaf[subject.OU] = \"\(successorSigningTeamIdentifier)\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
 
     private static let signingModePlistKey = "RepoPromptSigningMode"
     private static let debugStoragePlistKey = "RepoPromptDebugSecureStorageBackend"
@@ -195,6 +202,16 @@ enum RuntimeCodeSigningPolicy {
                 return ephemeral(.markerSignatureMismatch)
             }
             return RuntimeSecureStorageDecision(domain: .officialDeveloperID, rejectionReason: nil)
+        case "successor-developer-id":
+            guard matches(
+                signingInfo,
+                domain: .successorDeveloperID,
+                identifier: successorDeveloperIDBundleIdentifier,
+                teamIdentifier: successorSigningTeamIdentifier
+            ) else {
+                return ephemeral(.markerSignatureMismatch)
+            }
+            return RuntimeSecureStorageDecision(domain: .successorOfficialDeveloperID, rejectionReason: nil)
         case "local-self-signed":
             guard let localSigningContext else {
                 return ephemeral(.localIdentityRegistryUnavailable)

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift
@@ -82,10 +82,21 @@ enum SecureKeyValueStorageFactory {
     }()
 
     static func defaultBackend() -> SecureKeyValueStorageBackend {
-        guard cachedSelection.decision.domain == .officialDeveloperID else {
+        guard officialOverrideApplies(to: cachedSelection.decision.domain) else {
             return cachedSelection.backend
         }
         return State.shared.officialBackend(fallback: cachedSelection.backend)
+    }
+
+    /// The committed identity-migration bridge override is only meaningful for the two
+    /// official Developer ID identities; every other domain keeps its dedicated backend.
+    static func officialOverrideApplies(to domain: RuntimeSecureStorageDomain) -> Bool {
+        switch domain {
+        case .officialDeveloperID, .successorOfficialDeveloperID:
+            true
+        case .localSelfSigned, .appleDevelopmentDebug, .ephemeral:
+            false
+        }
     }
 
     static func currentDecision() -> RuntimeSecureStorageDecision {
@@ -101,6 +112,10 @@ enum SecureKeyValueStorageFactory {
         let backend: SecureKeyValueStorageBackend = switch decision.domain {
         case .officialDeveloperID:
             KeychainService.officialV2Shared
+        case .successorOfficialDeveloperID:
+            // The successor identity has no legacy fallback service. It stays ephemeral
+            // until bootstrap installs an authenticated committed-bridge override.
+            EphemeralSecureKeyValueStore.shared
         case .localSelfSigned:
             if let fingerprint = decision.localCertificateFingerprint,
                let generation = decision.localServiceGeneration,

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
@@ -87,8 +87,10 @@ struct SecureStorageIdentityMigrationManifest: Codable, Equatable {
 
 protocol SecureStorageIdentityMigrationStateStore {
     func load() throws -> SecureStorageIdentityMigrationManifest?
+    /// Creates the journal only when no journal item exists yet. A fresh attempt must
+    /// never overwrite an existing journal written by another actor or launch.
+    func create(_ manifest: SecureStorageIdentityMigrationManifest) throws
     func save(_ manifest: SecureStorageIdentityMigrationManifest) throws
-    func reset() throws
 }
 
 /// A Keychain item is the durable migration journal and authority. Production preparers
@@ -129,26 +131,31 @@ struct KeychainSecureStorageIdentityMigrationStateStore: SecureStorageIdentityMi
         return manifest
     }
 
+    func create(_ manifest: SecureStorageIdentityMigrationManifest) throws {
+        let value = try encodedManifestValue(manifest)
+        try store.create(value, for: Self.account, accessMode: accessMode)
+        try verifyPersistedValue(value)
+    }
+
     func save(_ manifest: SecureStorageIdentityMigrationManifest) throws {
+        let value = try encodedManifestValue(manifest)
+        try store.save(value, for: Self.account, accessMode: accessMode)
+        try verifyPersistedValue(value)
+    }
+
+    private func encodedManifestValue(_ manifest: SecureStorageIdentityMigrationManifest) throws -> String {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(manifest)
         guard let value = String(data: data, encoding: .utf8) else {
             throw StoreError.invalidManifest
         }
-        try store.save(value, for: Self.account, accessMode: accessMode)
-        guard try store.get(for: Self.account, accessMode: accessMode) == value else {
-            throw StoreError.verificationFailed
-        }
+        return value
     }
 
-    func reset() throws {
-        try store.delete(for: Self.account, accessMode: accessMode)
-        do {
-            _ = try store.get(for: Self.account, accessMode: accessMode)
+    private func verifyPersistedValue(_ value: String) throws {
+        guard try store.get(for: Self.account, accessMode: accessMode) == value else {
             throw StoreError.verificationFailed
-        } catch KeychainService.KeychainError.itemNotFound {
-            return
         }
     }
 }
@@ -195,14 +202,11 @@ final class SecureStorageIdentityMigrationCoordinator {
         let existingManifest: SecureStorageIdentityMigrationManifest?
         do {
             existingManifest = try stateStore.load()
-        } catch KeychainSecureStorageIdentityMigrationStateStore.StoreError.invalidManifest {
-            do {
-                try stateStore.reset()
-            } catch {
-                return blockedReport(error: error)
-            }
-            return prepareBridge()
         } catch {
+            // An unreadable or undecodable journal is an authority failure. After a bridge
+            // has been committed, the journal is the only pointer to it, so destructive
+            // reset-and-retry could silently restart migration from stale source data.
+            // Fail closed and keep the journal item intact for manual recovery.
             return blockedReport(error: error)
         }
 
@@ -236,7 +240,7 @@ final class SecureStorageIdentityMigrationCoordinator {
             catalogIdentifiers: expectedCatalogIdentifiers
         )
         do {
-            try stateStore.save(manifest)
+            try stateStore.create(manifest)
         } catch {
             return failedReport(records: preflightRecords, error: error)
         }
@@ -477,21 +481,19 @@ final class SecureStorageIdentityMigrationCoordinator {
         } catch {
             return blockedReport(error: error)
         }
-        guard let encoded = Self.encodeManifest(manifest) else {
-            return blockedReport()
-        }
+        let records: [SecureStorageIdentityMigrationRecord]
         do {
-            guard try bridgeStore.get(
-                for: Self.bridgeManifestAccount,
+            records = try SecureStorageIdentityMigrationCommittedProjection.verify(
+                manifest: manifest,
+                accounts: accounts,
+                bridgeStore: bridgeStore,
                 accessMode: accessMode
-            ) == encoded else {
-                return blockedReport()
-            }
+            )
         } catch {
             return blockedReport(error: error)
         }
         return SecureStorageIdentityMigrationReport(
-            records: [],
+            records: records,
             bridgeReady: true,
             blockingState: nil
         )
@@ -528,6 +530,48 @@ enum SecureStorageIdentityMigrationActivationError: Error {
     case invalidBridgeManifest
 }
 
+/// Shared verification of a committed bridge's full projection under the frozen
+/// version-2 manifest contract, expressed in the existing record states:
+/// - the journal manifest must be committed and must cover exactly the expected
+///   account catalog;
+/// - the bridge-manifest item must equal the committed journal encoding
+///   byte-for-byte -- any other present value (a mismatched attempt or a planted
+///   preparing manifest) is rejected as an invalid bridge manifest;
+/// - every cataloged account resolves to an explicit record state: a readable
+///   value is `.verified` (readability is the strongest value contract the frozen
+///   digest-free schema allows), a missing item is `.absent`, and any other read
+///   failure propagates so callers surface its specific blocked reason instead of
+///   silently accepting an unreadable projection.
+enum SecureStorageIdentityMigrationCommittedProjection {
+    static func verify(
+        manifest: SecureStorageIdentityMigrationManifest,
+        accounts: [SecureStorageAccount],
+        bridgeStore: SecureKeyValueStorageBackend,
+        accessMode: KeychainAccessMode
+    ) throws -> [SecureStorageIdentityMigrationRecord] {
+        guard manifest.status == .committed,
+              manifest.catalogIdentifiers == accounts.map(\.identifier).sorted(),
+              let encoded = SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest)
+        else {
+            throw SecureStorageIdentityMigrationActivationError.invalidJournal
+        }
+        guard try bridgeStore.get(
+            for: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
+            accessMode: accessMode
+        ) == encoded else {
+            throw SecureStorageIdentityMigrationActivationError.invalidBridgeManifest
+        }
+        return try accounts.map { account in
+            do {
+                _ = try bridgeStore.get(for: account.identifier, accessMode: accessMode)
+                return SecureStorageIdentityMigrationRecord(account: account, state: .verified)
+            } catch KeychainService.KeychainError.itemNotFound {
+                return SecureStorageIdentityMigrationRecord(account: account, state: .absent)
+            }
+        }
+    }
+}
+
 struct SecureStorageIdentityMigrationCommittedBridge {
     let manifest: SecureStorageIdentityMigrationManifest
     let store: SecureKeyValueStorageBackend
@@ -548,19 +592,18 @@ struct SecureStorageIdentityMigrationCommittedBridgeResolver {
               SecureStorageIdentityMigrationCoordinator.isStructurallyValid(
                   manifest,
                   expectedCatalogIdentifiers: accounts.map(\.identifier)
-              ),
-              let encoded = SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest)
+              )
         else {
             throw SecureStorageIdentityMigrationActivationError.invalidJournal
         }
 
         let bridgeStore = try bridgeStoreFactory(manifest.attemptIdentifier)
-        guard try bridgeStore.get(
-            for: SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount,
+        _ = try SecureStorageIdentityMigrationCommittedProjection.verify(
+            manifest: manifest,
+            accounts: accounts,
+            bridgeStore: bridgeStore,
             accessMode: .nonInteractive(reason: .launch)
-        ) == encoded else {
-            throw SecureStorageIdentityMigrationActivationError.invalidBridgeManifest
-        }
+        )
         return SecureStorageIdentityMigrationCommittedBridge(
             manifest: manifest,
             store: bridgeStore
@@ -590,14 +633,30 @@ final class IdentityMigrationRuntimeState: @unchecked Sendable {
 enum SecureStorageIdentityMigrationBootstrap {
     static let phaseInfoKey = "RepoPromptIdentityMigrationPhase"
     static let anchorRelativePathInfoKey = "RepoPromptIdentityMigrationAnchorRelativePath"
-    static let successorBundleIdentifier = "com.repoprompt.ce"
-    static let successorTeamIdentifier = "69N6K965SF"
-    static let successorDeveloperIDRequirement =
-        "anchor apple generic and identifier \"\(successorBundleIdentifier)\" and certificate leaf[subject.OU] = \"\(successorTeamIdentifier)\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
 
     enum Phase: String {
         case disabled
         case legacyPreparer = "legacy-preparer"
+    }
+
+    static let unrecognizedConfigurationMessage =
+        "Updates are paused because this build has an unrecognized secure credential migration configuration."
+    static let successorUnsupportedPhaseMessage =
+        "Updates are paused because this build has an unsupported secure credential migration configuration."
+    static let successorMissingBridgeMessage =
+        "Updates are paused because this Mac's credentials have not finished migrating from the previous RepoPrompt CE version. Open the previous RepoPrompt CE version to complete credential migration, then relaunch this app. Your existing credentials were not deleted."
+
+    /// Pure phase gate for a successor-identity launch. Returns nil when bridge
+    /// activation may proceed, or the stable blocked guidance otherwise.
+    static func successorBlockedMessage(forPhase phase: Phase?) -> String? {
+        switch phase {
+        case .disabled:
+            nil
+        case .legacyPreparer:
+            successorUnsupportedPhaseMessage
+        case nil:
+            unrecognizedConfigurationMessage
+        }
     }
 
     static func configuredPhase(from value: Any?) -> Phase? {
@@ -614,18 +673,30 @@ enum SecureStorageIdentityMigrationBootstrap {
 
     static func prepareIfConfigured(bundle: Bundle = .main) {
         IdentityMigrationRuntimeState.shared.setBlockedMessage(nil)
-        guard SecureKeyValueStorageFactory.currentDecision().domain == .officialDeveloperID else { return }
-        guard let phase = configuredPhase(from: bundle.object(forInfoDictionaryKey: phaseInfoKey))
-        else {
-            blockUpdates("Updates are paused because this build has an unrecognized secure credential migration configuration.")
+        let domain = SecureKeyValueStorageFactory.currentDecision().domain
+        let phase = configuredPhase(from: bundle.object(forInfoDictionaryKey: phaseInfoKey))
+        switch domain {
+        case .officialDeveloperID:
+            guard let phase else {
+                blockUpdates(unrecognizedConfigurationMessage)
+                return
+            }
+            switch phase {
+            case .disabled:
+                activateCommittedBridgeIfPresent(bridgeRequired: false)
+            case .legacyPreparer:
+                prepareLegacyBridge(bundle: bundle)
+            }
+        case .successorOfficialDeveloperID:
+            if let blockedMessage = successorBlockedMessage(forPhase: phase) {
+                blockUpdates(blockedMessage)
+                return
+            }
+            // The successor identity has no legacy storage fallback: without an
+            // authenticated committed bridge it must stay ephemeral and say so.
+            activateCommittedBridgeIfPresent(bridgeRequired: true)
+        case .localSelfSigned, .appleDevelopmentDebug, .ephemeral:
             return
-        }
-
-        switch phase {
-        case .disabled:
-            activateCommittedBridgeIfPresent()
-        case .legacyPreparer:
-            prepareLegacyBridge(bundle: bundle)
         }
     }
 
@@ -643,7 +714,7 @@ enum SecureStorageIdentityMigrationBootstrap {
               ),
               RuntimeCodeSigningDetector.validatesStaticCode(
                   at: anchorURL,
-                  requirementSource: successorDeveloperIDRequirement
+                  requirementSource: RuntimeCodeSigningPolicy.successorDeveloperIDRequirement
               )
         else {
             blockUpdates("Updates are paused because the secure credential migration package is incomplete, its account catalog changed, or it has an invalid identity anchor.")
@@ -663,7 +734,7 @@ enum SecureStorageIdentityMigrationBootstrap {
                     TrustedApplicationCodeRequirement(
                         trustedApplicationPath: anchorURL.path,
                         codeURL: anchorURL,
-                        requirementSource: successorDeveloperIDRequirement
+                        requirementSource: RuntimeCodeSigningPolicy.successorDeveloperIDRequirement
                     )
                 ]
             )
@@ -721,13 +792,13 @@ enum SecureStorageIdentityMigrationBootstrap {
         }
     }
 
-    private static func activateCommittedBridgeIfPresent() {
+    private static func activateCommittedBridgeIfPresent(bridgeRequired: Bool) {
         let accessValidator: ClassicKeychainACLValidator
         do {
             accessValidator = try ClassicKeychainACLValidator(
                 requirementSources: [
                     RuntimeCodeSigningPolicy.developerIDRequirement,
-                    successorDeveloperIDRequirement
+                    RuntimeCodeSigningPolicy.successorDeveloperIDRequirement
                 ]
             )
         } catch {
@@ -761,7 +832,12 @@ enum SecureStorageIdentityMigrationBootstrap {
             blockUpdates(for: error)
             return
         }
-        guard let resolution else { return }
+        guard let resolution else {
+            if bridgeRequired {
+                blockUpdates(successorMissingBridgeMessage)
+            }
+            return
+        }
         let manifest = resolution.manifest
 
         guard let bridgeServiceName = KeychainService.identityMigrationBridgeServiceName(

--- a/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
+++ b/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
@@ -188,10 +188,12 @@ final class AppPlatformUtilityRecoveryTests: XCTestCase {
                 <item>
                     <sparkle:shortVersionString>1.0.27</sparkle:shortVersionString>
                     <sparkle:version>28</sparkle:version>
+                    <enclosure url="https://example.com/RepoPrompt-1.0.27-28.zip" />
                 </item>
                 <item>
                     <sparkle:shortVersionString>1.0.27</sparkle:shortVersionString>
                     <sparkle:version>412</sparkle:version>
+                    <enclosure url="https://example.com/RepoPrompt-1.0.27-412.zip" />
                 </item>
             </channel>
         </rss>

--- a/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
+++ b/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
@@ -153,7 +153,7 @@ final class AppPlatformUtilityRecoveryTests: XCTestCase {
         </rss>
         """
 
-        let version = try XCTUnwrap(AppcastParser().parse(data: Data(xml.utf8)))
+        let version = try XCTUnwrap(AppcastParser().parse(data: Data(xml.utf8), context: Self.permissiveAppcastContext))
 
         XCTAssertEqual(version.version, "2.1.20")
         XCTAssertEqual(version.buildNumber, "320")
@@ -197,11 +197,16 @@ final class AppPlatformUtilityRecoveryTests: XCTestCase {
         </rss>
         """
 
-        let version = try XCTUnwrap(AppcastParser().parse(data: Data(xml.utf8)))
+        let version = try XCTUnwrap(AppcastParser().parse(data: Data(xml.utf8), context: Self.permissiveAppcastContext))
 
         XCTAssertEqual(version.version, "1.0.27")
         XCTAssertEqual(version.buildNumber, "412")
     }
+
+    private static let permissiveAppcastContext = AppcastEligibilityContext(
+        currentBuildNumber: "1",
+        osVersion: SparkleBuildVersion(major: 99, minor: 0, patch: 0)
+    )
 
     func testTipBuildVersionSortsBetweenAdjacentStableBuilds() throws {
         let currentStable = try XCTUnwrap(SparkleBuildVersion("28"))

--- a/Tests/RepoPromptTests/App/AppcastEligibilityTests.swift
+++ b/Tests/RepoPromptTests/App/AppcastEligibilityTests.swift
@@ -1,0 +1,195 @@
+@testable import RepoPromptApp
+import XCTest
+
+/// Passive appcast selection must tolerate sibling identity-transition items
+/// (preparer ZIP, transition PKG, successor ZIP) before the Stable feed ever
+/// carries more than one item. These tests pin the eligibility contract:
+/// filter first, then pick the greatest eligible build.
+final class AppcastEligibilityTests: XCTestCase {
+    /// Preparer ZIP: build 120, no autoupdate constraint.
+    /// Transition PKG: build 150, requires build 120, package install.
+    /// Successor ZIP: build 200, requires build 150.
+    private let siblingLadderXML = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+        <channel>
+            <item>
+                <title>Version 1.2.0</title>
+                <sparkle:shortVersionString>1.2.0</sparkle:shortVersionString>
+                <sparkle:version>120</sparkle:version>
+                <sparkle:minimumSystemVersion>13.5</sparkle:minimumSystemVersion>
+                <enclosure url="https://example.com/RepoPrompt-1.2.0.zip" />
+            </item>
+            <item>
+                <title>Version 1.5.0</title>
+                <sparkle:shortVersionString>1.5.0</sparkle:shortVersionString>
+                <sparkle:version>150</sparkle:version>
+                <sparkle:minimumSystemVersion>13.5</sparkle:minimumSystemVersion>
+                <sparkle:minimumAutoupdateVersion>120</sparkle:minimumAutoupdateVersion>
+                <enclosure url="https://example.com/RepoPromptTransition-1.5.0.pkg" sparkle:installationType="package" />
+            </item>
+            <item>
+                <title>Version 2.0.0</title>
+                <sparkle:shortVersionString>2.0.0</sparkle:shortVersionString>
+                <sparkle:version>200</sparkle:version>
+                <sparkle:minimumSystemVersion>13.5</sparkle:minimumSystemVersion>
+                <sparkle:minimumAutoupdateVersion>150</sparkle:minimumAutoupdateVersion>
+                <enclosure url="https://example.com/RepoPrompt-2.0.0.zip" />
+            </item>
+        </channel>
+    </rss>
+    """
+
+    private func context(build: String, osMajor: Int = 15) -> AppcastEligibilityContext {
+        AppcastEligibilityContext(
+            currentBuildNumber: build,
+            osVersion: SparkleBuildVersion(major: osMajor, minor: 0, patch: 0)
+        )
+    }
+
+    func testLegacySingleItemFeedSelectsExactlyAsBefore() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+                <item>
+                    <sparkle:shortVersionString>1.0.27</sparkle:shortVersionString>
+                    <sparkle:version>28</sparkle:version>
+                    <enclosure url="https://example.com/RepoPrompt-1.0.27.zip" />
+                </item>
+            </channel>
+        </rss>
+        """
+
+        let version = try XCTUnwrap(AppcastParser().parse(data: Data(xml.utf8), context: context(build: "27")))
+
+        XCTAssertEqual(version.buildNumber, "28")
+        XCTAssertNil(version.minimumAutoupdateVersion)
+        XCTAssertNil(version.installationType)
+    }
+
+    func testSiblingLadderFiltersBeforeSelectingGreatestBuild() throws {
+        let items = AppcastParser().parseItems(data: Data(siblingLadderXML.utf8))
+        XCTAssertEqual(items.count, 3)
+
+        // Unprepared legacy client sees only the preparer, not the higher builds.
+        let oldClient = try XCTUnwrap(AppcastParser.select(from: items, context: context(build: "100")))
+        XCTAssertEqual(oldClient.buildNumber, "120")
+
+        // Prepared legacy client (running the preparer) is offered the transition PKG.
+        let preparedClient = try XCTUnwrap(AppcastParser.select(from: items, context: context(build: "120")))
+        XCTAssertEqual(preparedClient.buildNumber, "150")
+        XCTAssertEqual(preparedClient.installationType, "package")
+
+        // A client that crossed the transition is offered the successor ZIP.
+        let transitionedClient = try XCTUnwrap(AppcastParser.select(from: items, context: context(build: "150")))
+        XCTAssertEqual(transitionedClient.buildNumber, "200")
+    }
+
+    func testMinimumSystemVersionExcludesItemsOnOlderOS() {
+        let items = AppcastParser().parseItems(data: Data(siblingLadderXML.utf8))
+
+        // All ladder items require macOS 13.5; a 12.x client gets no update at all.
+        XCTAssertNil(AppcastParser.select(from: items, context: context(build: "200", osMajor: 12)))
+    }
+
+    func testMinimumAutoupdateVersionBoundaryIsInclusive() {
+        let item = AppcastVersion(
+            version: "2.0.0",
+            buildNumber: "200",
+            title: nil,
+            date: nil,
+            description: nil,
+            releaseNotesURL: nil,
+            downloadURL: nil,
+            minimumSystemVersion: nil,
+            minimumAutoupdateVersion: "150",
+            installationType: nil
+        )
+
+        XCTAssertTrue(AppcastItemEligibility.isEligible(item, context: context(build: "150")))
+        XCTAssertTrue(AppcastItemEligibility.isEligible(item, context: context(build: "150.7.95")))
+        XCTAssertFalse(AppcastItemEligibility.isEligible(item, context: context(build: "149")))
+        // A malformed local build cannot prove eligibility for a constrained item.
+        XCTAssertFalse(AppcastItemEligibility.isEligible(item, context: context(build: "unknown")))
+    }
+
+    func testSupportedInstallationTypesAreApplicationAndPackageOnly() {
+        func item(installationType: String?) -> AppcastVersion {
+            AppcastVersion(
+                version: "1.0.0",
+                buildNumber: "100",
+                title: nil,
+                date: nil,
+                description: nil,
+                releaseNotesURL: nil,
+                downloadURL: nil,
+                minimumSystemVersion: nil,
+                minimumAutoupdateVersion: nil,
+                installationType: installationType
+            )
+        }
+
+        XCTAssertTrue(AppcastItemEligibility.isEligible(item(installationType: nil), context: context(build: "1")))
+        XCTAssertTrue(AppcastItemEligibility.isEligible(item(installationType: "application"), context: context(build: "1")))
+        XCTAssertTrue(AppcastItemEligibility.isEligible(item(installationType: "package"), context: context(build: "1")))
+        XCTAssertFalse(AppcastItemEligibility.isEligible(item(installationType: "interactive-package"), context: context(build: "1")))
+        XCTAssertFalse(AppcastItemEligibility.isEligible(item(installationType: "Package"), context: context(build: "1")))
+    }
+
+    func testMalformedConstraintsAndUnknownInstallationTypeFailClosedPerItem() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+                <item>
+                    <sparkle:shortVersionString>3.0.0</sparkle:shortVersionString>
+                    <sparkle:version>300</sparkle:version>
+                    <sparkle:minimumAutoupdateVersion>not-a-build</sparkle:minimumAutoupdateVersion>
+                    <enclosure url="https://example.com/RepoPrompt-3.0.0.zip" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>2.5.0</sparkle:shortVersionString>
+                    <sparkle:version>250</sparkle:version>
+                    <enclosure url="https://example.com/RepoPrompt-2.5.0.bin" sparkle:installationType="script" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>2.4.0</sparkle:shortVersionString>
+                    <sparkle:version>240</sparkle:version>
+                    <sparkle:minimumSystemVersion>not-an-os</sparkle:minimumSystemVersion>
+                    <enclosure url="https://example.com/RepoPrompt-2.4.0.zip" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>2.3.0</sparkle:shortVersionString>
+                    <sparkle:version>230</sparkle:version>
+                    <enclosure url="https://example.com/RepoPrompt-2.3.0.zip" />
+                </item>
+            </channel>
+        </rss>
+        """
+
+        let items = AppcastParser().parseItems(data: Data(xml.utf8))
+        XCTAssertEqual(items.count, 4)
+
+        // Malformed or unknown constraints hide those items, not the whole feed.
+        let selected = try XCTUnwrap(AppcastParser.select(from: items, context: context(build: "999")))
+        XCTAssertEqual(selected.buildNumber, "230")
+    }
+
+    func testMalformedXMLFailsEntireParse() {
+        let truncated = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+                <item>
+                    <sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
+                    <sparkle:version>100</sparkle:version>
+                </item>
+                <item>
+                    <sparkle:shortVersionString>2.0.0
+        """
+
+        XCTAssertTrue(AppcastParser().parseItems(data: Data(truncated.utf8)).isEmpty)
+        XCTAssertNil(AppcastParser().parse(data: Data(truncated.utf8), context: context(build: "1")))
+    }
+}

--- a/Tests/RepoPromptTests/App/AppcastEligibilityTests.swift
+++ b/Tests/RepoPromptTests/App/AppcastEligibilityTests.swift
@@ -101,7 +101,7 @@ final class AppcastEligibilityTests: XCTestCase {
             date: nil,
             description: nil,
             releaseNotesURL: nil,
-            downloadURL: nil,
+            downloadURL: "https://example.com/update.zip",
             minimumSystemVersion: nil,
             minimumAutoupdateVersion: "150",
             installationType: nil
@@ -123,7 +123,7 @@ final class AppcastEligibilityTests: XCTestCase {
                 date: nil,
                 description: nil,
                 releaseNotesURL: nil,
-                downloadURL: nil,
+                downloadURL: "https://example.com/update.zip",
                 minimumSystemVersion: nil,
                 minimumAutoupdateVersion: nil,
                 installationType: installationType
@@ -191,5 +191,122 @@ final class AppcastEligibilityTests: XCTestCase {
 
         XCTAssertTrue(AppcastParser().parseItems(data: Data(truncated.utf8)).isEmpty)
         XCTAssertNil(AppcastParser().parse(data: Data(truncated.utf8), context: context(build: "1")))
+    }
+
+    func testItemsWithoutValidEnclosureURLAreNotPassivelyEligible() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+                <item>
+                    <sparkle:shortVersionString>4.0.0</sparkle:shortVersionString>
+                    <sparkle:version>400</sparkle:version>
+                </item>
+                <item>
+                    <sparkle:shortVersionString>3.9.0</sparkle:shortVersionString>
+                    <sparkle:version>390</sparkle:version>
+                    <enclosure url="" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>3.8.0</sparkle:shortVersionString>
+                    <sparkle:version>380</sparkle:version>
+                    <enclosure url="not a valid url" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>3.7.0</sparkle:shortVersionString>
+                    <sparkle:version>370</sparkle:version>
+                    <enclosure url="relative/path.zip" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>3.6.0</sparkle:shortVersionString>
+                    <sparkle:version>360</sparkle:version>
+                    <enclosure url="https://example.com/RepoPrompt-3.6.0.zip" />
+                </item>
+            </channel>
+        </rss>
+        """
+
+        let items = AppcastParser().parseItems(data: Data(xml.utf8))
+        XCTAssertEqual(items.count, 5)
+
+        // Missing, empty, malformed, and schemeless/hostless enclosures are all
+        // excluded; the highest item with a downloadable enclosure wins.
+        let selected = try XCTUnwrap(AppcastParser.select(from: items, context: context(build: "1")))
+        XCTAssertEqual(selected.buildNumber, "360")
+
+        // Application and package enclosures both remain supported.
+        XCTAssertTrue(
+            AppcastItemEligibility.hasValidEnclosureURL(
+                AppcastVersion(
+                    version: "1.0.0",
+                    buildNumber: "100",
+                    title: nil,
+                    date: nil,
+                    description: nil,
+                    releaseNotesURL: nil,
+                    downloadURL: "https://example.com/Transition.pkg",
+                    minimumSystemVersion: nil,
+                    minimumAutoupdateVersion: nil,
+                    installationType: "package"
+                )
+            )
+        )
+    }
+
+    func testMalformedBuildFailsClosedAndValidBuildsBeatMarketingOnlyItems() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+                <item>
+                    <sparkle:shortVersionString>9.9.9</sparkle:shortVersionString>
+                    <sparkle:version>9999x</sparkle:version>
+                    <enclosure url="https://example.com/RepoPrompt-9.9.9.zip" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>99.0.0</sparkle:shortVersionString>
+                    <enclosure url="https://example.com/RepoPrompt-99.0.0.zip" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
+                    <sparkle:version>100</sparkle:version>
+                    <enclosure url="https://example.com/RepoPrompt-1.0.0.zip" />
+                </item>
+            </channel>
+        </rss>
+        """
+
+        let items = AppcastParser().parseItems(data: Data(xml.utf8))
+        XCTAssertEqual(items.count, 3)
+
+        // The malformed build fails closed even though it reads "highest";
+        // the buildless marketing-only item never outranks a valid build.
+        let selected = try XCTUnwrap(AppcastParser.select(from: items, context: context(build: "1")))
+        XCTAssertEqual(selected.buildNumber, "100")
+    }
+
+    func testAllBuildlessLegacyItemsFallBackToMarketingComparison() throws {
+        let xml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+                <item>
+                    <sparkle:shortVersionString>1.2.3</sparkle:shortVersionString>
+                    <enclosure url="https://example.com/RepoPrompt-1.2.3.zip" />
+                </item>
+                <item>
+                    <sparkle:shortVersionString>1.10.0</sparkle:shortVersionString>
+                    <enclosure url="https://example.com/RepoPrompt-1.10.0.zip" />
+                </item>
+            </channel>
+        </rss>
+        """
+
+        let items = AppcastParser().parseItems(data: Data(xml.utf8))
+        XCTAssertEqual(items.count, 2)
+
+        let selected = try XCTUnwrap(AppcastParser.select(from: items, context: context(build: "1")))
+        XCTAssertEqual(selected.version, "1.10.0")
+        XCTAssertNil(selected.buildNumber)
     }
 }

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -690,6 +690,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
             WindowStatesManager.shared.registerWindowState(window)
             defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            await window.workspaceManager.awaitInitialized()
 
             let root = FileManager.default.temporaryDirectory
                 .appendingPathComponent("ContextBuilderCleanupCommitTests-\(UUID().uuidString)")
@@ -807,11 +808,6 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 windowID: window.windowID,
                 runID: transitioningRunID
             )
-            var transitioningContext = try XCTUnwrap(
-                window.mcpServer.tabContextByConnectionID[transitioningConnectionID]
-            )
-            transitioningContext.promptText = transitioningPrompt
-            window.mcpServer.tabContextByConnectionID[transitioningConnectionID] = transitioningContext
 
             let transitioningConnection = ContextBuilderCleanupTestConnection(
                 pendingRequestCount: 1,
@@ -829,6 +825,11 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 purpose: .discoverRun,
                 windowID: window.windowID
             )
+            try await ServerNetworkManager.withConnectionID(transitioningConnectionID) {
+                try await window.mcpServer.updateCurrentTabContext(toolName: "lifecycle-test") { context in
+                    context.promptText = transitioningPrompt
+                }
+            }
 
             let handoffWaitStarted = LifecycleTestGate()
             let commitAfterPublication = LifecycleTestGate()
@@ -871,6 +872,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                             isStillCurrent: { true },
                             deferRunMappingCleanupUntilCaller: true
                         )
+                        XCTAssertEqual(outcome.committedTab?.tab.promptText, transitioningPrompt)
                         return outcome.outcome == .committed
                     },
                     beforeTerminationRequest: {},

--- a/Tests/RepoPromptTests/Security/DebugSecureStorageRuntimePolicyTests.swift
+++ b/Tests/RepoPromptTests/Security/DebugSecureStorageRuntimePolicyTests.swift
@@ -72,6 +72,76 @@ final class RuntimeCodeSigningPolicyTests: XCTestCase {
         )
     }
 
+    func testSuccessorIdentityRequiresExactMarkerAndSignaturePairing() {
+        let successor = RuntimeCodeSigningInfo.synthetic(
+            codeIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+            teamIdentifier: RuntimeCodeSigningPolicy.successorSigningTeamIdentifier,
+            validatedDomains: [.successorDeveloperID]
+        )
+        let legacy = RuntimeCodeSigningInfo.synthetic(
+            codeIdentifier: RuntimeCodeSigningPolicy.developerIDBundleIdentifier,
+            teamIdentifier: RuntimeCodeSigningPolicy.signingTeamIdentifier,
+            validatedDomains: [.developerID]
+        )
+
+        assertDecision(
+            marker: "successor-developer-id",
+            debugMarker: nil,
+            signingInfo: successor,
+            expectedDomain: .successorOfficialDeveloperID
+        )
+
+        // Cross-pairings between markers and signatures must fail closed.
+        let mismatches: [(String, RuntimeCodeSigningInfo)] = [
+            ("successor-developer-id", legacy),
+            ("developer-id", successor),
+            ("successor-developer-id", RuntimeCodeSigningInfo.synthetic(
+                codeIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+                teamIdentifier: RuntimeCodeSigningPolicy.signingTeamIdentifier,
+                validatedDomains: [.successorDeveloperID]
+            )),
+            ("successor-developer-id", RuntimeCodeSigningInfo.synthetic(
+                codeIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+                teamIdentifier: RuntimeCodeSigningPolicy.successorSigningTeamIdentifier,
+                validatedDomains: [.developerID]
+            )),
+            ("successor-developer-id", RuntimeCodeSigningInfo.synthetic(
+                codeIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+                teamIdentifier: RuntimeCodeSigningPolicy.successorSigningTeamIdentifier,
+                isAdHoc: true,
+                validatedDomains: [.successorDeveloperID]
+            ))
+        ]
+        for (marker, signingInfo) in mismatches {
+            assertDecision(
+                marker: marker,
+                debugMarker: nil,
+                signingInfo: signingInfo,
+                expectedDomain: .ephemeral,
+                expectedReason: .markerSignatureMismatch
+            )
+        }
+    }
+
+    func testSuccessorDomainStaysEphemeralUntilBridgeOverrideAndAcceptsOverride() {
+        let decision = RuntimeSecureStorageDecision(
+            domain: .successorOfficialDeveloperID,
+            rejectionReason: nil
+        )
+
+        // Without a committed-bridge override the successor identity must not
+        // fall back to the legacy Keychain service.
+        XCTAssertTrue(
+            SecureKeyValueStorageFactory.selection(for: decision).backend === EphemeralSecureKeyValueStore.shared
+        )
+
+        XCTAssertTrue(SecureKeyValueStorageFactory.officialOverrideApplies(to: .officialDeveloperID))
+        XCTAssertTrue(SecureKeyValueStorageFactory.officialOverrideApplies(to: .successorOfficialDeveloperID))
+        XCTAssertFalse(SecureKeyValueStorageFactory.officialOverrideApplies(to: .localSelfSigned))
+        XCTAssertFalse(SecureKeyValueStorageFactory.officialOverrideApplies(to: .appleDevelopmentDebug))
+        XCTAssertFalse(SecureKeyValueStorageFactory.officialOverrideApplies(to: .ephemeral))
+    }
+
     func testRejectedModesExhaustivelyFailClosedToEphemeralStorage() {
         let official = RuntimeCodeSigningInfo.synthetic(
             codeIdentifier: RuntimeCodeSigningPolicy.developerIDBundleIdentifier,
@@ -198,8 +268,15 @@ final class RuntimeCodeSigningPolicyTests: XCTestCase {
         XCTAssertEqual(RuntimeCodeSigningPolicy.developerIDBundleIdentifier, "com.pvncher.repoprompt.ce")
         XCTAssertEqual(RuntimeCodeSigningPolicy.appleDevelopmentDebugBundleIdentifier, "com.pvncher.repoprompt.ce.debug")
         XCTAssertEqual(RuntimeCodeSigningPolicy.signingTeamIdentifier, "648A27MST5")
+        XCTAssertEqual(RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier, "com.repoprompt.ce")
+        XCTAssertEqual(RuntimeCodeSigningPolicy.successorSigningTeamIdentifier, "69N6K965SF")
         XCTAssertTrue(RuntimeCodeSigningPolicy.developerIDRequirement.contains("1.2.840.113635.100.6.1.13"))
         XCTAssertTrue(RuntimeCodeSigningPolicy.appleDevelopmentDebugRequirement.contains("1.2.840.113635.100.6.1.12"))
+        XCTAssertTrue(RuntimeCodeSigningPolicy.successorDeveloperIDRequirement.contains("1.2.840.113635.100.6.1.13"))
+        XCTAssertEqual(
+            RuntimeCodeSigningPolicy.successorDeveloperIDRequirement,
+            "anchor apple generic and identifier \"com.repoprompt.ce\" and certificate leaf[subject.OU] = \"69N6K965SF\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+        )
     }
 
     private func assertDecision(

--- a/Tests/RepoPromptTests/Security/SecureStorageIdentityMigrationTests.swift
+++ b/Tests/RepoPromptTests/Security/SecureStorageIdentityMigrationTests.swift
@@ -25,6 +25,7 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         XCTAssertEqual(bridge.value(for: SecureStorageAccount.openAIAPI.identifier), "secret")
         XCTAssertFalse(source.calls.contains { $0.operation == .delete })
         XCTAssertEqual(state.savedManifests.map(\.status), [.preparing, .committed])
+        XCTAssertEqual(state.createdManifests.map(\.status), [.preparing])
 
         let committed = try XCTUnwrap(state.manifest)
         XCTAssertEqual(committed.version, SecureStorageIdentityMigrationManifest.currentVersion)
@@ -120,7 +121,7 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(state.manifest).status, .committed)
     }
 
-    func testLostJournalStartsNewServiceAndIgnoresOrphanedAttemptItems() throws {
+    func testLostJournalStartsNewServiceAndIgnoresOrphanedAttemptItems() {
         let source = MigrationTestBackend(values: [
             SecureStorageAccount.openAIAPI.identifier: "openai",
             SecureStorageAccount.anthropicAPI.identifier: "anthropic"
@@ -151,7 +152,7 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
             firstBridge.value(for: SecureStorageAccount.openAIAPI.identifier),
             "openai"
         )
-        try state.reset()
+        state.simulateJournalLoss()
 
         let recoveredReport = coordinator.prepareBridge()
 
@@ -176,7 +177,7 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         })
     }
 
-    func testCommittedManifestUsesSingleBridgeManifestRead() throws {
+    func testCommittedManifestVerifiesFullBridgeProjectionWithoutSourceReads() throws {
         let manifest = makeManifest(status: .committed)
         let encoded = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest))
         XCTAssertEqual(
@@ -192,9 +193,139 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
 
         XCTAssertTrue(report.bridgeReady)
-        XCTAssertTrue(report.records.isEmpty)
+        // The committed projection classifies every cataloged account explicitly;
+        // both accounts are absent from the bridge here, which is acceptable.
+        XCTAssertEqual(report.records.map(\.state), [.absent, .absent])
         XCTAssertTrue(source.calls.isEmpty)
-        XCTAssertEqual(bridge.calls.map(\.key), [SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount])
+        // Reads touch the bridge service only: the manifest plus each account.
+        XCTAssertEqual(
+            bridge.calls.map(\.key),
+            [SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount] + accounts.map(\.identifier)
+        )
+    }
+
+    func testCommittedProjectionAccountReadFailureBlocksWithSpecificReason() throws {
+        let manifest = makeManifest(status: .committed)
+        let encoded = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest))
+        let bridge = MigrationTestBackend(values: [
+            SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount: encoded
+        ])
+        bridge.getErrors[SecureStorageAccount.openAIAPI.identifier] =
+            KeychainService.KeychainError.interactionNotAllowed
+        let source = MigrationTestBackend()
+        let state = TestIdentityMigrationStateStore(manifest: manifest)
+
+        let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(report.blockingState, .interactionRequired)
+        XCTAssertTrue(report.blockedUpdateMessage?.contains("login Keychain is locked or unavailable") == true)
+        XCTAssertTrue(source.calls.isEmpty)
+    }
+
+    func testResolverRejectsCommittedBridgeWithUnreadableAccountProjection() throws {
+        let manifest = makeManifest(status: .committed)
+        let encoded = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest))
+        let bridge = MigrationTestBackend(values: [
+            SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount: encoded
+        ])
+        bridge.getErrors[SecureStorageAccount.anthropicAPI.identifier] =
+            KeychainService.KeychainError.authenticationFailed
+        let resolver = SecureStorageIdentityMigrationCommittedBridgeResolver(
+            accounts: accounts,
+            stateStore: TestIdentityMigrationStateStore(manifest: manifest),
+            bridgeStoreFactory: { _ in bridge }
+        )
+
+        XCTAssertThrowsError(try resolver.resolve()) { error in
+            guard case KeychainService.KeychainError.authenticationFailed = error else {
+                return XCTFail("Expected authenticationFailed, got \(error)")
+            }
+        }
+    }
+
+    func testCommittedProjectionReportsVerifiedRecordsForPresentValues() throws {
+        let manifest = makeManifest(status: .committed)
+        let encoded = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(manifest))
+        let bridge = MigrationTestBackend(values: [
+            SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount: encoded,
+            SecureStorageAccount.openAIAPI.identifier: "openai-secret"
+        ])
+        let state = TestIdentityMigrationStateStore(manifest: manifest)
+
+        let report = makeCoordinator(
+            source: MigrationTestBackend(),
+            bridge: bridge,
+            state: state
+        ).prepareBridge()
+
+        XCTAssertTrue(report.bridgeReady)
+        XCTAssertEqual(report.records.map(\.state), [.verified, .absent])
+        XCTAssertEqual(report.records.map(\.account), accounts)
+    }
+
+    func testCommittedProjectionRejectsMismatchedBridgeManifestWithoutDestructiveRecovery() throws {
+        let manifest = makeManifest(status: .committed)
+        let foreignManifest = SecureStorageIdentityMigrationManifest(
+            version: SecureStorageIdentityMigrationManifest.currentVersion,
+            status: .committed,
+            attemptIdentifier: secondAttemptIdentifier,
+            catalogIdentifiers: accounts.map(\.identifier).sorted()
+        )
+        let planted = try XCTUnwrap(SecureStorageIdentityMigrationCoordinator.encodeManifest(foreignManifest))
+        let bridge = MigrationTestBackend(values: [
+            SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount: planted
+        ])
+        let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
+
+        let report = makeCoordinator(
+            source: source,
+            bridge: bridge,
+            state: TestIdentityMigrationStateStore(manifest: manifest)
+        ).prepareBridge()
+
+        // A bridge manifest from a different attempt must not activate, and the
+        // mismatch must not trigger recovery writes against source or bridge.
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertEqual(report.blockingState, .failed)
+        XCTAssertTrue(source.calls.isEmpty)
+        XCTAssertTrue(bridge.calls.allSatisfy { $0.operation == .get })
+    }
+
+    func testResolverRejectsPlantedPreparingManifestInBridgeSlot() throws {
+        let manifest = makeManifest(status: .committed)
+        let planted = try XCTUnwrap(
+            SecureStorageIdentityMigrationCoordinator.encodeManifest(makeManifest(status: .preparing))
+        )
+        let bridge = MigrationTestBackend(values: [
+            SecureStorageIdentityMigrationCoordinator.bridgeManifestAccount: planted
+        ])
+        let resolver = SecureStorageIdentityMigrationCommittedBridgeResolver(
+            accounts: accounts,
+            stateStore: TestIdentityMigrationStateStore(manifest: manifest),
+            bridgeStoreFactory: { _ in bridge }
+        )
+
+        XCTAssertThrowsError(try resolver.resolve()) { error in
+            guard case SecureStorageIdentityMigrationActivationError.invalidBridgeManifest = error else {
+                return XCTFail("Expected invalidBridgeManifest, got \(error)")
+            }
+        }
+    }
+
+    func testSuccessorPhaseGateBlocksEverythingExceptDisabled() {
+        XCTAssertNil(SecureStorageIdentityMigrationBootstrap.successorBlockedMessage(forPhase: .disabled))
+        XCTAssertEqual(
+            SecureStorageIdentityMigrationBootstrap.successorBlockedMessage(forPhase: .legacyPreparer),
+            SecureStorageIdentityMigrationBootstrap.successorUnsupportedPhaseMessage
+        )
+        XCTAssertEqual(
+            SecureStorageIdentityMigrationBootstrap.successorBlockedMessage(forPhase: nil),
+            SecureStorageIdentityMigrationBootstrap.unrecognizedConfigurationMessage
+        )
+        XCTAssertTrue(
+            SecureStorageIdentityMigrationBootstrap.successorMissingBridgeMessage.contains("previous RepoPrompt CE version")
+        )
     }
 
     func testCommittedJournalWithoutMatchingBridgeManifestBlocks() {
@@ -335,7 +466,7 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
         XCTAssertTrue(bridge.calls.isEmpty)
     }
 
-    func testCorruptJournalIsResetAndMigrationRetriesFromIntactSource() {
+    func testCorruptJournalFailsClosedWithoutResetOrCredentialAccess() {
         let journalBackend = MigrationTestBackend(values: [
             KeychainSecureStorageIdentityMigrationStateStore.account: "not-json"
         ])
@@ -345,11 +476,47 @@ final class SecureStorageIdentityMigrationTests: XCTestCase {
 
         let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
 
-        XCTAssertTrue(report.bridgeReady)
-        XCTAssertEqual(bridge.value(for: SecureStorageAccount.openAIAPI.identifier), "secret")
-        XCTAssertTrue(journalBackend.calls.contains {
-            $0.operation == .delete && $0.key == KeychainSecureStorageIdentityMigrationStateStore.account
-        })
+        // A corrupt journal may be the only pointer to an already-committed bridge.
+        // It must never be deleted or replaced by a fresh attempt from stale source data.
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertNotNil(report.blockedUpdateMessage)
+        XCTAssertTrue(source.calls.isEmpty)
+        XCTAssertTrue(bridge.calls.isEmpty)
+        XCTAssertFalse(journalBackend.calls.contains { $0.operation == .delete })
+        XCTAssertFalse(journalBackend.calls.contains { $0.operation == .save })
+        XCTAssertFalse(journalBackend.calls.contains { $0.operation == .create })
+        XCTAssertEqual(journalBackend.value(for: KeychainSecureStorageIdentityMigrationStateStore.account), "not-json")
+    }
+
+    func testFreshAttemptJournalWriteIsCreateOnlyAndCannotOverwrite() throws {
+        // Keychain-backed store: an existing journal item must reject create-only writes.
+        let journalBackend = MigrationTestBackend(values: [
+            KeychainSecureStorageIdentityMigrationStateStore.account: "existing-journal"
+        ])
+        let store = KeychainSecureStorageIdentityMigrationStateStore(store: journalBackend)
+
+        XCTAssertThrowsError(try store.create(makeManifest(status: .preparing))) { error in
+            guard case KeychainService.KeychainError.duplicateItem = error else {
+                return XCTFail("Expected duplicateItem, got \(error)")
+            }
+        }
+        XCTAssertEqual(
+            journalBackend.value(for: KeychainSecureStorageIdentityMigrationStateStore.account),
+            "existing-journal"
+        )
+
+        // Coordinator: a journal that appears between load and create blocks the attempt.
+        let state = TestIdentityMigrationStateStore(
+            createError: KeychainService.KeychainError.duplicateItem
+        )
+        let source = MigrationTestBackend(values: [SecureStorageAccount.openAIAPI.identifier: "secret"])
+        let bridge = MigrationTestBackend()
+
+        let report = makeCoordinator(source: source, bridge: bridge, state: state).prepareBridge()
+
+        XCTAssertFalse(report.bridgeReady)
+        XCTAssertTrue(state.savedManifests.isEmpty)
+        XCTAssertTrue(bridge.calls.isEmpty)
     }
 
     func testBridgeManifestPersistenceFailureLeavesJournalPreparing() {
@@ -488,22 +655,40 @@ private enum TestStateError: Error {
 private final class TestIdentityMigrationStateStore: SecureStorageIdentityMigrationStateStore {
     private(set) var manifest: SecureStorageIdentityMigrationManifest?
     private(set) var savedManifests: [SecureStorageIdentityMigrationManifest] = []
+    private(set) var createdManifests: [SecureStorageIdentityMigrationManifest] = []
     var loadError: Error?
+    var createError: Error?
     var saveFailuresRemaining: Int
 
     init(
         manifest: SecureStorageIdentityMigrationManifest? = nil,
         loadError: Error? = nil,
+        createError: Error? = nil,
         saveFailuresRemaining: Int = 0
     ) {
         self.manifest = manifest
         self.loadError = loadError
+        self.createError = createError
         self.saveFailuresRemaining = saveFailuresRemaining
     }
 
     func load() throws -> SecureStorageIdentityMigrationManifest? {
         if let loadError { throw loadError }
         return manifest
+    }
+
+    func create(_ manifest: SecureStorageIdentityMigrationManifest) throws {
+        if let createError { throw createError }
+        if saveFailuresRemaining > 0 {
+            saveFailuresRemaining -= 1
+            throw TestStateError.failed
+        }
+        guard self.manifest == nil else {
+            throw KeychainService.KeychainError.duplicateItem
+        }
+        createdManifests.append(manifest)
+        savedManifests.append(manifest)
+        self.manifest = manifest
     }
 
     func save(_ manifest: SecureStorageIdentityMigrationManifest) throws {
@@ -515,7 +700,9 @@ private final class TestIdentityMigrationStateStore: SecureStorageIdentityMigrat
         self.manifest = manifest
     }
 
-    func reset() throws {
+    /// Test-only stand-in for out-of-band journal deletion. Production code has
+    /// no destructive journal reset API.
+    func simulateJournalLoss() {
         manifest = nil
     }
 }


### PR DESCRIPTION
## Summary

- make Sparkle appcast eligibility deterministic across legacy and successor bundle identities
- harden runtime signing and secure-storage migration authority checks
- fail closed on incomplete or unauthenticated migration state without deleting source credentials
- add focused regression coverage for eligibility, runtime policy, and migration recovery

## Stack

1. **This PR:** runtime safety and deterministic appcast selection
2. Release tooling and dormant Stable rollout controls
3. Tip P→T→S rehearsal, successor enablement, and diagnostics

## Validation

- focused identity-migration and appcast regression suites
- repository contribution preflight and outgoing-range secret scan
- path-selected PR-ready lint passed; the full suite had one unrelated worktree-routing failure that passed on immediate isolated rerun
