### PR TITLE
Restore automatic Tip publication for all rollout roles

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       confirm_identity_rollout_role:
-        description: For preparer/transition/successor, enter the exact checked-in role
-        required: false
+        description: Enter the exact checked-in role (legacy/preparer/transition/successor)
+        required: true
         type: string
 
 concurrency:
@@ -126,15 +126,14 @@ jobs:
 
           should_publish=true
           skip_reason=""
-          if [[ "$ROLLOUT_ROLE" != "legacy" ]]; then
-            if [[ "$EVENT_NAME" != "workflow_dispatch" ]]; then
-              should_publish=false
-              skip_reason="role-requires-dispatch"
-              echo "Identity rollout role $ROLLOUT_ROLE requires an explicit workflow dispatch; skipping automatic publication."
-            elif [[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
-              echo "confirm_identity_rollout_role must exactly match checked-in role $ROLLOUT_ROLE" >&2
-              exit 1
-            fi
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
+            echo "confirm_identity_rollout_role must exactly match checked-in role $ROLLOUT_ROLE" >&2
+            exit 1
+          fi
+          if [[ "$ROLLOUT_ROLE" != "legacy" && "$EVENT_NAME" != "workflow_dispatch" ]]; then
+            should_publish=false
+            skip_reason="role-requires-dispatch"
+            echo "Identity rollout role $ROLLOUT_ROLE requires an explicit workflow dispatch; skipping automatic publication."
           fi
 
           stable_appcast="$RUNNER_TEMP/stable-appcast.xml"
@@ -184,7 +183,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   automatic-tip-dormant:
-    name: Automatic Tip Publication Dormant (Dispatch Required)
+    name: Automatic Tip Publication Dormant (Manual Review Required)
     needs: setup
     if: >-
       github.event_name == 'workflow_run' &&
@@ -205,7 +204,7 @@ jobs:
           commit="${TIP_COMMIT:-unresolved}"
           tag="${TIP_TAG:-unresolved}"
           {
-            echo "## Automatic Tip Publication Dormant (Dispatch Required)"
+            echo "## Automatic Tip Publication Dormant (Manual Review Required)"
             echo
             echo "- Rollout role: $ROLLOUT_ROLE"
             echo "- Commit: $commit"
@@ -214,9 +213,10 @@ jobs:
             echo "This automatic workflow_run was intentionally suppressed because the nonlegacy rollout role requires an explicit dispatch."
             echo "Nothing was built, signed, or published."
             echo
-            echo "To publish this role, dispatch Publish Tip from protected main and enter confirm_identity_rollout_role=$ROLLOUT_ROLE. The candidate commit is selected automatically from main."
+            echo "This diagnostic does not authorize a release. Review docs/releasing.md and docs/architecture/apple-identity-migration.md and obtain an explicit go/no-go decision before any manual dispatch."
+            echo "If separately authorized, the dispatch must run from protected main with confirm_identity_rollout_role=$ROLLOUT_ROLE; the candidate commit is selected automatically."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "Automatic Tip publication is intentionally dormant for rollout role $ROLLOUT_ROLE."
+          echo "Automatic Tip publication is dormant for rollout role $ROLLOUT_ROLE; manual review is required."
 
   credential-preflight:
     name: Preflight Tip Rollout Credentials

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -1,10 +1,6 @@
 name: Publish Tip
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       confirm_identity_rollout_role:
@@ -13,12 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: >-
-    ${{
-      (github.event_name == 'workflow_dispatch' && 'main-tip-dispatch-channel') ||
-      (github.event.workflow_run.conclusion == 'success' && 'main-tip-channel') ||
-      format('main-tip-skipped-{0}', github.run_id)
-    }}
+  group: main-tip-dispatch-channel
   queue: max
 
 permissions:
@@ -27,9 +18,6 @@ permissions:
 jobs:
   setup:
     name: Resolve Tip Commit
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
     runs-on: macos-26
     timeout-minutes: 20
     outputs:
@@ -38,8 +26,6 @@ jobs:
       build-number: ${{ steps.tip.outputs.build-number }}
       tag: ${{ steps.tip.outputs.tag }}
       tooling-commit: ${{ steps.tip.outputs.tooling-commit }}
-      should-publish: ${{ steps.tip.outputs.should-publish }}
-      skip-reason: ${{ steps.tip.outputs.skip-reason }}
       rollout-role: ${{ steps.tip.outputs.rollout-role }}
       rollout-identity: ${{ steps.tip.outputs.rollout-identity }}
       migration-phase: ${{ steps.tip.outputs.migration-phase }}
@@ -55,32 +41,18 @@ jobs:
       - name: Resolve protected main commit
         id: tip
         env:
-          EVENT_NAME: ${{ github.event_name }}
           DISPATCH_COMMIT: ${{ github.sha }}
           DISPATCH_REF: ${{ github.ref }}
-          WORKFLOW_RUN_COMMIT: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_DEFINITION_COMMIT: ${{ github.workflow_sha }}
           TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
           CONFIRMED_ROLLOUT_ROLE: ${{ inputs.confirm_identity_rollout_role }}
         run: |
           set -euo pipefail
-          case "$EVENT_NAME" in
-            workflow_dispatch)
-              [[ "$DISPATCH_REF" == "refs/heads/main" ]] || {
-                echo "Manual Tip dispatch must run from protected main" >&2
-                exit 1
-              }
-              requested_commit="$DISPATCH_COMMIT"
-              ;;
-            workflow_run)
-              requested_commit="$WORKFLOW_RUN_COMMIT"
-              ;;
-            *)
-              echo "Unsupported Tip release event: $EVENT_NAME" >&2
-              exit 1
-              ;;
-          esac
-          [[ "$requested_commit" =~ ^[0-9a-f]{40}$ ]] || {
+          [[ "$DISPATCH_REF" == "refs/heads/main" ]] || {
+            echo "Manual Tip dispatch must run from protected main" >&2
+            exit 1
+          }
+          [[ "$DISPATCH_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
             echo "GitHub did not provide a full lowercase source commit SHA" >&2
             exit 1
           }
@@ -89,7 +61,7 @@ jobs:
             exit 1
           }
           git fetch --no-tags origin main
-          commit="$(git rev-parse "$requested_commit^{commit}")"
+          commit="$(git rev-parse "$DISPATCH_COMMIT^{commit}")"
           live_main="$(git rev-parse origin/main)"
           [[ "$commit" == "$live_main" ]] || {
             echo "Tip candidate is not the current protected-main commit: candidate=$commit live-main=$live_main" >&2
@@ -124,16 +96,9 @@ jobs:
             exit 1
           }
 
-          should_publish=true
-          skip_reason=""
-          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
+          if [[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
             echo "confirm_identity_rollout_role must exactly match checked-in role $ROLLOUT_ROLE" >&2
             exit 1
-          fi
-          if [[ "$ROLLOUT_ROLE" != "legacy" && "$EVENT_NAME" != "workflow_dispatch" ]]; then
-            should_publish=false
-            skip_reason="role-requires-dispatch"
-            echo "Identity rollout role $ROLLOUT_ROLE requires an explicit workflow dispatch; skipping automatic publication."
           fi
 
           stable_appcast="$RUNNER_TEMP/stable-appcast.xml"
@@ -174,54 +139,15 @@ jobs:
             echo "build-number=$build_number"
             echo "tag=$tag"
             echo "tooling-commit=$tooling_commit"
-            echo "should-publish=$should_publish"
-            echo "skip-reason=$skip_reason"
             echo "rollout-role=$ROLLOUT_ROLE"
             echo "rollout-identity=$ROLLOUT_IDENTITY"
             echo "migration-phase=$REPOPROMPT_IDENTITY_MIGRATION_PHASE"
             echo "installation-type=$ROLLOUT_INSTALLATION_TYPE"
           } >> "$GITHUB_OUTPUT"
 
-  automatic-tip-dormant:
-    name: Automatic Tip Publication Dormant (Manual Review Required)
-    needs: setup
-    if: >-
-      github.event_name == 'workflow_run' &&
-      needs.setup.outputs.should-publish != 'true' &&
-      needs.setup.outputs.skip-reason == 'role-requires-dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - name: Report suppressed automatic publication
-        env:
-          ROLLOUT_ROLE: ${{ needs.setup.outputs.rollout-role }}
-          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
-          TIP_TAG: ${{ needs.setup.outputs.tag }}
-        run: |
-          set -euo pipefail
-          commit="${TIP_COMMIT:-unresolved}"
-          tag="${TIP_TAG:-unresolved}"
-          {
-            echo "## Automatic Tip Publication Dormant (Manual Review Required)"
-            echo
-            echo "- Rollout role: $ROLLOUT_ROLE"
-            echo "- Commit: $commit"
-            echo "- Tag: $tag"
-            echo
-            echo "This automatic workflow_run was intentionally suppressed because the nonlegacy rollout role requires an explicit dispatch."
-            echo "Nothing was built, signed, or published."
-            echo
-            echo "This diagnostic does not authorize a release. Review docs/releasing.md and docs/architecture/apple-identity-migration.md and obtain an explicit go/no-go decision before any manual dispatch."
-            echo "If separately authorized, the dispatch must run from protected main with confirm_identity_rollout_role=$ROLLOUT_ROLE; the candidate commit is selected automatically."
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "Automatic Tip publication is dormant for rollout role $ROLLOUT_ROLE; manual review is required."
-
   credential-preflight:
     name: Preflight Tip Rollout Credentials
     needs: setup
-    if: needs.setup.outputs.should-publish == 'true'
     environment: tip-release
     runs-on: macos-26
     timeout-minutes: 30
@@ -388,7 +314,6 @@ jobs:
     needs:
       - setup
       - credential-preflight
-    if: needs.setup.outputs.should-publish == 'true'
     runs-on: macos-26
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -1,6 +1,10 @@
 name: Publish Tip
 
 on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       confirm_identity_rollout_role:
@@ -9,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: main-tip-dispatch-channel
+  group: main-tip-channel
   queue: max
 
 permissions:
@@ -18,6 +22,9 @@ permissions:
 jobs:
   setup:
     name: Resolve Tip Commit
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: macos-26
     timeout-minutes: 20
     outputs:
@@ -41,18 +48,32 @@ jobs:
       - name: Resolve protected main commit
         id: tip
         env:
+          EVENT_NAME: ${{ github.event_name }}
           DISPATCH_COMMIT: ${{ github.sha }}
           DISPATCH_REF: ${{ github.ref }}
+          WORKFLOW_RUN_COMMIT: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_DEFINITION_COMMIT: ${{ github.workflow_sha }}
           TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
           CONFIRMED_ROLLOUT_ROLE: ${{ inputs.confirm_identity_rollout_role }}
         run: |
           set -euo pipefail
-          [[ "$DISPATCH_REF" == "refs/heads/main" ]] || {
-            echo "Manual Tip dispatch must run from protected main" >&2
-            exit 1
-          }
-          [[ "$DISPATCH_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+          case "$EVENT_NAME" in
+            workflow_dispatch)
+              [[ "$DISPATCH_REF" == "refs/heads/main" ]] || {
+                echo "Manual Tip dispatch must run from protected main" >&2
+                exit 1
+              }
+              requested_commit="$DISPATCH_COMMIT"
+              ;;
+            workflow_run)
+              requested_commit="$WORKFLOW_RUN_COMMIT"
+              ;;
+            *)
+              echo "Unsupported Tip release event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          [[ "$requested_commit" =~ ^[0-9a-f]{40}$ ]] || {
             echo "GitHub did not provide a full lowercase source commit SHA" >&2
             exit 1
           }
@@ -61,7 +82,7 @@ jobs:
             exit 1
           }
           git fetch --no-tags origin main
-          commit="$(git rev-parse "$DISPATCH_COMMIT^{commit}")"
+          commit="$(git rev-parse "$requested_commit^{commit}")"
           live_main="$(git rev-parse origin/main)"
           [[ "$commit" == "$live_main" ]] || {
             echo "Tip candidate is not the current protected-main commit: candidate=$commit live-main=$live_main" >&2
@@ -96,7 +117,7 @@ jobs:
             exit 1
           }
 
-          if [[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
             echo "confirm_identity_rollout_role must exactly match checked-in role $ROLLOUT_ROLE" >&2
             exit 1
           fi

--- a/Scripts/stable_rollout.py
+++ b/Scripts/stable_rollout.py
@@ -16,8 +16,8 @@ Commands:
 - ``generate``: assemble the accumulated appcast plus rollout manifest.
 - ``validate``: prove a reviewed appcast/manifest pair against the declaration,
   policy, version metadata, and enclosure/app-manifest digests.
-- ``validate-live-tip-progression``: prove the candidate advances the authenticated
-  public Tip ladder without skipping or rewriting retained history.
+- ``validate-live-tip-progression``: prove the candidate rolls or advances the
+  authenticated public Tip ladder without skipping or rewriting retained history.
 - ``validate-stable-tip-floor``: keep Stable builds below the retained preparer so
   an unprepared Stable client cannot satisfy the transition hard gate.
 - ``max-build``: greatest Sparkle build in an appcast (monotonicity input).
@@ -818,6 +818,15 @@ def validate_tip_manifest_pair(
 def expected_retained_history(live: dict, live_digest: str, candidate_role: str) -> list[dict]:
     live_role = live["currentRole"]
     live_items = live["appcastItems"]
+    if live_role == candidate_role:
+        allowed_chain = next(chain for chain in ALLOWED_ROLE_CHAINS if chain[0] == live_role)
+        retained_roles = tuple(item["role"] for item in live_items[1:])
+        if retained_roles != allowed_chain[1:]:
+            expected = ", ".join(allowed_chain[1:]) or "no"
+            raise RolloutError(
+                f"live {live_role} must retain exactly {expected} predecessors"
+            )
+        return live_items[1:]
     if live_role == "preparer" and candidate_role == "transition":
         newest = dict(live_items[0])
         newest["rolloutManifestName"] = "identity-rollout.json"
@@ -830,14 +839,6 @@ def expected_retained_history(live: dict, live_digest: str, candidate_role: str)
         newest["rolloutManifestName"] = "identity-rollout.json"
         newest["rolloutManifestSha256"] = live_digest
         return [newest, *live_items[1:]]
-    if live_role == "successor" and candidate_role == "successor":
-        if [item["role"] for item in live_items[1:]] != ["transition", "preparer"]:
-            raise RolloutError(
-                "live successor must retain exactly the transition and preparer predecessors"
-            )
-        return live_items[1:]
-    if live_role == "legacy" and candidate_role == "legacy":
-        return []
     raise RolloutError(
         "candidate Tip rollout role would regress or skip the live rollout state: "
         f"live={live_role} candidate={candidate_role}"

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -266,7 +266,7 @@ APP_SIGN_ARGS=(){app_signing_body}
             signer.index('sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"'),
         )
 
-    def test_release_workflows_gate_stable_preparer_and_require_manual_tip_dispatch_confirmation(self) -> None:
+    def test_release_workflows_gate_stable_preparer_and_keep_automatic_tip_publication(self) -> None:
         workflows = SCRIPT_DIR.parent / ".github" / "workflows"
         release_workflow = (workflows / "release.yml").read_text(encoding="utf-8")
         tip_workflow = (workflows / "main-tip.yml").read_text(encoding="utf-8")
@@ -289,8 +289,10 @@ APP_SIGN_ARGS=(){app_signing_body}
 
         trigger = tip_workflow.split("\non:\n", 1)[1].split("\nconcurrency:", 1)[0]
         dispatch = tip_workflow.split("  workflow_dispatch:", 1)[1].split("\n\nconcurrency:", 1)[0]
+        self.assertIn("  workflow_run:", trigger)
+        self.assertIn("    workflows: [CI]", trigger)
+        self.assertIn("    branches: [main]", trigger)
         self.assertIn("  workflow_dispatch:", trigger)
-        self.assertNotIn("workflow_run:", trigger)
         self.assertNotIn("      commit:", dispatch)
         self.assertIn("confirm_identity_rollout_role:", dispatch)
         confirmation = dispatch.split("      confirm_identity_rollout_role:", 1)[1]
@@ -298,11 +300,14 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertNotIn("        required: false", confirmation)
         self.assertIn("DISPATCH_COMMIT: ${{ github.sha }}", tip_workflow)
         self.assertIn("DISPATCH_REF: ${{ github.ref }}", tip_workflow)
+        self.assertIn("WORKFLOW_RUN_COMMIT: ${{ github.event.workflow_run.head_sha }}", tip_workflow)
         self.assertIn('[[ "$DISPATCH_REF" == "refs/heads/main" ]]', tip_workflow)
         self.assertIn('[[ "$commit" == "$live_main" ]]', tip_workflow)
         self.assertIn('[[ "$tooling_commit" == "$commit" ]]', tip_workflow)
-        self.assertIn('[[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
-        self.assertNotIn("github.event.workflow_run", tip_workflow)
+        self.assertIn(
+            '[[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]',
+            tip_workflow,
+        )
         self.assertNotIn("automatic-tip-dormant", tip_workflow)
         self.assertNotIn("should-publish", tip_workflow)
         self.assertNotIn("skip-reason", tip_workflow)
@@ -3259,8 +3264,8 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
 
         self.assertIn("name: Publish Tip", workflow)
         concurrency = workflow.split("concurrency:", 1)[1].split("\npermissions:", 1)[0]
-        self.assertIn("group: main-tip-dispatch-channel", concurrency)
-        self.assertNotIn("main-tip-channel", concurrency)
+        self.assertIn("group: main-tip-channel", concurrency)
+        self.assertNotIn("main-tip-dispatch-channel", concurrency)
         self.assertNotIn("github.event", concurrency)
         self.assertIn("queue: max", concurrency)
         self.assertNotIn("cancel-in-progress:", concurrency)
@@ -3426,15 +3431,15 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
             invalid_type.stderr,
         )
 
-    def test_main_tip_setup_uses_github_dispatch_sha_and_defers_remote_mutation(self) -> None:
+    def test_main_tip_setup_uses_exact_event_sha_and_defers_remote_mutation(self) -> None:
         workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
         setup = workflow.split("\n  setup:", 1)[1].split("\n  credential-preflight:", 1)[0]
         before_publish, publish = workflow.split("\n  publish:", 1)
 
         self.assertIn("permissions:\n  contents: read", workflow)
         self.assertIn("DISPATCH_COMMIT: ${{ github.sha }}", setup)
-        self.assertNotIn("WORKFLOW_RUN_COMMIT", setup)
-        self.assertNotIn("github.event.workflow_run", workflow)
+        self.assertIn("WORKFLOW_RUN_COMMIT: ${{ github.event.workflow_run.head_sha }}", setup)
+        self.assertIn('requested_commit="$WORKFLOW_RUN_COMMIT"', setup)
         self.assertIn("git fetch --no-tags origin main", setup)
         self.assertIn('[[ "$commit" == "$live_main" ]]', setup)
         self.assertNotIn("TIP_GH_TOKEN", setup)
@@ -3442,14 +3447,15 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertNotIn("lookup_public_tip_release", workflow)
         self.assertIn("TIP_GH_TOKEN: ${{ secrets.TIP_UPDATE_REPOSITORY_TOKEN }}", publish)
 
-    def test_tip_workflow_is_manual_only_without_dormant_release_route(self) -> None:
+    def test_tip_workflow_automatically_publishes_without_dormant_release_route(self) -> None:
         workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
         trigger = workflow.split("\non:\n", 1)[1].split("\nconcurrency:", 1)[0]
         credential_preflight = workflow.split("\n  credential-preflight:", 1)[1].split("\n  stage:", 1)[0]
         stage = workflow.split("\n  stage:", 1)[1].split("\n  sign:", 1)[0]
 
         self.assertIn("  workflow_dispatch:", trigger)
-        self.assertNotIn("workflow_run:", trigger)
+        self.assertIn("  workflow_run:", trigger)
+        self.assertIn("github.event.workflow_run.conclusion == 'success'", workflow)
         self.assertNotIn("automatic-tip-dormant:", workflow)
         self.assertNotIn("should-publish", workflow)
         self.assertNotIn("skip-reason", workflow)
@@ -5467,7 +5473,7 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             self.assertIn("mismatch", result.stderr)
             successor["manifest"].write_text(manifest_text, encoding="utf-8")
 
-    def test_stable_surfaces_stay_locked_while_tip_requires_explicit_role_dispatch(self) -> None:
+    def test_stable_surfaces_stay_locked_while_tip_automatically_publishes_checked_in_role(self) -> None:
         temp_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, temp_dir, True)
 
@@ -5498,8 +5504,11 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertIn("stable_rollout.py packaging-context", tip_workflow)
         self.assertIn("confirm_identity_rollout_role", tip_workflow)
         self.assertIn("required: true", tip_workflow)
-        self.assertIn('[[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
-        self.assertNotIn("workflow_run", tip_workflow)
+        self.assertIn(
+            '[[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]',
+            tip_workflow,
+        )
+        self.assertIn("workflow_run", tip_workflow)
         self.assertNotIn("release-rollout.json", tip_workflow)
 
         release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -266,7 +266,7 @@ APP_SIGN_ARGS=(){app_signing_body}
             signer.index('sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"'),
         )
 
-    def test_release_workflows_gate_stable_preparer_and_require_explicit_nonlegacy_tip_dispatch(self) -> None:
+    def test_release_workflows_gate_stable_preparer_and_require_explicit_tip_dispatch_confirmation(self) -> None:
         workflows = SCRIPT_DIR.parent / ".github" / "workflows"
         release_workflow = (workflows / "release.yml").read_text(encoding="utf-8")
         tip_workflow = (workflows / "main-tip.yml").read_text(encoding="utf-8")
@@ -290,13 +290,19 @@ APP_SIGN_ARGS=(){app_signing_body}
         dispatch = tip_workflow.split("  workflow_dispatch:", 1)[1].split("\n\nconcurrency:", 1)[0]
         self.assertNotIn("      commit:", dispatch)
         self.assertIn("confirm_identity_rollout_role:", dispatch)
+        confirmation = dispatch.split("      confirm_identity_rollout_role:", 1)[1]
+        self.assertIn("        required: true", confirmation)
+        self.assertNotIn("        required: false", confirmation)
         self.assertIn("DISPATCH_COMMIT: ${{ github.sha }}", tip_workflow)
         self.assertIn("DISPATCH_REF: ${{ github.ref }}", tip_workflow)
         self.assertIn('[[ "$DISPATCH_REF" == "refs/heads/main" ]]', tip_workflow)
         self.assertIn('[[ "$commit" == "$live_main" ]]', tip_workflow)
         self.assertIn('[[ "$tooling_commit" == "$commit" ]]', tip_workflow)
-        self.assertIn('if [[ "$EVENT_NAME" != "workflow_dispatch" ]]', tip_workflow)
-        self.assertIn('[[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
+        self.assertIn('[[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
+        self.assertIn('[[ "$ROLLOUT_ROLE" != "legacy" && "$EVENT_NAME" != "workflow_dispatch" ]]', tip_workflow)
+        self.assertIn("Automatic Tip Publication Dormant (Manual Review Required)", tip_workflow)
+        self.assertIn("This diagnostic does not authorize a release", tip_workflow)
+        self.assertNotIn("To publish this role", tip_workflow)
         self.assertIn("if: needs.setup.outputs.rollout-role == 'preparer'", tip_workflow)
         self.assertIn("EXPECTED_MIGRATION_ANCHOR_SIGN_IDENTITY", tip_workflow)
         self.assertIn('--identifier "$EXPECTED_MIGRATION_ANCHOR_BUNDLE_ID"', tip_workflow)
@@ -5490,7 +5496,8 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertIn("tip-rollout.json", tip_workflow)
         self.assertIn("stable_rollout.py packaging-context", tip_workflow)
         self.assertIn("confirm_identity_rollout_role", tip_workflow)
-        self.assertIn('if [[ "$EVENT_NAME" != "workflow_dispatch" ]]', tip_workflow)
+        self.assertIn("required: true", tip_workflow)
+        self.assertIn('[[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
         self.assertNotIn("release-rollout.json", tip_workflow)
 
         release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -4923,6 +4923,77 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertEqual(successor["result"].returncode, 0, successor["result"].stderr)
         return temp_dir, preparer, transition, successor
 
+    def make_tip_release(
+        self,
+        directory: Path,
+        role: str,
+        build: str,
+        retained: tuple[dict, ...] = (),
+        release_tag: str | None = None,
+    ) -> dict:
+        predecessor_entries = []
+        predecessor_manifests = []
+        for release in retained:
+            manifest = json.loads(release["manifest"].read_text(encoding="utf-8"))
+            predecessor_entries.append(
+                {
+                    "role": manifest["currentRole"],
+                    "tag": manifest["sourceTag"],
+                    "rolloutManifestSha256": hashlib.sha256(
+                        release["manifest"].read_bytes()
+                    ).hexdigest(),
+                }
+            )
+            predecessor_manifests.append(release["manifest"])
+        tag = release_tag or f"tip-{role}-{build.replace('.', '-')}"
+        release = self.make_release(
+            directory,
+            role,
+            "1.2.0",
+            build,
+            predecessors=predecessor_entries,
+            predecessor_manifests=predecessor_manifests,
+            channel="tip",
+            release_tag=tag,
+            enclosure_basename=f"RepoPrompt-{tag}-{build}",
+        )
+        self.assertEqual(release["result"].returncode, 0, release["result"].stderr)
+        return release
+
+    def make_tip_pts_ladder(self) -> tuple[Path, dict, dict, dict]:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        preparer = self.make_tip_release(
+            temp_dir, "preparer", "100.1.1", release_tag="tip-preparer"
+        )
+        transition = self.make_tip_release(
+            temp_dir, "transition", "100.1.2", (preparer,), release_tag="tip-transition"
+        )
+        successor = self.make_tip_release(
+            temp_dir,
+            "successor",
+            "100.1.3",
+            (transition, preparer),
+            release_tag="tip-successor",
+        )
+        return temp_dir, preparer, transition, successor
+
+    def validate_tip_progression(
+        self, candidate: dict, live: dict | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        arguments = [
+            "validate-live-tip-progression",
+            "--policy", str(self.POLICY),
+            "--candidate-manifest", str(candidate["manifest"]),
+            "--candidate-appcast", str(candidate["appcast"]),
+        ]
+        if live is not None:
+            arguments += [
+                "--live-manifest", str(live["manifest"]),
+                "--live-appcast", str(live["appcast"]),
+            ]
+        return self.rollout(*arguments)
+
     def validate_arguments(self, release: dict, allowed_roles: str | None = None) -> list[str]:
         arguments = list(release["arguments"])
         arguments[0] = "validate"
@@ -5199,66 +5270,7 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertEqual(rows[0][7], "RepoPrompt-1.5.0-150-stable-rollout.json")
 
     def test_tip_pts_ladder_reuses_one_feed_and_accumulates_top_level_items(self) -> None:
-        temp_dir = Path(tempfile.mkdtemp())
-        self.addCleanup(shutil.rmtree, temp_dir, True)
-
-        preparer = self.make_release(
-            temp_dir,
-            "preparer",
-            "1.2.0",
-            "100.1.1",
-            channel="tip",
-            release_tag="tip-preparer",
-            enclosure_basename="RepoPrompt-tip-preparer-100.1.1",
-        )
-        self.assertEqual(preparer["result"].returncode, 0, preparer["result"].stderr)
-        transition = self.make_release(
-            temp_dir,
-            "transition",
-            "1.2.0",
-            "100.1.2",
-            predecessors=[
-                {
-                    "role": "preparer",
-                    "tag": "tip-preparer",
-                    "rolloutManifestSha256": hashlib.sha256(
-                        preparer["manifest"].read_bytes()
-                    ).hexdigest(),
-                }
-            ],
-            predecessor_manifests=[preparer["manifest"]],
-            channel="tip",
-            release_tag="tip-transition",
-            enclosure_basename="RepoPrompt-tip-transition-100.1.2",
-        )
-        self.assertEqual(transition["result"].returncode, 0, transition["result"].stderr)
-        successor = self.make_release(
-            temp_dir,
-            "successor",
-            "1.2.0",
-            "100.1.3",
-            predecessors=[
-                {
-                    "role": "transition",
-                    "tag": "tip-transition",
-                    "rolloutManifestSha256": hashlib.sha256(
-                        transition["manifest"].read_bytes()
-                    ).hexdigest(),
-                },
-                {
-                    "role": "preparer",
-                    "tag": "tip-preparer",
-                    "rolloutManifestSha256": hashlib.sha256(
-                        preparer["manifest"].read_bytes()
-                    ).hexdigest(),
-                },
-            ],
-            predecessor_manifests=[transition["manifest"], preparer["manifest"]],
-            channel="tip",
-            release_tag="tip-successor",
-            enclosure_basename="RepoPrompt-tip-successor-100.1.3",
-        )
-        self.assertEqual(successor["result"].returncode, 0, successor["result"].stderr)
+        temp_dir, preparer, transition, successor = self.make_tip_pts_ladder()
 
         appcast = successor["appcast"].read_text(encoding="utf-8")
         self.assertEqual(appcast.count("<item>"), 3)
@@ -5334,29 +5346,15 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertNotEqual(crossed_floor.returncode, 0)
         self.assertIn("Stable=101 preparer=100.1.1", crossed_floor.stderr)
 
-        def progression(candidate: dict, live: dict | None = None) -> subprocess.CompletedProcess[str]:
-            arguments = [
-                "validate-live-tip-progression",
-                "--policy", str(self.POLICY),
-                "--candidate-manifest", str(candidate["manifest"]),
-                "--candidate-appcast", str(candidate["appcast"]),
-            ]
-            if live is not None:
-                arguments += [
-                    "--live-manifest", str(live["manifest"]),
-                    "--live-appcast", str(live["appcast"]),
-                ]
-            return self.rollout(*arguments)
-
-        first = progression(preparer)
+        first = self.validate_tip_progression(preparer)
         self.assertEqual(first.returncode, 0, first.stderr)
-        p_to_t = progression(transition, preparer)
+        p_to_t = self.validate_tip_progression(transition, preparer)
         self.assertEqual(p_to_t.returncode, 0, p_to_t.stderr)
-        t_to_s = progression(successor, transition)
+        t_to_s = self.validate_tip_progression(successor, transition)
         self.assertEqual(t_to_s.returncode, 0, t_to_s.stderr)
-        idempotent = progression(successor, successor)
+        idempotent = self.validate_tip_progression(successor, successor)
         self.assertEqual(idempotent.returncode, 0, idempotent.stderr)
-        skipped = progression(successor, preparer)
+        skipped = self.validate_tip_progression(successor, preparer)
         self.assertNotEqual(skipped.returncode, 0)
         self.assertIn("regress or skip", skipped.stderr)
 
@@ -5366,10 +5364,83 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         successor["manifest"].write_text(
             json.dumps(changed, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
-        changed_history = progression(successor, transition)
+        changed_history = self.validate_tip_progression(successor, transition)
         self.assertNotEqual(changed_history.returncode, 0)
         self.assertIn("retained items do not exactly match", changed_history.stderr)
         successor["manifest"].write_text(successor_manifest_text, encoding="utf-8")
+
+    def test_live_tip_progression_allows_rolling_roles_and_phase_advances(self) -> None:
+        temp_dir, preparer, transition, successor = self.make_tip_pts_ladder()
+        legacy = self.make_tip_release(temp_dir, "legacy", "99.1.1")
+        next_legacy = self.make_tip_release(temp_dir, "legacy", "99.1.2")
+        next_preparer = self.make_tip_release(temp_dir, "preparer", "100.1.4")
+        next_transition = self.make_tip_release(
+            temp_dir, "transition", "100.1.4", (preparer,)
+        )
+        next_successor = self.make_tip_release(
+            temp_dir, "successor", "100.1.4", (transition, preparer)
+        )
+
+        for label, live, candidate in (
+            ("legacy to legacy", legacy, next_legacy),
+            ("preparer to preparer", preparer, next_preparer),
+            ("preparer to transition", preparer, transition),
+            ("transition to transition", transition, next_transition),
+            ("transition to successor", transition, successor),
+            ("successor to successor", successor, next_successor),
+        ):
+            with self.subTest(label):
+                result = self.validate_tip_progression(candidate, live)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn("with exact retained history", result.stdout)
+
+    def test_live_tip_progression_rejects_changed_history_regression_and_phase_skip(self) -> None:
+        temp_dir, preparer, transition, successor = self.make_tip_pts_ladder()
+        next_preparer = self.make_tip_release(temp_dir, "preparer", "100.1.4")
+
+        altered_root = temp_dir / "altered-history"
+        altered_preparer = self.make_tip_release(
+            altered_root,
+            "preparer",
+            "100.1.1",
+            release_tag="tip-preparer",
+        )
+        altered_preparer["enclosure"].write_text(
+            "altered authenticated preparer enclosure\n", encoding="utf-8"
+        )
+        regenerated = self.rollout(*altered_preparer["arguments"])
+        self.assertEqual(regenerated.returncode, 0, regenerated.stderr)
+        changed_transition = self.make_tip_release(
+            altered_root,
+            "transition",
+            "100.1.5",
+            (altered_preparer,),
+        )
+
+        live_preparer_item = json.loads(transition["manifest"].read_text(encoding="utf-8"))[
+            "appcastItems"
+        ][1]
+        changed_preparer_item = json.loads(
+            changed_transition["manifest"].read_text(encoding="utf-8")
+        )["appcastItems"][1]
+        self.assertEqual(changed_preparer_item["role"], live_preparer_item["role"])
+        self.assertEqual(changed_preparer_item["tag"], live_preparer_item["tag"])
+        self.assertEqual(changed_preparer_item["buildNumber"], live_preparer_item["buildNumber"])
+        self.assertNotEqual(
+            changed_preparer_item["enclosureSha256"], live_preparer_item["enclosureSha256"]
+        )
+
+        changed_history = self.validate_tip_progression(changed_transition, transition)
+        self.assertNotEqual(changed_history.returncode, 0)
+        self.assertIn("retained items do not exactly match", changed_history.stderr)
+
+        regression = self.validate_tip_progression(next_preparer, transition)
+        self.assertNotEqual(regression.returncode, 0)
+        self.assertIn("regress or skip", regression.stderr)
+
+        skipped = self.validate_tip_progression(successor, preparer)
+        self.assertNotEqual(skipped.returncode, 0)
+        self.assertIn("regress or skip", skipped.stderr)
 
     def test_rollout_tampering_and_invalid_ladders_fail_closed(self) -> None:
         temp_dir, preparer, transition, successor = self.make_pts_ladder()

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -266,7 +266,7 @@ APP_SIGN_ARGS=(){app_signing_body}
             signer.index('sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"'),
         )
 
-    def test_release_workflows_gate_stable_preparer_and_require_explicit_tip_dispatch_confirmation(self) -> None:
+    def test_release_workflows_gate_stable_preparer_and_require_manual_tip_dispatch_confirmation(self) -> None:
         workflows = SCRIPT_DIR.parent / ".github" / "workflows"
         release_workflow = (workflows / "release.yml").read_text(encoding="utf-8")
         tip_workflow = (workflows / "main-tip.yml").read_text(encoding="utf-8")
@@ -287,7 +287,10 @@ APP_SIGN_ARGS=(){app_signing_body}
         for literal in ("com.repoprompt.ce", "69N6K965SF"):
             self.assertNotIn(literal, release_workflow)
 
+        trigger = tip_workflow.split("\non:\n", 1)[1].split("\nconcurrency:", 1)[0]
         dispatch = tip_workflow.split("  workflow_dispatch:", 1)[1].split("\n\nconcurrency:", 1)[0]
+        self.assertIn("  workflow_dispatch:", trigger)
+        self.assertNotIn("workflow_run:", trigger)
         self.assertNotIn("      commit:", dispatch)
         self.assertIn("confirm_identity_rollout_role:", dispatch)
         confirmation = dispatch.split("      confirm_identity_rollout_role:", 1)[1]
@@ -298,11 +301,11 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn('[[ "$DISPATCH_REF" == "refs/heads/main" ]]', tip_workflow)
         self.assertIn('[[ "$commit" == "$live_main" ]]', tip_workflow)
         self.assertIn('[[ "$tooling_commit" == "$commit" ]]', tip_workflow)
-        self.assertIn('[[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
-        self.assertIn('[[ "$ROLLOUT_ROLE" != "legacy" && "$EVENT_NAME" != "workflow_dispatch" ]]', tip_workflow)
-        self.assertIn("Automatic Tip Publication Dormant (Manual Review Required)", tip_workflow)
-        self.assertIn("This diagnostic does not authorize a release", tip_workflow)
-        self.assertNotIn("To publish this role", tip_workflow)
+        self.assertIn('[[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
+        self.assertNotIn("github.event.workflow_run", tip_workflow)
+        self.assertNotIn("automatic-tip-dormant", tip_workflow)
+        self.assertNotIn("should-publish", tip_workflow)
+        self.assertNotIn("skip-reason", tip_workflow)
         self.assertIn("if: needs.setup.outputs.rollout-role == 'preparer'", tip_workflow)
         self.assertIn("EXPECTED_MIGRATION_ANCHOR_SIGN_IDENTITY", tip_workflow)
         self.assertIn('--identifier "$EXPECTED_MIGRATION_ANCHOR_BUNDLE_ID"', tip_workflow)
@@ -3256,8 +3259,9 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
 
         self.assertIn("name: Publish Tip", workflow)
         concurrency = workflow.split("concurrency:", 1)[1].split("\npermissions:", 1)[0]
-        self.assertIn("main-tip-dispatch-channel", concurrency)
-        self.assertIn("main-tip-channel", concurrency)
+        self.assertIn("group: main-tip-dispatch-channel", concurrency)
+        self.assertNotIn("main-tip-channel", concurrency)
+        self.assertNotIn("github.event", concurrency)
         self.assertIn("queue: max", concurrency)
         self.assertNotIn("cancel-in-progress:", concurrency)
         self.assertIn("concurrency:\n      group: main-tip-publish\n      queue: max", workflow)
@@ -3424,12 +3428,13 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
 
     def test_main_tip_setup_uses_github_dispatch_sha_and_defers_remote_mutation(self) -> None:
         workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
-        setup = workflow.split("\n  setup:", 1)[1].split("\n  automatic-tip-dormant:", 1)[0]
+        setup = workflow.split("\n  setup:", 1)[1].split("\n  credential-preflight:", 1)[0]
         before_publish, publish = workflow.split("\n  publish:", 1)
 
         self.assertIn("permissions:\n  contents: read", workflow)
         self.assertIn("DISPATCH_COMMIT: ${{ github.sha }}", setup)
-        self.assertIn("WORKFLOW_RUN_COMMIT: ${{ github.event.workflow_run.head_sha }}", setup)
+        self.assertNotIn("WORKFLOW_RUN_COMMIT", setup)
+        self.assertNotIn("github.event.workflow_run", workflow)
         self.assertIn("git fetch --no-tags origin main", setup)
         self.assertIn('[[ "$commit" == "$live_main" ]]', setup)
         self.assertNotIn("TIP_GH_TOKEN", setup)
@@ -3437,23 +3442,19 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertNotIn("lookup_public_tip_release", workflow)
         self.assertIn("TIP_GH_TOKEN: ${{ secrets.TIP_UPDATE_REPOSITORY_TOKEN }}", publish)
 
-    def test_tip_no_release_diagnostic_contract_is_truthful_and_read_only(self) -> None:
+    def test_tip_workflow_is_manual_only_without_dormant_release_route(self) -> None:
         workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
-        setup = workflow.split("\n  setup:", 1)[1].split("\n  automatic-tip-dormant:", 1)[0]
-        diagnostic = workflow.split("\n  automatic-tip-dormant:", 1)[1].split(
-            "\n  credential-preflight:", 1
-        )[0]
+        trigger = workflow.split("\non:\n", 1)[1].split("\nconcurrency:", 1)[0]
+        credential_preflight = workflow.split("\n  credential-preflight:", 1)[1].split("\n  stage:", 1)[0]
+        stage = workflow.split("\n  stage:", 1)[1].split("\n  sign:", 1)[0]
 
-        self.assertIn('skip_reason="role-requires-dispatch"', setup)
-        self.assertIn("name: Automatic Tip Publication Dormant (Dispatch Required)", diagnostic)
-        self.assertIn("runs-on: ubuntu-latest", diagnostic)
-        self.assertIn("contents: read", diagnostic)
-        self.assertIn("Nothing was built, signed, or published.", diagnostic)
-        self.assertIn("dispatch Publish Tip from protected main", diagnostic)
-        self.assertIn("candidate commit is selected automatically from main", diagnostic)
-        self.assertNotIn("::error::", diagnostic)
-        self.assertNotIn("exit 1", diagnostic)
-        self.assertNotIn("environment: tip-release", diagnostic)
+        self.assertIn("  workflow_dispatch:", trigger)
+        self.assertNotIn("workflow_run:", trigger)
+        self.assertNotIn("automatic-tip-dormant:", workflow)
+        self.assertNotIn("should-publish", workflow)
+        self.assertNotIn("skip-reason", workflow)
+        self.assertNotIn("if:", credential_preflight)
+        self.assertNotIn("if:", stage)
 
     def test_tip_publication_helper_is_resume_safe_and_byte_exact(self) -> None:
         helper = SCRIPT_DIR / "publish_tip_release.sh"
@@ -5497,7 +5498,8 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertIn("stable_rollout.py packaging-context", tip_workflow)
         self.assertIn("confirm_identity_rollout_role", tip_workflow)
         self.assertIn("required: true", tip_workflow)
-        self.assertIn('[[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
+        self.assertIn('[[ "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]', tip_workflow)
+        self.assertNotIn("workflow_run", tip_workflow)
         self.assertNotIn("release-rollout.json", tip_workflow)
 
         release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -30,22 +30,21 @@ The checked-in Tip declaration is the controlled `P → T → S` rehearsal:
   items and supplies the normal rollback window.
 
 All three roles use the same Tip feed and `appcast.xml`; the rollout manifest is the same
-`identity-rollout.json` asset name. No sibling feed or Sparkle key is introduced. Automatic
-`workflow_run` notifications publish only legacy Tip builds. For P, T, and S they stop successfully
-in a read-only diagnostic before credentials or builds; that outcome is not release authorization.
+`identity-rollout.json` asset name. No sibling feed or Sparkle key is introduced. `Publish Tip` is
+manual-only and has no CI-completion trigger, so ordinary `main` activity cannot allocate release
+runners or produce a successful no-publication workflow.
 
-Each nonlegacy role requires an explicit `workflow_dispatch` from protected `main`. Every manual
-dispatch, including legacy, requires a non-empty `confirm_identity_rollout_role` input exactly equal
-to the checked-in role, preventing an empty confirmation from starting a release job. There is no
-operator-supplied commit field. GitHub's selected `main` SHA is the candidate, and setup requires that
-SHA, the workflow definition, the release-tooling checkout, and freshly fetched protected
-`origin/main` to be the same commit.
+Every dispatch from protected `main` requires a non-empty `confirm_identity_rollout_role` input
+exactly equal to the checked-in role, preventing an empty confirmation from starting a release job.
+There is no operator-supplied commit field. GitHub's selected `main` SHA is the candidate, and setup
+requires that SHA, the workflow definition, the release-tooling checkout, and freshly fetched
+protected `origin/main` to be the same commit.
 
-Automatic and manual runs occupy separate concurrency lanes and queue without cancelling in-flight
-release work. Publication is serialized across the lanes. Before any draft mutation and again
-immediately before publication, the publisher rechecks protected `main`, validates the authenticated
-public Tip appcast/manifest, enforces the monotonic `P → T → S` state machine with exact retained
-manifest bytes, and verifies retained enclosure size/SHA-256 from the immutable release assets.
+Manual runs queue without cancelling in-flight release work, and publication is serialized. Before
+any draft mutation and again immediately before publication, the publisher rechecks protected
+`main`, validates the authenticated public Tip appcast/manifest, enforces the monotonic `P → T → S`
+state machine with exact retained manifest bytes, and verifies retained enclosure size/SHA-256 from
+immutable release assets.
 For T and S, setup and publication also require the greatest Stable build to remain strictly below
 P's retained Tip build; otherwise an unprepared later Stable build could satisfy T's Sparkle floor.
 Draft creation, asset upload, and publication are reconciled by observation after ambiguous network
@@ -116,7 +115,7 @@ present and usable in the ephemeral keychain before any `codesign` or `productbu
 The manual gates are ordered: approve and dispatch P first, inspect its signed/notarized ZIP and
 retained `identity-rollout.json`, then update the declaration with P's exact manifest digest before
 dispatching T. After T is verified, update the declaration with both exact predecessor digests before
-dispatching S. Never publish a nonlegacy role from an automatic `workflow_run` notification.
+dispatching S. Publish every role only through the reviewed manual dispatch.
 
 P was published and independently verified at `tip-2f94412e6ab5`; its retained
 `identity-rollout.json` SHA-256 is

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -34,11 +34,12 @@ All three roles use the same Tip feed and `appcast.xml`; the rollout manifest is
 `workflow_run` notifications publish only legacy Tip builds. For P, T, and S they stop successfully
 in a read-only diagnostic before credentials or builds; that outcome is not release authorization.
 
-Each nonlegacy role requires an explicit `workflow_dispatch` from protected `main` with
-`confirm_identity_rollout_role` exactly equal to the checked-in role. There is no operator-supplied
-commit field. GitHub's selected `main` SHA is the candidate, and setup requires that SHA, the workflow
-definition, the release-tooling checkout, and freshly fetched protected `origin/main` to be the same
-commit.
+Each nonlegacy role requires an explicit `workflow_dispatch` from protected `main`. Every manual
+dispatch, including legacy, requires a non-empty `confirm_identity_rollout_role` input exactly equal
+to the checked-in role, preventing an empty confirmation from starting a release job. There is no
+operator-supplied commit field. GitHub's selected `main` SHA is the candidate, and setup requires that
+SHA, the workflow definition, the release-tooling checkout, and freshly fetched protected
+`origin/main` to be the same commit.
 
 Automatic and manual runs occupy separate concurrency lanes and queue without cancelling in-flight
 release work. Publication is serialized across the lanes. Before any draft mutation and again

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -45,8 +45,8 @@ protected `origin/main` to be the same commit.
 Automatic and manual runs use one queue without cancelling in-flight release work, and publication
 is serialized. Before any draft mutation and again immediately before publication, the publisher
 rechecks protected `main`, validates the authenticated public Tip appcast/manifest, enforces the
-monotonic `P → T → S` state machine with exact retained manifest bytes, and verifies retained
-enclosure size/SHA-256 from immutable release assets.
+monotonic `P → T → S` state machine while allowing newer same-role builds with exact retained
+manifest bytes, and verifies retained enclosure size/SHA-256 from immutable release assets.
 For T and S, setup and publication also require the greatest Stable build to remain strictly below
 P's retained Tip build; otherwise an unprepared later Stable build could satisfy T's Sparkle floor.
 Draft creation, asset upload, and publication are reconciled by observation after ambiguous network

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -30,21 +30,23 @@ The checked-in Tip declaration is the controlled `P → T → S` rehearsal:
   items and supplies the normal rollback window.
 
 All three roles use the same Tip feed and `appcast.xml`; the rollout manifest is the same
-`identity-rollout.json` asset name. No sibling feed or Sparkle key is introduced. `Publish Tip` is
-manual-only and has no CI-completion trigger, so ordinary `main` activity cannot allocate release
-runners or produce a successful no-publication workflow.
+`identity-rollout.json` asset name. No sibling feed or Sparkle key is introduced. A successful `CI`
+run for protected `main` automatically continues into the complete `Publish Tip` pipeline for the
+exact passing commit, regardless of the checked-in rollout role. A role changes the artifact and
+identity policy; it never suppresses publication or produces a successful no-publication run.
 
-Every dispatch from protected `main` requires a non-empty `confirm_identity_rollout_role` input
+Manual dispatch is a recovery path. Every dispatch from protected `main` requires a non-empty
+`confirm_identity_rollout_role` input
 exactly equal to the checked-in role, preventing an empty confirmation from starting a release job.
 There is no operator-supplied commit field. GitHub's selected `main` SHA is the candidate, and setup
 requires that SHA, the workflow definition, the release-tooling checkout, and freshly fetched
 protected `origin/main` to be the same commit.
 
-Manual runs queue without cancelling in-flight release work, and publication is serialized. Before
-any draft mutation and again immediately before publication, the publisher rechecks protected
-`main`, validates the authenticated public Tip appcast/manifest, enforces the monotonic `P → T → S`
-state machine with exact retained manifest bytes, and verifies retained enclosure size/SHA-256 from
-immutable release assets.
+Automatic and manual runs use one queue without cancelling in-flight release work, and publication
+is serialized. Before any draft mutation and again immediately before publication, the publisher
+rechecks protected `main`, validates the authenticated public Tip appcast/manifest, enforces the
+monotonic `P → T → S` state machine with exact retained manifest bytes, and verifies retained
+enclosure size/SHA-256 from immutable release assets.
 For T and S, setup and publication also require the greatest Stable build to remain strictly below
 P's retained Tip build; otherwise an unprepared later Stable build could satisfy T's Sparkle floor.
 Draft creation, asset upload, and publication are reconciled by observation after ambiguous network
@@ -110,25 +112,25 @@ role separately requires the successor application P12/password only to create a
 successor anchor. After every P12 import, the signing job verifies that the policy-derived identity is
 present and usable in the ephemeral keychain before any `codesign` or `productbuild` call.
 
-## Manual gates and next operator action
+## Rollout gates and next operator action
 
-The manual gates are ordered: approve and dispatch P first, inspect its signed/notarized ZIP and
-retained `identity-rollout.json`, then update the declaration with P's exact manifest digest before
-dispatching T. After T is verified, update the declaration with both exact predecessor digests before
-dispatching S. Publish every role only through the reviewed manual dispatch.
+The checked-in declaration is the rollout authorization boundary. Review and merge P first, inspect
+its automatically published signed/notarized ZIP and retained `identity-rollout.json`, then update the
+declaration with P's exact manifest digest before merging T. After T is verified, update the
+declaration with both exact predecessor digests before merging S. Successful protected-main CI
+automatically publishes each reviewed role; no second dispatch approval is required.
 
 P was published and independently verified at `tip-2f94412e6ab5`; its retained
 `identity-rollout.json` SHA-256 is
 `3c69703fa7582105633b36e8874fe2a28e1832aabb776351e68dbf3367e122db`. The checked-in Tip
 declaration now pins that immutable predecessor and selects T.
 
-The workflow capability for T is now explicit and deterministic: after this change reaches protected
-`main`, a reviewed dispatch uses `confirm_identity_rollout_role=transition`, and GitHub selects the
-exact current main SHA without a commit field. That capability is not release authorization. T and S
-remain **NO-GO** until the runtime proof below is complete, including a reviewed recovery story for a
-lost committed P journal and a policy that distinguishes a fresh successor installation from a client
-that skipped the preparer/transition bridge. S also requires a later declaration change containing
-both T's and P's exact manifest digests.
+The workflow capability for T is explicit and deterministic: after a reviewed transition declaration
+reaches protected `main` and CI passes, GitHub selects and publishes that exact commit automatically.
+The declaration change must not merge until the runtime proof below is complete, including a reviewed
+recovery story for a lost committed P journal and a policy that distinguishes a fresh successor
+installation from a client that skipped the preparer/transition bridge. S also requires a later
+declaration change containing both T's and P's exact manifest digests.
 
 ## Required proof gate
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -254,9 +254,10 @@ updates the stable appcast.
 
 `Publish Tip` can be notified automatically after successful CI on `main` or dispatched manually.
 The automatic `workflow_run` path publishes only the legacy role. For P, T, and S it ends in a
-successful read-only diagnostic before credentials, staging, signing, or publication. A nonlegacy
-role is published only by an explicit dispatch from `main` whose
-`confirm_identity_rollout_role` exactly matches the checked-in role.
+successful read-only diagnostic before credentials, staging, signing, or publication. Every manual
+dispatch from `main` requires a non-empty `confirm_identity_rollout_role` input that exactly matches
+the checked-in role; this applies to legacy and nonlegacy manual runs so the dispatch UI cannot start
+an ambiguously authorized release.
 
 There is deliberately no commit input. For a manual dispatch, GitHub's selected `main` ref and
 `github.sha` are the immutable candidate. Setup fetches protected `origin/main` and requires the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -252,12 +252,11 @@ feeds and no Sparkle-key change. Tip workflows must never write to `repoprompt-c
 use `v*` tags, and must not feed into `Promote Release`. Stable promotion remains the only path that
 updates the stable appcast.
 
-`Publish Tip` can be notified automatically after successful CI on `main` or dispatched manually.
-The automatic `workflow_run` path publishes only the legacy role. For P, T, and S it ends in a
-successful read-only diagnostic before credentials, staging, signing, or publication. Every manual
+`Publish Tip` is manual-only. It is never triggered by a successful CI run, so ordinary `main`
+activity cannot allocate release runners or produce a successful no-publication workflow. Every
 dispatch from `main` requires a non-empty `confirm_identity_rollout_role` input that exactly matches
-the checked-in role; this applies to legacy and nonlegacy manual runs so the dispatch UI cannot start
-an ambiguously authorized release.
+the checked-in role; this applies to every role so the dispatch UI cannot start an ambiguously
+authorized release.
 
 There is deliberately no commit input. For a manual dispatch, GitHub's selected `main` ref and
 `github.sha` are the immutable candidate. Setup fetches protected `origin/main` and requires the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -252,11 +252,11 @@ feeds and no Sparkle-key change. Tip workflows must never write to `repoprompt-c
 use `v*` tags, and must not feed into `Promote Release`. Stable promotion remains the only path that
 updates the stable appcast.
 
-`Publish Tip` is manual-only. It is never triggered by a successful CI run, so ordinary `main`
-activity cannot allocate release runners or produce a successful no-publication workflow. Every
-dispatch from `main` requires a non-empty `confirm_identity_rollout_role` input that exactly matches
-the checked-in role; this applies to every role so the dispatch UI cannot start an ambiguously
-authorized release.
+`Publish Tip` runs automatically after successful CI on protected `main`. Every checked-in rollout
+role follows the complete build, sign, notarize, smoke, and publish path; a role changes the artifact
+and identity policy but never suppresses the release or produces a successful no-publication run.
+Manual dispatch remains a recovery path and requires a non-empty `confirm_identity_rollout_role`
+input that exactly matches the checked-in role.
 
 There is deliberately no commit input. For a manual dispatch, GitHub's selected `main` ref and
 `github.sha` are the immutable candidate. Setup fetches protected `origin/main` and requires the
@@ -273,10 +273,10 @@ because GitHub excludes prereleases from `releases/latest`.
 
 Current checkpoint: verified P is `tip-2f94412e6ab5`, with rollout-manifest SHA-256
 `3c69703fa7582105633b36e8874fe2a28e1832aabb776351e68dbf3367e122db`. The reviewed declaration
-pins that predecessor and selects T. The workflow can build T only through an exact-role dispatch,
-but T and S remain NO-GO until the isolated runtime proof is approved, including lost-journal recovery
-and a fresh-successor-install policy. Workflow capability, environment approval, and role confirmation
-are safety gates; they are not release authorization.
+pins that predecessor and selects T. Protected-main review of the rollout declaration is the release
+authorization boundary: after CI passes, Tip publication is automatic. Do not merge a T or S
+declaration until the isolated runtime proof is approved, including lost-journal recovery and a
+fresh-successor-install policy.
 
 Tip `CFBundleVersion` values sort between adjacent stable builds. The workflow reads the published
 stable appcast and combines that stable build with the source commit count. For example, commit

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -267,9 +267,9 @@ the secret-free build and uses an isolated ephemeral keychain without changing t
 keychain search list.
 
 After P is reviewed, advance `tip-rollout.json` with its exact `identity-rollout.json` digest before
-dispatching T; advance it again with T and P digests before S. Each published role uses an immutable
-`tip-<shortsha>` tag and the tip-only repository's latest release. Do not mark it as a prerelease,
-because GitHub excludes prereleases from `releases/latest`.
+merging T; advance it again with T and P digests before merging S. Each published role uses an
+immutable `tip-<shortsha>` tag and the tip-only repository's latest release. Do not mark it as a
+prerelease, because GitHub excludes prereleases from `releases/latest`.
 
 Current checkpoint: verified P is `tip-2f94412e6ab5`, with rollout-manifest SHA-256
 `3c69703fa7582105633b36e8874fe2a28e1832aabb776351e68dbf3367e122db`. The reviewed declaration
@@ -289,15 +289,17 @@ publisher require the greatest Stable build to remain strictly below the retaine
 Stable to the next integer first would make an unprepared Stable client appear new enough to satisfy
 T's `sparkle:minimumUpdateVersion`, bypassing the credential preparer.
 
-Automatic and manual runs use separate concurrency lanes, and neither lane cancels in-flight release
-work. The publication job is serialized across both lanes, so a retry resumes or audits one exact
-draft instead of abandoning a different tag halfway through publication.
+Automatic and manual runs use one concurrency lane and do not cancel in-flight release work, so a
+retry resumes or audits one exact draft instead of abandoning a different tag halfway through
+publication.
 
 Remote mutation is confined to that protected publication job. Immediately before draft creation
 and again immediately before making a draft public, it rechecks live protected `main`, downloads the
-public Tip manifest/appcast, proves that the candidate advances only `P → T → S` (or a later S) with
-exact retained history, and audits every retained enclosure against GitHub's published size and
-SHA-256. Existing drafts are resumed only when their metadata and uploaded bytes exactly match;
+public Tip manifest/appcast, proves that the candidate either rolls the current role or advances one
+step through `P → T → S` with exact retained history, and audits every retained enclosure against
+GitHub's published size and SHA-256. Rolling P retains no predecessor, rolling T retains the exact
+authenticated P, and rolling S retains the exact authenticated T and P. Existing drafts are resumed
+only when their metadata and uploaded bytes exactly match;
 missing assets are added without overwriting anything. After publication, every public asset is
 downloaded anonymously and compared byte-for-byte with the signed local inventory, and the release
 must be the repository's latest. The update-repository token is not available to setup, staging, or


### PR DESCRIPTION
## Summary
- restore the automatic `workflow_run` trigger after successful `CI` on protected `main`
- send every checked-in rollout role through the full credential, build, sign/notarize, smoke, and publish pipeline
- allow rolling `preparer` and `transition` Tip builds while preserving exact authenticated predecessor history
- keep rollout role as artifact/identity policy rather than release-routing policy
- remove the dormant diagnostic route and all `should-publish` / `skip-reason` state
- serialize automatic and recovery dispatches through one Tip queue
- retain exact-role confirmation for manual recovery dispatches

## Root causes
The identity-transition rollout made `legacy` versus `preparer` / `transition` / `successor` decide whether a successful protected-main CI run could publish. That violated the established Tip invariant: green CI on `main` should continue into one canonical Tip release.

[Run #33174306807](https://github.com/repoprompt/repoprompt-ce/actions/runs/33174306807) demonstrates the bad state: the workflow succeeded after a setup/diagnostic route while every actual release job was skipped and no artifact was produced. [Run #33172070026](https://github.com/repoprompt/repoprompt-ce/actions/runs/33172070026) also exposed the ambiguous blank manual-confirmation boundary.

The progression validator then allowed same-role rolling builds only for `legacy` and `successor`. With `transition` checked in, the first T could publish, but every later main commit would complete build/sign/notarize/smoke and fail at final publication on the rejected `transition → transition` edge.

## Behavior after this PR
- successful `CI` for protected `main` automatically selects that exact CI head SHA and runs the complete Tip pipeline
- failed CI does not start release work
- `legacy`, `preparer`, `transition`, and `successor` all publish through the same pipeline; their differences are confined to checked-in identity, migration, packaging, and appcast policy
- same-role updates preserve the authenticated retained history exactly:
  - `legacy → legacy`: retain `[]`
  - `preparer → preparer`: retain `[]`
  - `transition → transition`: retain exact P
  - `successor → successor`: retain exact T and P
- advancing `preparer → transition` and `transition → successor` remains allowed
- regressions, phase skips, non-increasing builds, changed predecessor bytes/hashes, or reordered retained history remain rejected
- manual dispatch remains an exact-role-confirmed recovery path, not the normal release mechanism
- there is no successful no-publication branch

The same-role rule derives its expected retained roles from the existing `ALLOWED_ROLE_CHAINS` authority rather than introducing another progression table. The direct release components already shared with the official release lane remain authoritative (`package_app.sh`, `validate_staged_release.sh`, `sign_staged_release.sh`, and the transition package helper).

## Transition consequence
The current checked-in Tip declaration selects `transition`. If this PR merges and protected-main CI passes, the automatic Tip workflow will attempt the complete transition release. Later commits can continue publishing newer T builds with the exact authenticated P retained until the declaration advances to `successor`.

## Validation
- complete `IdentityTransitionReleaseToolingTests`: 14/14 passed
- direct positive progression matrix: `L→L`, `P→P`, `P→T`, `T→T`, `T→S`, `S→S`
- direct negative progression coverage: altered authenticated P on `T→T`, `T→P` regression, and `P→S` phase skip
- `make release-preflight` (secret-free release validation)
- Python compilation and `git diff --check`
- mandatory staged and outgoing-range secret scans
- repository contribution guardrails
- exact-head hosted CI: [run #33240839913](https://github.com/repoprompt/repoprompt-ce/actions/runs/33240839913)

No release workflow was dispatched and no artifact was published from this PR branch.
