### PR TITLE
Fix redundant Tip package notarization

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -8,8 +8,14 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: main-tip-channel
-  queue: max
+  group: >-
+    ${{
+      (github.event_name == 'workflow_dispatch' && 'main-tip-dispatch-channel') ||
+      (github.event.workflow_run.conclusion == 'success' && 'main-tip-channel') ||
+      format('main-tip-skipped-{0}', github.run_id)
+    }}
+  queue: single
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -590,7 +596,7 @@ jobs:
           printf '%s' "$SENTRY_AUTH_TOKEN" > "$SENTRY_TOKEN_FILE"
           chmod 600 "$SENTRY_TOKEN_FILE"
 
-      - name: Sign and notarize staged tip
+      - name: Sign application
         env:
           TIP_COMMIT: ${{ needs.setup.outputs.commit }}
           TIP_SHORT_SHA: ${{ needs.setup.outputs.short-sha }}
@@ -609,7 +615,53 @@ jobs:
           REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
           REPOPROMPT_SENTRY_AUTH_TOKEN_FILE: ${{ runner.temp }}/repoprompt-tip-secrets/sentry-auth-token
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: ./trusted-control-plane/Scripts/main_tip_release.sh sign
+        run: ./trusted-control-plane/Scripts/main_tip_release.sh sign-application
+
+      - name: Build package
+        if: needs.setup.outputs.installation-type == 'package'
+        env:
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+          TIP_SHORT_SHA: ${{ needs.setup.outputs.short-sha }}
+          TIP_BUILD_NUMBER: ${{ needs.setup.outputs.build-number }}
+          TIP_TAG: ${{ needs.setup.outputs.tag }}
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
+        run: ./trusted-control-plane/Scripts/main_tip_release.sh build-package
+
+      - name: Submit package notarization
+        if: needs.setup.outputs.installation-type == 'package'
+        env:
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+          TIP_SHORT_SHA: ${{ needs.setup.outputs.short-sha }}
+          TIP_BUILD_NUMBER: ${{ needs.setup.outputs.build-number }}
+          TIP_TAG: ${{ needs.setup.outputs.tag }}
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
+        run: ./trusted-control-plane/Scripts/main_tip_release.sh submit-package-notarization
+
+      - name: Staple package
+        if: needs.setup.outputs.installation-type == 'package'
+        env:
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+          TIP_SHORT_SHA: ${{ needs.setup.outputs.short-sha }}
+          TIP_BUILD_NUMBER: ${{ needs.setup.outputs.build-number }}
+          TIP_TAG: ${{ needs.setup.outputs.tag }}
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
+        run: ./trusted-control-plane/Scripts/main_tip_release.sh staple-package
+
+      - name: Validate package
+        if: needs.setup.outputs.installation-type == 'package'
+        env:
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+          TIP_SHORT_SHA: ${{ needs.setup.outputs.short-sha }}
+          TIP_BUILD_NUMBER: ${{ needs.setup.outputs.build-number }}
+          TIP_TAG: ${{ needs.setup.outputs.tag }}
+          TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: ./trusted-control-plane/Scripts/main_tip_release.sh validate-package
 
       - name: Remove ephemeral keychain
         if: always()

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -614,7 +614,7 @@ jobs:
           REPOPROMPT_SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
           REPOPROMPT_SENTRY_AUTH_TOKEN_FILE: ${{ runner.temp }}/repoprompt-tip-secrets/sentry-auth-token
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          SPARKLE_PRIVATE_KEY: ${{ needs.setup.outputs.installation-type == 'application' && secrets.SPARKLE_PRIVATE_KEY || '' }}
         run: ./trusted-control-plane/Scripts/main_tip_release.sh sign-application
 
       - name: Build package

--- a/Scripts/build_identity_transition_pkg.sh
+++ b/Scripts/build_identity_transition_pkg.sh
@@ -204,13 +204,10 @@ build_transition_pkg() {
     [[ "$installer_identity" == "$SUCCESSOR_INSTALLER_IDENTITY" ]] ||
         fail "Transition Installer identity must match the reviewed policy"
     [[ ! -e "$output" && ! -L "$output" ]] || fail "Refusing to overwrite transition package: $output"
-    for command in codesign diff ditto pkgbuild pkgutil plutil productbuild productsign xcrun; do
+    for command in codesign diff ditto pkgbuild pkgutil plutil productbuild productsign; do
         require_command "$command"
     done
     validate_successor_app "$app" "Transition payload input"
-    [[ -n "${NOTARYTOOL_PRIVATE_KEY:-}" && -n "${NOTARYTOOL_KEY_ID:-}" && -n "${NOTARYTOOL_ISSUER_ID:-}" ]] ||
-        fail "Transition package notarization credentials are incomplete"
-    require_file "$NOTARYTOOL_PRIVATE_KEY"
 
     TMP_DIR="$(mktemp -d)"
     local payload_root="$TMP_DIR/payload-root"
@@ -238,17 +235,18 @@ build_transition_pkg() {
     productbuild --package "$component_pkg" "$unsigned_product"
     productsign --sign "$installer_identity" "$unsigned_product" "$signed_product"
 
-    xcrun notarytool submit "$signed_product" \
-        --key "$NOTARYTOOL_PRIVATE_KEY" \
-        --key-id "$NOTARYTOOL_KEY_ID" \
-        --issuer "$NOTARYTOOL_ISSUER_ID" \
-        --wait --timeout "${NOTARYTOOL_TIMEOUT:-30m}"
-    xcrun stapler staple "$signed_product"
-    validate_transition_pkg "$signed_product" --expected-app "$app"
     [[ -d "$(dirname "$output")" && ! -L "$(dirname "$output")" ]] ||
         fail "Transition package output parent must be a real directory"
     mv "$signed_product" "$output"
-    printf 'OK: created identity-transition package: %s\n' "$output"
+    printf 'OK: built and signed identity-transition package: %s\n' "$output"
+}
+
+staple_transition_pkg() {
+    local pkg="$1"
+    require_command xcrun
+    require_file "$pkg"
+    xcrun stapler staple "$pkg"
+    printf 'OK: stapled identity-transition package: %s\n' "$pkg"
 }
 
 validate_transition_pkg() {
@@ -307,10 +305,14 @@ validate_transition_pkg() {
 
 case "$MODE" in
     build) build_transition_pkg "$@" ;;
+    staple)
+        [[ $# -eq 1 ]] || fail "Usage: $0 staple <transition.pkg>"
+        staple_transition_pkg "$1"
+        ;;
     validate)
         [[ $# -ge 1 ]] || fail "Usage: $0 validate <transition.pkg> [--expected-app <app>] [--expanded-payload-dir <dir>]"
         pkg_path="$1"; shift
         validate_transition_pkg "$pkg_path" "$@"
         ;;
-    *) fail "Usage: $0 build|validate ..." ;;
+    *) fail "Usage: $0 build|staple|validate ..." ;;
 esac

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -332,6 +332,7 @@ derive_sparkle_public_key() {
 }
 
 generate_tip_rollout_appcast() {
+    require_env SPARKLE_PRIVATE_KEY
     local predecessor_dir="$TMP_DIR/predecessors"
     mkdir -p "$predecessor_dir"
     # macOS still ships Bash 3.2, where expanding an empty array under
@@ -461,7 +462,6 @@ sign_tip_application_phase() {
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift"
     require_env SIGN_IDENTITY
     require_env REPOPROMPT_PROVISIONING_PROFILE
-    require_env SPARKLE_PRIVATE_KEY
     require_env RELEASE_COMMIT
     require_env REPOPROMPT_APPROVED_SOURCE_ROOT
     require_tip_sentry_configuration
@@ -558,7 +558,6 @@ validate_tip_package_phase() {
     require_command curl
     require_command shasum
     require_command xcrun
-    require_env SPARKLE_PRIVATE_KEY
     require_file "$SIGN_UPDATE"
     require_file "$FINAL_ARTIFACT_MANIFEST"
     require_file "$FINAL_METADATA"

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -69,12 +69,34 @@ RUN_WITHOUT_GITHUB_TOKENS="$CONTROL_PLANE_SCRIPTS_DIR/run_without_github_tokens.
 SIGN_UPDATE="$TRUSTED_ROOT/Vendor/Sparkle/bin/sign_update"
 PUBLISH_TIP_RELEASE="$CONTROL_PLANE_SCRIPTS_DIR/publish_tip_release.sh"
 TMP_DIR=""
+PHASE_LABEL=""
+PHASE_START_EPOCH=""
 
 require_command() { command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"; }
 require_env() { [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"; }
 require_file() { [[ -f "$1" ]] || fail "Missing required file: $1"; }
 cleanup() { [[ -z "$TMP_DIR" ]] || rm -rf "$TMP_DIR"; }
-trap cleanup EXIT
+finish() {
+    local status="$1"
+    trap - EXIT
+    cleanup
+    if [[ -n "$PHASE_LABEL" ]]; then
+        local end_epoch end_utc elapsed outcome
+        end_epoch="$(date -u +%s)"
+        end_utc="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        elapsed=$((end_epoch - PHASE_START_EPOCH))
+        if (( status == 0 )); then outcome="success"; else outcome="failure"; fi
+        printf 'PHASE END: %s utc=%s elapsed_seconds=%s status=%s\n' \
+            "$PHASE_LABEL" "$end_utc" "$elapsed" "$outcome"
+    fi
+    exit "$status"
+}
+start_phase() {
+    PHASE_LABEL="$1"
+    PHASE_START_EPOCH="$(date -u +%s)"
+    printf 'PHASE START: %s utc=%s\n' "$PHASE_LABEL" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+}
+trap 'finish $?' EXIT
 
 prepare_dist() {
     [[ "$DIST_DIR" != "/" ]] || fail "DIST_DIR must not be /"
@@ -234,13 +256,75 @@ stage_tip() {
     printf 'OK: staged tip build %s (%s) for %s.\n' "$TIP_TAG" "$TIP_BUILD_NUMBER" "$TIP_COMMIT"
 }
 
+fetch_notarization_log() {
+    local submission_id="$1"
+    printf 'Fetching Apple notarization log for submission %s.\n' "$submission_id" >&2
+    if ! xcrun notarytool log "$submission_id" \
+        --key "$NOTARYTOOL_PRIVATE_KEY" \
+        --key-id "$NOTARYTOOL_KEY_ID" \
+        --issuer "$NOTARYTOOL_ISSUER_ID" \
+        --output-format json; then
+        printf 'WARNING: unable to retrieve Apple notarization log for submission %s.\n' "$submission_id" >&2
+    fi
+}
+
 submit_notarization() {
-    xcrun notarytool submit "$1" \
+    local artifact="$1"
+    require_file "$artifact"
+    require_env NOTARYTOOL_PRIVATE_KEY
+    require_env NOTARYTOOL_KEY_ID
+    require_env NOTARYTOOL_ISSUER_ID
+    require_file "$NOTARYTOOL_PRIVATE_KEY"
+    [[ -n "$TMP_DIR" ]] || TMP_DIR="$(mktemp -d)"
+
+    local response_file submit_status fields submission_id submission_status
+    response_file="$(mktemp "$TMP_DIR/notarytool-submit.XXXXXX")"
+    if xcrun notarytool submit "$artifact" \
         --key "$NOTARYTOOL_PRIVATE_KEY" \
         --key-id "$NOTARYTOOL_KEY_ID" \
         --issuer "$NOTARYTOOL_ISSUER_ID" \
         --wait \
-        --timeout "${NOTARYTOOL_TIMEOUT:-30m}"
+        --timeout "${NOTARYTOOL_TIMEOUT:-30m}" \
+        --output-format json > "$response_file"; then
+        submit_status=0
+    else
+        submit_status=$?
+    fi
+    cat "$response_file"
+
+    fields="$(python3 - "$response_file" <<'PYTHON'
+import json
+import sys
+import uuid
+from pathlib import Path
+
+try:
+    response = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, UnicodeError, json.JSONDecodeError):
+    print("|")
+    raise SystemExit(0)
+submission_id = response.get("id", "")
+status = response.get("status", "")
+try:
+    submission_id = str(uuid.UUID(str(submission_id))) if submission_id else ""
+except (ValueError, AttributeError, TypeError):
+    submission_id = ""
+print(f"{submission_id}|{status if isinstance(status, str) else ''}")
+PYTHON
+)"
+    submission_id="${fields%%|*}"
+    submission_status="${fields#*|}"
+    if [[ -n "$submission_id" ]]; then
+        printf 'Apple notarization submission ID: %s\n' "$submission_id"
+    fi
+    if (( submit_status != 0 )) || [[ "$submission_status" != "Accepted" || -z "$submission_id" ]]; then
+        if [[ -n "$submission_id" ]]; then
+            fetch_notarization_log "$submission_id"
+        else
+            printf 'Apple notarization did not return a valid submission ID; no notarytool log can be retrieved.\n' >&2
+        fi
+        fail "Apple notarization failed for $(basename "$artifact") (exit=$submit_status status=${submission_status:-unknown})"
+    fi
 }
 
 derive_sparkle_public_key() {
@@ -325,7 +409,45 @@ generate_tip_rollout_appcast() {
         "$public_key_file" "$enclosure_signature" "$ENCLOSURE"
 }
 
-sign_tip() {
+require_application_rollout() {
+    [[ "$ROLLOUT_INSTALLATION_TYPE" == "application" ]] ||
+        fail "Application notarization requires a policy-derived application rollout"
+}
+
+require_package_rollout() {
+    [[ "$ROLLOUT_INSTALLATION_TYPE" == "package" && "$ROLLOUT_ROLE" == "transition" ]] ||
+        fail "Package phase requires the policy-derived transition package rollout"
+    require_env EXPECTED_INSTALLER_IDENTITY
+}
+
+notarize_application_bundle() {
+    require_application_rollout
+    local notary_zip="$TMP_DIR/$ARCHIVE_BASENAME-notarization.zip"
+    ditto -c -k --norsrc --keepParent "$APP_BUNDLE" "$notary_zip"
+    submit_notarization "$notary_zip"
+    xcrun stapler staple "$APP_BUNDLE"
+    xcrun stapler validate "$APP_BUNDLE"
+}
+
+notarize_application_dmg() {
+    require_application_rollout
+    submit_notarization "$DMG"
+    xcrun stapler staple "$DMG"
+    xcrun stapler validate "$DMG"
+}
+
+notarize_signed_app_for_rollout() {
+    case "$ROLLOUT_INSTALLATION_TYPE" in
+        application) notarize_application_bundle ;;
+        package)
+            require_package_rollout
+            printf 'OK: package rollout skips standalone application notarization.\n'
+            ;;
+        *) fail "Unsupported policy-derived installation type: $ROLLOUT_INSTALLATION_TYPE" ;;
+    esac
+}
+
+sign_tip_application_phase() {
     require_command curl
     require_command ditto
     require_command hdiutil
@@ -340,17 +462,11 @@ sign_tip() {
     require_env SIGN_IDENTITY
     require_env REPOPROMPT_PROVISIONING_PROFILE
     require_env SPARKLE_PRIVATE_KEY
-    require_env NOTARYTOOL_PRIVATE_KEY
-    require_env NOTARYTOOL_KEY_ID
-    require_env NOTARYTOOL_ISSUER_ID
     require_env RELEASE_COMMIT
     require_env REPOPROMPT_APPROVED_SOURCE_ROOT
     require_tip_sentry_configuration
     [[ "$SIGN_IDENTITY" == "$EXPECTED_SIGN_IDENTITY" ]] ||
         fail "SIGN_IDENTITY does not match the reviewed $ROLLOUT_IDENTITY identity"
-    if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
-        require_env EXPECTED_INSTALLER_IDENTITY
-    fi
     [[ "$RELEASE_COMMIT" == "$TIP_COMMIT" ]] || fail "RELEASE_COMMIT must match TIP_COMMIT"
     [[ -d "$APP_BUNDLE" ]] || fail "Missing staged tip app bundle: $APP_BUNDLE"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
@@ -372,11 +488,9 @@ sign_tip() {
         "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
     prepare_dist
     TMP_DIR="$(mktemp -d)"
-    local notary_zip="$TMP_DIR/$ARCHIVE_BASENAME-notarization.zip"
-    ditto -c -k --norsrc --keepParent "$APP_BUNDLE" "$notary_zip"
-    submit_notarization "$notary_zip"
-    xcrun stapler staple "$APP_BUNDLE"
-    xcrun stapler validate "$APP_BUNDLE"
+
+    notarize_signed_app_for_rollout
+
     "$CONTROL_PLANE_SCRIPTS_DIR/write_app_artifact_manifest.py" write \
         --app "$APP_BUNDLE" \
         --output "$FINAL_ARTIFACT_MANIFEST" \
@@ -392,36 +506,86 @@ sign_tip() {
         "repoprompt-mcp.dSYM" \
         "repoprompt-mcp"
 
-    local checksum_assets=()
     if [[ "$ROLLOUT_INSTALLATION_TYPE" == "package" ]]; then
-        REPOPROMPT_ENABLE_IDENTITY_TRANSITION_PKG=1 \
-            "$CONTROL_PLANE_SCRIPTS_DIR/build_identity_transition_pkg.sh" build \
-            --app "$APP_BUNDLE" \
-            --output "$TRANSITION_PKG" \
-            --installer-identity "$EXPECTED_INSTALLER_IDENTITY"
-        checksum_assets+=("$(basename "$TRANSITION_PKG")")
-    else
-        local distribution_dir="$TMP_DIR/distribution"
-        mkdir -p "$distribution_dir"
-        ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
-        ditto -c -k --norsrc --keepParent "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
-        validate_distribution_zip "$UPDATE_ZIP" "$FINAL_ARTIFACT_MANIFEST" "Final tip distribution" "$SIGNING_TEAM_ID"
-        hdiutil create -volname "$DISPLAY_NAME Tip" -srcfolder "$distribution_dir" -ov -format UDZO "$DMG"
-        submit_notarization "$DMG"
-        xcrun stapler staple "$DMG"
-        xcrun stapler validate "$DMG"
-        checksum_assets+=("$(basename "$UPDATE_ZIP")" "$(basename "$DMG")")
+        printf 'OK: signed and validated Tip application for package rollout %s.\n' "$TIP_TAG"
+        return
     fi
 
+    local distribution_dir="$TMP_DIR/distribution"
+    mkdir -p "$distribution_dir"
+    ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
+    ditto -c -k --norsrc --keepParent "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
+    validate_distribution_zip "$UPDATE_ZIP" "$FINAL_ARTIFACT_MANIFEST" "Final tip distribution" "$SIGNING_TEAM_ID"
+    hdiutil create -volname "$DISPLAY_NAME Tip" -srcfolder "$distribution_dir" -ov -format UDZO "$DMG"
+    notarize_application_dmg
     generate_tip_rollout_appcast
-    checksum_assets+=(
+    local checksum_assets=(
+        "$(basename "$UPDATE_ZIP")"
+        "$(basename "$DMG")"
         "$(basename "$APPCAST")"
         "$(basename "$FINAL_ARTIFACT_MANIFEST")"
         "$(basename "$FINAL_METADATA")"
         "$(basename "$ROLLOUT_MANIFEST")"
     )
     (cd "$DIST_DIR" && shasum -a 256 "${checksum_assets[@]}" > "$(basename "$CHECKSUMS")")
-    printf 'OK: signed and notarized Tip %s artifact %s.\n' "$ROLLOUT_ROLE" "$TIP_TAG"
+    printf 'OK: signed and notarized Tip %s application artifact %s.\n' "$ROLLOUT_ROLE" "$TIP_TAG"
+}
+
+build_tip_package_phase() {
+    require_package_rollout
+    REPOPROMPT_ENABLE_IDENTITY_TRANSITION_PKG=1 \
+        "$CONTROL_PLANE_SCRIPTS_DIR/build_identity_transition_pkg.sh" build \
+        --app "$APP_BUNDLE" \
+        --output "$TRANSITION_PKG" \
+        --installer-identity "$EXPECTED_INSTALLER_IDENTITY"
+}
+
+submit_tip_package_notarization_phase() {
+    require_package_rollout
+    require_command xcrun
+    TMP_DIR="$(mktemp -d)"
+    submit_notarization "$TRANSITION_PKG"
+}
+
+staple_tip_package_phase() {
+    require_package_rollout
+    REPOPROMPT_ENABLE_IDENTITY_TRANSITION_PKG=1 \
+        "$CONTROL_PLANE_SCRIPTS_DIR/build_identity_transition_pkg.sh" staple "$TRANSITION_PKG"
+}
+
+validate_tip_package_phase() {
+    require_package_rollout
+    require_command curl
+    require_command shasum
+    require_command xcrun
+    require_env SPARKLE_PRIVATE_KEY
+    require_file "$SIGN_UPDATE"
+    require_file "$FINAL_ARTIFACT_MANIFEST"
+    require_file "$FINAL_METADATA"
+    TMP_DIR="$(mktemp -d)"
+    REPOPROMPT_ENABLE_IDENTITY_TRANSITION_PKG=1 \
+        "$CONTROL_PLANE_SCRIPTS_DIR/build_identity_transition_pkg.sh" validate \
+        "$TRANSITION_PKG" --expected-app "$APP_BUNDLE"
+    generate_tip_rollout_appcast
+    local checksum_assets=(
+        "$(basename "$TRANSITION_PKG")"
+        "$(basename "$APPCAST")"
+        "$(basename "$FINAL_ARTIFACT_MANIFEST")"
+        "$(basename "$FINAL_METADATA")"
+        "$(basename "$ROLLOUT_MANIFEST")"
+    )
+    (cd "$DIST_DIR" && shasum -a 256 "${checksum_assets[@]}" > "$(basename "$CHECKSUMS")")
+    printf 'OK: signed, notarized, stapled, and validated Tip package artifact %s.\n' "$TIP_TAG"
+}
+
+sign_tip() {
+    sign_tip_application_phase
+    if [[ "$ROLLOUT_INSTALLATION_TYPE" == "package" ]]; then
+        build_tip_package_phase
+        submit_tip_package_notarization_phase
+        staple_tip_package_phase
+        validate_tip_package_phase
+    fi
 }
 
 tip_publish_assets() {
@@ -518,10 +682,38 @@ publish_tip() {
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     case "$MODE" in
-        stage) stage_tip ;;
-        sign) sign_tip ;;
+        stage)
+            start_phase "Stage Tip application"
+            stage_tip
+            ;;
+        sign)
+            start_phase "Sign and notarize Tip"
+            sign_tip
+            ;;
+        sign-application)
+            start_phase "Sign application"
+            sign_tip_application_phase
+            ;;
+        build-package)
+            start_phase "Build package"
+            build_tip_package_phase
+            ;;
+        submit-package-notarization)
+            start_phase "Submit package notarization"
+            submit_tip_package_notarization_phase
+            ;;
+        staple-package)
+            start_phase "Staple package"
+            staple_tip_package_phase
+            ;;
+        validate-package)
+            start_phase "Validate package"
+            validate_tip_package_phase
+            ;;
         validate-assets) validate_tip_publish_assets ;;
         publish-tip) publish_tip ;;
-        *) fail "Usage: $0 stage|sign|validate-assets|publish-tip" ;;
+        *)
+            fail "Usage: $0 stage|sign|sign-application|build-package|submit-package-notarization|staple-package|validate-package|validate-assets|publish-tip"
+            ;;
     esac
 fi

--- a/Scripts/test_conductor_high_output.py
+++ b/Scripts/test_conductor_high_output.py
@@ -116,9 +116,12 @@ class HighOutputDiagnosticTest(unittest.TestCase):
         self.fail("job did not reach running state with a process PID")
 
     def _wait_for_terminal(self, ticket: str, timeout: float = 30.0) -> Dict[str, Any]:
-        return self._request(
-            {"type": "job-wait", "ticket": ticket, "timeout": timeout},
-            socket_timeout=timeout + 5.0,
+        return conductor.wait_for_terminal(
+            self.paths,
+            ticket,
+            request_key=None,
+            json_mode=True,
+            user_timeout=timeout,
         )
 
     def _pid(self, payload: Dict[str, Any]) -> int:

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -3259,11 +3259,12 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
 
         self.assertIn("name: Publish Tip", workflow)
         concurrency = workflow.split("concurrency:", 1)[1].split("\npermissions:", 1)[0]
-        self.assertIn("group: main-tip-channel", concurrency)
-        self.assertNotIn("main-tip-dispatch-channel", concurrency)
-        self.assertNotIn("github.event", concurrency)
-        self.assertIn("queue: max", concurrency)
-        self.assertNotIn("cancel-in-progress:", concurrency)
+        self.assertIn("main-tip-dispatch-channel", concurrency)
+        self.assertIn("main-tip-channel", concurrency)
+        self.assertIn("main-tip-skipped-{0}", concurrency)
+        self.assertIn("github.event_name == 'workflow_dispatch'", concurrency)
+        self.assertIn("queue: single", concurrency)
+        self.assertIn("cancel-in-progress: false", concurrency)
         self.assertIn("concurrency:\n      group: main-tip-publish\n      queue: max", workflow)
 
         self.assertIn("DISPATCH_COMMIT: ${{ github.sha }}", workflow)
@@ -3291,6 +3292,24 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         self.assertIn("SUCCESSOR_DEVELOPER_ID_INSTALLER_P12_BASE64", sign)
         self.assertIn("SUCCESSOR_NOTARYTOOL_PRIVATE_KEY_BASE64", sign)
         self.assertIn("SENTRY_DSN: ${{ secrets.SENTRY_DSN }}", sign)
+        phase_steps = [
+            "      - name: Sign application",
+            "      - name: Build package",
+            "      - name: Submit package notarization",
+            "      - name: Staple package",
+            "      - name: Validate package",
+        ]
+        phase_positions = [sign.index(step) for step in phase_steps]
+        self.assertEqual(phase_positions, sorted(phase_positions))
+        for step in phase_steps[1:]:
+            block = sign.split(step, 1)[1].split("\n      - name:", 1)[0]
+            self.assertIn("if: needs.setup.outputs.installation-type == 'package'", block)
+        for marker in ("PHASE START:", "PHASE END:", "elapsed_seconds=", "date -u"):
+            self.assertIn(marker, tip_script)
+        self.assertIn('submit_notarization "$notary_zip"', tip_script)
+        self.assertIn('submit_notarization "$DMG"', tip_script)
+        self.assertIn('submit_notarization "$TRANSITION_PKG"', tip_script)
+        self.assertIn('NOTARYTOOL_TIMEOUT:-30m', tip_script)
 
         self.assertIn('PUBLISH_TIP_RELEASE="$CONTROL_PLANE_SCRIPTS_DIR/publish_tip_release.sh"', tip_script)
         self.assertIn('exec "$PUBLISH_TIP_RELEASE"', tip_script)
@@ -3310,6 +3329,143 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
             self.assertIn(marker, publisher)
         self.assertNotIn("--clobber", publisher)
         self.assertNotIn("gh release delete", publisher)
+
+    def test_tip_notarization_contract_submits_one_package_and_keeps_application_explicit(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+        capture = temp_dir / "xcrun-calls.tsv"
+        submission_id = "12345678-1234-5678-1234-567812345678"
+        xcrun_stub = bin_dir / "xcrun"
+        xcrun_stub.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf '%s' "$1"
+  shift
+  printf '\t%s' "$@"
+  printf '\n'
+} >> "$XCRUN_CAPTURE"
+if [[ "${1:-}" == "submit" ]]; then
+  printf '{"id":"%s","status":"%s"}\n' "$NOTARY_STUB_ID" "$NOTARY_STUB_STATUS"
+  exit "$NOTARY_STUB_EXIT"
+elif [[ "${1:-}" == "log" ]]; then
+  printf '{"id":"%s","log":"fixture rejection details"}\n' "$NOTARY_STUB_ID"
+fi
+""",
+            encoding="utf-8",
+        )
+        xcrun_stub.chmod(0o755)
+        ditto_stub = bin_dir / "ditto"
+        ditto_stub.write_text(
+            "#!/usr/bin/env bash\nset -euo pipefail\noutput=\"${!#}\"\nmkdir -p \"$(dirname \"$output\")\"\nprintf 'fixture archive\\n' > \"$output\"\n",
+            encoding="utf-8",
+        )
+        ditto_stub.chmod(0o755)
+        notary_key = temp_dir / "notary-key.p8"
+        notary_key.write_text("fixture-key\n", encoding="utf-8")
+        fixture_root = temp_dir / "artifacts"
+        fixture_root.mkdir()
+
+        def run_probe(
+            body: str,
+            status: str = "Accepted",
+            exit_code: int = 0,
+        ) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
+            capture.write_text("", encoding="utf-8")
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DIST_DIR": str(temp_dir / "dist"),
+                    "FIXTURE_ROOT": str(fixture_root),
+                    "NOTARYTOOL_PRIVATE_KEY": str(notary_key),
+                    "NOTARYTOOL_KEY_ID": "fixture-key-id",
+                    "NOTARYTOOL_ISSUER_ID": "fixture-issuer-id",
+                    "NOTARY_STUB_EXIT": str(exit_code),
+                    "NOTARY_STUB_ID": submission_id,
+                    "NOTARY_STUB_STATUS": status,
+                    "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+                    "TIP_BUILD_NUMBER": "35.1.1",
+                    "TIP_COMMIT": "1" * 40,
+                    "TIP_SHORT_SHA": "1" * 12,
+                    "XCRUN_CAPTURE": str(capture),
+                }
+            )
+            result = subprocess.run(
+                ["/bin/bash", "-c", 'source "$1"\n' + body, "bash", str(SCRIPT_DIR / "main_tip_release.sh")],
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=30,
+            )
+            calls = [line.split("\t") for line in capture.read_text(encoding="utf-8").splitlines()]
+            return result, calls
+
+        package_result, package_calls = run_probe(
+            'TRANSITION_PKG="$FIXTURE_ROOT/RepoPrompt-transition.pkg"\n'
+            'printf "fixture package\\n" > "$TRANSITION_PKG"\n'
+            "notarize_signed_app_for_rollout\n"
+            "submit_tip_package_notarization_phase\n"
+        )
+        self.assertEqual(package_result.returncode, 0, package_result.stderr)
+        package_submissions = [call for call in package_calls if call[:2] == ["notarytool", "submit"]]
+        self.assertEqual(len(package_submissions), 1, package_calls)
+        self.assertTrue(package_submissions[0][2].endswith(".pkg"), package_submissions)
+        self.assertNotIn(".zip", package_submissions[0][2])
+        self.assertEqual(package_result.stdout.count(f"Apple notarization submission ID: {submission_id}"), 1)
+        self.assertFalse(any(call[:2] == ["notarytool", "log"] for call in package_calls))
+
+        application_result, application_calls = run_probe(
+            "ROLLOUT_INSTALLATION_TYPE=application\n"
+            "ROLLOUT_ROLE=preparer\n"
+            'APP_BUNDLE="$FIXTURE_ROOT/RepoPrompt.app"\n'
+            'DMG="$FIXTURE_ROOT/RepoPrompt.dmg"\n'
+            'ARCHIVE_BASENAME="RepoPrompt-application"\n'
+            'TMP_DIR="$(mktemp -d)"\n'
+            'mkdir -p "$APP_BUNDLE"\n'
+            'printf "fixture dmg\\n" > "$DMG"\n'
+            "notarize_signed_app_for_rollout\n"
+            "notarize_application_dmg\n"
+        )
+        self.assertEqual(application_result.returncode, 0, application_result.stderr)
+        application_submissions = [call for call in application_calls if call[:2] == ["notarytool", "submit"]]
+        self.assertEqual(len(application_submissions), 2, application_calls)
+        self.assertTrue(application_submissions[0][2].endswith("-notarization.zip"))
+        self.assertTrue(application_submissions[1][2].endswith(".dmg"))
+        self.assertEqual(application_result.stdout.count(f"Apple notarization submission ID: {submission_id}"), 2)
+        stapled_paths = [call[2] for call in application_calls if call[:2] == ["stapler", "staple"]]
+        validated_paths = [call[2] for call in application_calls if call[:2] == ["stapler", "validate"]]
+        self.assertEqual(stapled_paths, [str(fixture_root / "RepoPrompt.app"), str(fixture_root / "RepoPrompt.dmg")])
+        self.assertEqual(validated_paths, stapled_paths)
+
+        rejected_result, rejected_calls = run_probe(
+            'TRANSITION_PKG="$FIXTURE_ROOT/rejected.pkg"\n'
+            'printf "fixture package\\n" > "$TRANSITION_PKG"\n'
+            "submit_tip_package_notarization_phase\n",
+            status="Invalid",
+        )
+        self.assertNotEqual(rejected_result.returncode, 0)
+        self.assertIn(f"Apple notarization submission ID: {submission_id}", rejected_result.stdout)
+        self.assertIn("Apple notarization failed for rejected.pkg", rejected_result.stderr)
+        self.assertEqual(
+            [call[:3] for call in rejected_calls if call[:2] == ["notarytool", "log"]],
+            [["notarytool", "log", submission_id]],
+        )
+
+        timeout_result, timeout_calls = run_probe(
+            'TRANSITION_PKG="$FIXTURE_ROOT/timeout.pkg"\n'
+            'printf "fixture package\\n" > "$TRANSITION_PKG"\n'
+            "submit_tip_package_notarization_phase\n",
+            status="In Progress",
+            exit_code=1,
+        )
+        self.assertNotEqual(timeout_result.returncode, 0)
+        self.assertIn(f"Apple notarization submission ID: {submission_id}", timeout_result.stdout)
+        self.assertEqual(
+            [call[:3] for call in timeout_calls if call[:2] == ["notarytool", "log"]],
+            [["notarytool", "log", submission_id]],
+        )
 
     def test_tip_publish_asset_inventory_is_exact(self) -> None:
         temp_dir = Path(tempfile.mkdtemp())
@@ -5631,8 +5787,7 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
             '"BundleOverwriteAction": "upgrade"',
             'productbuild --package "$component_pkg" "$unsigned_product"',
             'productsign --sign "$installer_identity"',
-            'xcrun notarytool submit "$signed_product"',
-            'xcrun stapler staple "$signed_product"',
+            'xcrun stapler staple "$pkg"',
             'xcrun stapler validate "$pkg"',
             'mv "$signed_product" "$output"',
             'diff -qr "$expected_app" "$payload_app"',
@@ -5640,21 +5795,14 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         ):
             self.assertIn(marker, script)
         self.assertNotIn("pkgbuild --analyze", script)
-        self.assertNotIn('xcrun stapler staple "$output"', script)
+        self.assertNotIn("notarytool submit", script)
         self.assertNotIn("local package_infos=()", script)
         self.assertNotIn("plutil -replace 0.", script)
         self.assertLess(
-            script.index('xcrun notarytool submit "$signed_product"'),
-            script.index('xcrun stapler staple "$signed_product"'),
-        )
-        self.assertLess(
-            script.index('xcrun stapler staple "$signed_product"'),
-            script.index('validate_transition_pkg "$signed_product"'),
-        )
-        self.assertLess(
-            script.index('validate_transition_pkg "$signed_product"'),
+            script.index('productsign --sign "$installer_identity"'),
             script.index('mv "$signed_product" "$output"'),
         )
+        self.assertIn('staple)\n        [[ $# -eq 1 ]]', script)
         self.assertNotIn("skip-notarization", script)
         self.assertNotIn("allow-unstapled", script)
         for literal in ("com.repoprompt.ce", "69N6K965SF", "Developer ID Installer: Samuel Baron"):

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -3304,6 +3304,25 @@ values.write_text("\\n".join(remaining), encoding="utf-8")
         for step in phase_steps[1:]:
             block = sign.split(step, 1)[1].split("\n      - name:", 1)[0]
             self.assertIn("if: needs.setup.outputs.installation-type == 'package'", block)
+        sign_application_step = sign.split("      - name: Sign application", 1)[1].split(
+            "\n      - name: Build package", 1
+        )[0]
+        validate_package_step = sign.split("      - name: Validate package", 1)[1].split(
+            "\n      - name: Remove ephemeral keychain", 1
+        )[0]
+        self.assertIn(
+            "SPARKLE_PRIVATE_KEY: ${{ needs.setup.outputs.installation-type == 'application' && "
+            "secrets.SPARKLE_PRIVATE_KEY || '' }}",
+            sign_application_step,
+        )
+        self.assertIn("SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}", validate_package_step)
+        generate_appcast = tip_script.split("generate_tip_rollout_appcast() {", 1)[1].split("\n}", 1)[0]
+        sign_application_phase = tip_script.split("sign_tip_application_phase() {", 1)[1].split("\n}", 1)[0]
+        validate_package_phase = tip_script.split("validate_tip_package_phase() {", 1)[1].split("\n}", 1)[0]
+        self.assertEqual(tip_script.count("require_env SPARKLE_PRIVATE_KEY"), 1)
+        self.assertIn("require_env SPARKLE_PRIVATE_KEY", generate_appcast)
+        self.assertNotIn("require_env SPARKLE_PRIVATE_KEY", sign_application_phase)
+        self.assertNotIn("require_env SPARKLE_PRIVATE_KEY", validate_package_phase)
         for marker in ("PHASE START:", "PHASE END:", "elapsed_seconds=", "date -u"):
             self.assertIn(marker, tip_script)
         self.assertIn('submit_notarization "$notary_zip"', tip_script)

--- a/docs/architecture/apple-identity-migration.md
+++ b/docs/architecture/apple-identity-migration.md
@@ -41,8 +41,9 @@ operator-supplied commit field. GitHub's selected `main` SHA is the candidate, a
 requires that SHA, the workflow definition, the release-tooling checkout, and freshly fetched
 protected `origin/main` to be the same commit.
 
-Automatic and manual runs use one queue without cancelling in-flight release work, and publication
-is serialized. Before any draft mutation and again immediately before publication, the publisher
+Automatic and manual runs use separate single-entry rolling queues without cancelling in-flight
+release work, and publication remains serialized across both lanes. Before any draft mutation and
+again immediately before publication, the publisher
 rechecks protected `main`, validates the authenticated public Tip appcast/manifest, enforces the
 monotonic `P → T → S` state machine while allowing newer same-role builds with exact retained
 manifest bytes, and verifies retained enclosure size/SHA-256 from immutable release assets.
@@ -102,6 +103,14 @@ The protected release job builds a universal anchor from `Scripts/identity_migra
 trusted control-plane checkout. The minimal executable is never launched; it avoids embedding a second
 copy of the main app binary while still giving Security.framework a successor-signed designated
 requirement on both supported architectures.
+
+The transition packaging evidence chain is: validate the successor-signed app, build and
+Installer-sign the final PKG, submit that PKG once, print the accepted Apple submission ID, staple the
+PKG, then validate its ticket, package structure, and byte-identical app payload. Package mode does
+not create a temporary app notarization ZIP or separately staple the embedded app. Application mode
+continues to notarize/staple the app through a temporary ZIP and separately notarize/staple its DMG.
+Failed or non-accepted submissions with an Apple ID automatically emit the corresponding
+`notarytool log`.
 
 The Tip workflow performs the rehearsal under the protected `tip-release` environment. Its cheap
 role-aware credential preflight runs before the secret-free build and checks the policy projection plus

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -289,9 +289,10 @@ publisher require the greatest Stable build to remain strictly below the retaine
 Stable to the next integer first would make an unprepared Stable client appear new enough to satisfy
 T's `sparkle:minimumUpdateVersion`, bypassing the credential preparer.
 
-Automatic and manual runs use one concurrency lane and do not cancel in-flight release work, so a
-retry resumes or audits one exact draft instead of abandoning a different tag halfway through
-publication.
+Automatic and manual runs use separate rolling concurrency lanes. Each lane keeps at most one
+queued run and does not cancel in-flight release work; publication remains serialized across both
+lanes by `main-tip-publish`. A retry therefore resumes or audits one exact draft instead of abandoning
+a different tag halfway through publication.
 
 Remote mutation is confined to that protected publication job. Immediately before draft creation
 and again immediately before making a draft public, it rechecks live protected `main`, downloads the
@@ -324,6 +325,15 @@ alias as a second authority. The Tip publishing script fails closed if `TIP_UPDA
 points at the source or stable update repository. Tip artifacts also include a small
 `*-metadata.json` asset recording the source commit, immutable tag, marketing version, and build
 number.
+
+For application enclosures, the signing job retains the explicit application contract: it submits a
+temporary ZIP to notarize the signed app, staples and validates that app, then separately submits,
+staples, and validates the DMG. For a transition package, it signs and validates the embedded app
+without creating that temporary notarization ZIP. The job then exposes separate timed **Build
+package**, **Submit package notarization**, **Staple package**, and **Validate package** steps; the
+final Installer-signed PKG is the only Apple submission in package mode. Every submission prints its
+Apple submission ID. A failed or non-accepted submission with an ID automatically retrieves its
+`notarytool log` before the step fails.
 
 Tip builds use the same Sentry-linked binary and symbolication policy as stable
 releases. The secret-free stage enables Sentry linking and carries release dSYMs


### PR DESCRIPTION
## Summary

- make application and package enclosure notarization mutually exclusive so transition/package releases submit only the final signed PKG
- expose timed sign, build, submit, staple, and validate phases; print Apple submission IDs and fetch notarization logs on rejection or timeout
- add executable xcrun-stub contracts for package, application, rejection, and timeout paths
- retain only the newest pending Tip run with queue: single and cancel-in-progress: false
- narrow Sparkle private-key exposure so package-mode application signing does not receive it

## Validation

- full release-tooling suite: 118 tests passed
- focused executable regression suite: 4 tests passed; post-review secret-scope tests: 2 passed
- bash -n for changed shell scripts
- Ruby Psych workflow parsing
- Python AST parsing
- git diff --check
- contribution push and PR-ready preflights, including outgoing-range secret scan and guardrails
- make dev-release-preflight: passed (conductor ticket 337bba32-a16b-47f7-b981-5d32ba9cd04c)

## Validation limits

- no protected Apple signing/notarization, stapling, or Gatekeeper execution
- no hosted GitHub Actions timing proof
- no installed-app runtime smoke from a real transition PKG