### PR TITLE
Fix CLI single-shot selector routing

### DIFF
--- a/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
+++ b/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
@@ -1187,6 +1187,31 @@ actor InteractiveMCPClientSession {
         return CallTool.Result(content: [.text("Local window/context selection cleared.")], isError: false)
     }
 
+    func establishStartupRouting(contextID: String?, tabID: String?, windowID: Int?) async throws {
+        if let contextID {
+            let result = try await bindContextID(contextID, windowID: windowID)
+            let binding = try confirmedBinding(from: result)
+            guard binding.contextID?.uuidString.caseInsensitiveCompare(contextID) == .orderedSame else {
+                throw InteractiveSessionError.handshakeFailed(
+                    reason: "bind_context returned a different context than requested"
+                )
+            }
+            return
+        }
+
+        if let tabID {
+            let result = try await bindTab(selector: tabID, windowID: windowID)
+            let binding = try confirmedBinding(from: result)
+            guard let selectedContextID,
+                  binding.contextID?.uuidString.caseInsensitiveCompare(selectedContextID) == .orderedSame
+            else {
+                throw InteractiveSessionError.handshakeFailed(
+                    reason: "bind_context returned a different context than the selected tab"
+                )
+            }
+        }
+    }
+
     func bindContextID(_ contextID: String, windowID: Int? = nil) async throws -> CallTool.Result {
         var args: [String: Value] = [
             "op": .string("bind"),
@@ -1300,6 +1325,17 @@ actor InteractiveMCPClientSession {
         }
         let data = Data(text.utf8)
         return try JSONDecoder().decode(BindContextResponse.self, from: data)
+    }
+
+    private func confirmedBinding(from result: CallTool.Result) throws -> BindContextBinding {
+        guard result.isError != true else {
+            let reason = result.content.compactMap {
+                if case let .text(text, _, _) = $0 { return text }
+                return nil
+            }.first ?? "bind_context failed"
+            throw InteractiveSessionError.handshakeFailed(reason: reason)
+        }
+        return try decodeBindContextResponse(from: result).binding
     }
 
     // MARK: - Bootstrap Handshake

--- a/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
+++ b/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
@@ -1189,7 +1189,11 @@ actor InteractiveMCPClientSession {
 
     func establishStartupRouting(contextID: String?, tabID: String?, windowID: Int?) async throws {
         if let contextID {
-            let result = try await bindContextID(contextID, windowID: windowID)
+            let result = try await bindContextID(
+                contextID,
+                windowID: windowID,
+                requestRawJSON: true
+            )
             let binding = try confirmedBinding(from: result)
             guard binding.contextID?.uuidString.caseInsensitiveCompare(contextID) == .orderedSame else {
                 throw InteractiveSessionError.handshakeFailed(
@@ -1200,7 +1204,11 @@ actor InteractiveMCPClientSession {
         }
 
         if let tabID {
-            let result = try await bindTab(selector: tabID, windowID: windowID)
+            let result = try await bindTab(
+                selector: tabID,
+                windowID: windowID,
+                requestRawJSON: true
+            )
             let binding = try confirmedBinding(from: result)
             guard let selectedContextID,
                   binding.contextID?.uuidString.caseInsensitiveCompare(selectedContextID) == .orderedSame
@@ -1212,11 +1220,18 @@ actor InteractiveMCPClientSession {
         }
     }
 
-    func bindContextID(_ contextID: String, windowID: Int? = nil) async throws -> CallTool.Result {
+    func bindContextID(
+        _ contextID: String,
+        windowID: Int? = nil,
+        requestRawJSON: Bool = false
+    ) async throws -> CallTool.Result {
         var args: [String: Value] = [
             "op": .string("bind"),
             "context_id": .string(contextID)
         ]
+        if requestRawJSON {
+            args["_rawJSON"] = .bool(true)
+        }
         if let windowID {
             args["window_id"] = .int(windowID)
         }
@@ -1248,14 +1263,22 @@ actor InteractiveMCPClientSession {
         return result
     }
 
-    func bindTab(selector: String, windowID: Int? = nil) async throws -> CallTool.Result {
+    func bindTab(
+        selector: String,
+        windowID: Int? = nil,
+        requestRawJSON: Bool = false
+    ) async throws -> CallTool.Result {
         let trimmed = selector.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw InteractiveSessionError.handshakeFailed(reason: "Empty context selector")
         }
 
         if let contextID = UUID(uuidString: trimmed) {
-            return try await bindContextID(contextID.uuidString, windowID: windowID)
+            return try await bindContextID(
+                contextID.uuidString,
+                windowID: windowID,
+                requestRawJSON: requestRawJSON
+            )
         }
 
         let preferredWindowID = windowID ?? selectedWindowID
@@ -1291,7 +1314,11 @@ actor InteractiveMCPClientSession {
             throw InteractiveSessionError.handshakeFailed(reason: "Ambiguous compose tab '\(trimmed)': \(details). Re-run with -w or use a context_id.")
         }
 
-        return try await bindContextID(match.tab.contextID.uuidString, windowID: match.windowID)
+        return try await bindContextID(
+            match.tab.contextID.uuidString,
+            windowID: match.windowID,
+            requestRawJSON: requestRawJSON
+        )
     }
 
     func bindingStatus() async throws -> BindContextBinding {

--- a/Sources/RepoPromptMCP/Interactive/InteractiveREPL.swift
+++ b/Sources/RepoPromptMCP/Interactive/InteractiveREPL.swift
@@ -13,6 +13,8 @@ import MCP
 struct InteractiveOptions {
     var snapshotPath: String?
     var initialWindowID: Int?
+    var tabID: String?
+    var contextID: String?
     var prettyJSON: Bool = true
     var rawJSON: Bool = false
     var verbose: Bool = false
@@ -84,6 +86,11 @@ actor InteractiveREPL {
 
         if let toolName = options.callTool {
             await session.setSelectedWindowID(options.initialWindowID)
+            try await session.establishStartupRouting(
+                contextID: options.contextID,
+                tabID: options.tabID,
+                windowID: options.initialWindowID
+            )
             try await callToolSingleShot(name: toolName, argsJSON: options.callArgs)
             return
         }
@@ -111,6 +118,12 @@ actor InteractiveREPL {
             printCallResult(result)
             workspaceCacheDirty = true
         }
+
+        try await session.establishStartupRouting(
+            contextID: options.contextID,
+            tabID: options.tabID,
+            windowID: options.initialWindowID
+        )
 
         // Initial status fetch
         await refreshStatusCache()

--- a/Sources/RepoPromptMCP/main.swift
+++ b/Sources/RepoPromptMCP/main.swift
@@ -2553,8 +2553,8 @@ private func parseToolTimeoutSeconds(_ raw: String) -> Double? {
 }
 
 /// Parses command line arguments to determine CLI mode
-func parseCLIMode() -> CLIMode {
-    let args = CommandLine.arguments.dropFirst() // Skip executable name
+func parseCLIMode(arguments: [String] = CommandLine.arguments) -> CLIMode {
+    let args = arguments.dropFirst() // Skip executable name
     var hasNonBackendUserArgs = false
     if args.first == "policy" {
         return .policyAdministration(Array(args.dropFirst()))
@@ -2797,12 +2797,14 @@ func parseCLIMode() -> CLIMode {
         case "--tab", "-t":
             i = args.index(after: i)
             if i < args.endIndex {
+                interactiveOptions.tabID = args[i]
                 execOptions.tabID = args[i]
             }
 
         case "--context-id":
             i = args.index(after: i)
             if i < args.endIndex {
+                interactiveOptions.contextID = args[i]
                 execOptions.contextID = args[i]
             }
 

--- a/Tests/RepoPromptTests/MCP/Control/CLIModeParsingTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/CLIModeParsingTests.swift
@@ -1,0 +1,60 @@
+@testable import RepoPromptMCP
+import XCTest
+
+#if DEBUG
+    final class CLIModeParsingTests: XCTestCase {
+        func testSingleShotRetainsLastSharedSelectorValues() {
+            let mode = parseCLIMode(arguments: [
+                "rpce-cli",
+                "--tab", "first-tab",
+                "-t", "last-tab",
+                "--context-id", "first-context",
+                "--context-id", "last-context",
+                "-c", "workspace_context"
+            ])
+
+            guard case let .interactive(options) = mode else {
+                return XCTFail("Expected interactive mode for a single-shot tool call")
+            }
+
+            XCTAssertEqual(options.callTool, "workspace_context")
+            XCTAssertEqual(options.tabID, "last-tab")
+            XCTAssertEqual(options.contextID, "last-context")
+        }
+
+        func testPlainREPLRetainsBothSharedSelectors() {
+            let mode = parseCLIMode(arguments: [
+                "rpce-cli",
+                "-i",
+                "-t", "review-tab",
+                "--context-id", "compose-context"
+            ])
+
+            guard case let .interactive(options) = mode else {
+                return XCTFail("Expected interactive mode for the plain REPL")
+            }
+
+            XCTAssertNil(options.callTool)
+            XCTAssertEqual(options.tabID, "review-tab")
+            XCTAssertEqual(options.contextID, "compose-context")
+        }
+
+        func testExecModePrecedenceAndSelectorStateRemainUnchanged() {
+            let mode = parseCLIMode(arguments: [
+                "rpce-cli",
+                "-c", "workspace_context",
+                "-t", "review-tab",
+                "--context-id", "compose-context",
+                "-e", "tree"
+            ])
+
+            guard case let .exec(options) = mode else {
+                return XCTFail("Expected exec mode to retain precedence over interactive flags")
+            }
+
+            XCTAssertEqual(options.commands, ["tree"])
+            XCTAssertEqual(options.tabID, "review-tab")
+            XCTAssertEqual(options.contextID, "compose-context")
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/MCP/Control/InteractiveREPLSingleShotRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/InteractiveREPLSingleShotRoutingTests.swift
@@ -18,6 +18,7 @@ import XCTest
             let calls = await fixture.recorder.recordedCalls()
             XCTAssertEqual(calls.map(\.name), ["bind_context", "workspace_context"])
             XCTAssertEqual(calls[0].arguments?["context_id"], .string(contextID))
+            XCTAssertEqual(calls[0].arguments?["_rawJSON"], .bool(true))
             XCTAssertEqual(calls[1].arguments?["context_id"], .string(contextID))
         }
 
@@ -34,7 +35,9 @@ import XCTest
             let calls = await fixture.recorder.recordedCalls()
             XCTAssertEqual(calls.map(\.name), ["bind_context", "bind_context", "workspace_context"])
             XCTAssertEqual(calls[0].arguments?["op"], .string("list"))
+            XCTAssertEqual(calls[0].arguments?["_rawJSON"], .bool(true))
             XCTAssertEqual(calls[1].arguments?["context_id"], .string(fixture.namedTabContextID))
+            XCTAssertEqual(calls[1].arguments?["_rawJSON"], .bool(true))
             XCTAssertEqual(calls[2].arguments?["context_id"], .string(fixture.namedTabContextID))
         }
 
@@ -54,6 +57,7 @@ import XCTest
             XCTAssertEqual(calls.map(\.name), ["bind_context", "workspace_context"])
             XCTAssertEqual(calls[0].arguments?["op"], .string("bind"))
             XCTAssertEqual(calls[0].arguments?["context_id"], .string(contextID))
+            XCTAssertEqual(calls[0].arguments?["_rawJSON"], .bool(true))
             XCTAssertEqual(calls[1].arguments?["context_id"], .string(contextID))
         }
 
@@ -85,7 +89,15 @@ import XCTest
             )
             await server.withMethodHandler(CallTool.self) { params in
                 await recorder.record(params)
-                let text = if params.name == "bind_context", params.arguments?["op"] == .string("list") {
+                let text = if params.name == "bind_context",
+                              params.arguments?["_rawJSON"] != .bool(true)
+                {
+                    """
+                    ## Context Binding
+
+                    Bound to the requested context.
+                    """
+                } else if params.name == "bind_context", params.arguments?["op"] == .string("list") {
                     """
                     {"windows":[{"window_id":7,"workspace":null,"tabs":[{"context_id":"\(namedTabContextID)","name":"Review Tab"}]}],"binding":{"binding_kind":"unbound","window_id":null,"context_id":null,"workspace_name":null}}
                     """

--- a/Tests/RepoPromptTests/MCP/Control/InteractiveREPLSingleShotRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/InteractiveREPLSingleShotRoutingTests.swift
@@ -4,52 +4,80 @@ import XCTest
 
 #if DEBUG
     final class InteractiveREPLSingleShotRoutingTests: XCTestCase {
-        func testSingleShotCallWithInitialWindowInjectsHiddenWindowWithoutBinding() async throws {
+        func testContextIDRoutesSingleShotTargetCallToSelectedContext() async throws {
             let fixture = try await makeFixture()
             addTeardownBlock { await fixture.cleanup() }
 
             let contextID = "C72119FC-64CD-42E4-B14A-0E6A28DD4DC1"
             var options = InteractiveOptions()
-            options.initialWindowID = 7
-            options.callTool = "agent_run"
-            options.callArgs = """
-            {"window_id":42,"context_id":"\(contextID)"}
-            """
+            options.contextID = contextID
+            options.callTool = "workspace_context"
 
             try await InteractiveREPL(session: fixture.session, options: options).run()
 
             let calls = await fixture.recorder.recordedCalls()
-            XCTAssertEqual(calls.count, 1)
-            XCTAssertEqual(calls.first?.name, "agent_run")
-            XCTAssertEqual(calls.first?.arguments?["_windowID"], .int(7))
-            XCTAssertEqual(calls.first?.arguments?["window_id"], .int(42))
-            XCTAssertEqual(calls.first?.arguments?["context_id"], .string(contextID))
+            XCTAssertEqual(calls.map(\.name), ["bind_context", "workspace_context"])
+            XCTAssertEqual(calls[0].arguments?["context_id"], .string(contextID))
+            XCTAssertEqual(calls[1].arguments?["context_id"], .string(contextID))
         }
 
-        func testSingleShotCallWithoutInitialWindowPreservesPublicRoutingArgumentsOnly() async throws {
+        func testTabSelectorResolvesAndBindsBeforeSingleShotTargetCall() async throws {
+            let fixture = try await makeFixture()
+            addTeardownBlock { await fixture.cleanup() }
+
+            var options = InteractiveOptions()
+            options.tabID = "Review Tab"
+            options.callTool = "workspace_context"
+
+            try await InteractiveREPL(session: fixture.session, options: options).run()
+
+            let calls = await fixture.recorder.recordedCalls()
+            XCTAssertEqual(calls.map(\.name), ["bind_context", "bind_context", "workspace_context"])
+            XCTAssertEqual(calls[0].arguments?["op"], .string("list"))
+            XCTAssertEqual(calls[1].arguments?["context_id"], .string(fixture.namedTabContextID))
+            XCTAssertEqual(calls[2].arguments?["context_id"], .string(fixture.namedTabContextID))
+        }
+
+        func testContextIDTakesPrecedenceWithoutAttemptingTabResolution() async throws {
             let fixture = try await makeFixture()
             addTeardownBlock { await fixture.cleanup() }
 
             let contextID = "8FC92199-2D4B-4324-9790-98155550F0BF"
             var options = InteractiveOptions()
-            options.callTool = "agent_run"
-            options.callArgs = """
-            {"window_id":42,"context_id":"\(contextID)"}
-            """
+            options.contextID = contextID
+            options.tabID = "Review Tab"
+            options.callTool = "workspace_context"
+
+            try await InteractiveREPL(session: fixture.session, options: options).run()
+
+            let calls = await fixture.recorder.recordedCalls()
+            XCTAssertEqual(calls.map(\.name), ["bind_context", "workspace_context"])
+            XCTAssertEqual(calls[0].arguments?["op"], .string("bind"))
+            XCTAssertEqual(calls[0].arguments?["context_id"], .string(contextID))
+            XCTAssertEqual(calls[1].arguments?["context_id"], .string(contextID))
+        }
+
+        func testWindowOnlySingleShotInjectsHiddenWindowWithoutBinding() async throws {
+            let fixture = try await makeFixture()
+            addTeardownBlock { await fixture.cleanup() }
+
+            var options = InteractiveOptions()
+            options.initialWindowID = 7
+            options.callTool = "workspace_context"
 
             try await InteractiveREPL(session: fixture.session, options: options).run()
 
             let calls = await fixture.recorder.recordedCalls()
             XCTAssertEqual(calls.count, 1)
-            XCTAssertEqual(calls.first?.name, "agent_run")
-            XCTAssertNil(calls.first?.arguments?["_windowID"])
-            XCTAssertEqual(calls.first?.arguments?["window_id"], .int(42))
-            XCTAssertEqual(calls.first?.arguments?["context_id"], .string(contextID))
+            XCTAssertEqual(calls.first?.name, "workspace_context")
+            XCTAssertEqual(calls.first?.arguments?["_windowID"], .int(7))
+            XCTAssertNil(calls.first?.arguments?["context_id"])
         }
 
         private func makeFixture() async throws -> InteractiveREPLSingleShotRoutingFixture {
             let transports = await InMemoryTransport.createConnectedPair()
             let recorder = InteractiveREPLToolCallRecorder()
+            let namedTabContextID = "EC558D4B-0292-4935-AD42-CEFC6121A31A"
             let server = Server(
                 name: "CLI single-shot routing test server",
                 version: "1.0",
@@ -57,8 +85,21 @@ import XCTest
             )
             await server.withMethodHandler(CallTool.self) { params in
                 await recorder.record(params)
+                let text = if params.name == "bind_context", params.arguments?["op"] == .string("list") {
+                    """
+                    {"windows":[{"window_id":7,"workspace":null,"tabs":[{"context_id":"\(namedTabContextID)","name":"Review Tab"}]}],"binding":{"binding_kind":"unbound","window_id":null,"context_id":null,"workspace_name":null}}
+                    """
+                } else if params.name == "bind_context",
+                          case let .string(contextID)? = params.arguments?["context_id"]
+                {
+                    """
+                    {"binding":{"binding_kind":"tab","window_id":7,"context_id":"\(contextID)","workspace_name":"Test Workspace"}}
+                    """
+                } else {
+                    "ok"
+                }
                 return .init(
-                    content: [.text(text: "ok", annotations: nil, _meta: nil)],
+                    content: [.text(text: text, annotations: nil, _meta: nil)],
                     isError: false
                 )
             }
@@ -80,7 +121,8 @@ import XCTest
                 client: client,
                 server: server,
                 session: session,
-                recorder: recorder
+                recorder: recorder,
+                namedTabContextID: namedTabContextID
             )
         }
     }
@@ -107,6 +149,7 @@ import XCTest
         let server: Server
         let session: InteractiveMCPClientSession
         let recorder: InteractiveREPLToolCallRecorder
+        let namedTabContextID: String
 
         func cleanup() async {
             await client.disconnect()


### PR DESCRIPTION
## Summary

- Preserve `-t` and `--context-id` when `-c` selects interactive single-shot mode and when starting the plain interactive REPL.
- Establish the requested context or tab binding before the target tool call, with explicit context taking precedence over tab selection and with strict confirmation of the returned binding.
- Preserve existing `-e` precedence and selector-free/`-w`-only behavior, with focused parser and runtime-routing coverage.

## Problem

The CLI parser previously retained tab and context selectors only for exec mode. A single-shot `-c <tool>` invocation could therefore discard an explicit selector and dispatch against the active tab instead.

## Implementation

- Extend interactive options with tab and context selectors populated by the shared parser.
- Resolve named or UUID tab selectors and bind the selected context before single-shot dispatch and before the first plain-REPL status call.
- Fail before target dispatch when binding returns an MCP error or confirms a different context.
- Add deterministic parser and runtime fixtures for selector retention, precedence, bind-before-call ordering, and unchanged window-only injection.

## Review and validation

- The approved Deep Plan was implemented within its five-file boundary.
- RepoPrompt Context Builder correctness REVIEW converged with no must-fix findings.
- A separate Context Builder REFACTOR gate found no substantive in-scope simplification.
- `CLIModeParsingTests`: 3 passed.
- `InteractiveREPLSingleShotRoutingTests`: 4 passed.
- `BindContextRoutingRecoveryTests`: 10 passed.
- `InteractiveMCPClientSessionToolCatalogTests`: 5 passed.
- `repoprompt-mcp` product build passed.
- Strict SwiftFormat and SwiftLint passed.
- Diff checks and commit/push contribution preflights passed after rebasing onto current `upstream/main`.

## Campaign acceptance

Direct packaged RepoPrompt CE CLI/debug-app selector acceptance on the rebuilt stability stack, including the two-tab selector matrix and clean-restart replay, remains a required campaign gate. It has not yet run against this published branch and is not claimed as evidence here.

## Risk

The change is limited to CLI interactive startup routing and its tests. Server routing is unchanged, and existing exec-mode behavior remains separate.

Fixes #900