### PR TITLE
Fix Tip staged rollout authority

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -453,7 +453,8 @@ jobs:
           [[ "${checksums[0]}" == "${archives[0]}.sha256" ]] || { echo "Staged tip checksum name mismatch" >&2; exit 1; }
           (cd staged-tip && shasum -a 256 -c "$(basename "${checksums[0]}")")
           ./trusted-control-plane/Scripts/extract_staged_release.py "${archives[0]}" tip-source RepoPrompt
-          REPOPROMPT_RELEASE_SOURCE_ROOT=tip-source \
+          REPOPROMPT_TIP_ARCHIVE_CONTRACT=tip-rollout-v1 \
+            REPOPROMPT_RELEASE_SOURCE_ROOT=tip-source \
             REPOPROMPT_APPROVED_SOURCE_ROOT=approved-source \
             ./trusted-control-plane/Scripts/validate_staged_release.sh
 

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -221,6 +221,7 @@ stage_tip() {
         "$APP_NAME" \
         "repoprompt-mcp.dSYM" \
         "repoprompt-mcp"
+    cp "$ROLLOUT_DECLARATION" "$stage_root/tip-rollout.json"
     write_tip_version_env "$stage_root/version.env"
     cp "$ROOT_DIR/LICENSE" "$ROOT_DIR/THIRD_PARTY_NOTICES.md" "$stage_root/"
     cp -R "$ROOT_DIR/ThirdPartyLicenses" "$stage_root/"
@@ -335,6 +336,7 @@ sign_tip() {
     [[ -d "$APP_BUNDLE" ]] || fail "Missing staged tip app bundle: $APP_BUNDLE"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE="$TIP_BUILD_NUMBER" \
+        REPOPROMPT_TIP_ARCHIVE_CONTRACT=tip-rollout-v1 \
         REPOPROMPT_IDENTITY_MIGRATION_PHASE="$REPOPROMPT_IDENTITY_MIGRATION_PHASE" \
         "$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"
     verify_release_sentry_symbol_uuids_before_signing \
@@ -346,6 +348,7 @@ sign_tip() {
         "repoprompt-mcp"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE="$TIP_BUILD_NUMBER" \
+        REPOPROMPT_TIP_ARCHIVE_CONTRACT=tip-rollout-v1 \
         REPOPROMPT_IDENTITY_MIGRATION_PHASE="$REPOPROMPT_IDENTITY_MIGRATION_PHASE" \
         "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
     prepare_dist

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2661,6 +2661,56 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("OK: staged release payload matches approved source", result.stdout)
 
+    def test_tip_staged_release_carries_exact_rollout_authority(self) -> None:
+        tip_release = (SCRIPT_DIR / "main_tip_release.sh").read_text(encoding="utf-8")
+        tip_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('cp "$ROLLOUT_DECLARATION" "$stage_root/tip-rollout.json"', tip_release)
+        self.assertIn("REPOPROMPT_TIP_ARCHIVE_CONTRACT=tip-rollout-v1", tip_release)
+        self.assertIn("REPOPROMPT_TIP_ARCHIVE_CONTRACT=tip-rollout-v1", tip_workflow)
+
+        approved, staged, scripts = self.make_staged_release_fixture()
+        generic_override = self.run_staged_validation(
+            approved,
+            staged,
+            scripts,
+            release_build_number_override="1",
+        )
+        self.assertEqual(generic_override.returncode, 0, generic_override.stderr)
+
+        missing = self.run_staged_validation(
+            approved,
+            staged,
+            scripts,
+            release_build_number_override="1",
+            tip_archive_contract="tip-rollout-v1",
+        )
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn("missing staged file", missing.stderr)
+        self.assertIn("tip-rollout.json", missing.stderr)
+
+        shutil.copy2(approved / "tip-rollout.json", staged / "tip-rollout.json")
+        accepted = self.run_staged_validation(
+            approved,
+            staged,
+            scripts,
+            release_build_number_override="1",
+            tip_archive_contract="tip-rollout-v1",
+        )
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        (staged / "tip-rollout.json").write_text("{}\n", encoding="utf-8")
+        changed = self.run_staged_validation(
+            approved,
+            staged,
+            scripts,
+            release_build_number_override="1",
+            tip_archive_contract="tip-rollout-v1",
+        )
+        self.assertNotEqual(changed.returncode, 0)
+        self.assertIn("Staged Tip rollout declaration does not match approved source", changed.stderr)
+
     def test_staged_release_validator_rejects_requested_preparer_for_historical_template(self) -> None:
         approved, staged, scripts = self.make_staged_release_fixture()
         template_path = approved / "AppBundle" / "Info.plist.template"
@@ -4406,6 +4456,7 @@ extension Data {
             encoding="utf-8",
         )
         (approved / "Vendor" / "Codex" / "manifest.json").write_text("{}\n", encoding="utf-8")
+        shutil.copy2(SCRIPT_DIR.parent / "tip-rollout.json", approved / "tip-rollout.json")
         metadata = """\
 APP_NAME=RepoPrompt
 DISPLAY_NAME="RepoPrompt CE"
@@ -4524,6 +4575,8 @@ esac
         staged: Path,
         scripts: Path,
         identity_migration_phase: str | None = None,
+        release_build_number_override: str | None = None,
+        tip_archive_contract: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
@@ -4538,6 +4591,10 @@ esac
         )
         if identity_migration_phase is not None:
             env["REPOPROMPT_IDENTITY_MIGRATION_PHASE"] = identity_migration_phase
+        if release_build_number_override is not None:
+            env["REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE"] = release_build_number_override
+        if tip_archive_contract is not None:
+            env["REPOPROMPT_TIP_ARCHIVE_CONTRACT"] = tip_archive_contract
         return subprocess.run(
             [str(scripts / "validate_staged_release.sh")],
             env=env,

--- a/Scripts/validate_staged_release.sh
+++ b/Scripts/validate_staged_release.sh
@@ -59,8 +59,14 @@ if [[ -n "${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}" ]]; then
 fi
 
 APP_BUNDLE="$ROOT_DIR/.build/release/$APP_NAME.app"
+TIP_ROLLOUT_DECLARATION_NAME=""
+case "${REPOPROMPT_TIP_ARCHIVE_CONTRACT:-}" in
+    "") ;;
+    tip-rollout-v1) TIP_ROLLOUT_DECLARATION_NAME="tip-rollout.json" ;;
+    *) fail "Unsupported REPOPROMPT_TIP_ARCHIVE_CONTRACT: $REPOPROMPT_TIP_ARCHIVE_CONTRACT" ;;
+esac
 
-python3 - "$ROOT_DIR" "$APP_BUNDLE" <<'PYTHON'
+python3 - "$ROOT_DIR" "$APP_BUNDLE" "$TIP_ROLLOUT_DECLARATION_NAME" <<'PYTHON'
 import os
 import stat
 import sys
@@ -68,6 +74,7 @@ from pathlib import Path
 
 root = Path(sys.argv[1])
 app = Path(sys.argv[2])
+tip_rollout_declaration_name = sys.argv[3]
 
 def fail(message: str) -> None:
     raise SystemExit(f"ERROR: {message}")
@@ -113,9 +120,13 @@ for path in [
     app / "Contents" / "MacOS" / "repoprompt-mcp",
 ]:
     require_regular_file(path)
+if tip_rollout_declaration_name:
+    require_regular_file(root / tip_rollout_declaration_name)
 
 top_level = {path.name for path in root.iterdir()}
 expected_top_level = {".build", "LICENSE", "RELEASE_COMMIT", "THIRD_PARTY_NOTICES.md", "ThirdPartyLicenses", "version.env"}
+if tip_rollout_declaration_name:
+    expected_top_level.add(tip_rollout_declaration_name)
 if top_level != expected_top_level:
     fail(f"unexpected staged top-level entries: {sorted(top_level ^ expected_top_level)}")
 
@@ -139,6 +150,13 @@ for path in root.rglob("*"):
     elif not stat.S_ISDIR(mode) and not stat.S_ISREG(mode):
         fail(f"unsupported staged path type: {path}")
 PYTHON
+
+if [[ -n "$TIP_ROLLOUT_DECLARATION_NAME" ]]; then
+    [[ -f "$APPROVED_SOURCE_ROOT/$TIP_ROLLOUT_DECLARATION_NAME" ]] ||
+        fail "Missing approved Tip rollout declaration"
+    cmp "$ROOT_DIR/$TIP_ROLLOUT_DECLARATION_NAME" "$APPROVED_SOURCE_ROOT/$TIP_ROLLOUT_DECLARATION_NAME" ||
+        fail "Staged Tip rollout declaration does not match approved source"
+fi
 
 "$SCRIPT_DIR/validate_required_swiftpm_resource_bundles.sh" "$APP_BUNDLE" "Staged app SwiftPM resource bundle layout"
 "$SCRIPT_DIR/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Staged app MCP helper layout"


### PR DESCRIPTION
## Summary

- carry the approved `tip-rollout.json` declaration into the staged Tip source archive
- mark Tip archive validation with the explicit versioned `tip-rollout-v1` contract
- fail closed when the staged declaration is missing or differs from the approved source
- preserve Stable staged-release behavior when no Tip contract is present

## Root cause

The Tip build job staged the rewritten version metadata but omitted `tip-rollout.json`. The sign job then ran from the extracted stage, so `Scripts/main_tip_release.sh` could not load rollout authority and stopped before signing.

The credential correction itself is independently proven: Tip run 32916033110 passed Apple credential preflight and completed the source build, then failed at this missing staged-authority boundary. It created no tag or release.

## Validation

- focused release-tooling regression tests passed, including exact/missing/tampered Tip declaration cases and Stable compatibility
- workflow shell blocks and modified shell scripts pass syntax validation
- `git diff --check`
- mandatory commit and push safety preflights
- full path-selected `pr-ready` preflight
- `make dev-release-preflight`
- outgoing commit secret scan: no leaks

## Rollout

After merge, dispatch a fresh preparer-only Tip run against the merged `main` SHA. Publication remains a separate approval boundary.