### PR TITLE
Enable Tip identity transition rehearsal

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -11,6 +11,10 @@ on:
         description: Commit SHA on protected main to publish as tip
         required: false
         type: string
+      confirm_identity_rollout_role:
+        description: For preparer/transition/successor, enter the exact checked-in role
+        required: false
+        type: string
 
 concurrency:
   group: >-
@@ -43,6 +47,10 @@ jobs:
       tag: ${{ steps.tip.outputs.tag }}
       tooling-commit: ${{ steps.tip.outputs.tooling-commit }}
       should-publish: ${{ steps.tip.outputs.should-publish }}
+      rollout-role: ${{ steps.tip.outputs.rollout-role }}
+      rollout-identity: ${{ steps.tip.outputs.rollout-identity }}
+      migration-phase: ${{ steps.tip.outputs.migration-phase }}
+      installation-type: ${{ steps.tip.outputs.installation-type }}
     steps:
       - name: Check out trusted tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -57,6 +65,7 @@ jobs:
           REQUESTED_COMMIT: ${{ inputs.commit || github.event.workflow_run.head_sha }}
           TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
           TIP_GH_TOKEN: ${{ github.token }}
+          CONFIRMED_ROLLOUT_ROLE: ${{ inputs.confirm_identity_rollout_role }}
         run: |
           set -euo pipefail
           git fetch --no-tags origin main
@@ -73,25 +82,32 @@ jobs:
             exit 1
           }
 
+          rollout_declaration="$RUNNER_TEMP/tip-rollout.json"
+          git show "$commit:tip-rollout.json" > "$rollout_declaration"
+          eval "$(python3 Scripts/stable_rollout.py packaging-context \
+            --declaration "$rollout_declaration" \
+            --policy Scripts/apple_identity_policy.json)"
+          [[ "$ROLLOUT_UPDATE_REPOSITORY" == "$TIP_UPDATE_REPOSITORY" ]] || {
+            echo "Configured Tip update repository does not match the reviewed identity policy" >&2
+            exit 1
+          }
+
+          should_publish=true
+          if [[ "$ROLLOUT_ROLE" != "legacy" ]]; then
+            if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
+              should_publish=false
+              echo "Identity rollout role $ROLLOUT_ROLE requires an explicit workflow dispatch; skipping automatic publication."
+            elif [[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
+              echo "confirm_identity_rollout_role must exactly match checked-in role $ROLLOUT_ROLE" >&2
+              exit 1
+            fi
+          fi
+
           stable_appcast="$RUNNER_TEMP/stable-appcast.xml"
           curl --fail --location --retry 3 --silent --show-error \
             https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml \
             --output "$stable_appcast"
-          stable_build_number="$(python3 - "$stable_appcast" <<'PYTHON'
-          import sys
-          import xml.etree.ElementTree as ET
-
-          root = ET.parse(sys.argv[1]).getroot()
-          versions = [
-              (element.text or "").strip()
-              for element in root.iter()
-              if element.tag.rsplit("}", 1)[-1] == "version"
-          ]
-          if len(versions) != 1 or not versions[0].isdigit():
-              raise SystemExit("Stable appcast must contain exactly one numeric sparkle:version")
-          print(versions[0])
-          PYTHON
-          )"
+          stable_build_number="$(python3 Scripts/stable_rollout.py max-build --appcast "$stable_appcast")"
           (( ${#stable_build_number} <= 4 )) || {
             echo "Stable build number exceeds CFBundleVersion's four-digit major component" >&2
             exit 1
@@ -100,23 +116,24 @@ jobs:
           archive_basename="RepoPrompt-tip-$short_sha-$build_number"
           tag="tip-$short_sha"
 
-          lookup_classification="$(./Scripts/lookup_public_tip_release.sh \
-            "$TIP_UPDATE_REPOSITORY" \
-            "$tag" \
-            "$archive_basename")"
-          case "$lookup_classification" in
-            found)
-              should_publish=false
-              echo "Existing tip release response classification=complete; skipping rebuild."
-              ;;
-            not-found)
-              should_publish=true
-              ;;
-            *)
-              echo "GitHub public tip lookup classification=unexpected-helper-output" >&2
-              exit 1
-              ;;
-          esac
+          if [[ "$should_publish" == "true" ]]; then
+            lookup_classification="$(./Scripts/lookup_public_tip_release.sh \
+              "$TIP_UPDATE_REPOSITORY" \
+              "$tag" \
+              "$archive_basename" \
+              "$ROLLOUT_INSTALLATION_TYPE")"
+            case "$lookup_classification" in
+              found)
+                should_publish=false
+                echo "Existing tip release response classification=complete; skipping rebuild."
+                ;;
+              not-found) ;;
+              *)
+                echo "GitHub public tip lookup classification=unexpected-helper-output" >&2
+                exit 1
+                ;;
+            esac
+          fi
           {
             echo "commit=$commit"
             echo "short-sha=$short_sha"
@@ -124,6 +141,10 @@ jobs:
             echo "tag=$tag"
             echo "tooling-commit=$(git rev-parse HEAD)"
             echo "should-publish=$should_publish"
+            echo "rollout-role=$ROLLOUT_ROLE"
+            echo "rollout-identity=$ROLLOUT_IDENTITY"
+            echo "migration-phase=$REPOPROMPT_IDENTITY_MIGRATION_PHASE"
+            echo "installation-type=$ROLLOUT_INSTALLATION_TYPE"
           } >> "$GITHUB_OUTPUT"
 
   stage:
@@ -158,9 +179,6 @@ jobs:
           TIP_TAG: ${{ needs.setup.outputs.tag }}
           REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
           REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
-          # Tip is rolling and cannot preserve a migration phase across automatic
-          # workflow_run publishes. Preparers are Stable-only release artifacts.
-          REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled
           # Link Sentry and preserve dSYMs without exposing DSN or auth in this stage.
           REPOPROMPT_ENABLE_SENTRY: "1"
         run: ./trusted-control-plane/Scripts/main_tip_release.sh stage
@@ -211,7 +229,7 @@ jobs:
         env:
           RELEASE_COMMIT: ${{ needs.setup.outputs.commit }}
           REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE: ${{ needs.setup.outputs.build-number }}
-          REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ needs.setup.outputs.migration-phase }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -226,15 +244,41 @@ jobs:
             REPOPROMPT_APPROVED_SOURCE_ROOT=approved-source \
             ./trusted-control-plane/Scripts/validate_staged_release.sh
 
-      - name: Import Developer ID certificate
+      - name: Import role-selected Developer ID certificates
         env:
-          CERTIFICATE_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
-          CERTIFICATE_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          ROLLOUT_ROLE: ${{ needs.setup.outputs.rollout-role }}
+          ROLLOUT_IDENTITY: ${{ needs.setup.outputs.rollout-identity }}
+          LEGACY_CERTIFICATE_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          LEGACY_CERTIFICATE_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          SUCCESSOR_CERTIFICATE_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          SUCCESSOR_CERTIFICATE_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          SUCCESSOR_INSTALLER_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_BASE64 }}
+          SUCCESSOR_INSTALLER_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_PASSWORD }}
           CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
-          CONFIGURED_SIGN_IDENTITY: ${{ vars.SIGN_IDENTITY }}
+          CONFIGURED_LEGACY_SIGN_IDENTITY: ${{ vars.SIGN_IDENTITY }}
+          CONFIGURED_SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}
+          CONFIGURED_SUCCESSOR_INSTALLER_IDENTITY: ${{ vars.SUCCESSOR_INSTALLER_IDENTITY }}
         run: |
           set -euo pipefail
           umask 077
+          eval "$(python3 trusted-control-plane/Scripts/stable_rollout.py packaging-context \
+            --declaration approved-source/tip-rollout.json \
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json)"
+          if [[ "$ROLLOUT_IDENTITY" == "successor" ]]; then
+            CERTIFICATE_P12_BASE64="$SUCCESSOR_CERTIFICATE_P12_BASE64"
+            CERTIFICATE_P12_PASSWORD="$SUCCESSOR_CERTIFICATE_P12_PASSWORD"
+            CONFIGURED_SIGN_IDENTITY="$CONFIGURED_SUCCESSOR_SIGN_IDENTITY"
+          else
+            CERTIFICATE_P12_BASE64="$LEGACY_CERTIFICATE_P12_BASE64"
+            CERTIFICATE_P12_PASSWORD="$LEGACY_CERTIFICATE_P12_PASSWORD"
+            CONFIGURED_SIGN_IDENTITY="$CONFIGURED_LEGACY_SIGN_IDENTITY"
+          fi
+          : "${CERTIFICATE_P12_BASE64:?Application signing certificate is not configured for this identity}"
+          : "${CERTIFICATE_P12_PASSWORD:?Application signing certificate password is not configured for this identity}"
+          [[ "$CONFIGURED_SIGN_IDENTITY" == "$EXPECTED_SIGN_IDENTITY" ]] || {
+            echo "Configured signing identity must match the reviewed identity policy" >&2
+            exit 1
+          }
           KEYCHAIN_PATH="$RUNNER_TEMP/repoprompt-tip.keychain-db"
           CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-tip.p12"
           printf '%s' "$CERTIFICATE_P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
@@ -244,18 +288,75 @@ jobs:
           security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH"
+          if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
+            : "${SUCCESSOR_INSTALLER_P12_BASE64:?Successor Developer ID Installer certificate is not configured}"
+            : "${SUCCESSOR_INSTALLER_P12_PASSWORD:?Successor Developer ID Installer password is not configured}"
+            [[ "$CONFIGURED_SUCCESSOR_INSTALLER_IDENTITY" == "$EXPECTED_INSTALLER_IDENTITY" ]] || {
+              echo "Configured installer identity must match the reviewed identity policy" >&2
+              exit 1
+            }
+            installer_certificate="$RUNNER_TEMP/repoprompt-tip-installer.p12"
+            printf '%s' "$SUCCESSOR_INSTALLER_P12_BASE64" | base64 --decode > "$installer_certificate"
+            security import "$installer_certificate" -k "$KEYCHAIN_PATH" \
+              -P "$SUCCESSOR_INSTALLER_P12_PASSWORD" -T /usr/bin/productbuild -T /usr/bin/security
+            security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild: \
+              -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+            rm -f "$installer_certificate"
+            echo "INSTALLER_IDENTITY=$EXPECTED_INSTALLER_IDENTITY" >> "$GITHUB_ENV"
+          fi
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "SIGN_IDENTITY=${CONFIGURED_SIGN_IDENTITY:-Developer ID Application: Eric Provencher (648A27MST5)}" >> "$GITHUB_ENV"
+          echo "SIGN_IDENTITY=$CONFIGURED_SIGN_IDENTITY" >> "$GITHUB_ENV"
+
+      - name: Prepare successor identity migration anchor
+        if: needs.setup.outputs.rollout-role == 'preparer'
+        env:
+          SUCCESSOR_CERTIFICATE_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          SUCCESSOR_CERTIFICATE_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}
+          CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          umask 077
+          eval "$(python3 trusted-control-plane/Scripts/stable_rollout.py packaging-context \
+            --declaration approved-source/tip-rollout.json \
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json)"
+          [[ "$SUCCESSOR_SIGN_IDENTITY" == "Developer ID Application: Samuel Baron (69N6K965SF)" ]] || {
+            echo "Successor signing identity does not match the reviewed identity policy" >&2
+            exit 1
+          }
+          successor_certificate="$RUNNER_TEMP/repoprompt-tip-successor.p12"
+          anchor="$RUNNER_TEMP/repoprompt-successor-identity-anchor"
+          xcrun clang -arch arm64 -arch x86_64 -Os -Wl,-dead_strip \
+            -o "$anchor" trusted-control-plane/Scripts/identity_migration_anchor.c
+          printf '%s' "$SUCCESSOR_CERTIFICATE_P12_BASE64" | base64 --decode > "$successor_certificate"
+          security import "$successor_certificate" -k "$KEYCHAIN_PATH" \
+            -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          codesign --force --sign "$SUCCESSOR_SIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" \
+            --identifier com.repoprompt.ce --timestamp --options runtime "$anchor"
+          codesign --verify --strict --verbose=2 \
+            -R='anchor apple generic and identifier "com.repoprompt.ce" and certificate leaf[subject.OU] = "69N6K965SF" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists' \
+            "$anchor"
+          echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"
 
       - name: Prepare provisioning profile and notarization key
         env:
-          PROVISIONING_PROFILE_BASE64: ${{ secrets.REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64 }}
+          ROLLOUT_IDENTITY: ${{ needs.setup.outputs.rollout-identity }}
+          LEGACY_PROVISIONING_PROFILE_BASE64: ${{ secrets.REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64 }}
+          SUCCESSOR_PROVISIONING_PROFILE_BASE64: ${{ secrets.SUCCESSOR_REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64 }}
           NOTARYTOOL_PRIVATE_KEY_BASE64: ${{ secrets.NOTARYTOOL_PRIVATE_KEY_BASE64 }}
         run: |
           set -euo pipefail
           umask 077
           SECRETS_DIR="$RUNNER_TEMP/repoprompt-tip-secrets"
           mkdir -p "$SECRETS_DIR"
+          if [[ "$ROLLOUT_IDENTITY" == "successor" ]]; then
+            PROVISIONING_PROFILE_BASE64="$SUCCESSOR_PROVISIONING_PROFILE_BASE64"
+          else
+            PROVISIONING_PROFILE_BASE64="$LEGACY_PROVISIONING_PROFILE_BASE64"
+          fi
+          : "${PROVISIONING_PROFILE_BASE64:?Provisioning profile is not configured for this identity}"
           printf '%s' "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$SECRETS_DIR/repoprompt-ce.provisionprofile"
           printf '%s' "$NOTARYTOOL_PRIVATE_KEY_BASE64" | base64 --decode > "$SECRETS_DIR/notarytool-private-key.p8"
           echo "REPOPROMPT_PROVISIONING_PROFILE=$SECRETS_DIR/repoprompt-ce.provisionprofile" >> "$GITHUB_ENV"
@@ -293,7 +394,7 @@ jobs:
           REPOPROMPT_APPROVED_SOURCE_ROOT: ${{ github.workspace }}/approved-source
           REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE: ${{ needs.setup.outputs.build-number }}
           REPOPROMPT_ENABLE_SENTRY: "1"
-          REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled
+          REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ needs.setup.outputs.migration-phase }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           REPOPROMPT_SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
@@ -309,6 +410,8 @@ jobs:
           security delete-keychain "$RUNNER_TEMP/repoprompt-tip.keychain-db" || true
           rm -rf "$RUNNER_TEMP/repoprompt-tip-secrets"
           rm -f "$RUNNER_TEMP/repoprompt-tip.p12"
+          rm -f "$RUNNER_TEMP/repoprompt-tip-successor.p12"
+          rm -f "$RUNNER_TEMP/repoprompt-successor-identity-anchor"
 
       - name: Upload signed tip assets for smoke and publish
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -317,10 +420,12 @@ jobs:
           path: |
             tip-source/dist/*.zip
             tip-source/dist/*.dmg
+            tip-source/dist/*.pkg
             tip-source/dist/appcast.xml
             tip-source/dist/SHA256SUMS
             tip-source/dist/*-artifact-manifest.json
             tip-source/dist/*-metadata.json
+            tip-source/dist/identity-rollout.json
           if-no-files-found: error
           retention-days: 1
 
@@ -349,18 +454,27 @@ jobs:
 
       - name: Verify and smoke signed tip
         env:
+          ROLLOUT_INSTALLATION_TYPE: ${{ needs.setup.outputs.installation-type }}
           REPOPROMPT_PACKAGED_SMOKE_TIMEOUT: "240"
           REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT: "60"
           REPOPROMPT_PACKAGED_SMOKE_DIAGNOSTICS_DIR: ${{ runner.temp }}/tip-smoke-diagnostics
         run: |
           set -euo pipefail
           shopt -s nullglob
-          archives=(signed-tip/*.zip)
           manifests=(signed-tip/*-artifact-manifest.json)
-          [[ "${#archives[@]}" == "1" ]] || { echo "Expected one signed tip ZIP" >&2; exit 1; }
           [[ "${#manifests[@]}" == "1" ]] || { echo "Expected one signed tip manifest" >&2; exit 1; }
           mkdir extracted
-          ditto -x -k "${archives[0]}" extracted
+          if [[ "$ROLLOUT_INSTALLATION_TYPE" == "package" ]]; then
+            packages=(signed-tip/*.pkg)
+            [[ "${#packages[@]}" == "1" ]] || { echo "Expected one signed Tip transition PKG" >&2; exit 1; }
+            REPOPROMPT_ENABLE_IDENTITY_TRANSITION_PKG=1 \
+              ./trusted-control-plane/Scripts/build_identity_transition_pkg.sh validate \
+              "${packages[0]}" --expanded-payload-dir extracted
+          else
+            archives=(signed-tip/*.zip)
+            [[ "${#archives[@]}" == "1" ]] || { echo "Expected one signed Tip ZIP" >&2; exit 1; }
+            ditto -x -k "${archives[0]}" extracted
+          fi
           env -i \
             PATH=/usr/bin:/bin:/usr/sbin:/sbin \
             HOME="$HOME" \

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -83,10 +83,13 @@ jobs:
           }
 
           rollout_declaration="$RUNNER_TEMP/tip-rollout.json"
+          rollout_version_env="$RUNNER_TEMP/tip-version.env"
           git show "$commit:tip-rollout.json" > "$rollout_declaration"
+          git show "$commit:version.env" > "$rollout_version_env"
           eval "$(python3 Scripts/stable_rollout.py packaging-context \
             --declaration "$rollout_declaration" \
-            --policy Scripts/apple_identity_policy.json)"
+            --policy Scripts/apple_identity_policy.json \
+            --version-env "$rollout_version_env")"
           [[ "$ROLLOUT_UPDATE_REPOSITORY" == "$TIP_UPDATE_REPOSITORY" ]] || {
             echo "Configured Tip update repository does not match the reviewed identity policy" >&2
             exit 1
@@ -263,7 +266,8 @@ jobs:
           umask 077
           eval "$(python3 trusted-control-plane/Scripts/stable_rollout.py packaging-context \
             --declaration approved-source/tip-rollout.json \
-            --policy trusted-control-plane/Scripts/apple_identity_policy.json)"
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json \
+            --version-env approved-source/version.env)"
           if [[ "$ROLLOUT_IDENTITY" == "successor" ]]; then
             CERTIFICATE_P12_BASE64="$SUCCESSOR_CERTIFICATE_P12_BASE64"
             CERTIFICATE_P12_PASSWORD="$SUCCESSOR_CERTIFICATE_P12_PASSWORD"
@@ -319,8 +323,9 @@ jobs:
           umask 077
           eval "$(python3 trusted-control-plane/Scripts/stable_rollout.py packaging-context \
             --declaration approved-source/tip-rollout.json \
-            --policy trusted-control-plane/Scripts/apple_identity_policy.json)"
-          [[ "$SUCCESSOR_SIGN_IDENTITY" == "Developer ID Application: Samuel Baron (69N6K965SF)" ]] || {
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json \
+            --version-env approved-source/version.env)"
+          [[ "$SUCCESSOR_SIGN_IDENTITY" == "$EXPECTED_SUCCESSOR_SIGN_IDENTITY" ]] || {
             echo "Successor signing identity does not match the reviewed identity policy" >&2
             exit 1
           }

--- a/Scripts/apple_identity_policy.json
+++ b/Scripts/apple_identity_policy.json
@@ -4,18 +4,23 @@
     "legacy": {
       "bundleIdentifier": "com.pvncher.repoprompt.ce",
       "teamIdentifier": "648A27MST5",
-      "developerIDRequirement": "anchor apple generic and identifier \"com.pvncher.repoprompt.ce\" and certificate leaf[subject.OU] = \"648A27MST5\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+      "developerIDRequirement": "anchor apple generic and identifier \"com.pvncher.repoprompt.ce\" and certificate leaf[subject.OU] = \"648A27MST5\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists",
+      "developerIDApplicationIdentityName": "Developer ID Application: Eric Provencher (648A27MST5)"
     },
     "successor": {
       "bundleIdentifier": "com.repoprompt.ce",
       "teamIdentifier": "69N6K965SF",
-      "developerIDRequirement": "anchor apple generic and identifier \"com.repoprompt.ce\" and certificate leaf[subject.OU] = \"69N6K965SF\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+      "developerIDRequirement": "anchor apple generic and identifier \"com.repoprompt.ce\" and certificate leaf[subject.OU] = \"69N6K965SF\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists",
+      "developerIDApplicationIdentityName": "Developer ID Application: Samuel Baron (69N6K965SF)",
+      "developerIDInstallerIdentityName": "Developer ID Installer: Samuel Baron (69N6K965SF)"
     }
   },
   "sparkle": {
     "stableFeedURL": "https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml",
+    "tipFeedURL": "https://github.com/repoprompt/repoprompt-ce-tip-updates/releases/latest/download/appcast.xml",
     "sparklePublicEdDSAValue": "845kp9v5+kp4U6no85H53cUdnbfN3NmE1PJHKwH8Pd4=",
     "updateRepository": "repoprompt/repoprompt-ce-updates",
+    "tipUpdateRepository": "repoprompt/repoprompt-ce-tip-updates",
     "minimumSystemVersion": "14.0"
   }
 }

--- a/Scripts/build_identity_transition_pkg.sh
+++ b/Scripts/build_identity_transition_pkg.sh
@@ -3,10 +3,8 @@ set -euo pipefail
 
 # Builder/validator for the notarized Apple identity-transition package (T).
 #
-# DORMANT BY DESIGN: no protected workflow references this script, release.sh
-# refuses the transition artifact role, and promote_release.sh keeps the
-# transition role locked. Publishing a transition package stays impossible
-# until successor rollout enablement deliberately wires it up.
+# Stable remains dormant. The Tip dress rehearsal is the only protected caller
+# and must opt in explicitly for the transition role.
 
 MODE="${1:-}"
 if [[ $# -gt 0 ]]; then shift; fi
@@ -39,8 +37,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-[[ "${GITHUB_ACTIONS:-}" != "true" ]] ||
-    fail "build_identity_transition_pkg.sh is dormant and must not run inside protected workflows until successor rollout enablement"
+[[ "${REPOPROMPT_ENABLE_IDENTITY_TRANSITION_PKG:-}" == "1" ]] ||
+    fail "identity transition package construction requires explicit Tip rollout enablement"
 
 validate_successor_app() {
     local app="$1"
@@ -125,8 +123,8 @@ build_transition_pkg() {
 
     local payload_build
     payload_build="$(plutil -extract CFBundleVersion raw "$app/Contents/Info.plist")"
-    [[ "$payload_build" =~ ^[0-9]+$ ]] ||
-        fail "Transition payload build number must be numeric, got $payload_build"
+    [[ "$payload_build" =~ ^[0-9]{1,4}(\.[0-9]{1,2}){0,2}$ ]] ||
+        fail "Transition payload build number must be a valid CFBundleVersion, got $payload_build"
 
     local component_pkg="$TMP_DIR/transition-component.pkg"
     pkgbuild \

--- a/Scripts/lookup_public_tip_release.sh
+++ b/Scripts/lookup_public_tip_release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "$#" != 3 ]]; then
+if [[ "$#" != 4 ]]; then
     printf '%s\n' \
         'GitHub public tip lookup classification=invalid-input status=000 request_id=unavailable rate_limit_remaining=unavailable rate_limit_reset=unavailable retry_after=unavailable' \
         >&2
@@ -11,6 +11,8 @@ fi
 REPOSITORY="$1"
 TAG="$2"
 ARCHIVE_BASENAME="$3"
+INSTALLATION_TYPE="$4"
+[[ "$INSTALLATION_TYPE" == "application" || "$INSTALLATION_TYPE" == "package" ]] || exit 1
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/repoprompt-tip-lookup.XXXXXX")"
 RESPONSE_BODY="$TMP_DIR/response.json"
 RESPONSE_HEADERS="$TMP_DIR/response.headers"
@@ -61,7 +63,7 @@ PYTHON
 }
 
 classify_found_body() {
-    python3 - "$RESPONSE_BODY" "$ARCHIVE_BASENAME" <<'PYTHON'
+    python3 - "$RESPONSE_BODY" "$ARCHIVE_BASENAME" "$INSTALLATION_TYPE" <<'PYTHON'
 import json
 import sys
 
@@ -71,14 +73,18 @@ try:
     if not isinstance(release, dict):
         raise ValueError
     archive_basename = sys.argv[2]
+    installation_type = sys.argv[3]
     expected = {
-        f"{archive_basename}.zip",
-        f"{archive_basename}.dmg",
         "appcast.xml",
         "SHA256SUMS",
+        "identity-rollout.json",
         f"{archive_basename}-artifact-manifest.json",
         f"{archive_basename}-metadata.json",
     }
+    if installation_type == "package":
+        expected.add(f"{archive_basename}.pkg")
+    else:
+        expected.update({f"{archive_basename}.zip", f"{archive_basename}.dmg"})
     assets = release.get("assets", [])
     if not isinstance(assets, list) or not all(isinstance(asset, dict) for asset in assets):
         raise ValueError

--- a/Scripts/lookup_public_tip_release.sh
+++ b/Scripts/lookup_public_tip_release.sh
@@ -12,7 +12,12 @@ REPOSITORY="$1"
 TAG="$2"
 ARCHIVE_BASENAME="$3"
 INSTALLATION_TYPE="$4"
-[[ "$INSTALLATION_TYPE" == "application" || "$INSTALLATION_TYPE" == "package" ]] || exit 1
+if [[ "$INSTALLATION_TYPE" != "application" && "$INSTALLATION_TYPE" != "package" ]]; then
+    printf '%s\n' \
+        'GitHub public tip lookup classification=invalid-input status=000 request_id=unavailable rate_limit_remaining=unavailable rate_limit_reset=unavailable retry_after=unavailable' \
+        >&2
+    exit 1
+fi
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/repoprompt-tip-lookup.XXXXXX")"
 RESPONSE_BODY="$TMP_DIR/response.json"
 RESPONSE_HEADERS="$TMP_DIR/response.headers"

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -23,7 +23,8 @@ ROLLOUT_DECLARATION="$ROOT_DIR/tip-rollout.json"
     fail "Tip identity rollout authority is incomplete"
 eval "$(python3 "$ROLLOUT_TOOL" packaging-context \
     --declaration "$ROLLOUT_DECLARATION" \
-    --policy "$APPLE_IDENTITY_POLICY")"
+    --policy "$APPLE_IDENTITY_POLICY" \
+    --version-env "$ROOT_DIR/version.env")"
 [[ "$ROLLOUT_CHANNEL" == "tip" ]] || fail "Tip release requires a Tip rollout declaration"
 
 TIP_COMMIT="${TIP_COMMIT:-$(git rev-parse HEAD)}"

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -16,6 +16,16 @@ load_release_metadata "$ROOT_DIR"
 
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
+ROLLOUT_TOOL="$CONTROL_PLANE_SCRIPTS_DIR/stable_rollout.py"
+APPLE_IDENTITY_POLICY="$CONTROL_PLANE_SCRIPTS_DIR/apple_identity_policy.json"
+ROLLOUT_DECLARATION="$ROOT_DIR/tip-rollout.json"
+[[ -f "$ROLLOUT_TOOL" && -f "$APPLE_IDENTITY_POLICY" && -f "$ROLLOUT_DECLARATION" ]] ||
+    fail "Tip identity rollout authority is incomplete"
+eval "$(python3 "$ROLLOUT_TOOL" packaging-context \
+    --declaration "$ROLLOUT_DECLARATION" \
+    --policy "$APPLE_IDENTITY_POLICY")"
+[[ "$ROLLOUT_CHANNEL" == "tip" ]] || fail "Tip release requires a Tip rollout declaration"
+
 TIP_COMMIT="${TIP_COMMIT:-$(git rev-parse HEAD)}"
 TIP_SHORT_SHA="${TIP_SHORT_SHA:-${TIP_COMMIT:0:12}}"
 if [[ -z "${TIP_BUILD_NUMBER:-}" ]]; then
@@ -28,6 +38,8 @@ fi
 TIP_BUILD_NUMBER="${TIP_BUILD_NUMBER//[[:space:]]/}"
 TIP_TAG="${TIP_TAG:-tip-$TIP_SHORT_SHA}"
 TIP_UPDATE_REPOSITORY="${TIP_UPDATE_REPOSITORY:-repoprompt/repoprompt-ce-tip-updates}"
+[[ "$TIP_UPDATE_REPOSITORY" == "$ROLLOUT_UPDATE_REPOSITORY" ]] ||
+    fail "TIP_UPDATE_REPOSITORY must match the reviewed identity policy"
 TIP_DOWNLOAD_URL_PREFIX="${TIP_DOWNLOAD_URL_PREFIX:-https://github.com/$TIP_UPDATE_REPOSITORY/releases/download/$TIP_TAG/}"
 TIP_GH_TOKEN="${TIP_GH_TOKEN:-${GH_TOKEN:-}}"
 
@@ -37,12 +49,19 @@ DISTRIBUTION_APP_BUNDLE_NAME="$DISPLAY_NAME.app"
 ARCHIVE_BASENAME="$APP_NAME-tip-$TIP_SHORT_SHA-$TIP_BUILD_NUMBER"
 UPDATE_ZIP="$DIST_DIR/$ARCHIVE_BASENAME.zip"
 DMG="$DIST_DIR/$ARCHIVE_BASENAME.dmg"
+TRANSITION_PKG="$DIST_DIR/$ARCHIVE_BASENAME.pkg"
+if [[ "$ROLLOUT_INSTALLATION_TYPE" == "package" ]]; then
+    ENCLOSURE="$TRANSITION_PKG"
+else
+    ENCLOSURE="$UPDATE_ZIP"
+fi
 APPCAST="$DIST_DIR/appcast.xml"
 CHECKSUMS="$DIST_DIR/SHA256SUMS"
 BUILD_ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
 SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/release"
 FINAL_ARTIFACT_MANIFEST="$DIST_DIR/$ARCHIVE_BASENAME-artifact-manifest.json"
 FINAL_METADATA="$DIST_DIR/$ARCHIVE_BASENAME-metadata.json"
+ROLLOUT_MANIFEST="$DIST_DIR/identity-rollout.json"
 STAGE_ARCHIVE="$DIST_DIR/$ARCHIVE_BASENAME-stage.zip"
 STAGE_ARCHIVE_CHECKSUM="$STAGE_ARCHIVE.sha256"
 RUN_WITHOUT_GITHUB_TOKENS="$CONTROL_PLANE_SCRIPTS_DIR/run_without_github_tokens.sh"
@@ -129,7 +148,7 @@ validate_packaged_legal() {
 
 write_tip_metadata() {
     cat > "$FINAL_METADATA" <<JSON
-{"commit":"$TIP_COMMIT","short_sha":"$TIP_SHORT_SHA","tag":"$TIP_TAG","marketing_version":"$MARKETING_VERSION","build_number":"$TIP_BUILD_NUMBER"}
+{"commit":"$TIP_COMMIT","short_sha":"$TIP_SHORT_SHA","tag":"$TIP_TAG","marketing_version":"$MARKETING_VERSION","build_number":"$TIP_BUILD_NUMBER","rollout_role":"$ROLLOUT_ROLE","signing_identity":"$ROLLOUT_IDENTITY","migration_phase":"$REPOPROMPT_IDENTITY_MIGRATION_PHASE"}
 JSON
 }
 
@@ -160,6 +179,7 @@ PYTHON
 
 stage_tip() {
     require_command ditto
+    require_command curl
     require_command git
     require_command shasum
     [[ "$TIP_BUILD_NUMBER" =~ ^[0-9]{1,4}\.[0-9]{1,2}\.[0-9]{1,2}$ ]] ||
@@ -171,7 +191,10 @@ stage_tip() {
         REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR="$CONTROL_PLANE_SCRIPTS_DIR" \
         MARKETING_VERSION="$MARKETING_VERSION" \
+        BUNDLE_ID="$BUNDLE_ID" \
+        SIGNING_TEAM_ID="$SIGNING_TEAM_ID" \
         REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE="$TIP_BUILD_NUMBER" \
+        REPOPROMPT_IDENTITY_MIGRATION_PHASE="$REPOPROMPT_IDENTITY_MIGRATION_PHASE" \
         REPOPROMPT_ENABLE_SENTRY=1 \
         RELEASE_ALLOW_ADHOC_SIGNING=1 \
         "$CONTROL_PLANE_SCRIPTS_DIR/package_app.sh" release
@@ -220,112 +243,45 @@ derive_sparkle_public_key() {
     xcrun swift "$CONTROL_PLANE_SCRIPTS_DIR/derive_sparkle_public_key.swift" "$1"
 }
 
-label_generated_tip_appcast() {
-    python3 - "$APPCAST" "$MARKETING_VERSION" "$TIP_BUILD_NUMBER" "$TIP_SHORT_SHA" <<'PYTHON'
-import sys
-import xml.etree.ElementTree as ET
+generate_tip_rollout_appcast() {
+    local predecessor_dir="$TMP_DIR/predecessors"
+    mkdir -p "$predecessor_dir"
+    local predecessor_args=()
+    local position=0 role tag digest path actual_digest
+    while IFS=$'\t' read -r role tag digest; do
+        [[ -n "$role" ]] || continue
+        position=$((position + 1))
+        path="$predecessor_dir/$position-identity-rollout.json"
+        curl --fail --location --retry 3 --silent --show-error \
+            "https://github.com/$TIP_UPDATE_REPOSITORY/releases/download/$tag/identity-rollout.json" \
+            --output "$path"
+        actual_digest="$(shasum -a 256 "$path" | awk '{print $1}')"
+        [[ "$actual_digest" == "$digest" ]] ||
+            fail "Tip predecessor $role manifest digest mismatch for $tag"
+        predecessor_args+=(--predecessor-manifest "$path")
+    done < <(python3 "$ROLLOUT_TOOL" predecessor-values --declaration "$ROLLOUT_DECLARATION")
 
-sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
-ET.register_namespace("sparkle", sparkle)
-tree = ET.parse(sys.argv[1])
-root = tree.getroot()
-items = root.findall("./channel/item")
-if len(items) != 1:
-    raise SystemExit(f"tip appcast must contain exactly one item, got {len(items)}")
+    local enclosure_signature
+    enclosure_signature="$(printf '%s' "$SPARKLE_PRIVATE_KEY" |
+        "$SIGN_UPDATE" --ed-key-file - -p "$ENCLOSURE" |
+        tr -d '\r\n')"
+    [[ -n "$enclosure_signature" ]] || fail "Unable to sign Tip rollout enclosure"
 
-item = items[0]
-marketing_version, build_number, short_sha = sys.argv[2:]
-
-def singleton_or_create(element_name, qualified_name):
-    elements = item.findall(qualified_name)
-    if len(elements) > 1:
-        raise SystemExit(
-            f"tip appcast item must contain at most one {element_name}, got {len(elements)}"
-        )
-    return elements[0] if elements else ET.SubElement(item, qualified_name)
-
-title = singleton_or_create("title", "title")
-title.text = f"Tip build {build_number} · v{marketing_version} · commit {short_sha}"
-short_version = singleton_or_create(
-    "sparkle:shortVersionString", f"{{{sparkle}}}shortVersionString"
-)
-short_version.text = marketing_version
-# Sparkle embeds releaseNotesLink targets inside its stock update window.
-# Tip releases intentionally keep that dialog compact instead of loading a full
-# GitHub release page as web content.
-for release_notes_link in item.findall(f"{{{sparkle}}}releaseNotesLink"):
-    item.remove(release_notes_link)
-for description in item.findall("description"):
-    item.remove(description)
-
-tree.write(sys.argv[1], encoding="utf-8", xml_declaration=True)
-PYTHON
-}
-
-validate_generated_tip_appcast() {
-    local appcast_values="$TMP_DIR/tip-appcast-values.tsv"
-    python3 - "$APPCAST" > "$appcast_values" <<'PYTHON'
-import sys
-import xml.etree.ElementTree as ET
-
-sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
-root = ET.parse(sys.argv[1]).getroot()
-items = root.findall("./channel/item")
-if len(items) != 1:
-    raise SystemExit(f"tip appcast must contain exactly one item, got {len(items)}")
-enclosures = items[0].findall("enclosure")
-if len(enclosures) != 1:
-    raise SystemExit(f"tip appcast item must contain exactly one enclosure, got {len(enclosures)}")
-item = items[0]
-enclosure = enclosures[0]
-titles = item.findall("title")
-versions = item.findall(f"{{{sparkle}}}version")
-short_versions = item.findall(f"{{{sparkle}}}shortVersionString")
-release_notes_links = item.findall(f"{{{sparkle}}}releaseNotesLink")
-descriptions = item.findall("description")
-if len(titles) != 1:
-    raise SystemExit(f"tip appcast item must contain exactly one title, got {len(titles)}")
-if len(versions) != 1:
-    raise SystemExit(
-        f"tip appcast item must contain exactly one sparkle:version, got {len(versions)}"
-    )
-if len(short_versions) != 1:
-    raise SystemExit(
-        "tip appcast item must contain exactly one "
-        f"sparkle:shortVersionString, got {len(short_versions)}"
-    )
-if release_notes_links:
-    raise SystemExit(
-        "tip appcast item must not contain sparkle:releaseNotesLink"
-    )
-if descriptions:
-    raise SystemExit("tip appcast item must not contain description")
-values = [
-    enclosure.attrib.get("url", ""),
-    enclosure.attrib.get(f"{{{sparkle}}}edSignature", ""),
-    enclosure.attrib.get("length", ""),
-    versions[0].text or "",
-    short_versions[0].text or "",
-    titles[0].text or "",
-]
-print("\x1f".join([str(len(values)), *values]))
-PYTHON
-
-    local appcast_field_count enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing appcast_title
-    IFS=$'\x1f' read -r appcast_field_count enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing appcast_title < "$appcast_values"
-    [[ "$appcast_field_count" == "6" ]] ||
-        fail "Tip appcast metadata field count mismatch: expected 6, got $appcast_field_count"
-    [[ "$enclosure_url" == "$TIP_DOWNLOAD_URL_PREFIX$(basename "$UPDATE_ZIP")" ]] ||
-        fail "Tip appcast enclosure URL mismatch: $enclosure_url"
-    [[ -n "$enclosure_signature" ]] || fail "Tip appcast enclosure is missing an EdDSA signature"
-    [[ "$enclosure_length" == "$(stat -f %z "$UPDATE_ZIP")" ]] ||
-        fail "Tip appcast enclosure length does not match $(basename "$UPDATE_ZIP")"
-    [[ "$appcast_build" == "$TIP_BUILD_NUMBER" ]] ||
-        fail "Tip appcast build mismatch: expected $TIP_BUILD_NUMBER, got $appcast_build"
-    [[ "$appcast_marketing" == "$MARKETING_VERSION" ]] ||
-        fail "Tip appcast marketing version mismatch: expected $MARKETING_VERSION, got $appcast_marketing"
-    [[ "$appcast_title" == "Tip build $TIP_BUILD_NUMBER · v$MARKETING_VERSION · commit $TIP_SHORT_SHA" ]] ||
-        fail "Tip appcast presentation title mismatch: $appcast_title"
+    python3 "$ROLLOUT_TOOL" generate \
+        --declaration "$ROLLOUT_DECLARATION" \
+        --policy "$APPLE_IDENTITY_POLICY" \
+        --version-env "$ROOT_DIR/version.env" \
+        --release-tag "$TIP_TAG" \
+        --release-commit "$TIP_COMMIT" \
+        --migration-phase "$REPOPROMPT_IDENTITY_MIGRATION_PHASE" \
+        --allowed-roles legacy,preparer,transition,successor \
+        --enclosure "$ENCLOSURE" \
+        --enclosure-basename "$ARCHIVE_BASENAME" \
+        --enclosure-signature "$enclosure_signature" \
+        --app-artifact-manifest "$FINAL_ARTIFACT_MANIFEST" \
+        "${predecessor_args[@]}" \
+        --appcast-output "$APPCAST" \
+        --manifest-output "$ROLLOUT_MANIFEST"
 
     local private_key_file="$TMP_DIR/tip-sparkle-private-key"
     local public_key_file="$TMP_DIR/tip-sparkle-public-key"
@@ -338,17 +294,18 @@ PYTHON
     [[ "$derived_public_key" == "$committed_public_key" ]] ||
         fail "Tip Sparkle private key does not match the app bundle SUPublicEDKey"
     reproduced_signature="$(printf '%s' "$SPARKLE_PRIVATE_KEY" |
-        "$SIGN_UPDATE" --ed-key-file - -p "$UPDATE_ZIP" |
+        "$SIGN_UPDATE" --ed-key-file - -p "$ENCLOSURE" |
         tr -d '\r\n')"
     [[ "$reproduced_signature" == "$enclosure_signature" ]] ||
         fail "Tip Sparkle private key does not reproduce the generated appcast signature"
 
     printf '%s' "$committed_public_key" > "$public_key_file"
     xcrun swift "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift" \
-        "$public_key_file" "$enclosure_signature" "$UPDATE_ZIP"
+        "$public_key_file" "$enclosure_signature" "$ENCLOSURE"
 }
 
 sign_tip() {
+    require_command curl
     require_command ditto
     require_command hdiutil
     require_command plutil
@@ -368,10 +325,18 @@ sign_tip() {
     require_env RELEASE_COMMIT
     require_env REPOPROMPT_APPROVED_SOURCE_ROOT
     require_tip_sentry_configuration
+    [[ "$SIGN_IDENTITY" == "$EXPECTED_SIGN_IDENTITY" ]] ||
+        fail "SIGN_IDENTITY does not match the reviewed $ROLLOUT_IDENTITY identity"
+    if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
+        require_env INSTALLER_IDENTITY
+        [[ "$INSTALLER_IDENTITY" == "$EXPECTED_INSTALLER_IDENTITY" ]] ||
+            fail "INSTALLER_IDENTITY does not match the reviewed successor installer identity"
+    fi
     [[ "$RELEASE_COMMIT" == "$TIP_COMMIT" ]] || fail "RELEASE_COMMIT must match TIP_COMMIT"
     [[ -d "$APP_BUNDLE" ]] || fail "Missing staged tip app bundle: $APP_BUNDLE"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE="$TIP_BUILD_NUMBER" \
+        REPOPROMPT_IDENTITY_MIGRATION_PHASE="$REPOPROMPT_IDENTITY_MIGRATION_PHASE" \
         "$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"
     verify_release_sentry_symbol_uuids_before_signing \
         "$SENTRY_SYMBOLS_DIR" \
@@ -382,6 +347,7 @@ sign_tip() {
         "repoprompt-mcp"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE="$TIP_BUILD_NUMBER" \
+        REPOPROMPT_IDENTITY_MIGRATION_PHASE="$REPOPROMPT_IDENTITY_MIGRATION_PHASE" \
         "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
     prepare_dist
     TMP_DIR="$(mktemp -d)"
@@ -405,35 +371,36 @@ sign_tip() {
         "repoprompt-mcp.dSYM" \
         "repoprompt-mcp"
 
-    local distribution_dir="$TMP_DIR/distribution"
-    mkdir -p "$distribution_dir"
-    ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
-    ditto -c -k --norsrc --keepParent "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
-    validate_distribution_zip "$UPDATE_ZIP" "$FINAL_ARTIFACT_MANIFEST" "Final tip distribution" "$SIGNING_TEAM_ID"
-    hdiutil create -volname "$DISPLAY_NAME Tip" -srcfolder "$distribution_dir" -ov -format UDZO "$DMG"
-    submit_notarization "$DMG"
-    xcrun stapler staple "$DMG"
-    xcrun stapler validate "$DMG"
+    local checksum_assets=()
+    if [[ "$ROLLOUT_INSTALLATION_TYPE" == "package" ]]; then
+        REPOPROMPT_ENABLE_IDENTITY_TRANSITION_PKG=1 \
+            "$CONTROL_PLANE_SCRIPTS_DIR/build_identity_transition_pkg.sh" build \
+            --app "$APP_BUNDLE" \
+            --output "$TRANSITION_PKG" \
+            --installer-identity "$INSTALLER_IDENTITY"
+        checksum_assets+=("$(basename "$TRANSITION_PKG")")
+    else
+        local distribution_dir="$TMP_DIR/distribution"
+        mkdir -p "$distribution_dir"
+        ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
+        ditto -c -k --norsrc --keepParent "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
+        validate_distribution_zip "$UPDATE_ZIP" "$FINAL_ARTIFACT_MANIFEST" "Final tip distribution" "$SIGNING_TEAM_ID"
+        hdiutil create -volname "$DISPLAY_NAME Tip" -srcfolder "$distribution_dir" -ov -format UDZO "$DMG"
+        submit_notarization "$DMG"
+        xcrun stapler staple "$DMG"
+        xcrun stapler validate "$DMG"
+        checksum_assets+=("$(basename "$UPDATE_ZIP")" "$(basename "$DMG")")
+    fi
 
-    local appcast_dir="$TMP_DIR/appcast"
-    mkdir -p "$appcast_dir"
-    cp "$UPDATE_ZIP" "$appcast_dir/"
-    printf '%s' "$SPARKLE_PRIVATE_KEY" |
-        "$TRUSTED_ROOT/Vendor/Sparkle/bin/generate_appcast" \
-            --ed-key-file - \
-            --download-url-prefix "$TIP_DOWNLOAD_URL_PREFIX" \
-            -o "$APPCAST" \
-            "$appcast_dir"
-    label_generated_tip_appcast
-    validate_generated_tip_appcast
-    (cd "$DIST_DIR" && shasum -a 256 \
-        "$(basename "$UPDATE_ZIP")" \
-        "$(basename "$DMG")" \
-        "$(basename "$APPCAST")" \
-        "$(basename "$FINAL_ARTIFACT_MANIFEST")" \
-        "$(basename "$FINAL_METADATA")" \
-        > "$(basename "$CHECKSUMS")")
-    printf 'OK: signed and notarized tip artifact %s.\n' "$TIP_TAG"
+    generate_tip_rollout_appcast
+    checksum_assets+=(
+        "$(basename "$APPCAST")"
+        "$(basename "$FINAL_ARTIFACT_MANIFEST")"
+        "$(basename "$FINAL_METADATA")"
+        "$(basename "$ROLLOUT_MANIFEST")"
+    )
+    (cd "$DIST_DIR" && shasum -a 256 "${checksum_assets[@]}" > "$(basename "$CHECKSUMS")")
+    printf 'OK: signed and notarized Tip %s artifact %s.\n' "$ROLLOUT_ROLE" "$TIP_TAG"
 }
 
 publish_tip() {
@@ -444,21 +411,22 @@ publish_tip() {
             fail "TIP_UPDATE_REPOSITORY must not target the source or stable update repository"
             ;;
     esac
-    for path in "$UPDATE_ZIP" "$DMG" "$APPCAST" "$CHECKSUMS" "$FINAL_ARTIFACT_MANIFEST" "$FINAL_METADATA"; do
+    local role_assets=("$APPCAST" "$CHECKSUMS" "$FINAL_ARTIFACT_MANIFEST" "$FINAL_METADATA" "$ROLLOUT_MANIFEST")
+    if [[ "$ROLLOUT_INSTALLATION_TYPE" == "package" ]]; then
+        role_assets+=("$TRANSITION_PKG")
+    else
+        role_assets+=("$UPDATE_ZIP" "$DMG")
+    fi
+    for path in "${role_assets[@]}"; do
         [[ -f "$path" ]] || fail "Missing tip publish asset: $path"
     done
     GH_TOKEN="$TIP_GH_TOKEN" gh release create "$TIP_TAG" \
-        "$UPDATE_ZIP" \
-        "$DMG" \
-        "$APPCAST" \
-        "$CHECKSUMS" \
-        "$FINAL_ARTIFACT_MANIFEST" \
-        "$FINAL_METADATA" \
+        "${role_assets[@]}" \
         --repo "$TIP_UPDATE_REPOSITORY" \
         --target main \
         --latest \
-        --title "$DISPLAY_NAME Tip $TIP_SHORT_SHA" \
-        --notes "Tip build from main commit \`$TIP_COMMIT\` with build number \`$TIP_BUILD_NUMBER\`."
+        --title "$DISPLAY_NAME Tip $ROLLOUT_ROLE $TIP_SHORT_SHA" \
+        --notes "Tip identity rollout role \`$ROLLOUT_ROLE\` from main commit \`$TIP_COMMIT\` with build number \`$TIP_BUILD_NUMBER\`."
     printf 'OK: published tip update release %s to %s.\n' "$TIP_TAG" "$TIP_UPDATE_REPOSITORY"
 }
 

--- a/Scripts/stable_rollout.py
+++ b/Scripts/stable_rollout.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Single Stable rollout authority for the Apple identity transition.
+"""Single rollout authority for the Apple identity transition.
 
-Owns the reviewed declaration (`release-rollout.json`), the generated immutable
-rollout manifest (`dist/<archive-basename>-stable-rollout.json`), and the
-accumulated Stable appcast. Version/build/bundle/team values are never
+Owns reviewed channel declarations, generated immutable rollout manifests, and
+the accumulated Stable or Tip appcast. Version/build/bundle/team values are never
 duplicated in the declaration; they are derived from `version.env` and
 `Scripts/apple_identity_policy.json` and cross-checked here.
 
@@ -26,6 +25,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import shlex
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -37,6 +37,7 @@ MANIFEST_SCHEMA_VERSION = 1
 POLICY_SCHEMA_VERSION = 1
 
 ROLES = ("legacy", "preparer", "transition", "successor")
+CHANNELS = ("stable", "tip")
 WORKFLOW_ALLOWED_ROLES = ("legacy", "preparer")
 ROLE_IDENTITY = {
     "legacy": "legacy",
@@ -122,7 +123,14 @@ def load_policy(path: Path) -> dict:
     sparkle = policy.get("sparkle")
     if not isinstance(sparkle, dict) or not all(
         isinstance(sparkle.get(key), str) and sparkle.get(key)
-        for key in ("stableFeedURL", "sparklePublicEdDSAValue", "updateRepository", "minimumSystemVersion")
+        for key in (
+            "stableFeedURL",
+            "tipFeedURL",
+            "sparklePublicEdDSAValue",
+            "updateRepository",
+            "tipUpdateRepository",
+            "minimumSystemVersion",
+        )
     ):
         raise RolloutError("apple identity policy is missing sparkle invariants")
     return policy
@@ -137,8 +145,8 @@ def load_declaration(path: Path) -> dict:
         )
     if declaration["schemaVersion"] != DECLARATION_SCHEMA_VERSION:
         raise RolloutError("rollout declaration schema version mismatch")
-    if declaration["channel"] != "stable":
-        raise RolloutError("rollout declaration channel must be stable")
+    if declaration["channel"] not in CHANNELS:
+        raise RolloutError(f"rollout declaration channel must be one of {', '.join(CHANNELS)}")
     role = declaration["currentRole"]
     if role not in ROLES:
         raise RolloutError(f"unknown rollout role: {role!r}")
@@ -162,8 +170,12 @@ def load_declaration(path: Path) -> dict:
             )
         if entry["role"] not in ROLES:
             raise RolloutError(f"predecessor {position} has unknown role {entry['role']!r}")
-        if not isinstance(entry["tag"], str) or not entry["tag"].startswith("v"):
-            raise RolloutError(f"predecessor {position} tag must look like v<marketing-version>")
+        if not isinstance(entry["tag"], str) or not entry["tag"]:
+            raise RolloutError(f"predecessor {position} tag must be a nonempty string")
+        if declaration["channel"] == "stable" and not entry["tag"].startswith("v"):
+            raise RolloutError(f"predecessor {position} Stable tag must look like v<marketing-version>")
+        if declaration["channel"] == "tip" and not entry["tag"].startswith("tip-"):
+            raise RolloutError(f"predecessor {position} Tip tag must start with tip-")
         digest = entry["rolloutManifestSha256"]
         if not isinstance(digest, str) or len(digest) != 64 or not all(c in "0123456789abcdef" for c in digest):
             raise RolloutError(f"predecessor {position} rolloutManifestSha256 must be lowercase hex sha256")
@@ -191,19 +203,39 @@ def load_version_env(path: Path) -> dict[str, str]:
     return values
 
 
-def expected_enclosure_name(app_name: str, marketing: str, build: str, role: str) -> str:
-    return f"{app_name}-{marketing}-{build}{ROLE_ENCLOSURE_SUFFIX[role]}"
+def expected_enclosure_name(
+    app_name: str,
+    marketing: str,
+    build: str,
+    role: str,
+    enclosure_basename: str | None = None,
+) -> str:
+    basename = enclosure_basename or f"{app_name}-{marketing}-{build}"
+    return f"{basename}{ROLE_ENCLOSURE_SUFFIX[role]}"
 
 
-def rollout_manifest_name(app_name: str, marketing: str, build: str) -> str:
+def rollout_manifest_name(app_name: str, marketing: str, build: str, channel: str) -> str:
+    if channel == "tip":
+        return "identity-rollout.json"
     return f"{app_name}-{marketing}-{build}-stable-rollout.json"
+
+
+def update_repository(policy: dict, channel: str) -> str:
+    key = "tipUpdateRepository" if channel == "tip" else "updateRepository"
+    return policy["sparkle"][key]
 
 
 def enclosure_url(update_repository: str, tag: str, name: str) -> str:
     return f"https://github.com/{update_repository}/releases/download/{tag}/{name}"
 
 
-def validate_item_shape(item: dict, position: int, policy: dict, app_name: str) -> None:
+def validate_item_shape(
+    item: dict,
+    position: int,
+    policy: dict,
+    app_name: str,
+    channel: str,
+) -> None:
     minimum_system = policy["sparkle"]["minimumSystemVersion"]
     role = item.get("role")
     if role not in ROLES:
@@ -212,8 +244,10 @@ def validate_item_shape(item: dict, position: int, policy: dict, app_name: str) 
     marketing = str(item.get("marketingVersion", ""))
     parse_build(build, f"item {position} build number")
     tag = item.get("tag", "")
-    if tag != f"v{marketing}":
-        raise RolloutError(f"appcast item {position} tag must be v{marketing}, got {tag!r}")
+    if channel == "stable" and tag != f"v{marketing}":
+        raise RolloutError(f"appcast item {position} Stable tag must be v{marketing}, got {tag!r}")
+    if channel == "tip" and not str(tag).startswith("tip-"):
+        raise RolloutError(f"appcast item {position} Tip tag must start with tip-, got {tag!r}")
     if item.get("minimumSystemVersion") != minimum_system:
         raise RolloutError(
             f"appcast item {position} minimumSystemVersion must be exactly {minimum_system}"
@@ -223,12 +257,10 @@ def validate_item_shape(item: dict, position: int, policy: dict, app_name: str) 
             f"appcast item {position} installation type must be "
             f"{ROLE_INSTALLATION_TYPE[role]} for the {role} role"
         )
-    expected_name = expected_enclosure_name(app_name, marketing, build, role)
-    if item.get("enclosureName") != expected_name:
-        raise RolloutError(
-            f"appcast item {position} enclosure name must be {expected_name}, got {item.get('enclosureName')!r}"
-        )
-    if item.get("url") != enclosure_url(policy["sparkle"]["updateRepository"], tag, expected_name):
+    enclosure_name = item.get("enclosureName")
+    if not isinstance(enclosure_name, str) or not enclosure_name.endswith(ROLE_ENCLOSURE_SUFFIX[role]):
+        raise RolloutError(f"appcast item {position} enclosure name has the wrong role suffix")
+    if item.get("url") != enclosure_url(update_repository(policy, channel), tag, enclosure_name):
         raise RolloutError(f"appcast item {position} enclosure URL mismatch: {item.get('url')!r}")
     size = item.get("enclosureSize")
     if not isinstance(size, int) or size <= 0:
@@ -276,11 +308,16 @@ def render_appcast(manifest: dict) -> str:
         f'xmlns:sparkle="{SPARKLE_NAMESPACE}" '
         f'xmlns:repoprompt="{ROLLOUT_NAMESPACE}">',
         "  <channel>",
-        "    <title>RepoPrompt CE Stable</title>",
+        f"    <title>RepoPrompt CE {manifest['channel'].title()}</title>",
     ]
     for item in manifest["appcastItems"]:
         lines.append("    <item>")
-        lines.append(f"      <title>Version {xml_escape(str(item['marketingVersion']))}</title>")
+        title = (
+            f"Tip build {item['buildNumber']}"
+            if manifest["channel"] == "tip"
+            else f"Version {item['marketingVersion']}"
+        )
+        lines.append(f"      <title>{xml_escape(str(title))}</title>")
         lines.append(
             f"      <repoprompt:rolloutRole>{xml_escape(item['role'])}</repoprompt:rolloutRole>"
         )
@@ -341,6 +378,11 @@ def load_predecessor_manifests(
                 f"expected {entry['rolloutManifestSha256']}, got {digest}"
             )
         manifest = load_manifest(path)
+        if manifest.get("channel") != declaration["channel"]:
+            raise RolloutError(
+                f"predecessor {position} channel mismatch: declaration says {declaration['channel']}, "
+                f"manifest says {manifest.get('channel')}"
+            )
         if manifest.get("currentRole") != entry["role"]:
             raise RolloutError(
                 f"predecessor {position} manifest role mismatch: declaration says {entry['role']}, "
@@ -352,7 +394,7 @@ def load_predecessor_manifests(
                 f"manifest says {manifest.get('sourceTag')}"
             )
         current_item = manifest["appcastItems"][0]
-        validate_item_shape(current_item, position, policy, app_name)
+        validate_item_shape(current_item, position, policy, app_name, declaration["channel"])
         loaded.append(manifest)
     return loaded
 
@@ -362,6 +404,7 @@ def build_manifest(args: argparse.Namespace) -> tuple[dict, str]:
     declaration = load_declaration(Path(args.declaration))
     version = load_version_env(Path(args.version_env))
     role = declaration["currentRole"]
+    channel = declaration["channel"]
 
     allowed_roles = tuple(args.allowed_roles.split(",")) if args.allowed_roles else ROLES
     if role not in allowed_roles:
@@ -370,17 +413,18 @@ def build_manifest(args: argparse.Namespace) -> tuple[dict, str]:
         )
 
     identity = policy["identities"][ROLE_IDENTITY[role]]
-    if ROLE_IDENTITY[role] == "legacy":
-        if version["BUNDLE_ID"] != identity["bundleIdentifier"]:
-            raise RolloutError("version.env BUNDLE_ID does not match the legacy identity policy")
-        if version["SIGNING_TEAM_ID"] != identity["teamIdentifier"]:
-            raise RolloutError("version.env SIGNING_TEAM_ID does not match the legacy identity policy")
+    if version["BUNDLE_ID"] != identity["bundleIdentifier"]:
+        raise RolloutError(f"version.env BUNDLE_ID does not match the {ROLE_IDENTITY[role]} identity policy")
+    if version["SIGNING_TEAM_ID"] != identity["teamIdentifier"]:
+        raise RolloutError(f"version.env SIGNING_TEAM_ID does not match the {ROLE_IDENTITY[role]} identity policy")
 
     marketing = version["MARKETING_VERSION"]
     build = version["BUILD_NUMBER"]
     app_name = version["APP_NAME"]
-    if args.release_tag != f"v{marketing}":
-        raise RolloutError(f"release tag must be v{marketing}, got {args.release_tag}")
+    if channel == "stable" and args.release_tag != f"v{marketing}":
+        raise RolloutError(f"Stable release tag must be v{marketing}, got {args.release_tag}")
+    if channel == "tip" and not args.release_tag.startswith("tip-"):
+        raise RolloutError(f"Tip release tag must start with tip-, got {args.release_tag}")
     if args.migration_phase != ROLE_MIGRATION_PHASE[role]:
         raise RolloutError(
             f"migration phase must be {ROLE_MIGRATION_PHASE[role]} for the {role} role, "
@@ -388,7 +432,9 @@ def build_manifest(args: argparse.Namespace) -> tuple[dict, str]:
         )
 
     enclosure = Path(args.enclosure)
-    expected_name = expected_enclosure_name(app_name, marketing, build, role)
+    expected_name = expected_enclosure_name(
+        app_name, marketing, build, role, args.enclosure_basename
+    )
     if enclosure.name != expected_name:
         raise RolloutError(f"enclosure must be named {expected_name}, got {enclosure.name}")
     if not args.enclosure_signature.strip():
@@ -403,7 +449,7 @@ def build_manifest(args: argparse.Namespace) -> tuple[dict, str]:
     current_item = {
         "role": role,
         "tag": tag,
-        "url": enclosure_url(policy["sparkle"]["updateRepository"], tag, expected_name),
+        "url": enclosure_url(update_repository(policy, channel), tag, expected_name),
         "buildNumber": build,
         "marketingVersion": marketing,
         "minimumSystemVersion": policy["sparkle"]["minimumSystemVersion"],
@@ -428,16 +474,17 @@ def build_manifest(args: argparse.Namespace) -> tuple[dict, str]:
             app_name,
             str(predecessor_item["marketingVersion"]),
             str(predecessor_item["buildNumber"]),
+            channel,
         )
         items.append(predecessor_item)
 
     for position, item in enumerate(items, start=1):
-        validate_item_shape(item, position, policy, app_name)
+        validate_item_shape(item, position, policy, app_name, channel)
     validate_item_ladder(items)
 
     manifest = {
         "schemaVersion": MANIFEST_SCHEMA_VERSION,
-        "channel": "stable",
+        "channel": channel,
         "sourceTag": tag,
         "releaseCommit": args.release_commit,
         "currentRole": role,
@@ -448,7 +495,7 @@ def build_manifest(args: argparse.Namespace) -> tuple[dict, str]:
         "buildNumber": build,
         "migrationPhase": args.migration_phase,
         "eligibilityProfile": declaration["eligibilityProfile"],
-        "updateRepository": policy["sparkle"]["updateRepository"],
+        "updateRepository": update_repository(policy, channel),
         "appArtifactManifest": {
             "name": app_artifact_manifest.name,
             "sha256": sha256_file(app_artifact_manifest),
@@ -467,7 +514,7 @@ def run_generate(args: argparse.Namespace) -> None:
     )
     Path(args.appcast_output).write_text(appcast, encoding="utf-8")
     print(
-        f"OK: generated stable rollout manifest and appcast with {len(manifest['appcastItems'])} "
+        f"OK: generated {manifest['channel']} rollout manifest and appcast with {len(manifest['appcastItems'])} "
         f"item(s) for the {manifest['currentRole']} role."
     )
 
@@ -495,7 +542,7 @@ def run_validate(args: argparse.Namespace) -> None:
     if actual_appcast != expected_appcast:
         raise RolloutError("accumulated appcast does not match the generated rollout manifest")
     print(
-        f"OK: stable rollout manifest and appcast validated with "
+        f"OK: {expected_manifest['channel']} rollout manifest and appcast validated with "
         f"{len(expected_manifest['appcastItems'])} item(s)."
     )
 
@@ -503,6 +550,8 @@ def run_validate(args: argparse.Namespace) -> None:
 def run_workflow_guard(args: argparse.Namespace) -> None:
     load_policy(Path(args.policy))
     declaration = load_declaration(Path(args.declaration))
+    if declaration["channel"] != "stable":
+        raise RolloutError("protected Stable workflows require a Stable rollout declaration")
     role = declaration["currentRole"]
     if role not in WORKFLOW_ALLOWED_ROLES:
         raise RolloutError(
@@ -519,6 +568,38 @@ def run_workflow_guard(args: argparse.Namespace) -> None:
 
 def run_current_role(args: argparse.Namespace) -> None:
     print(load_declaration(Path(args.declaration))["currentRole"])
+
+
+def run_packaging_context(args: argparse.Namespace) -> None:
+    policy = load_policy(Path(args.policy))
+    declaration = load_declaration(Path(args.declaration))
+    role = declaration["currentRole"]
+    identity_name = ROLE_IDENTITY[role]
+    identity = policy["identities"][identity_name]
+    values = {
+        "ROLLOUT_CHANNEL": declaration["channel"],
+        "ROLLOUT_ROLE": role,
+        "ROLLOUT_IDENTITY": identity_name,
+        "BUNDLE_ID": identity["bundleIdentifier"],
+        "SIGNING_TEAM_ID": identity["teamIdentifier"],
+        "REPOPROMPT_IDENTITY_MIGRATION_PHASE": ROLE_MIGRATION_PHASE[role],
+        "ROLLOUT_INSTALLATION_TYPE": ROLE_INSTALLATION_TYPE[role],
+        "ROLLOUT_ENCLOSURE_SUFFIX": ROLE_ENCLOSURE_SUFFIX[role],
+        "EXPECTED_SIGN_IDENTITY": identity["developerIDApplicationIdentityName"],
+        "EXPECTED_INSTALLER_IDENTITY": identity.get("developerIDInstallerIdentityName", ""),
+        "ROLLOUT_UPDATE_REPOSITORY": update_repository(policy, declaration["channel"]),
+        "ROLLOUT_FEED_URL": policy["sparkle"][
+            "tipFeedURL" if declaration["channel"] == "tip" else "stableFeedURL"
+        ],
+    }
+    for key, value in values.items():
+        print(f"{key}={shlex.quote(value)}")
+
+
+def run_predecessor_values(args: argparse.Namespace) -> None:
+    declaration = load_declaration(Path(args.declaration))
+    for entry in declaration["predecessors"]:
+        print("\t".join((entry["role"], entry["tag"], entry["rolloutManifestSha256"])))
 
 
 def run_max_build(args: argparse.Namespace) -> None:
@@ -572,6 +653,7 @@ def add_shared_generate_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--app-artifact-manifest", required=True)
     parser.add_argument("--predecessor-manifest", action="append", default=[])
     parser.add_argument("--allowed-roles")
+    parser.add_argument("--enclosure-basename")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -586,6 +668,15 @@ def build_parser() -> argparse.ArgumentParser:
     current_role = subparsers.add_parser("current-role")
     current_role.add_argument("--declaration", required=True)
     current_role.set_defaults(func=run_current_role)
+
+    packaging_context = subparsers.add_parser("packaging-context")
+    packaging_context.add_argument("--declaration", required=True)
+    packaging_context.add_argument("--policy", required=True)
+    packaging_context.set_defaults(func=run_packaging_context)
+
+    predecessor_values = subparsers.add_parser("predecessor-values")
+    predecessor_values.add_argument("--declaration", required=True)
+    predecessor_values.set_defaults(func=run_predecessor_values)
 
     generate = subparsers.add_parser("generate")
     add_shared_generate_arguments(generate)

--- a/Scripts/stable_rollout.py
+++ b/Scripts/stable_rollout.py
@@ -258,7 +258,13 @@ def validate_item_shape(
             f"{ROLE_INSTALLATION_TYPE[role]} for the {role} role"
         )
     enclosure_name = item.get("enclosureName")
-    if not isinstance(enclosure_name, str) or not enclosure_name.endswith(ROLE_ENCLOSURE_SUFFIX[role]):
+    if channel == "stable":
+        expected_name = expected_enclosure_name(app_name, marketing, build, role)
+        if enclosure_name != expected_name:
+            raise RolloutError(
+                f"appcast item {position} enclosure name must be {expected_name}, got {enclosure_name!r}"
+            )
+    elif not isinstance(enclosure_name, str) or not enclosure_name.endswith(ROLE_ENCLOSURE_SUFFIX[role]):
         raise RolloutError(f"appcast item {position} enclosure name has the wrong role suffix")
     if item.get("url") != enclosure_url(update_repository(policy, channel), tag, enclosure_name):
         raise RolloutError(f"appcast item {position} enclosure URL mismatch: {item.get('url')!r}")
@@ -573,9 +579,19 @@ def run_current_role(args: argparse.Namespace) -> None:
 def run_packaging_context(args: argparse.Namespace) -> None:
     policy = load_policy(Path(args.policy))
     declaration = load_declaration(Path(args.declaration))
+    version = load_version_env(Path(args.version_env))
     role = declaration["currentRole"]
     identity_name = ROLE_IDENTITY[role]
     identity = policy["identities"][identity_name]
+    if version["BUNDLE_ID"] != identity["bundleIdentifier"]:
+        raise RolloutError(
+            f"version.env BUNDLE_ID does not match the {identity_name} identity policy"
+        )
+    if version["SIGNING_TEAM_ID"] != identity["teamIdentifier"]:
+        raise RolloutError(
+            f"version.env SIGNING_TEAM_ID does not match the {identity_name} identity policy"
+        )
+    successor = policy["identities"]["successor"]
     values = {
         "ROLLOUT_CHANNEL": declaration["channel"],
         "ROLLOUT_ROLE": role,
@@ -587,6 +603,7 @@ def run_packaging_context(args: argparse.Namespace) -> None:
         "ROLLOUT_ENCLOSURE_SUFFIX": ROLE_ENCLOSURE_SUFFIX[role],
         "EXPECTED_SIGN_IDENTITY": identity["developerIDApplicationIdentityName"],
         "EXPECTED_INSTALLER_IDENTITY": identity.get("developerIDInstallerIdentityName", ""),
+        "EXPECTED_SUCCESSOR_SIGN_IDENTITY": successor["developerIDApplicationIdentityName"],
         "ROLLOUT_UPDATE_REPOSITORY": update_repository(policy, declaration["channel"]),
         "ROLLOUT_FEED_URL": policy["sparkle"][
             "tipFeedURL" if declaration["channel"] == "tip" else "stableFeedURL"
@@ -672,6 +689,7 @@ def build_parser() -> argparse.ArgumentParser:
     packaging_context = subparsers.add_parser("packaging-context")
     packaging_context.add_argument("--declaration", required=True)
     packaging_context.add_argument("--policy", required=True)
+    packaging_context.add_argument("--version-env", required=True)
     packaging_context.set_defaults(func=run_packaging_context)
 
     predecessor_values = subparsers.add_parser("predecessor-values")

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -271,7 +271,7 @@ APP_SIGN_ARGS=(){app_signing_body}
             source.index('sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"'),
         )
 
-    def test_release_workflows_gate_legacy_preparer_and_keep_automatic_tip_disabled(self) -> None:
+    def test_release_workflows_gate_stable_preparer_and_require_explicit_nonlegacy_tip_dispatch(self) -> None:
         workflows = SCRIPT_DIR.parent / ".github" / "workflows"
         release_workflow = (workflows / "release.yml").read_text(encoding="utf-8")
         tip_workflow = (workflows / "main-tip.yml").read_text(encoding="utf-8")
@@ -316,12 +316,17 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-successor-identity-anchor"', release_publish)
 
         self.assertNotIn("identity_migration_phase:", tip_workflow)
-        self.assertNotIn("legacy-preparer", tip_workflow)
-        self.assertNotIn("SUCCESSOR_", tip_workflow)
-        self.assertNotIn("Prepare successor identity migration anchor", tip_workflow)
+        self.assertIn("confirm_identity_rollout_role:", tip_workflow)
+        self.assertIn('if [[ "$ROLLOUT_ROLE" != "legacy" ]]', tip_workflow)
+        self.assertIn('if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]', tip_workflow)
+        self.assertIn('[[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
+        self.assertIn("Prepare successor identity migration anchor", tip_workflow)
+        self.assertIn("if: needs.setup.outputs.rollout-role == 'preparer'", tip_workflow)
         self.assertEqual(
-            tip_workflow.count("REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled"),
-            3,
+            tip_workflow.count(
+                "REPOPROMPT_IDENTITY_MIGRATION_PHASE: ${{ needs.setup.outputs.migration-phase }}"
+            ),
+            2,
         )
 
     def test_codex_v8_entitlement_allowlist_matches_pinned_manifest_policy(self) -> None:
@@ -4282,7 +4287,9 @@ extension Data {
         ):
             directory.mkdir(parents=True, exist_ok=True)
         for name in (
+            "apple_identity_policy.json",
             "load_release_metadata.sh",
+            "stable_rollout.py",
             "validate_embedded_mcp_helper_layout.sh",
             "validate_app_architectures.sh",
             "write_app_artifact_manifest.py",
@@ -4465,6 +4472,9 @@ esac
                 **cls.codex_fixture_environment(approved, staged),
             }
         )
+        tip_declaration = staged / "tip-rollout.json"
+        if script_name == "main_tip_release.sh":
+            shutil.copy2(SCRIPT_DIR.parent / "tip-rollout.json", tip_declaration)
         result = subprocess.run(
             [
                 "bash",
@@ -4479,6 +4489,7 @@ esac
             text=True,
             capture_output=True,
         )
+        tip_declaration.unlink(missing_ok=True)
         return result, capture
 
     def make_git_remote(self) -> tuple[Path, Path]:

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -3324,12 +3324,12 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertLess(sign_staged, assert_telemetry)
         self.assertLess(assert_telemetry, upload_symbols)
         self.assertLess(upload_symbols, create_distribution)
-        generate_appcast = sign_tip.index('"$TRUSTED_ROOT/Vendor/Sparkle/bin/generate_appcast"')
-        validate_appcast = sign_tip.index("validate_generated_tip_appcast")
-        write_checksums = sign_tip.index('shasum -a 256', validate_appcast)
-        self.assertLess(generate_appcast, validate_appcast)
-        self.assertLess(validate_appcast, write_checksums)
-        self.assertIn('fail "Tip appcast enclosure is missing an EdDSA signature"', tip_script)
+        generate_appcast = sign_tip.index("generate_tip_rollout_appcast")
+        write_checksums = sign_tip.index('shasum -a 256', generate_appcast)
+        self.assertLess(generate_appcast, write_checksums)
+        self.assertIn('python3 "$ROLLOUT_TOOL" generate', tip_script)
+        self.assertIn('--allowed-roles legacy,preparer,transition,successor', tip_script)
+        self.assertIn('--manifest-output "$ROLLOUT_MANIFEST"', tip_script)
         self.assertIn('fail "Tip Sparkle private key does not match the app bundle SUPublicEDKey"', tip_script)
         self.assertIn('fail "Tip Sparkle private key does not reproduce the generated appcast signature"', tip_script)
         self.assertIn('"$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift"', tip_script)
@@ -3449,6 +3449,7 @@ expected = [
     f"{archive}.dmg",
     "appcast.xml",
     "SHA256SUMS",
+    "identity-rollout.json",
     f"{archive}-artifact-manifest.json",
     f"{archive}-metadata.json",
 ]
@@ -3515,7 +3516,13 @@ sys.stdout.write(str(status))
                 if tip_gh_token:
                     env["TIP_GH_TOKEN"] = tip_gh_token
                 result = subprocess.run(
-                    [str(helper), "example/public-tip", "tip-fixture", archive_basename],
+                    [
+                        str(helper),
+                        "example/public-tip",
+                        "tip-fixture",
+                        archive_basename,
+                        "application",
+                    ],
                     env=env,
                     text=True,
                     capture_output=True,
@@ -3543,188 +3550,22 @@ sys.stdout.write(str(status))
                         r"retry_after=[^ ]+$",
                     )
 
-    def test_generated_tip_appcast_validation_executes_crypto_and_rejects_missing_signature(self) -> None:
-        root = SCRIPT_DIR.parent
-        temp_dir = Path(tempfile.mkdtemp())
-        self.addCleanup(shutil.rmtree, temp_dir, True)
-        app_bundle = temp_dir / "RepoPrompt.app"
-        info_plist = app_bundle / "Contents" / "Info.plist"
-        archive = temp_dir / "RepoPrompt-tip-fixture.zip"
-        appcast = temp_dir / "appcast.xml"
-        private_key_file = temp_dir / "private-key"
-        validator_tmp_dir = temp_dir / "validator-tmp"
-        info_plist.parent.mkdir(parents=True)
-        archive.write_text("signed tip archive\n", encoding="utf-8")
-        private_key = base64.b64encode(bytes(range(32))).decode("ascii")
-        private_key_file.write_text(private_key, encoding="utf-8")
-        public_key = self.run_checked(
-            ["xcrun", "swift", str(SCRIPT_DIR / "derive_sparkle_public_key.swift"), str(private_key_file)]
-        ).stdout.strip()
-        info_plist.write_bytes(plistlib.dumps({"SUPublicEDKey": public_key}))
-        signature = self.run_checked(
-            [
-                str(root / "Vendor" / "Sparkle" / "bin" / "sign_update"),
-                "--ed-key-file",
-                str(private_key_file),
-                "-p",
-                str(archive),
-            ]
-        ).stdout.strip()
+    def test_tip_appcast_generation_uses_shared_rollout_authority_and_crypto_verifier(self) -> None:
+        tip_script = (SCRIPT_DIR / "main_tip_release.sh").read_text(encoding="utf-8")
+        generator = tip_script.split("generate_tip_rollout_appcast() {", 1)[1].split("\n}", 1)[0]
 
-        expected_title = "Tip build 1.2.3 · v9.8.7 · commit 0123456789ab"
-        def write_appcast(
-            enclosure_signature: str,
-            *,
-            marketing_version: str = "9.8.7",
-            title: str = expected_title,
-            release_notes_link: str | None = None,
-        ) -> None:
-            release_notes_xml = (
-                f"      <sparkle:releaseNotesLink>{release_notes_link}</sparkle:releaseNotesLink>\n"
-                if release_notes_link is not None
-                else ""
-            )
-            appcast.write_text(
-                f"""<?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-  <channel>
-    <item>
-      <title>{title}</title>
-      <sparkle:version>1.2.3</sparkle:version>
-      <sparkle:shortVersionString>{marketing_version}</sparkle:shortVersionString>
-{release_notes_xml}      <enclosure url="https://example.invalid/tip/{archive.name}"
-                 length="{archive.stat().st_size}"
-                 sparkle:edSignature="{enclosure_signature}" />
-    </item>
-  </channel>
-</rss>
-""",
-                encoding="utf-8",
-            )
-
-        env = os.environ.copy()
-        env.update(
-            {
-                "REPOPROMPT_RELEASE_SOURCE_ROOT": str(root),
-                "REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR": str(SCRIPT_DIR),
-                "TIP_COMMIT": "0123456789abcdef" * 2 + "01234567",
-                "TIP_SHORT_SHA": "0123456789ab",
-                "TIP_BUILD_NUMBER": "1.2.3",
-                "TIP_DOWNLOAD_URL_PREFIX": "https://example.invalid/tip/",
-                "SPARKLE_PRIVATE_KEY": private_key,
-                "VALIDATOR_APP_BUNDLE": str(app_bundle),
-                "VALIDATOR_UPDATE_ZIP": str(archive),
-                "VALIDATOR_APPCAST": str(appcast),
-                "VALIDATOR_TMP_DIR": str(validator_tmp_dir),
-            }
-        )
-        command = [
-            "bash",
-            "-c",
-            """source "$1"
-APP_BUNDLE="$VALIDATOR_APP_BUNDLE"
-UPDATE_ZIP="$VALIDATOR_UPDATE_ZIP"
-APPCAST="$VALIDATOR_APPCAST"
-TMP_DIR="$VALIDATOR_TMP_DIR"
-mkdir -p "$TMP_DIR"
-MARKETING_VERSION="9.8.7"
-validate_generated_tip_appcast""",
-            "tip-appcast-validation",
-            str(SCRIPT_DIR / "main_tip_release.sh"),
-        ]
-
-        write_appcast(signature)
-        accepted = subprocess.run(command, env=env, text=True, capture_output=True)
-        self.assertEqual(accepted.returncode, 0, accepted.stderr)
-
-        duplicate_version_tree = ET.parse(appcast)
-        duplicate_version_item = duplicate_version_tree.getroot().find("./channel/item")
-        self.assertIsNotNone(duplicate_version_item)
-        assert duplicate_version_item is not None
-        ET.SubElement(
-            duplicate_version_item,
-            "{http://www.andymatuschak.org/xml-namespaces/sparkle}version",
-        ).text = "999"
-        duplicate_version_tree.write(appcast, encoding="utf-8", xml_declaration=True)
-        rejected_duplicate_version = subprocess.run(command, env=env, text=True, capture_output=True)
-        self.assertNotEqual(rejected_duplicate_version.returncode, 0)
-        self.assertIn(
-            "tip appcast item must contain exactly one sparkle:version",
-            rejected_duplicate_version.stderr,
-        )
-
-        write_appcast(signature, marketing_version="9.8.8")
-        wrong_marketing = subprocess.run(command, env=env, text=True, capture_output=True)
-        self.assertNotEqual(wrong_marketing.returncode, 0)
-        self.assertIn(
-            "Tip appcast marketing version mismatch: expected 9.8.7, got 9.8.8",
-            wrong_marketing.stderr,
-        )
-
-        write_appcast(signature, title="Wrong tip title")
-        wrong_title = subprocess.run(command, env=env, text=True, capture_output=True)
-        self.assertNotEqual(wrong_title.returncode, 0)
-        self.assertIn("Tip appcast presentation title mismatch: Wrong tip title", wrong_title.stderr)
-
-        write_appcast(signature, release_notes_link="https://example.invalid/tip/details")
-        embedded_release_page = subprocess.run(command, env=env, text=True, capture_output=True)
-        self.assertNotEqual(embedded_release_page.returncode, 0)
-        self.assertIn(
-            "tip appcast item must not contain sparkle:releaseNotesLink",
-            embedded_release_page.stderr,
-        )
-
-        write_appcast("")
-        rejected_signature = subprocess.run(command, env=env, text=True, capture_output=True)
-        self.assertNotEqual(rejected_signature.returncode, 0)
-        self.assertIn("Tip appcast enclosure is missing an EdDSA signature", rejected_signature.stderr)
-
-    def test_tip_appcast_label_changes_display_metadata_without_changing_comparison_version(self) -> None:
-        temp_dir = Path(tempfile.mkdtemp())
-        self.addCleanup(shutil.rmtree, temp_dir, True)
-        appcast = temp_dir / "appcast.xml"
-        appcast.write_text(
-            """<?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-  <channel><item><title>Version 9.8.7</title>
-    <sparkle:version>29.8.52</sparkle:version>
-    <sparkle:shortVersionString>9.8.7</sparkle:shortVersionString>
-    <sparkle:releaseNotesLink>https://github.com/example/release</sparkle:releaseNotesLink>
-    <description>Embedded release content</description>
-  </item></channel>
-</rss>
-""",
-            encoding="utf-8",
-        )
-        command = [
-            "bash",
-            "-c",
-            """source "$1"
-APPCAST="$2"
-MARKETING_VERSION="9.8.7"
-TIP_BUILD_NUMBER="29.8.52"
-TIP_SHORT_SHA="abc1234def56"
-label_generated_tip_appcast""",
-            "tip-appcast-label",
-            str(SCRIPT_DIR / "main_tip_release.sh"),
-            str(appcast),
-        ]
-
-        labeled = subprocess.run(command, text=True, capture_output=True)
-        self.assertEqual(labeled.returncode, 0, labeled.stderr)
-        item = ET.parse(appcast).getroot().find("./channel/item")
-        self.assertIsNotNone(item)
-        assert item is not None
-        sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
-        self.assertEqual(item.findtext(f"{{{sparkle}}}version"), "29.8.52")
-        self.assertEqual(item.findtext(f"{{{sparkle}}}shortVersionString"), "9.8.7")
-        self.assertNotEqual(
-            item.findtext(f"{{{sparkle}}}shortVersionString"),
-            item.findtext(f"{{{sparkle}}}version"),
-        )
-        self.assertEqual(item.findtext("title"), "Tip build 29.8.52 · v9.8.7 · commit abc1234def56")
-        self.assertIsNone(item.find(f"{{{sparkle}}}releaseNotesLink"))
-        self.assertIsNone(item.find("description"))
+        self.assertIn('python3 "$ROLLOUT_TOOL" predecessor-values', generator)
+        self.assertIn('python3 "$ROLLOUT_TOOL" generate', generator)
+        self.assertIn('--declaration "$ROLLOUT_DECLARATION"', generator)
+        self.assertIn('--policy "$APPLE_IDENTITY_POLICY"', generator)
+        self.assertIn('--enclosure-basename "$ARCHIVE_BASENAME"', generator)
+        self.assertIn('--appcast-output "$APPCAST"', generator)
+        self.assertIn('--manifest-output "$ROLLOUT_MANIFEST"', generator)
+        self.assertIn('"$SIGN_UPDATE" --ed-key-file - -p "$ENCLOSURE"', generator)
+        self.assertIn('verify_sparkle_signature.swift', generator)
+        self.assertNotIn("validate_generated_tip_appcast", tip_script)
+        self.assertNotIn("label_generated_tip_appcast", tip_script)
+        self.assertNotIn("generate_appcast", generator)
 
     def test_release_sentry_runtime_wiring_uses_protected_dsn_and_stable_resolution(self) -> None:
         root = SCRIPT_DIR.parent
@@ -4674,13 +4515,14 @@ esac
 
 
 class IdentityTransitionReleaseToolingTests(unittest.TestCase):
-    """PR02 done-when coverage: the reviewed rollout declaration plus
-    Scripts/stable_rollout.py stay the single Stable rollout authority while
-    transition/successor publication remains dormant."""
+    """Shared rollout-authority coverage for the Stable safety lock and
+    the explicitly dispatched Tip identity dress rehearsal."""
 
     POLICY = SCRIPT_DIR / "apple_identity_policy.json"
     DECLARATION = SCRIPT_DIR.parent / "release-rollout.json"
+    TIP_DECLARATION = SCRIPT_DIR.parent / "tip-rollout.json"
     UPDATE_REPOSITORY = "repoprompt/repoprompt-ce-updates"
+    TIP_UPDATE_REPOSITORY = "repoprompt/repoprompt-ce-tip-updates"
 
     def rollout(self, *args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
@@ -4705,21 +4547,22 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         directory: Path,
         role: str,
         predecessors: list[dict] | None = None,
+        channel: str = "stable",
         **overrides: object,
     ) -> Path:
         phase = {"legacy": "disabled", "preparer": "legacy-preparer"}.get(role, "disabled")
         identity = "successor" if role in ("transition", "successor") else "legacy"
         declaration = {
             "schemaVersion": 1,
-            "channel": "stable",
+            "channel": channel,
             "currentRole": role,
-            "eligibilityProfile": "stable-rollout-v1",
+            "eligibilityProfile": f"{channel}-rollout-v1",
             "expectedMigrationPhase": phase,
             "expectedSigningIdentity": identity,
             "predecessors": predecessors or [],
         }
         declaration.update(overrides)
-        path = directory / f"release-rollout-{role}.json"
+        path = directory / f"{channel}-rollout-{role}.json"
         path.write_text(json.dumps(declaration, indent=2) + "\n", encoding="utf-8")
         return path
 
@@ -4731,32 +4574,46 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         build: str,
         predecessors: list[dict] | None = None,
         predecessor_manifests: list[Path] | None = None,
+        channel: str = "stable",
+        release_tag: str | None = None,
+        enclosure_basename: str | None = None,
     ) -> dict:
         release_dir = directory / f"{role}-{build}"
         release_dir.mkdir(parents=True, exist_ok=True)
         version_env = release_dir / "version.env"
+        successor_identity = role in ("transition", "successor")
         version_env.write_text(
             "APP_NAME=RepoPrompt\n"
             f"MARKETING_VERSION={marketing}\n"
             f"BUILD_NUMBER={build}\n"
-            "BUNDLE_ID=com.pvncher.repoprompt.ce\n"
-            "SIGNING_TEAM_ID=648A27MST5\n",
+            f"BUNDLE_ID={'com.repoprompt.ce' if successor_identity else 'com.pvncher.repoprompt.ce'}\n"
+            f"SIGNING_TEAM_ID={'69N6K965SF' if successor_identity else '648A27MST5'}\n",
             encoding="utf-8",
         )
         suffix = ".pkg" if role == "transition" else ".zip"
-        enclosure = release_dir / f"RepoPrompt-{marketing}-{build}{suffix}"
+        enclosure = release_dir / f"{enclosure_basename or f'RepoPrompt-{marketing}-{build}'}{suffix}"
         enclosure.write_text(f"enclosure {role} {build}\n", encoding="utf-8")
         app_manifest = release_dir / f"RepoPrompt-{marketing}-{build}-artifact-manifest.json"
         app_manifest.write_text('{"schema_version":1}\n', encoding="utf-8")
-        declaration = self.make_declaration(release_dir, role, predecessors)
+        declaration = self.make_declaration(
+            release_dir,
+            role,
+            predecessors,
+            channel=channel,
+        )
         appcast = release_dir / "appcast.xml"
-        manifest = release_dir / f"RepoPrompt-{marketing}-{build}-stable-rollout.json"
+        manifest = release_dir / (
+            "identity-rollout.json"
+            if channel == "tip"
+            else f"RepoPrompt-{marketing}-{build}-stable-rollout.json"
+        )
+        release_tag = release_tag or (f"tip-{build}" if channel == "tip" else f"v{marketing}")
         arguments = [
             "generate",
             "--declaration", str(declaration),
             "--policy", str(self.POLICY),
             "--version-env", str(version_env),
-            "--release-tag", f"v{marketing}",
+            "--release-tag", release_tag,
             "--release-commit", f"commit-{build}",
             "--migration-phase", "legacy-preparer" if role == "preparer" else "disabled",
             "--enclosure", str(enclosure),
@@ -4765,6 +4622,8 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             "--appcast-output", str(appcast),
             "--manifest-output", str(manifest),
         ]
+        if enclosure_basename:
+            arguments += ["--enclosure-basename", enclosure_basename]
         for predecessor_manifest in predecessor_manifests or []:
             arguments += ["--predecessor-manifest", str(predecessor_manifest)]
         result = self.rollout(*arguments)
@@ -4879,12 +4738,36 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             info_template,
         )
         self.assertEqual(sparkle["updateRepository"], self.UPDATE_REPOSITORY)
+        self.assertEqual(sparkle["tipUpdateRepository"], "repoprompt/repoprompt-ce-tip-updates")
+        self.assertEqual(
+            sparkle["tipFeedURL"],
+            "https://github.com/repoprompt/repoprompt-ce-tip-updates/releases/latest/download/appcast.xml",
+        )
+        self.assertEqual(
+            legacy["developerIDApplicationIdentityName"],
+            "Developer ID Application: Eric Provencher (648A27MST5)",
+        )
+        self.assertEqual(
+            successor["developerIDApplicationIdentityName"],
+            "Developer ID Application: Samuel Baron (69N6K965SF)",
+        )
+        self.assertEqual(
+            successor["developerIDInstallerIdentityName"],
+            "Developer ID Installer: Samuel Baron (69N6K965SF)",
+        )
 
         declaration = json.loads(self.DECLARATION.read_text(encoding="utf-8"))
         self.assertEqual(declaration["currentRole"], "legacy")
         self.assertEqual(declaration["predecessors"], [])
         self.assertEqual(declaration["expectedMigrationPhase"], "disabled")
         self.assertEqual(declaration["expectedSigningIdentity"], "legacy")
+
+        tip_declaration = json.loads(self.TIP_DECLARATION.read_text(encoding="utf-8"))
+        self.assertEqual(tip_declaration["channel"], "tip")
+        self.assertEqual(tip_declaration["currentRole"], "legacy")
+        self.assertEqual(tip_declaration["predecessors"], [])
+        self.assertEqual(tip_declaration["expectedMigrationPhase"], "disabled")
+        self.assertEqual(tip_declaration["expectedSigningIdentity"], "legacy")
 
     def test_single_legacy_release_generates_one_deterministic_application_item(self) -> None:
         temp_dir = Path(tempfile.mkdtemp())
@@ -4952,6 +4835,99 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         rows = [line.split("\t") for line in siblings.stdout.splitlines()]
         self.assertEqual([(row[1], row[2]) for row in rows], [("transition", "v1.5.0"), ("preparer", "v1.2.0")])
         self.assertEqual(rows[0][7], "RepoPrompt-1.5.0-150-stable-rollout.json")
+
+    def test_tip_pts_ladder_reuses_one_feed_and_accumulates_top_level_items(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+
+        preparer = self.make_release(
+            temp_dir,
+            "preparer",
+            "1.2.0",
+            "100.1.1",
+            channel="tip",
+            release_tag="tip-preparer",
+            enclosure_basename="RepoPrompt-tip-preparer-100.1.1",
+        )
+        self.assertEqual(preparer["result"].returncode, 0, preparer["result"].stderr)
+        transition = self.make_release(
+            temp_dir,
+            "transition",
+            "1.2.0",
+            "100.1.2",
+            predecessors=[
+                {
+                    "role": "preparer",
+                    "tag": "tip-preparer",
+                    "rolloutManifestSha256": hashlib.sha256(
+                        preparer["manifest"].read_bytes()
+                    ).hexdigest(),
+                }
+            ],
+            predecessor_manifests=[preparer["manifest"]],
+            channel="tip",
+            release_tag="tip-transition",
+            enclosure_basename="RepoPrompt-tip-transition-100.1.2",
+        )
+        self.assertEqual(transition["result"].returncode, 0, transition["result"].stderr)
+        successor = self.make_release(
+            temp_dir,
+            "successor",
+            "1.2.0",
+            "100.1.3",
+            predecessors=[
+                {
+                    "role": "transition",
+                    "tag": "tip-transition",
+                    "rolloutManifestSha256": hashlib.sha256(
+                        transition["manifest"].read_bytes()
+                    ).hexdigest(),
+                },
+                {
+                    "role": "preparer",
+                    "tag": "tip-preparer",
+                    "rolloutManifestSha256": hashlib.sha256(
+                        preparer["manifest"].read_bytes()
+                    ).hexdigest(),
+                },
+            ],
+            predecessor_manifests=[transition["manifest"], preparer["manifest"]],
+            channel="tip",
+            release_tag="tip-successor",
+            enclosure_basename="RepoPrompt-tip-successor-100.1.3",
+        )
+        self.assertEqual(successor["result"].returncode, 0, successor["result"].stderr)
+
+        appcast = successor["appcast"].read_text(encoding="utf-8")
+        self.assertEqual(appcast.count("<item>"), 3)
+        self.assertEqual(
+            re.findall(r"<repoprompt:rolloutRole>([a-z]+)</repoprompt:rolloutRole>", appcast),
+            ["successor", "transition", "preparer"],
+        )
+        self.assertEqual(
+            re.findall(r"<sparkle:version>([0-9.]+)</sparkle:version>", appcast),
+            ["100.1.3", "100.1.2", "100.1.1"],
+        )
+        self.assertEqual(appcast.count('sparkle:installationType="package"'), 1)
+        self.assertNotIn(self.UPDATE_REPOSITORY + "/releases", appcast)
+        for tag, basename, suffix in (
+            ("tip-successor", "RepoPrompt-tip-successor-100.1.3", ".zip"),
+            ("tip-transition", "RepoPrompt-tip-transition-100.1.2", ".pkg"),
+            ("tip-preparer", "RepoPrompt-tip-preparer-100.1.1", ".zip"),
+        ):
+            self.assertIn(
+                f"https://github.com/{self.TIP_UPDATE_REPOSITORY}/releases/download/"
+                f"{tag}/{basename}{suffix}",
+                appcast,
+            )
+
+        manifest = json.loads(successor["manifest"].read_text(encoding="utf-8"))
+        self.assertEqual(manifest["channel"], "tip")
+        self.assertEqual(manifest["currentRole"], "successor")
+        self.assertEqual(
+            [entry["rolloutManifestName"] for entry in manifest["appcastItems"][1:]],
+            ["identity-rollout.json", "identity-rollout.json"],
+        )
 
     def test_rollout_tampering_and_invalid_ladders_fail_closed(self) -> None:
         temp_dir, preparer, transition, successor = self.make_pts_ladder()
@@ -5055,7 +5031,7 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             self.assertIn("mismatch", result.stderr)
             successor["manifest"].write_text(manifest_text, encoding="utf-8")
 
-    def test_protected_surfaces_reject_dormant_roles_and_siblings(self) -> None:
+    def test_stable_surfaces_stay_locked_while_tip_requires_explicit_role_dispatch(self) -> None:
         temp_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, temp_dir, True)
 
@@ -5082,7 +5058,10 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         tip_workflow = (workflows_dir / "main-tip.yml").read_text(encoding="utf-8")
         self.assertEqual(release_workflow.count("stable_rollout.py workflow-guard"), 2)
         self.assertEqual(promote_workflow.count("stable_rollout.py workflow-guard"), 1)
-        self.assertNotIn("stable_rollout.py", tip_workflow)
+        self.assertIn("tip-rollout.json", tip_workflow)
+        self.assertIn("stable_rollout.py packaging-context", tip_workflow)
+        self.assertIn("confirm_identity_rollout_role", tip_workflow)
+        self.assertIn('if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]', tip_workflow)
         self.assertNotIn("release-rollout.json", tip_workflow)
 
         release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")
@@ -5122,14 +5101,16 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
                 )
                 self.assertEqual(syntax.returncode, 0, syntax.stderr)
 
-        # Tip isolation: exactly-one-item validation, legacy/disabled phase, and
-        # the separate tip updater repository stay untouched.
+        # Tip reuses its existing workflow, repository, feed, and appcast name;
+        # role changes add accumulated top-level items rather than a sibling feed.
         tip_script = (SCRIPT_DIR / "main_tip_release.sh").read_text(encoding="utf-8")
-        self.assertIn("tip appcast must contain exactly one item", tip_script)
+        self.assertIn("generate_tip_rollout_appcast", tip_script)
+        self.assertIn("identity-rollout.json", tip_script)
         self.assertIn("repoprompt-ce-tip-updates", tip_script)
-        self.assertIn("REPOPROMPT_IDENTITY_MIGRATION_PHASE: disabled", tip_workflow)
+        self.assertNotIn("tip-transition-appcast.xml", tip_script)
+        self.assertNotIn("tip-successor-appcast.xml", tip_script)
 
-    def test_transition_pkg_builder_stays_dormant_with_exact_payload_proof(self) -> None:
+    def test_transition_pkg_builder_requires_explicit_tip_enablement(self) -> None:
         script = (SCRIPT_DIR / "build_identity_transition_pkg.sh").read_text(encoding="utf-8")
         for marker in (
             "plutil -replace 0.BundleIsRelocatable -bool false",
@@ -5146,7 +5127,6 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertNotIn("allow-unstapled", script)
 
         env = dict(os.environ)
-        env["GITHUB_ACTIONS"] = "true"
         refused = subprocess.run(
             ["bash", str(SCRIPT_DIR / "build_identity_transition_pkg.sh"), "validate", "/nonexistent.pkg"],
             text=True,
@@ -5154,7 +5134,18 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             env=env,
         )
         self.assertNotEqual(refused.returncode, 0)
-        self.assertIn("dormant", refused.stderr)
+        self.assertIn("explicit Tip rollout enablement", refused.stderr)
+
+        env["REPOPROMPT_ENABLE_IDENTITY_TRANSITION_PKG"] = "1"
+        enabled = subprocess.run(
+            ["bash", str(SCRIPT_DIR / "build_identity_transition_pkg.sh"), "validate", "/nonexistent.pkg"],
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        self.assertNotEqual(enabled.returncode, 0)
+        self.assertNotIn("explicit Tip rollout enablement", enabled.stderr)
+        self.assertIn("Missing required file: /nonexistent.pkg", enabled.stderr)
 
 
 if __name__ == "__main__":

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -10,6 +10,7 @@ import json
 import os
 import plistlib
 import re
+import shlex
 import shutil
 import socket
 import stat
@@ -4530,6 +4531,58 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             text=True,
             capture_output=True,
         )
+
+    @staticmethod
+    def shell_assignments(output: str) -> dict[str, str]:
+        assignments = {}
+        for line in output.splitlines():
+            token = shlex.split(line)
+            if len(token) != 1 or "=" not in token[0]:
+                raise AssertionError(f"unexpected packaging-context output: {line!r}")
+            key, value = token[0].split("=", 1)
+            assignments[key] = value
+        return assignments
+
+    def test_packaging_context_rejects_version_identity_mismatch_before_packaging(self) -> None:
+        root = SCRIPT_DIR.parent
+        legacy = self.rollout(
+            "packaging-context",
+            "--declaration", str(self.TIP_DECLARATION),
+            "--policy", str(self.POLICY),
+            "--version-env", str(root / "version.env"),
+        )
+        self.assertEqual(legacy.returncode, 0, legacy.stderr)
+        context = self.shell_assignments(legacy.stdout)
+        policy = json.loads(self.POLICY.read_text(encoding="utf-8"))
+        self.assertEqual(context["ROLLOUT_ROLE"], "legacy")
+        self.assertEqual(context["BUNDLE_ID"], "com.pvncher.repoprompt.ce")
+        self.assertEqual(
+            context["EXPECTED_SUCCESSOR_SIGN_IDENTITY"],
+            policy["identities"]["successor"]["developerIDApplicationIdentityName"],
+        )
+
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        transition = self.make_declaration(
+            temp_dir,
+            "transition",
+            [
+                {
+                    "role": "preparer",
+                    "tag": "tip-preparer",
+                    "rolloutManifestSha256": "0" * 64,
+                }
+            ],
+            channel="tip",
+        )
+        mismatch = self.rollout(
+            "packaging-context",
+            "--declaration", str(transition),
+            "--policy", str(self.POLICY),
+            "--version-env", str(root / "version.env"),
+        )
+        self.assertNotEqual(mismatch.returncode, 0)
+        self.assertIn("version.env BUNDLE_ID does not match", mismatch.stderr)
 
     def chain_predecessors(self, role: str) -> list[dict]:
         placeholder = "0" * 64

--- a/Sources/RepoPrompt/App/RepoPromptApp.swift
+++ b/Sources/RepoPrompt/App/RepoPromptApp.swift
@@ -183,6 +183,17 @@ struct RepoPromptSwiftUIApp: App {
 @MainActor
 public enum RepoPromptApplication {
     public static func main() {
+        let defaultsReport = BundleIdentityDefaultsMigration.migrateIfNeeded()
+        let defaultsOutcome: IdentityTransitionDiagnosticEvent.Outcome = switch defaultsReport.outcome {
+        case .skipped, .alreadyCompleted: .skipped
+        case .migrated: .succeeded
+        case .verificationFailed: .failed
+        }
+        IdentityTransitionDiagnostics.shared.record(
+            subsystem: .defaultsMigration,
+            stage: "pre-bootstrap",
+            outcome: defaultsOutcome
+        )
         SecureStorageIdentityMigrationBootstrap.prepareIfConfigured()
         RepoPromptSwiftUIApp.main()
     }

--- a/Sources/RepoPrompt/App/RepoPromptApp.swift
+++ b/Sources/RepoPrompt/App/RepoPromptApp.swift
@@ -185,14 +185,19 @@ public enum RepoPromptApplication {
     public static func main() {
         let defaultsReport = BundleIdentityDefaultsMigration.migrateIfNeeded()
         let defaultsOutcome: IdentityTransitionDiagnosticEvent.Outcome = switch defaultsReport.outcome {
-        case .skipped, .alreadyCompleted: .skipped
+        case .skipped: .skipped
+        case .alreadyCompleted: .alreadyCompleted
         case .migrated: .succeeded
         case .verificationFailed: .failed
         }
         IdentityTransitionDiagnostics.shared.record(
             subsystem: .defaultsMigration,
             stage: "pre-bootstrap",
-            outcome: defaultsOutcome
+            outcome: defaultsOutcome,
+            recordStateCounts: [
+                "copied": defaultsReport.copiedKeyCount,
+                "preserved": defaultsReport.preservedKeyCount
+            ]
         )
         SecureStorageIdentityMigrationBootstrap.prepareIfConfigured()
         RepoPromptSwiftUIApp.main()

--- a/Sources/RepoPrompt/App/Sparkle/UpdateChannel.swift
+++ b/Sources/RepoPrompt/App/Sparkle/UpdateChannel.swift
@@ -112,10 +112,13 @@ final class SparkleUpdateFeedDelegate: NSObject, SPUUpdaterDelegate {
         didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
         error: Error?
     ) {
+        // Routine no-update checks are high-volume and would evict the one-time
+        // identity-migration milestones from the bounded diagnostic ledger.
+        guard let error else { return }
         record(
             stage: "update-cycle-finished",
-            outcome: error == nil ? .succeeded : .failed,
-            errorClass: error.map(Self.errorClass)
+            outcome: .failed,
+            errorClass: Self.errorClass(error)
         )
     }
 
@@ -148,22 +151,22 @@ final class SparkleUpdateFeedDelegate: NSObject, SPUUpdaterDelegate {
 
 private extension SPUUserUpdateChoice {
     var diagnosticName: String {
-        switch rawValue {
-        case 0: "skip"
-        case 1: "install"
-        case 2: "dismiss"
-        default: "unknown"
+        switch self {
+        case .skip: "skip"
+        case .install: "install"
+        case .dismiss: "dismiss"
+        @unknown default: "unknown"
         }
     }
 }
 
 private extension SPUUserUpdateStage {
     var diagnosticName: String {
-        switch rawValue {
-        case 0: "not-downloaded"
-        case 1: "downloaded"
-        case 2: "installing"
-        default: "unknown"
+        switch self {
+        case .notDownloaded: "not-downloaded"
+        case .downloaded: "downloaded"
+        case .installing: "installing"
+        @unknown default: "unknown"
         }
     }
 }

--- a/Sources/RepoPrompt/App/Sparkle/UpdateChannel.swift
+++ b/Sources/RepoPrompt/App/Sparkle/UpdateChannel.swift
@@ -52,4 +52,118 @@ final class SparkleUpdateFeedDelegate: NSObject, SPUUpdaterDelegate {
     func feedURLString(for updater: SPUUpdater) -> String? {
         UpdateChannel.load().feedURLString
     }
+
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        record(stage: "update-found", outcome: .succeeded, item: item)
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        userDidMake choice: SPUUserUpdateChoice,
+        forUpdate item: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        record(
+            stage: "user-choice-\(choice.diagnosticName)-\(state.stage.diagnosticName)",
+            outcome: .selected,
+            item: item
+        )
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        willDownloadUpdate item: SUAppcastItem,
+        with request: NSMutableURLRequest
+    ) {
+        record(stage: "download-started", outcome: .started, item: item)
+    }
+
+    func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
+        record(stage: "download-finished", outcome: .succeeded, item: item)
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        failedToDownloadUpdate item: SUAppcastItem,
+        error: Error
+    ) {
+        record(
+            stage: "download-finished",
+            outcome: .failed,
+            item: item,
+            errorClass: Self.errorClass(error)
+        )
+    }
+
+    func userDidCancelDownload(_ updater: SPUUpdater) {
+        record(stage: "download-finished", outcome: .cancelled)
+    }
+
+    func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        record(stage: "install-started", outcome: .started, item: item)
+    }
+
+    func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        record(stage: "relaunch-started", outcome: .started)
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+        error: Error?
+    ) {
+        record(
+            stage: "update-cycle-finished",
+            outcome: error == nil ? .succeeded : .failed,
+            errorClass: error.map(Self.errorClass)
+        )
+    }
+
+    private func record(
+        stage: String,
+        outcome: IdentityTransitionDiagnosticEvent.Outcome,
+        item: SUAppcastItem? = nil,
+        errorClass: String? = nil
+    ) {
+        IdentityTransitionDiagnostics.shared.record(
+            subsystem: .sparkle,
+            stage: stage,
+            outcome: outcome,
+            targetDisplayVersion: item?.displayVersionString,
+            targetBuildVersion: item?.versionString,
+            errorClass: errorClass
+        )
+    }
+
+    private static func errorClass(_ error: Error) -> String {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            return nsError.code == NSURLErrorCancelled ? "cancelled" : "network"
+        }
+        return nsError.domain.localizedCaseInsensitiveContains("sparkle")
+            ? "sparkle"
+            : "other"
+    }
+}
+
+private extension SPUUserUpdateChoice {
+    var diagnosticName: String {
+        switch rawValue {
+        case 0: "skip"
+        case 1: "install"
+        case 2: "dismiss"
+        default: "unknown"
+        }
+    }
+}
+
+private extension SPUUserUpdateStage {
+    var diagnosticName: String {
+        switch rawValue {
+        case 0: "not-downloaded"
+        case 1: "downloaded"
+        case 2: "installing"
+        default: "unknown"
+        }
+    }
 }

--- a/Sources/RepoPrompt/Infrastructure/Security/BundleIdentityDefaultsMigration.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/BundleIdentityDefaultsMigration.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+struct BundleIdentityDefaultsMigrationReport: Equatable {
+    enum Outcome: String {
+        case skipped
+        case alreadyCompleted = "already-completed"
+        case migrated
+        case verificationFailed = "verification-failed"
+    }
+
+    let outcome: Outcome
+    let copiedKeyCount: Int
+    let preservedKeyCount: Int
+}
+
+/// Moves the legacy application preference domain to the successor bundle ID once.
+/// Existing successor values always win, including Sparkle and window-state values.
+enum BundleIdentityDefaultsMigration {
+    static let completionMarker = "RepoPromptIdentityDefaultsMigrationV1Completed"
+
+    static func migrateIfNeeded(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        defaults: UserDefaults = .standard,
+        legacyDomainName: String = RuntimeCodeSigningPolicy.developerIDBundleIdentifier,
+        successorDomainName: String = RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier
+    ) -> BundleIdentityDefaultsMigrationReport {
+        guard bundleIdentifier == RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier else {
+            return BundleIdentityDefaultsMigrationReport(
+                outcome: .skipped,
+                copiedKeyCount: 0,
+                preservedKeyCount: 0
+            )
+        }
+
+        let successorDomain = defaults.persistentDomain(forName: successorDomainName) ?? [:]
+        if successorDomain[completionMarker] as? Bool == true {
+            return BundleIdentityDefaultsMigrationReport(
+                outcome: .alreadyCompleted,
+                copiedKeyCount: 0,
+                preservedKeyCount: successorDomain.count
+            )
+        }
+
+        let legacyDomain = defaults.persistentDomain(forName: legacyDomainName) ?? [:]
+        var mergedDomain = legacyDomain
+        mergedDomain.removeValue(forKey: completionMarker)
+        for (key, value) in successorDomain {
+            mergedDomain[key] = value
+        }
+        mergedDomain[completionMarker] = true
+
+        let copiedKeyCount = legacyDomain.keys.count(where: {
+            $0 != completionMarker && successorDomain[$0] == nil
+        })
+        let preservedKeyCount = successorDomain.keys.count(where: { $0 != completionMarker })
+
+        defaults.setPersistentDomain(mergedDomain, forName: successorDomainName)
+        let persistedDomain = defaults.persistentDomain(forName: successorDomainName) ?? [:]
+        guard domainsMatch(expected: mergedDomain, actual: persistedDomain) else {
+            return BundleIdentityDefaultsMigrationReport(
+                outcome: .verificationFailed,
+                copiedKeyCount: copiedKeyCount,
+                preservedKeyCount: preservedKeyCount
+            )
+        }
+
+        return BundleIdentityDefaultsMigrationReport(
+            outcome: .migrated,
+            copiedKeyCount: copiedKeyCount,
+            preservedKeyCount: preservedKeyCount
+        )
+    }
+
+    private static func domainsMatch(expected: [String: Any], actual: [String: Any]) -> Bool {
+        NSDictionary(dictionary: expected).isEqual(to: actual)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/Security/IdentityTransitionDiagnostics.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/IdentityTransitionDiagnostics.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+struct IdentityTransitionDiagnosticEvent: Codable, Equatable {
+    enum Subsystem: String, Codable {
+        case defaultsMigration = "defaults-migration"
+        case secureStorage = "secure-storage"
+        case sparkle
+    }
+
+    enum Outcome: String, Codable {
+        case started
+        case succeeded
+        case skipped
+        case blocked
+        case failed
+        case cancelled
+        case selected
+    }
+
+    let timestamp: Date
+    let subsystem: Subsystem
+    let stage: String
+    let outcome: Outcome
+    let bundleIdentifier: String?
+    let displayVersion: String?
+    let buildVersion: String?
+    let migrationPhase: String?
+    let secureStorageDomain: String?
+    let updateChannel: String?
+    let targetDisplayVersion: String?
+    let targetBuildVersion: String?
+    let recordStateCounts: [String: Int]?
+    let errorClass: String?
+}
+
+/// A small, local source of truth for the identity rollover. Events deliberately omit
+/// credential identifiers, values, attempt IDs, paths, URLs, and raw error text.
+final class IdentityTransitionDiagnostics: @unchecked Sendable {
+    private struct Ledger: Codable, Equatable {
+        static let currentVersion = 1
+
+        let schemaVersion: Int
+        var events: [IdentityTransitionDiagnosticEvent]
+    }
+
+    static let shared = IdentityTransitionDiagnostics()
+    static let maximumEventCount = 64
+
+    private let fileManager: FileManager
+    private let fileURL: URL?
+    private let maximumEventCount: Int
+    private let now: () -> Date
+    private let lock = NSLock()
+
+    init(
+        fileManager: FileManager = .default,
+        fileURL: URL? = IdentityTransitionDiagnostics.defaultFileURL(),
+        maximumEventCount: Int = IdentityTransitionDiagnostics.maximumEventCount,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.fileManager = fileManager
+        self.fileURL = fileURL
+        self.maximumEventCount = max(1, maximumEventCount)
+        self.now = now
+    }
+
+    func record(
+        subsystem: IdentityTransitionDiagnosticEvent.Subsystem,
+        stage: String,
+        outcome: IdentityTransitionDiagnosticEvent.Outcome,
+        bundle: Bundle = .main,
+        secureStorageDomain: RuntimeSecureStorageDomain? = nil,
+        targetDisplayVersion: String? = nil,
+        targetBuildVersion: String? = nil,
+        recordStateCounts: [String: Int]? = nil,
+        errorClass: String? = nil
+    ) {
+        let event = IdentityTransitionDiagnosticEvent(
+            timestamp: now(),
+            subsystem: subsystem,
+            stage: stage,
+            outcome: outcome,
+            bundleIdentifier: bundle.bundleIdentifier,
+            displayVersion: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            buildVersion: bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
+            migrationPhase: bundle.object(
+                forInfoDictionaryKey: SecureStorageIdentityMigrationBootstrap.phaseInfoKey
+            ) as? String,
+            secureStorageDomain: secureStorageDomain?.diagnosticName,
+            updateChannel: UpdateChannel.load().rawValue,
+            targetDisplayVersion: targetDisplayVersion,
+            targetBuildVersion: targetBuildVersion,
+            recordStateCounts: recordStateCounts,
+            errorClass: errorClass
+        )
+        record(event)
+    }
+
+    func record(_ event: IdentityTransitionDiagnosticEvent) {
+        print("[IdentityTransition] subsystem=\(event.subsystem.rawValue) stage=\(event.stage) outcome=\(event.outcome.rawValue)")
+        guard let fileURL else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        do {
+            let directoryURL = fileURL.deletingLastPathComponent()
+            try fileManager.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            try fileManager.setAttributes(
+                [.posixPermissions: 0o700],
+                ofItemAtPath: directoryURL.path
+            )
+
+            var ledger = loadLedger(from: fileURL) ?? Ledger(
+                schemaVersion: Ledger.currentVersion,
+                events: []
+            )
+            ledger.events.append(event)
+            if ledger.events.count > maximumEventCount {
+                ledger.events.removeFirst(ledger.events.count - maximumEventCount)
+            }
+
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(ledger).write(to: fileURL, options: .atomic)
+            try fileManager.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: fileURL.path
+            )
+        } catch {
+            // Diagnostics must never change update or migration behavior. The sanitized
+            // stderr event above remains available if durable persistence fails.
+        }
+    }
+
+    func readEvents() -> [IdentityTransitionDiagnosticEvent] {
+        guard let fileURL else { return [] }
+        lock.lock()
+        defer { lock.unlock() }
+        return loadLedger(from: fileURL)?.events ?? []
+    }
+
+    private func loadLedger(from fileURL: URL) -> Ledger? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let ledger = try? decoder.decode(Ledger.self, from: data),
+              ledger.schemaVersion == Ledger.currentVersion
+        else {
+            return nil
+        }
+        return ledger
+    }
+
+    private static func defaultFileURL(fileManager: FileManager = .default) -> URL? {
+        guard let supportURL = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        return supportURL
+            .appendingPathComponent("RepoPrompt CE", isDirectory: true)
+            .appendingPathComponent("Diagnostics", isDirectory: true)
+            .appendingPathComponent("identity-transition-v1.json", isDirectory: false)
+    }
+}
+
+private extension RuntimeSecureStorageDomain {
+    var diagnosticName: String {
+        switch self {
+        case .officialDeveloperID: "legacy-official"
+        case .successorOfficialDeveloperID: "successor-official"
+        case .localSelfSigned: "local-self-signed"
+        case .appleDevelopmentDebug: "apple-development"
+        case .ephemeral: "ephemeral"
+        }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/Security/IdentityTransitionDiagnostics.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/IdentityTransitionDiagnostics.swift
@@ -11,6 +11,7 @@ struct IdentityTransitionDiagnosticEvent: Codable, Equatable {
         case started
         case succeeded
         case skipped
+        case alreadyCompleted = "already-completed"
         case blocked
         case failed
         case cancelled
@@ -97,7 +98,8 @@ final class IdentityTransitionDiagnostics: @unchecked Sendable {
     }
 
     func record(_ event: IdentityTransitionDiagnosticEvent) {
-        print("[IdentityTransition] subsystem=\(event.subsystem.rawValue) stage=\(event.stage) outcome=\(event.outcome.rawValue)")
+        let line = "[IdentityTransition] subsystem=\(event.subsystem.rawValue) stage=\(event.stage) outcome=\(event.outcome.rawValue)\n"
+        FileHandle.standardError.write(Data(line.utf8))
         guard let fileURL else { return }
 
         lock.lock()

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
@@ -41,10 +41,28 @@ struct SecureStorageIdentityMigrationRecord: Equatable, Identifiable {
     }
 }
 
+enum SecureStorageIdentityMigrationStage: String, Equatable {
+    case journalLoad = "journal-load"
+    case journalValidation = "journal-validation"
+    case sourcePreflight = "source-preflight"
+    case attemptIdentifier = "attempt-identifier"
+    case journalCreate = "journal-create"
+    case bridgeOpen = "bridge-open"
+    case bridgePreflight = "bridge-preflight"
+    case bridgeReconcile = "bridge-reconcile"
+    case bridgeVerify = "bridge-verify"
+    case bridgeManifestPersist = "bridge-manifest-persist"
+    case journalCommit = "journal-commit"
+    case committedBridgeOpen = "committed-bridge-open"
+    case committedBridgeVerify = "committed-bridge-verify"
+    case ready
+}
+
 struct SecureStorageIdentityMigrationReport: Equatable {
     let records: [SecureStorageIdentityMigrationRecord]
     let bridgeReady: Bool
     let blockingState: SecureStorageIdentityMigrationRecordState?
+    let stage: SecureStorageIdentityMigrationStage
 
     var blockedUpdateMessage: String? {
         guard !bridgeReady else { return nil }
@@ -207,11 +225,13 @@ final class SecureStorageIdentityMigrationCoordinator {
             // has been committed, the journal is the only pointer to it, so destructive
             // reset-and-retry could silently restart migration from stale source data.
             // Fail closed and keep the journal item intact for manual recovery.
-            return blockedReport(error: error)
+            return blockedReport(error: error, stage: .journalLoad)
         }
 
         if let existingManifest {
-            guard isStructurallyValid(existingManifest) else { return blockedReport() }
+            guard isStructurallyValid(existingManifest) else {
+                return blockedReport(stage: .journalValidation)
+            }
             switch existingManifest.status {
             case .preparing:
                 return resumePreparation(existingManifest)
@@ -223,14 +243,15 @@ final class SecureStorageIdentityMigrationCoordinator {
         let sourceResults = readAll(from: sourceStore)
         let preflightRecords = recordsForReadFailures(sourceResults)
         guard preflightRecords.allSatisfy(\.state.isReady) else {
-            return failedReport(records: preflightRecords)
+            return failedReport(records: preflightRecords, stage: .sourcePreflight)
         }
 
         let attemptIdentifier = attemptIdentifierGenerator()
         guard KeychainService.identityMigrationBridgeServiceName(for: attemptIdentifier) != nil else {
             return failedReport(
                 records: preflightRecords,
-                error: KeychainACLValidationError.invalidExpectedPrincipalPolicy
+                error: KeychainACLValidationError.invalidExpectedPrincipalPolicy,
+                stage: .attemptIdentifier
             )
         }
         let manifest = SecureStorageIdentityMigrationManifest(
@@ -242,7 +263,7 @@ final class SecureStorageIdentityMigrationCoordinator {
         do {
             try stateStore.create(manifest)
         } catch {
-            return failedReport(records: preflightRecords, error: error)
+            return failedReport(records: preflightRecords, error: error, stage: .journalCreate)
         }
         return resumePreparation(manifest, sourceResults: sourceResults)
     }
@@ -317,13 +338,13 @@ final class SecureStorageIdentityMigrationCoordinator {
         do {
             bridgeStore = try bridgeStoreFactory(manifest.attemptIdentifier)
         } catch {
-            return blockedReport(error: error)
+            return blockedReport(error: error, stage: .bridgeOpen)
         }
         let sourceResults = suppliedSourceResults ?? readAll(from: sourceStore)
         let bridgeResults = readAll(from: bridgeStore)
         let preflightRecords = zipResults(source: sourceResults, bridge: bridgeResults)
         guard preflightRecords.allSatisfy(\.state.isReady) else {
-            return failedReport(records: preflightRecords)
+            return failedReport(records: preflightRecords, stage: .bridgePreflight)
         }
 
         var records: [SecureStorageIdentityMigrationRecord] = []
@@ -335,28 +356,37 @@ final class SecureStorageIdentityMigrationCoordinator {
             records.append(reconcile(account, source: source, bridge: bridge, bridgeStore: bridgeStore))
         }
         guard records.allSatisfy(\.state.isReady) else {
-            return failedReport(records: records)
+            return failedReport(records: records, stage: .bridgeReconcile)
         }
 
         if let verificationFailure = verifyValuesMatch(bridgeStore: bridgeStore) {
-            return failedReport(records: records, blockingState: verificationFailure)
+            return failedReport(
+                records: records,
+                blockingState: verificationFailure,
+                stage: .bridgeVerify
+            )
         }
 
         let committedManifest = manifest.changingStatus(to: .committed)
         do {
             try persistBridgeManifest(committedManifest, bridgeStore: bridgeStore)
         } catch {
-            return failedReport(records: records, error: error)
+            return failedReport(
+                records: records,
+                error: error,
+                stage: .bridgeManifestPersist
+            )
         }
         do {
             try stateStore.save(committedManifest)
         } catch {
-            return failedReport(records: records, error: error)
+            return failedReport(records: records, error: error, stage: .journalCommit)
         }
         return SecureStorageIdentityMigrationReport(
             records: records,
             bridgeReady: true,
-            blockingState: nil
+            blockingState: nil,
+            stage: .ready
         )
     }
 
@@ -479,7 +509,7 @@ final class SecureStorageIdentityMigrationCoordinator {
         do {
             bridgeStore = try bridgeStoreFactory(manifest.attemptIdentifier)
         } catch {
-            return blockedReport(error: error)
+            return blockedReport(error: error, stage: .committedBridgeOpen)
         }
         let records: [SecureStorageIdentityMigrationRecord]
         do {
@@ -490,12 +520,13 @@ final class SecureStorageIdentityMigrationCoordinator {
                 accessMode: accessMode
             )
         } catch {
-            return blockedReport(error: error)
+            return blockedReport(error: error, stage: .committedBridgeVerify)
         }
         return SecureStorageIdentityMigrationReport(
             records: records,
             bridgeReady: true,
-            blockingState: nil
+            blockingState: nil,
+            stage: .ready
         )
     }
 
@@ -509,19 +540,24 @@ final class SecureStorageIdentityMigrationCoordinator {
     private func failedReport(
         records: [SecureStorageIdentityMigrationRecord],
         error: Error? = nil,
-        blockingState: SecureStorageIdentityMigrationRecordState? = nil
+        blockingState: SecureStorageIdentityMigrationRecordState? = nil,
+        stage: SecureStorageIdentityMigrationStage
     ) -> SecureStorageIdentityMigrationReport {
         SecureStorageIdentityMigrationReport(
             records: records,
             bridgeReady: false,
             blockingState: error.map {
                 SecureStorageIdentityMigrationRecordState.failureState(for: $0)
-            } ?? blockingState
+            } ?? blockingState,
+            stage: stage
         )
     }
 
-    private func blockedReport(error: Error? = nil) -> SecureStorageIdentityMigrationReport {
-        failedReport(records: [], error: error)
+    private func blockedReport(
+        error: Error? = nil,
+        stage: SecureStorageIdentityMigrationStage
+    ) -> SecureStorageIdentityMigrationReport {
+        failedReport(records: [], error: error, stage: stage)
     }
 }
 
@@ -675,28 +711,51 @@ enum SecureStorageIdentityMigrationBootstrap {
         IdentityMigrationRuntimeState.shared.setBlockedMessage(nil)
         let domain = SecureKeyValueStorageFactory.currentDecision().domain
         let phase = configuredPhase(from: bundle.object(forInfoDictionaryKey: phaseInfoKey))
+        recordDiagnostic(
+            stage: "bootstrap",
+            outcome: .started,
+            bundle: bundle,
+            domain: domain
+        )
         switch domain {
         case .officialDeveloperID:
             guard let phase else {
+                recordDiagnostic(
+                    stage: "configuration",
+                    outcome: .blocked,
+                    bundle: bundle,
+                    domain: domain
+                )
                 blockUpdates(unrecognizedConfigurationMessage)
                 return
             }
             switch phase {
             case .disabled:
-                activateCommittedBridgeIfPresent(bridgeRequired: false)
+                activateCommittedBridgeIfPresent(bridgeRequired: false, bundle: bundle)
             case .legacyPreparer:
                 prepareLegacyBridge(bundle: bundle)
             }
         case .successorOfficialDeveloperID:
             if let blockedMessage = successorBlockedMessage(forPhase: phase) {
+                recordDiagnostic(
+                    stage: "configuration",
+                    outcome: .blocked,
+                    bundle: bundle,
+                    domain: domain
+                )
                 blockUpdates(blockedMessage)
                 return
             }
             // The successor identity has no legacy storage fallback: without an
             // authenticated committed bridge it must stay ephemeral and say so.
-            activateCommittedBridgeIfPresent(bridgeRequired: true)
+            activateCommittedBridgeIfPresent(bridgeRequired: true, bundle: bundle)
         case .localSelfSigned, .appleDevelopmentDebug, .ephemeral:
-            return
+            recordDiagnostic(
+                stage: "bootstrap",
+                outcome: .skipped,
+                bundle: bundle,
+                domain: domain
+            )
         }
     }
 
@@ -717,6 +776,12 @@ enum SecureStorageIdentityMigrationBootstrap {
                   requirementSource: RuntimeCodeSigningPolicy.successorDeveloperIDRequirement
               )
         else {
+            recordDiagnostic(
+                stage: "preparer-validation",
+                outcome: .blocked,
+                bundle: bundle,
+                domain: .officialDeveloperID
+            )
             blockUpdates("Updates are paused because the secure credential migration package is incomplete, its account catalog changed, or it has an invalid identity anchor.")
             return
         }
@@ -739,6 +804,13 @@ enum SecureStorageIdentityMigrationBootstrap {
                 ]
             )
         } catch {
+            recordDiagnostic(
+                stage: "preparer-authority",
+                outcome: .blocked,
+                bundle: bundle,
+                domain: .officialDeveloperID,
+                error: error
+            )
             blockUpdates(for: error)
             return
         }
@@ -762,6 +834,13 @@ enum SecureStorageIdentityMigrationBootstrap {
             stateStore: stateStore
         )
         let report = coordinator.prepareBridge()
+        recordDiagnostic(
+            stage: report.stage.rawValue,
+            outcome: report.bridgeReady ? .succeeded : .blocked,
+            bundle: bundle,
+            domain: .officialDeveloperID,
+            recordStateCounts: report.diagnosticStateCounts
+        )
         guard report.bridgeReady else {
             blockUpdates(report.blockedUpdateMessage)
             return
@@ -771,11 +850,24 @@ enum SecureStorageIdentityMigrationBootstrap {
             guard let loadedManifest = try stateStore.load(),
                   loadedManifest.status == .committed
             else {
+                recordDiagnostic(
+                    stage: "post-commit-journal-load",
+                    outcome: .blocked,
+                    bundle: bundle,
+                    domain: .officialDeveloperID
+                )
                 blockUpdates("Updates are paused because the secure credential migration journal is incomplete.")
                 return
             }
             manifest = loadedManifest
         } catch {
+            recordDiagnostic(
+                stage: "post-commit-journal-load",
+                outcome: .blocked,
+                bundle: bundle,
+                domain: .officialDeveloperID,
+                error: error
+            )
             blockUpdates(for: error)
             return
         }
@@ -787,12 +879,31 @@ enum SecureStorageIdentityMigrationBootstrap {
                 itemAccessValidator: authority.accessValidator
             )
             SecureKeyValueStorageFactory.installOfficialBackendOverride(bridge)
+            recordDiagnostic(
+                stage: "preparer-activation",
+                outcome: .succeeded,
+                bundle: bundle,
+                domain: .officialDeveloperID
+            )
         } catch {
+            recordDiagnostic(
+                stage: "preparer-activation",
+                outcome: .blocked,
+                bundle: bundle,
+                domain: .officialDeveloperID,
+                error: error
+            )
             blockUpdates(for: error)
         }
     }
 
-    private static func activateCommittedBridgeIfPresent(bridgeRequired: Bool) {
+    private static func activateCommittedBridgeIfPresent(
+        bridgeRequired: Bool,
+        bundle: Bundle
+    ) {
+        let domain: RuntimeSecureStorageDomain = bridgeRequired
+            ? .successorOfficialDeveloperID
+            : .officialDeveloperID
         let accessValidator: ClassicKeychainACLValidator
         do {
             accessValidator = try ClassicKeychainACLValidator(
@@ -802,6 +913,13 @@ enum SecureStorageIdentityMigrationBootstrap {
                 ]
             )
         } catch {
+            recordDiagnostic(
+                stage: "activation-authority",
+                outcome: .blocked,
+                bundle: bundle,
+                domain: domain,
+                error: error
+            )
             blockUpdates(for: error)
             return
         }
@@ -829,10 +947,23 @@ enum SecureStorageIdentityMigrationBootstrap {
                 }
             ).resolve()
         } catch {
+            recordDiagnostic(
+                stage: "committed-bridge-resolve",
+                outcome: .blocked,
+                bundle: bundle,
+                domain: domain,
+                error: error
+            )
             blockUpdates(for: error)
             return
         }
         guard let resolution else {
+            recordDiagnostic(
+                stage: "committed-bridge-resolve",
+                outcome: bridgeRequired ? .blocked : .skipped,
+                bundle: bundle,
+                domain: domain
+            )
             if bridgeRequired {
                 blockUpdates(successorMissingBridgeMessage)
             }
@@ -843,6 +974,12 @@ enum SecureStorageIdentityMigrationBootstrap {
         guard let bridgeServiceName = KeychainService.identityMigrationBridgeServiceName(
             for: manifest.attemptIdentifier
         ) else {
+            recordDiagnostic(
+                stage: "committed-bridge-service",
+                outcome: .blocked,
+                bundle: bundle,
+                domain: domain
+            )
             blockUpdates("Updates are paused because the secure credential migration journal is incomplete.")
             return
         }
@@ -859,7 +996,20 @@ enum SecureStorageIdentityMigrationBootstrap {
                 itemAccessValidator: accessValidator
             )
             SecureKeyValueStorageFactory.installOfficialBackendOverride(bridge)
+            recordDiagnostic(
+                stage: "committed-bridge-activation",
+                outcome: .succeeded,
+                bundle: bundle,
+                domain: domain
+            )
         } catch {
+            recordDiagnostic(
+                stage: "committed-bridge-activation",
+                outcome: .blocked,
+                bundle: bundle,
+                domain: domain,
+                error: error
+            )
             blockUpdates(for: error)
         }
     }
@@ -911,8 +1061,64 @@ enum SecureStorageIdentityMigrationBootstrap {
         let report = SecureStorageIdentityMigrationReport(
             records: [],
             bridgeReady: false,
-            blockingState: SecureStorageIdentityMigrationRecordState.failureState(for: error)
+            blockingState: SecureStorageIdentityMigrationRecordState.failureState(for: error),
+            stage: .committedBridgeVerify
         )
         blockUpdates(report.blockedUpdateMessage)
+    }
+
+    private static func recordDiagnostic(
+        stage: String,
+        outcome: IdentityTransitionDiagnosticEvent.Outcome,
+        bundle: Bundle,
+        domain: RuntimeSecureStorageDomain,
+        recordStateCounts: [String: Int]? = nil,
+        error: Error? = nil
+    ) {
+        IdentityTransitionDiagnostics.shared.record(
+            subsystem: .secureStorage,
+            stage: stage,
+            outcome: outcome,
+            bundle: bundle,
+            secureStorageDomain: domain,
+            recordStateCounts: recordStateCounts,
+            errorClass: error.map(diagnosticErrorClass)
+        )
+    }
+
+    private static func diagnosticErrorClass(_ error: Error) -> String {
+        switch SecureStorageIdentityMigrationRecordState.failureState(for: error) {
+        case .interactionRequired: "interaction-required"
+        case .userInteractionCancelled: "cancelled"
+        case .authenticationFailed: "authentication-failed"
+        case .absent, .copied, .verified, .failed: "other"
+        }
+    }
+}
+
+private extension SecureStorageIdentityMigrationReport {
+    var diagnosticStateCounts: [String: Int] {
+        var counts: [String: Int] = [:]
+        for record in records {
+            counts[record.state.diagnosticName, default: 0] += 1
+        }
+        if let blockingState {
+            counts["blocking-\(blockingState.diagnosticName)", default: 0] += 1
+        }
+        return counts
+    }
+}
+
+private extension SecureStorageIdentityMigrationRecordState {
+    var diagnosticName: String {
+        switch self {
+        case .absent: "absent"
+        case .copied: "copied"
+        case .verified: "verified"
+        case .interactionRequired: "interaction-required"
+        case .userInteractionCancelled: "cancelled"
+        case .authenticationFailed: "authentication-failed"
+        case .failed: "failed"
+        }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureStorageIdentityMigration.swift
@@ -711,14 +711,14 @@ enum SecureStorageIdentityMigrationBootstrap {
         IdentityMigrationRuntimeState.shared.setBlockedMessage(nil)
         let domain = SecureKeyValueStorageFactory.currentDecision().domain
         let phase = configuredPhase(from: bundle.object(forInfoDictionaryKey: phaseInfoKey))
-        recordDiagnostic(
-            stage: "bootstrap",
-            outcome: .started,
-            bundle: bundle,
-            domain: domain
-        )
         switch domain {
         case .officialDeveloperID:
+            recordDiagnostic(
+                stage: "bootstrap",
+                outcome: .started,
+                bundle: bundle,
+                domain: domain
+            )
             guard let phase else {
                 recordDiagnostic(
                     stage: "configuration",
@@ -736,6 +736,12 @@ enum SecureStorageIdentityMigrationBootstrap {
                 prepareLegacyBridge(bundle: bundle)
             }
         case .successorOfficialDeveloperID:
+            recordDiagnostic(
+                stage: "bootstrap",
+                outcome: .started,
+                bundle: bundle,
+                domain: domain
+            )
             if let blockedMessage = successorBlockedMessage(forPhase: phase) {
                 recordDiagnostic(
                     stage: "configuration",
@@ -750,12 +756,7 @@ enum SecureStorageIdentityMigrationBootstrap {
             // authenticated committed bridge it must stay ephemeral and say so.
             activateCommittedBridgeIfPresent(bridgeRequired: true, bundle: bundle)
         case .localSelfSigned, .appleDevelopmentDebug, .ephemeral:
-            recordDiagnostic(
-                stage: "bootstrap",
-                outcome: .skipped,
-                bundle: bundle,
-                domain: domain
-            )
+            return
         }
     }
 

--- a/Tests/RepoPromptTests/Security/IdentityTransitionDiagnosticsTests.swift
+++ b/Tests/RepoPromptTests/Security/IdentityTransitionDiagnosticsTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class IdentityTransitionDiagnosticsTests: XCTestCase {
+    func testDefaultsMigrationCopiesLegacyDomainWithoutOverwritingSuccessorValues() {
+        let names = DefaultsDomainNames()
+        let defaults = UserDefaults.standard
+        defer { names.remove(from: defaults) }
+
+        defaults.setPersistentDomain(
+            [
+                UpdateChannel.userDefaultsKey: UpdateChannel.tip.rawValue,
+                "NSWindow Frame Main": "legacy-frame",
+                "legacy-only": "legacy-value"
+            ],
+            forName: names.legacy
+        )
+        defaults.setPersistentDomain(
+            [
+                "NSWindow Frame Main": "successor-frame",
+                "successor-only": "successor-value"
+            ],
+            forName: names.successor
+        )
+
+        let report = BundleIdentityDefaultsMigration.migrateIfNeeded(
+            bundleIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+            defaults: defaults,
+            legacyDomainName: names.legacy,
+            successorDomainName: names.successor
+        )
+
+        XCTAssertEqual(report.outcome, .migrated)
+        XCTAssertEqual(report.copiedKeyCount, 2)
+        XCTAssertEqual(report.preservedKeyCount, 2)
+        let migrated = defaults.persistentDomain(forName: names.successor)
+        XCTAssertEqual(migrated?[UpdateChannel.userDefaultsKey] as? String, UpdateChannel.tip.rawValue)
+        XCTAssertEqual(migrated?["NSWindow Frame Main"] as? String, "successor-frame")
+        XCTAssertEqual(migrated?["legacy-only"] as? String, "legacy-value")
+        XCTAssertEqual(migrated?["successor-only"] as? String, "successor-value")
+        XCTAssertEqual(
+            migrated?[BundleIdentityDefaultsMigration.completionMarker] as? Bool,
+            true
+        )
+    }
+
+    func testDefaultsMigrationIsSuccessorOnlyAndIdempotent() {
+        let names = DefaultsDomainNames()
+        let defaults = UserDefaults.standard
+        defer { names.remove(from: defaults) }
+        defaults.setPersistentDomain(["legacy-only": 1], forName: names.legacy)
+
+        let skipped = BundleIdentityDefaultsMigration.migrateIfNeeded(
+            bundleIdentifier: RuntimeCodeSigningPolicy.developerIDBundleIdentifier,
+            defaults: defaults,
+            legacyDomainName: names.legacy,
+            successorDomainName: names.successor
+        )
+        XCTAssertEqual(skipped.outcome, .skipped)
+        XCTAssertNil(defaults.persistentDomain(forName: names.successor))
+
+        let first = BundleIdentityDefaultsMigration.migrateIfNeeded(
+            bundleIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+            defaults: defaults,
+            legacyDomainName: names.legacy,
+            successorDomainName: names.successor
+        )
+        XCTAssertEqual(first.outcome, .migrated)
+
+        defaults.setPersistentDomain(["legacy-only": 2, "late-key": true], forName: names.legacy)
+        let second = BundleIdentityDefaultsMigration.migrateIfNeeded(
+            bundleIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+            defaults: defaults,
+            legacyDomainName: names.legacy,
+            successorDomainName: names.successor
+        )
+        XCTAssertEqual(second.outcome, .alreadyCompleted)
+        let migrated = defaults.persistentDomain(forName: names.successor)
+        XCTAssertEqual(migrated?["legacy-only"] as? Int, 1)
+        XCTAssertNil(migrated?["late-key"])
+    }
+
+    func testDiagnosticLedgerIsBoundedPrivateAndContainsOnlyStructuredFields() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("identity-transition-v1.json")
+        let recorder = IdentityTransitionDiagnostics(
+            fileURL: fileURL,
+            maximumEventCount: 3,
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+
+        for index in 0 ..< 5 {
+            recorder.record(
+                IdentityTransitionDiagnosticEvent(
+                    timestamp: Date(timeIntervalSince1970: TimeInterval(index)),
+                    subsystem: .secureStorage,
+                    stage: "stage-\(index)",
+                    outcome: .succeeded,
+                    bundleIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+                    displayVersion: "1.2.3",
+                    buildVersion: "123",
+                    migrationPhase: "disabled",
+                    secureStorageDomain: "successor-official",
+                    updateChannel: UpdateChannel.tip.rawValue,
+                    targetDisplayVersion: nil,
+                    targetBuildVersion: nil,
+                    recordStateCounts: ["verified": 2],
+                    errorClass: nil
+                )
+            )
+        }
+
+        XCTAssertEqual(recorder.readEvents().map(\.stage), ["stage-2", "stage-3", "stage-4"])
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+
+        let encoded = try String(contentsOf: fileURL, encoding: .utf8)
+        XCTAssertFalse(encoded.contains("account"))
+        XCTAssertFalse(encoded.contains("attemptIdentifier"))
+        XCTAssertFalse(encoded.contains("fileURL"))
+        XCTAssertFalse(encoded.contains("rawError"))
+    }
+}
+
+private struct DefaultsDomainNames {
+    let legacy = "identity-transition-tests.legacy.\(UUID().uuidString)"
+    let successor = "identity-transition-tests.successor.\(UUID().uuidString)"
+
+    func remove(from defaults: UserDefaults) {
+        defaults.removePersistentDomain(forName: legacy)
+        defaults.removePersistentDomain(forName: successor)
+    }
+}

--- a/tip-rollout.json
+++ b/tip-rollout.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "channel": "tip",
+  "currentRole": "legacy",
+  "eligibilityProfile": "tip-identity-dress-rehearsal-v1",
+  "expectedMigrationPhase": "disabled",
+  "expectedSigningIdentity": "legacy",
+  "predecessors": []
+}


### PR DESCRIPTION
## Summary

- enable an explicit Tip-channel P→T→S identity migration rehearsal using the existing Tip workflow, update repository, Sparkle feed, and EdDSA signing authority
- retain the preparer and transition artifacts as additional top-level appcast entries while the successor becomes primary
- migrate successor defaults without overwriting successor-owned values
- record bounded, privacy-preserving diagnostics for defaults, secure storage, and Sparkle update/install stages
- reject role, bundle-ID, team-ID, certificate, predecessor, and artifact-shape mismatches before publication
- keep Stable locked; nonlegacy Tip publication requires an exact manual role confirmation

## Stack

1. Runtime safety and deterministic appcast selection
2. Dormant release tooling and Stable safety lock
3. **This PR:** Tip rehearsal, successor enablement, and operational diagnostics

## Diagnostics

The app writes a bounded structured ledger to:

`~/Library/Application Support/RepoPrompt CE/Diagnostics/identity-transition-v1.json`

It records migration stages, outcomes, bundle/build/channel context, safe counters, and structured error classes. It excludes credential values, accounts, filesystem paths, URLs, attempt identifiers, and raw error strings.

## Validation

- `swift test --filter 'IdentityTransitionDiagnosticsTests|SecureStorageIdentityMigrationTests'` — 31 passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest Scripts.test_release_tooling.IdentityTransitionReleaseToolingTests` — 8 passed
- SwiftFormat, shell syntax, workflow YAML parsing, and `git diff --check`
- mandatory contribution preflight and outgoing-range secret scan
- path-selected PR-ready lint passed; the full suite had one unrelated `DirectHeadlessRuntimeConfigurationTests` failure that passed on immediate isolated rerun (the later product-build phase did not run)

## Rollout boundary

This PR prepares the real Tip rehearsal but does not publish a Tip artifact. After merge, operators must advance and explicitly dispatch preparer, transition, and successor roles one at a time, inspecting the diagnostic ledger and published appcast between stages.
