### PR TITLE
Fail Tip identity credential errors before staging

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -242,6 +242,19 @@ jobs:
           CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
+          umask 077
+          PREFLIGHT_KEYCHAIN_PATH="$RUNNER_TEMP/repoprompt-tip-preflight.keychain-db"
+          CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-tip-preflight.p12"
+          SUCCESSOR_CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-tip-preflight-successor.p12"
+          INSTALLER_CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-tip-preflight-installer.p12"
+          preflight_keychain_created=0
+          cleanup_preflight_credentials() {
+            rm -f "$CERTIFICATE_PATH" "$SUCCESSOR_CERTIFICATE_PATH" "$INSTALLER_CERTIFICATE_PATH"
+            if (( preflight_keychain_created )); then
+              security delete-keychain "$PREFLIGHT_KEYCHAIN_PATH" || true
+            fi
+          }
+          trap cleanup_preflight_credentials EXIT
           fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
           require_value() {
             local name="$1"
@@ -292,11 +305,13 @@ jobs:
           require_value NOTARYTOOL_PRIVATE_KEY_BASE64
           require_value NOTARYTOOL_KEY_ID
           require_value NOTARYTOOL_ISSUER_ID
+
           decode_value "application certificate" "$CERTIFICATE_P12_BASE64"
           decode_value "provisioning profile" "$PROVISIONING_PROFILE_BASE64"
           decode_value "notarytool private key" "$NOTARYTOOL_PRIVATE_KEY_BASE64"
 
           if [[ "$ROLLOUT_ROLE" == "preparer" ]]; then
+            require_value EXPECTED_SUCCESSOR_SIGN_IDENTITY
             require_value SUCCESSOR_CERTIFICATE_P12_BASE64
             require_value SUCCESSOR_CERTIFICATE_P12_PASSWORD
             decode_value "successor anchor certificate" "$SUCCESSOR_CERTIFICATE_P12_BASE64"
@@ -306,6 +321,43 @@ jobs:
             require_value SUCCESSOR_INSTALLER_P12_BASE64
             require_value SUCCESSOR_INSTALLER_P12_PASSWORD
             decode_value "successor installer certificate" "$SUCCESSOR_INSTALLER_P12_BASE64"
+          fi
+
+          printf '%s' "$CERTIFICATE_P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH" || fail "application certificate"
+          security create-keychain -p "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH"
+          preflight_keychain_created=1
+          security set-keychain-settings -lut 21600 "$PREFLIGHT_KEYCHAIN_PATH"
+          security unlock-keychain -p "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$CERTIFICATE_P12_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security \
+            >/dev/null 2>&1 || fail "application certificate"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH" \
+            >/dev/null 2>&1 || fail "application certificate"
+          security find-identity -v -p codesigning "$PREFLIGHT_KEYCHAIN_PATH" |
+            grep -F "\"$EXPECTED_SIGN_IDENTITY\"" >/dev/null || fail "application signing identity"
+
+          if [[ "$ROLLOUT_ROLE" == "preparer" ]]; then
+            printf '%s' "$SUCCESSOR_CERTIFICATE_P12_BASE64" | base64 --decode > "$SUCCESSOR_CERTIFICATE_PATH" || fail "successor application certificate"
+            security import "$SUCCESSOR_CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" \
+              -T /usr/bin/codesign -T /usr/bin/security \
+              >/dev/null 2>&1 || fail "successor application certificate"
+            security set-key-partition-list -S apple-tool:,apple:,codesign: \
+              -s -k "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH" \
+              >/dev/null 2>&1 || fail "successor application certificate"
+            security find-identity -v -p codesigning "$PREFLIGHT_KEYCHAIN_PATH" |
+              grep -F "\"$EXPECTED_SUCCESSOR_SIGN_IDENTITY\"" >/dev/null || fail "successor application signing identity"
+          fi
+          if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
+            printf '%s' "$SUCCESSOR_INSTALLER_P12_BASE64" | base64 --decode > "$INSTALLER_CERTIFICATE_PATH" || fail "successor installer certificate"
+            security import "$INSTALLER_CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$SUCCESSOR_INSTALLER_P12_PASSWORD" \
+              -T /usr/bin/productbuild -T /usr/bin/security \
+              >/dev/null 2>&1 || fail "successor installer certificate"
+            security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild: \
+              -s -k "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH" \
+              >/dev/null 2>&1 || fail "successor installer certificate"
+            security find-identity -v -p basic "$PREFLIGHT_KEYCHAIN_PATH" |
+              grep -F "\"$EXPECTED_INSTALLER_IDENTITY\"" >/dev/null || fail "successor installer identity"
           fi
           printf 'OK: Tip %s credential/configuration preflight passed.\n' "$ROLLOUT_ROLE"
 

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -247,12 +247,10 @@ jobs:
           CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-tip-preflight.p12"
           SUCCESSOR_CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-tip-preflight-successor.p12"
           INSTALLER_CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-tip-preflight-installer.p12"
-          preflight_keychain_created=0
           cleanup_preflight_credentials() {
             rm -f "$CERTIFICATE_PATH" "$SUCCESSOR_CERTIFICATE_PATH" "$INSTALLER_CERTIFICATE_PATH"
-            if (( preflight_keychain_created )); then
-              security delete-keychain "$PREFLIGHT_KEYCHAIN_PATH" || true
-            fi
+            security delete-keychain "$PREFLIGHT_KEYCHAIN_PATH" || true
+            rm -f "$PREFLIGHT_KEYCHAIN_PATH"
           }
           trap cleanup_preflight_credentials EXIT
           fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -323,41 +321,40 @@ jobs:
             decode_value "successor installer certificate" "$SUCCESSOR_INSTALLER_P12_BASE64"
           fi
 
-          printf '%s' "$CERTIFICATE_P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH" || fail "application certificate"
+          printf '%s' "$CERTIFICATE_P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH" || fail "application P12 write failed"
           security create-keychain -p "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH"
-          preflight_keychain_created=1
           security set-keychain-settings -lut 21600 "$PREFLIGHT_KEYCHAIN_PATH"
           security unlock-keychain -p "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH"
           security import "$CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$CERTIFICATE_P12_PASSWORD" \
             -T /usr/bin/codesign -T /usr/bin/security \
-            >/dev/null 2>&1 || fail "application certificate"
+            >/dev/null || fail "application P12 import failed"
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH" \
-            >/dev/null 2>&1 || fail "application certificate"
+            >/dev/null || fail "application key partition setup failed"
           security find-identity -v -p codesigning "$PREFLIGHT_KEYCHAIN_PATH" |
-            grep -F "\"$EXPECTED_SIGN_IDENTITY\"" >/dev/null || fail "application signing identity"
+            grep -F "\"$EXPECTED_SIGN_IDENTITY\"" >/dev/null || fail "application identity verification failed"
 
           if [[ "$ROLLOUT_ROLE" == "preparer" ]]; then
-            printf '%s' "$SUCCESSOR_CERTIFICATE_P12_BASE64" | base64 --decode > "$SUCCESSOR_CERTIFICATE_PATH" || fail "successor application certificate"
+            printf '%s' "$SUCCESSOR_CERTIFICATE_P12_BASE64" | base64 --decode > "$SUCCESSOR_CERTIFICATE_PATH" || fail "successor application P12 write failed"
             security import "$SUCCESSOR_CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD" \
               -T /usr/bin/codesign -T /usr/bin/security \
-              >/dev/null 2>&1 || fail "successor application certificate"
+              >/dev/null || fail "successor application P12 import failed"
             security set-key-partition-list -S apple-tool:,apple:,codesign: \
               -s -k "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH" \
-              >/dev/null 2>&1 || fail "successor application certificate"
+              >/dev/null || fail "successor application key partition setup failed"
             security find-identity -v -p codesigning "$PREFLIGHT_KEYCHAIN_PATH" |
-              grep -F "\"$EXPECTED_SUCCESSOR_SIGN_IDENTITY\"" >/dev/null || fail "successor application signing identity"
+              grep -F "\"$EXPECTED_SUCCESSOR_SIGN_IDENTITY\"" >/dev/null || fail "successor application identity verification failed"
           fi
           if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
-            printf '%s' "$SUCCESSOR_INSTALLER_P12_BASE64" | base64 --decode > "$INSTALLER_CERTIFICATE_PATH" || fail "successor installer certificate"
+            printf '%s' "$SUCCESSOR_INSTALLER_P12_BASE64" | base64 --decode > "$INSTALLER_CERTIFICATE_PATH" || fail "successor installer P12 write failed"
             security import "$INSTALLER_CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$SUCCESSOR_INSTALLER_P12_PASSWORD" \
               -T /usr/bin/productbuild -T /usr/bin/security \
-              >/dev/null 2>&1 || fail "successor installer certificate"
+              >/dev/null || fail "successor installer P12 import failed"
             security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild: \
               -s -k "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH" \
-              >/dev/null 2>&1 || fail "successor installer certificate"
+              >/dev/null || fail "successor installer key partition setup failed"
             security find-identity -v -p basic "$PREFLIGHT_KEYCHAIN_PATH" |
-              grep -F "\"$EXPECTED_INSTALLER_IDENTITY\"" >/dev/null || fail "successor installer identity"
+              grep -F "\"$EXPECTED_INSTALLER_IDENTITY\"" >/dev/null || fail "successor installer identity verification failed"
           fi
           printf 'OK: Tip %s credential/configuration preflight passed.\n' "$ROLLOUT_ROLE"
 

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -331,6 +331,42 @@ APP_SIGN_ARGS=(){app_signing_body}
             2,
         )
 
+        credential_preflight = tip_workflow.split(
+            "      - name: Validate role-selected Tip credentials", 1
+        )[1].split("\n\n  stage:", 1)[0]
+        preflight_run = credential_preflight.split("        run: |\n", 1)[1]
+        self.assertIn('PREFLIGHT_KEYCHAIN_PATH="$RUNNER_TEMP/repoprompt-tip-preflight.keychain-db"', preflight_run)
+        self.assertIn("trap cleanup_preflight_credentials EXIT", preflight_run)
+        self.assertIn('rm -f "$CERTIFICATE_PATH"', preflight_run)
+        self.assertIn('security delete-keychain "$PREFLIGHT_KEYCHAIN_PATH" || true', preflight_run)
+        self.assertLess(
+            preflight_run.index("trap cleanup_preflight_credentials EXIT"),
+            preflight_run.index("base64 --decode"),
+        )
+        self.assertIn(
+            'security import "$CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$CERTIFICATE_P12_PASSWORD"',
+            preflight_run,
+        )
+        self.assertIn(
+            'security import "$SUCCESSOR_CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$SUCCESSOR_CERTIFICATE_P12_PASSWORD"',
+            preflight_run,
+        )
+        self.assertIn(
+            'security import "$INSTALLER_CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$SUCCESSOR_INSTALLER_P12_PASSWORD"',
+            preflight_run,
+        )
+        self.assertIn('security set-key-partition-list -S apple-tool:,apple:,codesign:', preflight_run)
+        self.assertIn('security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild:', preflight_run)
+        self.assertIn('security find-identity -v -p codesigning "$PREFLIGHT_KEYCHAIN_PATH"', preflight_run)
+        self.assertIn('grep -F "\\"$EXPECTED_SIGN_IDENTITY\\""', preflight_run)
+        self.assertIn('grep -F "\\"$EXPECTED_SUCCESSOR_SIGN_IDENTITY\\""', preflight_run)
+        self.assertIn('security find-identity -v -p basic "$PREFLIGHT_KEYCHAIN_PATH"', preflight_run)
+        self.assertIn('grep -F "\\"$EXPECTED_INSTALLER_IDENTITY\\""', preflight_run)
+        self.assertNotIn("security list-keychains", preflight_run)
+        self.assertNotIn("security default-keychain", preflight_run)
+        self.assertNotIn("GITHUB_ENV", preflight_run)
+        self.assertNotIn("GITHUB_OUTPUT", preflight_run)
+
     def test_codex_v8_entitlement_allowlist_matches_pinned_manifest_policy(self) -> None:
         v8_profile = {
             "com.apple.security.cs.allow-jit": True,

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -339,10 +339,25 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn("trap cleanup_preflight_credentials EXIT", preflight_run)
         self.assertIn('rm -f "$CERTIFICATE_PATH"', preflight_run)
         self.assertIn('security delete-keychain "$PREFLIGHT_KEYCHAIN_PATH" || true', preflight_run)
+        self.assertIn('rm -f "$PREFLIGHT_KEYCHAIN_PATH"', preflight_run)
+        self.assertLess(
+            preflight_run.index('security delete-keychain "$PREFLIGHT_KEYCHAIN_PATH" || true'),
+            preflight_run.index('rm -f "$PREFLIGHT_KEYCHAIN_PATH"'),
+        )
         self.assertLess(
             preflight_run.index("trap cleanup_preflight_credentials EXIT"),
             preflight_run.index("base64 --decode"),
         )
+        self.assertNotIn(">/dev/null 2>&1 || fail", preflight_run)
+        for noun_fragment in (
+            "application certificate",
+            "successor application certificate",
+            "successor installer certificate",
+            "application signing identity",
+            "successor application signing identity",
+            "successor installer identity",
+        ):
+            self.assertNotIn(f'|| fail "{noun_fragment}"', preflight_run)
         self.assertIn(
             'security import "$CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$CERTIFICATE_P12_PASSWORD"',
             preflight_run,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -261,7 +261,9 @@ A nonlegacy role is published only by an explicit dispatch whose
 `confirm_identity_rollout_role` exactly matches the checked-in role. The protected role-aware
 credential preflight runs before the secret-free build, and the environment approval is therefore a
 manual gate before any expensive staging work.
-It uses a separate ephemeral keychain to import and verify each role-required P12 without changing the runner user's keychain search list or exporting credential state to later steps.
+It uses a separate ephemeral keychain to import and verify each role-required P12
+without changing the runner user's keychain search list or exporting credential state
+to later steps.
 After P is reviewed, advance the declaration with its
 exact `identity-rollout.json` digest before dispatching T; advance it again with T and P digests before
 S. Each published role uses an immutable `tip-<shortsha>` tag and the tip-only repository's latest

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -260,7 +260,9 @@ remains green and records a concise no-op summary. This is diagnostic truthfulne
 A nonlegacy role is published only by an explicit dispatch whose
 `confirm_identity_rollout_role` exactly matches the checked-in role. The protected role-aware
 credential preflight runs before the secret-free build, and the environment approval is therefore a
-manual gate before any expensive staging work. After P is reviewed, advance the declaration with its
+manual gate before any expensive staging work.
+It uses a separate ephemeral keychain to import and verify each role-required P12 without changing the runner user's keychain search list or exporting credential state to later steps.
+After P is reviewed, advance the declaration with its
 exact `identity-rollout.json` digest before dispatching T; advance it again with T and P digests before
 S. Each published role uses an immutable `tip-<shortsha>` tag and the tip-only repository's latest
 release; do not mark the release as a prerelease because GitHub excludes prereleases from


### PR DESCRIPTION
## Summary
- import each role-required signing P12 into a disposable preflight keychain before the secret-free Tip build
- verify the policy-selected application, successor application, and installer identities before expensive staging work
- preserve native `security` diagnostics so a wrong password or corrupt P12 is actionable
- document and regression-test the preflight contract

## Why
Tip run 32842110727 spent about 80 minutes building before `Sign and Notarize Tip` failed while importing the successor application P12 with `SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)`. The existing credential preflight checked only presence/base64 shape, so it falsely passed.

This change does not alter signing, publishing, Sparkle feeds, or rollout roles. It moves real credential/identity validation ahead of staging and uses an isolated keychain without changing the runner search list.

## Validation
- release tooling tests: 108/108 passed
- `preflight.sh pr-ready`
- `make dev-release-preflight` (ticket `510693e2-a299-49d2-8aac-7f6f863b6541`)
- YAML parse, extracted shell `bash -n`, and `git diff --check`
- Fable 5 High advisory review: no must-fix findings

## Deployment blocker
The failed run proves the `tip-release` successor application P12/password pair is inconsistent. After this PR lands, the environment secret pair still must be corrected before rerunning the preparer release; the rerun will then fail in the short preflight rather than after the build if the pair remains invalid.