### PR TITLE
Fix: restore global Codex instructions in Agent Mode

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -443,6 +443,7 @@ actor CodexAppServerClient {
     private let livenessProbe: @Sendable (SpawnedProcess) -> Bool
     private let processSpawnPreparation: @Sendable () async throws -> Void
     private let processEnvironmentBuilder: @Sendable (ProcessEnvironmentRequest) async -> ProcessEnvironmentResult
+    private let runtimeStatePreparer: @Sendable (CodexRuntimeAuthority.Runtime) throws -> Void
     private let provisionsRepoPromptMCPOnStart: Bool
     private let processExitObserverFactory: @Sendable (pid_t) -> ChildProcessExitObserver
     private let expectedAgentPIDRegistrar: ExpectedAgentPIDRegistrar
@@ -466,6 +467,9 @@ actor CodexAppServerClient {
         processEnvironmentBuilder: @escaping @Sendable (ProcessEnvironmentRequest) async -> ProcessEnvironmentResult = {
             await ProcessEnvironmentBuilder.build($0)
         },
+        runtimeStatePreparer: @escaping @Sendable (CodexRuntimeAuthority.Runtime) throws -> Void = {
+            try $0.prepareState()
+        },
         provisionsRepoPromptMCPOnStart: Bool = true,
         processExitObserverFactory: @escaping @Sendable (pid_t) -> ChildProcessExitObserver = {
             ChildProcessExitObserver(pid: $0)
@@ -477,6 +481,7 @@ actor CodexAppServerClient {
         self.livenessProbe = livenessProbe
         self.processSpawnPreparation = processSpawnPreparation
         self.processEnvironmentBuilder = processEnvironmentBuilder
+        self.runtimeStatePreparer = runtimeStatePreparer
         self.provisionsRepoPromptMCPOnStart = provisionsRepoPromptMCPOnStart
         self.processExitObserverFactory = processExitObserverFactory
         self.expectedAgentPIDRegistrar = expectedAgentPIDRegistrar
@@ -499,6 +504,7 @@ actor CodexAppServerClient {
     /// the same captured launch context instead of consulting a second environment snapshot.
     func prepareRuntimeForLaunch() async throws -> CodexRuntimeAuthority.Runtime {
         if let runtime = preparedRuntimeLaunchContext?.resolution.runtime {
+            try prepareState(for: runtime)
             return runtime
         }
 
@@ -521,19 +527,23 @@ actor CodexAppServerClient {
         guard let runtime = resolution.runtime else {
             throw ClientError.executableUnavailable("RepoPrompt could not start Codex: runtime resolution completed without runtime metadata.")
         }
-        do {
-            try runtime.prepareState()
-        } catch {
-            throw ClientError.executableUnavailable(
-                "RepoPrompt could not start Codex: unable to prepare its isolated state directories (\(error.localizedDescription))."
-            )
-        }
+        try prepareState(for: runtime)
         environment.merge(resolution.environmentOverrides) { _, ownedValue in ownedValue }
         preparedRuntimeLaunchContext = PreparedRuntimeLaunchContext(
             environment: environment,
             resolution: resolution
         )
         return runtime
+    }
+
+    private func prepareState(for runtime: CodexRuntimeAuthority.Runtime) throws {
+        do {
+            try runtimeStatePreparer(runtime)
+        } catch {
+            throw ClientError.executableUnavailable(
+                "RepoPrompt could not start Codex: unable to prepare its isolated Codex state (\(error.localizedDescription))."
+            )
+        }
     }
 
     private static func processEnvironmentForCurrentLaunch(

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
@@ -11,6 +11,7 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
 
     private var runner: CLIProcessRunner?
     private let config: CodexExecAgentConfig
+    private let runtimeStatePreparer: @Sendable (CodexRuntimeAuthority.Runtime) throws -> Void
     private let configService = MCPConfigExportService.shared
     private let toolTracking = AgentToolTrackingController()
     private var streamTask: Task<Void, Never>?
@@ -20,8 +21,14 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
         config.enableDebugLogging
     }
 
-    init(config: CodexExecAgentConfig) {
+    init(
+        config: CodexExecAgentConfig,
+        runtimeStatePreparer: @escaping @Sendable (CodexRuntimeAuthority.Runtime) throws -> Void = {
+            try $0.prepareState()
+        }
+    ) {
         self.config = config
+        self.runtimeStatePreparer = runtimeStatePreparer
         if enableDebugLogging {
             print("[DEBUG] CodexExec: Initialized provider with model: \(config.modelString ?? "default")")
         }
@@ -119,10 +126,10 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
             throw AIProviderError.invalidConfiguration(detail: resolution.userMessage)
         }
         do {
-            try runtime.prepareState()
+            try runtimeStatePreparer(runtime)
         } catch {
             throw AIProviderError.invalidConfiguration(
-                detail: "RepoPrompt could not start Codex: unable to prepare its isolated state directories (\(error.localizedDescription))."
+                detail: "RepoPrompt could not start Codex: unable to prepare its isolated Codex state (\(error.localizedDescription))."
             )
         }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexGlobalInstructionsProjection.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexGlobalInstructionsProjection.swift
@@ -1,0 +1,278 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+enum CodexGlobalInstructionsProjection {
+    enum Failure: Error, LocalizedError {
+        case sourceUnreadable(URL, String)
+        case manifestInvalid(URL, String)
+        case unownedDestination(URL)
+        case modifiedDestination(URL)
+        case unsupportedDestination(URL, String)
+        case inspectionFailed(URL, String)
+        case destinationMutationFailed(URL, String)
+        case manifestMutationFailed(URL, String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .sourceUnreadable(url, detail):
+                "RepoPrompt could not read the global Codex instruction file at `\(url.path)` (\(detail)). Neither managed instruction file was changed."
+            case let .manifestInvalid(url, detail):
+                "RepoPrompt could not use its Codex instruction projection manifest at `\(url.path)` (\(detail)). Neither managed instruction file was changed. Preserve anything needed, move or remove the manifest, and try again."
+            case let .unownedDestination(url):
+                "RepoPrompt found an unowned Codex instruction file at `\(url.path)`. It was preserved and neither managed instruction file was changed. Preserve anything needed, move or remove the file, and try again."
+            case let .modifiedDestination(url):
+                "RepoPrompt found a modified managed Codex instruction file at `\(url.path)`. It was preserved and neither managed instruction file was changed. Preserve anything needed, move or remove the file, and try again."
+            case let .unsupportedDestination(url, kind):
+                "RepoPrompt found a \(kind) at managed Codex instruction path `\(url.path)`. It was preserved and neither managed instruction file was changed. Preserve anything needed, move or remove the entry, and try again."
+            case let .inspectionFailed(url, detail):
+                "RepoPrompt could not inspect Codex instruction state at `\(url.path)` (\(detail)). Neither managed instruction file was changed."
+            case let .destinationMutationFailed(url, detail):
+                "RepoPrompt could not update the managed Codex instruction file at `\(url.path)` (\(detail)). Try again so RepoPrompt can reconcile the managed projection."
+            case let .manifestMutationFailed(url, detail):
+                "RepoPrompt could not update its Codex instruction projection manifest at `\(url.path)` (\(detail)). Try again so RepoPrompt can reconcile the managed projection."
+            }
+        }
+    }
+
+    private struct InstructionFile {
+        let name: String
+    }
+
+    private struct SourceSnapshot {
+        let data: Data
+        let hash: String
+    }
+
+    private enum DestinationSnapshot {
+        case missing
+        case regular(hash: String)
+        case symbolicLink
+        case unsupported(String)
+    }
+
+    private enum DestinationAction {
+        case none
+        case write(Data)
+        case remove
+    }
+
+    private struct ProjectionAction {
+        let file: InstructionFile
+        let destination: URL
+        let action: DestinationAction
+        let desiredHash: String?
+    }
+
+    private struct Manifest: Codable {
+        let schemaVersion: Int
+        let projectedFileHashes: [String: String]
+    }
+
+    private static let files = [
+        InstructionFile(name: "AGENTS.override.md"),
+        InstructionFile(name: "AGENTS.md")
+    ]
+    private static let manifestName = ".repoprompt-agents-projection.json"
+    private static let lock = NSLock()
+
+    static func prepare(
+        ordinaryCodexHome: URL,
+        managedCodexHome: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let sourceSnapshots = try Dictionary(uniqueKeysWithValues: files.map { file in
+            let source = ordinaryCodexHome.appendingPathComponent(file.name)
+            return try (file.name, sourceSnapshot(at: source))
+        })
+        let manifestURL = managedCodexHome.appendingPathComponent(manifestName)
+        let previousManifest = try loadManifest(at: manifestURL)
+
+        let actions = try files.map { file in
+            let destination = managedCodexHome.appendingPathComponent(file.name)
+            let destinationSnapshot = try destinationSnapshot(at: destination)
+            return try projectionAction(
+                file: file,
+                destination: destination,
+                source: sourceSnapshots[file.name] ?? nil,
+                destinationSnapshot: destinationSnapshot,
+                manifestHash: previousManifest?.projectedFileHashes[file.name]
+            )
+        }
+
+        for action in actions {
+            try apply(action, fileManager: fileManager)
+        }
+
+        let projectedFileHashes = Dictionary(uniqueKeysWithValues: actions.compactMap { action in
+            action.desiredHash.map { (action.file.name, $0) }
+        })
+        try commitManifest(projectedFileHashes, at: manifestURL, fileManager: fileManager)
+    }
+
+    private static func sourceSnapshot(at url: URL) throws -> SourceSnapshot? {
+        var metadata = Darwin.stat()
+        let result = url.withUnsafeFileSystemRepresentation { path in
+            guard let path else { return Int32(-1) }
+            return stat(path, &metadata)
+        }
+        guard result == 0 else {
+            if errno == ENOENT || errno == ENOTDIR { return nil }
+            throw Failure.inspectionFailed(url, posixErrorDescription())
+        }
+        guard metadata.st_mode & S_IFMT == S_IFREG else { return nil }
+
+        do {
+            let data = try Data(contentsOf: url)
+            return SourceSnapshot(data: data, hash: hash(data))
+        } catch {
+            throw Failure.sourceUnreadable(url, error.localizedDescription)
+        }
+    }
+
+    private static func destinationSnapshot(at url: URL) throws -> DestinationSnapshot {
+        var metadata = Darwin.stat()
+        guard lstat(url.path, &metadata) == 0 else {
+            if errno == ENOENT || errno == ENOTDIR { return .missing }
+            throw Failure.inspectionFailed(url, posixErrorDescription())
+        }
+
+        switch metadata.st_mode & S_IFMT {
+        case S_IFREG:
+            do {
+                return try .regular(hash: hash(Data(contentsOf: url)))
+            } catch {
+                throw Failure.inspectionFailed(url, error.localizedDescription)
+            }
+        case S_IFLNK:
+            return .symbolicLink
+        case S_IFDIR:
+            return .unsupported("directory")
+        default:
+            return .unsupported("non-regular filesystem entry")
+        }
+    }
+
+    private static func loadManifest(at url: URL) throws -> Manifest? {
+        switch try destinationSnapshot(at: url) {
+        case .missing:
+            return nil
+        case .symbolicLink:
+            throw Failure.manifestInvalid(url, "the manifest is a symbolic link")
+        case let .unsupported(kind):
+            throw Failure.manifestInvalid(url, "the manifest is a \(kind)")
+        case .regular:
+            break
+        }
+
+        let manifest: Manifest
+        do {
+            manifest = try JSONDecoder().decode(Manifest.self, from: Data(contentsOf: url))
+        } catch {
+            throw Failure.manifestInvalid(url, error.localizedDescription)
+        }
+        guard manifest.schemaVersion == 1 else {
+            throw Failure.manifestInvalid(url, "unsupported schema version \(manifest.schemaVersion)")
+        }
+
+        let allowedNames = Set(files.map(\.name))
+        guard Set(manifest.projectedFileHashes.keys).isSubset(of: allowedNames) else {
+            throw Failure.manifestInvalid(url, "the manifest contains an unknown filename")
+        }
+        guard manifest.projectedFileHashes.values.allSatisfy(isValidHash) else {
+            throw Failure.manifestInvalid(url, "the manifest contains an invalid SHA-256 hash")
+        }
+        return manifest
+    }
+
+    private static func projectionAction(
+        file: InstructionFile,
+        destination: URL,
+        source: SourceSnapshot?,
+        destinationSnapshot: DestinationSnapshot,
+        manifestHash: String?
+    ) throws -> ProjectionAction {
+        switch destinationSnapshot {
+        case .missing:
+            if let source {
+                return ProjectionAction(file: file, destination: destination, action: .write(source.data), desiredHash: source.hash)
+            }
+            return ProjectionAction(file: file, destination: destination, action: .none, desiredHash: nil)
+        case .symbolicLink:
+            throw Failure.unsupportedDestination(destination, "symbolic link")
+        case let .unsupported(kind):
+            throw Failure.unsupportedDestination(destination, kind)
+        case let .regular(destinationHash):
+            guard let manifestHash else {
+                throw Failure.unownedDestination(destination)
+            }
+            guard destinationHash == manifestHash else {
+                if let source, destinationHash == source.hash {
+                    return ProjectionAction(file: file, destination: destination, action: .none, desiredHash: source.hash)
+                }
+                throw Failure.modifiedDestination(destination)
+            }
+            guard let source else {
+                return ProjectionAction(file: file, destination: destination, action: .remove, desiredHash: nil)
+            }
+            let action: DestinationAction = destinationHash == source.hash ? .none : .write(source.data)
+            return ProjectionAction(file: file, destination: destination, action: action, desiredHash: source.hash)
+        }
+    }
+
+    private static func apply(_ projection: ProjectionAction, fileManager: FileManager) throws {
+        do {
+            switch projection.action {
+            case .none:
+                return
+            case let .write(data):
+                try data.write(to: projection.destination, options: .atomic)
+            case .remove:
+                try fileManager.removeItem(at: projection.destination)
+            }
+        } catch {
+            throw Failure.destinationMutationFailed(projection.destination, error.localizedDescription)
+        }
+    }
+
+    private static func commitManifest(
+        _ projectedFileHashes: [String: String],
+        at url: URL,
+        fileManager: FileManager
+    ) throws {
+        do {
+            if projectedFileHashes.isEmpty {
+                if case .missing = try destinationSnapshot(at: url) { return }
+                try fileManager.removeItem(at: url)
+                return
+            }
+
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(Manifest(schemaVersion: 1, projectedFileHashes: projectedFileHashes))
+            try data.write(to: url, options: .atomic)
+        } catch let failure as Failure {
+            throw failure
+        } catch {
+            throw Failure.manifestMutationFailed(url, error.localizedDescription)
+        }
+    }
+
+    private static func hash(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func isValidHash(_ value: String) -> Bool {
+        let bytes = value.utf8
+        return bytes.count == 64 && bytes.allSatisfy { byte in
+            (48 ... 57).contains(byte) || (97 ... 102).contains(byte)
+        }
+    }
+
+    private static func posixErrorDescription() -> String {
+        String(cString: strerror(errno))
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
@@ -33,9 +33,19 @@ enum CodexRuntimeAuthority {
         let source: Source
         let statePaths: StatePaths
 
-        func prepareState(fileManager: FileManager = .default) throws {
+        func prepareState(
+            fileManager: FileManager = .default,
+            ordinaryCodexHomeURL: URL? = nil
+        ) throws {
             try fileManager.createDirectory(at: statePaths.codexHome, withIntermediateDirectories: true)
             try fileManager.createDirectory(at: statePaths.sqliteHome, withIntermediateDirectories: true)
+            let ordinaryCodexHome = ordinaryCodexHomeURL
+                ?? fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".codex", isDirectory: true)
+            try CodexGlobalInstructionsProjection.prepare(
+                ordinaryCodexHome: ordinaryCodexHome,
+                managedCodexHome: statePaths.codexHome,
+                fileManager: fileManager
+            )
         }
 
         var redactedDiagnosticSummary: String {

--- a/Tests/RepoPromptTests/AI/CodexGlobalInstructionsProjectionTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexGlobalInstructionsProjectionTests.swift
@@ -1,0 +1,223 @@
+import CryptoKit
+import Darwin
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class CodexGlobalInstructionsProjectionTests: XCTestCase {
+    private var root: URL!
+    private var ordinaryHome: URL!
+    private var managedHome: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexGlobalInstructionsProjectionTests-\(UUID().uuidString)")
+        ordinaryHome = root.appendingPathComponent("ordinary", isDirectory: true)
+        managedHome = root.appendingPathComponent("managed", isDirectory: true)
+        try FileManager.default.createDirectory(at: ordinaryHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func testPrepareCopiesBothFilesIncludingEmptyOverride() throws {
+        try write(Data(), to: ordinary("AGENTS.override.md"))
+        try write(Data("fallback".utf8), to: ordinary("AGENTS.md"))
+
+        try project()
+
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.override.md")), Data())
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.md")), Data("fallback".utf8))
+        assertRegularFile(managed("AGENTS.override.md"))
+        assertRegularFile(managed("AGENTS.md"))
+        let hashes = try manifestHashes()
+        XCTAssertEqual(hashes["AGENTS.override.md"], hash(Data()))
+        XCTAssertEqual(hashes["AGENTS.md"], hash(Data("fallback".utf8)))
+
+        try project()
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.md")), Data("fallback".utf8))
+    }
+
+    func testPrepareRefreshesOwnedFilesAndRemovesOwnedMissingSources() throws {
+        try write(Data("first override".utf8), to: ordinary("AGENTS.override.md"))
+        try write(Data("fallback".utf8), to: ordinary("AGENTS.md"))
+        try project()
+
+        try write(Data("second override".utf8), to: ordinary("AGENTS.override.md"))
+        try FileManager.default.removeItem(at: ordinary("AGENTS.md"))
+        try project()
+
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.override.md")), Data("second override".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managed("AGENTS.md").path))
+        XCTAssertEqual(try Set(manifestHashes().keys), ["AGENTS.override.md"])
+        try project()
+
+        try FileManager.default.removeItem(at: ordinary("AGENTS.override.md"))
+        try project()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managed("AGENTS.override.md").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: manifestURL.path))
+    }
+
+    func testPrepareRejectsUnmanifestedDestinationWithoutMutatingEitherFile() throws {
+        for existingData in [Data("foreign".utf8), Data("source".utf8)] {
+            try resetManagedHome()
+            try write(Data("source".utf8), to: ordinary("AGENTS.override.md"))
+            try write(Data("fallback".utf8), to: ordinary("AGENTS.md"))
+            try write(existingData, to: managed("AGENTS.override.md"))
+
+            XCTAssertThrowsError(try project()) { error in
+                guard case CodexGlobalInstructionsProjection.Failure.unownedDestination = error else {
+                    return XCTFail("Expected unowned destination failure, got \(error)")
+                }
+            }
+            XCTAssertEqual(try Data(contentsOf: managed("AGENTS.override.md")), existingData)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: managed("AGENTS.md").path))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: manifestURL.path))
+        }
+    }
+
+    func testPrepareRejectsModifiedOwnedDestinationWithoutMutatingEitherFile() throws {
+        try write(Data("override".utf8), to: ordinary("AGENTS.override.md"))
+        try write(Data("old fallback".utf8), to: ordinary("AGENTS.md"))
+        try project()
+        let originalManifest = try Data(contentsOf: manifestURL)
+
+        try write(Data("manual edit".utf8), to: managed("AGENTS.override.md"))
+        try write(Data("new fallback".utf8), to: ordinary("AGENTS.md"))
+
+        XCTAssertThrowsError(try project()) { error in
+            guard case CodexGlobalInstructionsProjection.Failure.modifiedDestination = error else {
+                return XCTFail("Expected modified destination failure, got \(error)")
+            }
+        }
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.override.md")), Data("manual edit".utf8))
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.md")), Data("old fallback".utf8))
+        XCTAssertEqual(try Data(contentsOf: manifestURL), originalManifest)
+    }
+
+    func testPrepareRejectsDestinationSymlinkWithoutFollowingIt() throws {
+        let external = root.appendingPathComponent("external")
+        try write(Data("external".utf8), to: external)
+        try write(Data("override".utf8), to: ordinary("AGENTS.override.md"))
+        try write(Data("fallback".utf8), to: ordinary("AGENTS.md"))
+        try FileManager.default.createSymbolicLink(at: managed("AGENTS.override.md"), withDestinationURL: external)
+
+        XCTAssertThrowsError(try project())
+        XCTAssertEqual(try Data(contentsOf: external), Data("external".utf8))
+        assertSymbolicLink(managed("AGENTS.override.md"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managed("AGENTS.md").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: manifestURL.path))
+    }
+
+    func testPrepareFollowsSourceSymlinkAndCreatesRegularDestination() throws {
+        let external = root.appendingPathComponent("source")
+        try write(Data("first".utf8), to: external)
+        try FileManager.default.createSymbolicLink(at: ordinary("AGENTS.md"), withDestinationURL: external)
+
+        try project()
+
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.md")), Data("first".utf8))
+        assertRegularFile(managed("AGENTS.md"))
+
+        try write(Data("second".utf8), to: external)
+        try project()
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.md")), Data("second".utf8))
+    }
+
+    func testPrepareReconcilesEstablishedInterruptedUpdate() throws {
+        try write(Data("old override".utf8), to: ordinary("AGENTS.override.md"))
+        try write(Data("old fallback".utf8), to: ordinary("AGENTS.md"))
+        try project()
+
+        try write(Data("new override".utf8), to: ordinary("AGENTS.override.md"))
+        try write(Data("new fallback".utf8), to: ordinary("AGENTS.md"))
+        try write(Data("new override".utf8), to: managed("AGENTS.override.md"))
+
+        try project()
+
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.override.md")), Data("new override".utf8))
+        XCTAssertEqual(try Data(contentsOf: managed("AGENTS.md")), Data("new fallback".utf8))
+        let hashes = try manifestHashes()
+        XCTAssertEqual(hashes["AGENTS.override.md"], hash(Data("new override".utf8)))
+        XCTAssertEqual(hashes["AGENTS.md"], hash(Data("new fallback".utf8)))
+    }
+
+    func testPrepareRejectsInvalidManifestBeforeMutation() throws {
+        try write(Data("source".utf8), to: ordinary("AGENTS.md"))
+        let unicodeDigits = String(repeating: "١", count: 64)
+        let invalidManifests = [
+            Data("not json".utf8),
+            Data(#"{"schemaVersion":2,"projectedFileHashes":{}}"#.utf8),
+            Data(#"{"schemaVersion":1,"projectedFileHashes":{"OTHER.md":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}"#.utf8),
+            Data(#"{"schemaVersion":1,"projectedFileHashes":{"AGENTS.md":"invalid"}}"#.utf8),
+            Data("{\"schemaVersion\":1,\"projectedFileHashes\":{\"AGENTS.md\":\"\(unicodeDigits)\"}}".utf8)
+        ]
+
+        for manifest in invalidManifests {
+            try resetManagedHome()
+            try write(manifest, to: manifestURL)
+            XCTAssertThrowsError(try project())
+            XCTAssertFalse(FileManager.default.fileExists(atPath: managed("AGENTS.md").path))
+        }
+
+        try resetManagedHome()
+        let external = root.appendingPathComponent("external-manifest")
+        try write(Data("{}".utf8), to: external)
+        try FileManager.default.createSymbolicLink(at: manifestURL, withDestinationURL: external)
+        XCTAssertThrowsError(try project())
+        assertSymbolicLink(manifestURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: managed("AGENTS.md").path))
+    }
+
+    private var manifestURL: URL {
+        managed(".repoprompt-agents-projection.json")
+    }
+
+    private func ordinary(_ name: String) -> URL {
+        ordinaryHome.appendingPathComponent(name)
+    }
+
+    private func managed(_ name: String) -> URL {
+        managedHome.appendingPathComponent(name)
+    }
+
+    private func project() throws {
+        try CodexGlobalInstructionsProjection.prepare(
+            ordinaryCodexHome: ordinaryHome,
+            managedCodexHome: managedHome
+        )
+    }
+
+    private func resetManagedHome() throws {
+        try? FileManager.default.removeItem(at: managedHome)
+        try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
+    }
+
+    private func write(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: .atomic)
+    }
+
+    private func manifestHashes() throws -> [String: String] {
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: manifestURL))
+        let dictionary = try XCTUnwrap(object as? [String: Any])
+        return try XCTUnwrap(dictionary["projectedFileHashes"] as? [String: String])
+    }
+
+    private func hash(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func assertRegularFile(_ url: URL, file: StaticString = #filePath, line: UInt = #line) {
+        var metadata = Darwin.stat()
+        XCTAssertEqual(lstat(url.path, &metadata), 0, file: file, line: line)
+        XCTAssertEqual(metadata.st_mode & S_IFMT, S_IFREG, file: file, line: line)
+    }
+
+    private func assertSymbolicLink(_ url: URL, file: StaticString = #filePath, line: UInt = #line) {
+        var metadata = Darwin.stat()
+        XCTAssertEqual(lstat(url.path, &metadata), 0, file: file, line: line)
+        XCTAssertEqual(metadata.st_mode & S_IFMT, S_IFLNK, file: file, line: line)
+    }
+}

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -39,12 +39,49 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         XCTAssertNotEqual(runtime.statePaths.codexHome.path, ("~/.codex" as NSString).expandingTildeInPath)
         XCTAssertEqual(runtime.statePaths.environment["CODEX_HOME"], runtime.statePaths.codexHome.path)
         XCTAssertEqual(runtime.statePaths.environment["CODEX_SQLITE_HOME"], runtime.statePaths.sqliteHome.path)
-        try runtime.prepareState()
+        try runtime.prepareState(
+            ordinaryCodexHomeURL: temporaryDirectory.appendingPathComponent("empty-ordinary-home")
+        )
         XCTAssertTrue(FileManager.default.fileExists(atPath: runtime.statePaths.codexHome.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: runtime.statePaths.sqliteHome.path))
         XCTAssertTrue(runtime.redactedDiagnosticSummary.contains("provenance=bundled:aarch64-apple-darwin"))
         XCTAssertTrue(runtime.redactedDiagnosticSummary.contains("version=0.149.0"))
         XCTAssertFalse(runtime.redactedDiagnosticSummary.contains(temporaryDirectory.path))
+    }
+
+    func testRuntimePrepareStateProjectsGlobalInstructionsIntoManagedCodexHome() throws {
+        let resources = temporaryDirectory.appendingPathComponent("Resources", isDirectory: true)
+        let support = temporaryDirectory.appendingPathComponent("Support", isDirectory: true)
+        let ordinaryHome = temporaryDirectory.appendingPathComponent("ordinary", isDirectory: true)
+        try FileManager.default.createDirectory(at: ordinaryHome, withIntermediateDirectories: true)
+        try Data().write(to: ordinaryHome.appendingPathComponent("AGENTS.override.md"))
+        try Data("global".utf8).write(to: ordinaryHome.appendingPathComponent("AGENTS.md"))
+        _ = try makePackage(in: resources, target: "aarch64-apple-darwin")
+
+        let runtime = try CodexRuntimeAuthority.resolve(
+            resourcesURL: resources,
+            architectureTarget: "aarch64-apple-darwin",
+            applicationSupportURL: support
+        ).get()
+
+        try runtime.prepareState(ordinaryCodexHomeURL: ordinaryHome)
+
+        XCTAssertEqual(
+            try Data(contentsOf: runtime.statePaths.codexHome.appendingPathComponent("AGENTS.override.md")),
+            Data()
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: runtime.statePaths.codexHome.appendingPathComponent("AGENTS.md")),
+            Data("global".utf8)
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: runtime.statePaths.codexHome.appendingPathComponent(".repoprompt-agents-projection.json").path
+            )
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: runtime.statePaths.sqliteHome.path))
+        XCTAssertEqual(runtime.statePaths.environment["CODEX_HOME"], runtime.statePaths.codexHome.path)
+        XCTAssertEqual(runtime.statePaths.environment["CODEX_SQLITE_HOME"], runtime.statePaths.sqliteHome.path)
     }
 
     func testBundledRuntimeResolvesIntelPackageIndependently() throws {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -364,9 +364,13 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         let directory = try makeTemporaryDirectory()
         let recordURL = directory.appendingPathComponent("requests.jsonl")
         let executable = try makePersistentServer(in: directory, recordURL: recordURL)
-        let client = CodexAppServerClient(writeFrameHandler: { _, _ in
-            throw FDWriteError.brokenPipe(errno: EPIPE)
-        })
+        let client = CodexAppServerClient(
+            writeFrameHandler: { _, _ in
+                throw FDWriteError.brokenPipe(errno: EPIPE)
+            },
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(.init(
             commandName: executable.path,
             additionalPathHints: [],
@@ -939,7 +943,7 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         launchDirectory: URL?,
         timeout: TimeInterval,
         processSpawnPreparation: @escaping @Sendable () async throws -> Void = {},
-        provisionsRepoPromptMCPOnStart: Bool = true,
+        provisionsRepoPromptMCPOnStart: Bool = false,
         processExitObserverFactory: @escaping @Sendable (pid_t) -> ChildProcessExitObserver = {
             ChildProcessExitObserver(pid: $0)
         },
@@ -947,6 +951,7 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
     ) async throws -> CodexAppServerClient {
         let client = CodexAppServerClient(
             processSpawnPreparation: processSpawnPreparation,
+            runtimeStatePreparer: { _ in },
             provisionsRepoPromptMCPOnStart: provisionsRepoPromptMCPOnStart,
             processExitObserverFactory: processExitObserverFactory,
             expectedAgentPIDRegistrar: expectedAgentPIDRegistrar

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexExecAgentProviderRuntimePreparationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexExecAgentProviderRuntimePreparationTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class CodexExecAgentProviderRuntimePreparationTests: XCTestCase {
+    func testPrepareUsesRuntimeStateAuthorityAndMapsFailureBeforeMCPBootstrap() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexExecAgentProviderRuntimePreparationTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let executable = directory.appendingPathComponent("codex")
+        try "#!/bin/sh\necho 'codex 0.149.0'\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        let recorder = PreparedRuntimeRecorder()
+        let provider = CodexExecAgentProvider(
+            config: .init(commandName: executable.path, additionalPathHints: []),
+            runtimeStatePreparer: { runtime in
+                recorder.record(runtime)
+                throw RuntimePreparationFailure.conflict
+            }
+        )
+
+        do {
+            _ = try await provider.prepare()
+            XCTFail("prepare must fail when isolated Codex state preparation fails")
+        } catch let AIProviderError.invalidConfiguration(detail) {
+            XCTAssertTrue(detail.contains("unable to prepare its isolated Codex state"))
+            XCTAssertTrue(detail.contains("projection conflict"))
+        }
+
+        XCTAssertEqual(recorder.callCount, 1)
+        XCTAssertEqual(recorder.runtime?.source, .externalOverride)
+        XCTAssertEqual(recorder.runtime?.executableURL, executable)
+    }
+}
+
+private enum RuntimePreparationFailure: Error, LocalizedError {
+    case conflict
+
+    var errorDescription: String? {
+        "projection conflict"
+    }
+}
+
+private final class PreparedRuntimeRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedRuntime: CodexRuntimeAuthority.Runtime?
+    private var recordedCallCount = 0
+
+    func record(_ runtime: CodexRuntimeAuthority.Runtime) {
+        lock.lock()
+        recordedRuntime = runtime
+        recordedCallCount += 1
+        lock.unlock()
+    }
+
+    var runtime: CodexRuntimeAuthority.Runtime? {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRuntime
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedCallCount
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPBootstrapReadinessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPBootstrapReadinessTests.swift
@@ -10,6 +10,106 @@ import XCTest
 final class CodexMCPBootstrapReadinessTests: XCTestCase {
     private let expectedClientName = "RepoPromptCE"
 
+    func testCachedRuntimeRecoversAfterStatePreparationFailureWithoutReresolvingRuntime() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexMCPBootstrapReadinessTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let executableURL = try makeFakeCodexAppServer(in: directory)
+        let environmentBuilds = CallCounter()
+        let statePreparations = CachedStatePreparationSequence()
+
+        let client = CodexAppServerClient(
+            processEnvironmentBuilder: { request in
+                environmentBuilds.increment()
+                return await ProcessEnvironmentBuilder.build(
+                    request,
+                    shellEnvironmentProvider: { _, _ in
+                        CLIEnvironmentSnapshot(
+                            environment: ["HOME": directory.path],
+                            source: .capturedLoginShell
+                        )
+                    }
+                )
+            },
+            runtimeStatePreparer: { _ in try statePreparations.prepare() },
+            provisionsRepoPromptMCPOnStart: false
+        )
+        await client.updateConfig(.init(
+            commandName: executableURL.path,
+            additionalPathHints: [],
+            requestTimeout: 5,
+            processLaunchDirectory: directory.path
+        ))
+
+        let first = try await client.prepareRuntimeForLaunch()
+        do {
+            _ = try await client.prepareRuntimeForLaunch()
+            XCTFail("cached state preparation must surface its failure")
+        } catch let CodexAppServerClient.ClientError.executableUnavailable(message) {
+            XCTAssertTrue(message.contains("projection conflict"))
+        }
+        let retried = try await client.prepareRuntimeForLaunch()
+
+        XCTAssertEqual(first, retried)
+        XCTAssertEqual(environmentBuilds.value, 1)
+        XCTAssertEqual(statePreparations.callCount, 3)
+    }
+
+    func testStatePreparationFailureAbortsBeforeProvisioningProcessAndThreadRequest() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexMCPBootstrapReadinessTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let executableURL = try makeFakeCodexAppServer(in: directory)
+        let registrar = RecordingExpectedAgentPIDRegistrar()
+        let requests = RecordedRequests()
+        let provisionerCalls = CallCounter()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in throw StatePreparationFailure.conflict },
+            provisionsRepoPromptMCPOnStart: false,
+            expectedAgentPIDRegistrar: registrar.registrar
+        )
+        await client.updateConfig(.init(
+            commandName: executableURL.path,
+            additionalPathHints: [],
+            requestTimeout: 5,
+            processLaunchDirectory: directory.path
+        ))
+        var options = makeAgentModeOptions()
+        options.repoPromptMCPProvisioner = { _ in provisionerCalls.increment() }
+        let controller = CodexNativeSessionController(
+            client: client,
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 0,
+            workspacePaths: .uniform(directory.path),
+            options: options,
+            clientShutdownBehavior: .stopOnShutdown,
+            expectedMCPClientName: expectedClientName,
+            requestExecutor: requests.executor
+        )
+        addTeardownBlock { await controller.shutdown() }
+
+        do {
+            _ = try await controller.startOrResume(existing: nil, baseInstructions: "Agent")
+            XCTFail("startOrResume must fail when isolated Codex state preparation fails")
+        } catch let CodexAppServerClient.ClientError.executableUnavailable(message) {
+            XCTAssertTrue(message.contains("unable to prepare its isolated Codex state"))
+            XCTAssertTrue(message.contains("projection conflict"))
+        }
+
+        XCTAssertEqual(provisionerCalls.value, 0)
+        XCTAssertEqual(requests.methods, [])
+        let processRunning = await client.debugIsProcessRunning()
+        XCTAssertFalse(processRunning)
+        XCTAssertEqual(registrar.registeredCount, 0)
+        XCTAssertEqual(registrar.clearedCount, 0)
+        let bindingState = try await controller.test_bindingBufferState()
+        XCTAssertFalse(bindingState.isBinding)
+        XCTAssertEqual(bindingState.bufferedCount, 0)
+    }
+
     // MARK: - Throwing provisioner fails closed (fresh start and resume)
 
     func testThrowingProvisionerAbortsBeforeProcessStartAndThreadRequest() async throws {
@@ -29,6 +129,7 @@ final class CodexMCPBootstrapReadinessTests: XCTestCase {
         for existing in [nil, resumeRef] {
             let registrar = RecordingExpectedAgentPIDRegistrar()
             let client = CodexAppServerClient(
+                runtimeStatePreparer: { _ in },
                 provisionsRepoPromptMCPOnStart: false,
                 expectedAgentPIDRegistrar: registrar.registrar
             )
@@ -87,6 +188,7 @@ final class CodexMCPBootstrapReadinessTests: XCTestCase {
         let executableURL = try makeFakeCodexAppServer(in: directory)
         let registrar = RecordingExpectedAgentPIDRegistrar()
         let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
             provisionsRepoPromptMCPOnStart: false,
             expectedAgentPIDRegistrar: registrar.registrar
         )
@@ -176,6 +278,7 @@ final class CodexMCPBootstrapReadinessTests: XCTestCase {
                     }
                 )
             },
+            runtimeStatePreparer: { _ in },
             provisionsRepoPromptMCPOnStart: false,
             expectedAgentPIDRegistrar: registrar.registrar
         )
@@ -311,6 +414,33 @@ final class CodexMCPBootstrapReadinessTests: XCTestCase {
 }
 
 // MARK: - Test doubles
+
+private enum StatePreparationFailure: Error, LocalizedError {
+    case conflict
+
+    var errorDescription: String? {
+        "projection conflict"
+    }
+}
+
+private final class CachedStatePreparationSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func prepare() throws {
+        lock.lock()
+        count += 1
+        let shouldFail = count == 2
+        lock.unlock()
+        if shouldFail { throw StatePreparationFailure.conflict }
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
 
 private final class ProvisionedRuntimeRecorder: @unchecked Sendable {
     private let lock = NSLock()

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
@@ -173,7 +173,10 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
 
         let recordURL = directory.appendingPathComponent("requests.jsonl")
         let executableURL = try makeFakeCodexAppServer(in: directory, recordURL: recordURL)
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(
             CodexAppServerClient.Config(
                 commandName: executableURL.path,
@@ -199,7 +202,10 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
 
         let recordURL = directory.appendingPathComponent("requests.jsonl")
         let executableURL = try makeFakeCodexAppServer(in: directory, recordURL: recordURL)
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(
             CodexAppServerClient.Config(
                 commandName: executableURL.path,
@@ -229,7 +235,10 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
 
         let recordURL = directory.appendingPathComponent("requests.jsonl")
         let executableURL = try makeFakeCodexAppServer(in: directory, recordURL: recordURL)
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(
             CodexAppServerClient.Config(
                 commandName: executableURL.path,
@@ -286,7 +295,10 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
 
         let recordURL = directory.appendingPathComponent("requests.jsonl")
         let executableURL = try makeFakeCodexAppServer(in: directory, recordURL: recordURL)
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(
             CodexAppServerClient.Config(
                 commandName: executableURL.path,
@@ -500,6 +512,7 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
         )
 
         let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
             provisionsRepoPromptMCPOnStart: false,
             expectedAgentPIDRegistrar: registrar
         )
@@ -538,6 +551,7 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
         await controller.shutdown()
 
         let resumeClient = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
             provisionsRepoPromptMCPOnStart: false,
             expectedAgentPIDRegistrar: registrar
         )
@@ -606,6 +620,7 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
 
         AgentModePerfDiagnostics.clearRecentMetrics()
         let failingClient = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
             provisionsRepoPromptMCPOnStart: false,
             expectedAgentPIDRegistrar: registrar
         )
@@ -670,7 +685,10 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
             recordURL: recordURL,
             ignoreInitializeRequests: true
         )
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(.init(
             commandName: executableURL.path,
             additionalPathHints: [],
@@ -743,7 +761,10 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
             recordURL: recordURL,
             ignoreTurnStartRequests: true
         )
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(.init(
             commandName: executableURL.path,
             additionalPathHints: [],
@@ -1153,7 +1174,10 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
             initialMemoryMode: initialMemoryMode,
             rejectMemoryModeRequests: rejectMemoryModeRequests
         )
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(
             CodexAppServerClient.Config(
                 commandName: executableURL.path,
@@ -1261,7 +1285,10 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
         workspacePaths: CodexRuntimeWorkspacePaths,
         options: CodexNativeSessionController.Options
     ) async -> CodexNativeSessionController {
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(.init(
             commandName: executableURL.path,
             additionalPathHints: [],

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerHookApprovalTests.swift
@@ -1379,7 +1379,10 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
             requestLogURL: requestLogURL,
             wrongResumeProcessNumber: wrongResumeProcessNumber
         )
-        let client = CodexAppServerClient()
+        let client = CodexAppServerClient(
+            runtimeStatePreparer: { _ in },
+            provisionsRepoPromptMCPOnStart: false
+        )
         await client.updateConfig(.init(
             commandName: executableURL.path,
             additionalPathHints: [],


### PR DESCRIPTION
Fixes https://github.com/repoprompt/repoprompt-ce/issues/831.  RepoPrompt CE uses an app-private `CODEX_HOME`, so Codex Agent Mode sessions load project-local `AGENTS.md` files but were silently missing the user's global `~/.codex/AGENTS.override.md` or `~/.codex/AGENTS.md`.

This patch projects both of those global instruction files into the managed Codex home before launch, leaving precedence and global-plus-project composition to Codex.

PR https://github.com/repoprompt/repoprompt-ce/pull/837 contains earlier work in this area as part of a broader managed-home change.  @baron agreed that this focused PR should proceed.  Afterward, we'll evaluate a pared-down version of #837 for any remaining work that doesn't overlap.

## Summary

- Project `AGENTS.override.md` and `AGENTS.md` independently into the managed Codex home
- Preserve Codex's native empty-override fallback and global-plus-project instruction composition
- Refresh the projection before app-server and `codex exec` launches, including cached app-server runtimes
- Use atomic regular-file copies rather than writable links into the user's real Codex home
- Track projected files with a small ownership manifest
- Fail closed instead of overwriting unowned, modified, or symlinked managed-home files

## Implementation Notes

- `CodexRuntimeAuthority.Runtime.prepareState()` remains the single preparation point for managed Codex state
- Source symlinks are supported, matching normal Codex file loading; managed-home destination symlinks are rejected
- Projection errors use the existing app-server and exec launch error paths
- No settings, logging, watcher, or general managed-home framework was added

## Review Approach

- The patch received focused reviews from 5.6-Sol-Pro and Fable against the scope of #831
- Findings around manifest hash parsing, ownership assertions, and cached-runtime recovery were fixed with focused regressions

## Validation

Passed locally:

- `make dev-test FILTER=CodexGlobalInstructionsProjectionTests`
- `make dev-test FILTER=CodexRuntimeAuthorityTests`
- `make dev-test FILTER=CodexMCPBootstrapReadinessTests`
- `make dev-test FILTER=CodexAppServerClientProcessExitTests`
- `make dev-test FILTER=CodexExecAgentProviderRuntimePreparationTests`
- `make dev-test FILTER=CodexNativeSessionControllerGoalConfigTests`
- `make dev-test FILTER=CodexNativeSessionControllerHookApprovalTests`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- Repository guardrails and the exact one-commit outgoing-range secret scan

The full root suite was also run.  Three Codex coordinator timing tests outside this patch failed under full-suite load and all three passed on focused rerun.  All projection and launch-path tests passed.  I also confirmed via a Debug app canary that global and project-local instructions were both loaded in the expected order.