### PR TITLE
Test MCP stdio and terminal commit barriers

### DIFF
--- a/Tests/RepoPromptTests/AgentMode/AgentRunLifecycleContractsTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentRunLifecycleContractsTests.swift
@@ -80,4 +80,86 @@ final class AgentRunLifecycleContractsTests: XCTestCase {
         XCTAssertNil(contextBuilderSession.activeRunOwnership)
         XCTAssertTrue(contextBuilderSession.agentLog.isEmpty)
     }
+
+    @MainActor
+    func testTerminalCommitRejectsStaleDrainAndDoesNotRepublishResolvedRevision() async throws {
+        let tabID = UUID()
+        let lifecycle = AgentRunAttemptLifecycle()
+        let ownership = lifecycle.beginAttempt(
+            context: .init(tabID: tabID, persistentSessionID: nil)
+        )
+        let providerDrainGeneration: UInt64 = 7
+        var publicationCount = 0
+        let hooks = AgentRunTerminalSessionBinding.Hooks(
+            flushPendingAssistantDelta: {},
+            finalizeStreamingItems: {},
+            finalizePendingToolCalls: { _ in },
+            finalizeNonCodexTurnUsage: {},
+            cancelPendingInteractions: { _ in },
+            finalizeAttachments: { _, _ in },
+            setAgentRunInactive: {},
+            prepareTerminalPublication: {},
+            makeTerminalPublicationEnvelope: { _, _, _, _ in nil },
+            updateBindings: {},
+            notifyAgentTurnComplete: {},
+            scheduleSave: {},
+            publishTerminalCommit: { _, _ in
+                publicationCount += 1
+                return .accepted(successorEpoch: nil)
+            },
+            startFollowUpRun: { _ in }
+        )
+        let binding = AgentRunTerminalSessionBinding(
+            tabID: tabID,
+            lifecycle: lifecycle,
+            hooks: hooks,
+            validatesOwnership: { candidate, expectedRunID in
+                lifecycle.isCurrentAttempt(candidate, expectedRunID: expectedRunID)
+            },
+            providerDrainGeneration: { providerDrainGeneration },
+            terminalTurnID: { nil },
+            queuedFollowUp: { nil },
+            setFollowUpPending: { _ in },
+            removeFirstQueuedFollowUp: { nil },
+            appendError: { _ in },
+            finishActiveState: { candidate, _, _ in
+                _ = lifecycle.endAttempt(ifCurrent: candidate)
+            },
+            retainProcessRunIdentity: { _, _ in },
+            sourceItemsRevision: { 3 },
+            assistantDeltaFlushGeneration: { 5 },
+            latestFailureText: { nil }
+        )
+        let barrier = AgentRunTerminalCommitBarrier()
+
+        func request(drainGeneration: UInt64) -> AgentRunTerminalCommitBarrier.Request {
+            AgentRunTerminalCommitBarrier.Request(
+                binding: binding,
+                ownership: ownership,
+                expectedRunID: nil,
+                terminalState: .completed,
+                source: "test.terminalCommit",
+                attachmentDisposition: .deleteFiles,
+                finalizeNonCodexUsage: false,
+                supportsFollowUp: false,
+                notifyTurnComplete: false,
+                providerDrainGeneration: drainGeneration
+            )
+        }
+
+        let staleRevision = await barrier.commit(request(drainGeneration: providerDrainGeneration - 1))
+        XCTAssertNil(staleRevision)
+        XCTAssertEqual(publicationCount, 0)
+        XCTAssertNil(lifecycle.lastTerminalCommitRevision)
+
+        let firstCandidate = await barrier.commit(request(drainGeneration: providerDrainGeneration))
+        let firstRevision = try XCTUnwrap(firstCandidate)
+        XCTAssertEqual(publicationCount, 1)
+        XCTAssertEqual(lifecycle.lastTerminalPublicationResult, .accepted(successorEpoch: nil))
+
+        let repeatedCandidate = await barrier.commit(request(drainGeneration: providerDrainGeneration))
+        let repeatedRevision = try XCTUnwrap(repeatedCandidate)
+        XCTAssertEqual(repeatedRevision, firstRevision)
+        XCTAssertEqual(publicationCount, 1)
+    }
 }

--- a/Tests/RepoPromptTests/MCP/MCPStdioServerTransportTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPStdioServerTransportTests.swift
@@ -1,0 +1,125 @@
+import Darwin
+import Foundation
+@testable import RepoPromptMCP
+import XCTest
+
+final class MCPStdioServerTransportTests: XCTestCase {
+    func testCompleteFramesAreDeliveredExactlyOnceInOrderBeforeCleanEOF() async throws {
+        var inputDescriptors = try makePipe()
+        defer {
+            closeDescriptor(&inputDescriptors[0])
+            closeDescriptor(&inputDescriptors[1])
+        }
+        var outputDescriptors = try makePipe()
+        defer {
+            closeDescriptor(&outputDescriptors[0])
+            closeDescriptor(&outputDescriptors[1])
+        }
+
+        let transport = MCPStdioServerTransport(
+            stdinFD: inputDescriptors[0],
+            stdoutFD: outputDescriptors[1],
+            parentPIDProvider: { 42 }
+        )
+        try await transport.connect()
+        let stream = await transport.receive()
+        async let terminal = transport.waitUntilTerminal()
+
+        let expectedFrames = [
+            Data(#"{"jsonrpc":"2.0","id":1}"#.utf8),
+            Data(#"{"jsonrpc":"2.0","id":2}"#.utf8)
+        ]
+        var wireBytes = Data()
+        for frame in expectedFrames {
+            wireBytes.append(frame)
+            wireBytes.append(0x0A)
+        }
+        writeExactly(wireBytes, to: inputDescriptors[1])
+        closeDescriptor(&inputDescriptors[1])
+
+        var receivedFrames: [Data] = []
+        for try await frame in stream {
+            receivedFrames.append(frame)
+        }
+
+        let observedTerminal = await terminal
+        XCTAssertEqual(receivedFrames, expectedFrames)
+        XCTAssertEqual(observedTerminal, .stdinEOF)
+        await transport.disconnect()
+    }
+
+    func testEOFWithIncompleteFrameReportsExactTruncatedByteCount() async throws {
+        var inputDescriptors = try makePipe()
+        defer {
+            closeDescriptor(&inputDescriptors[0])
+            closeDescriptor(&inputDescriptors[1])
+        }
+        var outputDescriptors = try makePipe()
+        defer {
+            closeDescriptor(&outputDescriptors[0])
+            closeDescriptor(&outputDescriptors[1])
+        }
+
+        let transport = MCPStdioServerTransport(
+            stdinFD: inputDescriptors[0],
+            stdoutFD: outputDescriptors[1],
+            parentPIDProvider: { 42 }
+        )
+        try await transport.connect()
+        let stream = await transport.receive()
+        async let terminal = transport.waitUntilTerminal()
+
+        let incompleteFrame = Data(#"{"jsonrpc":"2.0""#.utf8)
+        writeExactly(incompleteFrame, to: inputDescriptors[1])
+        closeDescriptor(&inputDescriptors[1])
+
+        var receivedFrames: [Data] = []
+        var streamError: Error?
+        do {
+            for try await frame in stream {
+                receivedFrames.append(frame)
+            }
+        } catch {
+            streamError = error
+        }
+
+        let expectedTerminal = MCPStdioServerTransport.TerminalError.stdinTruncatedFrame(
+            bytes: incompleteFrame.count
+        )
+        let observedTerminal = await terminal
+        XCTAssertTrue(receivedFrames.isEmpty)
+        XCTAssertEqual(streamError as? MCPStdioServerTransport.TerminalError, expectedTerminal)
+        XCTAssertEqual(observedTerminal, expectedTerminal)
+        await transport.disconnect()
+    }
+
+    private func makePipe() throws -> [Int32] {
+        var descriptors = [Int32](repeating: -1, count: 2)
+        guard Darwin.pipe(&descriptors) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        return descriptors
+    }
+
+    private func writeExactly(
+        _ data: Data,
+        to descriptor: Int32,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let written = data.withUnsafeBytes { bytes in
+            Darwin.write(descriptor, bytes.baseAddress, bytes.count)
+        }
+        XCTAssertEqual(written, data.count, file: file, line: line)
+    }
+
+    private func closeDescriptor(
+        _ descriptor: inout Int32,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard descriptor >= 0 else { return }
+        XCTAssertEqual(Darwin.close(descriptor), 0, file: file, line: line)
+        descriptor = -1
+    }
+}


### PR DESCRIPTION
## Summary

- add direct `MCPStdioServerTransport` tests using controlled pipe file descriptors
- verify complete frames are delivered exactly once and in order before clean EOF
- verify incomplete EOF reports the exact `stdinTruncatedFrame` byte count
- verify terminal commits reject stale provider-drain generations and resolved revisions are not republished

No production behavior or test-only production seam is changed. The tests introduce no sleeps, retries, polling loops, timeout expectations, child services, or live-app dependencies.

## Proof of value

Each test was run against a temporary production defect and failed as intended before the mutation was restored:

- duplicate frame yield: received 4 frames instead of 2
- truncated EOF treated as clean: observed `stdinEOF` instead of `stdinTruncatedFrame(bytes: 16)`
- provider-drain guards bypassed: stale request incorrectly published a terminal revision

## Validation

- focused stdio suite: 2 tests passed (`876bcdfc-4bc0-4b9a-a184-7941b159a439`)
- focused terminal-barrier test: passed (`bbee632e-387a-4401-9958-17149334d131`)
- full root test suite: passed (`d22d50f2-5006-4e4b-8642-8daa3d6071c9`)
- strict lint: passed (`09a6614a-363b-49e1-9742-570929c0e7b7`)
- commit and push contribution preflights: passed
- path-selected `pr-ready` preflight: passed
