### PR TITLE
Fix: codemaps to index nested repo worktree sources

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/VCS/GitBlobIdentityModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitBlobIdentityModels.swift
@@ -251,6 +251,7 @@ enum GitBlobValidatedWorktreeReason: String, Codable, Hashable {
     case indexFlag
     case checkoutTransformation
     case changedDuringClassification
+    case nestedRepository
     case generatedOrExplicit
 }
 

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitBlobIdentityService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitBlobIdentityService.swift
@@ -15,13 +15,23 @@ actor GitBlobIdentityService {
         let unstable: Bool
     }
 
-    private enum PathSecurityState {
+    private struct PathSecurityAssessment: Equatable {
+        let state: PathSecurityState
+        let crossedNestedRepository: Bool
+
+        init(_ state: PathSecurityState, crossedNestedRepository: Bool = false) {
+            self.state = state
+            self.crossedNestedRepository = crossedNestedRepository
+        }
+    }
+
+    private enum PathSecurityState: Equatable {
         case regular(GitBlobLStatFingerprint)
         case missing
         case symlinkLeaf(GitBlobLStatFingerprint)
         case symlinkComponent
         case nonRegular(GitBlobLStatFingerprint)
-        case repositoryBoundary(GitBlobLStatFingerprint?)
+        case repositoryProbeFailed
     }
 
     private let gitService: GitService
@@ -134,10 +144,16 @@ actor GitBlobIdentityService {
         let preSecurity = relativePaths.map { path in
             pathSecurityState(workspaceRoot: workspaceRoot, relativePath: path)
         }
+        let worktreeMetadataRepositoryPaths = repositoryPaths.indices.compactMap { index -> String? in
+            guard let repositoryPath = repositoryPaths[index],
+                  !preSecurity[index].crossedNestedRepository
+            else { return nil }
+            return repositoryPath
+        }
         let preFileFingerprints = preSecurity.map(Self.fingerprint)
         let preMetadata = Self.repositoryMetadataFingerprint(
             layout: layout,
-            repositoryRelativePaths: requestedRepositoryPaths
+            repositoryRelativePaths: worktreeMetadataRepositoryPaths
         )
         let preLayout = Self.repositoryLayoutFingerprint(layout)
         let preIndexFingerprint = Self.lstatFingerprint(at: layout.gitDir.appendingPathComponent("index"))
@@ -150,18 +166,26 @@ actor GitBlobIdentityService {
         do {
             objectFormat = try await gitService.gitBlobObjectFormat(at: layout.workTreeRoot)
             preConfiguration = try await gitService.gitBlobCheckoutConfiguration(at: layout.workTreeRoot)
-            preAttributes = try await gitService.gitBlobAttributes(
-                at: layout.workTreeRoot,
-                repositoryRelativePaths: requestedRepositoryPaths
-            )
+            preAttributes = if worktreeMetadataRepositoryPaths.isEmpty {
+                [:]
+            } else {
+                try await gitService.gitBlobAttributes(
+                    at: layout.workTreeRoot,
+                    repositoryRelativePaths: worktreeMetadataRepositoryPaths
+                )
+            }
             indexEntries = try await gitService.gitBlobIndexEntries(
                 at: layout.workTreeRoot,
                 repositoryRelativePaths: requestedRepositoryPaths
             )
-            statusRecords = try await gitService.gitBlobStatusRecords(
-                at: layout.workTreeRoot,
-                repositoryRelativePaths: requestedRepositoryPaths
-            )
+            statusRecords = if worktreeMetadataRepositoryPaths.isEmpty {
+                []
+            } else {
+                try await gitService.gitBlobStatusRecords(
+                    at: layout.workTreeRoot,
+                    repositoryRelativePaths: worktreeMetadataRepositoryPaths
+                )
+            }
         } catch GitBlobIdentityError.invalidObjectFormat {
             return Attempt(
                 batch: unsupportedBatch(paths: relativePaths, reason: .invalidObjectFormat),
@@ -189,10 +213,14 @@ actor GitBlobIdentityService {
         let postAttributes: [String: GitBlobPathAttributes]
         do {
             postConfiguration = try await gitService.gitBlobCheckoutConfiguration(at: layout.workTreeRoot)
-            postAttributes = try await gitService.gitBlobAttributes(
-                at: layout.workTreeRoot,
-                repositoryRelativePaths: requestedRepositoryPaths
-            )
+            postAttributes = if worktreeMetadataRepositoryPaths.isEmpty {
+                [:]
+            } else {
+                try await gitService.gitBlobAttributes(
+                    at: layout.workTreeRoot,
+                    repositoryRelativePaths: worktreeMetadataRepositoryPaths
+                )
+            }
         } catch {
             return Attempt(batch: unsupportedBatch(paths: relativePaths, reason: .unsupportedGit), unstable: true)
         }
@@ -204,7 +232,7 @@ actor GitBlobIdentityService {
         let postMetadata = postLayout.map {
             Self.repositoryMetadataFingerprint(
                 layout: $0,
-                repositoryRelativePaths: requestedRepositoryPaths
+                repositoryRelativePaths: worktreeMetadataRepositoryPaths
             )
         } ?? "<unresolved>"
         let postIndexFingerprint = postLayout.flatMap {
@@ -247,7 +275,8 @@ actor GitBlobIdentityService {
                 preWorktree: preFileFingerprints[index],
                 postWorktree: postFileFingerprints[index]
             )
-            if !tokens.isStable { unstable = true }
+            let pathSecurityStable = preSecurity[index] == postSecurity[index]
+            if !tokens.isStable || !pathSecurityStable { unstable = true }
             let entries = (entriesByPath[repositoryPath] ?? []).sorted { $0.stage < $1.stage }
             let record = recordsByPath[repositoryPath]
             let attributes = preAttributes[repositoryPath] ?? .unspecified
@@ -265,6 +294,7 @@ actor GitBlobIdentityService {
                 configuration: preConfiguration,
                 materialization: materialization,
                 security: postSecurity[index],
+                pathSecurityStable: pathSecurityStable,
                 tokens: tokens
             )
         }
@@ -290,9 +320,11 @@ actor GitBlobIdentityService {
                 relativePath: relativePaths[index]
             )
             let fingerprint = Self.fingerprint(security)
-            let outcome: GitBlobIdentityOutcome = switch security {
+            let outcome: GitBlobIdentityOutcome = switch security.state {
             case .regular:
-                .requiresValidatedWorktreeBytes(.nonGit)
+                security.crossedNestedRepository
+                    ? .requiresValidatedWorktreeBytes(.nestedRepository)
+                    : .requiresValidatedWorktreeBytes(.nonGit)
             case .missing:
                 .unavailable(.missing)
             case .symlinkLeaf:
@@ -301,7 +333,7 @@ actor GitBlobIdentityService {
                 .securityExcluded(.symlinkPathComponent)
             case .nonRegular:
                 .unsupported(.nonRegularFile)
-            case .repositoryBoundary:
+            case .repositoryProbeFailed:
                 .unavailable(.repositoryUnavailable)
             }
             return GitBlobIdentityClassification(
@@ -345,7 +377,8 @@ actor GitBlobIdentityService {
         attributes: GitBlobPathAttributes,
         configuration: GitBlobCheckoutConfiguration,
         materialization: GitBlobCheckoutMaterialization,
-        security: PathSecurityState,
+        security: PathSecurityAssessment,
+        pathSecurityStable: Bool,
         tokens: GitBlobValidationTokens
     ) -> GitBlobIdentityClassification {
         let stageZero = entries.first { $0.stage == 0 }
@@ -356,19 +389,23 @@ actor GitBlobIdentityService {
         let intentToAdd = record?.indexOID == zeroOID &&
             stageZero != nil && record?.kind == .ordinary
 
-        let outcome: GitBlobIdentityOutcome = if let stageZero, stageZero.isGitlink {
+        let outcome: GitBlobIdentityOutcome = if security.crossedNestedRepository,
+                                                 case .regular = security.state
+        {
+            .requiresValidatedWorktreeBytes(.nestedRepository)
+        } else if let stageZero, stageZero.isGitlink {
             .unsupported(.gitlink)
         } else if let stageZero, stageZero.isSymlink {
             .securityExcluded(.symlinkLeaf)
         } else {
-            switch security {
+            switch security.state {
             case .symlinkLeaf:
                 .securityExcluded(.symlinkLeaf)
             case .symlinkComponent:
                 .securityExcluded(.symlinkPathComponent)
             case .nonRegular:
                 .unsupported(.nonRegularFile)
-            case .repositoryBoundary:
+            case .repositoryProbeFailed:
                 .unavailable(.repositoryUnavailable)
             case .missing:
                 if skipWorktree, stageZero != nil {
@@ -385,7 +422,7 @@ actor GitBlobIdentityService {
                     .unsupported(.unknownIndexMode)
                 } else if skipWorktree || assumeUnchanged {
                     .requiresValidatedWorktreeBytes(.indexFlag)
-                } else if !tokens.isStable {
+                } else if !tokens.isStable || !pathSecurityStable {
                     .requiresValidatedWorktreeBytes(.changedDuringClassification)
                 } else if case .requiresValidatedWorktreeBytes = materialization {
                     .requiresValidatedWorktreeBytes(.checkoutTransformation)
@@ -568,15 +605,16 @@ actor GitBlobIdentityService {
     private func pathSecurityState(
         workspaceRoot: URL,
         relativePath: String
-    ) -> PathSecurityState {
-        guard Self.isValidRelativePath(relativePath) else { return .missing }
+    ) -> PathSecurityAssessment {
+        guard Self.isValidRelativePath(relativePath) else { return .init(.missing) }
         let components = relativePath.split(separator: "/").map(String.init)
         let rootDescriptor = open(
             workspaceRoot.path,
             O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
         )
-        guard rootDescriptor >= 0 else { return .missing }
+        guard rootDescriptor >= 0 else { return .init(.missing) }
         var directoryDescriptor = rootDescriptor
+        var crossedNestedRepository = false
         defer {
             if directoryDescriptor != rootDescriptor { close(directoryDescriptor) }
             close(rootDescriptor)
@@ -585,46 +623,57 @@ actor GitBlobIdentityService {
         for (index, component) in components.enumerated() {
             var value = stat()
             guard fstatat(directoryDescriptor, component, &value, AT_SYMLINK_NOFOLLOW) == 0 else {
-                return .missing
+                return .init(.missing, crossedNestedRepository: crossedNestedRepository)
             }
             let fingerprint = Self.lstatFingerprint(value)
             let isLeaf = index == components.count - 1
             if fingerprint.isSymbolicLink {
-                return isLeaf ? .symlinkLeaf(fingerprint) : .symlinkComponent
+                let state: PathSecurityState = isLeaf ? .symlinkLeaf(fingerprint) : .symlinkComponent
+                return .init(state, crossedNestedRepository: crossedNestedRepository)
             }
             if isLeaf {
-                return fingerprint.isRegularFile ? .regular(fingerprint) : .nonRegular(fingerprint)
+                let state: PathSecurityState = fingerprint.isRegularFile
+                    ? .regular(fingerprint)
+                    : .nonRegular(fingerprint)
+                return .init(state, crossedNestedRepository: crossedNestedRepository)
             }
-            guard (value.st_mode & S_IFMT) == S_IFDIR else { return .missing }
+            guard (value.st_mode & S_IFMT) == S_IFDIR else {
+                return .init(.missing, crossedNestedRepository: crossedNestedRepository)
+            }
             let nextDescriptor = openat(
                 directoryDescriptor,
                 component,
                 O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
             )
-            guard nextDescriptor >= 0 else { return .missing }
+            guard nextDescriptor >= 0 else {
+                return .init(.missing, crossedNestedRepository: crossedNestedRepository)
+            }
             var repositoryMarker = stat()
             if fstatat(nextDescriptor, ".git", &repositoryMarker, AT_SYMLINK_NOFOLLOW) == 0 {
-                let fingerprint = Self.lstatFingerprint(repositoryMarker)
-                close(nextDescriptor)
-                return .repositoryBoundary(fingerprint)
-            }
-            let markerError = errno
-            guard markerError == ENOENT else {
-                close(nextDescriptor)
-                return .repositoryBoundary(nil)
+                crossedNestedRepository = true
+            } else {
+                let markerError = errno
+                guard markerError == ENOENT else {
+                    close(nextDescriptor)
+                    return .init(
+                        .repositoryProbeFailed,
+                        crossedNestedRepository: crossedNestedRepository
+                    )
+                }
             }
             if directoryDescriptor != rootDescriptor { close(directoryDescriptor) }
             directoryDescriptor = nextDescriptor
             hooks.afterPathSecurityComponentOpen(components[0 ... index].joined(separator: "/"))
         }
-        return .missing
+        return .init(.missing, crossedNestedRepository: crossedNestedRepository)
     }
 
-    private static func fingerprint(_ state: PathSecurityState) -> GitBlobLStatFingerprint? {
-        switch state {
-        case let .regular(value), let .symlinkLeaf(value), let .nonRegular(value): value
-        case let .repositoryBoundary(value): value
-        case .missing, .symlinkComponent: nil
+    private static func fingerprint(_ assessment: PathSecurityAssessment) -> GitBlobLStatFingerprint? {
+        switch assessment.state {
+        case let .regular(value), let .symlinkLeaf(value), let .nonRegular(value):
+            value
+        case .missing, .symlinkComponent, .repositoryProbeFailed:
+            nil
         }
     }
 

--- a/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
@@ -1,0 +1,121 @@
+import Darwin
+import Foundation
+@testable import RepoPromptApp
+
+final class CodemapRuntimeTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var runtimes: [CodeMapArtifactRuntime] = []
+
+    func record(_ runtime: CodeMapArtifactRuntime) -> CodeMapArtifactRuntime {
+        lock.withLock { runtimes.append(runtime) }
+        return runtime
+    }
+
+    func snapshot() -> [CodeMapArtifactRuntime] {
+        lock.withLock { runtimes }
+    }
+}
+
+final class CodemapLockedValues<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Value] = []
+
+    var values: [Value] {
+        lock.withLock { storage }
+    }
+
+    func append(_ value: Value) {
+        lock.withLock { storage.append(value) }
+    }
+}
+
+final class CodemapStoreFixture: @unchecked Sendable {
+    let registry: WorkspaceCodemapBindingIntegrationRegistry
+    let builtSourceTexts: CodemapLockedValues<String>
+
+    private let sandbox: URL
+    private let runtimeTracker: CodemapRuntimeTracker
+    private let runtimeProvider: CodeMapArtifactRuntimeProvider
+
+    init(name: String) throws {
+        let registry = WorkspaceCodemapBindingIntegrationRegistry()
+        let builtSourceTexts = CodemapLockedValues<String>()
+        let runtimeTracker = CodemapRuntimeTracker()
+        let sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodemapStoreFixture-\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        let artifactRoot = sandbox.appendingPathComponent("artifacts", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: artifactRoot,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        guard chmod(artifactRoot.path, 0o700) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        let resolvedArtifactRoot = try artifactRoot.path.withCString { pointer -> URL in
+            guard let resolved = realpath(pointer, nil) else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            defer { free(resolved) }
+            return URL(fileURLWithPath: String(cString: resolved), isDirectory: true)
+        }
+
+        let defaultBuilder = CodeMapArtifactBuilderClient()
+        let runtimeProvider = CodeMapArtifactRuntimeProvider {
+            try runtimeTracker.record(CodeMapArtifactRuntime(
+                rootURL: resolvedArtifactRoot,
+                builder: CodeMapArtifactBuilderClient(execute: { input, ownerID, priority in
+                    if case let .decoded(source) = input.source.decodeResult {
+                        builtSourceTexts.append(source.text)
+                    }
+                    return try await defaultBuilder.execute(input, ownerID, priority)
+                }),
+                bindingIntegrationRegistry: registry,
+                bindingEngineFactory: { runtime in
+                    WorkspaceCodemapBindingEngine(
+                        runtime: runtime,
+                        capabilityService: WorkspaceCodemapGitCapabilityService(
+                            namespaceSalt: Data(
+                                repeating: 0x6C,
+                                count: GitBlobRepositoryNamespace.saltByteCount
+                            )
+                        ),
+                        sourceReader: registry.makeValidatedSourceReaderClient(),
+                        catalogClient: registry.makeBindingCatalogClient()
+                    )
+                }
+            ))
+        }
+        self.registry = registry
+        self.builtSourceTexts = builtSourceTexts
+        self.sandbox = sandbox
+        self.runtimeTracker = runtimeTracker
+        self.runtimeProvider = runtimeProvider
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: sandbox)
+    }
+
+    func makeStore() -> WorkspaceFileContextStore {
+        let runtimeProvider = runtimeProvider
+        return WorkspaceFileContextStore(
+            codemapRuntimeProvider: { try runtimeProvider.runtime() },
+            codemapLocalGitClassificationProbe: .init { _ in .requiresGitPreflight },
+            codemapGitEligibilityProbe: .init { _ in .eligible }
+        )
+    }
+
+    func runtime() throws -> CodeMapArtifactRuntime {
+        try runtimeProvider.runtime()
+    }
+
+    func shutdown() async {
+        for runtime in runtimeTracker.snapshot() {
+            if let engine = try? runtime.bindingEngine() {
+                await engine.shutdown()
+            }
+        }
+    }
+}

--- a/Tests/RepoPromptTests/Helpers/ReviewGitRepositoryFixture.swift
+++ b/Tests/RepoPromptTests/Helpers/ReviewGitRepositoryFixture.swift
@@ -1,0 +1,100 @@
+import Foundation
+@testable import RepoPromptApp
+
+final class ReviewGitRepositoryFixture {
+    let sandbox: URL
+
+    init(name: String = "ReviewGitRepositoryFixture") throws {
+        sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+            .standardizedFileURL
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        cleanup()
+    }
+
+    func cleanup() {
+        guard FileManager.default.fileExists(atPath: sandbox.path) else { return }
+        try? FileManager.default.removeItem(at: sandbox)
+    }
+
+    func makeRepository(named name: String, files: [String: String]) throws -> URL {
+        let root = sandbox.appendingPathComponent(name, isDirectory: true).standardizedFileURL
+        try initializeRepository(at: root)
+        for (path, contents) in files {
+            try write(contents, to: path, at: root)
+        }
+        _ = try runGit(["add", "-A"], at: root)
+        try commit("Initial commit", at: root)
+        return root
+    }
+
+    func initializeRepository(at root: URL, separateGitDirectory: URL? = nil) throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        var arguments = ["init"]
+        if let separateGitDirectory {
+            arguments.append("--separate-git-dir=\(separateGitDirectory.path)")
+        }
+        arguments.append(root.path)
+        _ = try runGit(arguments, at: sandbox)
+        _ = try runGit(["config", "user.name", "RepoPrompt Test"], at: root)
+        _ = try runGit(["config", "user.email", "repoprompt@example.test"], at: root)
+        _ = try runGit(["config", "commit.gpgSign", "false"], at: root)
+        _ = try runGit(["config", "core.autocrlf", "false"], at: root)
+        _ = try runGit(["checkout", "-b", "main"], at: root)
+    }
+
+    func write(_ contents: String, to relativePath: String, at root: URL) throws {
+        let file = root.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try contents.write(to: file, atomically: true, encoding: .utf8)
+    }
+
+    func stage(_ relativePath: String, at root: URL) throws {
+        _ = try runGit(["add", "--", relativePath], at: root)
+    }
+
+    func commit(_ message: String, at root: URL) throws {
+        _ = try runGit(["commit", "-m", message], at: root)
+    }
+
+    func headBlobOID(for relativePath: String, at root: URL) throws -> String {
+        try runGit(["rev-parse", "--verify", "HEAD:\(relativePath)"], at: root)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    @discardableResult
+    func runGit(_ arguments: [String], at root: URL) throws -> String {
+        let process = Process()
+        let standardOutput = Pipe()
+        let standardError = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + arguments
+        process.currentDirectoryURL = root
+        process.standardOutput = standardOutput
+        process.standardError = standardError
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+        environment["HOME"] = sandbox.path
+        environment["LC_ALL"] = "C"
+        process.environment = environment
+        try process.run()
+        process.waitUntilExit()
+        let output = standardOutput.fileHandleForReading.readDataToEndOfFile()
+        let error = standardError.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "ReviewGitRepositoryFixture.git",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: String(decoding: error, as: UTF8.self)]
+            )
+        }
+        return String(decoding: output, as: UTF8.self)
+    }
+}

--- a/Tests/RepoPromptTests/Services/VCS/GitBlobIdentityServiceTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitBlobIdentityServiceTests.swift
@@ -1,0 +1,133 @@
+import Darwin
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class GitBlobIdentityServiceTests: XCTestCase {
+    func testNestedRepositoryMarkersUseValidatedLeafBytesAndRetainOwnRootBlobEligibility() async throws {
+        let fixture = try ReviewGitRepositoryFixture(name: #function)
+        let contents = "struct BoundaryOwned {}\n"
+        let repository = try fixture.makeRepository(
+            named: "outer",
+            files: [
+                "Nested/Sources/Feature.swift": contents,
+                "Nested/Sources/Link.swift": contents,
+                "GitFileBoundary/Sources/Feature.swift": contents
+            ]
+        )
+        let nested = repository.appendingPathComponent("Nested", isDirectory: true)
+        try fixture.initializeRepository(at: nested)
+        try fixture.stage("Sources/Feature.swift", at: nested)
+        try fixture.stage("Sources/Link.swift", at: nested)
+        try fixture.commit("Nested repository", at: nested)
+        let nestedLink = nested.appendingPathComponent("Sources/Link.swift")
+        try FileManager.default.removeItem(at: nestedLink)
+        try FileManager.default.createSymbolicLink(
+            at: nestedLink,
+            withDestinationURL: URL(fileURLWithPath: "Feature.swift")
+        )
+        try fixture.stage("Sources/Link.swift", at: nested)
+        try fixture.commit("Nested symlink", at: nested)
+
+        let pointerWorktree = repository.appendingPathComponent("GitFileBoundary", isDirectory: true)
+        let pointerGitDirectory = fixture.sandbox.appendingPathComponent(
+            "GitFileBoundary.git",
+            isDirectory: true
+        )
+        try fixture.initializeRepository(
+            at: pointerWorktree,
+            separateGitDirectory: pointerGitDirectory
+        )
+        try fixture.stage("Sources/Feature.swift", at: pointerWorktree)
+        try fixture.commit("Pointer repository", at: pointerWorktree)
+
+        let service = GitBlobIdentityService()
+        for root in [nested, pointerWorktree] {
+            let batch = await service.classify(
+                workspaceRoot: root,
+                relativePaths: ["Sources/Feature.swift"]
+            )
+            let expectedOID = try fixture.headBlobOID(for: "Sources/Feature.swift", at: root)
+            guard case let .oidEligible(oid)? = batch.classifications.first?.outcome else {
+                return XCTFail("Nested repository root should retain its own Git blob eligibility")
+            }
+            XCTAssertEqual(oid.lowercaseHex, expectedOID)
+        }
+
+        for root in [nested, pointerWorktree] {
+            try fixture.write(
+                "Sources/*.swift filter=nested-owned\n",
+                to: ".gitattributes",
+                at: root
+            )
+            try fixture.stage(".gitattributes", at: root)
+            try fixture.commit("Nested attributes", at: root)
+        }
+
+        let relativePaths = [
+            "Nested/Sources/Feature.swift",
+            "GitFileBoundary/Sources/Feature.swift"
+        ]
+        let outer = await service.classify(
+            workspaceRoot: repository,
+            relativePaths: relativePaths
+        )
+
+        XCTAssertNil(outer.failure)
+        XCTAssertFalse(outer.retriedAfterInstability)
+        XCTAssertEqual(
+            outer.classifications.map(\.outcome),
+            [
+                .requiresValidatedWorktreeBytes(.nestedRepository),
+                .requiresValidatedWorktreeBytes(.nestedRepository)
+            ]
+        )
+
+        let markerURLs = [
+            nested.appendingPathComponent(".git"),
+            pointerWorktree.appendingPathComponent(".git")
+        ]
+        for (index, classification) in outer.classifications.enumerated() {
+            let sourceURL = repository.appendingPathComponent(relativePaths[index])
+            let sourceFingerprint = try XCTUnwrap(Self.fingerprint(at: sourceURL))
+            let markerFingerprint = try XCTUnwrap(Self.fingerprint(at: markerURLs[index]))
+            XCTAssertEqual(classification.validationTokens.preWorktree, sourceFingerprint)
+            XCTAssertEqual(classification.validationTokens.postWorktree, sourceFingerprint)
+            XCTAssertNotEqual(classification.validationTokens.postWorktree, markerFingerprint)
+            XCTAssertEqual(classification.attributes, .unspecified)
+            XCTAssertTrue(classification.indexEntries.contains { entry in
+                entry.stage == 0 &&
+                    entry.isRegularFile &&
+                    entry.oid == (try? fixture.headBlobOID(
+                        for: relativePaths[index],
+                        at: repository
+                    ))
+            })
+        }
+
+        let terminalBatch = await service.classify(
+            workspaceRoot: repository,
+            relativePaths: ["Nested/Sources/Link.swift"]
+        )
+        let terminal = try XCTUnwrap(terminalBatch.classifications.first)
+        XCTAssertNil(terminalBatch.failure)
+        XCTAssertEqual(terminal.outcome, .securityExcluded(.symlinkLeaf))
+        XCTAssertEqual(terminal.attributes, .unspecified)
+        XCTAssertTrue(terminal.indexEntries.contains { $0.stage == 0 && $0.isRegularFile })
+    }
+
+    private static func fingerprint(at url: URL) -> GitBlobLStatFingerprint? {
+        var value = stat()
+        guard lstat(url.path, &value) == 0 else { return nil }
+        return GitBlobLStatFingerprint(
+            device: UInt64(value.st_dev),
+            inode: UInt64(value.st_ino),
+            mode: UInt16(value.st_mode),
+            size: Int64(value.st_size),
+            modificationSeconds: Int64(value.st_mtimespec.tv_sec),
+            modificationNanoseconds: Int64(value.st_mtimespec.tv_nsec),
+            changeSeconds: Int64(value.st_ctimespec.tv_sec),
+            changeNanoseconds: Int64(value.st_ctimespec.tv_nsec)
+        )
+    }
+}

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class CodemapAutomaticSelectionGraphNativeTests: XCTestCase {
+    func testNestedRepositoryGraphUsesValidatedWorktreeBytesAndCompletesWithoutRetry() async throws {
+        let repository = try ReviewGitRepositoryFixture(name: #function)
+        let relativePath = "Nested/Sources/Feature.swift"
+        let rootURL = try repository.makeRepository(
+            named: "outer",
+            files: [relativePath: "struct OuterBlobOnly { let value: Int }\n"]
+        )
+        let nestedRoot = rootURL.appendingPathComponent("Nested", isDirectory: true)
+        try repository.initializeRepository(at: nestedRoot)
+        try repository.write(
+            "struct NestedWorktreeOnly { let value: Int }\n",
+            to: "Sources/Feature.swift",
+            at: nestedRoot
+        )
+        try repository.stage("Sources/Feature.swift", at: nestedRoot)
+        try repository.commit("Nested worktree content", at: nestedRoot)
+
+        let outerBlob = try repository.runGit(["show", "HEAD:\(relativePath)"], at: rootURL)
+        let worktreeBytes = try String(
+            contentsOf: rootURL.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+        XCTAssertTrue(outerBlob.contains("OuterBlobOnly"))
+        XCTAssertTrue(worktreeBytes.contains("NestedWorktreeOnly"))
+
+        let fixture = try CodemapStoreFixture(name: #function)
+        let store = fixture.makeStore()
+        let loaded = try await store.loadRoot(path: rootURL.path)
+        addTeardownBlock {
+            await store.unloadRoot(id: loaded.id)
+            await fixture.shutdown()
+            repository.cleanup()
+        }
+
+        let files = await store.files(inRoot: loaded.id)
+        let nestedFile = try XCTUnwrap(files.first {
+            $0.standardizedRelativePath == relativePath
+        })
+        let engine = try fixture.runtime().bindingEngine()
+        let rootAccounting = try await waitForGraphCompletion(
+            engine: engine,
+            rootID: loaded.id
+        )
+
+        XCTAssertEqual(rootAccounting.phase, .complete)
+        XCTAssertEqual(rootAccounting.retryAttempt, 0)
+        XCTAssertNil(rootAccounting.retry)
+        XCTAssertNotNil(rootAccounting.progress.catalogCompletion)
+        XCTAssertEqual(rootAccounting.progress.counts.transientCount, 0)
+        XCTAssertEqual(rootAccounting.progress.counts.terminalExcludedCount, 0)
+
+        let accounting = await engine.accounting()
+        XCTAssertEqual(accounting.counters.graphIndexRetries, 0)
+        let maybeGraph = await engine.selectionGraph(rootEpoch: rootAccounting.rootEpoch)
+        let graph = try XCTUnwrap(maybeGraph)
+        let pinned: WorkspaceCodemapGraphPinnedSnapshot
+        switch await graph.latestSnapshot() {
+        case let .ready(snapshot):
+            pinned = snapshot
+        case .pending:
+            return XCTFail("Completed graph index should publish a graph snapshot")
+        case let .revoked(reason):
+            return XCTFail("Completed graph index should not be revoked: \(reason)")
+        }
+
+        XCTAssertTrue(pinned.snapshot.coverage.isComplete)
+        XCTAssertEqual(pinned.snapshot.coverage.pendingCount, 0)
+        XCTAssertEqual(pinned.snapshot.coverage.terminalExcludedCount, 0)
+        let node = try XCTUnwrap(pinned.snapshot.nodesByFileID[nestedFile.id])
+        XCTAssertTrue(node.contribution.sortedUniqueDefinitions.contains("NestedWorktreeOnly"))
+        XCTAssertFalse(node.contribution.sortedUniqueDefinitions.contains("OuterBlobOnly"))
+        guard case .contributed = pinned.snapshot.slotsByFileID[nestedFile.id]?.state else {
+            return XCTFail("Nested source should contribute to the completed graph")
+        }
+        XCTAssertFalse(pinned.snapshot.slotsByFileID.values.contains { slot in
+            if case .terminalExcluded(.repositoryBoundary) = slot.state { return true }
+            return false
+        })
+        XCTAssertTrue(fixture.builtSourceTexts.values.contains { $0.contains("NestedWorktreeOnly") })
+        XCTAssertFalse(fixture.builtSourceTexts.values.contains { $0.contains("OuterBlobOnly") })
+    }
+
+    private func waitForGraphCompletion(
+        engine: WorkspaceCodemapBindingEngine,
+        rootID: UUID
+    ) async throws -> WorkspaceCodemapBindingEngineGraphIndexRootAccounting {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(20))
+        while clock.now < deadline {
+            let accounting = await engine.accounting()
+            if let root = accounting.graphIndexRoots.first(where: { $0.rootEpoch.rootID == rootID }),
+               root.phase == .complete
+            {
+                return root
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        throw GraphWaitError.timedOut
+    }
+}
+
+private enum GraphWaitError: Error {
+    case timedOut
+}


### PR DESCRIPTION
Fixes https://github.com/repoprompt/repoprompt-ce/issues/886.  A workspace root containing nested Git repos could leave background codemap (CM) indexing stuck retrying the same catalog page indefinitely.

The likely regression came from the content-addressed CM source-acquisition path (https://github.com/repoprompt/repoprompt-ce/pull/314).  Nested `.git` detection correctly prevented the outer repo's blob identity from authorizing those files, but classified them as repo-unavailable instead of using the existing validated-worktree path.  The graph treated that stable condition as transient, discarded the completed page, and retried the same cursor.

Instead of excluding nested source this patch restores CM eligibility for every supported file admitted by the workspace catalog.  Nested files are built from their current fingerprint-validated worktree bytes and normal ignore policy is unchanged.

## Summary

- Continue descriptor-safe traversal beyond nested `.git` directory and pointer-file markers
- Preserve the requested leaf fingerprint instead of the repo marker fingerprint
- Route regular nested source through the existing validated-worktree CM path
- Prevent outer Git blobs, attributes, status, and path-local metadata from becoming authoritative after a nested boundary
- Preserve existing missing, symlink, nonregular, and probe-failure outcomes
- Complete graph indexing without boundary-driven retries or terminal exclusions

## Implementation Notes

- `GitBlobIdentityService` remains the sole source-provenance classifier
- The graph index, workspace catalog, root topology, ignore handling, and UI are unchanged
- No nested Git commands, repo lifecycle, retry mechanism, compatibility path, or new source-acquisition path was added
- Outer index entries remain available as non-authoritative evidence that the nested boundary takes precedence

## Review Approach

- The patch received one focused maintainability review and complete-patch correctness reviews tethered to the originating issue's scope
- Findings around nested-owned Git metadata and retaining boundary state across terminal leaf outcomes were fixed with focused regressions

## Validation

Passed locally:

- `make dev-test FILTER=GitBlobIdentityServiceTests`
- `make dev-test FILTER=CodemapAutomaticSelectionGraphNativeTests`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- PR-ready preflight, including the matching path-selected heavyweight lanes
- Commit and push safety preflights, including staged-index and outgoing-range secret scans

I also validated the full flow in the Debug app with a real workspace root containing nested Git repos.  Once the repos were admitted by the workspace's existing ignore policy, they remained visible through the parent root and agents could retrieve their CMs while the parent graph completed normally.