### PR TITLE
Fix Tip transition stage identity validation

### DIFF
--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2691,6 +2691,17 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertIn("tip-rollout.json", missing.stderr)
 
         shutil.copy2(approved / "tip-rollout.json", staged / "tip-rollout.json")
+        legacy_identity = self.run_staged_validation(
+            approved,
+            staged,
+            scripts,
+            release_build_number_override="1",
+            tip_archive_contract="tip-rollout-v1",
+        )
+        self.assertNotEqual(legacy_identity.returncode, 0)
+        self.assertIn("BUNDLE_ID, SIGNING_TEAM_ID", legacy_identity.stderr)
+
+        self.project_staged_release_identity(staged, scripts, "com.repoprompt.ce", "69N6K965SF")
         accepted = self.run_staged_validation(
             approved,
             staged,
@@ -4785,6 +4796,48 @@ esac
                 app / "Contents" / "Resources" / "BundledRuntimes" / "Codex"
             ),
         }
+
+    @classmethod
+    def project_staged_release_identity(
+        cls,
+        staged: Path,
+        scripts: Path,
+        bundle_id: str,
+        signing_team_id: str,
+    ) -> None:
+        version_path = staged / "version.env"
+        version = version_path.read_text(encoding="utf-8")
+        version = re.sub(r"(?m)^BUNDLE_ID=.*$", f"BUNDLE_ID={bundle_id}", version)
+        version = re.sub(r"(?m)^SIGNING_TEAM_ID=.*$", f"SIGNING_TEAM_ID={signing_team_id}", version)
+        version_path.write_text(version, encoding="utf-8")
+
+        app = staged / ".build" / "release" / "RepoPrompt.app"
+        info_path = app / "Contents" / "Info.plist"
+        info = plistlib.loads(info_path.read_bytes())
+        info["CFBundleIdentifier"] = bundle_id
+        info_path.write_bytes(plistlib.dumps(info))
+
+        manifest = staged / ".build" / "release" / "RepoPrompt-artifact-manifest.json"
+        manifest_env = os.environ.copy()
+        manifest_env.update(
+            {"LIPO": str(scripts / "fake-lipo"), "CODESIGN": str(scripts / "fake-codesign")}
+        )
+        subprocess.run(
+            [
+                str(scripts / "write_app_artifact_manifest.py"),
+                "write",
+                "--app",
+                str(app),
+                "--output",
+                str(manifest),
+                "--expected-architectures",
+                "arm64,x86_64",
+            ],
+            env=manifest_env,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
 
     @classmethod
     def run_staged_validation(

--- a/Scripts/validate_staged_release.sh
+++ b/Scripts/validate_staged_release.sh
@@ -15,15 +15,43 @@ fail() {
 [[ -n "${RELEASE_COMMIT:-}" ]] ||
     fail "Missing required environment variable: RELEASE_COMMIT"
 
-if [[ -n "${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}" ]]; then
-    [[ "$REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE" =~ ^[0-9]{1,4}(\.[0-9]{1,2}){0,2}$ ]] ||
-        fail "REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE must be a valid numeric build version"
+TIP_ROLLOUT_DECLARATION_NAME=""
+case "${REPOPROMPT_TIP_ARCHIVE_CONTRACT:-}" in
+    "") ;;
+    tip-rollout-v1) TIP_ROLLOUT_DECLARATION_NAME="tip-rollout.json" ;;
+    *) fail "Unsupported REPOPROMPT_TIP_ARCHIVE_CONTRACT: $REPOPROMPT_TIP_ARCHIVE_CONTRACT" ;;
+esac
+
+PROJECTED_BUNDLE_ID=""
+PROJECTED_SIGNING_TEAM_ID=""
+if [[ -n "$TIP_ROLLOUT_DECLARATION_NAME" ]]; then
+    [[ -f "$APPROVED_SOURCE_ROOT/$TIP_ROLLOUT_DECLARATION_NAME" ]] ||
+        fail "Missing approved Tip rollout declaration"
+    [[ -f "$ROOT_DIR/$TIP_ROLLOUT_DECLARATION_NAME" ]] ||
+        fail "missing staged file: $ROOT_DIR/$TIP_ROLLOUT_DECLARATION_NAME"
+    rollout_context="$(
+        python3 "$SCRIPT_DIR/stable_rollout.py" packaging-context \
+            --declaration "$APPROVED_SOURCE_ROOT/$TIP_ROLLOUT_DECLARATION_NAME" \
+            --policy "$SCRIPT_DIR/apple_identity_policy.json" \
+            --version-env "$APPROVED_SOURCE_ROOT/version.env"
+    )" || fail "Unable to derive the reviewed Tip packaging context"
+    eval "$rollout_context"
+    PROJECTED_BUNDLE_ID="$BUNDLE_ID"
+    PROJECTED_SIGNING_TEAM_ID="$SIGNING_TEAM_ID"
+fi
+
+if [[ -n "${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}" || -n "$PROJECTED_BUNDLE_ID" ]]; then
+    if [[ -n "${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}" ]]; then
+        [[ "$REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE" =~ ^[0-9]{1,4}(\.[0-9]{1,2}){0,2}$ ]] ||
+            fail "REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE must be a valid numeric build version"
+    fi
     python3 - "$ROOT_DIR/version.env" "$APPROVED_SOURCE_ROOT/version.env" \
-        "$REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE" <<'PYTHON'
+        "${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}" "$PROJECTED_BUNDLE_ID" \
+        "$PROJECTED_SIGNING_TEAM_ID" <<'PYTHON'
 import sys
 from pathlib import Path
 
-staged_path, approved_path, build_override = sys.argv[1:]
+staged_path, approved_path, build_override, bundle_id, signing_team_id = sys.argv[1:]
 
 def parse(path: str) -> dict[str, str]:
     values: dict[str, str] = {}
@@ -40,13 +68,22 @@ def parse(path: str) -> dict[str, str]:
 staged = parse(staged_path)
 approved = parse(approved_path)
 expected = dict(approved)
-expected["BUILD_NUMBER"] = build_override
+for key, value in {
+    "BUILD_NUMBER": build_override,
+    "BUNDLE_ID": bundle_id,
+    "SIGNING_TEAM_ID": signing_team_id,
+}.items():
+    if value:
+        expected[key] = value
 if staged != expected:
     mismatches = sorted(set(staged) | set(expected))
     detail = ", ".join(
         key for key in mismatches if staged.get(key) != expected.get(key)
     )
-    raise SystemExit(f"ERROR: staged version.env does not match approved source plus build override: {detail}")
+    raise SystemExit(
+        "ERROR: staged version.env does not match approved source plus reviewed release projections: "
+        f"{detail}"
+    )
 PYTHON
 else
     cmp "$ROOT_DIR/version.env" "$APPROVED_SOURCE_ROOT/version.env" ||
@@ -57,14 +94,12 @@ load_release_metadata "$APPROVED_SOURCE_ROOT"
 if [[ -n "${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}" ]]; then
     BUILD_NUMBER="$REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE"
 fi
+if [[ -n "$PROJECTED_BUNDLE_ID" ]]; then
+    BUNDLE_ID="$PROJECTED_BUNDLE_ID"
+    SIGNING_TEAM_ID="$PROJECTED_SIGNING_TEAM_ID"
+fi
 
 APP_BUNDLE="$ROOT_DIR/.build/release/$APP_NAME.app"
-TIP_ROLLOUT_DECLARATION_NAME=""
-case "${REPOPROMPT_TIP_ARCHIVE_CONTRACT:-}" in
-    "") ;;
-    tip-rollout-v1) TIP_ROLLOUT_DECLARATION_NAME="tip-rollout.json" ;;
-    *) fail "Unsupported REPOPROMPT_TIP_ARCHIVE_CONTRACT: $REPOPROMPT_TIP_ARCHIVE_CONTRACT" ;;
-esac
 
 python3 - "$ROOT_DIR" "$APP_BUNDLE" "$TIP_ROLLOUT_DECLARATION_NAME" <<'PYTHON'
 import os


### PR DESCRIPTION
## Summary
- derive staged Tip bundle and team expectations from the reviewed rollout declaration and Apple identity policy
- preserve stable validation behavior while accepting the intentional successor identity projection for Tip T and S
- add regression coverage that rejects legacy staged metadata under the transition declaration and accepts the reviewed successor projection

## Failure addressed
Manual Tip transition run 33024929059 built and uploaded the exact T stage archive, then failed before certificate import because validate_staged_release.sh compared successor BUNDLE_ID and SIGNING_TEAM_ID against legacy stable version.env. No signing, notarization, smoke, feed, release, or installed-app mutation occurred.

The corrected validator clears that exact metadata failure on the downloaded 35.15.19 staged archive. Local replay subsequently reaches the separate embedded Codex signature check.

## Validation
- python3 Scripts/test_release_tooling.py: 112/112
- python3 Scripts/test_release_promotion.py: 22/22
- make dev-release-preflight
- make guardrails
- bash syntax, Python compile, and diff checks
- contribution commit, push, and PR-ready preflights