### PR TITLE
Add dormant identity transition release tooling

### DIFF
--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -161,6 +161,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Reject dormant rollout roles and sibling publication
+        run: |
+          python3 trusted-control-plane/Scripts/stable_rollout.py workflow-guard \
+            --declaration release-source/release-rollout.json \
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json
+
       - name: Prepare Sentry promotion token file
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Reject dormant rollout roles and sibling publication
+        run: |
+          python3 trusted-control-plane/Scripts/stable_rollout.py workflow-guard \
+            --declaration release-source/release-rollout.json \
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json
+
       - name: Build and stage approved source
         env:
           GH_TOKEN: ${{ github.token }}
@@ -128,6 +134,12 @@ jobs:
           path: approved-source
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Reject dormant rollout roles and sibling publication
+        run: |
+          python3 trusted-control-plane/Scripts/stable_rollout.py workflow-guard \
+            --declaration approved-source/release-rollout.json \
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json
 
       - name: Verify and expand staged release source
         env:

--- a/Scripts/apple_identity_policy.json
+++ b/Scripts/apple_identity_policy.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "identities": {
+    "legacy": {
+      "bundleIdentifier": "com.pvncher.repoprompt.ce",
+      "teamIdentifier": "648A27MST5",
+      "developerIDRequirement": "anchor apple generic and identifier \"com.pvncher.repoprompt.ce\" and certificate leaf[subject.OU] = \"648A27MST5\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+    },
+    "successor": {
+      "bundleIdentifier": "com.repoprompt.ce",
+      "teamIdentifier": "69N6K965SF",
+      "developerIDRequirement": "anchor apple generic and identifier \"com.repoprompt.ce\" and certificate leaf[subject.OU] = \"69N6K965SF\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+    }
+  },
+  "sparkle": {
+    "stableFeedURL": "https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml",
+    "sparklePublicEdDSAValue": "845kp9v5+kp4U6no85H53cUdnbfN3NmE1PJHKwH8Pd4=",
+    "updateRepository": "repoprompt/repoprompt-ce-updates",
+    "minimumSystemVersion": "14.0"
+  }
+}

--- a/Scripts/build_identity_transition_pkg.sh
+++ b/Scripts/build_identity_transition_pkg.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builder/validator for the notarized Apple identity-transition package (T).
+#
+# DORMANT BY DESIGN: no protected workflow references this script, release.sh
+# refuses the transition artifact role, and promote_release.sh keeps the
+# transition role locked. Publishing a transition package stays impossible
+# until successor rollout enablement deliberately wires it up.
+
+MODE="${1:-}"
+if [[ $# -gt 0 ]]; then shift; fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SUCCESSOR_BUNDLE_IDENTIFIER="com.repoprompt.ce"
+SUCCESSOR_TEAM_IDENTIFIER="69N6K965SF"
+SUCCESSOR_APP_REQUIREMENT='anchor apple generic and identifier "com.repoprompt.ce" and certificate leaf[subject.OU] = "69N6K965SF" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists'
+TRANSITION_PKG_IDENTIFIER="com.repoprompt.ce.transition"
+TRANSITION_INSTALL_LOCATION="/Applications"
+DISTRIBUTION_APP_BUNDLE_NAME="RepoPrompt CE.app"
+EXPECTED_FEED_URL="https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml"
+TMP_DIR=""
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+require_file() {
+    [[ -f "$1" ]] || fail "Missing required file: $1"
+}
+
+cleanup() {
+    [[ -z "$TMP_DIR" ]] || rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+[[ "${GITHUB_ACTIONS:-}" != "true" ]] ||
+    fail "build_identity_transition_pkg.sh is dormant and must not run inside protected workflows until successor rollout enablement"
+
+validate_successor_app() {
+    local app="$1"
+    local label="$2"
+    [[ -d "$app" ]] || fail "$label app bundle does not exist: $app"
+    codesign --verify --deep --strict --verbose=2 "$app"
+    codesign --verify --strict --verbose=2 -R="$SUCCESSOR_APP_REQUIREMENT" "$app"
+
+    local signature_details identifier team_identifier
+    signature_details="$(codesign -dv --verbose=4 "$app" 2>&1)"
+    identifier="$(printf '%s\n' "$signature_details" | awk -F= '$1 == "Identifier" { print $2; exit }')"
+    team_identifier="$(printf '%s\n' "$signature_details" | awk -F= '$1 == "TeamIdentifier" { print $2; exit }')"
+    printf '%s\n' "$signature_details" | grep -q '^Authority=Developer ID Application:' ||
+        fail "$label app is not signed with a Developer ID Application certificate"
+    [[ "$identifier" == "$SUCCESSOR_BUNDLE_IDENTIFIER" ]] ||
+        fail "$label app identifier mismatch: expected $SUCCESSOR_BUNDLE_IDENTIFIER, got ${identifier:-<missing>}"
+    [[ "$team_identifier" == "$SUCCESSOR_TEAM_IDENTIFIER" ]] ||
+        fail "$label app team mismatch: expected $SUCCESSOR_TEAM_IDENTIFIER, got ${team_identifier:-<missing>}"
+
+    local info_plist="$app/Contents/Info.plist"
+    require_file "$info_plist"
+    local bundle_identifier feed_url public_key
+    bundle_identifier="$(plutil -extract CFBundleIdentifier raw "$info_plist")"
+    feed_url="$(plutil -extract SUFeedURL raw "$info_plist")"
+    public_key="$(plutil -extract SUPublicEDKey raw "$info_plist")"
+    [[ "$bundle_identifier" == "$SUCCESSOR_BUNDLE_IDENTIFIER" ]] ||
+        fail "$label app CFBundleIdentifier mismatch: expected $SUCCESSOR_BUNDLE_IDENTIFIER, got $bundle_identifier"
+    [[ "$feed_url" == "$EXPECTED_FEED_URL" ]] ||
+        fail "$label app must keep the unchanged Stable feed URL, got $feed_url"
+    [[ -n "$public_key" ]] || fail "$label app is missing SUPublicEDKey"
+}
+
+assert_component_flag() {
+    local component_plist="$1"
+    local key="$2"
+    local expected="$3"
+    local actual
+    actual="$(plutil -extract "0.$key" raw "$component_plist")" ||
+        fail "Component plist is missing $key"
+    [[ "$actual" == "$expected" ]] ||
+        fail "Component plist $key mismatch: expected $expected, got $actual"
+}
+
+build_transition_pkg() {
+    local app="" output="" installer_identity=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --app) app="$2"; shift 2 ;;
+            --output) output="$2"; shift 2 ;;
+            --installer-identity) installer_identity="$2"; shift 2 ;;
+            *) fail "Unknown build argument: $1" ;;
+        esac
+    done
+    [[ -n "$app" && -n "$output" && -n "$installer_identity" ]] ||
+        fail "Usage: $0 build --app <successor.app> --output <transition.pkg> --installer-identity 'Developer ID Installer: ...'"
+    [[ "$installer_identity" == "Developer ID Installer: "* ]] ||
+        fail "Transition packages must be signed with a Developer ID Installer identity"
+    require_command codesign
+    require_command ditto
+    require_command pkgbuild
+    require_command plutil
+    require_command productbuild
+    require_command xcrun
+
+    validate_successor_app "$app" "Transition payload input"
+
+    TMP_DIR="$(mktemp -d)"
+    local payload_root="$TMP_DIR/payload-root"
+    mkdir -p "$payload_root"
+    ditto "$app" "$payload_root/$DISTRIBUTION_APP_BUNDLE_NAME"
+
+    local component_plist="$TMP_DIR/component.plist"
+    pkgbuild --analyze --root "$payload_root" "$component_plist"
+    plutil -replace 0.BundleIsRelocatable -bool false "$component_plist"
+    plutil -replace 0.BundleHasStrictIdentifier -bool false "$component_plist"
+    plutil -replace 0.BundleIsVersionChecked -bool false "$component_plist"
+    plutil -replace 0.BundleOverwriteAction -string upgrade "$component_plist"
+    assert_component_flag "$component_plist" BundleIsRelocatable false
+    assert_component_flag "$component_plist" BundleHasStrictIdentifier false
+    assert_component_flag "$component_plist" BundleIsVersionChecked false
+    assert_component_flag "$component_plist" BundleOverwriteAction upgrade
+
+    local payload_build
+    payload_build="$(plutil -extract CFBundleVersion raw "$app/Contents/Info.plist")"
+    [[ "$payload_build" =~ ^[0-9]+$ ]] ||
+        fail "Transition payload build number must be numeric, got $payload_build"
+
+    local component_pkg="$TMP_DIR/transition-component.pkg"
+    pkgbuild \
+        --root "$payload_root" \
+        --component-plist "$component_plist" \
+        --identifier "$TRANSITION_PKG_IDENTIFIER" \
+        --version "$payload_build" \
+        --install-location "$TRANSITION_INSTALL_LOCATION" \
+        --sign "$installer_identity" \
+        "$component_pkg"
+    productbuild \
+        --package "$component_pkg" \
+        --sign "$installer_identity" \
+        "$output"
+
+    require_env_for_notarization
+    xcrun notarytool submit "$output" \
+        --key "$NOTARYTOOL_PRIVATE_KEY" \
+        --key-id "$NOTARYTOOL_KEY_ID" \
+        --issuer "$NOTARYTOOL_ISSUER_ID" \
+        --wait \
+        --timeout "${NOTARYTOOL_TIMEOUT:-30m}"
+    xcrun stapler staple "$output"
+    validate_transition_pkg "$output" --expected-app "$app"
+    printf 'Created identity-transition package: %s\n' "$output"
+}
+
+require_env_for_notarization() {
+    [[ -n "${NOTARYTOOL_PRIVATE_KEY:-}" && -n "${NOTARYTOOL_KEY_ID:-}" && -n "${NOTARYTOOL_ISSUER_ID:-}" ]] ||
+        fail "Transition package notarization requires NOTARYTOOL_PRIVATE_KEY, NOTARYTOOL_KEY_ID, and NOTARYTOOL_ISSUER_ID"
+    require_file "$NOTARYTOOL_PRIVATE_KEY"
+}
+
+validate_transition_pkg() {
+    local pkg="$1"
+    shift
+    local expanded_payload_dir="" expected_app=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --expanded-payload-dir) expanded_payload_dir="$2"; shift 2 ;;
+            --expected-app) expected_app="$2"; shift 2 ;;
+            *) fail "Unknown validate argument: $1" ;;
+        esac
+    done
+    require_command codesign
+    require_command pkgutil
+    require_command plutil
+    require_command xcrun
+    require_file "$pkg"
+
+    local signature_details
+    signature_details="$(pkgutil --check-signature "$pkg")"
+    printf '%s\n' "$signature_details" | grep -q 'Developer ID Installer:' ||
+        fail "Transition package is not signed with a Developer ID Installer certificate"
+    printf '%s\n' "$signature_details" | grep -q "($SUCCESSOR_TEAM_IDENTIFIER)" ||
+        fail "Transition package installer team mismatch: expected $SUCCESSOR_TEAM_IDENTIFIER"
+
+    xcrun stapler validate "$pkg"
+
+    [[ -n "$TMP_DIR" ]] || TMP_DIR="$(mktemp -d)"
+    local expand_dir="$TMP_DIR/transition-expand"
+    rm -rf "$expand_dir"
+    pkgutil --expand-full "$pkg" "$expand_dir"
+
+    local package_info
+    package_info="$(find "$expand_dir" -maxdepth 2 -name PackageInfo -type f | head -n 1)"
+    [[ -n "$package_info" ]] || fail "Transition package is missing PackageInfo"
+    grep -q "install-location=\"$TRANSITION_INSTALL_LOCATION\"" "$package_info" ||
+        fail "Transition package must install into $TRANSITION_INSTALL_LOCATION"
+    grep -q "identifier=\"$TRANSITION_PKG_IDENTIFIER\"" "$package_info" ||
+        fail "Transition package identifier mismatch: expected $TRANSITION_PKG_IDENTIFIER"
+    ! grep -q '<relocate' "$package_info" ||
+        fail "Transition package must not contain bundle relocation rules"
+
+    local payload_app
+    payload_app="$(find "$expand_dir" -maxdepth 3 -type d -name "$DISTRIBUTION_APP_BUNDLE_NAME" | head -n 1)"
+    [[ -n "$payload_app" ]] || fail "Transition package payload is missing $DISTRIBUTION_APP_BUNDLE_NAME"
+    validate_successor_app "$payload_app" "Transition payload"
+
+    if [[ -n "$expected_app" ]]; then
+        # Exact byte/tree proof: the extracted payload must be identical to the
+        # signed input app, file for file.
+        diff -qr "$expected_app" "$payload_app" ||
+            fail "Transition package payload does not byte-match the signed input app"
+    fi
+
+    if [[ -n "$expanded_payload_dir" ]]; then
+        mkdir -p "$expanded_payload_dir"
+        ditto "$payload_app" "$expanded_payload_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
+    fi
+    printf 'OK: transition package validated: %s\n' "$pkg"
+}
+
+case "$MODE" in
+    build)
+        build_transition_pkg "$@"
+        ;;
+    validate)
+        [[ $# -ge 1 ]] || fail "Usage: $0 validate <transition.pkg> [--expected-app <app>] [--expanded-payload-dir <dir>]"
+        pkg_path="$1"
+        shift
+        validate_transition_pkg "$pkg_path" "$@"
+        ;;
+    *)
+        fail "Usage: $0 build|validate ..."
+        ;;
+esac

--- a/Scripts/promote_release.sh
+++ b/Scripts/promote_release.sh
@@ -67,6 +67,92 @@ require_env() {
     [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"
 }
 
+PKG_NAME="$ARCHIVE_BASENAME.pkg"
+ROLLOUT_MANIFEST_NAME="$ARCHIVE_BASENAME-stable-rollout.json"
+STABLE_ROLLOUT_TOOL="$CONTROL_PLANE_SCRIPTS_DIR/stable_rollout.py"
+APPLE_IDENTITY_POLICY="$CONTROL_PLANE_SCRIPTS_DIR/apple_identity_policy.json"
+ROLLOUT_DECLARATION="$ROOT_DIR/release-rollout.json"
+RELEASE_ARTIFACT_ROLE=""
+PRIMARY_ARTIFACT_NAME=""
+PRIMARY_ARTIFACT=""
+ROLLOUT_MANIFEST=""
+
+# The reviewed release-rollout.json in the tagged source is the single role
+# authority. PR2 promotes legacy/preparer application releases only; the
+# transition and successor roles fail unconditionally until successor rollout
+# enablement, with no override.
+resolve_release_artifact_role() {
+    require_file "$ROLLOUT_DECLARATION"
+    require_file "$APPLE_IDENTITY_POLICY"
+    require_file "$STABLE_ROLLOUT_TOOL"
+    RELEASE_ARTIFACT_ROLE="$(python3 "$STABLE_ROLLOUT_TOOL" current-role --declaration "$ROLLOUT_DECLARATION")"
+    case "$RELEASE_ARTIFACT_ROLE" in
+    legacy | preparer)
+        PRIMARY_ARTIFACT_NAME="$UPDATE_ZIP_NAME"
+        ;;
+    transition | successor)
+        fail "Stable promotion for the $RELEASE_ARTIFACT_ROLE rollout role is dormant until successor rollout enablement"
+        ;;
+    *)
+        fail "Unsupported rollout role: $RELEASE_ARTIFACT_ROLE"
+        ;;
+    esac
+    python3 "$STABLE_ROLLOUT_TOOL" workflow-guard \
+        --declaration "$ROLLOUT_DECLARATION" \
+        --policy "$APPLE_IDENTITY_POLICY"
+}
+
+require_resolved_role() {
+    [[ -n "$RELEASE_ARTIFACT_ROLE" ]] || fail "Rollout role has not been resolved from release-rollout.json"
+}
+
+# Application-style roles (legacy/preparer/successor) distribute a ZIP+DMG pair;
+# the transition role is a package-only artifact with no DMG.
+release_role_ships_dmg() {
+    require_resolved_role
+    case "$RELEASE_ARTIFACT_ROLE" in
+    legacy | preparer | successor) return 0 ;;
+    transition) return 1 ;;
+    *) fail "Unsupported rollout role: $RELEASE_ARTIFACT_ROLE" ;;
+    esac
+}
+
+source_asset_names() {
+    require_resolved_role
+    case "$RELEASE_ARTIFACT_ROLE" in
+    legacy | preparer | successor)
+        printf '%s\n' "$UPDATE_ZIP_NAME" "$DMG_NAME" "$APPCAST_NAME" "$CHECKSUMS_NAME" "$ARTIFACT_MANIFEST_NAME" "$ROLLOUT_MANIFEST_NAME"
+        ;;
+    transition)
+        printf '%s\n' "$PKG_NAME" "$APPCAST_NAME" "$CHECKSUMS_NAME" "$ARTIFACT_MANIFEST_NAME" "$ROLLOUT_MANIFEST_NAME"
+        ;;
+    esac
+}
+
+update_asset_names() {
+    require_resolved_role
+    case "$RELEASE_ARTIFACT_ROLE" in
+    legacy | preparer | successor)
+        printf '%s\n' "$UPDATE_ZIP_NAME" "$APPCAST_NAME" "$CHECKSUMS_NAME" "$ARTIFACT_MANIFEST_NAME" "$ROLLOUT_MANIFEST_NAME"
+        ;;
+    transition)
+        printf '%s\n' "$PKG_NAME" "$APPCAST_NAME" "$CHECKSUMS_NAME" "$ARTIFACT_MANIFEST_NAME" "$ROLLOUT_MANIFEST_NAME"
+        ;;
+    esac
+}
+
+checksum_asset_names() {
+    require_resolved_role
+    case "$RELEASE_ARTIFACT_ROLE" in
+    legacy | preparer | successor)
+        printf '%s\n' "$APPCAST_NAME" "$DMG_NAME" "$UPDATE_ZIP_NAME" "$ARTIFACT_MANIFEST_NAME" "$ROLLOUT_MANIFEST_NAME"
+        ;;
+    transition)
+        printf '%s\n' "$APPCAST_NAME" "$PKG_NAME" "$ARTIFACT_MANIFEST_NAME" "$ROLLOUT_MANIFEST_NAME"
+        ;;
+    esac
+}
+
 validate_bounded_positive_integer() {
     local name="$1" value="$2" maximum="$3"
     [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "$name must be a positive integer"
@@ -299,30 +385,31 @@ asset_snapshot() {
     jq -c '[.assets[] | {name, id, size, updatedAt, digest}] | sort_by(.name)'
 }
 
+assert_exact_asset_names() {
+    local release_json="$1"
+    local release_label="$2"
+    shift 2
+    local expected_json
+    expected_json="$(printf '%s\n' "$@" | jq -R . | jq -s 'sort')"
+    jq -e --argjson expected "$expected_json" \
+        '([.assets[].name] | sort) == $expected' \
+        <<< "$release_json" >/dev/null ||
+        fail "$release_label must contain exactly: $*"
+}
+
 assert_exact_release_assets() {
     local release_json="$1"
     local release_label="$2"
-    jq -e \
-        --arg zip "$UPDATE_ZIP_NAME" \
-        --arg dmg "$DMG_NAME" \
-        --arg appcast "$APPCAST_NAME" \
-        --arg checksums "$CHECKSUMS_NAME" \
-        --arg manifest "$ARTIFACT_MANIFEST_NAME" \
-        '([.assets[].name] | sort) == ([$zip, $dmg, $appcast, $checksums, $manifest] | sort)' \
-        <<< "$release_json" >/dev/null ||
-        fail "$release_label must contain exactly: $UPDATE_ZIP_NAME, $DMG_NAME, $APPCAST_NAME, $CHECKSUMS_NAME, $ARTIFACT_MANIFEST_NAME"
+    local names=()
+    while IFS= read -r name; do names+=("$name"); done < <(source_asset_names)
+    assert_exact_asset_names "$release_json" "$release_label" "${names[@]}"
 }
 
 assert_exact_update_assets() {
     local release_json="$1"
-    jq -e \
-        --arg zip "$UPDATE_ZIP_NAME" \
-        --arg appcast "$APPCAST_NAME" \
-        --arg checksums "$CHECKSUMS_NAME" \
-        --arg manifest "$ARTIFACT_MANIFEST_NAME" \
-        '([.assets[].name] | sort) == ([$zip, $appcast, $checksums, $manifest] | sort)' \
-        <<< "$release_json" >/dev/null ||
-        fail "Public updater release must contain exactly: $UPDATE_ZIP_NAME, $APPCAST_NAME, $CHECKSUMS_NAME, $ARTIFACT_MANIFEST_NAME"
+    local names=()
+    while IFS= read -r name; do names+=("$name"); done < <(update_asset_names)
+    assert_exact_asset_names "$release_json" "Public updater release" "${names[@]}"
 }
 
 derive_sparkle_public_key() {
@@ -333,10 +420,10 @@ derive_sparkle_public_key() {
 validate_checksum_manifest() {
     (
         cd "$SOURCE_ASSETS_DIR"
-        printf '%s\n' "$APPCAST_NAME" "$DMG_NAME" "$UPDATE_ZIP_NAME" "$ARTIFACT_MANIFEST_NAME" | sort > "$TMP_DIR/expected-checksum-files.txt"
+        checksum_asset_names | sort > "$TMP_DIR/expected-checksum-files.txt"
         awk '{ print $2 }' "$CHECKSUMS_NAME" | sort > "$TMP_DIR/checksum-files.txt"
         diff -u "$TMP_DIR/expected-checksum-files.txt" "$TMP_DIR/checksum-files.txt" ||
-            fail "$CHECKSUMS_NAME must contain exactly the reviewed ZIP, DMG, appcast, and artifact manifest"
+            fail "$CHECKSUMS_NAME must contain exactly the reviewed release asset set for the $RELEASE_ARTIFACT_ROLE role"
         shasum -a 256 -c "$CHECKSUMS_NAME"
     )
 }
@@ -411,42 +498,23 @@ validate_dmg_matches_zip_app() {
 }
 
 validate_appcast() {
-    local appcast_values="$TMP_DIR/appcast-values.tsv"
-    python3 - "$APPCAST" > "$appcast_values" <<'PYTHON'
-import sys
-import xml.etree.ElementTree as ET
+    require_resolved_role
+    python3 "$STABLE_ROLLOUT_TOOL" validate \
+        --declaration "$ROLLOUT_DECLARATION" \
+        --policy "$APPLE_IDENTITY_POLICY" \
+        --version-env "$ROOT_DIR/version.env" \
+        --release-tag "$RELEASE_TAG" \
+        --release-commit "$RELEASE_COMMIT" \
+        --migration-phase "$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['expectedMigrationPhase'])" "$ROLLOUT_DECLARATION")" \
+        --allowed-roles legacy,preparer \
+        --enclosure "$PRIMARY_ARTIFACT" \
+        --app-artifact-manifest "$ARTIFACT_MANIFEST" \
+        --appcast "$APPCAST" \
+        --manifest "$ROLLOUT_MANIFEST"
 
-sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
-root = ET.parse(sys.argv[1]).getroot()
-items = root.findall("./channel/item")
-if len(items) != 1:
-    raise SystemExit(f"appcast must contain exactly one item, got {len(items)}")
-enclosures = items[0].findall("enclosure")
-if len(enclosures) != 1:
-    raise SystemExit(f"appcast item must contain exactly one enclosure, got {len(enclosures)}")
-item = items[0]
-enclosure = enclosures[0]
-values = [
-    enclosure.attrib.get("url", ""),
-    enclosure.attrib.get(f"{{{sparkle}}}edSignature", ""),
-    enclosure.attrib.get("length", ""),
-    item.findtext(f"{{{sparkle}}}version", default=""),
-    item.findtext(f"{{{sparkle}}}shortVersionString", default=""),
-]
-print("\t".join(values))
-PYTHON
-
-    local enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing
-    IFS=$'\t' read -r enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing < "$appcast_values"
-    [[ "$enclosure_url" == "$PUBLIC_UPDATE_BASE_URL/$UPDATE_ZIP_NAME" ]] ||
-        fail "Appcast enclosure URL mismatch: $enclosure_url"
+    local enclosure_signature
+    enclosure_signature="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['appcastItems'][0]['edSignature'])" "$ROLLOUT_MANIFEST")"
     [[ -n "$enclosure_signature" ]] || fail "Appcast enclosure is missing an EdDSA signature"
-    [[ "$enclosure_length" == "$(stat -f %z "$UPDATE_ZIP")" ]] ||
-        fail "Appcast enclosure length does not match $UPDATE_ZIP_NAME"
-    [[ "$appcast_build" == "$BUILD_NUMBER" ]] ||
-        fail "Appcast build mismatch: expected $BUILD_NUMBER, got $appcast_build"
-    [[ "$appcast_marketing" == "$MARKETING_VERSION" ]] ||
-        fail "Appcast marketing version mismatch: expected $MARKETING_VERSION, got $appcast_marketing"
 
     local private_key_file="$TMP_DIR/sparkle-private-key"
     local committed_public_key_file="$TMP_DIR/sparkle-public-key"
@@ -458,16 +526,55 @@ PYTHON
     [[ "$derived_public_key" == "$committed_public_key" ]] ||
         fail "Protected Sparkle private key does not match the app bundle SUPublicEDKey"
     archive_signature="$(printf '%s' "$SPARKLE_PRIVATE_KEY" |
-        "$SIGN_UPDATE" --ed-key-file - -p "$UPDATE_ZIP" |
+        "$SIGN_UPDATE" --ed-key-file - -p "$PRIMARY_ARTIFACT" |
         tr -d '\r\n')"
     [[ "$archive_signature" == "$enclosure_signature" ]] ||
         fail "Protected Sparkle private key does not reproduce the reviewed appcast signature"
     printf '%s' "$committed_public_key" > "$committed_public_key_file"
     xcrun swift "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift" \
-        "$committed_public_key_file" "$enclosure_signature" "$UPDATE_ZIP"
+        "$committed_public_key_file" "$enclosure_signature" "$PRIMARY_ARTIFACT"
+
+    verify_sibling_enclosures "$committed_public_key_file"
+}
+
+# Every predecessor sibling stays on its own immutable per-tag updater URL.
+# Each sibling's enclosure is re-downloaded and proven by exact size, SHA-256
+# digest, and EdDSA signature under the unchanged committed key, and each
+# predecessor rollout manifest is re-downloaded and proven against the SHA-256
+# binding reviewed in release-rollout.json. Predecessor binaries are verified
+# in place and never copied into the current release.
+verify_sibling_enclosures() {
+    local committed_public_key_file="$1"
+    local sibling_values="$TMP_DIR/sibling-values.tsv"
+    python3 "$STABLE_ROLLOUT_TOOL" sibling-values --manifest "$ROLLOUT_MANIFEST" > "$sibling_values"
+    local sibling_dir="$TMP_DIR/sibling-enclosures"
+    mkdir -p "$sibling_dir"
+    local position role tag url size sha256 signature manifest_name manifest_sha256
+    local sibling_asset sibling_manifest actual_digest
+    while IFS=$'\t' read -r position role tag url size sha256 signature manifest_name manifest_sha256; do
+        [[ "$tag" != "$RELEASE_TAG" ]] ||
+            fail "Sibling appcast items must stay on their own updater tags, found current tag $tag"
+        sibling_asset="$sibling_dir/$position-$(basename "$url")"
+        curl_anonymous "$url" --output "$sibling_asset"
+        [[ "$(stat -f %z "$sibling_asset")" == "$size" ]] ||
+            fail "Sibling enclosure length mismatch for $url"
+        actual_digest="$(shasum -a 256 "$sibling_asset" | awk '{ print $1 }')"
+        [[ "$actual_digest" == "$sha256" ]] ||
+            fail "Sibling enclosure digest mismatch for $url"
+        xcrun swift "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift" \
+            "$committed_public_key_file" "$signature" "$sibling_asset"
+        sibling_manifest="$sibling_dir/$position-$manifest_name"
+        curl_anonymous \
+            "https://github.com/$PUBLIC_UPDATE_REPOSITORY/releases/download/$tag/$manifest_name" \
+            --output "$sibling_manifest"
+        actual_digest="$(shasum -a 256 "$sibling_manifest" | awk '{ print $1 }')"
+        [[ "$actual_digest" == "$manifest_sha256" ]] ||
+            fail "Sibling rollout manifest digest mismatch for tag $tag"
+    done < "$sibling_values"
 }
 
 verify_source_release() {
+    resolve_release_artifact_role
     require_env RELEASE_TAG
     require_env RELEASE_COMMIT
     require_env SOURCE_GH_TOKEN
@@ -517,19 +624,24 @@ verify_source_release() {
         --pattern "$CHECKSUMS_NAME"
     CHECKSUMS="$SOURCE_ASSETS_DIR/$CHECKSUMS_NAME"
     verify_reviewed_checksums_digest
+    local download_args=()
+    local expected_asset
+    while IFS= read -r expected_asset; do
+        [[ "$expected_asset" == "$CHECKSUMS_NAME" ]] && continue
+        download_args+=(--pattern "$expected_asset")
+    done < <(source_asset_names)
     source_gh release download "$RELEASE_TAG" \
         --repo "$SOURCE_GITHUB_REPOSITORY" \
         --dir "$SOURCE_ASSETS_DIR" \
-        --pattern "$UPDATE_ZIP_NAME" \
-        --pattern "$DMG_NAME" \
-        --pattern "$APPCAST_NAME" \
-        --pattern "$ARTIFACT_MANIFEST_NAME"
+        "${download_args[@]}"
     recheck_source_assets
 
     UPDATE_ZIP="$SOURCE_ASSETS_DIR/$UPDATE_ZIP_NAME"
     DMG="$SOURCE_ASSETS_DIR/$DMG_NAME"
+    PRIMARY_ARTIFACT="$SOURCE_ASSETS_DIR/$PRIMARY_ARTIFACT_NAME"
     APPCAST="$SOURCE_ASSETS_DIR/$APPCAST_NAME"
     ARTIFACT_MANIFEST="$SOURCE_ASSETS_DIR/$ARTIFACT_MANIFEST_NAME"
+    ROLLOUT_MANIFEST="$SOURCE_ASSETS_DIR/$ROLLOUT_MANIFEST_NAME"
     validate_checksum_manifest
 
     ditto -x -k "$UPDATE_ZIP" "$EXTRACT_DIR"
@@ -605,17 +717,7 @@ verify_strictly_newer_build() {
     curl_anonymous \
         "https://github.com/$PUBLIC_UPDATE_REPOSITORY/releases/download/$latest_tag/$APPCAST_NAME" \
         --output "$latest_appcast"
-    latest_build="$(python3 - "$latest_appcast" <<'PYTHON'
-import sys
-import xml.etree.ElementTree as ET
-
-sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
-items = ET.parse(sys.argv[1]).getroot().findall("./channel/item")
-if len(items) != 1:
-    raise SystemExit("latest stable appcast must contain exactly one item")
-print(items[0].findtext(f"{{{sparkle}}}version", default=""))
-PYTHON
-)"
+    latest_build="$(python3 "$STABLE_ROLLOUT_TOOL" max-build --appcast "$latest_appcast")"
     [[ "$BUILD_NUMBER" =~ ^[0-9]+$ && "$latest_build" =~ ^[0-9]+$ ]] ||
         fail "Stable build numbers must be numeric: current=$BUILD_NUMBER latest=$latest_build"
     (( BUILD_NUMBER > latest_build )) ||
@@ -627,17 +729,20 @@ verify_existing_update_release() {
     local existing_assets_dir="$TMP_DIR/existing-update-assets"
     assert_exact_update_assets "$update_release_json"
     mkdir -p "$existing_assets_dir"
+    local download_args=()
+    local expected_asset
+    while IFS= read -r expected_asset; do
+        download_args+=(--pattern "$expected_asset")
+    done < <(update_asset_names)
     update_gh release download "$RELEASE_TAG" \
         --repo "$PUBLIC_UPDATE_REPOSITORY" \
         --dir "$existing_assets_dir" \
-        --pattern "$UPDATE_ZIP_NAME" \
-        --pattern "$APPCAST_NAME" \
-        --pattern "$CHECKSUMS_NAME" \
-        --pattern "$ARTIFACT_MANIFEST_NAME"
-    cmp "$UPDATE_ZIP" "$existing_assets_dir/$UPDATE_ZIP_NAME"
+        "${download_args[@]}"
+    cmp "$PRIMARY_ARTIFACT" "$existing_assets_dir/$PRIMARY_ARTIFACT_NAME"
     cmp "$APPCAST" "$existing_assets_dir/$APPCAST_NAME"
     cmp "$CHECKSUMS" "$existing_assets_dir/$CHECKSUMS_NAME"
     cmp "$ARTIFACT_MANIFEST" "$existing_assets_dir/$ARTIFACT_MANIFEST_NAME"
+    cmp "$ROLLOUT_MANIFEST" "$existing_assets_dir/$ROLLOUT_MANIFEST_NAME"
 }
 
 prepare_update_release() {
@@ -660,10 +765,11 @@ prepare_update_release() {
     fi
 
     update_gh release create "$RELEASE_TAG" \
-        "$UPDATE_ZIP" \
+        "$PRIMARY_ARTIFACT" \
         "$APPCAST" \
         "$CHECKSUMS" \
         "$ARTIFACT_MANIFEST" \
+        "$ROLLOUT_MANIFEST" \
         --repo "$PUBLIC_UPDATE_REPOSITORY" \
         --target main \
         --draft \
@@ -717,34 +823,44 @@ publish_reviewed_release() {
 
 verify_anonymous_publish() {
     local published_update_appcast="$TMP_DIR/published-update-appcast.xml"
-    local published_update_zip="$TMP_DIR/published-update-$UPDATE_ZIP_NAME"
+    local published_update_primary="$TMP_DIR/published-update-$PRIMARY_ARTIFACT_NAME"
     local published_update_checksums="$TMP_DIR/published-update-$CHECKSUMS_NAME"
     local published_update_manifest="$TMP_DIR/published-update-$ARTIFACT_MANIFEST_NAME"
-    local published_source_zip="$TMP_DIR/published-source-$UPDATE_ZIP_NAME"
+    local published_update_rollout="$TMP_DIR/published-update-$ROLLOUT_MANIFEST_NAME"
+    local published_source_rollout="$TMP_DIR/published-source-$ROLLOUT_MANIFEST_NAME"
+    local published_source_primary="$TMP_DIR/published-source-$PRIMARY_ARTIFACT_NAME"
     local published_source_dmg="$TMP_DIR/published-source-$DMG_NAME"
     local published_source_appcast="$TMP_DIR/published-source-$APPCAST_NAME"
     local published_source_checksums="$TMP_DIR/published-source-$CHECKSUMS_NAME"
     local published_source_manifest="$TMP_DIR/published-source-$ARTIFACT_MANIFEST_NAME"
 
     curl_anonymous "$PUBLIC_FEED_URL" --output "$published_update_appcast"
-    curl_anonymous "$PUBLIC_UPDATE_BASE_URL/$UPDATE_ZIP_NAME" --output "$published_update_zip"
+    curl_anonymous "$PUBLIC_UPDATE_BASE_URL/$PRIMARY_ARTIFACT_NAME" --output "$published_update_primary"
     curl_anonymous "$PUBLIC_UPDATE_BASE_URL/$CHECKSUMS_NAME" --output "$published_update_checksums"
     curl_anonymous "$PUBLIC_UPDATE_BASE_URL/$ARTIFACT_MANIFEST_NAME" --output "$published_update_manifest"
-    curl_anonymous "$SOURCE_RELEASE_BASE_URL/$UPDATE_ZIP_NAME" --output "$published_source_zip"
-    curl_anonymous "$SOURCE_RELEASE_BASE_URL/$DMG_NAME" --output "$published_source_dmg"
+    curl_anonymous "$PUBLIC_UPDATE_BASE_URL/$ROLLOUT_MANIFEST_NAME" --output "$published_update_rollout"
+    curl_anonymous "$SOURCE_RELEASE_BASE_URL/$PRIMARY_ARTIFACT_NAME" --output "$published_source_primary"
+    if release_role_ships_dmg; then
+        curl_anonymous "$SOURCE_RELEASE_BASE_URL/$DMG_NAME" --output "$published_source_dmg"
+    fi
     curl_anonymous "$SOURCE_RELEASE_BASE_URL/$APPCAST_NAME" --output "$published_source_appcast"
     curl_anonymous "$SOURCE_RELEASE_BASE_URL/$CHECKSUMS_NAME" --output "$published_source_checksums"
     curl_anonymous "$SOURCE_RELEASE_BASE_URL/$ARTIFACT_MANIFEST_NAME" --output "$published_source_manifest"
+    curl_anonymous "$SOURCE_RELEASE_BASE_URL/$ROLLOUT_MANIFEST_NAME" --output "$published_source_rollout"
 
     cmp "$APPCAST" "$published_update_appcast"
-    cmp "$UPDATE_ZIP" "$published_update_zip"
+    cmp "$PRIMARY_ARTIFACT" "$published_update_primary"
     cmp "$CHECKSUMS" "$published_update_checksums"
     cmp "$ARTIFACT_MANIFEST" "$published_update_manifest"
-    cmp "$UPDATE_ZIP" "$published_source_zip"
-    cmp "$DMG" "$published_source_dmg"
+    cmp "$PRIMARY_ARTIFACT" "$published_source_primary"
+    if release_role_ships_dmg; then
+        cmp "$DMG" "$published_source_dmg"
+    fi
     cmp "$APPCAST" "$published_source_appcast"
     cmp "$CHECKSUMS" "$published_source_checksums"
     cmp "$ARTIFACT_MANIFEST" "$published_source_manifest"
+    cmp "$ROLLOUT_MANIFEST" "$published_update_rollout"
+    cmp "$ROLLOUT_MANIFEST" "$published_source_rollout"
 
     local update_latest_url source_latest_url
     update_latest_url="$(curl_anonymous \

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -36,15 +36,32 @@ STAGE_ARCHIVE_CHECKSUM="$STAGE_ARCHIVE.sha256"
 RELEASE_TAG="${RELEASE_TAG:-}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-repoprompt/repoprompt-ce}"
 PUBLIC_UPDATE_REPOSITORY="${PUBLIC_UPDATE_REPOSITORY:-repoprompt/repoprompt-ce-updates}"
-DOWNLOAD_URL_PREFIX="${DOWNLOAD_URL_PREFIX:-https://github.com/$PUBLIC_UPDATE_REPOSITORY/releases/download/$RELEASE_TAG/}"
 EXPECTED_FEED_URL="https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml"
 SPARKLE_FRAMEWORK_INFO="$ROOT_DIR/Vendor/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework/Versions/B/Resources/Info.plist"
 TMP_DIR=""
 RUN_WITHOUT_GITHUB_TOKENS="$CONTROL_PLANE_SCRIPTS_DIR/run_without_github_tokens.sh"
+STABLE_ROLLOUT_TOOL="$CONTROL_PLANE_SCRIPTS_DIR/stable_rollout.py"
+APPLE_IDENTITY_POLICY="$CONTROL_PLANE_SCRIPTS_DIR/apple_identity_policy.json"
+ROLLOUT_DECLARATION="$ROOT_DIR/release-rollout.json"
+ROLLOUT_MANIFEST="$DIST_DIR/$ARCHIVE_BASENAME-stable-rollout.json"
+SIGN_UPDATE="$TRUSTED_ROOT/Vendor/Sparkle/bin/sign_update"
 
 fail() {
     printf 'ERROR: %s\n' "$*" >&2
     exit 1
+}
+
+# release.sh builds legacy/preparer application artifacts only. The reviewed
+# release-rollout.json declaration is the single role authority: transition or
+# successor declarations, sibling predecessors, and the successor identity all
+# fail here before signing or GitHub mutation.
+require_dormant_rollout_declaration() {
+    require_file "$ROLLOUT_DECLARATION"
+    require_file "$APPLE_IDENTITY_POLICY"
+    require_file "$STABLE_ROLLOUT_TOOL"
+    python3 "$STABLE_ROLLOUT_TOOL" workflow-guard \
+        --declaration "$ROLLOUT_DECLARATION" \
+        --policy "$APPLE_IDENTITY_POLICY"
 }
 
 require_command() {
@@ -132,8 +149,10 @@ run_preflight() {
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"
     require_file "$TRUSTED_ROOT/Vendor/Sparkle/INSTALLED_MANIFEST.tsv"
-    require_file "$TRUSTED_ROOT/Vendor/Sparkle/bin/generate_appcast"
+    require_file "$SIGN_UPDATE"
     require_file "$SPARKLE_FRAMEWORK_INFO"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/build_identity_transition_pkg.sh"
+    require_dormant_rollout_declaration
 
     local sparkle_version feed_url
     sparkle_version="$(plutil -extract CFBundleShortVersionString raw "$SPARKLE_FRAMEWORK_INFO")"
@@ -693,15 +712,24 @@ publish_staged_release() {
     xcrun stapler staple "$DMG"
     xcrun stapler validate "$DMG"
 
-    local appcast_dir="$TMP_DIR/appcast"
-    mkdir -p "$appcast_dir"
-    cp "$UPDATE_ZIP" "$appcast_dir/"
-    printf '%s' "$SPARKLE_PRIVATE_KEY" |
-        "$TRUSTED_ROOT/Vendor/Sparkle/bin/generate_appcast" \
-            --ed-key-file - \
-            --download-url-prefix "$DOWNLOAD_URL_PREFIX" \
-            -o "$APPCAST" \
-            "$appcast_dir"
+    local enclosure_signature
+    enclosure_signature="$(printf '%s' "$SPARKLE_PRIVATE_KEY" |
+        "$SIGN_UPDATE" --ed-key-file - -p "$UPDATE_ZIP" |
+        tr -d '\r\n')"
+    [[ -n "$enclosure_signature" ]] || fail "Unable to produce the Sparkle EdDSA signature for the update archive"
+    python3 "$STABLE_ROLLOUT_TOOL" generate \
+        --declaration "$ROLLOUT_DECLARATION" \
+        --policy "$APPLE_IDENTITY_POLICY" \
+        --version-env "$ROOT_DIR/version.env" \
+        --release-tag "$RELEASE_TAG" \
+        --release-commit "$RELEASE_COMMIT" \
+        --migration-phase "${REPOPROMPT_IDENTITY_MIGRATION_PHASE:-disabled}" \
+        --allowed-roles legacy,preparer \
+        --enclosure "$UPDATE_ZIP" \
+        --enclosure-signature "$enclosure_signature" \
+        --app-artifact-manifest "$FINAL_ARTIFACT_MANIFEST" \
+        --appcast-output "$APPCAST" \
+        --manifest-output "$ROLLOUT_MANIFEST"
 
     (
         cd "$DIST_DIR"
@@ -710,6 +738,7 @@ publish_staged_release() {
             "$(basename "$DMG")" \
             "$(basename "$APPCAST")" \
             "$(basename "$FINAL_ARTIFACT_MANIFEST")" \
+            "$(basename "$ROLLOUT_MANIFEST")" \
             > "$(basename "$CHECKSUMS")"
     )
 
@@ -721,6 +750,7 @@ publish_staged_release() {
         "$APPCAST"
         "$CHECKSUMS"
         "$FINAL_ARTIFACT_MANIFEST"
+        "$ROLLOUT_MANIFEST"
         --verify-tag
         --title "$DISPLAY_NAME $MARKETING_VERSION"
         --generate-notes

--- a/Scripts/stable_rollout.py
+++ b/Scripts/stable_rollout.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Single Stable rollout authority for the Apple identity transition.
+
+Owns the reviewed declaration (`release-rollout.json`), the generated immutable
+rollout manifest (`dist/<archive-basename>-stable-rollout.json`), and the
+accumulated Stable appcast. Version/build/bundle/team values are never
+duplicated in the declaration; they are derived from `version.env` and
+`Scripts/apple_identity_policy.json` and cross-checked here.
+
+Commands:
+- ``workflow-guard``: protected workflows call this to reject transition or
+  successor roles, sibling predecessors, and the successor identity.
+- ``current-role``: print the declared role for shell callers.
+- ``generate``: assemble the accumulated appcast plus rollout manifest.
+- ``validate``: prove a reviewed appcast/manifest pair against the declaration,
+  policy, version metadata, and enclosure/app-manifest digests.
+- ``max-build``: greatest Sparkle build in an appcast (monotonicity input).
+- ``sibling-values``: TSV projection of predecessor items for shell loops.
+
+EdDSA signing/verification stays in shell (sign_update /
+verify_sparkle_signature.swift); publication stays in the protected workflows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+SPARKLE_NAMESPACE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+ROLLOUT_NAMESPACE = "https://repoprompt.com/xml-namespaces/rollout"
+DECLARATION_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 1
+POLICY_SCHEMA_VERSION = 1
+
+ROLES = ("legacy", "preparer", "transition", "successor")
+WORKFLOW_ALLOWED_ROLES = ("legacy", "preparer")
+ROLE_IDENTITY = {
+    "legacy": "legacy",
+    "preparer": "legacy",
+    "transition": "successor",
+    "successor": "successor",
+}
+ROLE_MIGRATION_PHASE = {
+    "legacy": "disabled",
+    "preparer": "legacy-preparer",
+    "transition": "disabled",
+    "successor": "disabled",
+}
+ROLE_INSTALLATION_TYPE = {
+    "legacy": "application",
+    "preparer": "application",
+    "transition": "package",
+    "successor": "application",
+}
+ROLE_ENCLOSURE_SUFFIX = {
+    "legacy": ".zip",
+    "preparer": ".zip",
+    "transition": ".pkg",
+    "successor": ".zip",
+}
+# Newest-first role chains permitted in an accumulated appcast.
+ALLOWED_ROLE_CHAINS = (
+    ("legacy",),
+    ("preparer",),
+    ("transition", "preparer"),
+    ("successor", "transition", "preparer"),
+)
+
+DECLARATION_KEYS = {
+    "schemaVersion",
+    "channel",
+    "currentRole",
+    "eligibilityProfile",
+    "expectedMigrationPhase",
+    "expectedSigningIdentity",
+    "predecessors",
+}
+PREDECESSOR_KEYS = {"role", "tag", "rolloutManifestSha256"}
+
+
+class RolloutError(Exception):
+    pass
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def parse_build(raw: str, label: str) -> tuple[int, ...]:
+    parts = str(raw).split(".")
+    if not (1 <= len(parts) <= 3) or not all(part.isdigit() and part != "" for part in parts):
+        raise RolloutError(f"malformed {label}: {raw!r}")
+    numbers = tuple(int(part) for part in parts)
+    return numbers + (0,) * (3 - len(numbers))
+
+
+def load_json(path: Path, label: str) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RolloutError(f"unreadable {label} at {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise RolloutError(f"{label} must be a JSON object")
+    return data
+
+
+def load_policy(path: Path) -> dict:
+    policy = load_json(path, "apple identity policy")
+    if policy.get("schemaVersion") != POLICY_SCHEMA_VERSION:
+        raise RolloutError("apple identity policy schema version mismatch")
+    for identity in ("legacy", "successor"):
+        entry = policy.get("identities", {}).get(identity)
+        if not isinstance(entry, dict) or not all(
+            isinstance(entry.get(key), str) and entry.get(key)
+            for key in ("bundleIdentifier", "teamIdentifier", "developerIDRequirement")
+        ):
+            raise RolloutError(f"apple identity policy is missing the {identity} identity")
+    sparkle = policy.get("sparkle")
+    if not isinstance(sparkle, dict) or not all(
+        isinstance(sparkle.get(key), str) and sparkle.get(key)
+        for key in ("stableFeedURL", "sparklePublicEdDSAValue", "updateRepository", "minimumSystemVersion")
+    ):
+        raise RolloutError("apple identity policy is missing sparkle invariants")
+    return policy
+
+
+def load_declaration(path: Path) -> dict:
+    declaration = load_json(path, "rollout declaration")
+    if set(declaration) != DECLARATION_KEYS:
+        raise RolloutError(
+            "rollout declaration keys must be exactly "
+            + ", ".join(sorted(DECLARATION_KEYS))
+        )
+    if declaration["schemaVersion"] != DECLARATION_SCHEMA_VERSION:
+        raise RolloutError("rollout declaration schema version mismatch")
+    if declaration["channel"] != "stable":
+        raise RolloutError("rollout declaration channel must be stable")
+    role = declaration["currentRole"]
+    if role not in ROLES:
+        raise RolloutError(f"unknown rollout role: {role!r}")
+    if not isinstance(declaration["eligibilityProfile"], str) or not declaration["eligibilityProfile"]:
+        raise RolloutError("rollout declaration eligibilityProfile must be a nonempty string")
+    if declaration["expectedMigrationPhase"] != ROLE_MIGRATION_PHASE[role]:
+        raise RolloutError(
+            f"declared migration phase must be {ROLE_MIGRATION_PHASE[role]} for the {role} role"
+        )
+    if declaration["expectedSigningIdentity"] != ROLE_IDENTITY[role]:
+        raise RolloutError(
+            f"declared signing identity must be {ROLE_IDENTITY[role]} for the {role} role"
+        )
+    predecessors = declaration["predecessors"]
+    if not isinstance(predecessors, list):
+        raise RolloutError("rollout declaration predecessors must be a list")
+    for position, entry in enumerate(predecessors, start=1):
+        if not isinstance(entry, dict) or set(entry) != PREDECESSOR_KEYS:
+            raise RolloutError(
+                f"predecessor {position} keys must be exactly " + ", ".join(sorted(PREDECESSOR_KEYS))
+            )
+        if entry["role"] not in ROLES:
+            raise RolloutError(f"predecessor {position} has unknown role {entry['role']!r}")
+        if not isinstance(entry["tag"], str) or not entry["tag"].startswith("v"):
+            raise RolloutError(f"predecessor {position} tag must look like v<marketing-version>")
+        digest = entry["rolloutManifestSha256"]
+        if not isinstance(digest, str) or len(digest) != 64 or not all(c in "0123456789abcdef" for c in digest):
+            raise RolloutError(f"predecessor {position} rolloutManifestSha256 must be lowercase hex sha256")
+    chain = (role, *[entry["role"] for entry in predecessors])
+    if chain not in ALLOWED_ROLE_CHAINS:
+        raise RolloutError(
+            "declared role chain "
+            + " -> ".join(chain)
+            + " is not an allowed newest-first rollout chain"
+        )
+    return declaration
+
+
+def load_version_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        values[key.strip()] = value.strip().strip('"')
+    for key in ("APP_NAME", "MARKETING_VERSION", "BUILD_NUMBER", "BUNDLE_ID", "SIGNING_TEAM_ID"):
+        if not values.get(key):
+            raise RolloutError(f"version.env is missing {key}")
+    return values
+
+
+def expected_enclosure_name(app_name: str, marketing: str, build: str, role: str) -> str:
+    return f"{app_name}-{marketing}-{build}{ROLE_ENCLOSURE_SUFFIX[role]}"
+
+
+def rollout_manifest_name(app_name: str, marketing: str, build: str) -> str:
+    return f"{app_name}-{marketing}-{build}-stable-rollout.json"
+
+
+def enclosure_url(update_repository: str, tag: str, name: str) -> str:
+    return f"https://github.com/{update_repository}/releases/download/{tag}/{name}"
+
+
+def validate_item_shape(item: dict, position: int, policy: dict, app_name: str) -> None:
+    minimum_system = policy["sparkle"]["minimumSystemVersion"]
+    role = item.get("role")
+    if role not in ROLES:
+        raise RolloutError(f"appcast item {position} has unknown role {role!r}")
+    build = str(item.get("buildNumber", ""))
+    marketing = str(item.get("marketingVersion", ""))
+    parse_build(build, f"item {position} build number")
+    tag = item.get("tag", "")
+    if tag != f"v{marketing}":
+        raise RolloutError(f"appcast item {position} tag must be v{marketing}, got {tag!r}")
+    if item.get("minimumSystemVersion") != minimum_system:
+        raise RolloutError(
+            f"appcast item {position} minimumSystemVersion must be exactly {minimum_system}"
+        )
+    if item.get("installationType") != ROLE_INSTALLATION_TYPE[role]:
+        raise RolloutError(
+            f"appcast item {position} installation type must be "
+            f"{ROLE_INSTALLATION_TYPE[role]} for the {role} role"
+        )
+    expected_name = expected_enclosure_name(app_name, marketing, build, role)
+    if item.get("enclosureName") != expected_name:
+        raise RolloutError(
+            f"appcast item {position} enclosure name must be {expected_name}, got {item.get('enclosureName')!r}"
+        )
+    if item.get("url") != enclosure_url(policy["sparkle"]["updateRepository"], tag, expected_name):
+        raise RolloutError(f"appcast item {position} enclosure URL mismatch: {item.get('url')!r}")
+    size = item.get("enclosureSize")
+    if not isinstance(size, int) or size <= 0:
+        raise RolloutError(f"appcast item {position} enclosure size must be a positive integer")
+    digest = item.get("enclosureSha256", "")
+    if not isinstance(digest, str) or len(digest) != 64:
+        raise RolloutError(f"appcast item {position} enclosure sha256 is malformed")
+    if not item.get("edSignature"):
+        raise RolloutError(f"appcast item {position} is missing an EdDSA signature")
+
+
+def validate_item_ladder(items: list[dict]) -> None:
+    chain = tuple(item["role"] for item in items)
+    if chain not in ALLOWED_ROLE_CHAINS:
+        raise RolloutError(
+            "appcast role chain " + " -> ".join(chain) + " is not an allowed newest-first rollout chain"
+        )
+    builds = [parse_build(str(item["buildNumber"]), "item build") for item in items]
+    for newer, older in zip(builds, builds[1:]):
+        if not newer > older:
+            raise RolloutError("appcast builds must be unique and strictly ordered newest-first")
+    for position, item in enumerate(items):
+        expected = str(items[position + 1]["buildNumber"]) if position + 1 < len(items) else None
+        actual = item.get("minimumAutoupdateVersion")
+        if actual != expected:
+            raise RolloutError(
+                f"appcast item {position + 1} minimumAutoupdateVersion must be "
+                f"{expected!r} (the immediately older build), got {actual!r}"
+            )
+
+
+def xml_escape(value: str) -> str:
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def render_appcast(manifest: dict) -> str:
+    lines = [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<rss version="2.0" '
+        f'xmlns:sparkle="{SPARKLE_NAMESPACE}" '
+        f'xmlns:repoprompt="{ROLLOUT_NAMESPACE}">',
+        "  <channel>",
+        "    <title>RepoPrompt CE Stable</title>",
+    ]
+    for item in manifest["appcastItems"]:
+        lines.append("    <item>")
+        lines.append(f"      <title>Version {xml_escape(str(item['marketingVersion']))}</title>")
+        lines.append(
+            f"      <repoprompt:rolloutRole>{xml_escape(item['role'])}</repoprompt:rolloutRole>"
+        )
+        lines.append(f"      <sparkle:version>{xml_escape(str(item['buildNumber']))}</sparkle:version>")
+        lines.append(
+            "      <sparkle:shortVersionString>"
+            f"{xml_escape(str(item['marketingVersion']))}</sparkle:shortVersionString>"
+        )
+        lines.append(
+            "      <sparkle:minimumSystemVersion>"
+            f"{xml_escape(item['minimumSystemVersion'])}</sparkle:minimumSystemVersion>"
+        )
+        if item["minimumAutoupdateVersion"] is not None:
+            lines.append(
+                "      <sparkle:minimumAutoupdateVersion>"
+                f"{xml_escape(str(item['minimumAutoupdateVersion']))}</sparkle:minimumAutoupdateVersion>"
+            )
+        enclosure = (
+            f'      <enclosure url="{xml_escape(item["url"])}" '
+            f'length="{item["enclosureSize"]}" '
+            'type="application/octet-stream" '
+            f'sparkle:edSignature="{xml_escape(item["edSignature"])}"'
+        )
+        if item["installationType"] == "package":
+            enclosure += ' sparkle:installationType="package"'
+        enclosure += "/>"
+        lines.append(enclosure)
+        lines.append("    </item>")
+    lines.append("  </channel>")
+    lines.append("</rss>")
+    return "\n".join(lines) + "\n"
+
+
+def load_manifest(path: Path) -> dict:
+    manifest = load_json(path, "rollout manifest")
+    if manifest.get("schemaVersion") != MANIFEST_SCHEMA_VERSION:
+        raise RolloutError("rollout manifest schema version mismatch")
+    if not isinstance(manifest.get("appcastItems"), list) or not manifest["appcastItems"]:
+        raise RolloutError("rollout manifest must contain appcast items")
+    return manifest
+
+
+def load_predecessor_manifests(
+    declaration: dict, manifest_paths: list[str], policy: dict, app_name: str
+) -> list[dict]:
+    predecessors = declaration["predecessors"]
+    if len(manifest_paths) != len(predecessors):
+        raise RolloutError(
+            f"expected {len(predecessors)} predecessor manifest file(s), got {len(manifest_paths)}"
+        )
+    loaded: list[dict] = []
+    for position, (entry, manifest_path) in enumerate(zip(predecessors, manifest_paths), start=1):
+        path = Path(manifest_path)
+        digest = sha256_file(path)
+        if digest != entry["rolloutManifestSha256"]:
+            raise RolloutError(
+                f"predecessor {position} rollout manifest digest mismatch for tag {entry['tag']}: "
+                f"expected {entry['rolloutManifestSha256']}, got {digest}"
+            )
+        manifest = load_manifest(path)
+        if manifest.get("currentRole") != entry["role"]:
+            raise RolloutError(
+                f"predecessor {position} manifest role mismatch: declaration says {entry['role']}, "
+                f"manifest says {manifest.get('currentRole')}"
+            )
+        if manifest.get("sourceTag") != entry["tag"]:
+            raise RolloutError(
+                f"predecessor {position} manifest tag mismatch: declaration says {entry['tag']}, "
+                f"manifest says {manifest.get('sourceTag')}"
+            )
+        current_item = manifest["appcastItems"][0]
+        validate_item_shape(current_item, position, policy, app_name)
+        loaded.append(manifest)
+    return loaded
+
+
+def build_manifest(args: argparse.Namespace) -> tuple[dict, str]:
+    policy = load_policy(Path(args.policy))
+    declaration = load_declaration(Path(args.declaration))
+    version = load_version_env(Path(args.version_env))
+    role = declaration["currentRole"]
+
+    allowed_roles = tuple(args.allowed_roles.split(",")) if args.allowed_roles else ROLES
+    if role not in allowed_roles:
+        raise RolloutError(
+            f"the {role} rollout role is not allowed here (allowed: {', '.join(allowed_roles)})"
+        )
+
+    identity = policy["identities"][ROLE_IDENTITY[role]]
+    if ROLE_IDENTITY[role] == "legacy":
+        if version["BUNDLE_ID"] != identity["bundleIdentifier"]:
+            raise RolloutError("version.env BUNDLE_ID does not match the legacy identity policy")
+        if version["SIGNING_TEAM_ID"] != identity["teamIdentifier"]:
+            raise RolloutError("version.env SIGNING_TEAM_ID does not match the legacy identity policy")
+
+    marketing = version["MARKETING_VERSION"]
+    build = version["BUILD_NUMBER"]
+    app_name = version["APP_NAME"]
+    if args.release_tag != f"v{marketing}":
+        raise RolloutError(f"release tag must be v{marketing}, got {args.release_tag}")
+    if args.migration_phase != ROLE_MIGRATION_PHASE[role]:
+        raise RolloutError(
+            f"migration phase must be {ROLE_MIGRATION_PHASE[role]} for the {role} role, "
+            f"got {args.migration_phase}"
+        )
+
+    enclosure = Path(args.enclosure)
+    expected_name = expected_enclosure_name(app_name, marketing, build, role)
+    if enclosure.name != expected_name:
+        raise RolloutError(f"enclosure must be named {expected_name}, got {enclosure.name}")
+    if not args.enclosure_signature.strip():
+        raise RolloutError("enclosure EdDSA signature must be nonempty")
+    app_artifact_manifest = Path(args.app_artifact_manifest)
+
+    predecessor_manifests = load_predecessor_manifests(
+        declaration, args.predecessor_manifest, policy, app_name
+    )
+
+    tag = args.release_tag
+    current_item = {
+        "role": role,
+        "tag": tag,
+        "url": enclosure_url(policy["sparkle"]["updateRepository"], tag, expected_name),
+        "buildNumber": build,
+        "marketingVersion": marketing,
+        "minimumSystemVersion": policy["sparkle"]["minimumSystemVersion"],
+        "minimumAutoupdateVersion": (
+            str(predecessor_manifests[0]["appcastItems"][0]["buildNumber"])
+            if predecessor_manifests
+            else None
+        ),
+        "installationType": ROLE_INSTALLATION_TYPE[role],
+        "enclosureName": expected_name,
+        "enclosureSize": enclosure.stat().st_size,
+        "enclosureSha256": sha256_file(enclosure),
+        "edSignature": args.enclosure_signature.strip(),
+        "rolloutManifestSha256": None,
+        "rolloutManifestName": None,
+    }
+    items = [current_item]
+    for entry, manifest in zip(declaration["predecessors"], predecessor_manifests):
+        predecessor_item = dict(manifest["appcastItems"][0])
+        predecessor_item["rolloutManifestSha256"] = entry["rolloutManifestSha256"]
+        predecessor_item["rolloutManifestName"] = rollout_manifest_name(
+            app_name,
+            str(predecessor_item["marketingVersion"]),
+            str(predecessor_item["buildNumber"]),
+        )
+        items.append(predecessor_item)
+
+    for position, item in enumerate(items, start=1):
+        validate_item_shape(item, position, policy, app_name)
+    validate_item_ladder(items)
+
+    manifest = {
+        "schemaVersion": MANIFEST_SCHEMA_VERSION,
+        "channel": "stable",
+        "sourceTag": tag,
+        "releaseCommit": args.release_commit,
+        "currentRole": role,
+        "signingIdentity": ROLE_IDENTITY[role],
+        "bundleIdentifier": identity["bundleIdentifier"],
+        "teamIdentifier": identity["teamIdentifier"],
+        "marketingVersion": marketing,
+        "buildNumber": build,
+        "migrationPhase": args.migration_phase,
+        "eligibilityProfile": declaration["eligibilityProfile"],
+        "updateRepository": policy["sparkle"]["updateRepository"],
+        "appArtifactManifest": {
+            "name": app_artifact_manifest.name,
+            "sha256": sha256_file(app_artifact_manifest),
+        },
+        "appcastItems": items,
+    }
+    return manifest, render_appcast(manifest)
+
+
+def run_generate(args: argparse.Namespace) -> None:
+    if not args.enclosure_signature.strip():
+        raise RolloutError("generate requires --enclosure-signature")
+    manifest, appcast = build_manifest(args)
+    Path(args.manifest_output).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    Path(args.appcast_output).write_text(appcast, encoding="utf-8")
+    print(
+        f"OK: generated stable rollout manifest and appcast with {len(manifest['appcastItems'])} "
+        f"item(s) for the {manifest['currentRole']} role."
+    )
+
+
+def run_validate(args: argparse.Namespace) -> None:
+    if not args.enclosure_signature:
+        # The reviewed manifest carries the published signature; shell callers
+        # separately prove it with the protected private key.
+        actual_items = load_manifest(Path(args.manifest))["appcastItems"]
+        args.enclosure_signature = str(actual_items[0].get("edSignature", ""))
+    expected_manifest, expected_appcast = build_manifest(args)
+    actual_manifest_text = Path(args.manifest).read_text(encoding="utf-8")
+    expected_manifest_text = json.dumps(expected_manifest, indent=2, sort_keys=True) + "\n"
+    if actual_manifest_text != expected_manifest_text:
+        actual = load_manifest(Path(args.manifest))
+        for key, expected_value in expected_manifest.items():
+            if actual.get(key) != expected_value:
+                raise RolloutError(
+                    f"rollout manifest field {key} mismatch: "
+                    f"expected {json.dumps(expected_value, sort_keys=True)}, "
+                    f"got {json.dumps(actual.get(key), sort_keys=True)}"
+                )
+        raise RolloutError("rollout manifest does not match its regenerated projection")
+    actual_appcast = Path(args.appcast).read_text(encoding="utf-8")
+    if actual_appcast != expected_appcast:
+        raise RolloutError("accumulated appcast does not match the generated rollout manifest")
+    print(
+        f"OK: stable rollout manifest and appcast validated with "
+        f"{len(expected_manifest['appcastItems'])} item(s)."
+    )
+
+
+def run_workflow_guard(args: argparse.Namespace) -> None:
+    load_policy(Path(args.policy))
+    declaration = load_declaration(Path(args.declaration))
+    role = declaration["currentRole"]
+    if role not in WORKFLOW_ALLOWED_ROLES:
+        raise RolloutError(
+            f"protected workflows reject the {role} rollout role until successor rollout enablement"
+        )
+    if declaration["predecessors"]:
+        raise RolloutError(
+            "protected workflows reject sibling predecessor publication until successor rollout enablement"
+        )
+    if declaration["expectedSigningIdentity"] != "legacy":
+        raise RolloutError("protected workflows reject the successor signing identity")
+    print(f"OK: rollout declaration permits the dormant-safe {role} role with no siblings.")
+
+
+def run_current_role(args: argparse.Namespace) -> None:
+    print(load_declaration(Path(args.declaration))["currentRole"])
+
+
+def run_max_build(args: argparse.Namespace) -> None:
+    try:
+        root = ET.parse(args.appcast).getroot()
+    except ET.ParseError as error:
+        raise RolloutError(f"unparseable appcast XML: {error}") from error
+    items = root.findall("./channel/item")
+    if not items:
+        raise RolloutError("appcast must contain at least one item")
+    builds: list[tuple[tuple[int, ...], str]] = []
+    for position, item in enumerate(items, start=1):
+        versions = item.findall(f"{{{SPARKLE_NAMESPACE}}}version")
+        if len(versions) != 1 or not (versions[0].text or "").strip():
+            raise RolloutError(f"appcast item {position} must contain exactly one sparkle:version")
+        raw = (versions[0].text or "").strip()
+        builds.append((parse_build(raw, f"item {position} build"), raw))
+    print(max(builds)[1])
+
+
+def run_sibling_values(args: argparse.Namespace) -> None:
+    manifest = load_manifest(Path(args.manifest))
+    for position, item in enumerate(manifest["appcastItems"][1:], start=2):
+        print(
+            "\t".join(
+                str(value)
+                for value in (
+                    position,
+                    item["role"],
+                    item["tag"],
+                    item["url"],
+                    item["enclosureSize"],
+                    item["enclosureSha256"],
+                    item["edSignature"],
+                    item["rolloutManifestName"],
+                    item["rolloutManifestSha256"],
+                )
+            )
+        )
+
+
+def add_shared_generate_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--declaration", required=True)
+    parser.add_argument("--policy", required=True)
+    parser.add_argument("--version-env", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--release-commit", required=True)
+    parser.add_argument("--migration-phase", required=True)
+    parser.add_argument("--enclosure", required=True)
+    parser.add_argument("--enclosure-signature", default="")
+    parser.add_argument("--app-artifact-manifest", required=True)
+    parser.add_argument("--predecessor-manifest", action="append", default=[])
+    parser.add_argument("--allowed-roles")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    guard = subparsers.add_parser("workflow-guard")
+    guard.add_argument("--declaration", required=True)
+    guard.add_argument("--policy", required=True)
+    guard.set_defaults(func=run_workflow_guard)
+
+    current_role = subparsers.add_parser("current-role")
+    current_role.add_argument("--declaration", required=True)
+    current_role.set_defaults(func=run_current_role)
+
+    generate = subparsers.add_parser("generate")
+    add_shared_generate_arguments(generate)
+    generate.add_argument("--appcast-output", required=True)
+    generate.add_argument("--manifest-output", required=True)
+    generate.set_defaults(func=run_generate)
+
+    validate = subparsers.add_parser("validate")
+    add_shared_generate_arguments(validate)
+    validate.add_argument("--appcast", required=True)
+    validate.add_argument("--manifest", required=True)
+    validate.set_defaults(func=run_validate)
+
+    max_build = subparsers.add_parser("max-build")
+    max_build.add_argument("--appcast", required=True)
+    max_build.set_defaults(func=run_max_build)
+
+    sibling_values = subparsers.add_parser("sibling-values")
+    sibling_values.add_argument("--manifest", required=True)
+    sibling_values.set_defaults(func=run_sibling_values)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        args.func(args)
+    except RolloutError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Scripts/test_release_promotion.py
+++ b/Scripts/test_release_promotion.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import textwrap
 import unittest
@@ -59,6 +61,15 @@ class ReleasePromotionTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("OK: anonymous release smoke passed for v1.0.0.", result.stdout)
+        # Application-style roles (legacy/preparer) must still anonymously fetch
+        # and byte-compare the source DMG; the fetch under the role predicate is
+        # immediately followed by cmp, so a skipped download here would mean the
+        # DMG verification silently regressed to a no-op.
+        tool_calls = tools.read_text(encoding="utf-8")
+        self.assertIn(
+            "curl GET https://github.com/repoprompt/repoprompt-ce/releases/download/v1.0.0/RepoPrompt-1.0.0-1.dmg",
+            tool_calls,
+        )
         calls = capture.read_text(encoding="utf-8").splitlines()
         create = next(index for index, line in enumerate(calls) if "release create v1.0.0" in line)
         publish_update = next(
@@ -150,7 +161,7 @@ class ReleasePromotionTests(unittest.TestCase):
         result, _capture, _tools = self.run_promotion("verify", duplicate_appcast_item=True)
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("appcast must contain exactly one item", result.stderr)
+        self.assertIn("accumulated appcast does not match the generated rollout manifest", result.stderr)
 
     def test_verify_rejects_mismatched_dmg_app(self) -> None:
         result, _capture, _tools = self.run_promotion("verify", mismatched_dmg_app=True)
@@ -191,7 +202,7 @@ class ReleasePromotionTests(unittest.TestCase):
         )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("Appcast enclosure URL mismatch", result.stderr)
+        self.assertIn("accumulated appcast does not match the generated rollout manifest", result.stderr)
 
     def test_verify_rejects_tag_that_disagrees_with_release_metadata(self) -> None:
         result, _capture, _tools = self.run_promotion("verify", release_tag="v1.0.1")
@@ -253,6 +264,8 @@ class ReleasePromotionTests(unittest.TestCase):
         shutil.copy2(SCRIPT_DIR / "validate_packaged_legal.sh", scripts / "validate_packaged_legal.sh")
         shutil.copy2(SCRIPT_DIR / "load_release_metadata.sh", scripts / "load_release_metadata.sh")
         shutil.copy2(SCRIPT_DIR / "verify_sparkle_signature.swift", scripts / "verify_sparkle_signature.swift")
+        shutil.copy2(SCRIPT_DIR / "stable_rollout.py", scripts / "stable_rollout.py")
+        shutil.copy2(SCRIPT_DIR / "apple_identity_policy.json", scripts / "apple_identity_policy.json")
         (scripts / "codex_runtime_artifact.py").write_text(
             "#!/usr/bin/env python3\nimport os\nimport sys\nfrom pathlib import Path\n\nargs = sys.argv[1:]\nexpected_manifest = Path(os.environ[\"FAKE_CODEX_MANIFEST\"])\nif len(args) != 9 or args[:6] != [\n    \"--manifest\",\n    str(expected_manifest),\n    \"verify-bundle\",\n    \"--arch\",\n    \"all\",\n    \"--bundle\",\n] or args[7:] != [\"--signed-team-identifier\", \"648A27MST5\"]:\n    print(f\"ERROR: unexpected Codex verifier arguments: {args!r}\", file=sys.stderr)\n    raise SystemExit(64)\nbundle = Path(args[6])\nif not expected_manifest.is_file():\n    print(f\"ERROR: missing approved Codex manifest: {expected_manifest}\", file=sys.stderr)\n    raise SystemExit(65)\nexpected_targets = {\"aarch64-apple-darwin\", \"x86_64-apple-darwin\"}\nif not bundle.is_dir() or {path.name for path in bundle.iterdir()} != expected_targets:\n    print(f\"ERROR: missing embedded Codex package targets: {bundle}\", file=sys.stderr)\n    raise SystemExit(66)\nexpected_suffix = Path(\"Contents/Resources/BundledRuntimes/Codex\")\nif tuple(bundle.parts[-len(expected_suffix.parts):]) != expected_suffix.parts:\n    print(f\"ERROR: unexpected embedded Codex bundle path: {bundle}\", file=sys.stderr)\n    raise SystemExit(67)\nwith Path(os.environ[\"FAKE_TOOL_CAPTURE\"]).open(\"a\", encoding=\"utf-8\") as handle:\n    handle.write(\"codex \" + \" \".join(args) + \"\\n\")\nprint(\"OK: fixture Codex bundle contract.\")\n",
             encoding="utf-8",
@@ -282,6 +295,22 @@ class ReleasePromotionTests(unittest.TestCase):
             ),
             encoding="utf-8",
         )
+        (root / "release-rollout.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "channel": "stable",
+                    "currentRole": "legacy",
+                    "eligibilityProfile": "stable-rollout-v1",
+                    "expectedMigrationPhase": "disabled",
+                    "expectedSigningIdentity": "legacy",
+                    "predecessors": [],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
         (app / "Contents" / "Info.plist").write_text("fixture plist\n", encoding="utf-8")
         self.write_stub(
             app / "Contents" / "MacOS",
@@ -307,28 +336,39 @@ class ReleasePromotionTests(unittest.TestCase):
         zip_path.write_text("fixture zip\n", encoding="utf-8")
         dmg_path.write_text("fixture dmg\n", encoding="utf-8")
         artifact_manifest_path.write_text('{"schema_version":1}\n', encoding="utf-8")
-        item = textwrap.dedent(
-            f"""\
-            <item>
-              <sparkle:version>1</sparkle:version>
-              <sparkle:shortVersionString>1.0.0</sparkle:shortVersionString>
-              <enclosure url="{enclosure_url}" length="{zip_path.stat().st_size}" sparkle:edSignature="fixture-signature" />
-            </item>
-            """
+        rollout_manifest_path = assets / "RepoPrompt-1.0.0-1-stable-rollout.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(scripts / "stable_rollout.py"),
+                "generate",
+                "--declaration", str(root / "release-rollout.json"),
+                "--policy", str(scripts / "apple_identity_policy.json"),
+                "--version-env", str(root / "version.env"),
+                "--release-tag", "v1.0.0",
+                "--release-commit", "fixture-release-commit",
+                "--migration-phase", "disabled",
+                "--enclosure", str(zip_path),
+                "--enclosure-signature", "fixture-signature",
+                "--app-artifact-manifest", str(artifact_manifest_path),
+                "--appcast-output", str(appcast_path),
+                "--manifest-output", str(rollout_manifest_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
         )
-        appcast_path.write_text(
-            textwrap.dedent(
-                f"""\
-                <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
-                  <channel>
-                    {item}
-                    {item if duplicate_appcast_item else ""}
-                  </channel>
-                </rss>
-                """
-            ),
-            encoding="utf-8",
+        canonical_enclosure_url = (
+            "https://github.com/repoprompt/repoprompt-ce-updates/"
+            "releases/download/v1.0.0/RepoPrompt-1.0.0-1.zip"
         )
+        appcast_text = appcast_path.read_text(encoding="utf-8")
+        if duplicate_appcast_item:
+            item_block = appcast_text[appcast_text.index("    <item>") : appcast_text.index("    </item>") + len("    </item>")]
+            appcast_text = appcast_text.replace(item_block, item_block + "\n" + item_block, 1)
+        if enclosure_url != canonical_enclosure_url:
+            appcast_text = appcast_text.replace(canonical_enclosure_url, enclosure_url)
+        appcast_path.write_text(appcast_text, encoding="utf-8")
         previous_appcast.write_text(
             textwrap.dedent(
                 f"""\
@@ -342,7 +382,7 @@ class ReleasePromotionTests(unittest.TestCase):
         checksums_path.write_text(
             "".join(
                 f"{self.sha256(path)}  {path.name}\n"
-                for path in (zip_path, dmg_path, appcast_path, artifact_manifest_path)
+                for path in (zip_path, dmg_path, appcast_path, artifact_manifest_path, rollout_manifest_path)
             ),
             encoding="utf-8",
         )
@@ -362,11 +402,11 @@ class ReleasePromotionTests(unittest.TestCase):
             "gh",
             """\
             printf '%s\\n' "$*" >> "$FAKE_GH_CAPTURE"
-            source_assets='[{"name":"RepoPrompt-1.0.0-1.zip"},{"name":"RepoPrompt-1.0.0-1.dmg"},{"name":"appcast.xml"},{"name":"SHA256SUMS"},{"name":"RepoPrompt-1.0.0-1-artifact-manifest.json"}]'
+            source_assets='[{"name":"RepoPrompt-1.0.0-1.zip"},{"name":"RepoPrompt-1.0.0-1.dmg"},{"name":"appcast.xml"},{"name":"SHA256SUMS"},{"name":"RepoPrompt-1.0.0-1-artifact-manifest.json"},{"name":"RepoPrompt-1.0.0-1-stable-rollout.json"}]'
             if [[ "$FAKE_EXTRA_SOURCE_ASSET" == "true" ]]; then
-                source_assets='[{"name":"RepoPrompt-1.0.0-1.zip"},{"name":"RepoPrompt-1.0.0-1.dmg"},{"name":"appcast.xml"},{"name":"SHA256SUMS"},{"name":"RepoPrompt-1.0.0-1-artifact-manifest.json"},{"name":"unexpected.txt"}]'
+                source_assets='[{"name":"RepoPrompt-1.0.0-1.zip"},{"name":"RepoPrompt-1.0.0-1.dmg"},{"name":"appcast.xml"},{"name":"SHA256SUMS"},{"name":"RepoPrompt-1.0.0-1-artifact-manifest.json"},{"name":"RepoPrompt-1.0.0-1-stable-rollout.json"},{"name":"unexpected.txt"}]'
             fi
-            update_assets='[{"name":"RepoPrompt-1.0.0-1.zip"},{"name":"appcast.xml"},{"name":"SHA256SUMS"},{"name":"RepoPrompt-1.0.0-1-artifact-manifest.json"}]'
+            update_assets='[{"name":"RepoPrompt-1.0.0-1.zip"},{"name":"appcast.xml"},{"name":"SHA256SUMS"},{"name":"RepoPrompt-1.0.0-1-artifact-manifest.json"},{"name":"RepoPrompt-1.0.0-1-stable-rollout.json"}]'
             if [[ "$1" == "release" && "$2" == "view" && "$*" == *"--repo repoprompt/repoprompt-ce "* ]]; then
                 printf '{"tagName":"v1.0.0","isDraft":%s,"isPrerelease":false,"assets":%s,"body":"Release-Commit: `fixture-release-commit`"}\\n' "$FAKE_SOURCE_IS_DRAFT" "$source_assets"
             elif [[ "$1" == "release" && "$2" == "view" && "$*" == *"--repo repoprompt/repoprompt-ce-updates "* ]]; then
@@ -392,6 +432,7 @@ class ReleasePromotionTests(unittest.TestCase):
                 cp "$FAKE_ASSET_DIR"/appcast.xml "$target/"
                 cp "$FAKE_ASSET_DIR"/SHA256SUMS "$target/"
                 cp "$FAKE_ASSET_DIR"/RepoPrompt-1.0.0-1-artifact-manifest.json "$target/"
+                cp "$FAKE_ASSET_DIR"/RepoPrompt-1.0.0-1-stable-rollout.json "$target/"
                 if [[ "$*" != *"--repo repoprompt/repoprompt-ce-updates "* ]]; then
                     cp "$FAKE_ASSET_DIR"/RepoPrompt-1.0.0-1.dmg "$target/"
                 fi
@@ -556,6 +597,7 @@ class ReleasePromotionTests(unittest.TestCase):
                 */RepoPrompt-1.0.0-1.dmg) cp "$FAKE_ASSET_DIR/RepoPrompt-1.0.0-1.dmg" "$output" ;;
                 */SHA256SUMS) cp "$FAKE_ASSET_DIR/SHA256SUMS" "$output" ;;
                 */RepoPrompt-1.0.0-1-artifact-manifest.json) cp "$FAKE_ASSET_DIR/RepoPrompt-1.0.0-1-artifact-manifest.json" "$output" ;;
+                */RepoPrompt-1.0.0-1-stable-rollout.json) cp "$FAKE_ASSET_DIR/RepoPrompt-1.0.0-1-stable-rollout.json" "$output" ;;
                 *) printf 'unexpected curl URL: %s\\n' "$url" >&2; exit 1 ;;
             esac
             """,

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -9,6 +9,7 @@ import importlib.util
 import json
 import os
 import plistlib
+import re
 import shutil
 import socket
 import stat
@@ -4670,6 +4671,490 @@ esac
     @staticmethod
     def run_checked(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
         return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=True)
+
+
+class IdentityTransitionReleaseToolingTests(unittest.TestCase):
+    """PR02 done-when coverage: the reviewed rollout declaration plus
+    Scripts/stable_rollout.py stay the single Stable rollout authority while
+    transition/successor publication remains dormant."""
+
+    POLICY = SCRIPT_DIR / "apple_identity_policy.json"
+    DECLARATION = SCRIPT_DIR.parent / "release-rollout.json"
+    UPDATE_REPOSITORY = "repoprompt/repoprompt-ce-updates"
+
+    def rollout(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "stable_rollout.py"), *args],
+            text=True,
+            capture_output=True,
+        )
+
+    def chain_predecessors(self, role: str) -> list[dict]:
+        placeholder = "0" * 64
+        if role == "transition":
+            return [{"role": "preparer", "tag": "v0.1.0", "rolloutManifestSha256": placeholder}]
+        if role == "successor":
+            return [
+                {"role": "transition", "tag": "v0.2.0", "rolloutManifestSha256": placeholder},
+                {"role": "preparer", "tag": "v0.1.0", "rolloutManifestSha256": placeholder},
+            ]
+        return []
+
+    def make_declaration(
+        self,
+        directory: Path,
+        role: str,
+        predecessors: list[dict] | None = None,
+        **overrides: object,
+    ) -> Path:
+        phase = {"legacy": "disabled", "preparer": "legacy-preparer"}.get(role, "disabled")
+        identity = "successor" if role in ("transition", "successor") else "legacy"
+        declaration = {
+            "schemaVersion": 1,
+            "channel": "stable",
+            "currentRole": role,
+            "eligibilityProfile": "stable-rollout-v1",
+            "expectedMigrationPhase": phase,
+            "expectedSigningIdentity": identity,
+            "predecessors": predecessors or [],
+        }
+        declaration.update(overrides)
+        path = directory / f"release-rollout-{role}.json"
+        path.write_text(json.dumps(declaration, indent=2) + "\n", encoding="utf-8")
+        return path
+
+    def make_release(
+        self,
+        directory: Path,
+        role: str,
+        marketing: str,
+        build: str,
+        predecessors: list[dict] | None = None,
+        predecessor_manifests: list[Path] | None = None,
+    ) -> dict:
+        release_dir = directory / f"{role}-{build}"
+        release_dir.mkdir(parents=True, exist_ok=True)
+        version_env = release_dir / "version.env"
+        version_env.write_text(
+            "APP_NAME=RepoPrompt\n"
+            f"MARKETING_VERSION={marketing}\n"
+            f"BUILD_NUMBER={build}\n"
+            "BUNDLE_ID=com.pvncher.repoprompt.ce\n"
+            "SIGNING_TEAM_ID=648A27MST5\n",
+            encoding="utf-8",
+        )
+        suffix = ".pkg" if role == "transition" else ".zip"
+        enclosure = release_dir / f"RepoPrompt-{marketing}-{build}{suffix}"
+        enclosure.write_text(f"enclosure {role} {build}\n", encoding="utf-8")
+        app_manifest = release_dir / f"RepoPrompt-{marketing}-{build}-artifact-manifest.json"
+        app_manifest.write_text('{"schema_version":1}\n', encoding="utf-8")
+        declaration = self.make_declaration(release_dir, role, predecessors)
+        appcast = release_dir / "appcast.xml"
+        manifest = release_dir / f"RepoPrompt-{marketing}-{build}-stable-rollout.json"
+        arguments = [
+            "generate",
+            "--declaration", str(declaration),
+            "--policy", str(self.POLICY),
+            "--version-env", str(version_env),
+            "--release-tag", f"v{marketing}",
+            "--release-commit", f"commit-{build}",
+            "--migration-phase", "legacy-preparer" if role == "preparer" else "disabled",
+            "--enclosure", str(enclosure),
+            "--enclosure-signature", f"sig-{role}-{build}",
+            "--app-artifact-manifest", str(app_manifest),
+            "--appcast-output", str(appcast),
+            "--manifest-output", str(manifest),
+        ]
+        for predecessor_manifest in predecessor_manifests or []:
+            arguments += ["--predecessor-manifest", str(predecessor_manifest)]
+        result = self.rollout(*arguments)
+        return {
+            "result": result,
+            "dir": release_dir,
+            "version_env": version_env,
+            "declaration": declaration,
+            "enclosure": enclosure,
+            "app_manifest": app_manifest,
+            "appcast": appcast,
+            "manifest": manifest,
+            "arguments": arguments,
+        }
+
+    def make_pts_ladder(self) -> tuple[Path, dict, dict, dict]:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        preparer = self.make_release(temp_dir, "preparer", "1.2.0", "120")
+        self.assertEqual(preparer["result"].returncode, 0, preparer["result"].stderr)
+        transition = self.make_release(
+            temp_dir,
+            "transition",
+            "1.5.0",
+            "150",
+            predecessors=[
+                {
+                    "role": "preparer",
+                    "tag": "v1.2.0",
+                    "rolloutManifestSha256": hashlib.sha256(preparer["manifest"].read_bytes()).hexdigest(),
+                }
+            ],
+            predecessor_manifests=[preparer["manifest"]],
+        )
+        self.assertEqual(transition["result"].returncode, 0, transition["result"].stderr)
+        successor = self.make_release(
+            temp_dir,
+            "successor",
+            "2.0.0",
+            "200",
+            predecessors=[
+                {
+                    "role": "transition",
+                    "tag": "v1.5.0",
+                    "rolloutManifestSha256": hashlib.sha256(transition["manifest"].read_bytes()).hexdigest(),
+                },
+                {
+                    "role": "preparer",
+                    "tag": "v1.2.0",
+                    "rolloutManifestSha256": hashlib.sha256(preparer["manifest"].read_bytes()).hexdigest(),
+                },
+            ],
+            predecessor_manifests=[transition["manifest"], preparer["manifest"]],
+        )
+        self.assertEqual(successor["result"].returncode, 0, successor["result"].stderr)
+        return temp_dir, preparer, transition, successor
+
+    def validate_arguments(self, release: dict, allowed_roles: str | None = None) -> list[str]:
+        arguments = list(release["arguments"])
+        arguments[0] = "validate"
+        generate_only = arguments.index("--appcast-output")
+        arguments[generate_only : generate_only + 4] = [
+            "--appcast", str(release["appcast"]),
+            "--manifest", str(release["manifest"]),
+        ]
+        signature_index = arguments.index("--enclosure-signature")
+        del arguments[signature_index : signature_index + 2]
+        if allowed_roles:
+            arguments += ["--allowed-roles", allowed_roles]
+        return arguments
+
+    def test_policy_declaration_and_requirement_authorities_agree(self) -> None:
+        policy = json.loads(self.POLICY.read_text(encoding="utf-8"))
+        runtime_policy = (
+            SCRIPT_DIR.parent
+            / "Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningPolicy.swift"
+        ).read_text(encoding="utf-8")
+        info_template = (SCRIPT_DIR.parent / "AppBundle/Info.plist.template").read_text(encoding="utf-8")
+        sign_staged = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
+        pkg_builder = (SCRIPT_DIR / "build_identity_transition_pkg.sh").read_text(encoding="utf-8")
+
+        legacy = policy["identities"]["legacy"]
+        successor = policy["identities"]["successor"]
+        requirement_template = (
+            'anchor apple generic and identifier "{bundle}" and certificate '
+            'leaf[subject.OU] = "{team}" and certificate '
+            "leaf[field.1.2.840.113635.100.6.1.13] exists"
+        )
+        for identity in (legacy, successor):
+            self.assertEqual(
+                identity["developerIDRequirement"],
+                requirement_template.format(
+                    bundle=identity["bundleIdentifier"], team=identity["teamIdentifier"]
+                ),
+            )
+        self.assertIn(f'developerIDBundleIdentifier = "{legacy["bundleIdentifier"]}"', runtime_policy)
+        self.assertIn(f'signingTeamIdentifier = "{legacy["teamIdentifier"]}"', runtime_policy)
+        self.assertIn(
+            f'successorDeveloperIDBundleIdentifier = "{successor["bundleIdentifier"]}"', runtime_policy
+        )
+        self.assertIn(f'successorSigningTeamIdentifier = "{successor["teamIdentifier"]}"', runtime_policy)
+        self.assertIn(
+            f"IDENTITY_MIGRATION_TARGET_REQUIREMENT='{successor['developerIDRequirement']}'", sign_staged
+        )
+        self.assertIn(f"SUCCESSOR_APP_REQUIREMENT='{successor['developerIDRequirement']}'", pkg_builder)
+
+        sparkle = policy["sparkle"]
+        self.assertIn(f"<string>{sparkle['stableFeedURL']}</string>", info_template)
+        self.assertIn(f"<string>{sparkle['sparklePublicEdDSAValue']}</string>", info_template)
+        self.assertIn(
+            f"<key>LSMinimumSystemVersion</key><string>{sparkle['minimumSystemVersion']}</string>",
+            info_template,
+        )
+        self.assertEqual(sparkle["updateRepository"], self.UPDATE_REPOSITORY)
+
+        declaration = json.loads(self.DECLARATION.read_text(encoding="utf-8"))
+        self.assertEqual(declaration["currentRole"], "legacy")
+        self.assertEqual(declaration["predecessors"], [])
+        self.assertEqual(declaration["expectedMigrationPhase"], "disabled")
+        self.assertEqual(declaration["expectedSigningIdentity"], "legacy")
+
+    def test_single_legacy_release_generates_one_deterministic_application_item(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        release = self.make_release(temp_dir, "legacy", "1.0.0", "1")
+        self.assertEqual(release["result"].returncode, 0, release["result"].stderr)
+
+        appcast = release["appcast"].read_text(encoding="utf-8")
+        self.assertEqual(appcast.count("<item>"), 1)
+        self.assertIn("<repoprompt:rolloutRole>legacy</repoprompt:rolloutRole>", appcast)
+        self.assertIn("<sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>", appcast)
+        self.assertNotIn("minimumAutoupdateVersion", appcast)
+        self.assertNotIn("installationType", appcast)
+        self.assertIn(
+            f"https://github.com/{self.UPDATE_REPOSITORY}/releases/download/v1.0.0/RepoPrompt-1.0.0-1.zip",
+            appcast,
+        )
+
+        first_manifest = release["manifest"].read_text(encoding="utf-8")
+        rerun = self.rollout(*release["arguments"])
+        self.assertEqual(rerun.returncode, 0, rerun.stderr)
+        self.assertEqual(release["manifest"].read_text(encoding="utf-8"), first_manifest)
+        self.assertEqual(release["appcast"].read_text(encoding="utf-8"), appcast)
+
+        validated = self.rollout(*self.validate_arguments(release, allowed_roles="legacy,preparer"))
+        self.assertEqual(validated.returncode, 0, validated.stderr)
+
+        preparer = self.make_release(temp_dir, "preparer", "1.1.0", "2")
+        self.assertEqual(preparer["result"].returncode, 0, preparer["result"].stderr)
+        self.assertEqual(preparer["appcast"].read_text(encoding="utf-8").count("<item>"), 1)
+
+    def test_synthetic_pts_fixtures_produce_deterministic_aggregate_appcast(self) -> None:
+        _temp_dir, preparer, transition, successor = self.make_pts_ladder()
+
+        appcast = successor["appcast"].read_text(encoding="utf-8")
+        self.assertEqual(appcast.count("<item>"), 3)
+        roles = re.findall(r"<repoprompt:rolloutRole>([a-z]+)</repoprompt:rolloutRole>", appcast)
+        self.assertEqual(roles, ["successor", "transition", "preparer"])
+        builds = re.findall(r"<sparkle:version>([0-9.]+)</sparkle:version>", appcast)
+        self.assertEqual(builds, ["200", "150", "120"])
+        ladders = re.findall(
+            r"<sparkle:minimumAutoupdateVersion>([0-9.]+)</sparkle:minimumAutoupdateVersion>", appcast
+        )
+        self.assertEqual(ladders, ["150", "120"])
+        self.assertEqual(appcast.count("<sparkle:minimumSystemVersion>14.0<"), 3)
+        self.assertEqual(appcast.count('sparkle:installationType="package"'), 1)
+        for tag, name in (
+            ("v2.0.0", "RepoPrompt-2.0.0-200.zip"),
+            ("v1.5.0", "RepoPromptTransition".replace("RepoPromptTransition", "RepoPrompt-1.5.0-150.pkg")),
+            ("v1.2.0", "RepoPrompt-1.2.0-120.zip"),
+        ):
+            self.assertIn(
+                f"https://github.com/{self.UPDATE_REPOSITORY}/releases/download/{tag}/{name}", appcast
+            )
+
+        validated = self.rollout(
+            *self.validate_arguments(successor, allowed_roles="successor,transition,preparer")
+        )
+        self.assertEqual(validated.returncode, 0, validated.stderr)
+
+        max_build = self.rollout("max-build", "--appcast", str(successor["appcast"]))
+        self.assertEqual(max_build.stdout.strip(), "200")
+
+        siblings = self.rollout("sibling-values", "--manifest", str(successor["manifest"]))
+        rows = [line.split("\t") for line in siblings.stdout.splitlines()]
+        self.assertEqual([(row[1], row[2]) for row in rows], [("transition", "v1.5.0"), ("preparer", "v1.2.0")])
+        self.assertEqual(rows[0][7], "RepoPrompt-1.5.0-150-stable-rollout.json")
+
+    def test_rollout_tampering_and_invalid_ladders_fail_closed(self) -> None:
+        temp_dir, preparer, transition, successor = self.make_pts_ladder()
+
+        def successor_validate() -> subprocess.CompletedProcess[str]:
+            return self.rollout(
+                *self.validate_arguments(successor, allowed_roles="successor,transition,preparer")
+            )
+
+        with self.subTest("predecessor manifest byte flip breaks the SHA-256 binding"):
+            original = preparer["manifest"].read_text(encoding="utf-8")
+            preparer["manifest"].write_text(original.replace("sig-preparer-120", "sig-tampered"), encoding="utf-8")
+            result = successor_validate()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("rollout manifest digest mismatch", result.stderr)
+            preparer["manifest"].write_text(original, encoding="utf-8")
+
+        with self.subTest("enclosure mutation breaks the digest binding"):
+            successor["enclosure"].write_text("tampered enclosure\n", encoding="utf-8")
+            result = successor_validate()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("mismatch", result.stderr)
+            successor["enclosure"].write_text("enclosure successor 200\n", encoding="utf-8")
+
+        with self.subTest("appcast text drift from the manifest is rejected"):
+            appcast_text = successor["appcast"].read_text(encoding="utf-8")
+            successor["appcast"].write_text(
+                appcast_text.replace(
+                    "<sparkle:minimumAutoupdateVersion>150<", "<sparkle:minimumAutoupdateVersion>149<", 1
+                ),
+                encoding="utf-8",
+            )
+            result = successor_validate()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("accumulated appcast does not match", result.stderr)
+            successor["appcast"].write_text(appcast_text, encoding="utf-8")
+
+        invalid_declarations = [
+            ("unknown role", {"currentRole": "beta"}, "unknown rollout role"),
+            (
+                "duplicate roles",
+                {
+                    "predecessors": [
+                        {"role": "preparer", "tag": "v1.2.0", "rolloutManifestSha256": "0" * 64},
+                        {"role": "preparer", "tag": "v1.1.0", "rolloutManifestSha256": "0" * 64},
+                    ],
+                    "currentRole": "successor",
+                    "expectedSigningIdentity": "successor",
+                },
+                "not an allowed newest-first rollout chain",
+            ),
+            (
+                "legacy cannot carry siblings",
+                {
+                    "predecessors": [
+                        {"role": "preparer", "tag": "v1.2.0", "rolloutManifestSha256": "0" * 64}
+                    ]
+                },
+                "not an allowed newest-first rollout chain",
+            ),
+            ("wrong phase for role", {"expectedMigrationPhase": "legacy-preparer"}, "must be disabled"),
+            ("wrong identity for role", {"expectedSigningIdentity": "successor"}, "must be legacy"),
+        ]
+        for label, overrides, expected_error in invalid_declarations:
+            with self.subTest(label):
+                declaration = self.make_declaration(temp_dir, "legacy", **overrides)
+                result = self.rollout("current-role", "--declaration", str(declaration))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_error, result.stderr)
+
+        with self.subTest("out-of-order builds are rejected"):
+            older_with_higher_build = self.make_release(temp_dir, "preparer", "9.9.9", "999")
+            self.assertEqual(older_with_higher_build["result"].returncode, 0)
+            broken = self.make_release(
+                temp_dir,
+                "transition",
+                "1.6.0",
+                "160",
+                predecessors=[
+                    {
+                        "role": "preparer",
+                        "tag": "v9.9.9",
+                        "rolloutManifestSha256": hashlib.sha256(
+                            older_with_higher_build["manifest"].read_bytes()
+                        ).hexdigest(),
+                    }
+                ],
+                predecessor_manifests=[older_with_higher_build["manifest"]],
+            )
+            self.assertNotEqual(broken["result"].returncode, 0)
+            self.assertIn("strictly ordered newest-first", broken["result"].stderr)
+
+        with self.subTest("manifest field tampering is rejected with the exact field"):
+            manifest_text = successor["manifest"].read_text(encoding="utf-8")
+            successor["manifest"].write_text(
+                manifest_text.replace('"installationType": "package"', '"installationType": "application"'),
+                encoding="utf-8",
+            )
+            result = successor_validate()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("mismatch", result.stderr)
+            successor["manifest"].write_text(manifest_text, encoding="utf-8")
+
+    def test_protected_surfaces_reject_dormant_roles_and_siblings(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+
+        for role in ("legacy", "preparer"):
+            with self.subTest(allowed=role):
+                declaration = self.make_declaration(temp_dir, role)
+                result = self.rollout(
+                    "workflow-guard", "--declaration", str(declaration), "--policy", str(self.POLICY)
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+        for role in ("transition", "successor"):
+            with self.subTest(rejected=role):
+                declaration = self.make_declaration(temp_dir, role, self.chain_predecessors(role))
+                result = self.rollout(
+                    "workflow-guard", "--declaration", str(declaration), "--policy", str(self.POLICY)
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(f"reject the {role} rollout role", result.stderr)
+
+        workflows_dir = SCRIPT_DIR.parent / ".github" / "workflows"
+        release_workflow = (workflows_dir / "release.yml").read_text(encoding="utf-8")
+        promote_workflow = (workflows_dir / "release-promote.yml").read_text(encoding="utf-8")
+        tip_workflow = (workflows_dir / "main-tip.yml").read_text(encoding="utf-8")
+        self.assertEqual(release_workflow.count("stable_rollout.py workflow-guard"), 2)
+        self.assertEqual(promote_workflow.count("stable_rollout.py workflow-guard"), 1)
+        self.assertNotIn("stable_rollout.py", tip_workflow)
+        self.assertNotIn("release-rollout.json", tip_workflow)
+
+        release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")
+        promote_script = (SCRIPT_DIR / "promote_release.sh").read_text(encoding="utf-8")
+        self.assertIn("require_dormant_rollout_declaration", release_script)
+        self.assertIn("resolve_release_artifact_role", promote_script)
+        for script_text in (release_script, promote_script):
+            self.assertNotIn("REPOPROMPT_IDENTITY_TRANSITION_TOOLING_UNLOCK", script_text)
+            self.assertNotIn("REPOPROMPT_RELEASE_ARTIFACT_ROLE", script_text)
+            self.assertNotIn("REPOPROMPT_PREDECESSOR_APPCAST", script_text)
+
+        # Behavioral: a transition declaration in the tagged source fails
+        # promotion before any release lookup or mutation.
+        fixture_root = temp_dir / "transition-source"
+        fixture_root.mkdir()
+        shutil.copy2(SCRIPT_DIR.parent / "version.env", fixture_root / "version.env")
+        transition_declaration = self.make_declaration(
+            fixture_root, "transition", self.chain_predecessors("transition")
+        )
+        shutil.move(str(transition_declaration), fixture_root / "release-rollout.json")
+        env = dict(os.environ)
+        env["REPOPROMPT_RELEASE_SOURCE_ROOT"] = str(fixture_root)
+        env["REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR"] = str(SCRIPT_DIR)
+        result = subprocess.run(
+            ["bash", str(SCRIPT_DIR / "promote_release.sh"), "verify"],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("dormant until successor rollout enablement", result.stderr)
+
+        for script_name in ("release.sh", "promote_release.sh", "build_identity_transition_pkg.sh", "main_tip_release.sh"):
+            with self.subTest(syntax=script_name):
+                syntax = subprocess.run(
+                    ["bash", "-n", str(SCRIPT_DIR / script_name)], text=True, capture_output=True
+                )
+                self.assertEqual(syntax.returncode, 0, syntax.stderr)
+
+        # Tip isolation: exactly-one-item validation, legacy/disabled phase, and
+        # the separate tip updater repository stay untouched.
+        tip_script = (SCRIPT_DIR / "main_tip_release.sh").read_text(encoding="utf-8")
+        self.assertIn("tip appcast must contain exactly one item", tip_script)
+        self.assertIn("repoprompt-ce-tip-updates", tip_script)
+        self.assertIn("REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled", tip_workflow)
+
+    def test_transition_pkg_builder_stays_dormant_with_exact_payload_proof(self) -> None:
+        script = (SCRIPT_DIR / "build_identity_transition_pkg.sh").read_text(encoding="utf-8")
+        for marker in (
+            "plutil -replace 0.BundleIsRelocatable -bool false",
+            "plutil -replace 0.BundleHasStrictIdentifier -bool false",
+            "plutil -replace 0.BundleIsVersionChecked -bool false",
+            "plutil -replace 0.BundleOverwriteAction -string upgrade",
+            'TRANSITION_INSTALL_LOCATION="/Applications"',
+            "pkgutil --expand-full",
+            "xcrun stapler validate",
+            'diff -qr "$expected_app" "$payload_app"',
+        ):
+            self.assertIn(marker, script)
+        self.assertNotIn("skip-notarization", script)
+        self.assertNotIn("allow-unstapled", script)
+
+        env = dict(os.environ)
+        env["GITHUB_ACTIONS"] = "true"
+        refused = subprocess.run(
+            ["bash", str(SCRIPT_DIR / "build_identity_transition_pkg.sh"), "validate", "/nonexistent.pkg"],
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        self.assertNotEqual(refused.returncode, 0)
+        self.assertIn("dormant", refused.stderr)
 
 
 if __name__ == "__main__":

--- a/release-rollout.json
+++ b/release-rollout.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "channel": "stable",
+  "currentRole": "legacy",
+  "eligibilityProfile": "stable-rollout-v1",
+  "expectedMigrationPhase": "disabled",
+  "expectedSigningIdentity": "legacy",
+  "predecessors": []
+}


### PR DESCRIPTION
## Summary

- add a policy-backed identity rollout authority for legacy, preparer, transition, and successor artifacts
- add transition-PKG construction and deterministic multi-item appcast generation/validation
- keep Stable locked in the legacy role until an explicit reviewed declaration changes it
- integrate the dormant machinery with existing Stable release and promotion workflows
- cover role ordering, predecessor manifests, artifact shapes, and promotion safety

## Stack

1. Runtime safety and deterministic appcast selection
2. **This PR:** dormant release tooling and Stable safety lock
3. Tip P→T→S rehearsal, successor enablement, and diagnostics

## Safety

This PR installs dormant release machinery only. It does not execute the identity rollover or change the Stable bundle identity.

## Validation

- identity release-tooling and promotion regression suites
- repository contribution preflight and outgoing-range secret scan
- path-selected PR-ready lint passed; the full suite had one unrelated worktree-routing failure that passed on immediate isolated rerun
