### PR TITLE
Fix Tip signer identity projection

### DIFF
--- a/Scripts/load_release_metadata.sh
+++ b/Scripts/load_release_metadata.sh
@@ -43,3 +43,41 @@ PYTHON
     )" || return
     eval "$assignments"
 }
+
+load_release_metadata_with_identity_projection() {
+    local metadata_root="$1"
+    local approved_source_root="$2"
+    local scripts_root="$3"
+    local archive_contract="${4:-}"
+    local assignments
+
+    load_release_metadata "$metadata_root" || return
+    case "$archive_contract" in
+    "") return 0 ;;
+    tip-rollout-v1)
+        [[ -n "$approved_source_root" ]] || {
+            printf 'ERROR: Tip release identity projection requires an approved source root\n' >&2
+            return 1
+        }
+        [[ -f "$approved_source_root/tip-rollout.json" ]] || {
+            printf 'ERROR: Missing approved Tip rollout declaration\n' >&2
+            return 1
+        }
+        assignments="$(
+            python3 "$scripts_root/stable_rollout.py" packaging-context \
+                --declaration "$approved_source_root/tip-rollout.json" \
+                --policy "$scripts_root/apple_identity_policy.json" \
+                --version-env "$approved_source_root/version.env"
+        )" || return
+        eval "$assignments"
+        [[ "$ROLLOUT_CHANNEL" == "tip" ]] || {
+            printf 'ERROR: Tip release identity projection requires a Tip rollout declaration\n' >&2
+            return 1
+        }
+        ;;
+    *)
+        printf 'ERROR: Unsupported REPOPROMPT_TIP_ARCHIVE_CONTRACT: %s\n' "$archive_contract" >&2
+        return 1
+        ;;
+    esac
+}

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -6,19 +6,13 @@ ROOT_DIR="${REPOPROMPT_RELEASE_SOURCE_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 METADATA_ROOT="${REPOPROMPT_APPROVED_SOURCE_ROOT:-$ROOT_DIR}"
 CODEX_MANIFEST="$METADATA_ROOT/Vendor/Codex/manifest.json"
 source "$SCRIPT_DIR/load_release_metadata.sh"
-load_release_metadata "$METADATA_ROOT"
 
-APP_BUNDLE="$ROOT_DIR/.build/release/$APP_NAME.app"
 TRUSTED_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 APPLE_IDENTITY_POLICY="$SCRIPT_DIR/apple_identity_policy.json"
 ROLLOUT_TOOL="$SCRIPT_DIR/stable_rollout.py"
 ENTITLEMENTS_TEMPLATE="$TRUSTED_ROOT/AppBundle/RepoPrompt.entitlements.template"
 CODEX_V8_ENTITLEMENTS="$TRUSTED_ROOT/AppBundle/CodexV8JIT.entitlements"
 TRUSTED_SPARKLE_FRAMEWORK="$TRUSTED_ROOT/Vendor/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
-STAGED_SPARKLE_FRAMEWORK="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
-CODEX_BUNDLE="$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex"
-ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
-IDENTITY_MIGRATION_ANCHOR_DESTINATION="$APP_BUNDLE/Contents/Resources/IdentityMigration/RepoPromptIdentityAnchor"
 IDENTITY_MIGRATION_TARGET_IDENTIFIER="com.repoprompt.ce"
 IDENTITY_MIGRATION_TARGET_TEAM_ID="69N6K965SF"
 IDENTITY_MIGRATION_TARGET_REQUIREMENT='anchor apple generic and identifier "com.repoprompt.ce" and certificate leaf[subject.OU] = "69N6K965SF" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists'
@@ -27,6 +21,18 @@ fail() {
     printf 'ERROR: %s\n' "$*" >&2
     exit 1
 }
+
+load_release_metadata_with_identity_projection \
+    "$METADATA_ROOT" \
+    "${REPOPROMPT_APPROVED_SOURCE_ROOT:-}" \
+    "$SCRIPT_DIR" \
+    "${REPOPROMPT_TIP_ARCHIVE_CONTRACT:-}" ||
+    fail "Unable to load the reviewed release identity context"
+APP_BUNDLE="$ROOT_DIR/.build/release/$APP_NAME.app"
+STAGED_SPARKLE_FRAMEWORK="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+CODEX_BUNDLE="$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex"
+ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
+IDENTITY_MIGRATION_ANCHOR_DESTINATION="$APP_BUNDLE/Contents/Resources/IdentityMigration/RepoPromptIdentityAnchor"
 
 [[ -n "${SIGN_IDENTITY:-}" ]] || fail "Missing required environment variable: SIGN_IDENTITY"
 [[ -f "${REPOPROMPT_PROVISIONING_PROFILE:-}" ]] ||

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -4298,6 +4298,51 @@ else:
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout, "28.7.95\n")
 
+    def test_release_metadata_loader_projects_reviewed_tip_identity_in_child_process(self) -> None:
+        root = self.make_metadata_root()
+        shutil.copy2(SCRIPT_DIR.parent / "tip-rollout.json", root / "tip-rollout.json")
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f'source "{SCRIPT_DIR / "load_release_metadata.sh"}"; '
+                f'load_release_metadata_with_identity_projection "{root}" "{root}" "{SCRIPT_DIR}" tip-rollout-v1; '
+                'printf "%s|%s|%s|%s\\n" "$BUNDLE_ID" "$SIGNING_TEAM_ID" "$ROLLOUT_ROLE" "$ROLLOUT_IDENTITY"',
+            ],
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "com.repoprompt.ce|69N6K965SF|transition|successor\n")
+
+    def test_release_metadata_loader_preserves_stable_identity_without_tip_contract(self) -> None:
+        root = self.make_metadata_root()
+
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f'source "{SCRIPT_DIR / "load_release_metadata.sh"}"; '
+                f'load_release_metadata_with_identity_projection "{root}" "" "{SCRIPT_DIR}" ""; '
+                'printf "%s|%s\\n" "$BUNDLE_ID" "$SIGNING_TEAM_ID"',
+            ],
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "com.pvncher.repoprompt.ce|648A27MST5\n")
+
+    def test_staged_signer_uses_reviewed_identity_projection_before_profile_validation(self) -> None:
+        source = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
+
+        projection = source.index("load_release_metadata_with_identity_projection")
+        profile_validation = source.index("profile_app_identifier=")
+        self.assertLess(projection, profile_validation)
+        self.assertIn('"${REPOPROMPT_TIP_ARCHIVE_CONTRACT:-}"', source)
+
     def test_release_metadata_parser_rejects_shell_execution(self) -> None:
         root = self.make_metadata_root()
         marker = root / "executed"


### PR DESCRIPTION
## Summary
- re-derive Tip signing metadata inside the staged signer process from the approved rollout declaration and trusted Apple identity policy
- preserve legacy version.env identity for stable and non-Tip signing paths
- add child-process regression coverage for successor projection and stable preservation

## Failure reproduced
Publish Tip run 33033997836 passed extracted-stage validation, then failed before signing with:

```
Provisioning profile app identifier mismatch: expected 648A27MST5.com.pvncher.repoprompt.ce, got 69N6K965SF.com.repoprompt.ce
```

The parent Tip script had projected the successor identity, but sign_staged_release.sh reloaded legacy version.env in a child process.

## Validation
- focused identity-projection tests: passed
- python3 Scripts/test_release_tooling.py: 115/115 passed
- python3 Scripts/test_release_promotion.py: 22/22 passed
- make guardrails: passed
- make dev-release-preflight: passed (ticket 5eac387d-9505-40db-b7b6-0bdf5ccb7e1f)
- contribution commit, push, and pr-ready gates: passed; secret scans clean

## Safety
The failed run published no release or appcast. It stopped before notarization, smoke, and publication; its ephemeral runner keychain was removed.