### PR TITLE
Fix Tip package signing key authorization

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -315,9 +315,9 @@ jobs:
           if [[ "$ROLLOUT_ROLE" == "transition" ]]; then
             printf '%s' "$SUCCESSOR_INSTALLER_P12_BASE64" | base64 --decode > "$INSTALLER_CERTIFICATE_PATH" || fail "successor installer P12 write failed"
             security import "$INSTALLER_CERTIFICATE_PATH" -k "$PREFLIGHT_KEYCHAIN_PATH" -P "$SUCCESSOR_INSTALLER_P12_PASSWORD" \
-              -T /usr/bin/productbuild -T /usr/bin/security \
+              -T /usr/bin/productbuild -T /usr/bin/productsign -T /usr/bin/security \
               >/dev/null || fail "successor installer P12 import failed"
-            security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild: \
+            security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild:,productsign: \
               -s -k "$CI_KEYCHAIN_PASSWORD" "$PREFLIGHT_KEYCHAIN_PATH" \
               >/dev/null || fail "successor installer key partition setup failed"
             security find-identity -v -p basic "$PREFLIGHT_KEYCHAIN_PATH" |
@@ -485,8 +485,8 @@ jobs:
             installer_certificate="$RUNNER_TEMP/repoprompt-tip-installer.p12"
             printf '%s' "$SUCCESSOR_INSTALLER_P12_BASE64" | base64 --decode > "$installer_certificate"
             security import "$installer_certificate" -k "$KEYCHAIN_PATH" \
-              -P "$SUCCESSOR_INSTALLER_P12_PASSWORD" -T /usr/bin/productbuild -T /usr/bin/security
-            security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild: \
+              -P "$SUCCESSOR_INSTALLER_P12_PASSWORD" -T /usr/bin/productbuild -T /usr/bin/productsign -T /usr/bin/security
+            security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild:,productsign: \
               -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
             verify_identity basic "$EXPECTED_INSTALLER_IDENTITY" installer
             rm -f "$installer_certificate"

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -669,6 +669,7 @@ jobs:
           security delete-keychain "$RUNNER_TEMP/repoprompt-tip.keychain-db" || true
           rm -rf "$RUNNER_TEMP/repoprompt-tip-secrets"
           rm -f "$RUNNER_TEMP/repoprompt-tip.p12"
+          rm -f "$RUNNER_TEMP/repoprompt-tip-installer.p12"
           rm -f "$RUNNER_TEMP/repoprompt-tip-successor.p12"
           rm -f "$RUNNER_TEMP/repoprompt-successor-identity-anchor"
 

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -5220,11 +5220,15 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         notary_step = workflow.split("      - name: Prepare provisioning profile and notarization key", 1)[1].split(
             "      - name: Install Sentry CLI", 1
         )[0]
+        cleanup_step = workflow.split("      - name: Remove ephemeral keychain", 1)[1].split(
+            "      - name: Validate signed Tip asset inventory", 1
+        )[0]
 
         self.assertIn('verify_identity codesigning "$EXPECTED_SIGN_IDENTITY" application', import_step)
         self.assertIn('verify_identity basic "$EXPECTED_INSTALLER_IDENTITY" installer', import_step)
         self.assertIn("-T /usr/bin/productsign", import_step)
         self.assertIn("productbuild:,productsign:", import_step)
+        self.assertIn('rm -f "$RUNNER_TEMP/repoprompt-tip-installer.p12"', cleanup_step)
         self.assertIn('printf \'SIGN_IDENTITY=%s\\n\' "$EXPECTED_SIGN_IDENTITY"', import_step)
         self.assertIn('grep -F "\\"$EXPECTED_MIGRATION_ANCHOR_SIGN_IDENTITY\\""', anchor_step)
         self.assertIn('codesign --force --sign "$EXPECTED_MIGRATION_ANCHOR_SIGN_IDENTITY"', anchor_step)

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -5202,6 +5202,8 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
         self.assertIn('decode_value "notarytool private key"', preflight)
         self.assertIn('if [[ "$ROLLOUT_ROLE" == "transition" ]]', preflight)
         self.assertIn('if [[ "$ROLLOUT_ROLE" == "preparer" ]]', preflight)
+        self.assertIn("-T /usr/bin/productsign", preflight)
+        self.assertIn("productbuild:,productsign:", preflight)
         self.assertIn("needs:\n      - setup\n      - credential-preflight", stage)
         self.assertLess(workflow.index("credential-preflight:"), workflow.index("\n  stage:"))
         self.assertLess(workflow.index("\n  stage:"), workflow.index("\n  sign:"))
@@ -5221,6 +5223,8 @@ class IdentityTransitionReleaseToolingTests(unittest.TestCase):
 
         self.assertIn('verify_identity codesigning "$EXPECTED_SIGN_IDENTITY" application', import_step)
         self.assertIn('verify_identity basic "$EXPECTED_INSTALLER_IDENTITY" installer', import_step)
+        self.assertIn("-T /usr/bin/productsign", import_step)
+        self.assertIn("productbuild:,productsign:", import_step)
         self.assertIn('printf \'SIGN_IDENTITY=%s\\n\' "$EXPECTED_SIGN_IDENTITY"', import_step)
         self.assertIn('grep -F "\\"$EXPECTED_MIGRATION_ANCHOR_SIGN_IDENTITY\\""', anchor_step)
         self.assertIn('codesign --force --sign "$EXPECTED_MIGRATION_ANCHOR_SIGN_IDENTITY"', anchor_step)


### PR DESCRIPTION
## Summary

- authorize `/usr/bin/productsign` to use the transition Installer private key in both credential-preflight and signing-job keychains
- restore the intended `productsign:` partition-list contract
- restore focused release-tooling assertions so the actual package signer cannot lose authorization silently

## Root cause

PR #895 retained the transition builder call to `productsign` but removed `/usr/bin/productsign` from the Installer P12 trusted-application list and removed its partition entry. Protected Tip runs then completed `pkgbuild` and `productbuild`, blocked in headless `productsign`, and were canceled at the 120-minute job timeout.

This was reproduced in independent runs [33274539073](https://github.com/repoprompt/repoprompt-ce/actions/runs/33274539073) and [33275290742](https://github.com/repoprompt/repoprompt-ce/actions/runs/33275290742). Package notarization never started.

## Validation

- focused identity-transition release-tooling tests: 2 passed
- `make release-selftest`: 179 passed
- YAML parse and shell syntax checks
- `git diff --check`
- `make dev-release-preflight`: passed (ticket `6bfdeb5d-75b5-4d4f-8cbb-40606a8f86a0`)
- contribution `commit`, `push`, and `pr-ready` preflights: passed
- Fable 5 High review: no blocking findings

## Validation limit

Local validation cannot exercise the protected Installer P12. A protected, non-publishing Tip rehearsal is still required to prove timestamped PKG signing, notarization, stapling, validation, and smoke testing complete in the hosted environment. No workflow was dispatched by this PR.