### PR TITLE
Fix Tip signed artifact handoff

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -656,19 +656,23 @@ jobs:
           rm -f "$RUNNER_TEMP/repoprompt-tip-successor.p12"
           rm -f "$RUNNER_TEMP/repoprompt-successor-identity-anchor"
 
+      - name: Validate signed Tip asset inventory
+        env:
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+          TIP_SHORT_SHA: ${{ needs.setup.outputs.short-sha }}
+          TIP_BUILD_NUMBER: ${{ needs.setup.outputs.build-number }}
+          TIP_TAG: ${{ needs.setup.outputs.tag }}
+          TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
+          TIP_PUBLISH_INSTALLATION_TYPE: ${{ needs.setup.outputs.installation-type }}
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
+        run: ./trusted-control-plane/Scripts/main_tip_release.sh validate-assets
+
       - name: Upload signed tip assets for smoke and publish
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: RepoPrompt-CE-signed-tip
-          path: |
-            tip-source/dist/*.zip
-            tip-source/dist/*.dmg
-            tip-source/dist/*.pkg
-            tip-source/dist/appcast.xml
-            tip-source/dist/SHA256SUMS
-            tip-source/dist/*-artifact-manifest.json
-            tip-source/dist/*-metadata.json
-            tip-source/dist/identity-rollout.json
+          path: tip-source/dist/
           if-no-files-found: error
           retention-days: 1
 
@@ -694,6 +698,19 @@ jobs:
         with:
           name: RepoPrompt-CE-signed-tip
           path: signed-tip
+
+      - name: Validate signed Tip asset inventory
+        env:
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+          TIP_SHORT_SHA: ${{ needs.setup.outputs.short-sha }}
+          TIP_BUILD_NUMBER: ${{ needs.setup.outputs.build-number }}
+          TIP_TAG: ${{ needs.setup.outputs.tag }}
+          TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
+          TIP_PUBLISH_INSTALLATION_TYPE: ${{ needs.setup.outputs.installation-type }}
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/trusted-control-plane
+          DIST_DIR: ${{ github.workspace }}/signed-tip
+        run: ./trusted-control-plane/Scripts/main_tip_release.sh validate-assets
 
       - name: Verify and smoke signed tip
         env:
@@ -776,6 +793,7 @@ jobs:
           TIP_TAG: ${{ needs.setup.outputs.tag }}
           TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
           TIP_GH_TOKEN: ${{ secrets.TIP_UPDATE_REPOSITORY_TOKEN }}
+          TIP_PUBLISH_INSTALLATION_TYPE: ${{ needs.setup.outputs.installation-type }}
           REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
           REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/trusted-control-plane
           DIST_DIR: ${{ github.workspace }}/tip-assets

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -26,6 +26,7 @@ eval "$(python3 "$ROLLOUT_TOOL" packaging-context \
     --policy "$APPLE_IDENTITY_POLICY" \
     --version-env "$ROOT_DIR/version.env")"
 [[ "$ROLLOUT_CHANNEL" == "tip" ]] || fail "Tip release requires a Tip rollout declaration"
+TIP_PUBLISH_INSTALLATION_TYPE="${TIP_PUBLISH_INSTALLATION_TYPE:-$ROLLOUT_INSTALLATION_TYPE}"
 
 TIP_COMMIT="${TIP_COMMIT:-$(git rev-parse HEAD)}"
 TIP_SHORT_SHA="${TIP_SHORT_SHA:-${TIP_COMMIT:0:12}}"
@@ -405,6 +406,47 @@ sign_tip() {
     printf 'OK: signed and notarized Tip %s artifact %s.\n' "$ROLLOUT_ROLE" "$TIP_TAG"
 }
 
+tip_publish_assets() {
+    TIP_PUBLISH_ASSETS=("$APPCAST" "$CHECKSUMS" "$FINAL_ARTIFACT_MANIFEST" "$FINAL_METADATA" "$ROLLOUT_MANIFEST")
+    case "$TIP_PUBLISH_INSTALLATION_TYPE" in
+        package) TIP_PUBLISH_ASSETS+=("$TRANSITION_PKG") ;;
+        application) TIP_PUBLISH_ASSETS+=("$UPDATE_ZIP" "$DMG") ;;
+        *) fail "TIP_PUBLISH_INSTALLATION_TYPE must be application or package" ;;
+    esac
+}
+
+validate_tip_publish_assets() {
+    require_command python3
+    tip_publish_assets
+    local expected_basenames=()
+    local path
+    for path in "${TIP_PUBLISH_ASSETS[@]}"; do
+        expected_basenames+=("$(basename "$path")")
+    done
+    python3 - "$DIST_DIR" "${expected_basenames[@]}" <<'PYTHON'
+import sys
+from pathlib import Path
+
+dist = Path(sys.argv[1])
+expected = set(sys.argv[2:])
+if not dist.is_dir():
+    raise SystemExit(f"ERROR: Missing Tip publish directory: {dist}")
+actual = {entry.name for entry in dist.iterdir()}
+missing = sorted(expected - actual)
+extra = sorted(actual - expected)
+if missing or extra:
+    raise SystemExit(
+        "ERROR: Tip publish asset inventory mismatch: "
+        f"missing={missing or 'none'} extra={extra or 'none'}"
+    )
+for name in sorted(expected):
+    path = dist / name
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"ERROR: Tip publish asset must be a regular non-symlink file: {path}")
+print(f"OK: Tip publish asset inventory contains exactly {len(expected)} files.")
+PYTHON
+}
+
 publish_tip() {
     require_command gh
     require_env TIP_GH_TOKEN
@@ -413,17 +455,9 @@ publish_tip() {
             fail "TIP_UPDATE_REPOSITORY must not target the source or stable update repository"
             ;;
     esac
-    local role_assets=("$APPCAST" "$CHECKSUMS" "$FINAL_ARTIFACT_MANIFEST" "$FINAL_METADATA" "$ROLLOUT_MANIFEST")
-    if [[ "$ROLLOUT_INSTALLATION_TYPE" == "package" ]]; then
-        role_assets+=("$TRANSITION_PKG")
-    else
-        role_assets+=("$UPDATE_ZIP" "$DMG")
-    fi
-    for path in "${role_assets[@]}"; do
-        [[ -f "$path" ]] || fail "Missing tip publish asset: $path"
-    done
+    validate_tip_publish_assets
     GH_TOKEN="$TIP_GH_TOKEN" gh release create "$TIP_TAG" \
-        "${role_assets[@]}" \
+        "${TIP_PUBLISH_ASSETS[@]}" \
         --repo "$TIP_UPDATE_REPOSITORY" \
         --target main \
         --latest \
@@ -436,7 +470,8 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     case "$MODE" in
         stage) stage_tip ;;
         sign) sign_tip ;;
+        validate-assets) validate_tip_publish_assets ;;
         publish-tip) publish_tip ;;
-        *) fail "Usage: $0 stage|sign|publish-tip" ;;
+        *) fail "Usage: $0 stage|sign|validate-assets|publish-tip" ;;
     esac
 fi

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -3344,7 +3344,16 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertIn("RELEASE_COMMIT: ${{ needs.setup.outputs.commit }}", tip_workflow)
         self.assertIn("REPOPROMPT_APPROVED_SOURCE_ROOT: ${{ github.workspace }}/approved-source", tip_workflow)
         self.assertIn("REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE: ${{ needs.setup.outputs.build-number }}", tip_workflow)
-        self.assertIn("tip-source/dist/*-metadata.json", tip_workflow)
+        self.assertIn("path: tip-source/dist/", tip_workflow)
+        self.assertEqual(tip_workflow.count("main_tip_release.sh validate-assets"), 2)
+        self.assertIn("path: signed-tip", tip_workflow)
+        self.assertIn("DIST_DIR: ${{ github.workspace }}/signed-tip", tip_workflow)
+        self.assertIn("path: tip-assets", tip_workflow)
+        self.assertIn("DIST_DIR: ${{ github.workspace }}/tip-assets", tip_workflow)
+        self.assertEqual(
+            tip_workflow.count("TIP_PUBLISH_INSTALLATION_TYPE: ${{ needs.setup.outputs.installation-type }}"),
+            3,
+        )
         self.assertNotIn("stable-release-channel", tip_workflow)
         self.assertNotIn("release-draft-creation", tip_workflow)
         self.assertNotIn("PUBLIC_UPDATE_REPOSITORY_TOKEN", tip_workflow)
@@ -3415,7 +3424,7 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertIn('REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE="$TIP_BUILD_NUMBER"', tip_script)
         self.assertEqual(tip_script.count('REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE="$TIP_BUILD_NUMBER"'), 3)
         self.assertNotIn('BUILD_NUMBER="$TIP_BUILD_NUMBER"', tip_script)
-        self.assertIn("stage|sign|publish-tip", tip_script)
+        self.assertIn("stage|sign|validate-assets|publish-tip", tip_script)
         self.assertIn('source "$CONTROL_PLANE_SCRIPTS_DIR/release_sentry_symbols.sh"', tip_script)
         self.assertIn("stage_release_sentry_symbols", tip_script)
         self.assertIn("require_tip_sentry_configuration", tip_script)
@@ -3459,6 +3468,105 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertIn(
             'fail "REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE must be a valid numeric build version"',
             package_script,
+        )
+
+    def test_tip_publish_asset_inventory_is_exact(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        short_sha = "0123456789ab"
+        build_number = "35.15.16"
+        archive_basename = f"RepoPrompt-tip-{short_sha}-{build_number}"
+        expected = {
+            f"{archive_basename}.zip",
+            f"{archive_basename}.dmg",
+            "appcast.xml",
+            "SHA256SUMS",
+            f"{archive_basename}-artifact-manifest.json",
+            f"{archive_basename}-metadata.json",
+            "identity-rollout.json",
+        }
+        for name in expected:
+            (temp_dir / name).write_text(f"{name}\n", encoding="utf-8")
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "TIP_COMMIT": "0123456789abcdef0123456789abcdef01234567",
+                "TIP_SHORT_SHA": short_sha,
+                "TIP_BUILD_NUMBER": build_number,
+                "DIST_DIR": str(temp_dir),
+            }
+        )
+
+        accepted = subprocess.run(
+            [str(SCRIPT_DIR / "main_tip_release.sh"), "validate-assets"],
+            cwd=SCRIPT_DIR.parent,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+        self.assertIn("contains exactly 7 files", accepted.stdout)
+
+        (temp_dir / "appcast.xml").unlink()
+        missing = subprocess.run(
+            [str(SCRIPT_DIR / "main_tip_release.sh"), "validate-assets"],
+            cwd=SCRIPT_DIR.parent,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn("missing=['appcast.xml']", missing.stderr)
+
+        (temp_dir / "appcast.xml").write_text("appcast\n", encoding="utf-8")
+        (temp_dir / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
+        extra = subprocess.run(
+            [str(SCRIPT_DIR / "main_tip_release.sh"), "validate-assets"],
+            cwd=SCRIPT_DIR.parent,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(extra.returncode, 0)
+        self.assertIn("extra=['unexpected.txt']", extra.stderr)
+
+        for path in temp_dir.iterdir():
+            path.unlink()
+        package_expected = {
+            f"{archive_basename}.pkg",
+            "appcast.xml",
+            "SHA256SUMS",
+            f"{archive_basename}-artifact-manifest.json",
+            f"{archive_basename}-metadata.json",
+            "identity-rollout.json",
+        }
+        for name in package_expected:
+            (temp_dir / name).write_text(f"{name}\n", encoding="utf-8")
+        package_env = env.copy()
+        package_env["TIP_PUBLISH_INSTALLATION_TYPE"] = "package"
+        package = subprocess.run(
+            [str(SCRIPT_DIR / "main_tip_release.sh"), "validate-assets"],
+            cwd=SCRIPT_DIR.parent,
+            env=package_env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(package.returncode, 0, package.stderr)
+        self.assertIn("contains exactly 6 files", package.stdout)
+
+        package_env["TIP_PUBLISH_INSTALLATION_TYPE"] = "invalid"
+        invalid_type = subprocess.run(
+            [str(SCRIPT_DIR / "main_tip_release.sh"), "validate-assets"],
+            cwd=SCRIPT_DIR.parent,
+            env=package_env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(invalid_type.returncode, 0)
+        self.assertIn(
+            "TIP_PUBLISH_INSTALLATION_TYPE must be application or package",
+            invalid_type.stderr,
         )
 
     def test_main_tip_setup_uses_read_only_github_token_for_release_lookup_helper(self) -> None:


### PR DESCRIPTION
## Summary

- upload the complete signed Tip dist directory instead of a mixed wildcard and literal asset list
- validate an exact role-dependent asset inventory before upload, after download for smoke, and before publication
- carry the setup-verified target commit installation type through every inventory gate
- cover application/package inventories, missing and extra files, invalid roles, artifact download roots, and trusted-tooling/target skew

## Failure addressed

Tip preparer run 32927486240 signed, notarized, and smoked successfully, but publication failed because appcast.xml was absent from the downloaded signed artifact. No Tip tag or release was created.

## Validation

- focused Tip release tooling regressions: pass
- full Scripts.test_release_tooling suite: 110 tests substantively pass; five sandbox-blocked Swift module-cache and Unix-socket cases passed when rerun with normal local permissions
- bash syntax, YAML parse, and git diff check: pass
- actionlint: only three pre-existing shellcheck warnings in unchanged workflow blocks
- make dev-release-preflight: pass
- contribution commit, PR-ready, and push preflights: pass
- staged and outgoing-range secret scans: no leaks

No release workflow was dispatched by this PR.