### PR TITLE
Fix Tip identity transition release credentials

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -150,9 +150,126 @@ jobs:
             echo "installation-type=$ROLLOUT_INSTALLATION_TYPE"
           } >> "$GITHUB_OUTPUT"
 
+  credential-preflight:
+    name: Preflight Tip Rollout Credentials
+    needs: setup
+    if: needs.setup.outputs.should-publish == 'true'
+    environment: tip-release
+    runs-on: macos-26
+    permissions:
+      contents: read
+    steps:
+      - name: Check out trusted tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.setup.outputs.tooling-commit }}
+          path: trusted-control-plane
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Check out approved tip source as data
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.setup.outputs.commit }}
+          path: approved-source
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate role-selected Tip credentials
+        env:
+          SETUP_ROLLOUT_ROLE: ${{ needs.setup.outputs.rollout-role }}
+          SETUP_ROLLOUT_IDENTITY: ${{ needs.setup.outputs.rollout-identity }}
+          SETUP_MIGRATION_PHASE: ${{ needs.setup.outputs.migration-phase }}
+          SETUP_INSTALLATION_TYPE: ${{ needs.setup.outputs.installation-type }}
+          LEGACY_CERTIFICATE_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          LEGACY_CERTIFICATE_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          SUCCESSOR_CERTIFICATE_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          SUCCESSOR_CERTIFICATE_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          SUCCESSOR_INSTALLER_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_BASE64 }}
+          SUCCESSOR_INSTALLER_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_PASSWORD }}
+          LEGACY_PROVISIONING_PROFILE_BASE64: ${{ secrets.REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64 }}
+          SUCCESSOR_PROVISIONING_PROFILE_BASE64: ${{ secrets.SUCCESSOR_REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64 }}
+          LEGACY_NOTARYTOOL_PRIVATE_KEY_BASE64: ${{ secrets.NOTARYTOOL_PRIVATE_KEY_BASE64 }}
+          LEGACY_NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
+          LEGACY_NOTARYTOOL_ISSUER_ID: ${{ secrets.NOTARYTOOL_ISSUER_ID }}
+          SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64: ${{ secrets.SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64 }}
+          SUCCESSOR_NOTARYTOOL_KEY_ID: ${{ secrets.SUCCESSOR_NOTARYTOOL_KEY_ID }}
+          SUCCESSOR_NOTARYTOOL_ISSUER_ID: ${{ secrets.SUCCESSOR_NOTARYTOOL_ISSUER_ID }}
+          CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+          require_value() {
+            local name="$1"
+            [[ -n "${!name:-}" ]] || fail "$name is not configured for the $ROLLOUT_ROLE rollout"
+          }
+          decode_value() {
+            local label="$1"
+            local value="$2"
+            printf '%s' "$value" | base64 --decode >/dev/null || fail "$label is not valid base64"
+          }
+
+          eval "$(python3 trusted-control-plane/Scripts/stable_rollout.py packaging-context \
+            --declaration approved-source/tip-rollout.json \
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json \
+            --version-env approved-source/version.env)"
+          [[ "$ROLLOUT_CHANNEL" == "tip" ]] || fail "Tip credential preflight requires a Tip declaration"
+          [[ "$ROLLOUT_ROLE" == "$SETUP_ROLLOUT_ROLE" ]] || fail "Tip rollout role changed after setup"
+          [[ "$ROLLOUT_IDENTITY" == "$SETUP_ROLLOUT_IDENTITY" ]] || fail "Tip rollout identity changed after setup"
+          [[ "$REPOPROMPT_IDENTITY_MIGRATION_PHASE" == "$SETUP_MIGRATION_PHASE" ]] || fail "Tip migration phase changed after setup"
+          [[ "$ROLLOUT_INSTALLATION_TYPE" == "$SETUP_INSTALLATION_TYPE" ]] || fail "Tip installation type changed after setup"
+          require_value EXPECTED_SIGN_IDENTITY
+          require_value CI_KEYCHAIN_PASSWORD
+
+          case "$ROLLOUT_IDENTITY" in
+            legacy)
+              CERTIFICATE_P12_BASE64="$LEGACY_CERTIFICATE_P12_BASE64"
+              CERTIFICATE_P12_PASSWORD="$LEGACY_CERTIFICATE_P12_PASSWORD"
+              PROVISIONING_PROFILE_BASE64="$LEGACY_PROVISIONING_PROFILE_BASE64"
+              NOTARYTOOL_PRIVATE_KEY_BASE64="$LEGACY_NOTARYTOOL_PRIVATE_KEY_BASE64"
+              NOTARYTOOL_KEY_ID="$LEGACY_NOTARYTOOL_KEY_ID"
+              NOTARYTOOL_ISSUER_ID="$LEGACY_NOTARYTOOL_ISSUER_ID"
+              ;;
+            successor)
+              CERTIFICATE_P12_BASE64="$SUCCESSOR_CERTIFICATE_P12_BASE64"
+              CERTIFICATE_P12_PASSWORD="$SUCCESSOR_CERTIFICATE_P12_PASSWORD"
+              PROVISIONING_PROFILE_BASE64="$SUCCESSOR_PROVISIONING_PROFILE_BASE64"
+              NOTARYTOOL_PRIVATE_KEY_BASE64="$SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64"
+              NOTARYTOOL_KEY_ID="$SUCCESSOR_NOTARYTOOL_KEY_ID"
+              NOTARYTOOL_ISSUER_ID="$SUCCESSOR_NOTARYTOOL_ISSUER_ID"
+              ;;
+            *)
+              fail "Unsupported Tip rollout identity: $ROLLOUT_IDENTITY"
+              ;;
+          esac
+          require_value CERTIFICATE_P12_BASE64
+          require_value CERTIFICATE_P12_PASSWORD
+          require_value PROVISIONING_PROFILE_BASE64
+          require_value NOTARYTOOL_PRIVATE_KEY_BASE64
+          require_value NOTARYTOOL_KEY_ID
+          require_value NOTARYTOOL_ISSUER_ID
+          decode_value "application certificate" "$CERTIFICATE_P12_BASE64"
+          decode_value "provisioning profile" "$PROVISIONING_PROFILE_BASE64"
+          decode_value "notarytool private key" "$NOTARYTOOL_PRIVATE_KEY_BASE64"
+
+          if [[ "$ROLLOUT_ROLE" == "preparer" ]]; then
+            require_value SUCCESSOR_CERTIFICATE_P12_BASE64
+            require_value SUCCESSOR_CERTIFICATE_P12_PASSWORD
+            decode_value "successor anchor certificate" "$SUCCESSOR_CERTIFICATE_P12_BASE64"
+          fi
+          if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
+            require_value EXPECTED_INSTALLER_IDENTITY
+            require_value SUCCESSOR_INSTALLER_P12_BASE64
+            require_value SUCCESSOR_INSTALLER_P12_PASSWORD
+            decode_value "successor installer certificate" "$SUCCESSOR_INSTALLER_P12_BASE64"
+          fi
+          printf 'OK: Tip %s credential/configuration preflight passed.\n' "$ROLLOUT_ROLE"
+
   stage:
     name: Build Tip Source Without Secrets
-    needs: setup
+    needs:
+      - setup
+      - credential-preflight
     if: needs.setup.outputs.should-publish == 'true'
     runs-on: macos-26
     permissions:
@@ -258,31 +375,38 @@ jobs:
           SUCCESSOR_INSTALLER_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_BASE64 }}
           SUCCESSOR_INSTALLER_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_PASSWORD }}
           CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
-          CONFIGURED_LEGACY_SIGN_IDENTITY: ${{ vars.SIGN_IDENTITY }}
-          CONFIGURED_SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}
-          CONFIGURED_SUCCESSOR_INSTALLER_IDENTITY: ${{ vars.SUCCESSOR_INSTALLER_IDENTITY }}
         run: |
           set -euo pipefail
           umask 077
+          fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+          verify_identity() {
+            local policy="$1"
+            local identity="$2"
+            local label="$3"
+            security find-identity -v -p "$policy" "$KEYCHAIN_PATH" |
+              grep -F "\"$identity\"" >/dev/null ||
+              fail "Expected $label identity is not present and usable in the ephemeral keychain"
+          }
           eval "$(python3 trusted-control-plane/Scripts/stable_rollout.py packaging-context \
             --declaration approved-source/tip-rollout.json \
             --policy trusted-control-plane/Scripts/apple_identity_policy.json \
             --version-env approved-source/version.env)"
-          if [[ "$ROLLOUT_IDENTITY" == "successor" ]]; then
-            CERTIFICATE_P12_BASE64="$SUCCESSOR_CERTIFICATE_P12_BASE64"
-            CERTIFICATE_P12_PASSWORD="$SUCCESSOR_CERTIFICATE_P12_PASSWORD"
-            CONFIGURED_SIGN_IDENTITY="$CONFIGURED_SUCCESSOR_SIGN_IDENTITY"
-          else
-            CERTIFICATE_P12_BASE64="$LEGACY_CERTIFICATE_P12_BASE64"
-            CERTIFICATE_P12_PASSWORD="$LEGACY_CERTIFICATE_P12_PASSWORD"
-            CONFIGURED_SIGN_IDENTITY="$CONFIGURED_LEGACY_SIGN_IDENTITY"
-          fi
+          : "${CI_KEYCHAIN_PASSWORD:?CI keychain password is not configured}"
+          case "$ROLLOUT_IDENTITY" in
+            successor)
+              CERTIFICATE_P12_BASE64="$SUCCESSOR_CERTIFICATE_P12_BASE64"
+              CERTIFICATE_P12_PASSWORD="$SUCCESSOR_CERTIFICATE_P12_PASSWORD"
+              ;;
+            legacy)
+              CERTIFICATE_P12_BASE64="$LEGACY_CERTIFICATE_P12_BASE64"
+              CERTIFICATE_P12_PASSWORD="$LEGACY_CERTIFICATE_P12_PASSWORD"
+              ;;
+            *)
+              fail "Unsupported Tip rollout identity: $ROLLOUT_IDENTITY"
+              ;;
+          esac
           : "${CERTIFICATE_P12_BASE64:?Application signing certificate is not configured for this identity}"
           : "${CERTIFICATE_P12_PASSWORD:?Application signing certificate password is not configured for this identity}"
-          [[ "$CONFIGURED_SIGN_IDENTITY" == "$EXPECTED_SIGN_IDENTITY" ]] || {
-            echo "Configured signing identity must match the reviewed identity policy" >&2
-            exit 1
-          }
           KEYCHAIN_PATH="$RUNNER_TEMP/repoprompt-tip.keychain-db"
           CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-tip.p12"
           printf '%s' "$CERTIFICATE_P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
@@ -292,31 +416,27 @@ jobs:
           security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH"
+          verify_identity codesigning "$EXPECTED_SIGN_IDENTITY" application
           if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
             : "${SUCCESSOR_INSTALLER_P12_BASE64:?Successor Developer ID Installer certificate is not configured}"
             : "${SUCCESSOR_INSTALLER_P12_PASSWORD:?Successor Developer ID Installer password is not configured}"
-            [[ "$CONFIGURED_SUCCESSOR_INSTALLER_IDENTITY" == "$EXPECTED_INSTALLER_IDENTITY" ]] || {
-              echo "Configured installer identity must match the reviewed identity policy" >&2
-              exit 1
-            }
             installer_certificate="$RUNNER_TEMP/repoprompt-tip-installer.p12"
             printf '%s' "$SUCCESSOR_INSTALLER_P12_BASE64" | base64 --decode > "$installer_certificate"
             security import "$installer_certificate" -k "$KEYCHAIN_PATH" \
               -P "$SUCCESSOR_INSTALLER_P12_PASSWORD" -T /usr/bin/productbuild -T /usr/bin/security
             security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild: \
               -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+            verify_identity basic "$EXPECTED_INSTALLER_IDENTITY" installer
             rm -f "$installer_certificate"
-            echo "INSTALLER_IDENTITY=$EXPECTED_INSTALLER_IDENTITY" >> "$GITHUB_ENV"
           fi
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "SIGN_IDENTITY=$CONFIGURED_SIGN_IDENTITY" >> "$GITHUB_ENV"
+          printf 'KEYCHAIN_PATH=%s\n' "$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          printf 'SIGN_IDENTITY=%s\n' "$EXPECTED_SIGN_IDENTITY" >> "$GITHUB_ENV"
 
       - name: Prepare successor identity migration anchor
         if: needs.setup.outputs.rollout-role == 'preparer'
         env:
           SUCCESSOR_CERTIFICATE_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
           SUCCESSOR_CERTIFICATE_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
-          SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}
           CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
@@ -325,10 +445,8 @@ jobs:
             --declaration approved-source/tip-rollout.json \
             --policy trusted-control-plane/Scripts/apple_identity_policy.json \
             --version-env approved-source/version.env)"
-          [[ "$SUCCESSOR_SIGN_IDENTITY" == "$EXPECTED_SUCCESSOR_SIGN_IDENTITY" ]] || {
-            echo "Successor signing identity does not match the reviewed identity policy" >&2
-            exit 1
-          }
+          : "${SUCCESSOR_CERTIFICATE_P12_BASE64:?Successor Developer ID Application certificate is not configured}"
+          : "${SUCCESSOR_CERTIFICATE_P12_PASSWORD:?Successor Developer ID Application password is not configured}"
           successor_certificate="$RUNNER_TEMP/repoprompt-tip-successor.p12"
           anchor="$RUNNER_TEMP/repoprompt-successor-identity-anchor"
           xcrun clang -arch arm64 -arch x86_64 -Os -Wl,-dead_strip \
@@ -338,34 +456,62 @@ jobs:
             -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          codesign --force --sign "$SUCCESSOR_SIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" \
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" |
+            grep -F "\"$EXPECTED_SUCCESSOR_SIGN_IDENTITY\"" >/dev/null || {
+              echo "Expected successor application identity is not present and usable in the ephemeral keychain" >&2
+              exit 1
+            }
+          codesign --force --sign "$EXPECTED_SUCCESSOR_SIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" \
             --identifier com.repoprompt.ce --timestamp --options runtime "$anchor"
           codesign --verify --strict --verbose=2 \
             -R='anchor apple generic and identifier "com.repoprompt.ce" and certificate leaf[subject.OU] = "69N6K965SF" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists' \
             "$anchor"
-          echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"
+          printf 'REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=%s\n' "$anchor" >> "$GITHUB_ENV"
 
       - name: Prepare provisioning profile and notarization key
         env:
           ROLLOUT_IDENTITY: ${{ needs.setup.outputs.rollout-identity }}
           LEGACY_PROVISIONING_PROFILE_BASE64: ${{ secrets.REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64 }}
           SUCCESSOR_PROVISIONING_PROFILE_BASE64: ${{ secrets.SUCCESSOR_REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64 }}
-          NOTARYTOOL_PRIVATE_KEY_BASE64: ${{ secrets.NOTARYTOOL_PRIVATE_KEY_BASE64 }}
+          LEGACY_NOTARYTOOL_PRIVATE_KEY_BASE64: ${{ secrets.NOTARYTOOL_PRIVATE_KEY_BASE64 }}
+          LEGACY_NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
+          LEGACY_NOTARYTOOL_ISSUER_ID: ${{ secrets.NOTARYTOOL_ISSUER_ID }}
+          SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64: ${{ secrets.SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64 }}
+          SUCCESSOR_NOTARYTOOL_KEY_ID: ${{ secrets.SUCCESSOR_NOTARYTOOL_KEY_ID }}
+          SUCCESSOR_NOTARYTOOL_ISSUER_ID: ${{ secrets.SUCCESSOR_NOTARYTOOL_ISSUER_ID }}
         run: |
           set -euo pipefail
           umask 077
           SECRETS_DIR="$RUNNER_TEMP/repoprompt-tip-secrets"
           mkdir -p "$SECRETS_DIR"
-          if [[ "$ROLLOUT_IDENTITY" == "successor" ]]; then
-            PROVISIONING_PROFILE_BASE64="$SUCCESSOR_PROVISIONING_PROFILE_BASE64"
-          else
-            PROVISIONING_PROFILE_BASE64="$LEGACY_PROVISIONING_PROFILE_BASE64"
-          fi
+          case "$ROLLOUT_IDENTITY" in
+            successor)
+              PROVISIONING_PROFILE_BASE64="$SUCCESSOR_PROVISIONING_PROFILE_BASE64"
+              NOTARYTOOL_PRIVATE_KEY_BASE64="$SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64"
+              NOTARYTOOL_KEY_ID="$SUCCESSOR_NOTARYTOOL_KEY_ID"
+              NOTARYTOOL_ISSUER_ID="$SUCCESSOR_NOTARYTOOL_ISSUER_ID"
+              ;;
+            legacy)
+              PROVISIONING_PROFILE_BASE64="$LEGACY_PROVISIONING_PROFILE_BASE64"
+              NOTARYTOOL_PRIVATE_KEY_BASE64="$LEGACY_NOTARYTOOL_PRIVATE_KEY_BASE64"
+              NOTARYTOOL_KEY_ID="$LEGACY_NOTARYTOOL_KEY_ID"
+              NOTARYTOOL_ISSUER_ID="$LEGACY_NOTARYTOOL_ISSUER_ID"
+              ;;
+            *)
+              echo "Unsupported Tip rollout identity: $ROLLOUT_IDENTITY" >&2
+              exit 1
+              ;;
+          esac
           : "${PROVISIONING_PROFILE_BASE64:?Provisioning profile is not configured for this identity}"
+          : "${NOTARYTOOL_PRIVATE_KEY_BASE64:?Notarytool private key is not configured for this identity}"
+          : "${NOTARYTOOL_KEY_ID:?Notarytool key ID is not configured for this identity}"
+          : "${NOTARYTOOL_ISSUER_ID:?Notarytool issuer ID is not configured for this identity}"
           printf '%s' "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$SECRETS_DIR/repoprompt-ce.provisionprofile"
           printf '%s' "$NOTARYTOOL_PRIVATE_KEY_BASE64" | base64 --decode > "$SECRETS_DIR/notarytool-private-key.p8"
-          echo "REPOPROMPT_PROVISIONING_PROFILE=$SECRETS_DIR/repoprompt-ce.provisionprofile" >> "$GITHUB_ENV"
-          echo "NOTARYTOOL_PRIVATE_KEY=$SECRETS_DIR/notarytool-private-key.p8" >> "$GITHUB_ENV"
+          printf 'REPOPROMPT_PROVISIONING_PROFILE=%s\n' "$SECRETS_DIR/repoprompt-ce.provisionprofile" >> "$GITHUB_ENV"
+          printf 'NOTARYTOOL_PRIVATE_KEY=%s\n' "$SECRETS_DIR/notarytool-private-key.p8" >> "$GITHUB_ENV"
+          printf 'NOTARYTOOL_KEY_ID=%s\n' "$NOTARYTOOL_KEY_ID" >> "$GITHUB_ENV"
+          printf 'NOTARYTOOL_ISSUER_ID=%s\n' "$NOTARYTOOL_ISSUER_ID" >> "$GITHUB_ENV"
 
       - name: Install Sentry CLI for Tip symbol upload
         run: |
@@ -405,8 +551,6 @@ jobs:
           REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
           REPOPROMPT_SENTRY_AUTH_TOKEN_FILE: ${{ runner.temp }}/repoprompt-tip-secrets/sentry-auth-token
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-          NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
-          NOTARYTOOL_ISSUER_ID: ${{ secrets.NOTARYTOOL_ISSUER_ID }}
         run: ./trusted-control-plane/Scripts/main_tip_release.sh sign
 
       - name: Remove ephemeral keychain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,6 @@ jobs:
           CERTIFICATE_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
           CERTIFICATE_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
           CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
-          CONFIGURED_SIGN_IDENTITY: ${{ vars.SIGN_IDENTITY }}
         run: |
           set -euo pipefail
           umask 077
@@ -181,6 +180,11 @@ jobs:
             fi
           }
           trap cleanup_certificate_and_failed_keychain EXIT
+          eval "$(python3 trusted-control-plane/Scripts/stable_rollout.py packaging-context \
+            --declaration approved-source/release-rollout.json \
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json \
+            --version-env approved-source/version.env)"
+          : "${EXPECTED_SIGN_IDENTITY:?Apple application identity is missing from the reviewed policy}"
           printf '%s' "$CERTIFICATE_P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
           security create-keychain -p "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           keychain_created=1
@@ -189,24 +193,32 @@ jobs:
           security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH"
-          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "SIGN_IDENTITY=${CONFIGURED_SIGN_IDENTITY:-Developer ID Application: Eric Provencher (648A27MST5)}" >> "$GITHUB_ENV"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" |
+            grep -F "\"$EXPECTED_SIGN_IDENTITY\"" >/dev/null || {
+              echo "Expected application identity is not present and usable in the ephemeral keychain" >&2
+              exit 1
+            }
+          printf 'KEYCHAIN_PATH=%s\n' "$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          printf 'SIGN_IDENTITY=%s\n' "$EXPECTED_SIGN_IDENTITY" >> "$GITHUB_ENV"
 
       - name: Prepare successor identity migration anchor
         if: inputs.identity_migration_phase == 'legacy-preparer'
         env:
           SUCCESSOR_CERTIFICATE_P12_BASE64: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64 }}
           SUCCESSOR_CERTIFICATE_P12_PASSWORD: ${{ secrets.SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
-          SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}
           CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
           umask 077
           : "${SUCCESSOR_CERTIFICATE_P12_BASE64:?Successor Developer ID Application certificate is not configured}"
           : "${SUCCESSOR_CERTIFICATE_P12_PASSWORD:?Successor Developer ID Application password is not configured}"
-          expected_identity="Developer ID Application: Samuel Baron (69N6K965SF)"
-          [[ "$SUCCESSOR_SIGN_IDENTITY" == "$expected_identity" ]] || {
-            echo "Successor signing identity must be $expected_identity" >&2
+          eval "$(python3 trusted-control-plane/Scripts/stable_rollout.py packaging-context \
+            --declaration approved-source/release-rollout.json \
+            --policy trusted-control-plane/Scripts/apple_identity_policy.json \
+            --version-env approved-source/version.env)"
+          expected_identity="$EXPECTED_SUCCESSOR_SIGN_IDENTITY"
+          [[ -n "$expected_identity" ]] || {
+            echo "Successor signing identity is missing from the reviewed policy" >&2
             exit 1
           }
           successor_certificate="$RUNNER_TEMP/repoprompt-release-successor.p12"
@@ -226,14 +238,19 @@ jobs:
             -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          codesign --force --sign "$SUCCESSOR_SIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" \
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" |
+            grep -F "\"$expected_identity\"" >/dev/null || {
+              echo "Expected successor application identity is not present and usable in the ephemeral keychain" >&2
+              exit 1
+            }
+          codesign --force --sign "$expected_identity" --keychain "$KEYCHAIN_PATH" \
             --identifier com.repoprompt.ce --timestamp --options runtime "$anchor"
           successor_requirement='anchor apple generic and identifier "com.repoprompt.ce" and certificate leaf[subject.OU] = "69N6K965SF" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists'
           codesign --verify --strict --verbose=2 -R="$successor_requirement" "$anchor"
           signature_details="$(codesign -dv --verbose=4 "$anchor" 2>&1)"
           grep -Fx 'Identifier=com.repoprompt.ce' <<< "$signature_details" >/dev/null
           grep -Fx 'TeamIdentifier=69N6K965SF' <<< "$signature_details" >/dev/null
-          echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"
+          printf 'REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=%s\n' "$anchor" >> "$GITHUB_ENV"
 
       - name: Prepare provisioning profile and notarization key
         env:

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -329,9 +329,7 @@ sign_tip() {
     [[ "$SIGN_IDENTITY" == "$EXPECTED_SIGN_IDENTITY" ]] ||
         fail "SIGN_IDENTITY does not match the reviewed $ROLLOUT_IDENTITY identity"
     if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
-        require_env INSTALLER_IDENTITY
-        [[ "$INSTALLER_IDENTITY" == "$EXPECTED_INSTALLER_IDENTITY" ]] ||
-            fail "INSTALLER_IDENTITY does not match the reviewed successor installer identity"
+        require_env EXPECTED_INSTALLER_IDENTITY
     fi
     [[ "$RELEASE_COMMIT" == "$TIP_COMMIT" ]] || fail "RELEASE_COMMIT must match TIP_COMMIT"
     [[ -d "$APP_BUNDLE" ]] || fail "Missing staged tip app bundle: $APP_BUNDLE"
@@ -378,7 +376,7 @@ sign_tip() {
             "$CONTROL_PLANE_SCRIPTS_DIR/build_identity_transition_pkg.sh" build \
             --app "$APP_BUNDLE" \
             --output "$TRANSITION_PKG" \
-            --installer-identity "$INSTALLER_IDENTITY"
+              --installer-identity "$EXPECTED_INSTALLER_IDENTITY"
         checksum_assets+=("$(basename "$TRANSITION_PKG")")
     else
         local distribution_dir="$TMP_DIR/distribution"

--- a/Scripts/stable_rollout.py
+++ b/Scripts/stable_rollout.py
@@ -10,6 +10,7 @@ Commands:
 - ``workflow-guard``: protected workflows call this to reject transition or
   successor roles, sibling predecessors, and the successor identity.
 - ``current-role``: print the declared role for shell callers.
+- ``packaging-context``: emit policy-derived bundle, team, application, and installer identity labels.
 - ``generate``: assemble the accumulated appcast plus rollout manifest.
 - ``validate``: prove a reviewed appcast/manifest pair against the declaration,
   policy, version metadata, and enclosure/app-manifest digests.
@@ -117,9 +118,19 @@ def load_policy(path: Path) -> dict:
         entry = policy.get("identities", {}).get(identity)
         if not isinstance(entry, dict) or not all(
             isinstance(entry.get(key), str) and entry.get(key)
-            for key in ("bundleIdentifier", "teamIdentifier", "developerIDRequirement")
+            for key in (
+                "bundleIdentifier",
+                "teamIdentifier",
+                "developerIDRequirement",
+                "developerIDApplicationIdentityName",
+            )
         ):
             raise RolloutError(f"apple identity policy is missing the {identity} identity")
+    successor = policy["identities"]["successor"]
+    if not isinstance(successor.get("developerIDInstallerIdentityName"), str) or not successor[
+        "developerIDInstallerIdentityName"
+    ]:
+        raise RolloutError("apple identity policy is missing the successor installer identity")
     sparkle = policy.get("sparkle")
     if not isinstance(sparkle, dict) or not all(
         isinstance(sparkle.get(key), str) and sparkle.get(key)

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -281,7 +281,9 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn("- legacy-preparer", release_workflow)
         self.assertEqual(release_workflow.count("SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64"), 1)
         self.assertEqual(release_workflow.count("SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD"), 1)
-        self.assertEqual(release_workflow.count("SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}"), 1)
+        self.assertNotIn("SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}", release_workflow)
+        self.assertNotIn("vars.SIGN_IDENTITY", release_workflow)
+        self.assertIn("EXPECTED_SUCCESSOR_SIGN_IDENTITY", release_workflow)
         self.assertNotIn("SUCCESSOR_DEVELOPER_ID_INSTALLER", release_workflow)
         self.assertNotIn("SUCCESSOR_NOTARYTOOL", release_workflow)
         self.assertIn("--identifier com.repoprompt.ce", release_workflow)
@@ -289,7 +291,7 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn("grep -Fx 'TeamIdentifier=69N6K965SF'", release_workflow)
         self.assertIn('successor_requirement=', release_workflow)
         self.assertIn('-R="$successor_requirement" "$anchor"', release_workflow)
-        self.assertIn('echo "REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=$anchor" >> "$GITHUB_ENV"', release_workflow)
+        self.assertIn('printf \'REPOPROMPT_IDENTITY_MIGRATION_ANCHOR=%s\\n\' "$anchor" >> "$GITHUB_ENV"', release_workflow)
 
         release_stage = release_workflow.split("\n  stage:", 1)[1].split("\n  publish:", 1)[0]
         release_publish = release_workflow.split("\n  publish:", 1)[1].split("\n  smoke-signed-helper:", 1)[0]
@@ -3354,7 +3356,7 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
 
     def test_main_tip_setup_uses_read_only_github_token_for_release_lookup_helper(self) -> None:
         tip_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
-        setup_job = tip_workflow.split("\n  setup:", 1)[1].split("\n  stage:", 1)[0]
+        setup_job = tip_workflow.split("\n  setup:", 1)[1].split("\n  credential-preflight:", 1)[0]
         after_setup = tip_workflow.split("\n  stage:", 1)[1]
         before_publish, publish_job = tip_workflow.split("\n  publish:", 1)
 
@@ -4565,7 +4567,7 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertEqual(legacy.returncode, 0, legacy.stderr)
         context = self.shell_assignments(legacy.stdout)
         policy = json.loads(self.POLICY.read_text(encoding="utf-8"))
-        self.assertEqual(context["ROLLOUT_ROLE"], "legacy")
+        self.assertEqual(context["ROLLOUT_ROLE"], "preparer")
         self.assertEqual(context["BUNDLE_ID"], "com.pvncher.repoprompt.ce")
         self.assertEqual(
             context["EXPECTED_SUCCESSOR_SIGN_IDENTITY"],
@@ -4759,6 +4761,104 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             arguments += ["--allowed-roles", allowed_roles]
         return arguments
 
+    def test_tip_workflow_preflights_role_credentials_before_secret_free_stage(self) -> None:
+        workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
+        preflight = workflow.split("\n  credential-preflight:", 1)[1].split("\n  stage:", 1)[0]
+        stage = workflow.split("\n  stage:", 1)[1].split("\n  sign:", 1)[0]
+
+        self.assertIn("needs: setup", preflight)
+        self.assertIn("environment: tip-release", preflight)
+        self.assertIn("stable_rollout.py packaging-context", preflight)
+        self.assertIn('case "$ROLLOUT_IDENTITY" in', preflight)
+        for secret_name in (
+            "SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64",
+            "SUCCESSOR_NOTARYTOOL_KEY_ID",
+            "SUCCESSOR_NOTARYTOOL_ISSUER_ID",
+        ):
+            self.assertIn(f"{secret_name}: ${{{{ secrets.{secret_name} }}}}", preflight)
+        for secret_name in (
+            "SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_BASE64",
+            "SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_PASSWORD",
+        ):
+            self.assertIn(f"secrets.{secret_name}", preflight)
+        self.assertIn('decode_value "application certificate"', preflight)
+        self.assertIn('decode_value "notarytool private key"', preflight)
+        self.assertIn('if [[ "$ROLLOUT_ROLE" == "transition" ]]', preflight)
+        self.assertIn('if [[ "$ROLLOUT_ROLE" == "preparer" ]]', preflight)
+        self.assertIn("needs:\n      - setup\n      - credential-preflight", stage)
+        self.assertLess(workflow.index("credential-preflight:"), workflow.index("\n  stage:"))
+        self.assertLess(workflow.index("\n  stage:"), workflow.index("\n  sign:"))
+        self.assertNotIn("TIP_UPDATE_REPOSITORY_TOKEN", preflight)
+
+    def test_tip_signing_uses_policy_labels_and_role_selected_notary_credentials(self) -> None:
+        workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
+        import_step = workflow.split("      - name: Import role-selected Developer ID certificates", 1)[1].split(
+            "      - name: Prepare successor identity migration anchor", 1
+        )[0]
+        anchor_step = workflow.split("      - name: Prepare successor identity migration anchor", 1)[1].split(
+            "      - name: Prepare provisioning profile and notarization key", 1
+        )[0]
+        notary_step = workflow.split("      - name: Prepare provisioning profile and notarization key", 1)[1].split(
+            "      - name: Install Sentry CLI", 1
+        )[0]
+
+        for stale_name in (
+            "CONFIGURED_LEGACY_SIGN_IDENTITY",
+            "CONFIGURED_SUCCESSOR_SIGN_IDENTITY",
+            "CONFIGURED_SUCCESSOR_INSTALLER_IDENTITY",
+            "SUCCESSOR_INSTALLER_IDENTITY",
+            "SUCCESSOR_SIGN_IDENTITY: ${{ vars.SUCCESSOR_SIGN_IDENTITY }}",
+            "SIGN_IDENTITY: ${{ vars.SIGN_IDENTITY }}",
+        ):
+            self.assertNotIn(stale_name, workflow)
+        self.assertIn('verify_identity codesigning "$EXPECTED_SIGN_IDENTITY" application', import_step)
+        self.assertIn('verify_identity basic "$EXPECTED_INSTALLER_IDENTITY" installer', import_step)
+        self.assertIn('security import "$installer_certificate" -k "$KEYCHAIN_PATH"', import_step)
+        self.assertIn('printf \'SIGN_IDENTITY=%s\\n\' "$EXPECTED_SIGN_IDENTITY"', import_step)
+        self.assertIn('grep -F "\\\"$EXPECTED_SUCCESSOR_SIGN_IDENTITY\\\""', anchor_step)
+        self.assertIn('codesign --force --sign "$EXPECTED_SUCCESSOR_SIGN_IDENTITY"', anchor_step)
+        for secret_name in (
+            "NOTARYTOOL_PRIVATE_KEY_BASE64",
+            "NOTARYTOOL_KEY_ID",
+            "NOTARYTOOL_ISSUER_ID",
+            "SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64",
+            "SUCCESSOR_NOTARYTOOL_KEY_ID",
+            "SUCCESSOR_NOTARYTOOL_ISSUER_ID",
+        ):
+            self.assertIn(f"secrets.{secret_name}", notary_step)
+        self.assertIn('case "$ROLLOUT_IDENTITY" in', notary_step)
+        self.assertIn("printf 'NOTARYTOOL_KEY_ID=%s\\n'", notary_step)
+        self.assertIn("printf 'NOTARYTOOL_ISSUER_ID=%s\\n'", notary_step)
+        self.assertNotIn("\n          NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}", workflow)
+        self.assertNotIn("\n          NOTARYTOOL_ISSUER_ID: ${{ secrets.NOTARYTOOL_ISSUER_ID }}", workflow)
+        self.assertNotIn("\n          INSTALLER_IDENTITY=", workflow)
+
+    def test_packaging_context_projects_policy_application_and_installer_labels(self) -> None:
+        _temp_dir, preparer, transition, successor = self.make_pts_ladder()
+        policy = json.loads(self.POLICY.read_text(encoding="utf-8"))
+        for role, release, identity_name in (
+            ("preparer", preparer, "legacy"),
+            ("transition", transition, "successor"),
+            ("successor", successor, "successor"),
+        ):
+            with self.subTest(role=role):
+                result = self.rollout(
+                    "packaging-context",
+                    "--declaration", str(release["declaration"]),
+                    "--policy", str(self.POLICY),
+                    "--version-env", str(release["version_env"]),
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                context = self.shell_assignments(result.stdout)
+                identity = policy["identities"][identity_name]
+                self.assertEqual(context["EXPECTED_SIGN_IDENTITY"], identity["developerIDApplicationIdentityName"])
+                expected_installer = (
+                    policy["identities"]["successor"]["developerIDInstallerIdentityName"]
+                    if identity_name == "successor"
+                    else ""
+                )
+                self.assertEqual(context["EXPECTED_INSTALLER_IDENTITY"], expected_installer)
+
     def test_policy_declaration_and_requirement_authorities_agree(self) -> None:
         policy = json.loads(self.POLICY.read_text(encoding="utf-8"))
         runtime_policy = (
@@ -4828,9 +4928,9 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
 
         tip_declaration = json.loads(self.TIP_DECLARATION.read_text(encoding="utf-8"))
         self.assertEqual(tip_declaration["channel"], "tip")
-        self.assertEqual(tip_declaration["currentRole"], "legacy")
+        self.assertEqual(tip_declaration["currentRole"], "preparer")
         self.assertEqual(tip_declaration["predecessors"], [])
-        self.assertEqual(tip_declaration["expectedMigrationPhase"], "disabled")
+        self.assertEqual(tip_declaration["expectedMigrationPhase"], "legacy-preparer")
         self.assertEqual(tip_declaration["expectedSigningIdentity"], "legacy")
 
     def test_single_legacy_release_generates_one_deterministic_application_item(self) -> None:

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -12,7 +12,27 @@ storage, then use a notarized transition installer to cross the application iden
 | Successor | `com.repoprompt.ce` | `69N6K965SF` |
 
 The existing Sparkle EdDSA key and the Stable and Tip feed URLs remain unchanged. Each channel may
-contain multiple update items during the transition; this does not require extra feeds.
+contain multiple update items during the transition; this does not require extra feeds. The application
+and installer identity labels are policy data in `Scripts/apple_identity_policy.json`; protected
+workflows use `Scripts/stable_rollout.py packaging-context` and do not require duplicated GitHub
+Actions identity-name variables.
+
+## Tip rehearsal
+
+The checked-in Tip declaration is the controlled `P → T → S` rehearsal:
+
+- **P (preparer)** is a legacy-identity ZIP with `legacy-preparer` migration phase and no
+  predecessors. It carries the successor-signed anchor needed to prove the future identity, but its
+  application, profile, and notary credentials remain legacy-selected.
+- **T (transition)** is a successor-identity, successor-Installer-signed and notarized `.pkg`. Its
+  appcast retains P as the immediately older top-level item.
+- **S (successor)** is a successor-identity ZIP/DMG. Its appcast retains both T and P as top-level
+  items and supplies the normal rollback window.
+
+All three roles use the same Tip feed and `appcast.xml`; the rollout manifest is the same
+`identity-rollout.json` asset name. No sibling feed or Sparkle key is introduced. Automatic
+`workflow_run` notifications skip every nonlegacy role. Each nonlegacy role requires an explicit
+`workflow_dispatch` with `confirm_identity_rollout_role` exactly equal to the checked-in role.
 
 ## Release ladder
 
@@ -65,8 +85,25 @@ trusted control-plane checkout. The minimal executable is never launched; it avo
 copy of the main app binary while still giving Security.framework a successor-signed designated
 requirement on both supported architectures.
 
-Preparers are Stable-only artifacts. The rolling Tip workflow always packages, validates, and signs
-with phase `disabled`; it has no migration-phase input or access to successor signing secrets.
+The Tip workflow performs the rehearsal under the protected `tip-release` environment. Its cheap
+role-aware credential preflight runs before the secret-free build and checks the policy projection plus
+the role-selected application P12/password, provisioning profile, and notarytool private key/key ID/
+issuer. The transition role additionally requires the successor Installer P12/password. The preparer
+role separately requires the successor application P12/password only to create and verify the embedded
+successor anchor. After every P12 import, the signing job verifies that the policy-derived identity is
+present and usable in the ephemeral keychain before any `codesign` or `productbuild` call.
+
+## Manual gates and next operator action
+
+The manual gates are ordered: approve and dispatch P first, inspect its signed/notarized ZIP and
+retained `identity-rollout.json`, then update the declaration with P's exact manifest digest before
+dispatching T. After T is verified, update the declaration with both exact predecessor digests before
+dispatching S. Never publish a nonlegacy role from an automatic `workflow_run` notification.
+
+The next operator action after this change is merged to protected `main`: dispatch **Publish Tip**
+with `commit` set to that exact main SHA and `confirm_identity_rollout_role=preparer`. Do not rely on
+the automatic CI notification for P. Subsequent T and S dispatches require the checked-in declaration
+and exact role confirmation to be advanced and reviewed first.
 
 ## Required proof gate
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -235,20 +235,32 @@ Stable: https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/down
 Tip:    https://github.com/repoprompt/repoprompt-ce-tip-updates/releases/latest/download/appcast.xml
 ```
 
-The initial Tip channel shares the CE Sparkle EdDSA key and Developer ID identity
-with stable releases, but it publishes only to the separate tip update
-repository. Tip workflows must never write to `repoprompt-ce-updates`, must not
-use `v*` tags, and must not feed into `Promote Release`. Stable promotion remains
-the only path that updates the stable appcast.
+The Tip channel uses the same CE Sparkle EdDSA key and the same application/feed contract as
+stable, but publishes only to the separate tip update repository. It is currently the controlled
+`P → T → S` identity-transition rehearsal:
 
-`Publish Tip` runs after successful CI on `main` and can also be dispatched
-manually. It stages the tip source without secrets, signs and notarizes without
-executing packaged app/helper code, runs the PR #441 hardened packaged smoke on a
-fresh no-secret runner, then publishes a normal GitHub release in the dedicated
-tip update repository using an immutable tag shaped like `tip-<shortsha>`. The
-release is marked latest inside the tip-only repository so GitHub's
-`releases/latest/download/appcast.xml` URL resolves for opted-in clients. Do not
-mark the tip release as a prerelease: GitHub excludes prereleases from
+| Role | Application identity | Artifact | Feed contents |
+| --- | --- | --- | --- |
+| P / `preparer` | Legacy | ZIP, `legacy-preparer` phase | P only |
+| T / `transition` | Successor | Notarized successor-Installer-signed PKG | T and retained P |
+| S / `successor` | Successor | Notarized ZIP/DMG | S, retained T, and retained P |
+
+`tip-rollout.json` is the checked-in authority for the current role, expected identity, migration
+phase, and predecessor manifest digests. Every role uses the same Tip feed URL and `appcast.xml`
+asset, with retained top-level entries in that appcast; there are no transition/successor sibling
+feeds and no Sparkle-key change. Tip workflows must never write to `repoprompt-ce-updates`, must not
+use `v*` tags, and must not feed into `Promote Release`. Stable promotion remains the only path that
+updates the stable appcast.
+
+`Publish Tip` can be notified automatically after successful CI on `main` or dispatched manually. The
+automatic `workflow_run` path publishes only the legacy role; it skips every nonlegacy role before
+staging. A nonlegacy role is published only by an explicit dispatch whose
+`confirm_identity_rollout_role` exactly matches the checked-in role. The protected role-aware
+credential preflight runs before the secret-free build, and the environment approval is therefore a
+manual gate before any expensive staging work. After P is reviewed, advance the declaration with its
+exact `identity-rollout.json` digest before dispatching T; advance it again with T and P digests before
+S. Each published role uses an immutable `tip-<shortsha>` tag and the tip-only repository's latest
+release; do not mark the release as a prerelease because GitHub excludes prereleases from
 `releases/latest`.
 
 Tip `CFBundleVersion` values sort between adjacent stable builds. The workflow
@@ -267,14 +279,25 @@ or notarization run finishes. Before compiling, it uses the workflow's read-only
 tag and skips an already-published commit. The protected update-repository token
 remains confined to the publishing job.
 
-Configure a protected GitHub Actions environment named `tip-release`. It can use
-the same Developer ID, provisioning, notarization, and Sparkle secrets as stable
-initially, but it needs a separate `TIP_UPDATE_REPOSITORY_TOKEN` scoped only to
-the tip update repository. Optionally set repository variable
-`TIP_UPDATE_REPOSITORY`; it defaults to `repoprompt/repoprompt-ce-tip-updates`.
-The publishing script fails closed if this variable points at the source repo or
-the stable update repo. Tip artifacts also include a small `*-metadata.json` asset
-recording the source commit, immutable tag, marketing version, and build number.
+Configure protected GitHub Actions environments named `release` and `tip-release`, with maintainer
+approval and protected-branch restrictions. Before the rehearsal, store this one-time identity
+inventory in both environments:
+
+| Material | Legacy/preparer selection | Transition/successor selection |
+| --- | --- | --- |
+| Application P12/password | `DEVELOPER_ID_APPLICATION_P12_BASE64` / `DEVELOPER_ID_APPLICATION_P12_PASSWORD` | `SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_BASE64` / `SUCCESSOR_DEVELOPER_ID_APPLICATION_P12_PASSWORD` |
+| Provisioning profile | `REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64` | `SUCCESSOR_REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64` |
+| Notarytool private key/key ID/issuer | `NOTARYTOOL_PRIVATE_KEY_BASE64` / `NOTARYTOOL_KEY_ID` / `NOTARYTOOL_ISSUER_ID` | `SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64` / `SUCCESSOR_NOTARYTOOL_KEY_ID` / `SUCCESSOR_NOTARYTOOL_ISSUER_ID` |
+| Transition Installer P12/password | not used | `SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_BASE64` / `SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_PASSWORD` |
+
+Also retain `CI_KEYCHAIN_PASSWORD`, `SPARKLE_PRIVATE_KEY`, the Sentry credentials/configuration,
+and the environment-specific update-repository token. The workflows derive application and Installer
+identity labels from `Scripts/apple_identity_policy.json` through `stable_rollout.py
+packaging-context`; do not configure `SIGN_IDENTITY`, `SUCCESSOR_SIGN_IDENTITY`, or an installer-name
+alias as a second authority. The Tip publishing script fails closed if `TIP_UPDATE_REPOSITORY`
+points at the source or stable update repository. Tip artifacts also include a small
+`*-metadata.json` asset recording the source commit, immutable tag, marketing version, and build
+number.
 
 Tip builds use the same Sentry-linked binary and symbolication policy as stable
 releases. The secret-free stage enables Sentry linking and carries release dSYMs
@@ -542,19 +565,11 @@ Sentry event detail:
 Relaunch the app once without the argument so the SDK can flush the cached native
 crash report.
 
-The optional `SIGN_IDENTITY` environment variable defaults to:
-
-```text
-Developer ID Application: Eric Provencher (648A27MST5)
-```
-
-The provisioning profile must authorize:
-
-```text
-648A27MST5.com.pvncher.repoprompt.ce
-```
-
-The release script validates that identifier before signing.
+Official workflows do not take an application or Installer identity label from a GitHub Actions
+string variable. They derive the expected labels from `Scripts/apple_identity_policy.json` through
+`stable_rollout.py packaging-context`, then validate the imported identity in the ephemeral keychain
+before signing. The selected provisioning profile must match the role-selected bundle/team pair; the
+release tooling validates that identifier before signing.
 
 `PUBLIC_UPDATE_REPOSITORY_TOKEN` is intentionally separate from the workflow's
 source-repository `github.token`. Keep its repository scope narrow: the

--- a/tip-rollout.json
+++ b/tip-rollout.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
   "channel": "tip",
-  "currentRole": "legacy",
+  "currentRole": "preparer",
   "eligibilityProfile": "tip-identity-dress-rehearsal-v1",
-  "expectedMigrationPhase": "disabled",
+  "expectedMigrationPhase": "legacy-preparer",
   "expectedSigningIdentity": "legacy",
   "predecessors": []
 }


### PR DESCRIPTION
## Summary

- make `Scripts/apple_identity_policy.json` plus `stable_rollout.py packaging-context` the single authority for application and Installer identity labels
- add a protected, role-aware credential preflight before the expensive secret-free Tip build
- select application P12, provisioning profile, and notary credentials by rollout identity; select and verify the successor Installer identity for T
- verify imported identities in the ephemeral keychain instead of relying on duplicated GitHub string variables
- advance `tip-rollout.json` to the legacy-signed preparer rung and document the manual P -> T -> S gates on the existing Tip feed/workflow

## Failure addressed

The failed Tip run reached signing with an empty legacy identity variable and stopped before signing/notarization. This removes that second configuration authority and makes missing/invalid role credentials fail at the protected preflight with explicit diagnostics.

Failed run: https://github.com/repoprompt/repoprompt-ce/actions/runs/32808153305

## Validation

- `python3 -m unittest Scripts.test_release_tooling.IdentityTransitionReleaseToolingTests` (11 passed)
- `python3 Scripts/test_release_tooling.py` (107 passed)
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- `make dev-release-preflight` (ticket `313d92db-797a-4a09-88b6-2f606f161e44`)
- Fable 5 High read-only implementation review: no must-fix findings

## Deployment after merge

Dispatch `Publish Tip` for the exact merged `main` SHA with `confirm_identity_rollout_role=preparer`. Automatic `workflow_run` publication intentionally skips nonlegacy roles, so the preparer cannot publish accidentally. Transition and successor remain separately reviewed declaration changes with exact predecessor manifest digests.