### PR TITLE
Separate sidebar command progress from bulk selection UI

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -590,6 +590,12 @@ extension AgentModeViewModel {
             return cached.projection
         }
 
+        let existingSelectionIdentities = Set(
+            composeTabs.map { AgentSidebarSelectionIdentity.active(tabID: $0.id) }
+                + stashedTabs.map {
+                    AgentSidebarSelectionIdentity.archived(stashedTabID: $0.id, tabID: $0.tab.id)
+                }
+        )
         let canonicalRows = buildSidebarSessions(
             for: composeTabs,
             workspaceID: workspaceID,
@@ -640,6 +646,7 @@ extension AgentModeViewModel {
                 in: canonicalRows,
                 searchText: sidebarSnapshot.searchText
             ),
+            existingSelectionIdentities: existingSelectionIdentities,
             renderedSelectionOrder: renderedSelectionOrder
         )
         sidebarListProjectionCache = (key, projection)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
@@ -168,6 +168,13 @@ extension AgentModeViewModel {
             return workspaceManager?.activeWorkspaceID == workspaceID
                 && ui.sessionSidebar.isCurrentBulkAction(token: token, workspaceID: targets.workspaceID)
         }
+        let onProjectionRemovalCommitted: PromptViewModel.ComposeTabsProjectionRemovalCallback = { [weak self] tabIDs in
+            self?.ui.sessionSidebar.retireCommandRowProgress(
+                token: token,
+                forRemovedTabIDs: tabIDs,
+                workspaceID: workspaceID
+            )
+        }
         var notice: AgentSidebarBulkActionNotice?
 
         switch action {
@@ -184,13 +191,15 @@ extension AgentModeViewModel {
             let report = await promptManager.deleteComposeAndStashedTabs(
                 composeTabIDs: targets.activeDeleteTabIDs,
                 archivedTargets: targets.archivedDeleteTargets,
-                isMutationContextCurrent: contextIsCurrent
+                isMutationContextCurrent: contextIsCurrent,
+                onProjectionRemovalCommitted: onProjectionRemovalCommitted
             )
             notice = sidebarBulkActionNotice(for: report, action: action, origin: origin)
         case .stash:
             let report = await promptManager.stashComposeTabs(
                 withIDs: targets.stashTabIDs,
-                isMutationContextCurrent: contextIsCurrent
+                isMutationContextCurrent: contextIsCurrent,
+                onProjectionRemovalCommitted: onProjectionRemovalCommitted
             )
             notice = sidebarBulkActionNotice(for: report, action: action, origin: origin)
         case .pin:

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
@@ -147,21 +147,18 @@ extension AgentModeViewModel {
     func performSidebarBulkAction(
         _ action: AgentSidebarBulkActionKind,
         origin: AgentSidebarBulkActionOrigin,
+        commandProgressPlacement: AgentSidebarCommandProgressPlacement?,
         targets: SidebarBulkMutationTargets,
         promptManager: PromptViewModel
     ) async {
-        let targetCount: Int = switch action {
-        case .delete: targets.activeDeleteTabIDs.count + targets.archivedDeleteTargets.count
-        case .stash: targets.stashTabIDs.count
-        case .pin: targets.pinTabIDs.count
-        case .unpin: targets.unpinTabIDs.count
-        }
+        let presentationTargets = targets.presentationTargets(for: action)
         guard workspaceManager?.activeWorkspaceID == targets.workspaceID else { return }
         if origin == .command, ui.sessionSidebar.selectionState.showsSelectionPresentation { return }
         guard let token = ui.sessionSidebar.beginBulkAction(
             kind: action,
             origin: origin,
-            targetCount: targetCount,
+            presentationTargets: presentationTargets,
+            commandProgressPlacement: commandProgressPlacement,
             workspaceID: targets.workspaceID
         ) else { return }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
@@ -137,8 +137,16 @@ extension AgentModeViewModel {
         )
     }
 
+    func canPerformDirectSidebarCommand(workspaceID: UUID) -> Bool {
+        let selectionState = ui.sessionSidebar.selectionState
+        return workspaceManager?.activeWorkspaceID == workspaceID
+            && !selectionState.isMutationInFlight
+            && !selectionState.showsSelectionPresentation
+    }
+
     func performSidebarBulkAction(
         _ action: AgentSidebarBulkActionKind,
+        origin: AgentSidebarBulkActionOrigin,
         targets: SidebarBulkMutationTargets,
         promptManager: PromptViewModel
     ) async {
@@ -148,13 +156,14 @@ extension AgentModeViewModel {
         case .pin: targets.pinTabIDs.count
         case .unpin: targets.unpinTabIDs.count
         }
-        guard workspaceManager?.activeWorkspaceID == targets.workspaceID,
-              let token = ui.sessionSidebar.beginBulkAction(
-                  kind: action,
-                  targetCount: targetCount,
-                  workspaceID: targets.workspaceID
-              )
-        else { return }
+        guard workspaceManager?.activeWorkspaceID == targets.workspaceID else { return }
+        if origin == .command, ui.sessionSidebar.selectionState.showsSelectionPresentation { return }
+        guard let token = ui.sessionSidebar.beginBulkAction(
+            kind: action,
+            origin: origin,
+            targetCount: targetCount,
+            workspaceID: targets.workspaceID
+        ) else { return }
 
         let workspaceID = targets.workspaceID
         let contextIsCurrent: @MainActor () -> Bool = { [weak self] in
@@ -180,13 +189,13 @@ extension AgentModeViewModel {
                 archivedTargets: targets.archivedDeleteTargets,
                 isMutationContextCurrent: contextIsCurrent
             )
-            notice = sidebarBulkActionNotice(for: report, action: action)
+            notice = sidebarBulkActionNotice(for: report, action: action, origin: origin)
         case .stash:
             let report = await promptManager.stashComposeTabs(
                 withIDs: targets.stashTabIDs,
                 isMutationContextCurrent: contextIsCurrent
             )
-            notice = sidebarBulkActionNotice(for: report, action: action)
+            notice = sidebarBulkActionNotice(for: report, action: action, origin: origin)
         case .pin:
             let report = promptManager.setComposeTabsPinned(
                 true,
@@ -197,7 +206,9 @@ extension AgentModeViewModel {
                 notice = AgentSidebarBulkActionNotice(
                     severity: .warning,
                     title: "Chats were not pinned",
-                    message: "The workspace or selected chats changed before the action could be applied."
+                    message: origin == .selection
+                        ? "The workspace or selected chats changed before the action could be applied."
+                        : "The workspace or requested chats changed before the action could be applied."
                 )
             }
         case .unpin:
@@ -210,7 +221,9 @@ extension AgentModeViewModel {
                 notice = AgentSidebarBulkActionNotice(
                     severity: .warning,
                     title: "Chats were not unpinned",
-                    message: "The workspace or selected chats changed before the action could be applied."
+                    message: origin == .selection
+                        ? "The workspace or selected chats changed before the action could be applied."
+                        : "The workspace or requested chats changed before the action could be applied."
                 )
             }
         }
@@ -223,13 +236,18 @@ extension AgentModeViewModel {
 
     func sidebarBulkActionNotice(
         for report: PromptViewModel.ComposeTabMutationReport,
-        action: AgentSidebarBulkActionKind
+        action: AgentSidebarBulkActionKind,
+        origin: AgentSidebarBulkActionOrigin
     ) -> AgentSidebarBulkActionNotice? {
+        let partialTitle = origin == .selection
+            ? "Bulk action partially completed"
+            : "Action partially completed"
+        let targetDescription = origin == .selection ? "selected" : "requested"
         if let cleanupIssue = report.cleanupIssues.first, !report.rejections.isEmpty {
             return AgentSidebarBulkActionNotice(
                 severity: .error,
-                title: "Bulk action partially completed",
-                message: "Some chats changed, cleanup failed for \(report.cleanupIssues.count) chat(s), and some selected or related chats were not changed. \(cleanupIssue.message)"
+                title: partialTitle,
+                message: "Some chats changed, cleanup failed for \(report.cleanupIssues.count) chat(s), and some \(targetDescription) or related chats were not changed. \(cleanupIssue.message)"
             )
         }
         if let cleanupIssue = report.cleanupIssues.first {
@@ -242,8 +260,8 @@ extension AgentModeViewModel {
         if report.didMutateProjection, !report.rejections.isEmpty {
             return AgentSidebarBulkActionNotice(
                 severity: .warning,
-                title: "Bulk action partially completed",
-                message: "Some chats changed, but some selected or related chats were rejected before mutation."
+                title: partialTitle,
+                message: "Some chats changed, but some \(targetDescription) or related chats were rejected before mutation."
             )
         }
         if let rejection = report.rejections.first {
@@ -257,7 +275,7 @@ extension AgentModeViewModel {
             return AgentSidebarBulkActionNotice(
                 severity: .information,
                 title: "No chats were changed",
-                message: "The selected chats no longer matched the \(action.rawValue) action."
+                message: "The \(targetDescription) chats no longer matched the \(action.rawValue) action."
             )
         }
         return nil

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -209,6 +209,7 @@ extension AgentModeViewModel {
         let archivedDateInfoByStashedTabID: [UUID: SidebarSessionDateInfo]
         let archivedSessionIDByStashedTabID: [UUID: UUID]
         let defaultCollapseSeedKeys: [AgentSidebarThreadKey]
+        let existingSelectionIdentities: Set<AgentSidebarSelectionIdentity>
         let renderedSelectionOrder: [AgentSidebarSelectionIdentity]
 
         var hasMoreSessions: Bool {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -235,6 +235,24 @@ extension AgentModeViewModel {
         let stashTabIDs: Set<UUID>
         let pinTabIDs: Set<UUID>
         let unpinTabIDs: Set<UUID>
+
+        func presentationTargets(
+            for action: AgentSidebarBulkActionKind
+        ) -> Set<AgentSidebarSelectionIdentity> {
+            switch action {
+            case .delete:
+                Set(activeDeleteTabIDs.map(AgentSidebarSelectionIdentity.active(tabID:)))
+                    .union(archivedDeleteTargets.map {
+                        .archived(stashedTabID: $0.stashedTabID, tabID: $0.tabID)
+                    })
+            case .stash:
+                Set(stashTabIDs.map(AgentSidebarSelectionIdentity.active(tabID:)))
+            case .pin:
+                Set(pinTabIDs.map(AgentSidebarSelectionIdentity.active(tabID:)))
+            case .unpin:
+                Set(unpinTabIDs.map(AgentSidebarSelectionIdentity.active(tabID:)))
+            }
+        }
     }
 
     /// Signature of a compose tab's sidebar-rendered metadata. Captured separately

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -12376,7 +12376,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         reason: PromptViewModel.ComposeTabRemovalReason,
         workspaceID: UUID
     ) async -> [PromptViewModel.ComposeTabPostRemovalIssue] {
-        ui.sessionSidebar.retireCommandRowProgress(forRemovedTabIDs: tabIDs, workspaceID: workspaceID)
         let removalWorkspace = workspaceManager?.workspaces.first(where: { $0.id == workspaceID })
         var issues: [PromptViewModel.ComposeTabPostRemovalIssue] = []
         let orderedTabIDs = tabIDs.sorted(by: { $0.uuidString < $1.uuidString })

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -707,7 +707,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         var test_sidebarListProjectionBuildCount = 0
         private var test_afterMCPStoreEpochBegan: (@MainActor () async -> Void)?
         private var test_afterDurableChildTabCreation: (@MainActor () async -> Void)?
-        private var test_composeTabRemovalTeardownObserver: (@MainActor (UUID) -> Void)?
+        private var test_composeTabRemovalTeardownObserver: (@MainActor (UUID) async -> Void)?
         private var test_terminalPublicationOverride: ((
             AgentRunTerminalCommitRevision,
             AgentRunEpochTransitionKind?,
@@ -757,7 +757,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             }
         }
 
-        func test_setComposeTabRemovalTeardownObserver(_ observer: @escaping @MainActor (UUID) -> Void) {
+        func test_setComposeTabRemovalTeardownObserver(_ observer: @escaping @MainActor (UUID) async -> Void) {
             test_composeTabRemovalTeardownObserver = observer
         }
 
@@ -12376,6 +12376,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         reason: PromptViewModel.ComposeTabRemovalReason,
         workspaceID: UUID
     ) async -> [PromptViewModel.ComposeTabPostRemovalIssue] {
+        ui.sessionSidebar.retireCommandRowProgress(forRemovedTabIDs: tabIDs, workspaceID: workspaceID)
         let removalWorkspace = workspaceManager?.workspaces.first(where: { $0.id == workspaceID })
         var issues: [PromptViewModel.ComposeTabPostRemovalIssue] = []
         let orderedTabIDs = tabIDs.sorted(by: { $0.uuidString < $1.uuidString })
@@ -12458,7 +12459,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
         for tabID in orderedRuntimeCleanupTabIDs {
             #if DEBUG
-                test_composeTabRemovalTeardownObserver?(tabID)
+                if let test_composeTabRemovalTeardownObserver {
+                    await test_composeTabRemovalTeardownObserver(tabID)
+                }
             #endif
             let capturedSession = capturedSessionsByTabID[tabID] ?? nil
             let boundID = capturedBoundSessionIDByTabID[tabID] ?? nil

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
@@ -84,17 +84,33 @@ final class AgentSessionSidebarUIStore: ObservableObject {
     func beginBulkAction(
         kind: AgentSidebarBulkActionKind,
         origin: AgentSidebarBulkActionOrigin,
-        targetCount: Int,
+        presentationTargets: Set<AgentSidebarSelectionIdentity>,
+        commandProgressPlacement: AgentSidebarCommandProgressPlacement?,
         workspaceID: UUID
     ) -> UUID? {
-        guard selectionState.inFlightAction == nil, targetCount > 0 else { return nil }
+        guard selectionState.inFlightAction == nil, !presentationTargets.isEmpty else { return nil }
         switch origin {
         case .selection:
-            guard selectionState.workspaceID == workspaceID,
-                  !selectionState.selectedIdentities.isEmpty
+            guard commandProgressPlacement == nil,
+                  selectionState.workspaceID == workspaceID,
+                  !selectionState.selectedIdentities.isEmpty,
+                  presentationTargets.isSubset(of: selectionState.selectedIdentities)
             else { return nil }
         case .command:
-            guard selectionState.selectedIdentities.isEmpty else { return nil }
+            guard selectionState.selectedIdentities.isEmpty,
+                  let commandProgressPlacement
+            else { return nil }
+            switch commandProgressPlacement {
+            case .row:
+                guard presentationTargets.count == 1 else { return nil }
+            case .archivedHeader:
+                guard kind == .delete,
+                      presentationTargets.allSatisfy({ identity in
+                          if case .archived = identity { return true }
+                          return false
+                      })
+                else { return nil }
+            }
         }
 
         let token = UUID()
@@ -106,7 +122,8 @@ final class AgentSessionSidebarUIStore: ObservableObject {
             workspaceID: workspaceID,
             kind: kind,
             origin: origin,
-            targetCount: targetCount
+            presentationTargets: presentationTargets,
+            commandProgressPlacement: commandProgressPlacement
         )
         next.revision &+= 1
         publishSelection(next, eventName: "sessionSidebar.selection.bulkBegin")
@@ -269,6 +286,13 @@ final class AgentSessionSidebarUIStore: ObservableObject {
                     "selectedCount": String(next.selectedIdentities.count),
                     "hasAnchor": String(next.anchor != nil),
                     "inFlightKind": next.inFlightAction?.kind.rawValue ?? "none",
+                    "inFlightTargetCount": String(next.inFlightAction?.targetCount ?? 0),
+                    "inFlightPlacement": next.inFlightAction?.commandProgressPlacement.map {
+                        switch $0 {
+                        case .row: "row"
+                        case .archivedHeader: "archivedHeader"
+                        }
+                    } ?? "none",
                     "inFlightOrigin": next.inFlightAction.map {
                         switch $0.origin {
                         case .selection: "selection"

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
@@ -135,6 +135,23 @@ final class AgentSessionSidebarUIStore: ObservableObject {
             && selectionState.inFlightAction?.workspaceID == workspaceID
     }
 
+    func retireCommandRowProgress(forRemovedTabIDs tabIDs: Set<UUID>, workspaceID: UUID) {
+        guard !tabIDs.isEmpty,
+              var operation = selectionState.inFlightAction,
+              operation.origin == .command,
+              operation.commandProgressPlacement == .row,
+              operation.workspaceID == workspaceID,
+              !operation.commandRowProgressRetired,
+              operation.presentationTargets.contains(where: { tabIDs.contains($0.tabID) })
+        else { return }
+
+        operation.commandRowProgressRetired = true
+        var next = selectionState
+        next.inFlightAction = operation
+        next.revision &+= 1
+        publishSelection(next, eventName: "sessionSidebar.selection.commandRowProgressRetired")
+    }
+
     func finishBulkAction(token: UUID, workspaceID: UUID, notice: AgentSidebarBulkActionNotice?) {
         guard isCurrentBulkAction(token: token, workspaceID: workspaceID) else { return }
         var next = selectionState
@@ -287,6 +304,7 @@ final class AgentSessionSidebarUIStore: ObservableObject {
                     "hasAnchor": String(next.anchor != nil),
                     "inFlightKind": next.inFlightAction?.kind.rawValue ?? "none",
                     "inFlightTargetCount": String(next.inFlightAction?.targetCount ?? 0),
+                    "inFlightRowProgressRetired": String(next.inFlightAction?.commandRowProgressRetired ?? false),
                     "inFlightPlacement": next.inFlightAction?.commandProgressPlacement.map {
                         switch $0 {
                         case .row: "row"

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
@@ -88,6 +88,15 @@ final class AgentSessionSidebarUIStore: ObservableObject {
         workspaceID: UUID
     ) -> UUID? {
         guard selectionState.inFlightAction == nil, targetCount > 0 else { return nil }
+        switch origin {
+        case .selection:
+            guard selectionState.workspaceID == workspaceID,
+                  !selectionState.selectedIdentities.isEmpty
+            else { return nil }
+        case .command:
+            guard selectionState.selectedIdentities.isEmpty else { return nil }
+        }
+
         let token = UUID()
         var next = selectionState
         next.workspaceID = workspaceID

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
@@ -135,9 +135,14 @@ final class AgentSessionSidebarUIStore: ObservableObject {
             && selectionState.inFlightAction?.workspaceID == workspaceID
     }
 
-    func retireCommandRowProgress(forRemovedTabIDs tabIDs: Set<UUID>, workspaceID: UUID) {
+    func retireCommandRowProgress(
+        token: UUID,
+        forRemovedTabIDs tabIDs: Set<UUID>,
+        workspaceID: UUID
+    ) {
         guard !tabIDs.isEmpty,
               var operation = selectionState.inFlightAction,
+              operation.token == token,
               operation.origin == .command,
               operation.commandProgressPlacement == .row,
               operation.workspaceID == workspaceID,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
@@ -81,7 +81,12 @@ final class AgentSessionSidebarUIStore: ObservableObject {
         publishSelection(next, eventName: "sessionSidebar.selection.reconcile")
     }
 
-    func beginBulkAction(kind: AgentSidebarBulkActionKind, targetCount: Int, workspaceID: UUID) -> UUID? {
+    func beginBulkAction(
+        kind: AgentSidebarBulkActionKind,
+        origin: AgentSidebarBulkActionOrigin,
+        targetCount: Int,
+        workspaceID: UUID
+    ) -> UUID? {
         guard selectionState.inFlightAction == nil, targetCount > 0 else { return nil }
         let token = UUID()
         var next = selectionState
@@ -91,6 +96,7 @@ final class AgentSessionSidebarUIStore: ObservableObject {
             token: token,
             workspaceID: workspaceID,
             kind: kind,
+            origin: origin,
             targetCount: targetCount
         )
         next.revision &+= 1
@@ -253,7 +259,13 @@ final class AgentSessionSidebarUIStore: ObservableObject {
                     "revision": String(next.revision),
                     "selectedCount": String(next.selectedIdentities.count),
                     "hasAnchor": String(next.anchor != nil),
-                    "inFlightKind": next.inFlightAction?.kind.rawValue ?? "none"
+                    "inFlightKind": next.inFlightAction?.kind.rawValue ?? "none",
+                    "inFlightOrigin": next.inFlightAction.map {
+                        switch $0.origin {
+                        case .selection: "selection"
+                        case .command: "command"
+                        }
+                    } ?? "none"
                 ]
             )
         #endif

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
@@ -130,8 +130,8 @@ struct AgentSidebarSelectionState: Equatable {
               operation.origin == .command,
               operation.workspaceID == workspaceID,
               operation.commandProgressPlacement == .row,
-              operation.commandRowProgressRetired
-              || !renderedOrder.contains(where: operation.presentationTargets.contains)
+              !operation.commandRowProgressRetired,
+              !renderedOrder.contains(where: operation.presentationTargets.contains)
         else { return nil }
         return operation
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
@@ -45,6 +45,15 @@ enum AgentSidebarBulkActionKind: String, Equatable {
     case stash
     case pin
     case unpin
+
+    var rowProgressAccessibilityLabel: String {
+        switch self {
+        case .delete: "Deleting chat"
+        case .stash: "Stashing chat"
+        case .pin: "Pinning chat"
+        case .unpin: "Unpinning chat"
+        }
+    }
 }
 
 enum AgentSidebarBulkActionOrigin: Equatable {
@@ -64,6 +73,7 @@ struct AgentSidebarBulkActionOperation: Equatable {
     let origin: AgentSidebarBulkActionOrigin
     let presentationTargets: Set<AgentSidebarSelectionIdentity>
     let commandProgressPlacement: AgentSidebarCommandProgressPlacement?
+    var commandRowProgressRetired = false
 
     var targetCount: Int {
         presentationTargets.count
@@ -106,7 +116,22 @@ struct AgentSidebarSelectionState: Equatable {
               operation.origin == .command,
               operation.workspaceID == workspaceID,
               operation.commandProgressPlacement == .row,
+              !operation.commandRowProgressRetired,
               operation.presentationTargets.contains(identity)
+        else { return nil }
+        return operation
+    }
+
+    func commandFallbackProgressOperation(
+        renderedOrder: [AgentSidebarSelectionIdentity],
+        workspaceID: UUID?
+    ) -> AgentSidebarBulkActionOperation? {
+        guard let operation = inFlightAction,
+              operation.origin == .command,
+              operation.workspaceID == workspaceID,
+              operation.commandProgressPlacement == .row,
+              operation.commandRowProgressRetired
+              || !renderedOrder.contains(where: operation.presentationTargets.contains)
         else { return nil }
         return operation
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
@@ -52,12 +52,22 @@ enum AgentSidebarBulkActionOrigin: Equatable {
     case command
 }
 
+enum AgentSidebarCommandProgressPlacement: Equatable {
+    case row
+    case archivedHeader
+}
+
 struct AgentSidebarBulkActionOperation: Equatable {
     let token: UUID
     let workspaceID: UUID
     let kind: AgentSidebarBulkActionKind
     let origin: AgentSidebarBulkActionOrigin
-    let targetCount: Int
+    let presentationTargets: Set<AgentSidebarSelectionIdentity>
+    let commandProgressPlacement: AgentSidebarCommandProgressPlacement?
+
+    var targetCount: Int {
+        presentationTargets.count
+    }
 }
 
 struct AgentSidebarBulkActionNotice: Equatable {
@@ -88,9 +98,23 @@ struct AgentSidebarSelectionState: Equatable {
         inFlightAction != nil
     }
 
-    var commandProgressOperation: AgentSidebarBulkActionOperation? {
-        guard inFlightAction?.origin == .command else { return nil }
-        return inFlightAction
+    func commandRowProgressOperation(
+        for identity: AgentSidebarSelectionIdentity
+    ) -> AgentSidebarBulkActionOperation? {
+        guard let operation = inFlightAction,
+              operation.origin == .command,
+              operation.commandProgressPlacement == .row,
+              operation.presentationTargets.contains(identity)
+        else { return nil }
+        return operation
+    }
+
+    var archivedHeaderCommandProgressOperation: AgentSidebarBulkActionOperation? {
+        guard let operation = inFlightAction,
+              operation.origin == .command,
+              operation.commandProgressPlacement == .archivedHeader
+        else { return nil }
+        return operation
     }
 
     mutating func handle(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
@@ -99,10 +99,12 @@ struct AgentSidebarSelectionState: Equatable {
     }
 
     func commandRowProgressOperation(
-        for identity: AgentSidebarSelectionIdentity
+        for identity: AgentSidebarSelectionIdentity,
+        workspaceID: UUID?
     ) -> AgentSidebarBulkActionOperation? {
         guard let operation = inFlightAction,
               operation.origin == .command,
+              operation.workspaceID == workspaceID,
               operation.commandProgressPlacement == .row,
               operation.presentationTargets.contains(identity)
         else { return nil }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
@@ -123,7 +123,8 @@ struct AgentSidebarSelectionState: Equatable {
     }
 
     func commandFallbackProgressOperation(
-        renderedOrder: [AgentSidebarSelectionIdentity],
+        existingIdentities: Set<AgentSidebarSelectionIdentity>,
+        renderedIdentities: Set<AgentSidebarSelectionIdentity>,
         workspaceID: UUID?
     ) -> AgentSidebarBulkActionOperation? {
         guard let operation = inFlightAction,
@@ -131,7 +132,8 @@ struct AgentSidebarSelectionState: Equatable {
               operation.workspaceID == workspaceID,
               operation.commandProgressPlacement == .row,
               !operation.commandRowProgressRetired,
-              !renderedOrder.contains(where: operation.presentationTargets.contains)
+              !operation.presentationTargets.isDisjoint(with: existingIdentities),
+              operation.presentationTargets.isDisjoint(with: renderedIdentities)
         else { return nil }
         return operation
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSidebarSelectionState.swift
@@ -47,10 +47,16 @@ enum AgentSidebarBulkActionKind: String, Equatable {
     case unpin
 }
 
+enum AgentSidebarBulkActionOrigin: Equatable {
+    case selection
+    case command
+}
+
 struct AgentSidebarBulkActionOperation: Equatable {
     let token: UUID
     let workspaceID: UUID
     let kind: AgentSidebarBulkActionKind
+    let origin: AgentSidebarBulkActionOrigin
     let targetCount: Int
 }
 
@@ -74,8 +80,17 @@ struct AgentSidebarSelectionState: Equatable {
     var notice: AgentSidebarBulkActionNotice?
     var revision = 0
 
-    var isSelectionMode: Bool {
-        !selectedIdentities.isEmpty || inFlightAction != nil
+    var showsSelectionPresentation: Bool {
+        !selectedIdentities.isEmpty || inFlightAction?.origin == .selection
+    }
+
+    var isMutationInFlight: Bool {
+        inFlightAction != nil
+    }
+
+    var commandProgressOperation: AgentSidebarBulkActionOperation? {
+        guard inFlightAction?.origin == .command else { return nil }
+        return inFlightAction
     }
 
     mutating func handle(
@@ -91,7 +106,7 @@ struct AgentSidebarSelectionState: Equatable {
 
         switch gesture {
         case .primary:
-            guard isSelectionMode else { return .activate }
+            guard !selectedIdentities.isEmpty else { return .activate }
             selectedIdentities = [identity]
             anchor = identity
         case .toggle:

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -33,8 +33,8 @@ struct AgentSessionRow: View {
     var hiddenThreadDescendantAttentionCount: Int = 0
     var onToggleThreadCollapse: (() -> Void)?
     var isSelected = false
-    var isSelectionMode = false
-    var isSelectionEnabled = true
+    var showsSelectionPresentation = false
+    var isInteractionEnabled = true
     let onSelectionGesture: (AgentSidebarSelectionGesture) -> AgentSidebarSelectionGestureDisposition
     let onSelect: () -> Void
     let onTogglePin: () -> Void
@@ -142,12 +142,18 @@ struct AgentSessionRow: View {
         "Delete chat"
     }
 
+    private var allowsDirectMutations: Bool {
+        isInteractionEnabled && !showsSelectionPresentation
+    }
+
     private func beginRename() {
+        guard allowsDirectMutations else { return }
         renameText = title
         showRenameAlert = true
     }
 
     private func requestDeleteConfirmation() {
+        guard allowsDirectMutations else { return }
         showDeleteConfirmation = true
     }
 
@@ -160,25 +166,26 @@ struct AgentSessionRow: View {
     }
 
     private func handleRowTap() {
+        guard isInteractionEnabled else { return }
         if onSelectionGesture(currentSelectionGesture) == .activate {
             onSelect()
         }
     }
 
     private func toggleSelection() {
-        guard isSelectionEnabled else { return }
+        guard isInteractionEnabled else { return }
         _ = onSelectionGesture(.toggle)
     }
 
     var body: some View {
         HStack(spacing: rowSpacing) {
-            if isSelectionMode {
+            if showsSelectionPresentation {
                 Button(action: toggleSelection) {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
                 }
                 .buttonStyle(.plain)
-                .disabled(!isSelectionEnabled)
+                .disabled(!isInteractionEnabled)
                 .accessibilityLabel("\(isSelected ? "Deselect" : "Select") \(title)")
                 .accessibilityValue(isSelected ? "Selected" : "Not selected")
             }
@@ -231,8 +238,8 @@ struct AgentSessionRow: View {
             Spacer()
 
             // Trailing indicator (checkmark or delete button)
-            if isHovered, !isSelectionMode {
-                if attentionRunState != nil, let onDismissAttention {
+            if isHovered {
+                if !showsSelectionPresentation, attentionRunState != nil, let onDismissAttention {
                     Button(action: onDismissAttention) {
                         Image(systemName: "bell.slash")
                             .font(.system(size: 11))
@@ -244,43 +251,45 @@ struct AgentSessionRow: View {
                     .accessibilityLabel(dismissAttentionActionLabel)
                 }
 
-                Button(action: onTogglePin) {
-                    Image(systemName: isPinned ? "pin.slash" : "pin")
-                        .font(.system(size: 11))
-                        .foregroundColor(isPinHovered ? .accentColor : .secondary)
-                }
-                .buttonStyle(.plain)
-                .onHover { isPinHovered = $0 }
-                .hoverTooltip(pinActionLabel)
-
-                Button(action: beginRename) {
-                    Image(systemName: "pencil")
-                        .font(.system(size: 11))
-                        .foregroundColor(isRenameHovered ? .accentColor : .secondary)
-                }
-                .buttonStyle(.plain)
-                .onHover { isRenameHovered = $0 }
-                .hoverTooltip(renameActionLabel)
-
-                if let onStash {
-                    Button(action: onStash) {
-                        Image(systemName: "tray.and.arrow.down")
+                if allowsDirectMutations {
+                    Button(action: onTogglePin) {
+                        Image(systemName: isPinned ? "pin.slash" : "pin")
                             .font(.system(size: 11))
-                            .foregroundColor(isStashHovered ? .accentColor : .secondary)
+                            .foregroundColor(isPinHovered ? .accentColor : .secondary)
                     }
                     .buttonStyle(.plain)
-                    .onHover { isStashHovered = $0 }
-                    .hoverTooltip(stashActionLabel)
-                }
+                    .onHover { isPinHovered = $0 }
+                    .hoverTooltip(pinActionLabel)
 
-                Button(action: requestDeleteConfirmation) {
-                    Image(systemName: "trash")
-                        .font(.system(size: 11))
-                        .foregroundColor(isDeleteHovered ? .red : .secondary)
+                    Button(action: beginRename) {
+                        Image(systemName: "pencil")
+                            .font(.system(size: 11))
+                            .foregroundColor(isRenameHovered ? .accentColor : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isRenameHovered = $0 }
+                    .hoverTooltip(renameActionLabel)
+
+                    if let onStash {
+                        Button(action: onStash) {
+                            Image(systemName: "tray.and.arrow.down")
+                                .font(.system(size: 11))
+                                .foregroundColor(isStashHovered ? .accentColor : .secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .onHover { isStashHovered = $0 }
+                        .hoverTooltip(stashActionLabel)
+                    }
+
+                    Button(action: requestDeleteConfirmation) {
+                        Image(systemName: "trash")
+                            .font(.system(size: 11))
+                            .foregroundColor(isDeleteHovered ? .red : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isDeleteHovered = $0 }
+                    .hoverTooltip(deleteActionLabel)
                 }
-                .buttonStyle(.plain)
-                .onHover { isDeleteHovered = $0 }
-                .hoverTooltip(deleteActionLabel)
             }
             // Selected state is already signaled by the accent-tinted background +
             // semibold title weight; a trailing checkmark was redundant.
@@ -304,21 +313,23 @@ struct AgentSessionRow: View {
         )
         .contentShape(Rectangle())
         .contextMenu {
-            if !isSelectionMode {
-                Button("Select chat", action: toggleSelection)
+            if !showsSelectionPresentation {
+                if isInteractionEnabled {
+                    Button("Select chat", action: toggleSelection)
 
-                Divider()
+                    Divider()
 
-                Button(pinActionLabel, action: onTogglePin)
+                    Button(pinActionLabel, action: onTogglePin)
 
-                Button(renameActionLabel, action: beginRename)
+                    Button(renameActionLabel, action: beginRename)
+                }
 
                 Button(AgentSidebarSessionIDCopyAction.menuTitle) {
                     sessionIDCopyAction.perform()
                 }
                 .disabled(!sessionIDCopyAction.isEnabled)
 
-                if let onStash {
+                if isInteractionEnabled, let onStash {
                     Button(stashActionLabel, action: onStash)
                 }
 
@@ -326,9 +337,11 @@ struct AgentSessionRow: View {
                     Button(dismissAttentionActionLabel, action: onDismissAttention)
                 }
 
-                Divider()
+                if isInteractionEnabled {
+                    Divider()
 
-                Button(deleteActionLabel, role: .destructive, action: requestDeleteConfirmation)
+                    Button(deleteActionLabel, role: .destructive, action: requestDeleteConfirmation)
+                }
             }
         }
         .onHover { isHovered = $0 }
@@ -354,10 +367,12 @@ struct AgentSessionRow: View {
                         showDeleteConfirmation = false
                     }
                     Button("Delete") {
+                        guard allowsDirectMutations else { return }
                         showDeleteConfirmation = false
                         onDelete()
                     }
                     .keyboardShortcut(.defaultAction)
+                    .disabled(!allowsDirectMutations)
                 }
             }
             .padding()
@@ -367,6 +382,7 @@ struct AgentSessionRow: View {
             AgentSessionRenameSheet(
                 renameText: $renameText,
                 onConfirm: { newName in
+                    guard allowsDirectMutations else { return }
                     showRenameAlert = false
                     onRename(newName)
                 },
@@ -374,6 +390,11 @@ struct AgentSessionRow: View {
                     showRenameAlert = false
                 }
             )
+        }
+        .onChange(of: isInteractionEnabled) { _, isEnabled in
+            guard !isEnabled else { return }
+            showDeleteConfirmation = false
+            showRenameAlert = false
         }
     }
 
@@ -753,8 +774,8 @@ struct AgentSessionRow: View {
 struct AgentStashedSessionRow: View {
     let stashed: StashedTab
     var isSelected = false
-    var isSelectionMode = false
-    var isSelectionEnabled = true
+    var showsSelectionPresentation = false
+    var isInteractionEnabled = true
     let onSelectionGesture: (AgentSidebarSelectionGesture) -> AgentSidebarSelectionGestureDisposition
     let onRestore: () -> Void
     let onDelete: () -> Void
@@ -804,6 +825,10 @@ struct AgentStashedSessionRow: View {
         fontPreset.scaledClamped(10, max: 13)
     }
 
+    private var allowsDirectMutations: Bool {
+        isInteractionEnabled && !showsSelectionPresentation
+    }
+
     private var restoreActionLabel: String {
         "Restore tab"
     }
@@ -821,25 +846,26 @@ struct AgentStashedSessionRow: View {
     }
 
     private func handleRowTap() {
+        guard isInteractionEnabled else { return }
         if onSelectionGesture(currentSelectionGesture) == .activate {
             onRestore()
         }
     }
 
     private func toggleSelection() {
-        guard isSelectionEnabled else { return }
+        guard isInteractionEnabled else { return }
         _ = onSelectionGesture(.toggle)
     }
 
     var body: some View {
         HStack(spacing: rowSpacing) {
-            if isSelectionMode {
+            if showsSelectionPresentation {
                 Button(action: toggleSelection) {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
                         .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
                 }
                 .buttonStyle(.plain)
-                .disabled(!isSelectionEnabled)
+                .disabled(!isInteractionEnabled)
                 .accessibilityLabel("\(isSelected ? "Deselect" : "Select") \(stashed.tab.name)")
                 .accessibilityValue(isSelected ? "Selected" : "Not selected")
             }
@@ -864,7 +890,7 @@ struct AgentStashedSessionRow: View {
 
             Spacer()
 
-            if isHovered, !isSelectionMode {
+            if isHovered, allowsDirectMutations {
                 Button(action: onRestore) {
                     Image(systemName: "tray.and.arrow.up")
                         .font(.system(size: 11))
@@ -900,16 +926,20 @@ struct AgentStashedSessionRow: View {
         )
         .contentShape(Rectangle())
         .contextMenu {
-            if !isSelectionMode {
-                Button("Select chat", action: toggleSelection)
-                Divider()
-                Button(restoreActionLabel, action: onRestore)
+            if !showsSelectionPresentation {
+                if isInteractionEnabled {
+                    Button("Select chat", action: toggleSelection)
+                    Divider()
+                    Button(restoreActionLabel, action: onRestore)
+                }
                 Button(AgentSidebarSessionIDCopyAction.menuTitle) {
                     sessionIDCopyAction.perform()
                 }
                 .disabled(!sessionIDCopyAction.isEnabled)
-                Divider()
-                Button(deleteActionLabel, role: .destructive, action: onDelete)
+                if isInteractionEnabled {
+                    Divider()
+                    Button(deleteActionLabel, role: .destructive, action: onDelete)
+                }
             }
         }
         .onHover { isHovered = $0 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -975,17 +975,6 @@ struct AgentStashedSessionRow: View {
     }
 }
 
-private extension AgentSidebarBulkActionKind {
-    var rowProgressAccessibilityLabel: String {
-        switch self {
-        case .delete: "Deleting chat"
-        case .stash: "Stashing chat"
-        case .pin: "Pinning chat"
-        case .unpin: "Unpinning chat"
-        }
-    }
-}
-
 // MARK: - Agent Row Activity Arc
 
 /// A compact, calm rotating arc used in place of the native `ProgressView`

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -35,6 +35,7 @@ struct AgentSessionRow: View {
     var isSelected = false
     var showsSelectionPresentation = false
     var isInteractionEnabled = true
+    var commandProgressKind: AgentSidebarBulkActionKind?
     let onSelectionGesture: (AgentSidebarSelectionGesture) -> AgentSidebarSelectionGestureDisposition
     let onSelect: () -> Void
     let onTogglePin: () -> Void
@@ -237,8 +238,10 @@ struct AgentSessionRow: View {
 
             Spacer()
 
-            // Trailing indicator (checkmark or delete button)
-            if isHovered {
+            // Trailing command progress or hover actions.
+            if let commandProgressKind {
+                commandProgressIndicator(for: commandProgressKind)
+            } else if isHovered {
                 if !showsSelectionPresentation, attentionRunState != nil, let onDismissAttention {
                     Button(action: onDismissAttention) {
                         Image(systemName: "bell.slash")
@@ -755,6 +758,16 @@ struct AgentSessionRow: View {
         return isMCPControlledRoot ? "MCP controlled" : ""
     }
 
+    private func commandProgressIndicator(
+        for kind: AgentSidebarBulkActionKind
+    ) -> some View {
+        ProgressView()
+            .controlSize(.small)
+            .frame(width: 16, height: 16)
+            .allowsHitTesting(false)
+            .accessibilityLabel(kind.rowProgressAccessibilityLabel)
+    }
+
     private func waitingTooltip(
         for state: AgentSessionRunState,
         unseen: Bool
@@ -776,6 +789,7 @@ struct AgentStashedSessionRow: View {
     var isSelected = false
     var showsSelectionPresentation = false
     var isInteractionEnabled = true
+    var commandProgressKind: AgentSidebarBulkActionKind?
     let onSelectionGesture: (AgentSidebarSelectionGesture) -> AgentSidebarSelectionGestureDisposition
     let onRestore: () -> Void
     let onDelete: () -> Void
@@ -890,7 +904,13 @@ struct AgentStashedSessionRow: View {
 
             Spacer()
 
-            if isHovered, allowsDirectMutations {
+            if let commandProgressKind {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 16, height: 16)
+                    .allowsHitTesting(false)
+                    .accessibilityLabel(commandProgressKind.rowProgressAccessibilityLabel)
+            } else if isHovered, allowsDirectMutations {
                 Button(action: onRestore) {
                     Image(systemName: "tray.and.arrow.up")
                         .font(.system(size: 11))
@@ -952,6 +972,17 @@ struct AgentStashedSessionRow: View {
         .accessibilityLabel("\(stashed.tab.name), archived session")
         .accessibilityValue(isSelected ? "Selected" : "Not selected")
         .accessibilityAction(named: Text(isSelected ? "Deselect chat" : "Select chat"), toggleSelection)
+    }
+}
+
+private extension AgentSidebarBulkActionKind {
+    var rowProgressAccessibilityLabel: String {
+        switch self {
+        case .delete: "Deleting chat"
+        case .stash: "Stashing chat"
+        case .pin: "Pinning chat"
+        case .unpin: "Unpinning chat"
+        }
     }
 }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -515,7 +515,10 @@ struct AgentModeSessionsListView: View {
                                     isSelected: selectionState.selectedIdentities.contains(identity),
                                     showsSelectionPresentation: showsSelectionPresentation,
                                     isInteractionEnabled: isInteractionEnabled,
-                                    commandProgressKind: selectionState.commandRowProgressOperation(for: identity)?.kind,
+                                    commandProgressKind: selectionState.commandRowProgressOperation(
+                                        for: identity,
+                                        workspaceID: snapshot.workspaceID
+                                    )?.kind,
                                     onSelectionGesture: { gesture in
                                         agentModeVM.handleSidebarSelectionGesture(
                                             gesture,
@@ -727,31 +730,35 @@ struct AgentModeSessionsListView: View {
         operation: AgentSidebarBulkActionOperation
     ) -> some View {
         let selectedCount = selectionState.selectedIdentities.count
-        return ZStack(alignment: .topLeading) {
-            VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
-                HStack(spacing: 8) {
-                    Text("1 selected")
-                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
-                    Spacer(minLength: 8)
-                    Text("Select All")
-                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
-                    Text("Cancel")
-                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
-                }
-                HStack(spacing: bulkChipSpacing) {
-                    BulkActionChipLabel(systemImage: "trash", count: operation.targetCount)
-                }
+        return VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
+            HStack(spacing: 8) {
+                Text("1 selected")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
+                Spacer(minLength: 8)
+                Text("Select All")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                Text("Cancel")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
             }
-            .hidden()
-            .allowsHitTesting(false)
-            .accessibilityHidden(true)
-
+            HStack(spacing: bulkChipSpacing) {
+                BulkActionChipLabel(systemImage: "trash", count: operation.targetCount)
+            }
+        }
+        .hidden()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+        .overlay(alignment: .topLeading) {
             VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
                 if selectedCount > 0 {
                     Text("\(selectedCount) selected")
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
                         .foregroundStyle(.secondary)
                         .accessibilityAddTraits(.isHeader)
+                } else {
+                    Text("1 selected")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
+                        .hidden()
+                        .accessibilityHidden(true)
                 }
 
                 HStack(spacing: 6) {
@@ -759,6 +766,8 @@ struct AgentModeSessionsListView: View {
                     Text("\(operation.kind.rawValue.capitalized) \(operation.targetCount) \(operation.targetCount == 1 ? "chat" : "chats")…")
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                         .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                     Spacer(minLength: 0)
                 }
             }
@@ -1253,7 +1262,10 @@ struct ArchivedSessionsList: View {
                         isSelected: selectionState.selectedIdentities.contains(identity),
                         showsSelectionPresentation: selectionState.showsSelectionPresentation,
                         isInteractionEnabled: !selectionState.isMutationInFlight,
-                        commandProgressKind: selectionState.commandRowProgressOperation(for: identity)?.kind,
+                        commandProgressKind: selectionState.commandRowProgressOperation(
+                            for: identity,
+                            workspaceID: workspaceID
+                        )?.kind,
                         onSelectionGesture: { gesture in
                             agentModeVM.handleSidebarSelectionGesture(
                                 gesture,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -450,7 +450,8 @@ struct AgentModeSessionsListView: View {
             AgentSidebarSelectionIdentity.archived(stashedTabID: $0.id, tabID: $0.tab.id)
         } : [])
         let fallbackProgressOperation = selectionState.commandFallbackProgressOperation(
-            renderedOrder: renderedProgressRowIdentities,
+            existingIdentities: snapshot.existingSelectionIdentities,
+            renderedIdentities: Set(renderedProgressRowIdentities),
             workspaceID: snapshot.workspaceID
         )
         VStack(spacing: 4) {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -444,6 +444,10 @@ struct AgentModeSessionsListView: View {
         let archivedHeaderProgressOperation = selectionState.archivedHeaderCommandProgressOperation.flatMap {
             $0.workspaceID == snapshot.workspaceID ? $0 : nil
         }
+        let fallbackProgressOperation = selectionState.commandFallbackProgressOperation(
+            renderedOrder: snapshot.renderedSelectionOrder,
+            workspaceID: snapshot.workspaceID
+        )
         VStack(spacing: 4) {
             if showsSelectionPresentation {
                 if let operation = selectionState.inFlightAction {
@@ -701,6 +705,19 @@ struct AgentModeSessionsListView: View {
                     }
                 }
                 .padding(.horizontal, listHorizontalPadding)
+            }
+            .overlay(alignment: .topTrailing) {
+                if let fallbackProgressOperation {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 16, height: 16)
+                        .padding(6)
+                        .background(.regularMaterial, in: Circle())
+                        .padding(.top, 4)
+                        .padding(.trailing, listHorizontalPadding)
+                        .allowsHitTesting(false)
+                        .accessibilityLabel(fallbackProgressOperation.kind.rowProgressAccessibilityLabel)
+                }
             }
         }
         .id(snapshot.workspaceID)

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -715,10 +715,12 @@ struct AgentModeSessionsListView: View {
     ) -> some View {
         let selectedCount = selectionState.selectedIdentities.count
         return VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
-            Text("\(selectedCount) selected")
-                .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .accessibilityAddTraits(.isHeader)
+            if selectedCount > 0 {
+                Text("\(selectedCount) selected")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .accessibilityAddTraits(.isHeader)
+            }
 
             HStack(spacing: 6) {
                 ProgressView().controlSize(.small)

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -258,16 +258,13 @@ private struct AgentSidebarSelectionRenderIdentity: Equatable {
 /// Compact, evenly-sized pill used for the sidebar bulk-action row. Renders an
 /// SF Symbol plus the affected-chat count and matches the app's plain,
 /// `fontPreset`-scaled chip language rather than bordered system buttons.
-private struct BulkActionChip: View {
+private struct BulkActionChipLabel: View {
     let systemImage: String
-    let verb: String
     let count: Int
     var isDestructive = false
-    var tooltip: String?
-    let action: () -> Void
+    var isHovered = false
 
     @ObservedObject private var fontScale = FontScaleManager.shared
-    @State private var isHovered = false
     private var fontPreset: FontScalePreset {
         fontScale.preset
     }
@@ -300,26 +297,46 @@ private struct BulkActionChip: View {
         return isHovered ? Color(NSColor.labelColor) : .secondary
     }
 
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: systemImage)
+                .font(.system(size: iconSize, weight: .semibold))
+            Text("\(count)")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, horizontalPadding)
+        .padding(.vertical, verticalPadding)
+        .background(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous).fill(fillColor)
+        )
+        .foregroundStyle(foreground)
+        .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+}
+
+private struct BulkActionChip: View {
+    let systemImage: String
+    let verb: String
+    let count: Int
+    var isDestructive = false
+    var tooltip: String?
+    let action: () -> Void
+
+    @State private var isHovered = false
+
     private var accessibilityText: String {
         "\(verb) \(count) \(count == 1 ? "chat" : "chats")"
     }
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: 4) {
-                Image(systemName: systemImage)
-                    .font(.system(size: iconSize, weight: .semibold))
-                Text("\(count)")
-                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, horizontalPadding)
-            .padding(.vertical, verticalPadding)
-            .background(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous).fill(fillColor)
+            BulkActionChipLabel(
+                systemImage: systemImage,
+                count: count,
+                isDestructive: isDestructive,
+                isHovered: isHovered
             )
-            .foregroundStyle(foreground)
-            .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
@@ -424,10 +441,11 @@ struct AgentModeSessionsListView: View {
         let showsSelectionPresentation = selectionState.showsSelectionPresentation
         let isInteractionEnabled = !selectionState.isMutationInFlight
         let allowsDirectMutations = !showsSelectionPresentation && isInteractionEnabled
+        let archivedHeaderProgressOperation = selectionState.archivedHeaderCommandProgressOperation.flatMap {
+            $0.workspaceID == snapshot.workspaceID ? $0 : nil
+        }
         VStack(spacing: 4) {
-            if let operation = selectionState.commandProgressOperation {
-                commandProgress(operation)
-            } else if showsSelectionPresentation {
+            if showsSelectionPresentation {
                 if let operation = selectionState.inFlightAction {
                     inFlightBulkActionBar(selectionState: selectionState, operation: operation)
                 } else if let bulkTargets = agentModeVM.sidebarBulkMutationTargets(
@@ -458,6 +476,7 @@ struct AgentModeSessionsListView: View {
 
                         ForEach(section.groups) { group in
                             ForEach(group.rows, id: \.id) { session in
+                                let identity = AgentSidebarSelectionIdentity.active(tabID: session.tabID)
                                 let hasAgentSession = session.sessionID != nil
                                 let runState: AgentSessionRunState = hasAgentSession
                                     ? agentModeVM.runState(for: session.tabID)
@@ -493,13 +512,14 @@ struct AgentModeSessionsListView: View {
                                     hiddenThreadDescendantCount: session.hiddenThreadDescendantCount,
                                     hiddenThreadDescendantAttentionCount: session.hiddenThreadDescendantAttentionCount,
                                     onToggleThreadCollapse: toggleThreadAction,
-                                    isSelected: selectionState.selectedIdentities.contains(.active(tabID: session.tabID)),
+                                    isSelected: selectionState.selectedIdentities.contains(identity),
                                     showsSelectionPresentation: showsSelectionPresentation,
                                     isInteractionEnabled: isInteractionEnabled,
+                                    commandProgressKind: selectionState.commandRowProgressOperation(for: identity)?.kind,
                                     onSelectionGesture: { gesture in
                                         agentModeVM.handleSidebarSelectionGesture(
                                             gesture,
-                                            identity: .active(tabID: session.tabID),
+                                            identity: identity,
                                             renderedOrder: snapshot.renderedSelectionOrder,
                                             workspaceID: snapshot.workspaceID
                                         )
@@ -558,11 +578,13 @@ struct AgentModeSessionsListView: View {
                         .foregroundColor(.accentColor)
                     }
 
-                    if !snapshot.archivedSessionTabsForHeader.isEmpty {
+                    if !snapshot.archivedSessionTabsForHeader.isEmpty || archivedHeaderProgressOperation != nil {
                         Divider()
                             .padding(.vertical, dividerVerticalPadding)
 
                         VStack(spacing: listRowSpacing) {
+                            let archivedCount = archivedHeaderProgressOperation?.targetCount
+                                ?? snapshot.archivedSessionTabsForHeader.count
                             HStack(spacing: archivedHeaderSpacing) {
                                 Button {
                                     withAnimation(.easeInOut(duration: 0.15)) {
@@ -581,7 +603,7 @@ struct AgentModeSessionsListView: View {
                                         Text("Archived Sessions")
                                             .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
                                             .foregroundStyle(.secondary)
-                                        Text("\(snapshot.archivedSessionTabsForHeader.count)")
+                                        Text("\(archivedCount)")
                                             .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                                             .foregroundStyle(.tertiary)
                                         Spacer()
@@ -590,52 +612,69 @@ struct AgentModeSessionsListView: View {
                                 }
                                 .buttonStyle(.plain)
 
-                                Button("Clear…") {
-                                    showingClearArchivedConfirmation = true
-                                }
-                                .buttonStyle(.plain)
-                                .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
-                                .foregroundStyle(.tertiary)
-                                .disabled(!allowsDirectMutations)
-                                .popover(isPresented: $showingClearArchivedConfirmation, arrowEdge: .bottom) {
-                                    VStack(alignment: .leading, spacing: 12) {
-                                        Text("Clear archived sessions?")
-                                            .font(.headline)
-                                        Text("This permanently deletes \(snapshot.archivedSessionTabsForHeader.count) archived sessions. Related active and archived sub-agent chats may also be deleted.")
-                                            .font(.subheadline)
-                                            .foregroundStyle(.secondary)
-                                        HStack {
-                                            Spacer()
-                                            Button("Cancel") {
-                                                showingClearArchivedConfirmation = false
-                                            }
-                                            Button("Clear") {
-                                                showingClearArchivedConfirmation = false
-                                                guard let workspaceID = snapshot.workspaceID,
-                                                      agentModeVM.canPerformDirectSidebarCommand(workspaceID: workspaceID)
-                                                else { return }
-                                                let archivedTargets = Set(snapshot.archivedSessionTabsForHeader.map {
-                                                    PromptViewModel.ArchivedTabMutationTarget(
-                                                        stashedTabID: $0.id,
-                                                        tabID: $0.tab.id
-                                                    )
-                                                })
-                                                guard !archivedTargets.isEmpty else { return }
-                                                performBulkAction(.delete, origin: .command, targets: .init(
-                                                    workspaceID: workspaceID,
-                                                    activeDeleteTabIDs: [],
-                                                    archivedDeleteTargets: archivedTargets,
-                                                    stashTabIDs: [],
-                                                    pinTabIDs: [],
-                                                    unpinTabIDs: []
-                                                ))
-                                            }
-                                            .keyboardShortcut(.defaultAction)
-                                            .disabled(!allowsDirectMutations)
-                                        }
+                                if archivedHeaderProgressOperation != nil {
+                                    HStack(spacing: 5) {
+                                        ProgressView().controlSize(.small)
+                                        Text("Clearing…")
+                                            .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
                                     }
-                                    .padding()
-                                    .frame(width: 300)
+                                    .foregroundStyle(.tertiary)
+                                    .allowsHitTesting(false)
+                                    .accessibilityElement(children: .ignore)
+                                    .accessibilityLabel("Clearing archived sessions")
+                                } else {
+                                    Button("Clear…") {
+                                        showingClearArchivedConfirmation = true
+                                    }
+                                    .buttonStyle(.plain)
+                                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                                    .foregroundStyle(.tertiary)
+                                    .disabled(!allowsDirectMutations)
+                                    .popover(isPresented: $showingClearArchivedConfirmation, arrowEdge: .bottom) {
+                                        VStack(alignment: .leading, spacing: 12) {
+                                            Text("Clear archived sessions?")
+                                                .font(.headline)
+                                            Text("This permanently deletes \(snapshot.archivedSessionTabsForHeader.count) archived sessions. Related active and archived sub-agent chats may also be deleted.")
+                                                .font(.subheadline)
+                                                .foregroundStyle(.secondary)
+                                            HStack {
+                                                Spacer()
+                                                Button("Cancel") {
+                                                    showingClearArchivedConfirmation = false
+                                                }
+                                                Button("Clear") {
+                                                    showingClearArchivedConfirmation = false
+                                                    guard let workspaceID = snapshot.workspaceID,
+                                                          agentModeVM.canPerformDirectSidebarCommand(workspaceID: workspaceID)
+                                                    else { return }
+                                                    let archivedTargets = Set(snapshot.archivedSessionTabsForHeader.map {
+                                                        PromptViewModel.ArchivedTabMutationTarget(
+                                                            stashedTabID: $0.id,
+                                                            tabID: $0.tab.id
+                                                        )
+                                                    })
+                                                    guard !archivedTargets.isEmpty else { return }
+                                                    performBulkAction(
+                                                        .delete,
+                                                        origin: .command,
+                                                        commandProgressPlacement: .archivedHeader,
+                                                        targets: .init(
+                                                            workspaceID: workspaceID,
+                                                            activeDeleteTabIDs: [],
+                                                            archivedDeleteTargets: archivedTargets,
+                                                            stashTabIDs: [],
+                                                            pinTabIDs: [],
+                                                            unpinTabIDs: []
+                                                        )
+                                                    )
+                                                }
+                                                .keyboardShortcut(.defaultAction)
+                                                .disabled(!allowsDirectMutations)
+                                            }
+                                        }
+                                        .padding()
+                                        .frame(width: 300)
+                                    }
                                 }
                             }
                             .padding(.horizontal, archivedHeaderHorizontalPadding)
@@ -683,52 +722,47 @@ struct AgentModeSessionsListView: View {
         }
     }
 
-    private func commandProgress(_ operation: AgentSidebarBulkActionOperation) -> some View {
-        let verb = switch operation.kind {
-        case .delete: "Deleting"
-        case .stash: "Stashing"
-        case .pin: "Pinning"
-        case .unpin: "Unpinning"
-        }
-        let message = operation.targetCount == 1
-            ? "\(verb) chat…"
-            : "\(verb) \(operation.targetCount) chats…"
-        let accessibilityLabel = operation.targetCount == 1
-            ? "\(verb) chat"
-            : "\(verb) \(operation.targetCount) chats"
-        return HStack(spacing: 6) {
-            ProgressView().controlSize(.small)
-            Text(message)
-                .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
-            Spacer(minLength: 0)
-        }
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, listHorizontalPadding)
-        .padding(.top, 4)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
-    }
-
     private func inFlightBulkActionBar(
         selectionState: AgentSidebarSelectionState,
         operation: AgentSidebarBulkActionOperation
     ) -> some View {
         let selectedCount = selectionState.selectedIdentities.count
-        return VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
-            if selectedCount > 0 {
-                Text("\(selectedCount) selected")
-                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .accessibilityAddTraits(.isHeader)
+        return ZStack(alignment: .topLeading) {
+            VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
+                HStack(spacing: 8) {
+                    Text("1 selected")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
+                    Spacer(minLength: 8)
+                    Text("Select All")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                    Text("Cancel")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                }
+                HStack(spacing: bulkChipSpacing) {
+                    BulkActionChipLabel(systemImage: "trash", count: operation.targetCount)
+                }
             }
+            .hidden()
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
 
-            HStack(spacing: 6) {
-                ProgressView().controlSize(.small)
-                Text("\(operation.kind.rawValue.capitalized) \(operation.targetCount) \(operation.targetCount == 1 ? "chat" : "chats")…")
-                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
-                    .foregroundStyle(.secondary)
-                Spacer(minLength: 0)
+            VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
+                if selectedCount > 0 {
+                    Text("\(selectedCount) selected")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .accessibilityAddTraits(.isHeader)
+                }
+
+                HStack(spacing: 6) {
+                    ProgressView().controlSize(.small)
+                    Text("\(operation.kind.rawValue.capitalized) \(operation.targetCount) \(operation.targetCount == 1 ? "chat" : "chats")…")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 0)
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, bulkBarInnerHorizontalPadding)
         .padding(.vertical, bulkBarInnerVerticalPadding)
@@ -776,12 +810,12 @@ struct AgentModeSessionsListView: View {
             HStack(spacing: bulkChipSpacing) {
                 if !targets.pinTabIDs.isEmpty {
                     BulkActionChip(systemImage: "pin", verb: "Pin", count: targets.pinTabIDs.count) {
-                        performBulkAction(.pin, origin: .selection, targets: targets)
+                        performBulkAction(.pin, origin: .selection, commandProgressPlacement: nil, targets: targets)
                     }
                 }
                 if !targets.unpinTabIDs.isEmpty {
                     BulkActionChip(systemImage: "pin.slash", verb: "Unpin", count: targets.unpinTabIDs.count) {
-                        performBulkAction(.unpin, origin: .selection, targets: targets)
+                        performBulkAction(.unpin, origin: .selection, commandProgressPlacement: nil, targets: targets)
                     }
                 }
                 if !targets.stashTabIDs.isEmpty {
@@ -791,7 +825,7 @@ struct AgentModeSessionsListView: View {
                         count: targets.stashTabIDs.count,
                         tooltip: "Stash — related sub-agent chats may also be stashed"
                     ) {
-                        performBulkAction(.stash, origin: .selection, targets: targets)
+                        performBulkAction(.stash, origin: .selection, commandProgressPlacement: nil, targets: targets)
                     }
                 }
                 BulkActionChip(
@@ -837,7 +871,7 @@ struct AgentModeSessionsListView: View {
                     .keyboardShortcut(.cancelAction)
                 Button("Delete", role: .destructive) {
                     showingBulkDeleteConfirmation = false
-                    performBulkAction(.delete, origin: .selection, targets: targets)
+                    performBulkAction(.delete, origin: .selection, commandProgressPlacement: nil, targets: targets)
                 }
             }
         }
@@ -879,7 +913,7 @@ struct AgentModeSessionsListView: View {
         workspaceID: UUID?
     ) {
         guard let workspaceID else { return }
-        performBulkAction(action, origin: .command, targets: .init(
+        performBulkAction(action, origin: .command, commandProgressPlacement: .row, targets: .init(
             workspaceID: workspaceID,
             activeDeleteTabIDs: action == .delete ? [tabID] : [],
             archivedDeleteTargets: [],
@@ -892,12 +926,14 @@ struct AgentModeSessionsListView: View {
     private func performBulkAction(
         _ action: AgentSidebarBulkActionKind,
         origin: AgentSidebarBulkActionOrigin,
+        commandProgressPlacement: AgentSidebarCommandProgressPlacement?,
         targets: AgentModeViewModel.SidebarBulkMutationTargets
     ) {
         Task {
             await agentModeVM.performSidebarBulkAction(
                 action,
                 origin: origin,
+                commandProgressPlacement: commandProgressPlacement,
                 targets: targets,
                 promptManager: promptManager
             )
@@ -1190,6 +1226,7 @@ struct ArchivedSessionsList: View {
             await agentModeVM.performSidebarBulkAction(
                 .delete,
                 origin: .command,
+                commandProgressPlacement: .row,
                 targets: targets,
                 promptManager: promptManager
             )
@@ -1216,6 +1253,7 @@ struct ArchivedSessionsList: View {
                         isSelected: selectionState.selectedIdentities.contains(identity),
                         showsSelectionPresentation: selectionState.showsSelectionPresentation,
                         isInteractionEnabled: !selectionState.isMutationInFlight,
+                        commandProgressKind: selectionState.commandRowProgressOperation(for: identity)?.kind,
                         onSelectionGesture: { gesture in
                             agentModeVM.handleSidebarSelectionGesture(
                                 gesture,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -421,9 +421,16 @@ struct AgentModeSessionsListView: View {
         let activeSections = AgentSidebarDateSectionBuilder.activeSections(for: snapshot.pagedSessions)
         let firstActiveSectionID = activeSections.first?.id
         let selectionState = sidebarUI.selectionState
+        let showsSelectionPresentation = selectionState.showsSelectionPresentation
+        let isInteractionEnabled = !selectionState.isMutationInFlight
+        let allowsDirectMutations = !showsSelectionPresentation && isInteractionEnabled
         VStack(spacing: 4) {
-            if selectionState.isSelectionMode {
-                if let bulkTargets = agentModeVM.sidebarBulkMutationTargets(
+            if let operation = selectionState.commandProgressOperation {
+                commandProgress(operation)
+            } else if showsSelectionPresentation {
+                if let operation = selectionState.inFlightAction {
+                    inFlightBulkActionBar(selectionState: selectionState, operation: operation)
+                } else if let bulkTargets = agentModeVM.sidebarBulkMutationTargets(
                     selection: selectionState.selectedIdentities,
                     selectionWorkspaceID: selectionState.workspaceID,
                     projection: snapshot,
@@ -487,8 +494,8 @@ struct AgentModeSessionsListView: View {
                                     hiddenThreadDescendantAttentionCount: session.hiddenThreadDescendantAttentionCount,
                                     onToggleThreadCollapse: toggleThreadAction,
                                     isSelected: selectionState.selectedIdentities.contains(.active(tabID: session.tabID)),
-                                    isSelectionMode: selectionState.isSelectionMode,
-                                    isSelectionEnabled: selectionState.inFlightAction == nil,
+                                    showsSelectionPresentation: showsSelectionPresentation,
+                                    isInteractionEnabled: isInteractionEnabled,
                                     onSelectionGesture: { gesture in
                                         agentModeVM.handleSidebarSelectionGesture(
                                             gesture,
@@ -512,6 +519,9 @@ struct AgentModeSessionsListView: View {
                                     },
                                     onStash: stashAction,
                                     onDelete: {
+                                        guard let workspaceID = snapshot.workspaceID,
+                                              agentModeVM.canPerformDirectSidebarCommand(workspaceID: workspaceID)
+                                        else { return }
                                         #if DEBUG
                                             agentModeVM.debugBeginSidebarDeleteRequest(
                                                 tabID: session.tabID,
@@ -519,10 +529,12 @@ struct AgentModeSessionsListView: View {
                                                 reason: "row_delete_confirmation"
                                             )
                                         #endif
-                                        performSingleActiveBulkAction(.delete, tabID: session.tabID, workspaceID: snapshot.workspaceID)
+                                        performSingleActiveBulkAction(.delete, tabID: session.tabID, workspaceID: workspaceID)
                                     },
                                     onRename: { newName in
-                                        guard agentModeVM.workspaceManager?.activeWorkspaceID == snapshot.workspaceID else { return }
+                                        guard let workspaceID = snapshot.workspaceID,
+                                              agentModeVM.canPerformDirectSidebarCommand(workspaceID: workspaceID)
+                                        else { return }
                                         agentModeVM.renameSession(tabID: session.tabID, to: newName)
                                     },
                                     onDismissAttention: dismissAttentionAction,
@@ -584,7 +596,7 @@ struct AgentModeSessionsListView: View {
                                 .buttonStyle(.plain)
                                 .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
                                 .foregroundStyle(.tertiary)
-                                .disabled(selectionState.isSelectionMode)
+                                .disabled(!allowsDirectMutations)
                                 .popover(isPresented: $showingClearArchivedConfirmation, arrowEdge: .bottom) {
                                     VStack(alignment: .leading, spacing: 12) {
                                         Text("Clear archived sessions?")
@@ -599,14 +611,17 @@ struct AgentModeSessionsListView: View {
                                             }
                                             Button("Clear") {
                                                 showingClearArchivedConfirmation = false
-                                                guard let workspaceID = snapshot.workspaceID else { return }
+                                                guard let workspaceID = snapshot.workspaceID,
+                                                      agentModeVM.canPerformDirectSidebarCommand(workspaceID: workspaceID)
+                                                else { return }
                                                 let archivedTargets = Set(snapshot.archivedSessionTabsForHeader.map {
                                                     PromptViewModel.ArchivedTabMutationTarget(
                                                         stashedTabID: $0.id,
                                                         tabID: $0.tab.id
                                                     )
                                                 })
-                                                performBulkAction(.delete, targets: .init(
+                                                guard !archivedTargets.isEmpty else { return }
+                                                performBulkAction(.delete, origin: .command, targets: .init(
                                                     workspaceID: workspaceID,
                                                     activeDeleteTabIDs: [],
                                                     archivedDeleteTargets: archivedTargets,
@@ -616,6 +631,7 @@ struct AgentModeSessionsListView: View {
                                                 ))
                                             }
                                             .keyboardShortcut(.defaultAction)
+                                            .disabled(!allowsDirectMutations)
                                         }
                                     }
                                     .padding()
@@ -650,6 +666,11 @@ struct AgentModeSessionsListView: View {
             showingClearArchivedConfirmation = false
             showingBulkDeleteConfirmation = false
         }
+        .task(id: selectionState.inFlightAction?.token) {
+            guard selectionState.inFlightAction != nil else { return }
+            showingClearArchivedConfirmation = false
+            showingBulkDeleteConfirmation = false
+        }
         .task(id: defaultCollapseSeedKeys) {
             agentModeVM.seedDefaultCollapsedSidebarThreads(defaultCollapseSeedKeys)
         }
@@ -662,6 +683,65 @@ struct AgentModeSessionsListView: View {
         }
     }
 
+    private func commandProgress(_ operation: AgentSidebarBulkActionOperation) -> some View {
+        let verb = switch operation.kind {
+        case .delete: "Deleting"
+        case .stash: "Stashing"
+        case .pin: "Pinning"
+        case .unpin: "Unpinning"
+        }
+        let message = operation.targetCount == 1
+            ? "\(verb) chat…"
+            : "\(verb) \(operation.targetCount) chats…"
+        let accessibilityLabel = operation.targetCount == 1
+            ? "\(verb) chat"
+            : "\(verb) \(operation.targetCount) chats"
+        return HStack(spacing: 6) {
+            ProgressView().controlSize(.small)
+            Text(message)
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, listHorizontalPadding)
+        .padding(.top, 4)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private func inFlightBulkActionBar(
+        selectionState: AgentSidebarSelectionState,
+        operation: AgentSidebarBulkActionOperation
+    ) -> some View {
+        let selectedCount = selectionState.selectedIdentities.count
+        return VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
+            Text("\(selectedCount) selected")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .accessibilityAddTraits(.isHeader)
+
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("\(operation.kind.rawValue.capitalized) \(operation.targetCount) \(operation.targetCount == 1 ? "chat" : "chats")…")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.horizontal, bulkBarInnerHorizontalPadding)
+        .padding(.vertical, bulkBarInnerVerticalPadding)
+        .background(
+            RoundedRectangle(cornerRadius: bulkBarCornerRadius, style: .continuous)
+                .fill(Color(NSColor.systemGray).opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: bulkBarCornerRadius, style: .continuous)
+                        .stroke(Color(NSColor.systemGray).opacity(0.3), lineWidth: 0.5)
+                )
+        )
+        .padding(.horizontal, listHorizontalPadding)
+        .padding(.top, 4)
+    }
+
     private func bulkActionBar(
         selectionState: AgentSidebarSelectionState,
         targets: AgentModeViewModel.SidebarBulkMutationTargets,
@@ -669,8 +749,7 @@ struct AgentModeSessionsListView: View {
     ) -> some View {
         let selectedCount = selectionState.selectedIdentities.count
         let deleteCount = targets.activeDeleteTabIDs.count + targets.archivedDeleteTargets.count
-        let isBusy = selectionState.inFlightAction != nil
-        let canSelectAll = !isBusy && selectedCount != renderedOrder.count
+        let canSelectAll = selectedCount != renderedOrder.count
         return VStack(alignment: .leading, spacing: bulkBarRowSpacing) {
             HStack(spacing: 8) {
                 Text("\(selectedCount) selected")
@@ -688,52 +767,41 @@ struct AgentModeSessionsListView: View {
                 Button("Cancel") { sidebarUI.clearSelection() }
                     .buttonStyle(.plain)
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
-                    .foregroundStyle(isBusy ? Color.secondary.opacity(0.5) : .secondary)
+                    .foregroundStyle(.secondary)
                     .keyboardShortcut(.cancelAction)
-                    .disabled(isBusy)
             }
 
-            if let operation = selectionState.inFlightAction {
-                HStack(spacing: 6) {
-                    ProgressView().controlSize(.small)
-                    Text("\(operation.kind.rawValue.capitalized) \(operation.targetCount) chats…")
-                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
-                        .foregroundStyle(.secondary)
-                    Spacer(minLength: 0)
+            HStack(spacing: bulkChipSpacing) {
+                if !targets.pinTabIDs.isEmpty {
+                    BulkActionChip(systemImage: "pin", verb: "Pin", count: targets.pinTabIDs.count) {
+                        performBulkAction(.pin, origin: .selection, targets: targets)
+                    }
                 }
-            } else {
-                HStack(spacing: bulkChipSpacing) {
-                    if !targets.pinTabIDs.isEmpty {
-                        BulkActionChip(systemImage: "pin", verb: "Pin", count: targets.pinTabIDs.count) {
-                            performBulkAction(.pin, targets: targets)
-                        }
+                if !targets.unpinTabIDs.isEmpty {
+                    BulkActionChip(systemImage: "pin.slash", verb: "Unpin", count: targets.unpinTabIDs.count) {
+                        performBulkAction(.unpin, origin: .selection, targets: targets)
                     }
-                    if !targets.unpinTabIDs.isEmpty {
-                        BulkActionChip(systemImage: "pin.slash", verb: "Unpin", count: targets.unpinTabIDs.count) {
-                            performBulkAction(.unpin, targets: targets)
-                        }
-                    }
-                    if !targets.stashTabIDs.isEmpty {
-                        BulkActionChip(
-                            systemImage: "tray.and.arrow.down",
-                            verb: "Stash",
-                            count: targets.stashTabIDs.count,
-                            tooltip: "Stash — related sub-agent chats may also be stashed"
-                        ) {
-                            performBulkAction(.stash, targets: targets)
-                        }
-                    }
+                }
+                if !targets.stashTabIDs.isEmpty {
                     BulkActionChip(
-                        systemImage: "trash",
-                        verb: "Delete",
-                        count: deleteCount,
-                        isDestructive: true
+                        systemImage: "tray.and.arrow.down",
+                        verb: "Stash",
+                        count: targets.stashTabIDs.count,
+                        tooltip: "Stash — related sub-agent chats may also be stashed"
                     ) {
-                        showingBulkDeleteConfirmation = true
+                        performBulkAction(.stash, origin: .selection, targets: targets)
                     }
-                    .popover(isPresented: $showingBulkDeleteConfirmation, arrowEdge: .bottom) {
-                        bulkDeleteConfirmation(targets: targets)
-                    }
+                }
+                BulkActionChip(
+                    systemImage: "trash",
+                    verb: "Delete",
+                    count: deleteCount,
+                    isDestructive: true
+                ) {
+                    showingBulkDeleteConfirmation = true
+                }
+                .popover(isPresented: $showingBulkDeleteConfirmation, arrowEdge: .bottom) {
+                    bulkDeleteConfirmation(targets: targets)
                 }
             }
 
@@ -767,7 +835,7 @@ struct AgentModeSessionsListView: View {
                     .keyboardShortcut(.cancelAction)
                 Button("Delete", role: .destructive) {
                     showingBulkDeleteConfirmation = false
-                    performBulkAction(.delete, targets: targets)
+                    performBulkAction(.delete, origin: .selection, targets: targets)
                 }
             }
         }
@@ -798,7 +866,7 @@ struct AgentModeSessionsListView: View {
             Button { sidebarUI.dismissBulkActionNotice() } label: { Image(systemName: "xmark") }
                 .buttonStyle(.plain)
                 .font(.system(size: fontPreset.scaledClamped(10, max: 13)))
-                .accessibilityLabel("Dismiss bulk action notice")
+                .accessibilityLabel("Dismiss action notice")
         }
         .foregroundStyle(presentation.color)
     }
@@ -809,7 +877,7 @@ struct AgentModeSessionsListView: View {
         workspaceID: UUID?
     ) {
         guard let workspaceID else { return }
-        performBulkAction(action, targets: .init(
+        performBulkAction(action, origin: .command, targets: .init(
             workspaceID: workspaceID,
             activeDeleteTabIDs: action == .delete ? [tabID] : [],
             archivedDeleteTargets: [],
@@ -821,11 +889,13 @@ struct AgentModeSessionsListView: View {
 
     private func performBulkAction(
         _ action: AgentSidebarBulkActionKind,
+        origin: AgentSidebarBulkActionOrigin,
         targets: AgentModeViewModel.SidebarBulkMutationTargets
     ) {
         Task {
             await agentModeVM.performSidebarBulkAction(
                 action,
+                origin: origin,
                 targets: targets,
                 promptManager: promptManager
             )
@@ -1099,7 +1169,9 @@ struct ArchivedSessionsList: View {
     }
 
     private func deleteArchived(_ stashed: StashedTab) {
-        guard let workspaceID else { return }
+        guard let workspaceID,
+              agentModeVM.canPerformDirectSidebarCommand(workspaceID: workspaceID)
+        else { return }
         let target = PromptViewModel.ArchivedTabMutationTarget(
             stashedTabID: stashed.id,
             tabID: stashed.tab.id
@@ -1113,7 +1185,12 @@ struct ArchivedSessionsList: View {
             unpinTabIDs: []
         )
         Task {
-            await agentModeVM.performSidebarBulkAction(.delete, targets: targets, promptManager: promptManager)
+            await agentModeVM.performSidebarBulkAction(
+                .delete,
+                origin: .command,
+                targets: targets,
+                promptManager: promptManager
+            )
         }
     }
 
@@ -1135,8 +1212,8 @@ struct ArchivedSessionsList: View {
                     AgentStashedSessionRow(
                         stashed: stashed,
                         isSelected: selectionState.selectedIdentities.contains(identity),
-                        isSelectionMode: selectionState.isSelectionMode,
-                        isSelectionEnabled: selectionState.inFlightAction == nil,
+                        showsSelectionPresentation: selectionState.showsSelectionPresentation,
+                        isInteractionEnabled: !selectionState.isMutationInFlight,
                         onSelectionGesture: { gesture in
                             agentModeVM.handleSidebarSelectionGesture(
                                 gesture,
@@ -1147,7 +1224,9 @@ struct ArchivedSessionsList: View {
                         },
                         onRestore: {
                             Task {
-                                guard agentModeVM.workspaceManager?.activeWorkspaceID == workspaceID else { return }
+                                guard let workspaceID,
+                                      agentModeVM.canPerformDirectSidebarCommand(workspaceID: workspaceID)
+                                else { return }
                                 await promptManager.unstashTab(stashed.id)
                             }
                         },

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -444,8 +444,13 @@ struct AgentModeSessionsListView: View {
         let archivedHeaderProgressOperation = selectionState.archivedHeaderCommandProgressOperation.flatMap {
             $0.workspaceID == snapshot.workspaceID ? $0 : nil
         }
+        let renderedProgressRowIdentities = snapshot.pagedSessions.map {
+            AgentSidebarSelectionIdentity.active(tabID: $0.tabID)
+        } + (archivedSessionsExpanded ? snapshot.pagedArchivedSessionTabsForRows.map {
+            AgentSidebarSelectionIdentity.archived(stashedTabID: $0.id, tabID: $0.tab.id)
+        } : [])
         let fallbackProgressOperation = selectionState.commandFallbackProgressOperation(
-            renderedOrder: snapshot.renderedSelectionOrder,
+            renderedOrder: renderedProgressRowIdentities,
             workspaceID: snapshot.workspaceID
         )
         VStack(spacing: 4) {

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -248,6 +248,7 @@ class PromptViewModel: ObservableObject {
     }
 
     typealias ComposeTabsWillCloseListener = @Sendable (_ tabIDs: Set<UUID>, _ reason: ComposeTabRemovalReason) async -> Void
+    typealias ComposeTabsProjectionRemovalCallback = @MainActor (_ actualRemovedTabIDs: Set<UUID>) -> Void
     typealias ComposeTabsDidRemoveListener = @MainActor @Sendable (
         _ tabIDs: Set<UUID>,
         _ reason: ComposeTabRemovalReason,
@@ -2964,7 +2965,8 @@ class PromptViewModel: ObservableObject {
     func deleteComposeAndStashedTabs(
         composeTabIDs: Set<UUID>,
         archivedTargets: Set<ArchivedTabMutationTarget>,
-        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil,
+        onProjectionRemovalCommitted: ComposeTabsProjectionRemovalCallback? = nil
     ) async -> ComposeTabMutationReport {
         guard !composeTabIDs.isEmpty || !archivedTargets.isEmpty else {
             return ComposeTabMutationReport(noOpReasons: [.close, .deleteStashed])
@@ -3089,14 +3091,16 @@ class PromptViewModel: ObservableObject {
                 withIDs: resolvedComposeTabIDs,
                 expandCascade: false,
                 isMutationContextCurrent: mutationContextIsCurrent,
-                postPreflightValidation: cascadeIsCurrentAfterPreflight
+                postPreflightValidation: cascadeIsCurrentAfterPreflight,
+                onProjectionRemovalCommitted: onProjectionRemovalCommitted
             ))
         }
         if !allArchivedTargets.isEmpty, report.rejections.isEmpty {
             if mutationContextIsCurrent() {
                 await report.merge(deleteResolvedStashedTabs(
                     targets: allArchivedTargets,
-                    isMutationContextCurrent: mutationContextIsCurrent
+                    isMutationContextCurrent: mutationContextIsCurrent,
+                    onProjectionRemovalCommitted: onProjectionRemovalCommitted
                 ))
             } else {
                 report.rejections.append(ComposeTabMutationRejection(
@@ -3113,12 +3117,14 @@ class PromptViewModel: ObservableObject {
     @MainActor
     func stashComposeTabs(
         withIDs ids: Set<UUID>,
-        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil,
+        onProjectionRemovalCommitted: ComposeTabsProjectionRemovalCallback? = nil
     ) async -> ComposeTabMutationReport {
         await removeComposeTabs(
             withIDs: ids,
             reason: .stash,
-            isMutationContextCurrent: isMutationContextCurrent
+            isMutationContextCurrent: isMutationContextCurrent,
+            onProjectionRemovalCommitted: onProjectionRemovalCommitted
         )
     }
 
@@ -3171,7 +3177,8 @@ class PromptViewModel: ObservableObject {
         reason: ComposeTabRemovalReason = .close,
         expandCascade: Bool = true,
         isMutationContextCurrent: (@MainActor () -> Bool)? = nil,
-        postPreflightValidation: (@MainActor () -> Bool)? = nil
+        postPreflightValidation: (@MainActor () -> Bool)? = nil,
+        onProjectionRemovalCommitted: ComposeTabsProjectionRemovalCallback? = nil
     ) async -> ComposeTabMutationReport {
         guard !ids.isEmpty else {
             return ComposeTabMutationReport(noOpReasons: [reason])
@@ -3262,7 +3269,8 @@ class PromptViewModel: ObservableObject {
             if reason == .close, expandCascade, !archivedTargetsToDelete.isEmpty {
                 await report.merge(deleteResolvedStashedTabs(
                     targets: archivedTargetsToDelete,
-                    isMutationContextCurrent: mutationContextIsCurrent
+                    isMutationContextCurrent: mutationContextIsCurrent,
+                    onProjectionRemovalCommitted: onProjectionRemovalCommitted
                 ))
             }
             return report
@@ -3359,7 +3367,8 @@ class PromptViewModel: ObservableObject {
             if reason == .close, expandCascade, !archivedTargetsToDelete.isEmpty {
                 await report.merge(deleteResolvedStashedTabs(
                     targets: archivedTargetsToDelete,
-                    isMutationContextCurrent: mutationContextIsCurrent
+                    isMutationContextCurrent: mutationContextIsCurrent,
+                    onProjectionRemovalCommitted: onProjectionRemovalCommitted
                 ))
             }
             return report
@@ -3374,6 +3383,7 @@ class PromptViewModel: ObservableObject {
         if tabs.isEmpty {
             await appendReplacementBlankComposeTabIfNeeded(manager: manager, workspaceIndex: index)
             loadComposeTabsFromWorkspace(manager.workspaces[index])
+            onProjectionRemovalCommitted?(tabsBeingClosed)
             #if DEBUG
                 for tabID in tabsBeingClosed {
                     AgentModePerfDiagnostics.markSidebarDeleteVisibleRemoved(
@@ -3393,7 +3403,8 @@ class PromptViewModel: ObservableObject {
             if reason == .close, expandCascade, !archivedTargetsToDelete.isEmpty {
                 await report.merge(deleteResolvedStashedTabs(
                     targets: archivedTargetsToDelete,
-                    isMutationContextCurrent: mutationContextIsCurrent
+                    isMutationContextCurrent: mutationContextIsCurrent,
+                    onProjectionRemovalCommitted: onProjectionRemovalCommitted
                 ))
             }
             return report
@@ -3429,6 +3440,7 @@ class PromptViewModel: ObservableObject {
         }
 
         loadComposeTabsFromWorkspace(manager.workspaces[index])
+        onProjectionRemovalCommitted?(tabsBeingClosed)
         #if DEBUG
             for tabID in tabsBeingClosed {
                 AgentModePerfDiagnostics.markSidebarDeleteVisibleRemoved(
@@ -3448,7 +3460,8 @@ class PromptViewModel: ObservableObject {
         if reason == .close, expandCascade, !archivedTargetsToDelete.isEmpty {
             await report.merge(deleteResolvedStashedTabs(
                 targets: archivedTargetsToDelete,
-                isMutationContextCurrent: mutationContextIsCurrent
+                isMutationContextCurrent: mutationContextIsCurrent,
+                onProjectionRemovalCommitted: onProjectionRemovalCommitted
             ))
         }
         return report
@@ -3686,7 +3699,8 @@ class PromptViewModel: ObservableObject {
     @MainActor
     private func deleteResolvedStashedTabs(
         targets: Set<ArchivedTabMutationTarget>,
-        isMutationContextCurrent: (@MainActor () -> Bool)?
+        isMutationContextCurrent: (@MainActor () -> Bool)?,
+        onProjectionRemovalCommitted: ComposeTabsProjectionRemovalCallback? = nil
     ) async -> ComposeTabMutationReport {
         guard !targets.isEmpty else {
             return ComposeTabMutationReport(noOpReasons: [.deleteStashed])
@@ -3777,6 +3791,7 @@ class PromptViewModel: ObservableObject {
         }
         manager.workspaces[index].stashedTabs = freshStashedTabs.filter { !stashedTabIDs.contains($0.id) }
         loadComposeTabsFromWorkspace(manager.workspaces[index])
+        onProjectionRemovalCommitted?(tabIDs)
         manager.markWorkspaceDirty()
         manager.pollAndSaveState()
         report.removedStashedTabIDs.formUnion(stashedTabsToDelete.map(\.id))

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -821,6 +821,77 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertEqual(searched.renderedSelectionOrder.count, 25)
     }
 
+    func testSidebarProjectionTracksExistingIdentitiesIndependentlyFromRenderedRows() {
+        let viewModel = makeViewModel()
+        let visibleTab = ComposeTabState(id: UUID(), name: "Visible", activeAgentSessionID: UUID())
+        let sessionlessTab = ComposeTabState(id: UUID(), name: "Hidden")
+        let archivedSessionID = UUID()
+        let stashedTab = StashedTab(tab: ComposeTabState(
+            id: UUID(),
+            name: "Archived",
+            activeAgentSessionID: archivedSessionID
+        ))
+        let composeTabs = [visibleTab, sessionlessTab]
+        var workspace = makeWorkspace(
+            name: "Existing sidebar identities",
+            tabs: composeTabs,
+            activeTabID: visibleTab.id
+        )
+        workspace.stashedTabs = [stashedTab]
+        let manager = makeWorkspaceManager(workspaces: [workspace])
+        manager.activeWorkspace = workspace
+        viewModel.workspaceManager = manager
+        let owner = AgentModeViewModel.SessionIndexOwner(workspaceID: workspace.id, activationEpoch: 1)
+        let archivedEntry = makeIndexEntry(
+            id: archivedSessionID,
+            tabID: stashedTab.tab.id,
+            lastUserMessageAt: Date(timeIntervalSince1970: 1)
+        )
+        viewModel.test_installSessionIndexSnapshot(
+            [archivedSessionID: archivedEntry],
+            owner: owner,
+            latestOwner: owner,
+            activeWorkspace: workspace
+        )
+        let expectedExisting: Set<AgentSidebarSelectionIdentity> = [
+            .active(tabID: visibleTab.id),
+            .active(tabID: sessionlessTab.id),
+            .archived(stashedTabID: stashedTab.id, tabID: stashedTab.tab.id)
+        ]
+
+        let collapsed = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: composeTabs,
+            stashedTabs: [stashedTab],
+            currentTabID: visibleTab.id,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: false,
+            showComposeTabsWithoutAgentSessions: false
+        )
+
+        XCTAssertEqual(collapsed.existingSelectionIdentities, expectedExisting)
+        XCTAssertEqual(collapsed.renderedSelectionOrder, [.active(tabID: visibleTab.id)])
+        XCTAssertFalse(collapsed.existingSelectionIdentities.contains(
+            .archived(stashedTabID: UUID(), tabID: stashedTab.tab.id)
+        ))
+
+        let expanded = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: composeTabs,
+            stashedTabs: [stashedTab],
+            currentTabID: visibleTab.id,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
+        )
+
+        XCTAssertEqual(expanded.existingSelectionIdentities, expectedExisting)
+        XCTAssertTrue(expanded.renderedSelectionOrder.contains(
+            .archived(stashedTabID: stashedTab.id, tabID: stashedTab.tab.id)
+        ))
+        XCTAssertFalse(expanded.renderedSelectionOrder.contains(.active(tabID: sessionlessTab.id)))
+    }
+
     func testArchivedCopyUsesIndexSessionIDWhenStoredBindingIsMissing() {
         let viewModel = makeViewModel()
         let activeTab = ComposeTabState(id: UUID(), name: "Active")

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -104,13 +104,33 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         ))
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: id(98)))
         XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [target],
+            existingIdentities: [target],
+            renderedIdentities: [target],
             workspaceID: workspaceID
         ))
         XCTAssertEqual(
-            store.selectionState.commandFallbackProgressOperation(renderedOrder: [], workspaceID: workspaceID),
+            store.selectionState.commandFallbackProgressOperation(
+                existingIdentities: [target],
+                renderedIdentities: [],
+                workspaceID: workspaceID
+            ),
             store.selectionState.inFlightAction
         )
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            existingIdentities: [],
+            renderedIdentities: [],
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            existingIdentities: [.active(tabID: id(2))],
+            renderedIdentities: [],
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            existingIdentities: [target],
+            renderedIdentities: [],
+            workspaceID: id(98)
+        ))
         XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
 
         store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
@@ -119,7 +139,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertFalse(store.selectionState.showsSelectionPresentation)
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID))
         XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [],
+            existingIdentities: [target],
+            renderedIdentities: [],
             workspaceID: workspaceID
         ))
     }
@@ -148,11 +169,13 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertEqual(store.selectionState.revision, initialRevision + 1)
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID))
         XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [target],
+            existingIdentities: [target],
+            renderedIdentities: [target],
             workspaceID: workspaceID
         ))
         XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [],
+            existingIdentities: [target],
+            renderedIdentities: [],
             workspaceID: workspaceID
         ))
 
@@ -161,7 +184,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
 
         store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
         XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [target],
+            existingIdentities: [target],
+            renderedIdentities: [target],
             workspaceID: workspaceID
         ))
     }
@@ -180,11 +204,18 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
 
         XCTAssertNotNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID))
         XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [target],
+            existingIdentities: [target],
+            renderedIdentities: [target],
             workspaceID: workspaceID
         ))
         XCTAssertNotNil(store.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [],
+            existingIdentities: [target],
+            renderedIdentities: [],
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            existingIdentities: [.archived(stashedTabID: id(11), tabID: target.tabID)],
+            renderedIdentities: [],
             workspaceID: workspaceID
         ))
     }
@@ -205,6 +236,11 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertTrue(store.selectionState.isMutationInFlight)
         XCTAssertTrue(store.selectionState.showsSelectionPresentation)
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first, workspaceID: workspaceID))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            existingIdentities: [first],
+            renderedIdentities: [],
+            workspaceID: workspaceID
+        ))
         XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
 
         store.reconcileSelection(renderedOrder: [], workspaceID: workspaceID)
@@ -452,7 +488,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertEqual(operation.presentationTargets, [first, second])
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first, workspaceID: workspaceID))
         XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [],
+            existingIdentities: [first, second],
+            renderedIdentities: [],
             workspaceID: workspaceID
         ))
 

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -229,21 +229,102 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         }
     }
 
-    func testCommandOriginWithSelectionKeepsBothPresentationPoliciesRepresentable() throws {
+    func testWorkspaceMismatchReconciliationClearsBothOriginsAndRejectsStaleFinish() throws {
+        for origin in [AgentSidebarBulkActionOrigin.selection, .command] {
+            let store = AgentSessionSidebarUIStore()
+            let originalWorkspaceID = id(98)
+            let nextWorkspaceID = id(99)
+            let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+            if origin == .selection {
+                _ = store.handleSelectionGesture(
+                    .toggle,
+                    identity: first,
+                    renderedOrder: [first],
+                    workspaceID: originalWorkspaceID
+                )
+            }
+            let token = try XCTUnwrap(store.beginBulkAction(
+                kind: .delete,
+                origin: origin,
+                targetCount: 1,
+                workspaceID: originalWorkspaceID
+            ))
+
+            store.reconcileSelection(renderedOrder: [], workspaceID: nextWorkspaceID)
+            store.finishBulkAction(
+                token: token,
+                workspaceID: originalWorkspaceID,
+                notice: .init(severity: .error, title: "Stale", message: "Stale")
+            )
+
+            XCTAssertNil(store.selectionState.inFlightAction)
+            XCTAssertNil(store.selectionState.commandProgressOperation)
+            XCTAssertFalse(store.selectionState.isMutationInFlight)
+            XCTAssertFalse(store.selectionState.showsSelectionPresentation)
+            XCTAssertNil(store.selectionState.notice)
+            XCTAssertNil(store.selectionState.workspaceID)
+            XCTAssertTrue(store.selectionState.selectedIdentities.isEmpty)
+        }
+    }
+
+    func testCommandBulkActionRequiresEmptySelection() {
         let store = AgentSessionSidebarUIStore()
         let workspaceID = id(99)
         let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
         _ = store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: workspaceID)
+        let selectedState = store.selectionState
 
-        let token = try XCTUnwrap(store.beginBulkAction(
+        XCTAssertNil(store.beginBulkAction(
             kind: .delete,
             origin: .command,
             targetCount: 1,
             workspaceID: workspaceID
         ))
+        XCTAssertEqual(store.selectionState, selectedState)
 
-        XCTAssertTrue(store.selectionState.showsSelectionPresentation)
-        XCTAssertEqual(store.selectionState.commandProgressOperation?.token, token)
+        store.clearSelection()
+        XCTAssertNotNil(store.beginBulkAction(
+            kind: .delete,
+            origin: .command,
+            targetCount: 1,
+            workspaceID: workspaceID
+        ))
+    }
+
+    func testSelectionBulkActionRequiresNonemptySelectionOwnedByWorkspace() {
+        let store = AgentSessionSidebarUIStore()
+        let selectionWorkspaceID = id(98)
+        let otherWorkspaceID = id(99)
+        let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+
+        XCTAssertNil(store.beginBulkAction(
+            kind: .delete,
+            origin: .selection,
+            targetCount: 1,
+            workspaceID: selectionWorkspaceID
+        ))
+
+        _ = store.handleSelectionGesture(
+            .toggle,
+            identity: first,
+            renderedOrder: [first],
+            workspaceID: selectionWorkspaceID
+        )
+        let selectedState = store.selectionState
+
+        XCTAssertNil(store.beginBulkAction(
+            kind: .delete,
+            origin: .selection,
+            targetCount: 1,
+            workspaceID: otherWorkspaceID
+        ))
+        XCTAssertEqual(store.selectionState, selectedState)
+        XCTAssertNotNil(store.beginBulkAction(
+            kind: .delete,
+            origin: .selection,
+            targetCount: 1,
+            workspaceID: selectionWorkspaceID
+        ))
     }
 
     func testModifierMappingGivesShiftPrecedence() {

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -147,13 +147,14 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertTrue(retiredOperation.commandRowProgressRetired)
         XCTAssertEqual(store.selectionState.revision, initialRevision + 1)
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID))
-        XCTAssertEqual(
-            store.selectionState.commandFallbackProgressOperation(
-                renderedOrder: [target],
-                workspaceID: workspaceID
-            ),
-            retiredOperation
-        )
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [target],
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [],
+            workspaceID: workspaceID
+        ))
 
         store.retireCommandRowProgress(forRemovedTabIDs: [id(1)], workspaceID: workspaceID)
         XCTAssertEqual(store.selectionState.revision, initialRevision + 1)

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -103,6 +103,14 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             workspaceID: workspaceID
         ))
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: id(98)))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [target],
+            workspaceID: workspaceID
+        ))
+        XCTAssertEqual(
+            store.selectionState.commandFallbackProgressOperation(renderedOrder: [], workspaceID: workspaceID),
+            store.selectionState.inFlightAction
+        )
         XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
 
         store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
@@ -110,6 +118,74 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertFalse(store.selectionState.isMutationInFlight)
         XCTAssertFalse(store.selectionState.showsSelectionPresentation)
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [],
+            workspaceID: workspaceID
+        ))
+    }
+
+    func testCommandRowProgressRetirementIsMonotonicAndPreventsSameIdentityReattachment() throws {
+        let store = AgentSessionSidebarUIStore()
+        let workspaceID = id(99)
+        let target = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        let token = try XCTUnwrap(store.beginBulkAction(
+            kind: .stash,
+            origin: .command,
+            presentationTargets: [target],
+            commandProgressPlacement: .row,
+            workspaceID: workspaceID
+        ))
+
+        let initialRevision = store.selectionState.revision
+        store.retireCommandRowProgress(forRemovedTabIDs: [id(2)], workspaceID: workspaceID)
+        store.retireCommandRowProgress(forRemovedTabIDs: [id(1)], workspaceID: id(98))
+        XCTAssertEqual(store.selectionState.revision, initialRevision)
+
+        store.retireCommandRowProgress(forRemovedTabIDs: [id(1)], workspaceID: workspaceID)
+
+        let retiredOperation = try XCTUnwrap(store.selectionState.inFlightAction)
+        XCTAssertTrue(retiredOperation.commandRowProgressRetired)
+        XCTAssertEqual(store.selectionState.revision, initialRevision + 1)
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID))
+        XCTAssertEqual(
+            store.selectionState.commandFallbackProgressOperation(
+                renderedOrder: [target],
+                workspaceID: workspaceID
+            ),
+            retiredOperation
+        )
+
+        store.retireCommandRowProgress(forRemovedTabIDs: [id(1)], workspaceID: workspaceID)
+        XCTAssertEqual(store.selectionState.revision, initialRevision + 1)
+
+        store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [target],
+            workspaceID: workspaceID
+        ))
+    }
+
+    func testArchivedRowUsesFallbackOnlyWhenItsRowIsAbsent() throws {
+        let store = AgentSessionSidebarUIStore()
+        let workspaceID = id(99)
+        let target = AgentSidebarSelectionIdentity.archived(stashedTabID: id(10), tabID: id(1))
+        _ = try XCTUnwrap(store.beginBulkAction(
+            kind: .delete,
+            origin: .command,
+            presentationTargets: [target],
+            commandProgressPlacement: .row,
+            workspaceID: workspaceID
+        ))
+
+        XCTAssertNotNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [target],
+            workspaceID: workspaceID
+        ))
+        XCTAssertNotNil(store.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [],
+            workspaceID: workspaceID
+        ))
     }
 
     func testSelectionOriginSurvivesEmptyReconciliationUntilFinish() throws {
@@ -374,6 +450,15 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertEqual(operation.targetCount, 2)
         XCTAssertEqual(operation.presentationTargets, [first, second])
         XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first, workspaceID: workspaceID))
+        XCTAssertNil(store.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [],
+            workspaceID: workspaceID
+        ))
+
+        let revision = store.selectionState.revision
+        store.retireCommandRowProgress(forRemovedTabIDs: [first.tabID], workspaceID: workspaceID)
+        XCTAssertEqual(store.selectionState.revision, revision)
+        XCTAssertEqual(store.selectionState.archivedHeaderCommandProgressOperation, operation)
     }
 
     func testBulkActionRejectsInvalidOriginAndProgressPlacementCombinations() {

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -158,11 +158,11 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         ))
 
         let initialRevision = store.selectionState.revision
-        store.retireCommandRowProgress(forRemovedTabIDs: [id(2)], workspaceID: workspaceID)
-        store.retireCommandRowProgress(forRemovedTabIDs: [id(1)], workspaceID: id(98))
+        store.retireCommandRowProgress(token: token, forRemovedTabIDs: [id(2)], workspaceID: workspaceID)
+        store.retireCommandRowProgress(token: token, forRemovedTabIDs: [id(1)], workspaceID: id(98))
         XCTAssertEqual(store.selectionState.revision, initialRevision)
 
-        store.retireCommandRowProgress(forRemovedTabIDs: [id(1)], workspaceID: workspaceID)
+        store.retireCommandRowProgress(token: token, forRemovedTabIDs: [id(1)], workspaceID: workspaceID)
 
         let retiredOperation = try XCTUnwrap(store.selectionState.inFlightAction)
         XCTAssertTrue(retiredOperation.commandRowProgressRetired)
@@ -179,7 +179,7 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             workspaceID: workspaceID
         ))
 
-        store.retireCommandRowProgress(forRemovedTabIDs: [id(1)], workspaceID: workspaceID)
+        store.retireCommandRowProgress(token: token, forRemovedTabIDs: [id(1)], workspaceID: workspaceID)
         XCTAssertEqual(store.selectionState.revision, initialRevision + 1)
 
         store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
@@ -188,6 +188,52 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             renderedIdentities: [target],
             workspaceID: workspaceID
         ))
+    }
+
+    func testStaleCommandRowRetirementCannotMutateNewOperationGeneration() throws {
+        let store = AgentSessionSidebarUIStore()
+        let workspaceID = id(99)
+        let target = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        let tokenA = try XCTUnwrap(store.beginBulkAction(
+            kind: .stash,
+            origin: .command,
+            presentationTargets: [target],
+            commandProgressPlacement: .row,
+            workspaceID: workspaceID
+        ))
+
+        store.invalidateSelectionForWorkspaceChange()
+
+        let tokenB = try XCTUnwrap(store.beginBulkAction(
+            kind: .stash,
+            origin: .command,
+            presentationTargets: [target],
+            commandProgressPlacement: .row,
+            workspaceID: workspaceID
+        ))
+        XCTAssertNotEqual(tokenA, tokenB)
+        let revision = store.selectionState.revision
+
+        store.retireCommandRowProgress(token: tokenA, forRemovedTabIDs: [target.tabID], workspaceID: workspaceID)
+        store.finishBulkAction(token: tokenA, workspaceID: workspaceID, notice: nil)
+
+        let currentOperation = try XCTUnwrap(store.selectionState.inFlightAction)
+        XCTAssertEqual(currentOperation.token, tokenB)
+        XCTAssertFalse(currentOperation.commandRowProgressRetired)
+        XCTAssertEqual(store.selectionState.revision, revision)
+        XCTAssertEqual(
+            store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID),
+            currentOperation
+        )
+
+        store.retireCommandRowProgress(token: tokenB, forRemovedTabIDs: [target.tabID], workspaceID: workspaceID)
+        let retiredOperation = try XCTUnwrap(store.selectionState.inFlightAction)
+        XCTAssertEqual(retiredOperation.token, tokenB)
+        XCTAssertTrue(retiredOperation.commandRowProgressRetired)
+        XCTAssertEqual(store.selectionState.revision, revision + 1)
+
+        store.finishBulkAction(token: tokenB, workspaceID: workspaceID, notice: nil)
+        XCTAssertNil(store.selectionState.inFlightAction)
     }
 
     func testArchivedRowUsesFallbackOnlyWhenItsRowIsAbsent() throws {
@@ -494,7 +540,7 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         ))
 
         let revision = store.selectionState.revision
-        store.retireCommandRowProgress(forRemovedTabIDs: [first.tabID], workspaceID: workspaceID)
+        store.retireCommandRowProgress(token: token, forRemovedTabIDs: [first.tabID], workspaceID: workspaceID)
         XCTAssertEqual(store.selectionState.revision, revision)
         XCTAssertEqual(store.selectionState.archivedHeaderCommandProgressOperation, operation)
     }

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -72,19 +72,108 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertNil(store.selectionState.anchor)
     }
 
-    func testBulkActionFreezesSelectionAndRejectsReentry() throws {
+    func testCommandOriginWithoutSelectionUsesCommandProgressPolicy() throws {
         let store = AgentSessionSidebarUIStore()
-        let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
-        _ = store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: id(99))
-        let token = store.beginBulkAction(kind: .delete, targetCount: 1, workspaceID: id(99))
-        XCTAssertNotNil(token)
-        XCTAssertNil(store.beginBulkAction(kind: .delete, targetCount: 1, workspaceID: id(99)))
-        XCTAssertEqual(store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: id(99)), .ignored)
+        let workspaceID = id(99)
+        let token = try XCTUnwrap(store.beginBulkAction(
+            kind: .delete,
+            origin: .command,
+            targetCount: 1,
+            workspaceID: workspaceID
+        ))
 
-        store.reconcileSelection(renderedOrder: [], workspaceID: id(99))
+        XCTAssertEqual(store.selectionState.inFlightAction, AgentSidebarBulkActionOperation(
+            token: token,
+            workspaceID: workspaceID,
+            kind: .delete,
+            origin: .command,
+            targetCount: 1
+        ))
+        XCTAssertTrue(store.selectionState.isMutationInFlight)
+        XCTAssertFalse(store.selectionState.showsSelectionPresentation)
+        XCTAssertEqual(store.selectionState.commandProgressOperation, store.selectionState.inFlightAction)
+
+        store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
+
+        XCTAssertFalse(store.selectionState.isMutationInFlight)
+        XCTAssertFalse(store.selectionState.showsSelectionPresentation)
+        XCTAssertNil(store.selectionState.commandProgressOperation)
+    }
+
+    func testSelectionOriginSurvivesEmptyReconciliationUntilFinish() throws {
+        let store = AgentSessionSidebarUIStore()
+        let workspaceID = id(99)
+        let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        _ = store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: workspaceID)
+        let token = try XCTUnwrap(store.beginBulkAction(
+            kind: .stash,
+            origin: .selection,
+            targetCount: 1,
+            workspaceID: workspaceID
+        ))
+
+        XCTAssertTrue(store.selectionState.isMutationInFlight)
+        XCTAssertTrue(store.selectionState.showsSelectionPresentation)
+        XCTAssertNil(store.selectionState.commandProgressOperation)
+
+        store.reconcileSelection(renderedOrder: [], workspaceID: workspaceID)
+
         XCTAssertTrue(store.selectionState.selectedIdentities.isEmpty)
-        try store.finishBulkAction(token: XCTUnwrap(token), workspaceID: id(99), notice: nil)
-        XCTAssertTrue(store.selectionState.selectedIdentities.isEmpty)
+        XCTAssertTrue(store.selectionState.showsSelectionPresentation)
+        XCTAssertEqual(store.selectionState.inFlightAction, .init(
+            token: token,
+            workspaceID: workspaceID,
+            kind: .stash,
+            origin: .selection,
+            targetCount: 1
+        ))
+
+        store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
+
+        XCTAssertFalse(store.selectionState.isMutationInFlight)
+        XCTAssertFalse(store.selectionState.showsSelectionPresentation)
+    }
+
+    func testBulkActionLocksSelectionMutationsAndRejectsReentryForBothOrigins() throws {
+        for origin in [AgentSidebarBulkActionOrigin.selection, .command] {
+            let store = AgentSessionSidebarUIStore()
+            let workspaceID = id(99)
+            let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+            let second = AgentSidebarSelectionIdentity.active(tabID: id(2))
+            if origin == .selection {
+                _ = store.handleSelectionGesture(
+                    .toggle,
+                    identity: first,
+                    renderedOrder: [first, second],
+                    workspaceID: workspaceID
+                )
+            }
+            let token = try XCTUnwrap(store.beginBulkAction(
+                kind: .delete,
+                origin: origin,
+                targetCount: 1,
+                workspaceID: workspaceID
+            ))
+            let frozenState = store.selectionState
+
+            XCTAssertNil(store.beginBulkAction(
+                kind: .stash,
+                origin: origin,
+                targetCount: 1,
+                workspaceID: workspaceID
+            ))
+            XCTAssertEqual(store.handleSelectionGesture(
+                .toggle,
+                identity: second,
+                renderedOrder: [first, second],
+                workspaceID: workspaceID
+            ), .ignored)
+            store.selectAll(renderedOrder: [first, second], workspaceID: workspaceID)
+            store.clearSelection()
+
+            XCTAssertEqual(store.selectionState, frozenState)
+            store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
+        }
     }
 
     func testDirectBulkActionRetainsWorkspaceOwnerWithoutSelection() throws {
@@ -92,6 +181,7 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         let workspaceID = id(99)
         let token = try XCTUnwrap(store.beginBulkAction(
             kind: .delete,
+            origin: .command,
             targetCount: 1,
             workspaceID: workspaceID
         ))
@@ -102,35 +192,58 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertTrue(store.isCurrentBulkAction(token: token, workspaceID: workspaceID))
     }
 
-    func testWorkspaceMismatchReconciliationInvalidatesBulkAction() throws {
-        let store = AgentSessionSidebarUIStore()
-        let firstWorkspaceID = id(98)
-        let token = try XCTUnwrap(store.beginBulkAction(
-            kind: .delete,
-            targetCount: 1,
-            workspaceID: firstWorkspaceID
-        ))
+    func testWorkspaceInvalidationClearsBothOriginsAndRejectsStaleFinish() throws {
+        for origin in [AgentSidebarBulkActionOrigin.selection, .command] {
+            let store = AgentSessionSidebarUIStore()
+            let workspaceID = id(99)
+            let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
+            if origin == .selection {
+                _ = store.handleSelectionGesture(
+                    .toggle,
+                    identity: first,
+                    renderedOrder: [first],
+                    workspaceID: workspaceID
+                )
+            }
+            let token = try XCTUnwrap(store.beginBulkAction(
+                kind: .delete,
+                origin: origin,
+                targetCount: 1,
+                workspaceID: workspaceID
+            ))
 
-        store.reconcileSelection(renderedOrder: [], workspaceID: id(99))
-        store.finishBulkAction(
-            token: token,
-            workspaceID: firstWorkspaceID,
-            notice: .init(severity: .error, title: "Stale", message: "Stale")
-        )
+            store.invalidateSelectionForWorkspaceChange()
+            store.finishBulkAction(
+                token: token,
+                workspaceID: workspaceID,
+                notice: .init(severity: .error, title: "Stale", message: "Stale")
+            )
 
-        XCTAssertNil(store.selectionState.inFlightAction)
-        XCTAssertNil(store.selectionState.notice)
-        XCTAssertNil(store.selectionState.workspaceID)
+            XCTAssertNil(store.selectionState.inFlightAction)
+            XCTAssertNil(store.selectionState.commandProgressOperation)
+            XCTAssertFalse(store.selectionState.isMutationInFlight)
+            XCTAssertFalse(store.selectionState.showsSelectionPresentation)
+            XCTAssertNil(store.selectionState.notice)
+            XCTAssertNil(store.selectionState.workspaceID)
+            XCTAssertTrue(store.selectionState.selectedIdentities.isEmpty)
+        }
     }
 
-    func testStaleBulkCompletionCannotMutateNewWorkspaceState() throws {
+    func testCommandOriginWithSelectionKeepsBothPresentationPoliciesRepresentable() throws {
         let store = AgentSessionSidebarUIStore()
+        let workspaceID = id(99)
         let first = AgentSidebarSelectionIdentity.active(tabID: id(1))
-        _ = store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: id(99))
-        let token = try XCTUnwrap(store.beginBulkAction(kind: .stash, targetCount: 1, workspaceID: id(99)))
-        store.invalidateSelectionForWorkspaceChange()
-        store.finishBulkAction(token: token, workspaceID: id(99), notice: .init(severity: .error, title: "Old", message: "Old"))
-        XCTAssertEqual(store.selectionState, AgentSidebarSelectionState(revision: store.selectionState.revision))
+        _ = store.handleSelectionGesture(.toggle, identity: first, renderedOrder: [first], workspaceID: workspaceID)
+
+        let token = try XCTUnwrap(store.beginBulkAction(
+            kind: .delete,
+            origin: .command,
+            targetCount: 1,
+            workspaceID: workspaceID
+        ))
+
+        XCTAssertTrue(store.selectionState.showsSelectionPresentation)
+        XCTAssertEqual(store.selectionState.commandProgressOperation?.token, token)
     }
 
     func testModifierMappingGivesShiftPrecedence() {

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -94,15 +94,22 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         ))
         XCTAssertTrue(store.selectionState.isMutationInFlight)
         XCTAssertFalse(store.selectionState.showsSelectionPresentation)
-        XCTAssertEqual(store.selectionState.commandRowProgressOperation(for: target), store.selectionState.inFlightAction)
-        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: .active(tabID: id(2))))
+        XCTAssertEqual(
+            store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID),
+            store.selectionState.inFlightAction
+        )
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(
+            for: .active(tabID: id(2)),
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: id(98)))
         XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
 
         store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
 
         XCTAssertFalse(store.selectionState.isMutationInFlight)
         XCTAssertFalse(store.selectionState.showsSelectionPresentation)
-        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target))
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target, workspaceID: workspaceID))
     }
 
     func testSelectionOriginSurvivesEmptyReconciliationUntilFinish() throws {
@@ -120,7 +127,7 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
 
         XCTAssertTrue(store.selectionState.isMutationInFlight)
         XCTAssertTrue(store.selectionState.showsSelectionPresentation)
-        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first))
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first, workspaceID: workspaceID))
         XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
 
         store.reconcileSelection(renderedOrder: [], workspaceID: workspaceID)
@@ -233,7 +240,7 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             )
 
             XCTAssertNil(store.selectionState.inFlightAction)
-            XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first))
+            XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first, workspaceID: workspaceID))
             XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
             XCTAssertFalse(store.selectionState.isMutationInFlight)
             XCTAssertFalse(store.selectionState.showsSelectionPresentation)
@@ -273,7 +280,7 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             )
 
             XCTAssertNil(store.selectionState.inFlightAction)
-            XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first))
+            XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first, workspaceID: originalWorkspaceID))
             XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
             XCTAssertFalse(store.selectionState.isMutationInFlight)
             XCTAssertFalse(store.selectionState.showsSelectionPresentation)
@@ -366,7 +373,7 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertEqual(operation.token, token)
         XCTAssertEqual(operation.targetCount, 2)
         XCTAssertEqual(operation.presentationTargets, [first, second])
-        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first))
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first, workspaceID: workspaceID))
     }
 
     func testBulkActionRejectsInvalidOriginAndProgressPlacementCombinations() {

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -75,10 +75,12 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
     func testCommandOriginWithoutSelectionUsesCommandProgressPolicy() throws {
         let store = AgentSessionSidebarUIStore()
         let workspaceID = id(99)
+        let target = AgentSidebarSelectionIdentity.active(tabID: id(1))
         let token = try XCTUnwrap(store.beginBulkAction(
             kind: .delete,
             origin: .command,
-            targetCount: 1,
+            presentationTargets: [target],
+            commandProgressPlacement: .row,
             workspaceID: workspaceID
         ))
 
@@ -87,17 +89,20 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             workspaceID: workspaceID,
             kind: .delete,
             origin: .command,
-            targetCount: 1
+            presentationTargets: [target],
+            commandProgressPlacement: .row
         ))
         XCTAssertTrue(store.selectionState.isMutationInFlight)
         XCTAssertFalse(store.selectionState.showsSelectionPresentation)
-        XCTAssertEqual(store.selectionState.commandProgressOperation, store.selectionState.inFlightAction)
+        XCTAssertEqual(store.selectionState.commandRowProgressOperation(for: target), store.selectionState.inFlightAction)
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: .active(tabID: id(2))))
+        XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
 
         store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
 
         XCTAssertFalse(store.selectionState.isMutationInFlight)
         XCTAssertFalse(store.selectionState.showsSelectionPresentation)
-        XCTAssertNil(store.selectionState.commandProgressOperation)
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: target))
     }
 
     func testSelectionOriginSurvivesEmptyReconciliationUntilFinish() throws {
@@ -108,13 +113,15 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         let token = try XCTUnwrap(store.beginBulkAction(
             kind: .stash,
             origin: .selection,
-            targetCount: 1,
+            presentationTargets: [first],
+            commandProgressPlacement: nil,
             workspaceID: workspaceID
         ))
 
         XCTAssertTrue(store.selectionState.isMutationInFlight)
         XCTAssertTrue(store.selectionState.showsSelectionPresentation)
-        XCTAssertNil(store.selectionState.commandProgressOperation)
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first))
+        XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
 
         store.reconcileSelection(renderedOrder: [], workspaceID: workspaceID)
 
@@ -125,7 +132,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             workspaceID: workspaceID,
             kind: .stash,
             origin: .selection,
-            targetCount: 1
+            presentationTargets: [first],
+            commandProgressPlacement: nil
         ))
 
         store.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
@@ -151,7 +159,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             let token = try XCTUnwrap(store.beginBulkAction(
                 kind: .delete,
                 origin: origin,
-                targetCount: 1,
+                presentationTargets: [first],
+                commandProgressPlacement: origin == .command ? .row : nil,
                 workspaceID: workspaceID
             ))
             let frozenState = store.selectionState
@@ -159,7 +168,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             XCTAssertNil(store.beginBulkAction(
                 kind: .stash,
                 origin: origin,
-                targetCount: 1,
+                presentationTargets: [first],
+                commandProgressPlacement: origin == .command ? .row : nil,
                 workspaceID: workspaceID
             ))
             XCTAssertEqual(store.handleSelectionGesture(
@@ -179,10 +189,12 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
     func testDirectBulkActionRetainsWorkspaceOwnerWithoutSelection() throws {
         let store = AgentSessionSidebarUIStore()
         let workspaceID = id(99)
+        let target = AgentSidebarSelectionIdentity.active(tabID: id(1))
         let token = try XCTUnwrap(store.beginBulkAction(
             kind: .delete,
             origin: .command,
-            targetCount: 1,
+            presentationTargets: [target],
+            commandProgressPlacement: .row,
             workspaceID: workspaceID
         ))
 
@@ -208,7 +220,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             let token = try XCTUnwrap(store.beginBulkAction(
                 kind: .delete,
                 origin: origin,
-                targetCount: 1,
+                presentationTargets: [first],
+                commandProgressPlacement: origin == .command ? .row : nil,
                 workspaceID: workspaceID
             ))
 
@@ -220,7 +233,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             )
 
             XCTAssertNil(store.selectionState.inFlightAction)
-            XCTAssertNil(store.selectionState.commandProgressOperation)
+            XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first))
+            XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
             XCTAssertFalse(store.selectionState.isMutationInFlight)
             XCTAssertFalse(store.selectionState.showsSelectionPresentation)
             XCTAssertNil(store.selectionState.notice)
@@ -246,7 +260,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             let token = try XCTUnwrap(store.beginBulkAction(
                 kind: .delete,
                 origin: origin,
-                targetCount: 1,
+                presentationTargets: [first],
+                commandProgressPlacement: origin == .command ? .row : nil,
                 workspaceID: originalWorkspaceID
             ))
 
@@ -258,7 +273,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
             )
 
             XCTAssertNil(store.selectionState.inFlightAction)
-            XCTAssertNil(store.selectionState.commandProgressOperation)
+            XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first))
+            XCTAssertNil(store.selectionState.archivedHeaderCommandProgressOperation)
             XCTAssertFalse(store.selectionState.isMutationInFlight)
             XCTAssertFalse(store.selectionState.showsSelectionPresentation)
             XCTAssertNil(store.selectionState.notice)
@@ -277,7 +293,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertNil(store.beginBulkAction(
             kind: .delete,
             origin: .command,
-            targetCount: 1,
+            presentationTargets: [first],
+            commandProgressPlacement: .row,
             workspaceID: workspaceID
         ))
         XCTAssertEqual(store.selectionState, selectedState)
@@ -286,7 +303,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertNotNil(store.beginBulkAction(
             kind: .delete,
             origin: .command,
-            targetCount: 1,
+            presentationTargets: [first],
+            commandProgressPlacement: .row,
             workspaceID: workspaceID
         ))
     }
@@ -300,7 +318,8 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertNil(store.beginBulkAction(
             kind: .delete,
             origin: .selection,
-            targetCount: 1,
+            presentationTargets: [first],
+            commandProgressPlacement: nil,
             workspaceID: selectionWorkspaceID
         ))
 
@@ -315,16 +334,104 @@ final class AgentSessionSidebarUIStoreTests: XCTestCase {
         XCTAssertNil(store.beginBulkAction(
             kind: .delete,
             origin: .selection,
-            targetCount: 1,
+            presentationTargets: [first],
+            commandProgressPlacement: nil,
             workspaceID: otherWorkspaceID
         ))
         XCTAssertEqual(store.selectionState, selectedState)
         XCTAssertNotNil(store.beginBulkAction(
             kind: .delete,
             origin: .selection,
-            targetCount: 1,
+            presentationTargets: [first],
+            commandProgressPlacement: nil,
             workspaceID: selectionWorkspaceID
         ))
+    }
+
+    func testArchivedHeaderCommandFreezesTargetsWithoutRowProgress() throws {
+        let store = AgentSessionSidebarUIStore()
+        let workspaceID = id(99)
+        let first = AgentSidebarSelectionIdentity.archived(stashedTabID: id(10), tabID: id(1))
+        let second = AgentSidebarSelectionIdentity.archived(stashedTabID: id(20), tabID: id(2))
+
+        let token = try XCTUnwrap(store.beginBulkAction(
+            kind: .delete,
+            origin: .command,
+            presentationTargets: [first, second],
+            commandProgressPlacement: .archivedHeader,
+            workspaceID: workspaceID
+        ))
+
+        let operation = try XCTUnwrap(store.selectionState.archivedHeaderCommandProgressOperation)
+        XCTAssertEqual(operation.token, token)
+        XCTAssertEqual(operation.targetCount, 2)
+        XCTAssertEqual(operation.presentationTargets, [first, second])
+        XCTAssertNil(store.selectionState.commandRowProgressOperation(for: first))
+    }
+
+    func testBulkActionRejectsInvalidOriginAndProgressPlacementCombinations() {
+        let store = AgentSessionSidebarUIStore()
+        let workspaceID = id(99)
+        let active = AgentSidebarSelectionIdentity.active(tabID: id(1))
+        let otherActive = AgentSidebarSelectionIdentity.active(tabID: id(2))
+
+        XCTAssertNil(store.beginBulkAction(
+            kind: .delete,
+            origin: .command,
+            presentationTargets: [active, otherActive],
+            commandProgressPlacement: .row,
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(store.beginBulkAction(
+            kind: .delete,
+            origin: .command,
+            presentationTargets: [active],
+            commandProgressPlacement: .archivedHeader,
+            workspaceID: workspaceID
+        ))
+
+        _ = store.handleSelectionGesture(.toggle, identity: active, renderedOrder: [active], workspaceID: workspaceID)
+        XCTAssertNil(store.beginBulkAction(
+            kind: .delete,
+            origin: .selection,
+            presentationTargets: [active],
+            commandProgressPlacement: .row,
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(store.beginBulkAction(
+            kind: .delete,
+            origin: .selection,
+            presentationTargets: [otherActive],
+            commandProgressPlacement: nil,
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(store.selectionState.inFlightAction)
+    }
+
+    func testBulkMutationTargetsMapOnlyTheRequestedAction() {
+        let workspaceID = id(99)
+        let activeDelete = id(1)
+        let stashed = id(10)
+        let archivedTab = id(2)
+        let stash = id(3)
+        let pin = id(4)
+        let unpin = id(5)
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [activeDelete],
+            archivedDeleteTargets: [.init(stashedTabID: stashed, tabID: archivedTab)],
+            stashTabIDs: [stash],
+            pinTabIDs: [pin],
+            unpinTabIDs: [unpin]
+        )
+
+        XCTAssertEqual(targets.presentationTargets(for: .delete), [
+            .active(tabID: activeDelete),
+            .archived(stashedTabID: stashed, tabID: archivedTab)
+        ])
+        XCTAssertEqual(targets.presentationTargets(for: .stash), [.active(tabID: stash)])
+        XCTAssertEqual(targets.presentationTargets(for: .pin), [.active(tabID: pin)])
+        XCTAssertEqual(targets.presentationTargets(for: .unpin), [.active(tabID: unpin)])
     }
 
     func testModifierMappingGivesShiftPrecedence() {

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -660,7 +660,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         )
     }
 
-    func testCommandCoordinatorShowsFallbackAfterProjectionRemovalUntilCleanupFinishes() async throws {
+    func testCommandCoordinatorRetiresAllCommandProgressAfterProjectionRemoval() async throws {
         let fixture = makeFixture(initialTabCount: 2)
         let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
         let tabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
@@ -713,13 +713,10 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             for: identity,
             workspaceID: workspaceID
         ))
-        XCTAssertEqual(
-            viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
-                renderedOrder: projection.renderedSelectionOrder,
-                workspaceID: workspaceID
-            ),
-            operation
-        )
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
+            renderedOrder: projection.renderedSelectionOrder,
+            workspaceID: workspaceID
+        ))
         XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
 
         fence.release()
@@ -800,13 +797,10 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             for: identity,
             workspaceID: workspaceID
         ))
-        XCTAssertEqual(
-            viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
-                renderedOrder: projection.renderedSelectionOrder,
-                workspaceID: workspaceID
-            ),
-            operation
-        )
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
+            renderedOrder: projection.renderedSelectionOrder,
+            workspaceID: workspaceID
+        ))
         XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
 
         fence.release()

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -621,11 +621,17 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
         XCTAssertEqual(
-            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: .active(tabID: tabID)),
+            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+                for: .active(tabID: tabID),
+                workspaceID: workspaceID
+            ),
             operation
         )
         XCTAssertNil(
-            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: .active(tabID: UUID()))
+            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+                for: .active(tabID: UUID()),
+                workspaceID: workspaceID
+            )
         )
 
         await viewModel.performSidebarBulkAction(
@@ -647,7 +653,10 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
         XCTAssertNil(
-            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: .active(tabID: tabID))
+            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+                for: .active(tabID: tabID),
+                workspaceID: workspaceID
+            )
         )
     }
 
@@ -697,7 +706,10 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertNil(operation.commandProgressPlacement)
         XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
         XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
-        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: identity))
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+            for: identity,
+            workspaceID: workspaceID
+        ))
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.archivedHeaderCommandProgressOperation)
 
         viewModel.ui.sessionSidebar.reconcileSelection(renderedOrder: [], workspaceID: workspaceID)
@@ -712,7 +724,10 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == tabID }))
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
-        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: identity))
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+            for: identity,
+            workspaceID: workspaceID
+        ))
     }
 
     func testMixedDeleteDoesNotRetryArchivedTargetRejectedDuringActiveCascade() async throws {

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -696,6 +696,17 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertTrue(cleanupEntered)
 
         XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == tabID }))
+        let workspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let projection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: workspace.composeTabs,
+            stashedTabs: workspace.stashedTabs,
+            currentTabID: fixture.prompt.activeComposeTabID,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: true
+        )
+        XCTAssertFalse(projection.renderedSelectionOrder.contains(identity))
         let operation = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
         XCTAssertTrue(operation.commandRowProgressRetired)
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
@@ -704,7 +715,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         ))
         XCTAssertEqual(
             viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
-                renderedOrder: [],
+                renderedOrder: projection.renderedSelectionOrder,
                 workspaceID: workspaceID
             ),
             operation
@@ -772,6 +783,17 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertTrue(fixture.manager.activeWorkspace?.composeTabs.contains(where: { $0.id == tabID }) == true)
         XCTAssertFalse(viewModel.sessions[tabID] === removedSession)
         XCTAssertTrue(viewModel.sessions[tabID] === replacementSession)
+        let workspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let projection = viewModel.sidebarListProjection(
+            workspaceID: workspace.id,
+            composeTabs: workspace.composeTabs,
+            stashedTabs: workspace.stashedTabs,
+            currentTabID: fixture.prompt.activeComposeTabID,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: true
+        )
+        XCTAssertTrue(projection.renderedSelectionOrder.contains(identity))
         let operation = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
         XCTAssertTrue(operation.commandRowProgressRetired)
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
@@ -780,7 +802,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         ))
         XCTAssertEqual(
             viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
-                renderedOrder: [identity],
+                renderedOrder: projection.renderedSelectionOrder,
                 workspaceID: workspaceID
             ),
             operation

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -553,11 +553,141 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             unpinTabIDs: []
         )
 
-        await viewModel.performSidebarBulkAction(.delete, targets: targets, promptManager: fixture.prompt)
+        await viewModel.performSidebarBulkAction(
+            .delete,
+            origin: .selection,
+            targets: targets,
+            promptManager: fixture.prompt
+        )
 
         XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == activeTabID }))
         XCTAssertFalse(fixture.prompt.currentStashedTabs.contains(where: { $0.id == stashed.id }))
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+    }
+
+    func testCommandCoordinatorPublishesCommandProgressAndRejectsReentryWhileDeleteIsSuspended() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let tabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        let fence = TestReleaseFence(name: "command sidebar delete preflight")
+        defer { fence.release() }
+        let preflightRecorder = RemovalPreflightRecorder()
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, reason, _ in
+            await preflightRecorder.record(reason)
+            if reason == .close { await fence.enterAndWait() }
+            return .proceed
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [tabID],
+            archivedDeleteTargets: [],
+            stashTabIDs: [],
+            pinTabIDs: [],
+            unpinTabIDs: []
+        )
+
+        let deleteTask = Task {
+            await viewModel.performSidebarBulkAction(
+                .delete,
+                origin: .command,
+                targets: targets,
+                promptManager: fixture.prompt
+            )
+        }
+        let preflightEntered = await fence.waitUntilEntered()
+        XCTAssertTrue(preflightEntered)
+
+        let operation = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertEqual(operation.workspaceID, workspaceID)
+        XCTAssertEqual(operation.kind, .delete)
+        XCTAssertEqual(operation.origin, .command)
+        XCTAssertEqual(operation.targetCount, 1)
+        XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
+        XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
+        XCTAssertEqual(viewModel.ui.sessionSidebar.selectionState.commandProgressOperation, operation)
+
+        await viewModel.performSidebarBulkAction(
+            .delete,
+            origin: .command,
+            targets: targets,
+            promptManager: fixture.prompt
+        )
+
+        XCTAssertEqual(viewModel.ui.sessionSidebar.selectionState.inFlightAction, operation)
+        let closePreflightCount = await preflightRecorder.count(for: .close)
+        XCTAssertEqual(closePreflightCount, 1)
+
+        fence.release()
+        await deleteTask.value
+
+        XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == tabID }))
+        XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
+        XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandProgressOperation)
+    }
+
+    func testSelectionCoordinatorRetainsProgressAfterReconciliationWhileDeleteIsSuspended() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let tabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let identity = AgentSidebarSelectionIdentity.active(tabID: tabID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        viewModel.ui.sessionSidebar.selectAll(renderedOrder: [identity], workspaceID: workspaceID)
+        let fence = TestReleaseFence(name: "selection sidebar delete preflight")
+        defer { fence.release() }
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, reason, _ in
+            if reason == .close { await fence.enterAndWait() }
+            return .proceed
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [tabID],
+            archivedDeleteTargets: [],
+            stashTabIDs: [],
+            pinTabIDs: [],
+            unpinTabIDs: []
+        )
+
+        let deleteTask = Task {
+            await viewModel.performSidebarBulkAction(
+                .delete,
+                origin: .selection,
+                targets: targets,
+                promptManager: fixture.prompt
+            )
+        }
+        let preflightEntered = await fence.waitUntilEntered()
+        XCTAssertTrue(preflightEntered)
+
+        let operation = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertEqual(operation.workspaceID, workspaceID)
+        XCTAssertEqual(operation.kind, .delete)
+        XCTAssertEqual(operation.origin, .selection)
+        XCTAssertEqual(operation.targetCount, 1)
+        XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
+        XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandProgressOperation)
+
+        viewModel.ui.sessionSidebar.reconcileSelection(renderedOrder: [], workspaceID: workspaceID)
+
+        XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.selectedIdentities.isEmpty)
+        XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
+        XCTAssertEqual(viewModel.ui.sessionSidebar.selectionState.inFlightAction, operation)
+
+        fence.release()
+        await deleteTask.value
+
+        XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == tabID }))
+        XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
+        XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandProgressOperation)
     }
 
     func testMixedDeleteDoesNotRetryArchivedTargetRejectedDuringActiveCascade() async throws {
@@ -735,7 +865,12 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             unpinTabIDs: []
         )
 
-        await viewModel.performSidebarBulkAction(.pin, targets: targets, promptManager: fixture.prompt)
+        await viewModel.performSidebarBulkAction(
+            .pin,
+            origin: .command,
+            targets: targets,
+            promptManager: fixture.prompt
+        )
 
         XCTAssertFalse(fixture.manager.activeWorkspace?.composeTabs.first(where: { $0.id == tabID })?.isPinned == true)
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
@@ -756,11 +891,181 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             cleanupIssues: [.init(tabID: tabID, reason: .close, message: "Cleanup failed.")]
         )
 
-        let notice = viewModel.sidebarBulkActionNotice(for: report, action: .delete)
+        let selectionNotice = viewModel.sidebarBulkActionNotice(
+            for: report,
+            action: .delete,
+            origin: .selection
+        )
+        let commandNotice = viewModel.sidebarBulkActionNotice(
+            for: report,
+            action: .delete,
+            origin: .command
+        )
 
-        XCTAssertEqual(notice?.severity, .error)
-        XCTAssertTrue(notice?.message.contains("cleanup failed for 1") == true)
-        XCTAssertTrue(notice?.message.contains("selected or related chats") == true)
+        XCTAssertEqual(selectionNotice, .init(
+            severity: .error,
+            title: "Bulk action partially completed",
+            message: "Some chats changed, cleanup failed for 1 chat(s), and some selected or related chats were not changed. Cleanup failed."
+        ))
+        XCTAssertEqual(commandNotice, .init(
+            severity: .error,
+            title: "Action partially completed",
+            message: "Some chats changed, cleanup failed for 1 chat(s), and some requested or related chats were not changed. Cleanup failed."
+        ))
+    }
+
+    func testBulkNoticeUsesOriginAwarePartialAndNoOpWording() {
+        let fixture = makeFixture(initialTabCount: 2)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let tabID = UUID()
+        let partialReport = PromptViewModel.ComposeTabMutationReport(
+            removedComposeTabIDs: [tabID],
+            rejections: [.init(
+                kind: .close,
+                reason: .requiredSessionPreflight,
+                tabID: UUID(),
+                message: "Required persistence failed."
+            )]
+        )
+        let noOpReport = PromptViewModel.ComposeTabMutationReport(noOpReasons: [.close])
+
+        let selectionPartial = viewModel.sidebarBulkActionNotice(
+            for: partialReport,
+            action: .delete,
+            origin: .selection
+        )
+        let commandPartial = viewModel.sidebarBulkActionNotice(
+            for: partialReport,
+            action: .delete,
+            origin: .command
+        )
+        let selectionNoOp = viewModel.sidebarBulkActionNotice(
+            for: noOpReport,
+            action: .delete,
+            origin: .selection
+        )
+        let commandNoOp = viewModel.sidebarBulkActionNotice(
+            for: noOpReport,
+            action: .delete,
+            origin: .command
+        )
+
+        XCTAssertEqual(selectionPartial, .init(
+            severity: .warning,
+            title: "Bulk action partially completed",
+            message: "Some chats changed, but some selected or related chats were rejected before mutation."
+        ))
+        XCTAssertEqual(commandPartial, .init(
+            severity: .warning,
+            title: "Action partially completed",
+            message: "Some chats changed, but some requested or related chats were rejected before mutation."
+        ))
+        XCTAssertEqual(selectionNoOp?.message, "The selected chats no longer matched the delete action.")
+        XCTAssertEqual(commandNoOp?.message, "The requested chats no longer matched the delete action.")
+        XCTAssertFalse(commandPartial?.title.contains("Bulk") == true)
+        XCTAssertFalse(commandPartial?.message.contains("selected") == true)
+        XCTAssertFalse(commandNoOp?.message.contains("selected") == true)
+    }
+
+    func testPinContextRejectionNoticeUsesOriginWording() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let selectedTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let missingTabID = UUID()
+        let pinTargets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [],
+            archivedDeleteTargets: [],
+            stashTabIDs: [],
+            pinTabIDs: [missingTabID],
+            unpinTabIDs: []
+        )
+
+        await viewModel.performSidebarBulkAction(
+            .pin,
+            origin: .command,
+            targets: pinTargets,
+            promptManager: fixture.prompt
+        )
+
+        XCTAssertEqual(viewModel.ui.sessionSidebar.selectionState.notice, .init(
+            severity: .warning,
+            title: "Chats were not pinned",
+            message: "The workspace or requested chats changed before the action could be applied."
+        ))
+
+        viewModel.ui.sessionSidebar.dismissBulkActionNotice()
+        viewModel.ui.sessionSidebar.selectAll(
+            renderedOrder: [.active(tabID: selectedTabID)],
+            workspaceID: workspaceID
+        )
+        let unpinTargets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [],
+            archivedDeleteTargets: [],
+            stashTabIDs: [],
+            pinTabIDs: [],
+            unpinTabIDs: [missingTabID]
+        )
+
+        await viewModel.performSidebarBulkAction(
+            .unpin,
+            origin: .selection,
+            targets: unpinTargets,
+            promptManager: fixture.prompt
+        )
+
+        XCTAssertEqual(viewModel.ui.sessionSidebar.selectionState.notice, .init(
+            severity: .warning,
+            title: "Chats were not unpinned",
+            message: "The workspace or selected chats changed before the action could be applied."
+        ))
+    }
+
+    func testCommandCoordinatorGuardAndDirectCommandPredicateUseLiveSelectionState() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let tabID = try XCTUnwrap(
+            fixture.manager.activeWorkspace?.composeTabs.first(where: { !$0.isPinned })?.id
+        )
+        let identity = AgentSidebarSelectionIdentity.active(tabID: tabID)
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [],
+            archivedDeleteTargets: [],
+            stashTabIDs: [],
+            pinTabIDs: [tabID],
+            unpinTabIDs: []
+        )
+
+        XCTAssertTrue(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
+        XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: UUID()))
+
+        viewModel.ui.sessionSidebar.selectAll(renderedOrder: [identity], workspaceID: workspaceID)
+        XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
+
+        await viewModel.performSidebarBulkAction(
+            .pin,
+            origin: .command,
+            targets: targets,
+            promptManager: fixture.prompt
+        )
+
+        XCTAssertFalse(fixture.manager.activeWorkspace?.composeTabs.first(where: { $0.id == tabID })?.isPinned == true)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+
+        viewModel.ui.sessionSidebar.clearSelection()
+        let token = try XCTUnwrap(viewModel.ui.sessionSidebar.beginBulkAction(
+            kind: .delete,
+            origin: .command,
+            targetCount: 1,
+            workspaceID: workspaceID
+        ))
+        XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
+        viewModel.ui.sessionSidebar.finishBulkAction(token: token, workspaceID: workspaceID, notice: nil)
+        XCTAssertTrue(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
     }
 
     func testPostRemovalClearsOnlyRemovedTabTranscriptRefreshSignature() async throws {

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -564,6 +564,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         await viewModel.performSidebarBulkAction(
             .delete,
             origin: .selection,
+            commandProgressPlacement: nil,
             targets: targets,
             promptManager: fixture.prompt
         )
@@ -602,6 +603,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             await viewModel.performSidebarBulkAction(
                 .delete,
                 origin: .command,
+                commandProgressPlacement: .row,
                 targets: targets,
                 promptManager: fixture.prompt
             )
@@ -614,13 +616,22 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertEqual(operation.kind, .delete)
         XCTAssertEqual(operation.origin, .command)
         XCTAssertEqual(operation.targetCount, 1)
+        XCTAssertEqual(operation.presentationTargets, [.active(tabID: tabID)])
+        XCTAssertEqual(operation.commandProgressPlacement, .row)
         XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
-        XCTAssertEqual(viewModel.ui.sessionSidebar.selectionState.commandProgressOperation, operation)
+        XCTAssertEqual(
+            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: .active(tabID: tabID)),
+            operation
+        )
+        XCTAssertNil(
+            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: .active(tabID: UUID()))
+        )
 
         await viewModel.performSidebarBulkAction(
             .delete,
             origin: .command,
+            commandProgressPlacement: .row,
             targets: targets,
             promptManager: fixture.prompt
         )
@@ -635,7 +646,9 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == tabID }))
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
-        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandProgressOperation)
+        XCTAssertNil(
+            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: .active(tabID: tabID))
+        )
     }
 
     func testSelectionCoordinatorRetainsProgressAfterReconciliationWhileDeleteIsSuspended() async throws {
@@ -667,6 +680,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             await viewModel.performSidebarBulkAction(
                 .delete,
                 origin: .selection,
+                commandProgressPlacement: nil,
                 targets: targets,
                 promptManager: fixture.prompt
             )
@@ -679,9 +693,12 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertEqual(operation.kind, .delete)
         XCTAssertEqual(operation.origin, .selection)
         XCTAssertEqual(operation.targetCount, 1)
+        XCTAssertEqual(operation.presentationTargets, [identity])
+        XCTAssertNil(operation.commandProgressPlacement)
         XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
         XCTAssertTrue(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
-        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandProgressOperation)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: identity))
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.archivedHeaderCommandProgressOperation)
 
         viewModel.ui.sessionSidebar.reconcileSelection(renderedOrder: [], workspaceID: workspaceID)
 
@@ -695,7 +712,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == tabID }))
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.isMutationInFlight)
         XCTAssertFalse(viewModel.ui.sessionSidebar.selectionState.showsSelectionPresentation)
-        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandProgressOperation)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(for: identity))
     }
 
     func testMixedDeleteDoesNotRetryArchivedTargetRejectedDuringActiveCascade() async throws {
@@ -876,6 +893,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         await viewModel.performSidebarBulkAction(
             .pin,
             origin: .command,
+            commandProgressPlacement: .row,
             targets: targets,
             promptManager: fixture.prompt
         )
@@ -979,7 +997,6 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         let fixture = makeFixture(initialTabCount: 2)
         let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
         let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
-        let selectedTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
         let missingTabID = UUID()
         let pinTargets = AgentModeViewModel.SidebarBulkMutationTargets(
             workspaceID: workspaceID,
@@ -993,6 +1010,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         await viewModel.performSidebarBulkAction(
             .pin,
             origin: .command,
+            commandProgressPlacement: .row,
             targets: pinTargets,
             promptManager: fixture.prompt
         )
@@ -1005,7 +1023,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
 
         viewModel.ui.sessionSidebar.dismissBulkActionNotice()
         viewModel.ui.sessionSidebar.selectAll(
-            renderedOrder: [.active(tabID: selectedTabID)],
+            renderedOrder: [.active(tabID: missingTabID)],
             workspaceID: workspaceID
         )
         let unpinTargets = AgentModeViewModel.SidebarBulkMutationTargets(
@@ -1020,6 +1038,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         await viewModel.performSidebarBulkAction(
             .unpin,
             origin: .selection,
+            commandProgressPlacement: nil,
             targets: unpinTargets,
             promptManager: fixture.prompt
         )
@@ -1057,6 +1076,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         await viewModel.performSidebarBulkAction(
             .pin,
             origin: .command,
+            commandProgressPlacement: .row,
             targets: targets,
             promptManager: fixture.prompt
         )
@@ -1068,7 +1088,8 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         let token = try XCTUnwrap(viewModel.ui.sessionSidebar.beginBulkAction(
             kind: .delete,
             origin: .command,
-            targetCount: 1,
+            presentationTargets: [identity],
+            commandProgressPlacement: .row,
             workspaceID: workspaceID
         ))
         XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -660,6 +660,140 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         )
     }
 
+    func testCommandCoordinatorShowsFallbackAfterProjectionRemovalUntilCleanupFinishes() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let tabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let identity = AgentSidebarSelectionIdentity.active(tabID: tabID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        let fence = TestReleaseFence(name: "command sidebar delete post-projection cleanup")
+        defer { fence.release() }
+        viewModel.test_setComposeTabRemovalTeardownObserver { removedTabID in
+            guard removedTabID == tabID else { return }
+            await fence.enterAndWait()
+        }
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [tabID],
+            archivedDeleteTargets: [],
+            stashTabIDs: [],
+            pinTabIDs: [],
+            unpinTabIDs: []
+        )
+
+        let deleteTask = Task {
+            await viewModel.performSidebarBulkAction(
+                .delete,
+                origin: .command,
+                commandProgressPlacement: .row,
+                targets: targets,
+                promptManager: fixture.prompt
+            )
+        }
+        let cleanupEntered = await fence.waitUntilEntered()
+        XCTAssertTrue(cleanupEntered)
+
+        XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == tabID }))
+        let operation = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertTrue(operation.commandRowProgressRetired)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+            for: identity,
+            workspaceID: workspaceID
+        ))
+        XCTAssertEqual(
+            viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
+                renderedOrder: [],
+                workspaceID: workspaceID
+            ),
+            operation
+        )
+        XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
+
+        fence.release()
+        await deleteTask.value
+
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
+            renderedOrder: [],
+            workspaceID: workspaceID
+        ))
+    }
+
+    func testCommandCoordinatorDoesNotAttachOldProgressToSameIDReplacement() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let tabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let identity = AgentSidebarSelectionIdentity.active(tabID: tabID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let removedSession = viewModel.session(for: tabID)
+        var replacementSession = viewModel.sessions[UUID()]
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        let fence = TestReleaseFence(name: "command sidebar stash same-ID replacement")
+        defer { fence.release() }
+        viewModel.test_setComposeTabRemovalTeardownObserver { removedTabID in
+            guard removedTabID == tabID,
+                  let workspaceIndex = fixture.manager.workspaces.firstIndex(where: { $0.id == workspaceID }),
+                  let stashedIndex = fixture.manager.workspaces[workspaceIndex].stashedTabs.firstIndex(
+                      where: { $0.tab.id == removedTabID }
+                  )
+            else {
+                XCTFail("Expected stashed command target")
+                return
+            }
+            let restoredTab = fixture.manager.workspaces[workspaceIndex].stashedTabs.remove(at: stashedIndex).tab
+            fixture.manager.workspaces[workspaceIndex].composeTabs.append(restoredTab)
+            replacementSession = viewModel.session(for: removedTabID)
+            await fence.enterAndWait()
+        }
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [],
+            archivedDeleteTargets: [],
+            stashTabIDs: [tabID],
+            pinTabIDs: [],
+            unpinTabIDs: []
+        )
+
+        let stashTask = Task {
+            await viewModel.performSidebarBulkAction(
+                .stash,
+                origin: .command,
+                commandProgressPlacement: .row,
+                targets: targets,
+                promptManager: fixture.prompt
+            )
+        }
+        let cleanupEntered = await fence.waitUntilEntered()
+        XCTAssertTrue(cleanupEntered)
+
+        XCTAssertTrue(fixture.manager.activeWorkspace?.composeTabs.contains(where: { $0.id == tabID }) == true)
+        XCTAssertFalse(viewModel.sessions[tabID] === removedSession)
+        XCTAssertTrue(viewModel.sessions[tabID] === replacementSession)
+        let operation = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertTrue(operation.commandRowProgressRetired)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+            for: identity,
+            workspaceID: workspaceID
+        ))
+        XCTAssertEqual(
+            viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
+                renderedOrder: [identity],
+                workspaceID: workspaceID
+            ),
+            operation
+        )
+        XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
+
+        fence.release()
+        await stashTask.value
+
+        XCTAssertTrue(viewModel.sessions[tabID] === replacementSession)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+    }
+
     func testSelectionCoordinatorRetainsProgressAfterReconciliationWhileDeleteIsSuspended() async throws {
         let fixture = makeFixture(initialTabCount: 2)
         let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -539,13 +539,21 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
 
     func testBulkCoordinatorAppliesExactMixedDeleteTargets() async throws {
         let fixture = makeFixture(initialTabCount: 2)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
         let activeTabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
         let stashed = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
         let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
         let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
         defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
-        let targets = try AgentModeViewModel.SidebarBulkMutationTargets(
-            workspaceID: XCTUnwrap(fixture.manager.activeWorkspace?.id),
+        viewModel.ui.sessionSidebar.selectAll(
+            renderedOrder: [
+                .active(tabID: activeTabID),
+                .archived(stashedTabID: stashed.id, tabID: stashed.tab.id)
+            ],
+            workspaceID: workspaceID
+        )
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
             activeDeleteTabIDs: [activeTabID],
             archivedDeleteTargets: [.init(stashedTabID: stashed.id, tabID: stashed.tab.id)],
             stashTabIDs: [],

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -660,7 +660,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         )
     }
 
-    func testCommandCoordinatorSuppressesFallbackAfterStashProjectionRemovalBeforeRetirement() async throws {
+    func testCommandCoordinatorRetiresProgressAfterStashProjectionRemovalBeforeCleanup() async throws {
         let fixture = makeFixture(initialTabCount: 2)
         let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
         let tabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
@@ -705,7 +705,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             tabID: tabID
         )
         let operation = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
-        XCTAssertFalse(operation.commandRowProgressRetired)
+        XCTAssertTrue(operation.commandRowProgressRetired)
         XCTAssertEqual(operation.presentationTargets, [activeIdentity])
 
         let projection = viewModel.sidebarListProjection(
@@ -888,6 +888,138 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
 
         XCTAssertTrue(viewModel.sessions[tabID] === replacementSession)
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+    }
+
+    func testStaleCommandCleanupCannotRetireSameIDReplacementOperation() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let sourceWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let workspaceID = sourceWorkspace.id
+        let tabID = try XCTUnwrap(sourceWorkspace.composeTabs.first?.id)
+        let identity = AgentSidebarSelectionIdentity.active(tabID: tabID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+
+        let cleanupFenceA = TestReleaseFence(name: "stale command A post-projection cleanup")
+        defer { cleanupFenceA.release() }
+        viewModel.test_setComposeTabRemovalTeardownObserver { removedTabID in
+            guard removedTabID == tabID else { return }
+            await cleanupFenceA.enterAndWait()
+        }
+
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [],
+            archivedDeleteTargets: [],
+            stashTabIDs: [tabID],
+            pinTabIDs: [],
+            unpinTabIDs: []
+        )
+        let stashTaskA = Task {
+            await viewModel.performSidebarBulkAction(
+                .stash,
+                origin: .command,
+                commandProgressPlacement: .row,
+                targets: targets,
+                promptManager: fixture.prompt
+            )
+        }
+        let cleanupAEntered = await cleanupFenceA.waitUntilEntered()
+        XCTAssertTrue(cleanupAEntered)
+
+        let snapshotAfterA = try XCTUnwrap(fixture.prompt.sidebarWorkspaceSnapshot)
+        XCTAssertEqual(snapshotAfterA.workspaceID, workspaceID)
+        XCTAssertFalse(snapshotAfterA.composeTabs.contains(where: { $0.id == tabID }))
+        XCTAssertTrue(snapshotAfterA.stashedTabs.contains(where: { $0.tab.id == tabID }))
+        let operationA = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertTrue(operationA.commandRowProgressRetired)
+
+        let destinationWorkspace = WorkspaceModel(
+            name: "Command retirement destination",
+            repoPaths: sourceWorkspace.repoPaths,
+            ephemeralFlag: true,
+            composeTabs: [ComposeTabState(name: "Destination tab", activeAgentSessionID: UUID())]
+        )
+        fixture.manager.workspaces.append(destinationWorkspace)
+        fixture.manager.activeWorkspace = destinationWorkspace
+        fixture.prompt.loadComposeTabsFromWorkspace(destinationWorkspace)
+        await viewModel.handleWorkspaceSwitch(destinationWorkspace)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+
+        let latestSourceWorkspace = try XCTUnwrap(
+            fixture.manager.workspaces.first(where: { $0.id == workspaceID })
+        )
+        fixture.manager.activeWorkspace = latestSourceWorkspace
+        fixture.prompt.loadComposeTabsFromWorkspace(latestSourceWorkspace)
+        await viewModel.handleWorkspaceSwitch(latestSourceWorkspace)
+
+        let restoredTabResult = await fixture.prompt.restoreStashedComposeTab(containingTabID: tabID)
+        let restoredTab = try XCTUnwrap(restoredTabResult)
+        XCTAssertEqual(restoredTab.id, tabID)
+        XCTAssertTrue(fixture.manager.activeWorkspace?.composeTabs.contains(where: { $0.id == tabID }) == true)
+
+        let preflightFenceB = TestReleaseFence(name: "replacement command B preflight")
+        defer { preflightFenceB.release() }
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { tabIDs, reason, _ in
+            guard reason == .stash, tabIDs.contains(tabID) else { return .proceed }
+            await preflightFenceB.enterAndWait()
+            return .proceed
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+
+        let stashTaskB = Task {
+            await viewModel.performSidebarBulkAction(
+                .stash,
+                origin: .command,
+                commandProgressPlacement: .row,
+                targets: targets,
+                promptManager: fixture.prompt
+            )
+        }
+        let preflightBEntered = await preflightFenceB.waitUntilEntered()
+        XCTAssertTrue(preflightBEntered)
+
+        let operationB = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertNotEqual(operationA.token, operationB.token)
+        XCTAssertFalse(operationB.commandRowProgressRetired)
+        XCTAssertEqual(
+            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+                for: identity,
+                workspaceID: workspaceID
+            ),
+            operationB
+        )
+        XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
+
+        cleanupFenceA.release()
+        await stashTaskA.value
+
+        let operationBAfterA = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertEqual(operationBAfterA.token, operationB.token)
+        XCTAssertFalse(operationBAfterA.commandRowProgressRetired)
+        XCTAssertEqual(
+            viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+                for: identity,
+                workspaceID: workspaceID
+            ),
+            operationBAfterA
+        )
+        XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
+
+        preflightFenceB.release()
+        await stashTaskB.value
+
+        XCTAssertTrue(fixture.manager.activeWorkspace?.stashedTabs.contains(where: { $0.tab.id == tabID }) == true)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandRowProgressOperation(
+            for: identity,
+            workspaceID: workspaceID
+        ))
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
+            existingIdentities: [],
+            renderedIdentities: [],
+            workspaceID: workspaceID
+        ))
     }
 
     func testSelectionCoordinatorRetainsProgressAfterReconciliationWhileDeleteIsSuspended() async throws {

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -660,6 +660,83 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         )
     }
 
+    func testCommandCoordinatorSuppressesFallbackAfterStashProjectionRemovalBeforeRetirement() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
+        let tabID = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs.first?.id)
+        let activeIdentity = AgentSidebarSelectionIdentity.active(tabID: tabID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        let fence = TestReleaseFence(name: "command sidebar stash will-close")
+        defer { fence.release() }
+        let willCloseToken = fixture.prompt.addComposeTabsWillCloseListener { tabIDs, reason in
+            guard reason == .stash, tabIDs.contains(tabID) else { return }
+            await fence.enterAndWait()
+        }
+        defer { fixture.prompt.removeComposeTabsWillCloseListener(willCloseToken) }
+        let targets = AgentModeViewModel.SidebarBulkMutationTargets(
+            workspaceID: workspaceID,
+            activeDeleteTabIDs: [],
+            archivedDeleteTargets: [],
+            stashTabIDs: [tabID],
+            pinTabIDs: [],
+            unpinTabIDs: []
+        )
+
+        let stashTask = Task {
+            await viewModel.performSidebarBulkAction(
+                .stash,
+                origin: .command,
+                commandProgressPlacement: .row,
+                targets: targets,
+                promptManager: fixture.prompt
+            )
+        }
+        let willCloseEntered = await fence.waitUntilEntered()
+        XCTAssertTrue(willCloseEntered)
+
+        let workspaceSnapshot = try XCTUnwrap(fixture.prompt.sidebarWorkspaceSnapshot)
+        XCTAssertEqual(workspaceSnapshot.workspaceID, workspaceID)
+        XCTAssertFalse(workspaceSnapshot.composeTabs.contains(where: { $0.id == tabID }))
+        let stashedTab = try XCTUnwrap(workspaceSnapshot.stashedTabs.first(where: { $0.tab.id == tabID }))
+        let archivedIdentity = AgentSidebarSelectionIdentity.archived(
+            stashedTabID: stashedTab.id,
+            tabID: tabID
+        )
+        let operation = try XCTUnwrap(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+        XCTAssertFalse(operation.commandRowProgressRetired)
+        XCTAssertEqual(operation.presentationTargets, [activeIdentity])
+
+        let projection = viewModel.sidebarListProjection(
+            workspaceID: workspaceSnapshot.workspaceID,
+            composeTabs: workspaceSnapshot.composeTabs,
+            stashedTabs: workspaceSnapshot.stashedTabs,
+            currentTabID: fixture.prompt.activeComposeTabID,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: false,
+            showComposeTabsWithoutAgentSessions: true
+        )
+        let renderedIdentities = Set(projection.pagedSessions.map {
+            AgentSidebarSelectionIdentity.active(tabID: $0.tabID)
+        })
+        XCTAssertFalse(projection.existingSelectionIdentities.contains(activeIdentity))
+        XCTAssertTrue(projection.existingSelectionIdentities.contains(archivedIdentity))
+        XCTAssertFalse(projection.existingSelectionIdentities.contains(
+            .archived(stashedTabID: UUID(), tabID: tabID)
+        ))
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
+            existingIdentities: projection.existingSelectionIdentities,
+            renderedIdentities: renderedIdentities,
+            workspaceID: workspaceID
+        ))
+
+        fence.release()
+        await stashTask.value
+
+        XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
+    }
+
     func testCommandCoordinatorRetiresAllCommandProgressAfterProjectionRemoval() async throws {
         let fixture = makeFixture(initialTabCount: 2)
         let workspaceID = try XCTUnwrap(fixture.manager.activeWorkspace?.id)
@@ -714,7 +791,8 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             workspaceID: workspaceID
         ))
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
-            renderedOrder: projection.renderedSelectionOrder,
+            existingIdentities: projection.existingSelectionIdentities,
+            renderedIdentities: Set(projection.renderedSelectionOrder),
             workspaceID: workspaceID
         ))
         XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))
@@ -724,7 +802,8 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
 
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.inFlightAction)
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
-            renderedOrder: [],
+            existingIdentities: [],
+            renderedIdentities: [],
             workspaceID: workspaceID
         ))
     }
@@ -798,7 +877,8 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             workspaceID: workspaceID
         ))
         XCTAssertNil(viewModel.ui.sessionSidebar.selectionState.commandFallbackProgressOperation(
-            renderedOrder: projection.renderedSelectionOrder,
+            existingIdentities: projection.existingSelectionIdentities,
+            renderedIdentities: Set(projection.renderedSelectionOrder),
             workspaceID: workspaceID
         ))
         XCTAssertFalse(viewModel.canPerformDirectSidebarCommand(workspaceID: workspaceID))


### PR DESCRIPTION
## Summary

A direct action on one sidebar row put the whole sidebar into multi-select presentation for the length of the operation. Selection circles appeared beside every session, normal row actions hid, and the header read "0 selected" when nothing was selected. Stash and delete showed it most because they stay pending through cascade and cleanup work, but archived delete, Clear Archived, and direct pin and unpin all publish the same state. Direct actions now show plain progress with no selection count. Bulk-selection actions keep their real count.

## Changes

- Each sidebar mutation records whether it came from bulk selection or from a direct command. The shared mutation coordinator and its workspace/token fencing stay as they were.
- The selection UI no longer keys off the global mutation lock, so a direct action never draws selection circles or a selected-count header.
- Bulk actions keep showing progress after reconciliation removes the selected rows. The active mutation now carries its own copy of the operation targets instead of reading rows that may be gone.
- Row, archived-session, rename, and confirmation callbacks bail out when the workspace changed or another mutation is already running.
- New tests cover both origins, in the store and against a suspended coordinator: reentry rejection, reconciliation, workspace invalidation, and notice wording.

## Validation

CI is green on all eight checks, including the four app test shards, Provider Tests, Style, and the Sentry-enabled build.

Locally:

- `make dev-test FILTER=AgentSessionSidebarUIStoreTests`, 11 tests passed.
- `make dev-test FILTER=BackgroundComposeTabAdmissionTests`, 39 tests passed.
- `make dev-lint`, passed.
- `ALLOW_ADHOC_SIGNING=1 make dev-build`, passed.

Closes #875
