### PR TITLE
Enable Tip identity transition role

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -82,6 +82,7 @@ finish(){
 trap 'finish $?' EXIT
 
 BUNDLE_ID_OVERRIDE="${BUNDLE_ID:-}"
+SIGNING_TEAM_ID_OVERRIDE="${SIGNING_TEAM_ID:-}"
 RELEASE_BUILD_NUMBER_OVERRIDE="${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}"
 # Invalidate public-release manifests before metadata parsing, checks, or builds
 # so failed non-public packaging cannot leave stale release metadata behind.
@@ -93,7 +94,7 @@ if [[ -n "$RELEASE_BUILD_NUMBER_OVERRIDE" ]]; then
         fail "REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE must be a valid numeric build version"
     BUILD_NUMBER="$RELEASE_BUILD_NUMBER_OVERRIDE"
 fi
-APP_NAME="${APP_NAME:-RepoPrompt}"; DISPLAY_NAME="${DISPLAY_NAME:-RepoPrompt CE}"; BASE_BUNDLE_ID="${BUNDLE_ID:-com.pvncher.repoprompt.ce}"; MARKETING_VERSION="${MARKETING_VERSION:-0.1.0}"; BUILD_NUMBER="${BUILD_NUMBER:-1}"; SIGNING_TEAM_ID="${SIGNING_TEAM_ID:-648A27MST5}"
+APP_NAME="${APP_NAME:-RepoPrompt}"; DISPLAY_NAME="${DISPLAY_NAME:-RepoPrompt CE}"; BASE_BUNDLE_ID="${BUNDLE_ID:-com.pvncher.repoprompt.ce}"; MARKETING_VERSION="${MARKETING_VERSION:-0.1.0}"; BUILD_NUMBER="${BUILD_NUMBER:-1}"; BASE_SIGNING_TEAM_ID="${SIGNING_TEAM_ID:-648A27MST5}"; SIGNING_TEAM_ID="${SIGNING_TEAM_ID_OVERRIDE:-$BASE_SIGNING_TEAM_ID}"
 IDENTITY_MIGRATION_PHASE="${REPOPROMPT_IDENTITY_MIGRATION_PHASE:-disabled}"
 case "$IDENTITY_MIGRATION_PHASE" in
 disabled | legacy-preparer) ;;
@@ -203,7 +204,11 @@ if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
     SIGNING_MODE_MARKER="local-self-signed"
 elif (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
     DEBUG_STORAGE_BACKEND_MARKER="keychain"
-    SIGNING_MODE_MARKER="developer-id"
+    SIGNING_MODE_MARKER="$(python3 "$CONTROL_PLANE_SCRIPTS_DIR/stable_rollout.py" signing-mode \
+        --policy "$CONTROL_PLANE_SCRIPTS_DIR/apple_identity_policy.json" \
+        --bundle-id "$BUNDLE_ID" \
+        --team-id "$SIGNING_TEAM_ID")" ||
+        fail "Release bundle/team pair is not a reviewed Apple identity"
 elif (( IS_RELEASE )); then
     SIGNING_MODE_MARKER="release-candidate-adhoc"
 elif [[ -n "$DEBUG_SECURE_STORAGE_BACKEND" ]]; then

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -10,6 +10,8 @@ load_release_metadata "$METADATA_ROOT"
 
 APP_BUNDLE="$ROOT_DIR/.build/release/$APP_NAME.app"
 TRUSTED_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+APPLE_IDENTITY_POLICY="$SCRIPT_DIR/apple_identity_policy.json"
+ROLLOUT_TOOL="$SCRIPT_DIR/stable_rollout.py"
 ENTITLEMENTS_TEMPLATE="$TRUSTED_ROOT/AppBundle/RepoPrompt.entitlements.template"
 CODEX_V8_ENTITLEMENTS="$TRUSTED_ROOT/AppBundle/CodexV8JIT.entitlements"
 TRUSTED_SPARKLE_FRAMEWORK="$TRUSTED_ROOT/Vendor/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
@@ -77,7 +79,12 @@ PYTHON
 plutil -lint "$app_entitlements"
 plutil -lint "$CODEX_V8_ENTITLEMENTS"
 plutil -replace RepoPromptDebugSecureStorageBackend -string keychain "$APP_BUNDLE/Contents/Info.plist"
-plutil -replace RepoPromptSigningMode -string developer-id "$APP_BUNDLE/Contents/Info.plist"
+signing_mode_marker="$(python3 "$ROLLOUT_TOOL" signing-mode \
+    --policy "$APPLE_IDENTITY_POLICY" \
+    --bundle-id "$BUNDLE_ID" \
+    --team-id "$SIGNING_TEAM_ID")" ||
+    fail "Release bundle/team pair is not a reviewed Apple identity"
+plutil -replace RepoPromptSigningMode -string "$signing_mode_marker" "$APP_BUNDLE/Contents/Info.plist"
 
 identity_migration_phase="$(
     plutil -extract RepoPromptIdentityMigrationPhase raw "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null ||

--- a/Scripts/stable_rollout.py
+++ b/Scripts/stable_rollout.py
@@ -11,6 +11,7 @@ Commands:
   successor roles, sibling predecessors, and the successor identity.
 - ``current-role``: print the declared role for shell callers.
 - ``packaging-context``: emit policy-derived bundle, team, application, and installer identity labels.
+- ``signing-mode``: map one reviewed bundle/team pair to its runtime signing marker.
 - ``generate``: assemble the accumulated appcast plus rollout manifest.
 - ``validate``: prove a reviewed appcast/manifest pair against the declaration,
   policy, version metadata, and enclosure/app-manifest digests.
@@ -63,6 +64,10 @@ ROLE_ENCLOSURE_SUFFIX = {
     "preparer": ".zip",
     "transition": ".pkg",
     "successor": ".zip",
+}
+SIGNING_MODE_BY_IDENTITY = {
+    "legacy": "developer-id",
+    "successor": "successor-developer-id",
 }
 # Newest-first role chains permitted in an accumulated appcast.
 ALLOWED_ROLE_CHAINS = (
@@ -212,6 +217,20 @@ def load_version_env(path: Path) -> dict[str, str]:
         if not values.get(key):
             raise RolloutError(f"version.env is missing {key}")
     return values
+
+
+def identity_name_for_bundle_and_team(policy: dict, bundle_id: str, team_id: str) -> str:
+    matches = [
+        identity_name
+        for identity_name, identity in policy["identities"].items()
+        if identity["bundleIdentifier"] == bundle_id and identity["teamIdentifier"] == team_id
+    ]
+    if len(matches) != 1:
+        raise RolloutError(
+            "bundle/team pair does not match exactly one reviewed Apple identity: "
+            f"{bundle_id} / {team_id}"
+        )
+    return matches[0]
 
 
 def expected_enclosure_name(
@@ -594,13 +613,15 @@ def run_packaging_context(args: argparse.Namespace) -> None:
     role = declaration["currentRole"]
     identity_name = ROLE_IDENTITY[role]
     identity = policy["identities"][identity_name]
-    if version["BUNDLE_ID"] != identity["bundleIdentifier"]:
+    version_identity_name = identity_name_for_bundle_and_team(
+        policy, version["BUNDLE_ID"], version["SIGNING_TEAM_ID"]
+    )
+    # Stable metadata remains pinned to the currently releasable identity. Tip
+    # T/S builds intentionally project the role-selected successor identity
+    # without changing the repository-wide Stable/debug defaults mid-rehearsal.
+    if declaration["channel"] == "stable" and version_identity_name != identity_name:
         raise RolloutError(
-            f"version.env BUNDLE_ID does not match the {identity_name} identity policy"
-        )
-    if version["SIGNING_TEAM_ID"] != identity["teamIdentifier"]:
-        raise RolloutError(
-            f"version.env SIGNING_TEAM_ID does not match the {identity_name} identity policy"
+            f"version.env identity does not match the {identity_name} Stable rollout identity"
         )
     successor = policy["identities"]["successor"]
     values = {
@@ -622,6 +643,12 @@ def run_packaging_context(args: argparse.Namespace) -> None:
     }
     for key, value in values.items():
         print(f"{key}={shlex.quote(value)}")
+
+
+def run_signing_mode(args: argparse.Namespace) -> None:
+    policy = load_policy(Path(args.policy))
+    identity_name = identity_name_for_bundle_and_team(policy, args.bundle_id, args.team_id)
+    print(SIGNING_MODE_BY_IDENTITY[identity_name])
 
 
 def run_predecessor_values(args: argparse.Namespace) -> None:
@@ -702,6 +729,12 @@ def build_parser() -> argparse.ArgumentParser:
     packaging_context.add_argument("--policy", required=True)
     packaging_context.add_argument("--version-env", required=True)
     packaging_context.set_defaults(func=run_packaging_context)
+
+    signing_mode = subparsers.add_parser("signing-mode")
+    signing_mode.add_argument("--policy", required=True)
+    signing_mode.add_argument("--bundle-id", required=True)
+    signing_mode.add_argument("--team-id", required=True)
+    signing_mode.set_defaults(func=run_signing_mode)
 
     predecessor_values = subparsers.add_parser("predecessor-values")
     predecessor_values.add_argument("--declaration", required=True)

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -3461,10 +3461,16 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         capture_override = package_script.index(
             'RELEASE_BUILD_NUMBER_OVERRIDE="${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}"'
         )
+        capture_team_override = package_script.index('SIGNING_TEAM_ID_OVERRIDE="${SIGNING_TEAM_ID:-}"')
         load_metadata = package_script.index('load_release_metadata "$ROOT_DIR"')
         apply_override = package_script.index('BUILD_NUMBER="$RELEASE_BUILD_NUMBER_OVERRIDE"')
+        apply_team_override = package_script.index(
+            'SIGNING_TEAM_ID="${SIGNING_TEAM_ID_OVERRIDE:-$BASE_SIGNING_TEAM_ID}"'
+        )
         self.assertLess(capture_override, load_metadata)
+        self.assertLess(capture_team_override, load_metadata)
         self.assertLess(load_metadata, apply_override)
+        self.assertLess(load_metadata, apply_team_override)
         self.assertIn(
             'fail "REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE must be a valid numeric build version"',
             package_script,
@@ -3477,8 +3483,7 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         build_number = "35.15.16"
         archive_basename = f"RepoPrompt-tip-{short_sha}-{build_number}"
         expected = {
-            f"{archive_basename}.zip",
-            f"{archive_basename}.dmg",
+            f"{archive_basename}.pkg",
             "appcast.xml",
             "SHA256SUMS",
             f"{archive_basename}-artifact-manifest.json",
@@ -3494,6 +3499,7 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
                 "TIP_COMMIT": "0123456789abcdef0123456789abcdef01234567",
                 "TIP_SHORT_SHA": short_sha,
                 "TIP_BUILD_NUMBER": build_number,
+                "TIP_PUBLISH_INSTALLATION_TYPE": "package",
                 "DIST_DIR": str(temp_dir),
             }
         )
@@ -3506,7 +3512,7 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
             capture_output=True,
         )
         self.assertEqual(accepted.returncode, 0, accepted.stderr)
-        self.assertIn("contains exactly 7 files", accepted.stdout)
+        self.assertIn("contains exactly 6 files", accepted.stdout)
 
         (temp_dir / "appcast.xml").unlink()
         missing = subprocess.run(
@@ -4922,19 +4928,21 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             assignments[key] = value
         return assignments
 
-    def test_packaging_context_rejects_version_identity_mismatch_before_packaging(self) -> None:
+    def test_packaging_context_projects_tip_role_without_advancing_stable_metadata(self) -> None:
         root = SCRIPT_DIR.parent
-        legacy = self.rollout(
+        transition_context = self.rollout(
             "packaging-context",
             "--declaration", str(self.TIP_DECLARATION),
             "--policy", str(self.POLICY),
             "--version-env", str(root / "version.env"),
         )
-        self.assertEqual(legacy.returncode, 0, legacy.stderr)
-        context = self.shell_assignments(legacy.stdout)
+        self.assertEqual(transition_context.returncode, 0, transition_context.stderr)
+        context = self.shell_assignments(transition_context.stdout)
         policy = json.loads(self.POLICY.read_text(encoding="utf-8"))
-        self.assertEqual(context["ROLLOUT_ROLE"], "preparer")
-        self.assertEqual(context["BUNDLE_ID"], "com.pvncher.repoprompt.ce")
+        self.assertEqual(context["ROLLOUT_ROLE"], "transition")
+        self.assertEqual(context["ROLLOUT_IDENTITY"], "successor")
+        self.assertEqual(context["ROLLOUT_INSTALLATION_TYPE"], "package")
+        self.assertEqual(context["BUNDLE_ID"], "com.repoprompt.ce")
         self.assertEqual(
             context["EXPECTED_SUCCESSOR_SIGN_IDENTITY"],
             policy["identities"]["successor"]["developerIDApplicationIdentityName"],
@@ -4942,26 +4950,51 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
 
         temp_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, temp_dir, True)
-        transition = self.make_declaration(
+        stable_transition = self.make_declaration(
             temp_dir,
             "transition",
             [
                 {
                     "role": "preparer",
-                    "tag": "tip-preparer",
+                    "tag": "v0.1.0",
                     "rolloutManifestSha256": "0" * 64,
                 }
             ],
-            channel="tip",
         )
         mismatch = self.rollout(
             "packaging-context",
-            "--declaration", str(transition),
+            "--declaration", str(stable_transition),
             "--policy", str(self.POLICY),
             "--version-env", str(root / "version.env"),
         )
         self.assertNotEqual(mismatch.returncode, 0)
-        self.assertIn("version.env BUNDLE_ID does not match", mismatch.stderr)
+        self.assertIn("version.env identity does not match the successor Stable rollout identity", mismatch.stderr)
+
+    def test_signing_mode_is_derived_from_the_reviewed_bundle_team_pair(self) -> None:
+        policy = json.loads(self.POLICY.read_text(encoding="utf-8"))
+        for identity_name, marker in (
+            ("legacy", "developer-id"),
+            ("successor", "successor-developer-id"),
+        ):
+            with self.subTest(identity=identity_name):
+                identity = policy["identities"][identity_name]
+                result = self.rollout(
+                    "signing-mode",
+                    "--policy", str(self.POLICY),
+                    "--bundle-id", identity["bundleIdentifier"],
+                    "--team-id", identity["teamIdentifier"],
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), marker)
+
+        rejected = self.rollout(
+            "signing-mode",
+            "--policy", str(self.POLICY),
+            "--bundle-id", policy["identities"]["successor"]["bundleIdentifier"],
+            "--team-id", policy["identities"]["legacy"]["teamIdentifier"],
+        )
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("does not match exactly one reviewed Apple identity", rejected.stderr)
 
     def chain_predecessors(self, role: str) -> list[dict]:
         placeholder = "0" * 64
@@ -5234,6 +5267,8 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         info_template = (SCRIPT_DIR.parent / "AppBundle/Info.plist.template").read_text(encoding="utf-8")
         sign_staged = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
         pkg_builder = (SCRIPT_DIR / "build_identity_transition_pkg.sh").read_text(encoding="utf-8")
+        package_app = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        mcp_source = (SCRIPT_DIR.parent / "Sources/RepoPromptMCP/main.swift").read_text(encoding="utf-8")
 
         legacy = policy["identities"]["legacy"]
         successor = policy["identities"]["successor"]
@@ -5259,6 +5294,12 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             f"IDENTITY_MIGRATION_TARGET_REQUIREMENT='{successor['developerIDRequirement']}'", sign_staged
         )
         self.assertIn(f"SUCCESSOR_APP_REQUIREMENT='{successor['developerIDRequirement']}'", pkg_builder)
+        self.assertIn('"$ROLLOUT_TOOL" signing-mode', sign_staged)
+        self.assertIn('stable_rollout.py" signing-mode', package_app)
+        self.assertIn(
+            f'repoPromptCEReleaseBundleIdentifier = "{successor["bundleIdentifier"]}"',
+            mcp_source,
+        )
 
         sparkle = policy["sparkle"]
         self.assertIn(f"<string>{sparkle['stableFeedURL']}</string>", info_template)
@@ -5294,10 +5335,19 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
 
         tip_declaration = json.loads(self.TIP_DECLARATION.read_text(encoding="utf-8"))
         self.assertEqual(tip_declaration["channel"], "tip")
-        self.assertEqual(tip_declaration["currentRole"], "preparer")
-        self.assertEqual(tip_declaration["predecessors"], [])
-        self.assertEqual(tip_declaration["expectedMigrationPhase"], "legacy-preparer")
-        self.assertEqual(tip_declaration["expectedSigningIdentity"], "legacy")
+        self.assertEqual(tip_declaration["currentRole"], "transition")
+        self.assertEqual(tip_declaration["expectedMigrationPhase"], "disabled")
+        self.assertEqual(tip_declaration["expectedSigningIdentity"], "successor")
+        self.assertEqual(
+            tip_declaration["predecessors"],
+            [
+                {
+                    "role": "preparer",
+                    "tag": "tip-2f94412e6ab5",
+                    "rolloutManifestSha256": "3c69703fa7582105633b36e8874fe2a28e1832aabb776351e68dbf3367e122db",
+                }
+            ],
+        )
 
     def test_single_legacy_release_generates_one_deterministic_application_item(self) -> None:
         temp_dir = Path(tempfile.mkdtemp())

--- a/Sources/RepoPromptMCP/main.swift
+++ b/Sources/RepoPromptMCP/main.swift
@@ -3424,7 +3424,7 @@ func printVersion() {
     print("\(cliDisplayCommand()) (repoprompt-mcp) \(CLI_VERSION)")
 }
 
-private let repoPromptCEReleaseBundleIdentifier = "com.pvncher.repoprompt.ce"
+private let repoPromptCEReleaseBundleIdentifier = "com.repoprompt.ce"
 private let repoPromptCEDebugBundleIdentifier = "com.pvncher.repoprompt.ce.debug"
 private let repoPromptCEBundleIdentifier: String = {
     #if DEBUG

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -111,10 +111,16 @@ retained `identity-rollout.json`, then update the declaration with P's exact man
 dispatching T. After T is verified, update the declaration with both exact predecessor digests before
 dispatching S. Never publish a nonlegacy role from an automatic `workflow_run` notification.
 
-The next operator action after this change is merged to protected `main`: dispatch **Publish Tip**
-with `commit` set to that exact main SHA and `confirm_identity_rollout_role=preparer`. Do not rely on
-the automatic CI notification for P. Subsequent T and S dispatches require the checked-in declaration
-and exact role confirmation to be advanced and reviewed first.
+P was published and independently verified at `tip-2f94412e6ab5`; its retained
+`identity-rollout.json` SHA-256 is
+`3c69703fa7582105633b36e8874fe2a28e1832aabb776351e68dbf3367e122db`. The checked-in Tip
+declaration now pins that immutable predecessor and selects T.
+
+The next operator action after this change is merged to protected `main` and exact-head CI succeeds:
+dispatch **Publish Tip** with `commit` set to that exact main SHA and
+`confirm_identity_rollout_role=transition`. Do not rely on the automatic CI notification for T. S
+still requires a later reviewed declaration change containing both T's and P's exact manifest
+digests.
 
 ## Required proof gate
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -270,6 +270,11 @@ S. Each published role uses an immutable `tip-<shortsha>` tag and the tip-only r
 release; do not mark the release as a prerelease because GitHub excludes prereleases from
 `releases/latest`.
 
+Current checkpoint: verified P is `tip-2f94412e6ab5`, with rollout-manifest SHA-256
+`3c69703fa7582105633b36e8874fe2a28e1832aabb776351e68dbf3367e122db`. The reviewed declaration
+pins that predecessor and selects T; T still requires an exact-role manual dispatch after its
+declaration change reaches protected `main` and passes exact-head CI.
+
 Tip `CFBundleVersion` values sort between adjacent stable builds. The workflow
 reads the currently published stable appcast and combines that stable build with
 the source commit count. For example, commit sequence `795` on stable build `28`

--- a/tip-rollout.json
+++ b/tip-rollout.json
@@ -1,9 +1,15 @@
 {
   "schemaVersion": 1,
   "channel": "tip",
-  "currentRole": "preparer",
+  "currentRole": "transition",
   "eligibilityProfile": "tip-identity-dress-rehearsal-v1",
-  "expectedMigrationPhase": "legacy-preparer",
-  "expectedSigningIdentity": "legacy",
-  "predecessors": []
+  "expectedMigrationPhase": "disabled",
+  "expectedSigningIdentity": "successor",
+  "predecessors": [
+    {
+      "role": "preparer",
+      "tag": "tip-2f94412e6ab5",
+      "rolloutManifestSha256": "3c69703fa7582105633b36e8874fe2a28e1832aabb776351e68dbf3367e122db"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- advance the Tip identity rehearsal from the verified preparer to the transition role
- pin preparer tag tip-2f94412e6ab5 and rollout manifest SHA-256 3c69703fa7582105633b36e8874fe2a28e1832aabb776351e68dbf3367e122db
- project the successor bundle and Team identity for Tip T while preserving legacy Stable and debug defaults
- derive release signing-mode markers from the reviewed Apple identity policy and preserve the role-selected Team override
- update the release MCP fallback to the successor bundle identifier

## Safety boundaries

- Stable release-rollout.json and version.env remain on the legacy identity
- T retains P in the same Tip appcast for delayed upgraders
- no Keychain values, signing certificates, or GitHub secrets are changed by this PR
- publication remains gated behind an exact-role manual Publish Tip dispatch after merge

## Validation

- contribution commit, push, and PR-ready preflights
- release tooling: 112 tests
- release promotion: 22 tests
- Codex runtime artifact: 28 tests
- update candidate: 9 tests
- update workflow: 2 tests
- IdentityTransitionDiagnosticsTests: 3 tests
- coordinated strict SwiftFormat and SwiftLint
- coordinated repoprompt-mcp product build
- coordinated release preflight
- shell syntax, Python compilation, and git diff whitespace checks