### PR TITLE
Make Tip identity rollout dispatches reliable and truthful

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -46,6 +46,7 @@ jobs:
       tag: ${{ steps.tip.outputs.tag }}
       tooling-commit: ${{ steps.tip.outputs.tooling-commit }}
       should-publish: ${{ steps.tip.outputs.should-publish }}
+      skip-reason: ${{ steps.tip.outputs.skip-reason }}
       rollout-role: ${{ steps.tip.outputs.rollout-role }}
       rollout-identity: ${{ steps.tip.outputs.rollout-identity }}
       migration-phase: ${{ steps.tip.outputs.migration-phase }}
@@ -95,9 +96,11 @@ jobs:
           }
 
           should_publish=true
+          skip_reason=""
           if [[ "$ROLLOUT_ROLE" != "legacy" ]]; then
             if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
               should_publish=false
+              skip_reason="role-requires-dispatch"
               echo "Identity rollout role $ROLLOUT_ROLE requires an explicit workflow dispatch; skipping automatic publication."
             elif [[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
               echo "confirm_identity_rollout_role must exactly match checked-in role $ROLLOUT_ROLE" >&2
@@ -127,7 +130,13 @@ jobs:
             case "$lookup_classification" in
               found)
                 should_publish=false
+                skip_reason="already-published"
                 echo "Existing tip release response classification=complete; skipping rebuild."
+                {
+                  echo "## Tip publication deduplicated"
+                  echo
+                  echo "Complete immutable release $tag for commit $commit is already published. No build, signing, or publication was performed."
+                } >> "$GITHUB_STEP_SUMMARY"
                 ;;
               not-found) ;;
               *)
@@ -143,11 +152,47 @@ jobs:
             echo "tag=$tag"
             echo "tooling-commit=$(git rev-parse HEAD)"
             echo "should-publish=$should_publish"
+            echo "skip-reason=$skip_reason"
             echo "rollout-role=$ROLLOUT_ROLE"
             echo "rollout-identity=$ROLLOUT_IDENTITY"
             echo "migration-phase=$REPOPROMPT_IDENTITY_MIGRATION_PHASE"
             echo "installation-type=$ROLLOUT_INSTALLATION_TYPE"
           } >> "$GITHUB_OUTPUT"
+
+  automatic-tip-dormant:
+    name: Automatic Tip Publication Dormant (Dispatch Required)
+    needs: setup
+    if: >-
+      github.event_name == 'workflow_run' &&
+      needs.setup.outputs.should-publish != 'true' &&
+      needs.setup.outputs.skip-reason == 'role-requires-dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Report suppressed automatic publication
+        env:
+          ROLLOUT_ROLE: ${{ needs.setup.outputs.rollout-role }}
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+          TIP_TAG: ${{ needs.setup.outputs.tag }}
+        run: |
+          set -euo pipefail
+          commit="${TIP_COMMIT:-unresolved}"
+          tag="${TIP_TAG:-unresolved}"
+          {
+            echo "## Automatic Tip Publication Dormant (Dispatch Required)"
+            echo
+            echo "- Rollout role: $ROLLOUT_ROLE"
+            echo "- Commit: $commit"
+            echo "- Tag: $tag"
+            echo
+            echo "This automatic workflow_run was intentionally suppressed because the nonlegacy rollout role requires an explicit dispatch."
+            echo "Nothing was built, signed, or published."
+            echo
+            echo "To publish this role, dispatch the Publish Tip workflow manually from protected main with commit=$commit and confirm_identity_rollout_role=$ROLLOUT_ROLE."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Automatic Tip publication is dormant; rollout role $ROLLOUT_ROLE requires an explicit workflow dispatch."
+          exit 1
 
   credential-preflight:
     name: Preflight Tip Rollout Credentials

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -19,15 +19,14 @@ on:
 concurrency:
   group: >-
     ${{
-      (github.event_name == 'workflow_dispatch' ||
-        github.event.workflow_run.conclusion == 'success') &&
-      'main-tip-channel' ||
+      (github.event_name == 'workflow_dispatch' && 'main-tip-dispatch-channel') ||
+      (github.event.workflow_run.conclusion == 'success' && 'main-tip-channel') ||
       format('main-tip-skipped-{0}', github.run_id)
     }}
-  # Tip is a rolling channel: once main advances, completing an older artifact only
-  # delays the commit users actually asked the channel to publish. A failed CI
-  # notification receives a unique group so it cannot evict a healthy pending or
-  # in-flight Tip build before setup's success guard skips the replacement run.
+  # Explicit dispatches use a separate rolling lane so automatic successful CI
+  # notifications cannot cancel a requested dispatch. Newer dispatches supersede
+  # older dispatches; successful CI notifications retain the automatic rolling lane.
+  # Failed CI notifications keep a unique group and cannot evict either lane.
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
 permissions:
@@ -649,6 +648,9 @@ jobs:
 
   publish:
     name: Publish Tip Appcast
+    concurrency:
+      group: main-tip-publish
+      cancel-in-progress: false
     needs:
       - setup
       - smoke-no-secrets

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -3205,9 +3205,9 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         concurrency_block = tip_workflow.split("concurrency:", 1)[1].split("\npermissions:", 1)[0]
         normalized_concurrency = " ".join(concurrency_block.split())
         self.assertIn(
-            "group: >- ${{ (github.event_name == 'workflow_dispatch' || "
-            "github.event.workflow_run.conclusion == 'success') && "
-            "'main-tip-channel' || format('main-tip-skipped-{0}', github.run_id) }}",
+            "group: >- ${{ (github.event_name == 'workflow_dispatch' && 'main-tip-dispatch-channel') || "
+            "(github.event.workflow_run.conclusion == 'success' && 'main-tip-channel') || "
+            "format('main-tip-skipped-{0}', github.run_id) }}",
             normalized_concurrency,
         )
         self.assertIn(
@@ -3216,6 +3216,12 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
             normalized_concurrency,
         )
         self.assertNotIn("cancel-in-progress: true", concurrency_block)
+
+        publish_header = tip_workflow.split("\n  publish:", 1)[1].split("\n    needs:", 1)[0]
+        self.assertIn(
+            "concurrency:\n      group: main-tip-publish\n      cancel-in-progress: false",
+            publish_header,
+        )
         self.assertIn("should-publish", tip_workflow)
         self.assertIn("stable-appcast.xml", tip_workflow)
         self.assertIn('build_number="$stable_build_number.$((build_sequence / 100)).$((build_sequence % 100))"', tip_workflow)

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -3378,6 +3378,46 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertIn("TIP_GH_TOKEN: ${{ secrets.TIP_UPDATE_REPOSITORY_TOKEN }}", publish_job)
         self.assertEqual(tip_workflow.count("TIP_UPDATE_REPOSITORY_TOKEN"), 1)
 
+    def test_tip_no_release_diagnostic_contract_is_truthful_and_read_only(self) -> None:
+        workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
+        setup_job = workflow.split("\n  setup:", 1)[1].split("\n  automatic-tip-dormant:", 1)[0]
+        resolve_step = setup_job.split("      - name: Resolve protected main commit", 1)[1]
+        diagnostic_job = workflow.split("\n  automatic-tip-dormant:", 1)[1].split(
+            "\n  credential-preflight:", 1
+        )[0]
+
+        self.assertIn("skip-reason: ${{ steps.tip.outputs.skip-reason }}", setup_job)
+        for marker in (
+            'skip_reason=""',
+            'skip_reason="role-requires-dispatch"',
+            'skip_reason="already-published"',
+            'echo "skip-reason=$skip_reason"',
+            "## Tip publication deduplicated",
+            "GITHUB_STEP_SUMMARY",
+        ):
+            self.assertIn(marker, resolve_step)
+        self.assertIn(
+            "    if: >-\n"
+            "      github.event_name == 'workflow_run' &&\n"
+            "      needs.setup.outputs.should-publish != 'true' &&\n"
+            "      needs.setup.outputs.skip-reason == 'role-requires-dispatch'",
+            diagnostic_job,
+        )
+        self.assertIn("name: Automatic Tip Publication Dormant (Dispatch Required)", diagnostic_job)
+        self.assertIn("runs-on: ubuntu-latest", diagnostic_job)
+        self.assertIn("    permissions:\n      contents: read", diagnostic_job)
+        for marker in (
+            "GITHUB_STEP_SUMMARY",
+            "ROLLOUT_ROLE: ${{ needs.setup.outputs.rollout-role }}",
+            "TIP_COMMIT: ${{ needs.setup.outputs.commit }}",
+            "TIP_TAG: ${{ needs.setup.outputs.tag }}",
+            "Nothing was built, signed, or published.",
+            "dispatch the Publish Tip workflow manually",
+            "::error::",
+            "exit 1",
+        ):
+            self.assertIn(marker, diagnostic_job)
+
     def test_public_tip_release_lookup_helper_handles_github_outcomes_safely(self) -> None:
         root = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, root, True)

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -31,9 +31,12 @@ The checked-in Tip declaration is the controlled `P → T → S` rehearsal:
 
 All three roles use the same Tip feed and `appcast.xml`; the rollout manifest is the same
 `identity-rollout.json` asset name. No sibling feed or Sparkle key is introduced. Automatic
-`workflow_run` notifications skip every nonlegacy role. Each nonlegacy role requires an explicit
-`workflow_dispatch` with `confirm_identity_rollout_role` exactly equal to the checked-in role.
-Tip workflow uses separate rolling/superseding lanes: newer runs replace older work only within
+`workflow_run` notifications skip every nonlegacy role. During migration, an automatic nonlegacy run
+intentionally fails visibly in a read-only diagnostic rather than appearing successful; nothing is
+built, signed, or published. A complete immutable-release dedupe remains green. This is diagnostic
+truthfulness, not publication. Each nonlegacy role requires an explicit `workflow_dispatch` with
+`confirm_identity_rollout_role` exactly equal to the checked-in role. Tip workflow uses separate
+rolling/superseding lanes: newer runs replace older work only within
 the same lane, so automatic successes cannot evict explicit dispatches; failed-CI notifications
 use unique groups. Different lanes may build concurrently. The `publish` job is separately
 serialized across lanes once it reaches that job, but its job-level `cancel-in-progress: false`

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -33,6 +33,14 @@ All three roles use the same Tip feed and `appcast.xml`; the rollout manifest is
 `identity-rollout.json` asset name. No sibling feed or Sparkle key is introduced. Automatic
 `workflow_run` notifications skip every nonlegacy role. Each nonlegacy role requires an explicit
 `workflow_dispatch` with `confirm_identity_rollout_role` exactly equal to the checked-in role.
+Tip workflow uses separate rolling/superseding lanes: newer runs replace older work only within
+the same lane, so automatic successes cannot evict explicit dispatches; failed-CI notifications
+use unique groups. Different lanes may build concurrently. The `publish` job is separately
+serialized across lanes once it reaches that job, but its job-level `cancel-in-progress: false`
+does not override workflow-level cancellation in the source lane. A duplicate immutable
+`tip-<shortsha>` tag publish may safely fail rather than corrupt the feed. An older run for a
+different commit that publishes late can move the latest pointer backward; this bounded risk is
+especially relevant outside migration-role gating, and the existing next publish recovers it.
 
 ## Release ladder
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -272,12 +272,19 @@ space without forcing stable releases to adopt repository-sized build numbers.
 The source commit count must remain at or below `9999`; replace this encoding
 before the repository reaches that limit.
 
-The workflow uses GitHub concurrency to allow one active and one pending run.
-New successful `main` runs replace an older pending run while an active signing
-or notarization run finishes. Before compiling, it uses the workflow's read-only
-`github.token` to check for a complete release for the immutable `tip-<shortsha>`
-tag and skips an already-published commit. The protected update-repository token
-remains confined to the publishing job.
+The workflow uses separate rolling/superseding GitHub concurrency lanes: successful
+automatic `main` notifications use `main-tip-channel`, and explicit dispatches use
+`main-tip-dispatch-channel`. Newer runs replace older work only within their own lane, so an
+automatic success cannot supersede a dispatch; failed-CI notifications use unique run-specific
+groups. Different lanes may build concurrently. The `publish` job is separately serialized
+across lanes once it reaches that job, but its job-level `cancel-in-progress: false` does not
+override workflow-level cancellation in the source lane. A duplicate immutable
+`tip-<shortsha>` tag publish may safely fail rather than corrupt the feed. An older run for a
+different commit that publishes late can move the Tip latest pointer backward; this bounded risk
+is especially relevant outside migration-role gating, and the existing next publish recovers it.
+Before compiling, it uses the workflow's read-only `github.token` to check for a complete
+release for the immutable `tip-<shortsha>` tag and skips an already-published commit. The protected
+update-repository token remains confined to the publishing job.
 
 Configure protected GitHub Actions environments named `release` and `tip-release`, with maintainer
 approval and protected-branch restrictions. Before the rehearsal, store this one-time identity

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -254,7 +254,10 @@ updates the stable appcast.
 
 `Publish Tip` can be notified automatically after successful CI on `main` or dispatched manually. The
 automatic `workflow_run` path publishes only the legacy role; it skips every nonlegacy role before
-staging. A nonlegacy role is published only by an explicit dispatch whose
+staging. During migration, an automatic nonlegacy run intentionally fails visibly in a read-only
+terminal diagnostic: nothing is built, signed, or published. A complete immutable-release dedupe
+remains green and records a concise no-op summary. This is diagnostic truthfulness, not publication.
+A nonlegacy role is published only by an explicit dispatch whose
 `confirm_identity_rollout_role` exactly matches the checked-in role. The protected role-aware
 credential preflight runs before the secret-free build, and the environment approval is therefore a
 manual gate before any expensive staging work. After P is reviewed, advance the declaration with its


### PR DESCRIPTION
## Summary
- isolate explicit Tip dispatches from automatic-success concurrency so automatic CI cannot evict a requested identity-rollout release
- serialize the publish mutation across lanes without changing credentials, feeds, or signing behavior
- fail automatic nonlegacy no-release runs with a read-only diagnostic instead of a misleading green result
- preserve already-published immutable releases as a documented green no-op

## Incident evidence
- explicit preparer dispatch `32830529020` was canceled during its secret-free build
- automatic `workflow_run` `32833085271` entered the old shared lane, then skipped every release job because role `preparer` requires dispatch, producing a misleading green no-release result

## Validation
- `Scripts/test_release_tooling.py`: 108/108
- focused Tip contract tests: pass
- YAML parse and shell syntax: pass
- actionlint: only pre-existing ShellCheck warnings
- contribution `commit`, `pr-ready`, and `push` gates: pass
- `make dev-release-preflight`: pass (ticket `2b69c391-2d3d-4697-b1f4-5589dc1204e1`)
- Fable 5 High final review: no must-fix findings

## Deployment plan
After exact-head hosted checks pass, merge this PR and explicitly dispatch `Publish Tip` on the merged main SHA with `confirm_identity_rollout_role=preparer`; then verify credential preflight, build, signing/notarization, smoke, publish, appcast, and rollout manifest.