### PR TITLE
Remove manual Tip rollout role input

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -6,11 +6,6 @@ on:
     types: [completed]
     branches: [main]
   workflow_dispatch:
-    inputs:
-      confirm_identity_rollout_role:
-        description: Enter the exact checked-in role (legacy/preparer/transition/successor)
-        required: true
-        type: string
 
 concurrency:
   group: main-tip-channel
@@ -54,7 +49,6 @@ jobs:
           WORKFLOW_RUN_COMMIT: ${{ github.event.workflow_run.head_sha }}
           WORKFLOW_DEFINITION_COMMIT: ${{ github.workflow_sha }}
           TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
-          CONFIRMED_ROLLOUT_ROLE: ${{ inputs.confirm_identity_rollout_role }}
         run: |
           set -euo pipefail
           case "$EVENT_NAME" in
@@ -116,11 +110,6 @@ jobs:
             echo "Configured Tip update repository does not match the reviewed identity policy" >&2
             exit 1
           }
-
-          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]; then
-            echo "confirm_identity_rollout_role must exactly match checked-in role $ROLLOUT_ROLE" >&2
-            exit 1
-          fi
 
           stable_appcast="$RUNNER_TEMP/stable-appcast.xml"
           stable_feed_url="$(python3 Scripts/stable_rollout.py feed-url \

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -294,20 +294,15 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn("    branches: [main]", trigger)
         self.assertIn("  workflow_dispatch:", trigger)
         self.assertNotIn("      commit:", dispatch)
-        self.assertIn("confirm_identity_rollout_role:", dispatch)
-        confirmation = dispatch.split("      confirm_identity_rollout_role:", 1)[1]
-        self.assertIn("        required: true", confirmation)
-        self.assertNotIn("        required: false", confirmation)
+        self.assertNotIn("    inputs:", dispatch)
+        self.assertNotIn("confirm_identity_rollout_role", tip_workflow)
         self.assertIn("DISPATCH_COMMIT: ${{ github.sha }}", tip_workflow)
         self.assertIn("DISPATCH_REF: ${{ github.ref }}", tip_workflow)
         self.assertIn("WORKFLOW_RUN_COMMIT: ${{ github.event.workflow_run.head_sha }}", tip_workflow)
         self.assertIn('[[ "$DISPATCH_REF" == "refs/heads/main" ]]', tip_workflow)
         self.assertIn('[[ "$commit" == "$live_main" ]]', tip_workflow)
         self.assertIn('[[ "$tooling_commit" == "$commit" ]]', tip_workflow)
-        self.assertIn(
-            '[[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]',
-            tip_workflow,
-        )
+        self.assertNotIn("CONFIRMED_ROLLOUT_ROLE", tip_workflow)
         self.assertNotIn("automatic-tip-dormant", tip_workflow)
         self.assertNotIn("should-publish", tip_workflow)
         self.assertNotIn("skip-reason", tip_workflow)
@@ -5573,12 +5568,8 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertEqual(promote_workflow.count("stable_rollout.py workflow-guard"), 1)
         self.assertIn("tip-rollout.json", tip_workflow)
         self.assertIn("stable_rollout.py packaging-context", tip_workflow)
-        self.assertIn("confirm_identity_rollout_role", tip_workflow)
-        self.assertIn("required: true", tip_workflow)
-        self.assertIn(
-            '[[ "$EVENT_NAME" == "workflow_dispatch" && "$CONFIRMED_ROLLOUT_ROLE" != "$ROLLOUT_ROLE" ]]',
-            tip_workflow,
-        )
+        self.assertNotIn("confirm_identity_rollout_role", tip_workflow)
+        self.assertNotIn("CONFIRMED_ROLLOUT_ROLE", tip_workflow)
         self.assertIn("workflow_run", tip_workflow)
         self.assertNotIn("release-rollout.json", tip_workflow)
 

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -35,10 +35,9 @@ run for protected `main` automatically continues into the complete `Publish Tip`
 exact passing commit, regardless of the checked-in rollout role. A role changes the artifact and
 identity policy; it never suppresses publication or produces a successful no-publication run.
 
-Manual dispatch is a recovery path. Every dispatch from protected `main` requires a non-empty
-`confirm_identity_rollout_role` input
-exactly equal to the checked-in role, preventing an empty confirmation from starting a release job.
-There is no operator-supplied commit field. GitHub's selected `main` SHA is the candidate, and setup
+Manual dispatch is a recovery path and takes no operator-supplied release inputs. The checked-in
+declaration on protected `main` supplies the rollout role and identity policy. There is no
+operator-supplied commit field. GitHub's selected `main` SHA is the candidate, and setup
 requires that SHA, the workflow definition, the release-tooling checkout, and freshly fetched
 protected `origin/main` to be the same commit.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -255,8 +255,8 @@ updates the stable appcast.
 `Publish Tip` runs automatically after successful CI on protected `main`. Every checked-in rollout
 role follows the complete build, sign, notarize, smoke, and publish path; a role changes the artifact
 and identity policy but never suppresses the release or produces a successful no-publication run.
-Manual dispatch remains a recovery path and requires a non-empty `confirm_identity_rollout_role`
-input that exactly matches the checked-in role.
+Manual dispatch remains a recovery path and takes no operator-supplied release inputs. It derives the
+rollout role and identity policy from the checked-in declaration on protected `main`.
 
 There is deliberately no commit input. For a manual dispatch, GitHub's selected `main` ref and
 `github.sha` are the immutable candidate. Setup fetches protected `origin/main` and requires the


### PR DESCRIPTION
## Summary

- remove the operator-supplied rollout-role input from manual Publish Tip dispatch
- derive rollout role and identity policy solely from the checked-in `tip-rollout.json` on exact protected `main`
- update release documentation and lock the input-free contract with structural tests

Automatic CI-to-Tip publication, exact-main/workflow/tooling SHA checks, credentials, signing, notarization, rollout state validation, and publication gates are unchanged.

## Validation

- `python3 -m unittest Scripts.test_release_tooling.ReleaseToolingTests.test_release_workflows_gate_stable_preparer_and_keep_automatic_tip_publication Scripts.test_release_tooling.IdentityTransitionReleaseToolingTests.test_stable_surfaces_stay_locked_while_tip_automatically_publishes_checked_in_role`
- Ruby Psych parse of `.github/workflows/main-tip.yml`
- `make dev-release-preflight`
- `git diff --check`
- repository commit and push preflights