### PR TITLE
Add Oracle image attachments

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
@@ -151,7 +151,7 @@ enum AgentToolArgumentPersistencePolicy {
         guard let data = argsJSON.data(using: .utf8),
               var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
-            return argsJSON.contains("\"images\"") ? nil : argsJSON
+            return partialArgumentsCouldContainImagesKey(argsJSON) ? nil : argsJSON
         }
         guard object.removeValue(forKey: "images") != nil else { return argsJSON }
         guard JSONSerialization.isValidJSONObject(object),
@@ -160,6 +160,109 @@ enum AgentToolArgumentPersistencePolicy {
             return nil
         }
         return String(data: sanitized, encoding: .utf8)
+    }
+
+    private static func partialArgumentsCouldContainImagesKey(_ text: String) -> Bool {
+        let target = "images"
+        let scalars = Array(text.unicodeScalars)
+        var index = 0
+        while index < scalars.count, CharacterSet.whitespacesAndNewlines.contains(scalars[index]) {
+            index += 1
+        }
+        guard index < scalars.count else { return false }
+        guard scalars[index] == "{" else { return true }
+        index += 1
+
+        var depth = 1
+        var expectingTopLevelKey = true
+        var inString = false
+        var stringIsTopLevelKey = false
+        var key = ""
+        var escaped = false
+
+        func appendKeyScalar(_ scalar: UnicodeScalar, to key: inout String) {
+            guard key.count <= target.count else { return }
+            key.unicodeScalars.append(scalar)
+        }
+
+        while index < scalars.count {
+            let scalar = scalars[index]
+            if inString {
+                if escaped {
+                    if scalar == "u" {
+                        guard index + 4 < scalars.count else {
+                            return stringIsTopLevelKey && target.hasPrefix(key)
+                        }
+                        if stringIsTopLevelKey {
+                            let digits = String(String.UnicodeScalarView(scalars[(index + 1) ... (index + 4)]))
+                            guard let value = UInt32(digits, radix: 16), let decoded = UnicodeScalar(value) else {
+                                return true
+                            }
+                            appendKeyScalar(decoded, to: &key)
+                        }
+                        index += 5
+                        escaped = false
+                        continue
+                    }
+                    if stringIsTopLevelKey {
+                        let decoded: UnicodeScalar = switch scalar {
+                        case "\"": "\""
+                        case "\\": "\\"
+                        case "/": "/"
+                        case "b": "\u{08}"
+                        case "f": "\u{0C}"
+                        case "n": "\n"
+                        case "r": "\r"
+                        case "t": "\t"
+                        default: scalar
+                        }
+                        appendKeyScalar(decoded, to: &key)
+                    }
+                    escaped = false
+                    index += 1
+                    continue
+                }
+                if scalar == "\\" {
+                    escaped = true
+                } else if scalar == "\"" {
+                    if stringIsTopLevelKey, key == target {
+                        return true
+                    }
+                    inString = false
+                    if stringIsTopLevelKey {
+                        expectingTopLevelKey = false
+                    }
+                } else if stringIsTopLevelKey {
+                    appendKeyScalar(scalar, to: &key)
+                }
+                index += 1
+                continue
+            }
+
+            switch scalar {
+            case "\"":
+                inString = true
+                stringIsTopLevelKey = depth == 1 && expectingTopLevelKey
+                key = ""
+            case "{", "[":
+                depth += 1
+            case "}", "]":
+                depth -= 1
+                if depth <= 0 { return true }
+            case "," where depth == 1:
+                expectingTopLevelKey = true
+            default:
+                if depth == 1, expectingTopLevelKey,
+                   !CharacterSet.whitespacesAndNewlines.contains(scalar)
+                {
+                    return true
+                }
+            }
+            index += 1
+        }
+
+        guard inString, stringIsTopLevelKey else { return false }
+        return escaped || target.hasPrefix(key)
     }
 
     private static func normalizedToolName(_ toolName: String?) -> String? {
@@ -332,6 +435,34 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
         )?.validated
     }
 
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(text, forKey: .text)
+        try container.encode(attachments, forKey: .attachments)
+        try container.encode(taggedFileAttachments, forKey: .taggedFileAttachments)
+        let acceptedToolName = AgentToolNamePolicy.accepted(toolName)
+        try container.encodeIfPresent(acceptedToolName, forKey: .toolName)
+        try container.encodeIfPresent(toolInvocationID, forKey: .toolInvocationID)
+        try container.encodeIfPresent(
+            AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+                toolName: acceptedToolName,
+                argsJSON: toolArgsJSON
+            ),
+            forKey: .toolArgsJSON
+        )
+        try container.encodeIfPresent(toolResultJSON, forKey: .toolResultJSON)
+        try container.encodeIfPresent(toolIsError, forKey: .toolIsError)
+        try container.encodeIfPresent(reasoning, forKey: .reasoning)
+        try container.encode(sequenceIndex, forKey: .sequenceIndex)
+        try container.encode(isStreaming, forKey: .isStreaming)
+        try container.encodeIfPresent(workflow, forKey: .workflow)
+        try container.encodeIfPresent(codexGoalMode, forKey: .codexGoalMode)
+        try container.encode(isLocalControlPlaneEcho, forKey: .isLocalControlPlaneEcho)
+    }
+
     // MARK: - Factory Methods
 
     public static func user(_ text: String, attachments: [AgentImageAttachment] = [], taggedFileAttachments: [AgentTaggedFileAttachment] = [], sequenceIndex: Int = 0, workflow: AgentWorkflowDefinition? = nil, codexGoalMode: AgentCodexGoalModeMetadata? = nil, isLocalControlPlaneEcho: Bool = false, crossSessionAttribution: AgentCrossSessionAttribution? = nil) -> AgentChatItem {
@@ -446,11 +577,23 @@ public struct AgentChatItemPersist: Codable, Identifiable, Sendable, Equatable {
     public var toolName: String? {
         didSet {
             toolName = AgentToolNamePolicy.accepted(toolName)
+            toolArgsJSON = AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+                toolName: toolName,
+                argsJSON: toolArgsJSON
+            )
         }
     }
 
     public var toolInvocationID: UUID?
-    public var toolArgsJSON: String?
+    public var toolArgsJSON: String? {
+        didSet {
+            toolArgsJSON = AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+                toolName: toolName,
+                argsJSON: toolArgsJSON
+            )
+        }
+    }
+
     public var toolResultJSON: String?
     public var toolIsError: Bool?
     public var toolResultStatus: String?
@@ -472,7 +615,11 @@ public struct AgentChatItemPersist: Codable, Identifiable, Sendable, Equatable {
         taggedFileAttachments = item.taggedFileAttachments
         toolName = AgentToolNamePolicy.accepted(item.toolName)
         toolInvocationID = item.toolInvocationID
-        toolArgsJSON = sanitizeToolResults && (item.kind == .toolCall || item.kind == .toolResult) ? nil : item.toolArgsJSON
+        let copiedToolArgs = sanitizeToolResults && (item.kind == .toolCall || item.kind == .toolResult) ? nil : item.toolArgsJSON
+        toolArgsJSON = AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+            toolName: toolName,
+            argsJSON: copiedToolArgs
+        )
         reasoning = item.reasoning
         sequenceIndex = item.sequenceIndex
         workflow = item.workflow
@@ -605,6 +752,34 @@ public struct AgentChatItemPersist: Codable, Identifiable, Sendable, Equatable {
         case laneUpdateDisplayAttribution
     }
 
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(text, forKey: .text)
+        try container.encode(attachments, forKey: .attachments)
+        try container.encode(taggedFileAttachments, forKey: .taggedFileAttachments)
+        let acceptedToolName = AgentToolNamePolicy.accepted(toolName)
+        try container.encodeIfPresent(acceptedToolName, forKey: .toolName)
+        try container.encodeIfPresent(toolInvocationID, forKey: .toolInvocationID)
+        try container.encodeIfPresent(
+            AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+                toolName: acceptedToolName,
+                argsJSON: toolArgsJSON
+            ),
+            forKey: .toolArgsJSON
+        )
+        try container.encodeIfPresent(toolResultJSON, forKey: .toolResultJSON)
+        try container.encodeIfPresent(toolIsError, forKey: .toolIsError)
+        try container.encodeIfPresent(toolResultStatus, forKey: .toolResultStatus)
+        try container.encodeIfPresent(reasoning, forKey: .reasoning)
+        try container.encode(sequenceIndex, forKey: .sequenceIndex)
+        try container.encodeIfPresent(workflow, forKey: .workflow)
+        try container.encodeIfPresent(codexGoalMode, forKey: .codexGoalMode)
+        try container.encode(isLocalControlPlaneEcho, forKey: .isLocalControlPlaneEcho)
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
@@ -615,7 +790,10 @@ public struct AgentChatItemPersist: Codable, Identifiable, Sendable, Equatable {
         taggedFileAttachments = try container.decodeIfPresent([AgentTaggedFileAttachment].self, forKey: .taggedFileAttachments) ?? []
         toolName = try AgentToolNamePolicy.accepted(container.decodeIfPresent(String.self, forKey: .toolName))
         toolInvocationID = try container.decodeIfPresent(UUID.self, forKey: .toolInvocationID)
-        toolArgsJSON = try container.decodeIfPresent(String.self, forKey: .toolArgsJSON)
+        toolArgsJSON = try AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+            toolName: toolName,
+            argsJSON: container.decodeIfPresent(String.self, forKey: .toolArgsJSON)
+        )
         toolResultJSON = try container.decodeIfPresent(String.self, forKey: .toolResultJSON)
         toolIsError = try container.decodeIfPresent(Bool.self, forKey: .toolIsError)
         toolResultStatus = try container.decodeIfPresent(String.self, forKey: .toolResultStatus)

--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
@@ -144,6 +144,33 @@ public struct AgentCrossSessionAttribution: Codable, Sendable, Equatable, Hashab
 
 // MARK: - Agent Chat Item
 
+enum AgentToolArgumentPersistencePolicy {
+    static func sanitizedArgsJSON(toolName: String?, argsJSON: String?) -> String? {
+        guard let argsJSON else { return nil }
+        guard normalizedToolName(toolName) == "ask_oracle" else { return argsJSON }
+        guard let data = argsJSON.data(using: .utf8),
+              var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        guard object.removeValue(forKey: "images") != nil else { return argsJSON }
+        guard JSONSerialization.isValidJSONObject(object),
+              let sanitized = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        else {
+            return nil
+        }
+        return String(data: sanitized, encoding: .utf8)
+    }
+
+    private static func normalizedToolName(_ toolName: String?) -> String? {
+        toolName?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .components(separatedBy: "__")
+            .last
+    }
+}
+
 /// A single item in an agent chat transcript (user message, assistant message, tool call, etc.)
 public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
     public let id: UUID
@@ -163,11 +190,23 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
     public var toolName: String? {
         didSet {
             toolName = AgentToolNamePolicy.accepted(toolName)
+            toolArgsJSON = AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+                toolName: toolName,
+                argsJSON: toolArgsJSON
+            )
         }
     }
 
     public var toolInvocationID: UUID?
-    public var toolArgsJSON: String? // JSON string of tool arguments
+    public var toolArgsJSON: String? {
+        didSet {
+            toolArgsJSON = AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+                toolName: toolName,
+                argsJSON: toolArgsJSON
+            )
+        }
+    }
+
     public var toolResultJSON: String? // Tool execution result JSON (for toolResult kind)
     public var toolIsError: Bool?
 
@@ -228,7 +267,10 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
         self.taggedFileAttachments = taggedFileAttachments
         self.toolName = AgentToolNamePolicy.accepted(toolName)
         self.toolInvocationID = toolInvocationID
-        self.toolArgsJSON = toolArgsJSON
+        self.toolArgsJSON = AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+            toolName: self.toolName,
+            argsJSON: toolArgsJSON
+        )
         self.toolResultJSON = toolResultJSON
         self.toolIsError = toolIsError
         self.reasoning = reasoning
@@ -266,7 +308,10 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
         taggedFileAttachments = try c.decodeIfPresent([AgentTaggedFileAttachment].self, forKey: .taggedFileAttachments) ?? []
         toolName = try AgentToolNamePolicy.accepted(c.decodeIfPresent(String.self, forKey: .toolName))
         toolInvocationID = try c.decodeIfPresent(UUID.self, forKey: .toolInvocationID)
-        toolArgsJSON = try c.decodeIfPresent(String.self, forKey: .toolArgsJSON)
+        toolArgsJSON = try AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+            toolName: toolName,
+            argsJSON: c.decodeIfPresent(String.self, forKey: .toolArgsJSON)
+        )
         toolResultJSON = try c.decodeIfPresent(String.self, forKey: .toolResultJSON)
         toolIsError = try c.decodeIfPresent(Bool.self, forKey: .toolIsError)
         reasoning = try c.decodeIfPresent(String.self, forKey: .reasoning)

--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
@@ -151,7 +151,7 @@ enum AgentToolArgumentPersistencePolicy {
         guard let data = argsJSON.data(using: .utf8),
               var object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
-            return nil
+            return argsJSON.contains("\"images\"") ? nil : argsJSON
         }
         guard object.removeValue(forKey: "images") != nil else { return argsJSON }
         guard JSONSerialization.isValidJSONObject(object),

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+Groups.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+Groups.swift
@@ -314,7 +314,7 @@ extension OracleViewModel {
                         "Image attachments require every Oracle lane model to be configured; Oracle \(laneIndex + 1) is unavailable."
                     )
                 }
-                guard OracleImageRouteAdmission.supportsCurrentRoute(resolvedModel) else {
+                guard OracleImageRouteAdmission.supports(resolvedModel) else {
                     throw ChatToolError.invalidParams(
                         "Image attachments are not supported by Oracle \(laneIndex + 1)'s model '\(resolvedModel.displayName)' on provider '\(resolvedModel.providerType.displayName)'."
                     )

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+Groups.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+Groups.swift
@@ -303,6 +303,24 @@ extension OracleViewModel {
             primaryRaw: args["model"]?.stringValue ?? profile.planningModelRaw,
             additionalRaws: profile.additionalOracleModelRaws
         )
+        if let images = tabContext?.transientImages, !images.isEmpty {
+            for (laneIndex, laneModel) in roster.orderedModels.enumerated() {
+                let resolution = PromptViewModel.mcpOraclePlanningModelResolution(
+                    rawValue: laneModel.modelID,
+                    isModelAvailable: { promptVM.mcpOracleIsProviderConfigured(for: $0) }
+                )
+                guard case let .configured(resolvedModel) = resolution else {
+                    throw ChatToolError.invalidParams(
+                        "Image attachments require every Oracle lane model to be configured; Oracle \(laneIndex + 1) is unavailable."
+                    )
+                }
+                guard OracleImageRouteAdmission.supportsCurrentRoute(resolvedModel) else {
+                    throw ChatToolError.invalidParams(
+                        "Image attachments are not supported by Oracle \(laneIndex + 1)'s model '\(resolvedModel.displayName)' on provider '\(resolvedModel.providerType.displayName)'."
+                    )
+                }
+            }
+        }
         let input = try frozenInput ?? OracleInput(mode: mode, userMessage: message)
         guard input.mode == mode, input.userMessage == message else {
             throw ChatToolError.invalidParams("Frozen Oracle input does not match the requested mode and message.")
@@ -677,7 +695,8 @@ extension OracleViewModel {
             agentModeSessionID: context.agentModeSessionID,
             agentModeRunID: context.agentModeRunID,
             activationPolicy: .background,
-            packaging: context.packaging
+            packaging: context.packaging,
+            transientImages: context.transientImages
         )
     }
 

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -1196,7 +1196,7 @@ extension OracleViewModel {
         let selectedModel = modelSelection.model
         let transientImages = tabContext?.transientImages ?? []
         if !transientImages.isEmpty,
-           !OracleImageRouteAdmission.supportsCurrentRoute(selectedModel)
+           !OracleImageRouteAdmission.supports(selectedModel)
         {
             throw ChatToolError.invalidParams(
                 "Image attachments are not supported by the selected Oracle model '\(selectedModel.displayName)' on provider '\(selectedModel.providerType.displayName)'."

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -129,6 +129,7 @@ extension OracleViewModel {
         let agentModeRunID: UUID?
         let activationPolicy: OracleSendActivationPolicy
         let packaging: OracleSendPackagingContext
+        let transientImages: [AITransientImage]
 
         init(
             tabID: UUID,
@@ -137,7 +138,8 @@ extension OracleViewModel {
             agentModeSessionID: UUID? = nil,
             agentModeRunID: UUID? = nil,
             activationPolicy: OracleSendActivationPolicy = .foregroundWhenActive,
-            packaging: OracleSendPackagingContext
+            packaging: OracleSendPackagingContext,
+            transientImages: [AITransientImage] = []
         ) {
             self.tabID = tabID
             self.workspaceID = workspaceID
@@ -146,6 +148,7 @@ extension OracleViewModel {
             self.agentModeRunID = agentModeRunID
             self.activationPolicy = activationPolicy
             self.packaging = packaging
+            self.transientImages = transientImages
         }
     }
 
@@ -818,6 +821,14 @@ extension OracleViewModel {
         return true
     }
 
+    static func validateRawImageDispatchInvariant(_ args: [String: Value]) throws {
+        guard args["images"] == nil else {
+            throw ChatToolError.internalError(
+                "Raw ask_oracle image arguments must be consumed before Oracle dispatch."
+            )
+        }
+    }
+
     static func sessionMatchesOracleOwnerForExplicitContinuation(
         _ session: ChatSession,
         agentModeSessionID: UUID?,
@@ -1122,6 +1133,7 @@ extension OracleViewModel {
         -> [String: Value]
     {
         // ────────── 1. Validate & extract parameters ──────────
+        try Self.validateRawImageDispatchInvariant(args)
         let removedArgs = ["selected_paths", "git_scope", "git_base"].filter { args[$0] != nil }
         if !removedArgs.isEmpty {
             throw ChatToolError.invalidParams(
@@ -1182,6 +1194,14 @@ extension OracleViewModel {
         }
 
         let selectedModel = modelSelection.model
+        let transientImages = tabContext?.transientImages ?? []
+        if !transientImages.isEmpty,
+           !OracleImageRouteAdmission.supportsCurrentRoute(selectedModel)
+        {
+            throw ChatToolError.invalidParams(
+                "Image attachments are not supported by the selected Oracle model '\(selectedModel.displayName)' on provider '\(selectedModel.providerType.displayName)'."
+            )
+        }
         let mcpControlledModel = modelSelection.mcpControlInfo
         let overrideModelName = selectedModel.displayName
         let overrideChatPresetName: String? = {
@@ -1245,6 +1265,7 @@ extension OracleViewModel {
                 lookupContextOverride: lookupContextOverride,
                 reviewGitContextOverride: reviewGitContextOverride,
                 overrideAIMessage: tabContext?.packaging.prebuiltAIMessage,
+                oracleTransientImages: transientImages,
                 onProgress: onProgress
             )
         }

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -3216,7 +3216,7 @@ class OracleViewModel: ObservableObject {
                     )
                 }
                 if !oracleTransientImages.isEmpty {
-                    aiMessage = aiMessage.replacingTransientImages(oracleTransientImages)
+                    aiMessage.transientImages = oracleTransientImages
                 }
                 guard await shouldContinueStreaming() else {
                     throw CancellationError()

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -3068,6 +3068,7 @@ class OracleViewModel: ObservableObject {
         lookupContextOverride: WorkspaceLookupContext? = nil,
         reviewGitContextOverride: FrozenPromptGitReviewContext? = nil,
         overrideAIMessage: AIMessage? = nil,
+        oracleTransientImages: [AITransientImage] = [],
         completionPolicy: OracleResponseCompletionPolicy = .interactive,
         onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
     ) async -> UUID? {
@@ -3180,7 +3181,7 @@ class OracleViewModel: ObservableObject {
                     throw CancellationError()
                 }
 
-                let aiMessage: AIMessage
+                var aiMessage: AIMessage
                 if let overrideAIMessage = overrideAIMessage.flatMap({
                     self.validatedOverrideAIMessage(
                         $0,
@@ -3213,6 +3214,9 @@ class OracleViewModel: ObservableObject {
                         lookupContextOverride: lookupContextOverride,
                         reviewGitContextOverride: reviewGitContextOverride
                     )
+                }
+                if !oracleTransientImages.isEmpty {
+                    aiMessage = aiMessage.replacingTransientImages(oracleTransientImages)
                 }
                 guard await shouldContinueStreaming() else {
                     throw CancellationError()

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPPromptContentBuilder.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPPromptContentBuilder.swift
@@ -17,8 +17,16 @@ enum ACPPromptContentBuilder {
         text: String,
         attachments: [AgentImageAttachment]
     ) throws -> [[String: Any]] {
+        try blocks(text: text, attachments: attachments, transientImages: [])
+    }
+
+    static func blocks(
+        text: String,
+        attachments: [AgentImageAttachment],
+        transientImages: [AITransientImage]
+    ) throws -> [[String: Any]] {
         var blocks: [[String: Any]] = []
-        if !text.isEmpty || attachments.isEmpty {
+        if !text.isEmpty || attachments.isEmpty && transientImages.isEmpty {
             blocks.append([
                 "type": "text",
                 "text": text
@@ -29,6 +37,19 @@ enum ACPPromptContentBuilder {
             if let block = try imageBlock(for: attachment) {
                 blocks.append(block)
             }
+        }
+        for image in transientImages {
+            if let title = image.normalizedTitle {
+                blocks.append([
+                    "type": "text",
+                    "text": "Image title: \(title)"
+                ])
+            }
+            blocks.append([
+                "type": "image",
+                "mimeType": image.mediaType.rawValue,
+                "data": image.base64Payload
+            ])
         }
 
         return blocks

--- a/Sources/RepoPrompt/Infrastructure/AI/AIMessage.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIMessage.swift
@@ -1,6 +1,20 @@
 import Foundation
 import SwiftOpenAI
 
+enum AIImageMediaType: String, Equatable {
+    case png = "image/png"
+    case jpeg = "image/jpeg"
+    case gif = "image/gif"
+    case webp = "image/webp"
+}
+
+/// Request-scoped Oracle image data. Deliberately non-Codable and path-free.
+struct AITransientImage: Equatable {
+    let bytes: Data
+    let mediaType: AIImageMediaType
+    let title: String?
+}
+
 /// A single conversation entry
 struct ConversationEntry {
     enum Role {
@@ -31,6 +45,9 @@ struct AIMessage {
 
     /// NEW: Full conversation array, user + AI in order
     let conversationMessages: [ConversationEntry]
+
+    /// Request-scoped provider payload. Never copied into persisted chat messages.
+    let transientImages: [AITransientImage]
 
     let temperature: Double?
 
@@ -118,6 +135,7 @@ struct AIMessage {
         fileBlocks: [String] = [],
         gitDiff: String? = nil,
         conversationMessages: [ConversationEntry] = [],
+        transientImages: [AITransientImage] = [],
         temperature: Double?,
         promptSectionsOrder: [PromptSection],
         disabledPromptSections: Set<PromptSection>,
@@ -129,6 +147,7 @@ struct AIMessage {
         self.fileBlocks = fileBlocks
         self.gitDiff = gitDiff
         self.conversationMessages = conversationMessages
+        self.transientImages = transientImages
         self.temperature = temperature
         self.promptSectionsOrder = promptSectionsOrder
         self.disabledPromptSections = disabledPromptSections
@@ -148,10 +167,27 @@ struct AIMessage {
         conversationMessages = [
             ConversationEntry(role: .user, content: userMessage)
         ]
+        transientImages = []
         // Use library defaults for prompt ordering
         promptSectionsOrder = PromptAssemblyBuilder.defaultSectionOrder
         disabledPromptSections = []
         duplicateUserInstructionsAtTop = false
+    }
+
+    func replacingTransientImages(_ images: [AITransientImage]) -> AIMessage {
+        AIMessage(
+            systemPrompt: systemPrompt,
+            metaPrompts: metaPrompts,
+            fileTree: fileTree,
+            fileBlocks: fileBlocks,
+            gitDiff: gitDiff,
+            conversationMessages: conversationMessages,
+            transientImages: images,
+            temperature: temperature,
+            promptSectionsOrder: promptSectionsOrder,
+            disabledPromptSections: disabledPromptSections,
+            duplicateUserInstructionsAtTop: duplicateUserInstructionsAtTop
+        )
     }
 
     /// Builds the text block that must be *prepended* to the **final** user

--- a/Sources/RepoPrompt/Infrastructure/AI/AIMessage.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIMessage.swift
@@ -13,6 +13,29 @@ struct AITransientImage: Equatable {
     let bytes: Data
     let mediaType: AIImageMediaType
     let title: String?
+
+    var base64Payload: String {
+        bytes.base64EncodedString()
+    }
+
+    var openAIDataURL: String {
+        "data:\(mediaType.rawValue);base64,\(base64Payload)"
+    }
+
+    var normalizedTitle: String? {
+        guard let title else { return nil }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    var preferredFileExtension: String {
+        switch mediaType {
+        case .png: "png"
+        case .jpeg: "jpg"
+        case .gif: "gif"
+        case .webp: "webp"
+        }
+    }
 }
 
 /// A single conversation entry
@@ -247,7 +270,15 @@ struct AIMessage {
             let role: ChatCompletionParameters.Message.Role = (entry.role == .user)
                 ? .user
                 : .assistant
-            msgs.append(.init(role: role, content: .text(text)))
+            if entry.role == .user, idx == lastUserIndex, !transientImages.isEmpty {
+                msgs.append(.init(role: role, content: openAIChatContent(text: text)))
+            } else {
+                msgs.append(.init(role: role, content: .text(text)))
+            }
+        }
+
+        if lastUserIndex == nil, !transientImages.isEmpty {
+            msgs.append(.init(role: .user, content: openAIChatContent(text: tail)))
         }
 
         return msgs
@@ -268,9 +299,10 @@ struct AIMessage {
 
         var items: [SwiftOpenAI.InputItem] = []
         var firstUser = true
+        let lastUserIndex = conversationMessages.lastIndex { $0.role == .user }
 
         // 2. Walk through the stored conversation.
-        for entry in conversationMessages {
+        for (index, entry) in conversationMessages.enumerated() {
             switch entry.role {
             case .user:
                 var text = entry.content
@@ -279,9 +311,14 @@ struct AIMessage {
                     firstUser = false
                 }
 
+                let content = if index == lastUserIndex, !transientImages.isEmpty {
+                    openAIResponsesContent(text: text)
+                } else {
+                    SwiftOpenAI.MessageContent.text(text)
+                }
                 let msg = SwiftOpenAI.InputMessage(
                     role: "user",
-                    content: .text(text)
+                    content: content
                 )
                 items.append(.message(msg))
 
@@ -295,16 +332,47 @@ struct AIMessage {
             }
         }
 
-        // 3. Edge-case: no user message yet but there *is* a tail.
-        if items.isEmpty, !additions.isEmpty {
-            let msg = SwiftOpenAI.InputMessage(
-                role: "user",
-                content: .text(additions)
-            )
+        // 3. Edge-case: no user message yet. Preserve the text-only behavior of
+        // adding context only when there are no existing conversation items.
+        if lastUserIndex == nil,
+           !transientImages.isEmpty || items.isEmpty && !additions.isEmpty
+        {
+            let content = transientImages.isEmpty
+                ? SwiftOpenAI.MessageContent.text(additions)
+                : openAIResponsesContent(text: additions)
+            let msg = SwiftOpenAI.InputMessage(role: "user", content: content)
             items.append(.message(msg))
         }
 
         return .array(items)
+    }
+
+    private func openAIChatContent(text: String) -> ChatCompletionParameters.Message.ContentType {
+        var parts: [ChatCompletionParameters.Message.ContentType.MessageContent] = []
+        if !text.isEmpty {
+            parts.append(.text(text))
+        }
+        for image in transientImages {
+            if let title = image.normalizedTitle {
+                parts.append(.text("Image title: \(title)"))
+            }
+            parts.append(.imageUrl(.init(url: URL(string: image.openAIDataURL)!, detail: nil)))
+        }
+        return .contentArray(parts)
+    }
+
+    private func openAIResponsesContent(text: String) -> SwiftOpenAI.MessageContent {
+        var parts: [SwiftOpenAI.ContentItem] = []
+        if !text.isEmpty {
+            parts.append(.text(SwiftOpenAI.TextContent(text: text)))
+        }
+        for image in transientImages {
+            if let title = image.normalizedTitle {
+                parts.append(.text(SwiftOpenAI.TextContent(text: "Image title: \(title)")))
+            }
+            parts.append(.image(SwiftOpenAI.ImageContent(detail: "auto", imageUrl: image.openAIDataURL)))
+        }
+        return .array(parts)
     }
 
     // MARK: - Temperature helpers

--- a/Sources/RepoPrompt/Infrastructure/AI/AIMessage.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIMessage.swift
@@ -47,7 +47,7 @@ struct AIMessage {
     let conversationMessages: [ConversationEntry]
 
     /// Request-scoped provider payload. Never copied into persisted chat messages.
-    let transientImages: [AITransientImage]
+    var transientImages: [AITransientImage]
 
     let temperature: Double?
 
@@ -172,22 +172,6 @@ struct AIMessage {
         promptSectionsOrder = PromptAssemblyBuilder.defaultSectionOrder
         disabledPromptSections = []
         duplicateUserInstructionsAtTop = false
-    }
-
-    func replacingTransientImages(_ images: [AITransientImage]) -> AIMessage {
-        AIMessage(
-            systemPrompt: systemPrompt,
-            metaPrompts: metaPrompts,
-            fileTree: fileTree,
-            fileBlocks: fileBlocks,
-            gitDiff: gitDiff,
-            conversationMessages: conversationMessages,
-            transientImages: images,
-            temperature: temperature,
-            promptSectionsOrder: promptSectionsOrder,
-            disabledPromptSections: disabledPromptSections,
-            duplicateUserInstructionsAtTop: duplicateUserInstructionsAtTop
-        )
     }
 
     /// Builds the text block that must be *prepended* to the **final** user

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AgentMessage.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AgentMessage.swift
@@ -18,6 +18,9 @@ public struct AgentMessage: Sendable, Equatable {
     /// The user's message / task
     public var userMessage: String
 
+    /// Request-scoped, path-free images for non-agent provider adapters.
+    var transientImages: [AITransientImage]
+
     /// Optional provider-specific session ID for resuming conversations
     /// Used by Claude CLI to resume with --resume <session-id> instead of replaying history
     public var resumeSessionID: String?
@@ -25,6 +28,19 @@ public struct AgentMessage: Sendable, Equatable {
     public init(systemPrompt: String = "", userMessage: String, resumeSessionID: String? = nil) {
         self.systemPrompt = systemPrompt
         self.userMessage = userMessage
+        transientImages = []
+        self.resumeSessionID = resumeSessionID
+    }
+
+    init(
+        systemPrompt: String = "",
+        userMessage: String,
+        transientImages: [AITransientImage],
+        resumeSessionID: String? = nil
+    ) {
+        self.systemPrompt = systemPrompt
+        self.userMessage = userMessage
+        self.transientImages = transientImages
         self.resumeSessionID = resumeSessionID
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicProvider.swift
@@ -17,7 +17,7 @@ class AnthropicProvider: AIProvider {
         }
     }
 
-    private func createMessages(for aiMessage: AIMessage) -> [MessageParameter.Message] {
+    static func makeMessages(for aiMessage: AIMessage) -> [MessageParameter.Message] {
         let tail = aiMessage.buildTail(embedSystemPrompt: false)
         let lastUserIndex = aiMessage.conversationMessages.lastIndex { $0.role == .user }
         var messages: [MessageParameter.Message] = []
@@ -34,10 +34,33 @@ class AnthropicProvider: AIProvider {
             }
 
             let role: MessageParameter.Message.Role = (entry.role == .user) ? .user : .assistant
+            let content: MessageParameter.Message.Content
+            if entry.role == .user, idx == lastUserIndex, !aiMessage.transientImages.isEmpty {
+                var blocks: [MessageParameter.Message.Content.ContentObject] = [.text(contentText)]
+                for image in aiMessage.transientImages {
+                    if let title = image.title, !title.isEmpty {
+                        blocks.append(.text("Image title: \(title)"))
+                    }
+                    let mediaType: MessageParameter.Message.Content.ImageSource.MediaType = switch image.mediaType {
+                    case .png: .png
+                    case .jpeg: .jpeg
+                    case .gif: .gif
+                    case .webp: .webp
+                    }
+                    blocks.append(.image(.init(
+                        type: .base64,
+                        mediaType: mediaType,
+                        data: image.bytes.base64EncodedString()
+                    )))
+                }
+                content = .list(blocks)
+            } else {
+                content = .text(contentText)
+            }
             messages.append(
                 MessageParameter.Message(
                     role: role,
-                    content: .text(contentText)
+                    content: content
                 )
             )
         }
@@ -108,7 +131,7 @@ class AnthropicProvider: AIProvider {
 
         // Use your existing helper functions
         let systemParameter = createSystemParameter(systemPrompt: aiMessage.systemPrompt)
-        let messages = createMessages(for: aiMessage)
+        let messages = Self.makeMessages(for: aiMessage)
 
         var temperature: Double? = 0
         // Skip temperature setting for thinking models
@@ -279,7 +302,7 @@ class AnthropicProvider: AIProvider {
         }
 
         let systemParameter = createSystemParameter(systemPrompt: aiMessage.systemPrompt)
-        let messages = createMessages(for: aiMessage)
+        let messages = Self.makeMessages(for: aiMessage)
 
         let parameters = MessageParameter(
             model: model,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeProvider.swift
@@ -17,6 +17,7 @@ struct ClaudeCLIOptions {
     var effortLevel: ClaudeCodeEffortLevel?
     var mcpConfigPath: String?
     var systemPromptOverride: String?
+    var inputFormat: String?
     var timeout: TimeInterval?
     var environmentOverrides: [String: String] = [:]
     var removedEnvironmentKeys: Set<String> = []
@@ -40,6 +41,7 @@ struct ClaudeCLIOptions {
         if let permissionMode { tokens.append(contentsOf: ["--permission-mode", permissionMode]) }
         if let model { tokens.append(contentsOf: ["--model", model]) }
         if let systemPromptOverride { tokens.append(contentsOf: ["--system-prompt", systemPromptOverride]) }
+        if let inputFormat { tokens.append(contentsOf: ["--input-format", inputFormat]) }
         if let mcpConfigPath {
             tokens.append(contentsOf: ["--mcp-config", mcpConfigPath])
             // Use strict mode to ignore project-level MCP configs from ~/.claude.json
@@ -152,6 +154,13 @@ final class ClaudeCodeProvider: AIProvider {
         if options.timeout == nil {
             options.timeout = defaultRequestTimeout
         }
+        let stdin: String
+        if aiMessage.transientImages.isEmpty {
+            stdin = prompt
+        } else {
+            options.inputFormat = "stream-json"
+            stdin = try Self.makeStreamJSONInput(prompt: prompt, images: aiMessage.transientImages)
+        }
         let args = options.toTokens()
 
         var attempt = 0
@@ -162,7 +171,7 @@ final class ClaudeCodeProvider: AIProvider {
             do {
                 result = try await runner.run(
                     args: args,
-                    stdin: prompt,
+                    stdin: stdin,
                     outputMode: .auto(.json),
                     timeout: options.timeout,
                     additionalEnvironment: options.additionalEnvironment,
@@ -214,6 +223,36 @@ final class ClaudeCodeProvider: AIProvider {
     }
 
     // MARK: - Private Helpers
+
+    static func makeStreamJSONInput(prompt: String, images: [AITransientImage]) throws -> String {
+        var content: [[String: Any]] = []
+        if !prompt.isEmpty {
+            content.append(["type": "text", "text": prompt])
+        }
+        for image in images {
+            if let title = image.normalizedTitle {
+                content.append(["type": "text", "text": "Image title: \(title)"])
+            }
+            content.append([
+                "type": "image",
+                "source": [
+                    "type": "base64",
+                    "media_type": image.mediaType.rawValue,
+                    "data": image.base64Payload
+                ]
+            ])
+        }
+        let payload: [String: Any] = [
+            "type": "user",
+            "message": ["role": "user", "content": content],
+            "parent_tool_use_id": NSNull()
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        guard let line = String(data: data, encoding: .utf8) else {
+            throw AIProviderError.invalidConfiguration(detail: "Unable to encode Claude image input.")
+        }
+        return line + "\n"
+    }
 
     static func resolveCLIModelSelection(for model: AIModel) throws -> ClaudeCodeCLIModelSelection {
         guard model.providerType == .claudeCode else {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
@@ -6,6 +6,65 @@ final class CodexCLIProvider: AIProvider {
         let emittedOutput: Bool
     }
 
+    private struct TransientImageLease {
+        let directory: URL
+        let attachments: [AgentImageAttachment]
+
+        static func stage(_ images: [AITransientImage]) async throws -> Self? {
+            guard !images.isEmpty else { return nil }
+            try Task.checkCancellation()
+            let task = Task.detached(priority: .userInitiated) {
+                let directory = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("RepoPromptOracleImages-\(UUID().uuidString)", isDirectory: true)
+                do {
+                    try FileManager.default.createDirectory(
+                        at: directory,
+                        withIntermediateDirectories: false,
+                        attributes: [.posixPermissions: 0o700]
+                    )
+                    var attachments: [AgentImageAttachment] = []
+                    for (index, image) in images.enumerated() {
+                        try Task.checkCancellation()
+                        let url = directory.appendingPathComponent(
+                            "image-\(index).\(image.preferredFileExtension)",
+                            isDirectory: false
+                        )
+                        try image.bytes.write(to: url, options: .withoutOverwriting)
+                        try FileManager.default.setAttributes(
+                            [.posixPermissions: 0o600],
+                            ofItemAtPath: url.path
+                        )
+                        attachments.append(
+                            AgentImageAttachment(source: .localFile(path: url.path), title: image.normalizedTitle)
+                        )
+                    }
+                    return Self(directory: directory, attachments: attachments)
+                } catch {
+                    try? FileManager.default.removeItem(at: directory)
+                    throw error
+                }
+            }
+
+            do {
+                return try await withTaskCancellationHandler {
+                    try await task.value
+                } onCancel: {
+                    task.cancel()
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                throw AIProviderError.invalidConfiguration(
+                    detail: "Codex could not securely stage Oracle image input in temporary storage."
+                )
+            }
+        }
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
     private struct ReconciledTerminalTurn: Equatable {
         let turnID: String
         let status: CodexNativeSessionController.TurnStatus
@@ -132,9 +191,25 @@ final class CodexCLIProvider: AIProvider {
         _ = MCPIntegrationHelper.ensureCodexServerForDiscovery(launchSnapshot: launchSnapshot)
     }
 
+    #if DEBUG
+        static func test_withStagedTransientImages(
+            _ images: [AITransientImage],
+            inspect: ([AgentImageAttachment]) throws -> Void
+        ) async throws {
+            let lease = try await TransientImageLease.stage(images)
+            defer { lease?.cleanup() }
+            try inspect(lease?.attachments ?? [])
+        }
+
+        func test_registerActiveStreamTask(_ task: Task<Void, Never>, id: UUID) {
+            registerActiveStreamTask(task, id: id)
+        }
+    #endif
+
     func streamMessage(_ aiMessage: AIMessage, model: AIModel, maxTokens _: Int? = nil) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
         let baseInstructions = buildBaseInstructions(from: aiMessage)
-        let prompt = buildPrompt(from: aiMessage)
+        let transientImages = aiMessage.transientImages
+        let prompt = promptAppendingImageTitles(buildPrompt(from: aiMessage), images: transientImages)
         let requestedModelIdentifier = modelIdentifier(for: model)
         let fallbackReasoningEffort = model.defaultReasoningEffort
         let serviceTier = model.codexServiceTier
@@ -152,9 +227,12 @@ final class CodexCLIProvider: AIProvider {
                 }
 
                 do {
+                    let imageLease = try await TransientImageLease.stage(transientImages)
+                    defer { imageLease?.cleanup() }
                     try await streamViaAppServer(
                         baseInstructions: baseInstructions,
                         prompt: prompt,
+                        images: imageLease?.attachments ?? [],
                         requestedModelIdentifier: requestedModelIdentifier,
                         fallbackReasoningEffort: fallbackReasoningEffort,
                         serviceTier: serviceTier,
@@ -215,10 +293,13 @@ final class CodexCLIProvider: AIProvider {
     }
 
     func dispose() async {
-        cancelActiveStreamTasks()
+        let activeTasks = cancelAndRemoveActiveStreamTasks()
         let activeClients = snapshotActiveRequestClients()
         for client in activeClients {
             await client.stop()
+        }
+        for task in activeTasks {
+            await task.value
         }
     }
 
@@ -307,6 +388,7 @@ final class CodexCLIProvider: AIProvider {
     private func streamViaAppServer(
         baseInstructions: String,
         prompt: String,
+        images: [AgentImageAttachment],
         requestedModelIdentifier: String?,
         fallbackReasoningEffort: String?,
         serviceTier: String?,
@@ -331,6 +413,7 @@ final class CodexCLIProvider: AIProvider {
                     try await runSingleStreamAttempt(
                         baseInstructions: baseInstructions,
                         prompt: prompt,
+                        images: images,
                         requestedModelIdentifier: activeModelIdentifier,
                         fallbackReasoningEffort: fallbackReasoningEffort,
                         serviceTier: serviceTier,
@@ -426,6 +509,7 @@ final class CodexCLIProvider: AIProvider {
     private func runSingleStreamAttempt(
         baseInstructions: String,
         prompt: String,
+        images: [AgentImageAttachment],
         requestedModelIdentifier: String?,
         fallbackReasoningEffort: String?,
         serviceTier: String?,
@@ -467,7 +551,7 @@ final class CodexCLIProvider: AIProvider {
                 )
                 let turnReceipt = try await controller.startUserTurn(
                     text: prompt,
-                    images: [],
+                    images: images,
                     model: selection.model,
                     reasoningEffort: selection.reasoningEffort,
                     serviceTier: selection.serviceTier
@@ -1025,6 +1109,14 @@ final class CodexCLIProvider: AIProvider {
         aiMessage.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private func promptAppendingImageTitles(_ prompt: String, images: [AITransientImage]) -> String {
+        let titles = images.compactMap { image in
+            image.normalizedTitle.map { "Image title: \($0)" }
+        }
+        guard !titles.isEmpty else { return prompt }
+        return ([prompt] + titles).filter { !$0.isEmpty }.joined(separator: "\n\n")
+    }
+
     private func buildPrompt(from aiMessage: AIMessage) -> String {
         let tail = aiMessage.buildTail(embedSystemPrompt: false)
         var conversation = ""
@@ -1206,12 +1298,13 @@ final class CodexCLIProvider: AIProvider {
         activeStreamTasksLock.unlock()
     }
 
-    private func cancelActiveStreamTasks() {
+    private func cancelAndRemoveActiveStreamTasks() -> [Task<Void, Never>] {
         activeStreamTasksLock.lock()
         let tasks = Array(activeStreamTasks.values)
         activeStreamTasks.removeAll()
         activeStreamTasksLock.unlock()
         tasks.forEach { $0.cancel() }
+        return tasks
     }
 
     private func registerActiveRequestClient(_ client: CodexAppServerClient, id: UUID) {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
@@ -65,6 +65,41 @@ final class CodexCLIProvider: AIProvider {
         }
     }
 
+    private final class ActiveStreamTaskStore: @unchecked Sendable {
+        private let lock = NSLock()
+        private var isAccepting = true
+        private var tasks: [UUID: Task<Void, Never>] = [:]
+
+        /// `start` must only construct a task; it runs while the non-reentrant lock is held.
+        func register(
+            id: UUID,
+            start: () -> Task<Void, Never>
+        ) -> Task<Void, Never>? {
+            lock.lock()
+            defer { lock.unlock() }
+            guard isAccepting else { return nil }
+            let task = start()
+            tasks[id] = task
+            return task
+        }
+
+        func remove(_ id: UUID) {
+            lock.lock()
+            tasks.removeValue(forKey: id)
+            lock.unlock()
+        }
+
+        func closeAndCancelAll() -> [Task<Void, Never>] {
+            lock.lock()
+            isAccepting = false
+            let activeTasks = Array(tasks.values)
+            tasks.removeAll()
+            lock.unlock()
+            activeTasks.forEach { $0.cancel() }
+            return activeTasks
+        }
+    }
+
     private struct ReconciledTerminalTurn: Equatable {
         let turnID: String
         let status: CodexNativeSessionController.TurnStatus
@@ -154,8 +189,7 @@ final class CodexCLIProvider: AIProvider {
     <codex reminder>You are operating in text only mode. No tool calls are permitted, as they will result in task failure. You must carefully read the system prompt, attached files and user message, and format your response as specified. Think carefully through your response and then answer comprehensively to address the user's task, specified in <user_instructions>.</codex reminder>
     """
 
-    private let activeStreamTasksLock = NSLock()
-    private var activeStreamTasks: [UUID: Task<Void, Never>] = [:]
+    private let activeStreamTasks = ActiveStreamTaskStore()
     private let activeRequestClientsLock = NSLock()
     private var activeRequestClients: [UUID: CodexAppServerClient] = [:]
 
@@ -201,8 +235,11 @@ final class CodexCLIProvider: AIProvider {
             try inspect(lease?.attachments ?? [])
         }
 
-        func test_registerActiveStreamTask(_ task: Task<Void, Never>, id: UUID) {
-            registerActiveStreamTask(task, id: id)
+        func test_registerActiveStreamTask(
+            id: UUID,
+            start: () -> Task<Void, Never>
+        ) -> Task<Void, Never>? {
+            activeStreamTasks.register(id: id, start: start)
         }
     #endif
 
@@ -216,38 +253,44 @@ final class CodexCLIProvider: AIProvider {
 
         return AsyncThrowingStream { continuation in
             let streamID = UUID()
-            let bridgeTask = Task { [weak self] in
-                defer {
-                    self?.unregisterActiveStreamTask(streamID)
-                    self?.unregisterActiveRequestClient(streamID)
-                }
-                guard let self else {
-                    continuation.finish(throwing: AIProviderError.invalidConfiguration(detail: "Codex provider was released before streaming started."))
-                    return
-                }
+            guard let bridgeTask = activeStreamTasks.register(id: streamID, start: {
+                Task { [weak self] in
+                    defer {
+                        self?.activeStreamTasks.remove(streamID)
+                        self?.unregisterActiveRequestClient(streamID)
+                    }
+                    guard let self else {
+                        continuation.finish(throwing: AIProviderError.invalidConfiguration(detail: "Codex provider was released before streaming started."))
+                        return
+                    }
 
-                do {
-                    let imageLease = try await TransientImageLease.stage(transientImages)
-                    defer { imageLease?.cleanup() }
-                    try await streamViaAppServer(
-                        baseInstructions: baseInstructions,
-                        prompt: prompt,
-                        images: imageLease?.attachments ?? [],
-                        requestedModelIdentifier: requestedModelIdentifier,
-                        fallbackReasoningEffort: fallbackReasoningEffort,
-                        serviceTier: serviceTier,
-                        requestID: streamID,
-                        continuation: continuation
-                    )
-                    continuation.finish()
-                } catch is CancellationError {
-                    continuation.finish(throwing: CancellationError())
-                } catch {
-                    continuation.finish(throwing: error)
+                    do {
+                        let imageLease = try await TransientImageLease.stage(transientImages)
+                        defer { imageLease?.cleanup() }
+                        try await streamViaAppServer(
+                            baseInstructions: baseInstructions,
+                            prompt: prompt,
+                            images: imageLease?.attachments ?? [],
+                            requestedModelIdentifier: requestedModelIdentifier,
+                            fallbackReasoningEffort: fallbackReasoningEffort,
+                            serviceTier: serviceTier,
+                            requestID: streamID,
+                            continuation: continuation
+                        )
+                        continuation.finish()
+                    } catch is CancellationError {
+                        continuation.finish(throwing: CancellationError())
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
                 }
+            }) else {
+                continuation.finish(throwing: AIProviderError.invalidConfiguration(
+                    detail: "Codex provider was disposed before streaming started."
+                ))
+                return
             }
 
-            registerActiveStreamTask(bridgeTask, id: streamID)
             continuation.onTermination = { @Sendable _ in
                 bridgeTask.cancel()
             }
@@ -293,7 +336,7 @@ final class CodexCLIProvider: AIProvider {
     }
 
     func dispose() async {
-        let activeTasks = cancelAndRemoveActiveStreamTasks()
+        let activeTasks = activeStreamTasks.closeAndCancelAll()
         let activeClients = snapshotActiveRequestClients()
         for client in activeClients {
             await client.stop()
@@ -1284,27 +1327,6 @@ final class CodexCLIProvider: AIProvider {
             cost: nil,
             cleanupHandle: cleanupHandle
         )
-    }
-
-    private func registerActiveStreamTask(_ task: Task<Void, Never>, id: UUID) {
-        activeStreamTasksLock.lock()
-        activeStreamTasks[id] = task
-        activeStreamTasksLock.unlock()
-    }
-
-    private func unregisterActiveStreamTask(_ id: UUID) {
-        activeStreamTasksLock.lock()
-        activeStreamTasks.removeValue(forKey: id)
-        activeStreamTasksLock.unlock()
-    }
-
-    private func cancelAndRemoveActiveStreamTasks() -> [Task<Void, Never>] {
-        activeStreamTasksLock.lock()
-        let tasks = Array(activeStreamTasks.values)
-        activeStreamTasks.removeAll()
-        activeStreamTasksLock.unlock()
-        tasks.forEach { $0.cancel() }
-        return tasks
     }
 
     private func registerActiveRequestClient(_ client: CodexAppServerClient, id: UUID) {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPAgentProvider.swift
@@ -144,7 +144,8 @@ struct CursorACPAgentProvider: ACPAgentProvider {
 
         return try ACPPromptContentBuilder.blocks(
             text: text,
-            attachments: request.attachments
+            attachments: request.attachments,
+            transientImages: message.transientImages
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorCLIProvider.swift
@@ -20,6 +20,10 @@ final class CursorCLIProvider: AIProvider {
         static func test_makeHeadlessConfig(modelName: String?) -> CursorAgentConfig {
             makeHeadlessConfig(modelName: modelName)
         }
+
+        static func test_makeAgentMessage(from aiMessage: AIMessage) -> AgentMessage {
+            CursorCLIProvider().makeAgentMessage(from: aiMessage)
+        }
     #endif
 
     func streamMessage(_ aiMessage: AIMessage, model: AIModel, maxTokens _: Int? = nil) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
@@ -133,6 +137,7 @@ final class CursorCLIProvider: AIProvider {
         return AgentMessage(
             systemPrompt: systemPrompt.isEmpty ? systemPrompt : systemPrompt + Self.noToolsSuffix,
             userMessage: buildPrompt(from: aiMessage),
+            transientImages: aiMessage.transientImages,
             resumeSessionID: nil
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/CustomOpenai/CustomOpenAIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/CustomOpenai/CustomOpenAIProvider.swift
@@ -2,16 +2,54 @@ import Foundation
 
 /// Common chat completion parameters
 enum CompletionParams {
-    struct Message {
-        enum Role: String {
+    struct Message: Encodable {
+        enum Role: String, Encodable {
             case system
             case user
             case assistant
         }
 
-        enum Content {
+        enum Content: Encodable {
             case text(String)
-            case contentArray([Content])
+            case parts([Part])
+
+            struct ImageURL: Encodable {
+                let url: String
+                let detail: String
+            }
+
+            enum Part: Encodable {
+                case text(String)
+                case imageURL(url: String, detail: String)
+
+                private enum CodingKeys: String, CodingKey {
+                    case type
+                    case text
+                    case imageURL = "image_url"
+                }
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self {
+                    case let .text(text):
+                        try container.encode("text", forKey: .type)
+                        try container.encode(text, forKey: .text)
+                    case let .imageURL(url, detail):
+                        try container.encode("image_url", forKey: .type)
+                        try container.encode(ImageURL(url: url, detail: detail), forKey: .imageURL)
+                    }
+                }
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                switch self {
+                case let .text(text):
+                    try container.encode(text)
+                case let .parts(parts):
+                    try container.encode(parts)
+                }
+            }
         }
 
         let role: Role
@@ -120,20 +158,20 @@ class CustomOpenAIProvider: AIProvider, AIModelGetter {
         }
     }
 
-    struct ChatMessage: Codable {
+    struct ChatMessage: Encodable {
         let role: String
-        let content: String
+        let content: CompletionParams.Message.Content
     }
 
     /// Added support for max_tokens and temperature in the request payload
-    struct ChatRequest: Codable {
+    struct ChatRequest: Encodable {
         let model: String
         let messages: [ChatMessage]
         let max_tokens: Int?
         let temperature: Double?
     }
 
-    struct ChatStreamRequest: Codable {
+    struct ChatStreamRequest: Encodable {
         let model: String
         let messages: [ChatMessage]
         let stream: Bool
@@ -432,12 +470,23 @@ class CustomOpenAIProvider: AIProvider, AIModelGetter {
                     userContent = entry.content
                 }
 
-                results.append(
-                    CompletionParams.Message(
-                        role: .user,
-                        content: .text(userContent)
-                    )
-                )
+                let content: CompletionParams.Message.Content
+                if index == lastUserIndex, !aiMessage.transientImages.isEmpty {
+                    var parts: [CompletionParams.Message.Content.Part] = []
+                    if !userContent.isEmpty {
+                        parts.append(.text(userContent))
+                    }
+                    for image in aiMessage.transientImages {
+                        if let title = image.normalizedTitle {
+                            parts.append(.text("Image title: \(title)"))
+                        }
+                        parts.append(.imageURL(url: image.openAIDataURL, detail: "auto"))
+                    }
+                    content = .parts(parts)
+                } else {
+                    content = .text(userContent)
+                }
+                results.append(CompletionParams.Message(role: .user, content: content))
             } else {
                 results.append(
                     CompletionParams.Message(
@@ -446,6 +495,20 @@ class CustomOpenAIProvider: AIProvider, AIModelGetter {
                     )
                 )
             }
+        }
+
+        if lastUserIndex == nil, !aiMessage.transientImages.isEmpty {
+            var parts: [CompletionParams.Message.Content.Part] = []
+            if !additionsForFinalUserMessage.isEmpty {
+                parts.append(.text(additionsForFinalUserMessage))
+            }
+            for image in aiMessage.transientImages {
+                if let title = image.normalizedTitle {
+                    parts.append(.text("Image title: \(title)"))
+                }
+                parts.append(.imageURL(url: image.openAIDataURL, detail: "auto"))
+            }
+            results.append(CompletionParams.Message(role: .user, content: .parts(parts)))
         }
 
         return results
@@ -674,22 +737,8 @@ class CustomOpenAIProvider: AIProvider, AIModelGetter {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
-        let openAIMessages = messages.map { message -> ChatMessage in
-            let content: String = switch message.content {
-            case let .text(text):
-                text
-            case let .contentArray(array):
-                array.compactMap { chunk -> String? in
-                    if case let .text(part) = chunk {
-                        return part
-                    }
-                    return nil
-                }.joined(separator: "\n")
-            }
-            return ChatMessage(
-                role: message.role.rawValue,
-                content: content
-            )
+        let openAIMessages = messages.map { message in
+            ChatMessage(role: message.role.rawValue, content: message.content)
         }
 
         // Use the provided temperature if available, or fall back to the provider default

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildACPAgentProvider.swift
@@ -84,7 +84,7 @@ struct GrokBuildACPAgentProvider: ACPAgentProvider {
         for message: AgentMessage,
         request: ACPRunRequest
     ) throws -> [[String: Any]] {
-        // Grok Build 1.0.3 advertises promptCapabilities.image = false over ACP, so v1 is
+        // Grok Build 1.0.5 advertises promptCapabilities.image = false over ACP, so v1 is
         // text-only: reject attachments explicitly instead of silently dropping them.
         guard request.attachments.isEmpty else {
             throw AIProviderError.invalidConfiguration(

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildCLIProvider.swift
@@ -200,6 +200,7 @@ final class GrokBuildCLIProvider: AIProvider {
         return AgentMessage(
             systemPrompt: nonAgentSystemPrompt,
             userMessage: buildPrompt(from: aiMessage),
+            transientImages: aiMessage.transientImages,
             resumeSessionID: nil
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildOneShotHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildOneShotHeadlessAgentProvider.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Prompt-only Grok Build adapter for chat, Oracle, and other non-Agent-Mode requests.
+/// Text-only Grok Build adapter for chat, Oracle, and other non-Agent-Mode requests.
 /// Agent Mode continues to use `grok agent stdio`; this adapter uses the documented
-/// one-shot JSON CLI and preserves the existing trusted Grok executable preflight.
+/// one-shot prompt-file CLI and rejects images before launch.
 final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
     typealias APIKeyProvider = @Sendable () async throws -> String?
 
@@ -11,9 +11,6 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
     private let requestTimeout: TimeInterval
     private let apiKeyProvider: APIKeyProvider
     private let activeRuns = ActiveGrokBuildOneShotRunStore()
-
-    /// Leaves roughly half of macOS's 1 MiB ARG_MAX for environment and other arguments.
-    private static let maxPromptJSONArgumentBytes = 512 * 1024
 
     init(
         config: GrokBuildAgentConfig,
@@ -30,16 +27,11 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
     }
 
     #if DEBUG
-        static var test_promptJSONArgumentByteLimit: Int {
-            maxPromptJSONArgumentBytes
-        }
-
         static func test_promptArguments(
-            for message: AgentMessage,
             promptFilePath: String = "/tmp/prompt.txt"
-        ) throws -> [String] {
-            try GrokBuildOneShotCLIOptions(
-                prompt: promptArgument(from: message, promptFilePath: promptFilePath),
+        ) -> [String] {
+            GrokBuildOneShotCLIOptions(
+                promptFilePath: promptFilePath,
                 model: nil,
                 effort: nil
             ).toTokens()
@@ -53,6 +45,11 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
         guard message.resumeSessionID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false else {
             throw AIProviderError.invalidConfiguration(
                 detail: "Grok Build one-shot requests cannot resume a previous session."
+            )
+        }
+        guard message.transientImages.isEmpty else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Grok Build one-shot requests do not accept image attachments. Choose an image-capable Oracle model or remove the images and retry."
             )
         }
 
@@ -125,13 +122,11 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
 
         let promptURL = promptDirectory.appendingPathComponent("prompt.txt")
         let prompt = Self.promptText(from: message)
-        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !message.transientImages.isEmpty else {
+        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw AIProviderError.invalidResponse(detail: "Grok Build prompt is empty")
         }
-        if message.transientImages.isEmpty {
-            try prompt.write(to: promptURL, atomically: true, encoding: .utf8)
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: promptURL.path)
-        }
+        try prompt.write(to: promptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: promptURL.path)
 
         let processConfig = CLIProcessConfiguration(
             command: launch.command,
@@ -154,8 +149,8 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
         }
         try Task.checkCancellation()
 
-        let arguments = try GrokBuildOneShotCLIOptions(
-            prompt: Self.promptArgument(from: message, promptFilePath: promptURL.path),
+        let arguments = GrokBuildOneShotCLIOptions(
+            promptFilePath: promptURL.path,
             model: selection.model,
             effort: selection.effort
         ).toTokens()
@@ -287,40 +282,6 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
         return systemPrompt + "\n\n" + userMessage
     }
 
-    private static func promptArgument(
-        from message: AgentMessage,
-        promptFilePath: String
-    ) throws -> GrokBuildOneShotPromptArgument {
-        guard !message.transientImages.isEmpty else {
-            return .file(promptFilePath)
-        }
-
-        let blocks = try ACPPromptContentBuilder.blocks(
-            text: promptText(from: message),
-            attachments: [],
-            transientImages: message.transientImages
-        )
-        let data: Data
-        do {
-            data = try JSONSerialization.data(withJSONObject: blocks, options: [.sortedKeys])
-        } catch {
-            throw AIProviderError.invalidConfiguration(
-                detail: "Grok Build could not encode the Oracle image prompt as JSON."
-            )
-        }
-        guard data.count <= maxPromptJSONArgumentBytes else {
-            throw AIProviderError.invalidConfiguration(
-                detail: "Grok Build image prompt is too large for a safe macOS command-line launch (\(data.count) bytes; limit \(maxPromptJSONArgumentBytes) bytes). Reduce the number or size of attached images and retry."
-            )
-        }
-        guard let json = String(data: data, encoding: .utf8) else {
-            throw AIProviderError.invalidConfiguration(
-                detail: "Grok Build could not encode the Oracle image prompt as UTF-8 JSON."
-            )
-        }
-        return .json(json)
-    }
-
     private static func resolveModelSelection(
         modelString: String?,
         snapshot: ACPDiscoveredSessionModels?
@@ -414,11 +375,6 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
     }
 }
 
-private enum GrokBuildOneShotPromptArgument {
-    case file(String)
-    case json(String)
-}
-
 private struct GrokBuildOneShotCLIOptions {
     static let disallowedTools = ["read_file", "search_tool", "use_tool"]
 
@@ -440,17 +396,12 @@ private struct GrokBuildOneShotCLIOptions {
         "MCPTool"
     ]
 
-    var prompt: GrokBuildOneShotPromptArgument
+    var promptFilePath: String
     var model: String?
     var effort: String?
 
     func toTokens() -> [String] {
-        var tokens: [String] = switch prompt {
-        case let .file(path):
-            ["--prompt-file", path]
-        case let .json(json):
-            ["--prompt-json", json]
-        }
+        var tokens = ["--prompt-file", promptFilePath]
         tokens += [
             "--output-format", "json",
             "--verbatim",

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildOneShotHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/GrokBuild/GrokBuildOneShotHeadlessAgentProvider.swift
@@ -12,6 +12,9 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
     private let apiKeyProvider: APIKeyProvider
     private let activeRuns = ActiveGrokBuildOneShotRunStore()
 
+    /// Leaves roughly half of macOS's 1 MiB ARG_MAX for environment and other arguments.
+    private static let maxPromptJSONArgumentBytes = 512 * 1024
+
     init(
         config: GrokBuildAgentConfig,
         launchResolver: GrokBuildACPLaunchResolver = GrokBuildACPLaunchResolver(),
@@ -25,6 +28,23 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
         self.requestTimeout = requestTimeout
         self.apiKeyProvider = apiKeyProvider
     }
+
+    #if DEBUG
+        static var test_promptJSONArgumentByteLimit: Int {
+            maxPromptJSONArgumentBytes
+        }
+
+        static func test_promptArguments(
+            for message: AgentMessage,
+            promptFilePath: String = "/tmp/prompt.txt"
+        ) throws -> [String] {
+            try GrokBuildOneShotCLIOptions(
+                prompt: promptArgument(from: message, promptFilePath: promptFilePath),
+                model: nil,
+                effort: nil
+            ).toTokens()
+        }
+    #endif
 
     func streamAgentMessage(
         _ message: AgentMessage,
@@ -105,11 +125,13 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
 
         let promptURL = promptDirectory.appendingPathComponent("prompt.txt")
         let prompt = Self.promptText(from: message)
-        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !message.transientImages.isEmpty else {
             throw AIProviderError.invalidResponse(detail: "Grok Build prompt is empty")
         }
-        try prompt.write(to: promptURL, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: promptURL.path)
+        if message.transientImages.isEmpty {
+            try prompt.write(to: promptURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: promptURL.path)
+        }
 
         let processConfig = CLIProcessConfiguration(
             command: launch.command,
@@ -132,8 +154,8 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
         }
         try Task.checkCancellation()
 
-        let arguments = GrokBuildOneShotCLIOptions(
-            promptFilePath: promptURL.path,
+        let arguments = try GrokBuildOneShotCLIOptions(
+            prompt: Self.promptArgument(from: message, promptFilePath: promptURL.path),
             model: selection.model,
             effort: selection.effort
         ).toTokens()
@@ -265,6 +287,40 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
         return systemPrompt + "\n\n" + userMessage
     }
 
+    private static func promptArgument(
+        from message: AgentMessage,
+        promptFilePath: String
+    ) throws -> GrokBuildOneShotPromptArgument {
+        guard !message.transientImages.isEmpty else {
+            return .file(promptFilePath)
+        }
+
+        let blocks = try ACPPromptContentBuilder.blocks(
+            text: promptText(from: message),
+            attachments: [],
+            transientImages: message.transientImages
+        )
+        let data: Data
+        do {
+            data = try JSONSerialization.data(withJSONObject: blocks, options: [.sortedKeys])
+        } catch {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Grok Build could not encode the Oracle image prompt as JSON."
+            )
+        }
+        guard data.count <= maxPromptJSONArgumentBytes else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Grok Build image prompt is too large for a safe macOS command-line launch (\(data.count) bytes; limit \(maxPromptJSONArgumentBytes) bytes). Reduce the number or size of attached images and retry."
+            )
+        }
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Grok Build could not encode the Oracle image prompt as UTF-8 JSON."
+            )
+        }
+        return .json(json)
+    }
+
     private static func resolveModelSelection(
         modelString: String?,
         snapshot: ACPDiscoveredSessionModels?
@@ -358,6 +414,11 @@ final class GrokBuildOneShotHeadlessAgentProvider: HeadlessAgentProvider {
     }
 }
 
+private enum GrokBuildOneShotPromptArgument {
+    case file(String)
+    case json(String)
+}
+
 private struct GrokBuildOneShotCLIOptions {
     static let disallowedTools = ["read_file", "search_tool", "use_tool"]
 
@@ -379,13 +440,18 @@ private struct GrokBuildOneShotCLIOptions {
         "MCPTool"
     ]
 
-    var promptFilePath: String
+    var prompt: GrokBuildOneShotPromptArgument
     var model: String?
     var effort: String?
 
     func toTokens() -> [String] {
-        var tokens = [
-            "--prompt-file", promptFilePath,
+        var tokens: [String] = switch prompt {
+        case let .file(path):
+            ["--prompt-file", path]
+        case let .json(json):
+            ["--prompt-json", json]
+        }
+        tokens += [
             "--output-format", "json",
             "--verbatim",
             "--max-turns", "1",

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
@@ -105,7 +105,8 @@ struct OpenCodeACPAgentProvider: ACPAgentProvider {
 
         return try ACPPromptContentBuilder.blocks(
             text: text,
-            attachments: request.attachments
+            attachments: request.attachments,
+            transientImages: message.transientImages
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeCLIProvider.swift
@@ -9,6 +9,10 @@ final class OpenCodeCLIProvider: AIProvider {
         static func test_makeHeadlessConfig(modelName: String?) -> OpenCodeAgentConfig {
             makeHeadlessConfig(modelName: modelName)
         }
+
+        static func test_makeAgentMessage(from aiMessage: AIMessage) -> AgentMessage {
+            OpenCodeCLIProvider().makeAgentMessage(from: aiMessage)
+        }
     #endif
 
     func streamMessage(_ aiMessage: AIMessage, model: AIModel, maxTokens _: Int? = nil) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
@@ -130,6 +134,7 @@ final class OpenCodeCLIProvider: AIProvider {
         AgentMessage(
             systemPrompt: aiMessage.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines),
             userMessage: buildPrompt(from: aiMessage),
+            transientImages: aiMessage.transientImages,
             resumeSessionID: nil
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -783,20 +783,27 @@ struct MCPOracleToolService {
         let namespace = lookupContext.exactFileNamespace(storeRoots: storeRoots)
         do {
             var seen: Set<String> = []
+            var capturesByPhysicalRootPath: [String: OracleImagePhysicalRootCapture] = [:]
             var projections: [OracleImageRootProjection] = []
             for binding in namespace.rootBindings
                 where representedPhysicalPaths.contains(binding.lookupRoot.standardizedFullPath)
             {
                 let physicalRootPath = binding.lookupRoot.standardizedFullPath
+                let capture: OracleImagePhysicalRootCapture
+                if let existing = capturesByPhysicalRootPath[physicalRootPath] {
+                    capture = existing
+                } else {
+                    capture = try OracleImagePhysicalRootCapture.capture(
+                        physicalRootPath: physicalRootPath,
+                        index: requests[0].index
+                    )
+                    capturesByPhysicalRootPath[physicalRootPath] = capture
+                }
                 let logicalRootPaths = [physicalRootPath] + binding.clientRoots.map(\.standardizedFullPath)
                 for logicalRootPath in logicalRootPaths {
                     let key = "\(logicalRootPath)\u{0}\(physicalRootPath)"
                     guard seen.insert(key).inserted else { continue }
-                    try projections.append(OracleImageRootProjection.capture(
-                        logicalRootPath: logicalRootPath,
-                        physicalRootPath: physicalRootPath,
-                        index: requests[0].index
-                    ))
+                    projections.append(capture.projection(logicalRootPath: logicalRootPath))
                 }
             }
             return try await OracleImageAttachmentLoader.loadDetached(

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -117,17 +117,18 @@ struct MCPOracleToolService {
     // MARK: - ask_oracle (agent-mode only)
 
     func executeAskOracle(args: [String: Value]) async throws -> Value {
-        let allowedArgs: Set = ["message", "mode", "chat_id", "new_chat", "model", "export_response"]
+        let allowedArgs: Set = ["message", "mode", "chat_id", "new_chat", "model", "images", "export_response"]
         let unsupported = args.keys
             .filter { !$0.hasPrefix("_") && !allowedArgs.contains($0) }
             .sorted()
         if !unsupported.isEmpty {
             throw MCPError.invalidParams(
-                "ask_oracle only accepts: message, mode, chat_id, new_chat, model, export_response. Unsupported args: \(unsupported.joined(separator: ", "))"
+                "ask_oracle only accepts: message, mode, chat_id, new_chat, model, images, export_response. Unsupported args: \(unsupported.joined(separator: ", "))"
             )
         }
 
         try validateCommonOracleArgs(args)
+        let imageRequests = try Self.parseOracleImageRequests(args["images"])
 
         guard let connectionID = ServerNetworkManager.currentConnectionID else {
             throw MCPError.invalidParams("ask_oracle requires an active MCP connection")
@@ -185,13 +186,18 @@ struct MCPOracleToolService {
                 from: virtualContext,
                 owner: owner,
                 origin: .askOracle,
-                mode: modeRaw
+                mode: modeRaw,
+                imageRequests: imageRequests
             )
         } else {
             guard let tabSnapshot = targetWindow.workspaceManager.composeTabSnapshot(for: tabID) else {
                 throw MCPError.internalError("Unable to resolve compose tab context for ask_oracle")
             }
             let lookupContext = try await oraclePackagingLookupContext(owner: owner)
+            let transientImages = try await loadOracleImages(
+                imageRequests,
+                lookupContext: lookupContext
+            )
             let reviewGitContext = await promptVM.freezePromptGitReviewContext(
                 workspaceID: targetWindow.workspaceManager.activeWorkspace?.id,
                 tabID: tabID,
@@ -230,7 +236,8 @@ struct MCPOracleToolService {
                 origin: .askOracle,
                 agentModeSessionID: owner.agentSessionID,
                 agentModeRunID: owner.runID,
-                packaging: packaging
+                packaging: packaging,
+                transientImages: transientImages
             )
         }
 
@@ -428,6 +435,55 @@ struct MCPOracleToolService {
             throw MCPError.invalidParams("export_response must be a boolean")
         }
         return boolValue
+    }
+
+    static func parseOracleImageRequests(_ value: Value?) throws -> [OracleImageRequest] {
+        guard let value else { return [] }
+        guard case let .array(items) = value else {
+            throw MCPError.invalidParams("images must be an array of objects.")
+        }
+        guard !items.isEmpty else {
+            throw MCPError.invalidParams("images cannot be empty when provided.")
+        }
+        guard items.count <= OracleImageAttachmentLimits.production.maxCount else {
+            throw MCPError.invalidParams(
+                "images supports at most \(OracleImageAttachmentLimits.production.maxCount) items."
+            )
+        }
+        return try items.enumerated().map { index, item in
+            guard case let .object(object) = item else {
+                throw MCPError.invalidParams("images[\(index)] must be an object.")
+            }
+            let unsupported = object.keys
+                .filter { !$0.hasPrefix("_") && !["path", "title"].contains($0) }
+                .sorted()
+            guard unsupported.isEmpty else {
+                throw MCPError.invalidParams(
+                    "images[\(index)] unsupported keys: \(unsupported.joined(separator: ", "))."
+                )
+            }
+            guard let rawPath = object["path"]?.stringValue else {
+                throw MCPError.invalidParams("images[\(index)].path must be a string.")
+            }
+            let path = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !path.isEmpty else {
+                throw MCPError.invalidParams("images[\(index)].path must be a non-empty local file path.")
+            }
+            let title: String?
+            if let titleValue = object["title"] {
+                guard let rawTitle = titleValue.stringValue else {
+                    throw MCPError.invalidParams("images[\(index)].title must be a string.")
+                }
+                let normalized = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard normalized.count <= 200 else {
+                    throw MCPError.invalidParams("images[\(index)].title exceeds 200 characters.")
+                }
+                title = normalized.isEmpty ? nil : normalized
+            } else {
+                title = nil
+            }
+            return OracleImageRequest(index: index, path: path, title: title)
+        }
     }
 
     private func parseOracleModelOverride(_ value: Value?) throws -> String? {
@@ -674,10 +730,15 @@ struct MCPOracleToolService {
             worktreeBindingState: .notApplicable
         ),
         origin: OracleSendOrigin,
-        mode: String
+        mode: String,
+        imageRequests: [OracleImageRequest] = []
     ) async throws -> OracleViewModel.OracleSendTabContext {
         let stabilizedContext = await stabilizedVirtualContext(context)
         let lookupContext = try await oraclePackagingLookupContext(for: stabilizedContext)
+        let transientImages = try await loadOracleImages(
+            imageRequests,
+            lookupContext: lookupContext
+        )
         let reviewGitContext = await promptVM.freezePromptGitReviewContext(
             workspaceID: stabilizedContext.workspaceID,
             tabID: stabilizedContext.tabID,
@@ -710,8 +771,43 @@ struct MCPOracleToolService {
             origin: origin,
             agentModeSessionID: owner.agentSessionID,
             agentModeRunID: owner.runID,
-            packaging: packaging
+            packaging: packaging,
+            transientImages: transientImages
         )
+    }
+
+    private func loadOracleImages(
+        _ requests: [OracleImageRequest],
+        lookupContext: WorkspaceLookupContext
+    ) async throws -> [AITransientImage] {
+        guard !requests.isEmpty else { return [] }
+        let storeRoots = await promptVM.workspaceFileContextStore.rootRefs(scope: lookupContext.rootScope)
+        let representedPhysicalPaths = Set(storeRoots.map(\.standardizedFullPath))
+        let namespace = lookupContext.exactFileNamespace(storeRoots: storeRoots)
+        var seen: Set<String> = []
+        let projections = namespace.rootBindings
+            .filter { representedPhysicalPaths.contains($0.lookupRoot.standardizedFullPath) }
+            .flatMap { binding in
+                binding.clientRoots.compactMap { clientRoot -> OracleImageRootProjection? in
+                    let projection = OracleImageRootProjection(
+                        logicalRootPath: clientRoot.standardizedFullPath,
+                        physicalRootPath: binding.lookupRoot.standardizedFullPath
+                    )
+                    let key = "\(projection.logicalRootPath)\u{0}\(projection.physicalRootPath)"
+                    return seen.insert(key).inserted ? projection : nil
+                }
+            }
+        let authority = OracleImageWorkspaceAuthority(roots: projections)
+        do {
+            return try await OracleImageAttachmentLoader.loadDetached(
+                requests: requests,
+                authority: authority
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw MCPError.invalidParams(error.localizedDescription)
+        }
     }
 
     private func reviewPackaging(

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -442,9 +442,7 @@ struct MCPOracleToolService {
         guard case let .array(items) = value else {
             throw MCPError.invalidParams("images must be an array of objects.")
         }
-        guard !items.isEmpty else {
-            throw MCPError.invalidParams("images cannot be empty when provided.")
-        }
+        guard !items.isEmpty else { return [] }
         guard items.count <= OracleImageAttachmentLimits.production.maxCount else {
             throw MCPError.invalidParams(
                 "images supports at most \(OracleImageAttachmentLimits.production.maxCount) items."
@@ -465,8 +463,7 @@ struct MCPOracleToolService {
             guard let rawPath = object["path"]?.stringValue else {
                 throw MCPError.invalidParams("images[\(index)].path must be a string.")
             }
-            let path = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !path.isEmpty else {
+            guard !rawPath.isEmpty else {
                 throw MCPError.invalidParams("images[\(index)].path must be a non-empty local file path.")
             }
             let title: String?
@@ -482,7 +479,7 @@ struct MCPOracleToolService {
             } else {
                 title = nil
             }
-            return OracleImageRequest(index: index, path: path, title: title)
+            return OracleImageRequest(index: index, path: rawPath, title: title)
         }
     }
 
@@ -784,24 +781,27 @@ struct MCPOracleToolService {
         let storeRoots = await promptVM.workspaceFileContextStore.rootRefs(scope: lookupContext.rootScope)
         let representedPhysicalPaths = Set(storeRoots.map(\.standardizedFullPath))
         let namespace = lookupContext.exactFileNamespace(storeRoots: storeRoots)
-        var seen: Set<String> = []
-        let projections = namespace.rootBindings
-            .filter { representedPhysicalPaths.contains($0.lookupRoot.standardizedFullPath) }
-            .flatMap { binding in
-                binding.clientRoots.compactMap { clientRoot -> OracleImageRootProjection? in
-                    let projection = OracleImageRootProjection(
-                        logicalRootPath: clientRoot.standardizedFullPath,
-                        physicalRootPath: binding.lookupRoot.standardizedFullPath
-                    )
-                    let key = "\(projection.logicalRootPath)\u{0}\(projection.physicalRootPath)"
-                    return seen.insert(key).inserted ? projection : nil
+        do {
+            var seen: Set<String> = []
+            var projections: [OracleImageRootProjection] = []
+            for binding in namespace.rootBindings
+                where representedPhysicalPaths.contains(binding.lookupRoot.standardizedFullPath)
+            {
+                let physicalRootPath = binding.lookupRoot.standardizedFullPath
+                let logicalRootPaths = [physicalRootPath] + binding.clientRoots.map(\.standardizedFullPath)
+                for logicalRootPath in logicalRootPaths {
+                    let key = "\(logicalRootPath)\u{0}\(physicalRootPath)"
+                    guard seen.insert(key).inserted else { continue }
+                    try projections.append(OracleImageRootProjection.capture(
+                        logicalRootPath: logicalRootPath,
+                        physicalRootPath: physicalRootPath,
+                        index: requests[0].index
+                    ))
                 }
             }
-        let authority = OracleImageWorkspaceAuthority(roots: projections)
-        do {
             return try await OracleImageAttachmentLoader.loadDetached(
                 requests: requests,
-                authority: authority
+                authority: OracleImageWorkspaceAuthority(roots: projections)
             )
         } catch is CancellationError {
             throw CancellationError()

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
@@ -14,18 +14,15 @@ struct OracleImageRootIdentity: Equatable {
     let mode: mode_t
 }
 
-struct OracleImageRootProjection: Equatable {
-    let logicalRootPath: String
+struct OracleImagePhysicalRootCapture: Equatable {
     let physicalRootPath: String
     let resolvedPhysicalRootPath: String
     let rootIdentity: OracleImageRootIdentity
 
     static func capture(
-        logicalRootPath: String,
         physicalRootPath: String,
         index: Int
-    ) throws -> OracleImageRootProjection {
-        let logicalRootPath = StandardizedPath.absolute(logicalRootPath)
+    ) throws -> OracleImagePhysicalRootCapture {
         let physicalRootPath = StandardizedPath.absolute(physicalRootPath)
         let resolvedPhysicalRootPath = StandardizedPath.absolute(
             URL(fileURLWithPath: physicalRootPath).resolvingSymlinksInPath().path
@@ -41,8 +38,7 @@ struct OracleImageRootProjection: Equatable {
         guard fstat(descriptor, &info) == 0 else {
             throw OracleImageLoadError.missingOrUnreadable(index: index)
         }
-        return OracleImageRootProjection(
-            logicalRootPath: logicalRootPath,
+        return OracleImagePhysicalRootCapture(
             physicalRootPath: physicalRootPath,
             resolvedPhysicalRootPath: resolvedPhysicalRootPath,
             rootIdentity: OracleImageRootIdentity(
@@ -53,6 +49,22 @@ struct OracleImageRootProjection: Equatable {
             )
         )
     }
+
+    func projection(logicalRootPath: String) -> OracleImageRootProjection {
+        OracleImageRootProjection(
+            logicalRootPath: StandardizedPath.absolute(logicalRootPath),
+            physicalRootPath: physicalRootPath,
+            resolvedPhysicalRootPath: resolvedPhysicalRootPath,
+            rootIdentity: rootIdentity
+        )
+    }
+}
+
+struct OracleImageRootProjection: Equatable {
+    let logicalRootPath: String
+    let physicalRootPath: String
+    let resolvedPhysicalRootPath: String
+    let rootIdentity: OracleImageRootIdentity
 }
 
 struct OracleImageWorkspaceAuthority: Equatable {
@@ -555,9 +567,10 @@ enum OracleImageRouteAdmission {
              .claudeCode,
              .codex,
              .openCode,
-             .cursor,
-             .grokBuild:
+             .cursor:
             true
+        case .grokBuild:
+            false
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
@@ -1,0 +1,568 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+struct OracleImageRequest: Equatable {
+    let index: Int
+    let path: String
+    let title: String?
+}
+
+struct OracleImageRootProjection: Equatable {
+    let logicalRootPath: String
+    let physicalRootPath: String
+}
+
+struct OracleImageWorkspaceAuthority: Equatable {
+    let roots: [OracleImageRootProjection]
+}
+
+struct OracleImageAttachmentLimits: Equatable {
+    let maxCount: Int
+    let maxBytesPerImage: Int
+    let maxTotalBytes: Int
+
+    static let production = OracleImageAttachmentLimits(
+        maxCount: 10,
+        maxBytesPerImage: 20 * 1024 * 1024,
+        maxTotalBytes: 50 * 1024 * 1024
+    )
+}
+
+enum OracleImageLoadError: Error, LocalizedError, Equatable {
+    case tooMany(maximumCount: Int)
+    case invalidPath(index: Int)
+    case outsideAuthority(index: Int)
+    case unsafePath(index: Int)
+    case missingOrUnreadable(index: Int)
+    case notRegularFile(index: Int)
+    case tooLarge(index: Int, maximumBytes: Int)
+    case totalTooLarge(maximumBytes: Int)
+    case changedWhileReading(index: Int)
+    case unsupportedFormat(index: Int)
+    case extensionMismatch(index: Int, mediaType: AIImageMediaType)
+
+    var errorDescription: String? {
+        switch self {
+        case let .tooMany(maximumCount):
+            "images supports at most \(maximumCount) items."
+        case let .invalidPath(index):
+            "images[\(index)].path must be a canonical absolute local workspace path."
+        case let .outsideAuthority(index):
+            "images[\(index)].path is outside the current workspace roots."
+        case let .unsafePath(index):
+            "images[\(index)].path changed or contains a symbolic link."
+        case let .missingOrUnreadable(index):
+            "images[\(index)] is missing or unreadable."
+        case let .notRegularFile(index):
+            "images[\(index)] must point to a regular file."
+        case let .tooLarge(index, maximumBytes):
+            "images[\(index)] exceeds the \(maximumBytes) byte per-image limit."
+        case let .totalTooLarge(maximumBytes):
+            "images total size exceeds the \(maximumBytes) byte limit."
+        case let .changedWhileReading(index):
+            "images[\(index)] changed while it was being read."
+        case let .unsupportedFormat(index):
+            "images[\(index)] is not a supported PNG, JPEG, WebP, or GIF file."
+        case let .extensionMismatch(index, mediaType):
+            "images[\(index)] file extension does not match detected MIME type \(mediaType.rawValue)."
+        }
+    }
+}
+
+struct OracleImageAttachmentLoader {
+    typealias AfterFirstRead = @Sendable (_ requestIndex: Int) throws -> Void
+
+    let limits: OracleImageAttachmentLimits
+    let afterFirstRead: AfterFirstRead?
+
+    init(
+        limits: OracleImageAttachmentLimits = .production,
+        afterFirstRead: AfterFirstRead? = nil
+    ) {
+        self.limits = limits
+        self.afterFirstRead = afterFirstRead
+    }
+
+    static func duplicateDirectoryDescriptor(_ descriptor: Int32) -> Int32 {
+        fcntl(descriptor, F_DUPFD_CLOEXEC, 0)
+    }
+
+    static func loadDetached(
+        requests: [OracleImageRequest],
+        authority: OracleImageWorkspaceAuthority,
+        loader: OracleImageAttachmentLoader = .init()
+    ) async throws -> [AITransientImage] {
+        try Task.checkCancellation()
+        let task = Task.detached(priority: .userInitiated) {
+            try loader.load(requests: requests, authority: authority)
+        }
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    func load(
+        requests: [OracleImageRequest],
+        authority: OracleImageWorkspaceAuthority
+    ) throws -> [AITransientImage] {
+        guard requests.count <= limits.maxCount else {
+            throw OracleImageLoadError.tooMany(maximumCount: limits.maxCount)
+        }
+        guard !requests.isEmpty else { return [] }
+        guard !authority.roots.isEmpty else {
+            throw OracleImageLoadError.outsideAuthority(index: requests[0].index)
+        }
+
+        var opened: [OpenedImage] = []
+        defer {
+            for item in opened {
+                Darwin.close(item.fileDescriptor)
+                Darwin.close(item.rootDescriptor)
+            }
+        }
+
+        var totalBytes = 0
+        for request in requests {
+            try Task.checkCancellation()
+            let resolution = try resolve(request: request, authority: authority)
+            let rootDescriptor = try openTrustedRootDirectory(
+                resolution.physicalRootPath,
+                index: request.index
+            )
+            do {
+                let rootIdentity = try descriptorIdentity(rootDescriptor, index: request.index)
+                let fileDescriptor = try openFileWithoutSymlinks(
+                    from: rootDescriptor,
+                    relativePath: resolution.relativePath,
+                    index: request.index
+                )
+                do {
+                    let identity = try fileIdentity(fileDescriptor, index: request.index)
+                    guard identity.isRegular else {
+                        throw OracleImageLoadError.notRegularFile(index: request.index)
+                    }
+                    guard identity.size >= 0,
+                          let byteCount = Int(exactly: identity.size)
+                    else {
+                        throw OracleImageLoadError.tooLarge(
+                            index: request.index,
+                            maximumBytes: limits.maxBytesPerImage
+                        )
+                    }
+                    guard byteCount <= limits.maxBytesPerImage else {
+                        throw OracleImageLoadError.tooLarge(
+                            index: request.index,
+                            maximumBytes: limits.maxBytesPerImage
+                        )
+                    }
+                    totalBytes += byteCount
+                    guard totalBytes <= limits.maxTotalBytes else {
+                        throw OracleImageLoadError.totalTooLarge(maximumBytes: limits.maxTotalBytes)
+                    }
+                    opened.append(OpenedImage(
+                        request: request,
+                        rootDescriptor: rootDescriptor,
+                        fileDescriptor: fileDescriptor,
+                        resolution: resolution,
+                        rootIdentity: rootIdentity,
+                        identity: identity,
+                        byteCount: byteCount
+                    ))
+                } catch {
+                    Darwin.close(fileDescriptor)
+                    throw error
+                }
+            } catch {
+                Darwin.close(rootDescriptor)
+                throw error
+            }
+        }
+
+        var images: [AITransientImage] = []
+        images.reserveCapacity(opened.count)
+        for item in opened {
+            try Task.checkCancellation()
+            let data = try readExactly(
+                descriptor: item.fileDescriptor,
+                byteCount: item.byteCount,
+                index: item.request.index
+            )
+            try afterFirstRead?(item.request.index)
+            let postReadIdentity = try fileIdentity(item.fileDescriptor, index: item.request.index)
+            guard postReadIdentity == item.identity else {
+                throw OracleImageLoadError.changedWhileReading(index: item.request.index)
+            }
+            let secondDigest = try hashExactly(
+                descriptor: item.fileDescriptor,
+                byteCount: item.byteCount,
+                index: item.request.index
+            )
+            guard Data(SHA256.hash(data: data)) == secondDigest else {
+                throw OracleImageLoadError.changedWhileReading(index: item.request.index)
+            }
+
+            let reopened = try openFileWithoutSymlinks(
+                from: item.rootDescriptor,
+                relativePath: item.resolution.relativePath,
+                index: item.request.index
+            )
+            defer { Darwin.close(reopened) }
+            let reopenedIdentity = try fileIdentity(reopened, index: item.request.index)
+            let reopenedRoot = try openTrustedRootDirectory(
+                item.resolution.physicalRootPath,
+                index: item.request.index
+            )
+            defer { Darwin.close(reopenedRoot) }
+            guard reopenedIdentity == item.identity,
+                  try descriptorIdentity(item.rootDescriptor, index: item.request.index) == item.rootIdentity,
+                  try descriptorIdentity(reopenedRoot, index: item.request.index) == item.rootIdentity
+            else {
+                throw OracleImageLoadError.changedWhileReading(index: item.request.index)
+            }
+
+            let mediaType = try detectMediaType(data, index: item.request.index)
+            try validateExtension(
+                item.resolution.physicalFilePath,
+                mediaType: mediaType,
+                index: item.request.index
+            )
+            images.append(AITransientImage(
+                bytes: data,
+                mediaType: mediaType,
+                title: item.request.title
+            ))
+        }
+        return images
+    }
+
+    private struct Resolution {
+        let physicalRootPath: String
+        let physicalFilePath: String
+        let relativePath: String
+    }
+
+    private struct OpenedImage {
+        let request: OracleImageRequest
+        let rootDescriptor: Int32
+        let fileDescriptor: Int32
+        let resolution: Resolution
+        let rootIdentity: DescriptorIdentity
+        let identity: FileIdentity
+        let byteCount: Int
+    }
+
+    private struct DescriptorIdentity: Equatable {
+        let device: dev_t
+        let inode: ino_t
+        let generation: UInt32
+        let mode: mode_t
+    }
+
+    private struct FileIdentity: Equatable {
+        let device: dev_t
+        let inode: ino_t
+        let generation: UInt32
+        let mode: mode_t
+        let size: off_t
+        let modifiedSeconds: Int
+        let modifiedNanoseconds: Int
+        let changedSeconds: Int
+        let changedNanoseconds: Int
+
+        var isRegular: Bool {
+            (mode & S_IFMT) == S_IFREG
+        }
+    }
+
+    private func resolve(
+        request: OracleImageRequest,
+        authority: OracleImageWorkspaceAuthority
+    ) throws -> Resolution {
+        let rawPath = request.path
+        guard rawPath.hasPrefix("/"),
+              !rawPath.contains("\0"),
+              rawPath == rawPath.trimmingCharacters(in: .whitespacesAndNewlines),
+              rawPath == StandardizedPath.absolute(rawPath),
+              !rawPath.hasSuffix("/")
+        else {
+            throw OracleImageLoadError.invalidPath(index: request.index)
+        }
+        let components = rawPath.split(separator: "/", omittingEmptySubsequences: false)
+        guard components.dropFirst().allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+            throw OracleImageLoadError.invalidPath(index: request.index)
+        }
+
+        var matches: [(specificity: Int, resolution: Resolution)] = []
+        for root in authority.roots {
+            let logicalRoot = StandardizedPath.absolute(root.logicalRootPath)
+            let physicalRoot = StandardizedPath.absolute(root.physicalRootPath)
+            if let relative = relativePath(rawPath, under: logicalRoot) {
+                matches.append((logicalRoot.count, Resolution(
+                    physicalRootPath: physicalRoot,
+                    physicalFilePath: join(root: physicalRoot, relativePath: relative),
+                    relativePath: relative
+                )))
+            }
+            if logicalRoot != physicalRoot,
+               let relative = relativePath(rawPath, under: physicalRoot)
+            {
+                matches.append((physicalRoot.count, Resolution(
+                    physicalRootPath: physicalRoot,
+                    physicalFilePath: join(root: physicalRoot, relativePath: relative),
+                    relativePath: relative
+                )))
+            }
+        }
+        guard let maximumSpecificity = matches.map(\.specificity).max() else {
+            throw OracleImageLoadError.outsideAuthority(index: request.index)
+        }
+        let mostSpecific = matches.filter { $0.specificity == maximumSpecificity }
+        let physicalPaths = Set(mostSpecific.map(\.resolution.physicalFilePath))
+        guard physicalPaths.count == 1, let resolution = mostSpecific.first?.resolution,
+              !resolution.relativePath.isEmpty
+        else {
+            throw OracleImageLoadError.outsideAuthority(index: request.index)
+        }
+        return resolution
+    }
+
+    private func relativePath(_ path: String, under root: String) -> String? {
+        guard path != root, path.hasPrefix(root + "/") else { return nil }
+        return String(path.dropFirst(root.count + 1))
+    }
+
+    private func join(root: String, relativePath: String) -> String {
+        root + "/" + relativePath
+    }
+
+    private func openTrustedRootDirectory(_ path: String, index: Int) throws -> Int32 {
+        let descriptor = path.withCString {
+            Darwin.open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        }
+        guard descriptor >= 0 else {
+            throw OracleImageLoadError.missingOrUnreadable(index: index)
+        }
+        return descriptor
+    }
+
+    private func openFileWithoutSymlinks(
+        from rootDescriptor: Int32,
+        relativePath: String,
+        index: Int
+    ) throws -> Int32 {
+        let components = relativePath.split(separator: "/").map(String.init)
+        guard let filename = components.last else {
+            throw OracleImageLoadError.notRegularFile(index: index)
+        }
+        var directoryDescriptor = Self.duplicateDirectoryDescriptor(rootDescriptor)
+        guard directoryDescriptor >= 0 else {
+            throw OracleImageLoadError.missingOrUnreadable(index: index)
+        }
+        do {
+            for component in components.dropLast() {
+                let next = component.withCString {
+                    Darwin.openat(
+                        directoryDescriptor,
+                        $0,
+                        O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
+                    )
+                }
+                guard next >= 0 else {
+                    if errno == ELOOP {
+                        throw OracleImageLoadError.unsafePath(index: index)
+                    }
+                    throw OracleImageLoadError.missingOrUnreadable(index: index)
+                }
+                Darwin.close(directoryDescriptor)
+                directoryDescriptor = next
+            }
+            let descriptor = filename.withCString {
+                Darwin.openat(
+                    directoryDescriptor,
+                    $0,
+                    O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC
+                )
+            }
+            guard descriptor >= 0 else {
+                if errno == ELOOP {
+                    throw OracleImageLoadError.unsafePath(index: index)
+                }
+                throw OracleImageLoadError.missingOrUnreadable(index: index)
+            }
+            Darwin.close(directoryDescriptor)
+            return descriptor
+        } catch {
+            Darwin.close(directoryDescriptor)
+            throw error
+        }
+    }
+
+    private func descriptorIdentity(_ descriptor: Int32, index: Int) throws -> DescriptorIdentity {
+        var info = stat()
+        guard fstat(descriptor, &info) == 0 else {
+            throw OracleImageLoadError.changedWhileReading(index: index)
+        }
+        return DescriptorIdentity(
+            device: info.st_dev,
+            inode: info.st_ino,
+            generation: info.st_gen,
+            mode: info.st_mode
+        )
+    }
+
+    private func fileIdentity(_ descriptor: Int32, index: Int) throws -> FileIdentity {
+        var info = stat()
+        guard fstat(descriptor, &info) == 0 else {
+            throw OracleImageLoadError.changedWhileReading(index: index)
+        }
+        return FileIdentity(
+            device: info.st_dev,
+            inode: info.st_ino,
+            generation: info.st_gen,
+            mode: info.st_mode,
+            size: info.st_size,
+            modifiedSeconds: info.st_mtimespec.tv_sec,
+            modifiedNanoseconds: info.st_mtimespec.tv_nsec,
+            changedSeconds: info.st_ctimespec.tv_sec,
+            changedNanoseconds: info.st_ctimespec.tv_nsec
+        )
+    }
+
+    private func readExactly(descriptor: Int32, byteCount: Int, index: Int) throws -> Data {
+        guard lseek(descriptor, 0, SEEK_SET) >= 0 else {
+            throw OracleImageLoadError.changedWhileReading(index: index)
+        }
+        var data = Data(count: byteCount)
+        var offset = 0
+        while offset < byteCount {
+            try Task.checkCancellation()
+            let count = data.withUnsafeMutableBytes { buffer -> Int in
+                guard let base = buffer.baseAddress else { return 0 }
+                return Darwin.read(descriptor, base.advanced(by: offset), byteCount - offset)
+            }
+            if count > 0 {
+                offset += count
+            } else if count == 0 {
+                throw OracleImageLoadError.changedWhileReading(index: index)
+            } else if errno != EINTR {
+                throw OracleImageLoadError.missingOrUnreadable(index: index)
+            }
+        }
+        try requireEndOfFile(descriptor: descriptor, index: index)
+        return data
+    }
+
+    private func hashExactly(descriptor: Int32, byteCount: Int, index: Int) throws -> Data {
+        guard lseek(descriptor, 0, SEEK_SET) >= 0 else {
+            throw OracleImageLoadError.changedWhileReading(index: index)
+        }
+        var hasher = SHA256()
+        var buffer = Data(count: min(64 * 1024, max(byteCount, 1)))
+        var remaining = byteCount
+        while remaining > 0 {
+            try Task.checkCancellation()
+            let requested = min(buffer.count, remaining)
+            let count = buffer.withUnsafeMutableBytes { bytes -> Int in
+                Darwin.read(descriptor, bytes.baseAddress, requested)
+            }
+            if count > 0 {
+                hasher.update(data: buffer.prefix(count))
+                remaining -= count
+            } else if count == 0 {
+                throw OracleImageLoadError.changedWhileReading(index: index)
+            } else if errno != EINTR {
+                throw OracleImageLoadError.missingOrUnreadable(index: index)
+            }
+        }
+        try requireEndOfFile(descriptor: descriptor, index: index)
+        return Data(hasher.finalize())
+    }
+
+    private func requireEndOfFile(descriptor: Int32, index: Int) throws {
+        var extra: UInt8 = 0
+        while true {
+            let count = Darwin.read(descriptor, &extra, 1)
+            if count == 0 { return }
+            if count > 0 {
+                throw OracleImageLoadError.changedWhileReading(index: index)
+            }
+            if errno != EINTR {
+                throw OracleImageLoadError.missingOrUnreadable(index: index)
+            }
+        }
+    }
+
+    private func detectMediaType(_ data: Data, index: Int) throws -> AIImageMediaType {
+        if data.count >= 33,
+           data.starts(with: [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+           String(data: data[12 ..< 16], encoding: .ascii) == "IHDR"
+        {
+            return .png
+        }
+        if data.count >= 4,
+           data.starts(with: [0xFF, 0xD8, 0xFF]),
+           Array(data.suffix(2)) == [0xFF, 0xD9]
+        {
+            return .jpeg
+        }
+        if data.count >= 10,
+           data.starts(with: Array("GIF87a".utf8)) || data.starts(with: Array("GIF89a".utf8))
+        {
+            let width = Int(data[6]) | (Int(data[7]) << 8)
+            let height = Int(data[8]) | (Int(data[9]) << 8)
+            if width > 0, height > 0 { return .gif }
+        }
+        if data.count >= 16,
+           String(data: data[0 ..< 4], encoding: .ascii) == "RIFF",
+           String(data: data[8 ..< 12], encoding: .ascii) == "WEBP",
+           let chunk = String(data: data[12 ..< 16], encoding: .ascii),
+           ["VP8 ", "VP8L", "VP8X"].contains(chunk)
+        {
+            return .webp
+        }
+        throw OracleImageLoadError.unsupportedFormat(index: index)
+    }
+
+    private func validateExtension(
+        _ path: String,
+        mediaType: AIImageMediaType,
+        index: Int
+    ) throws {
+        let fileExtension = (path as NSString).pathExtension.lowercased()
+        let expected: Set<String> = switch mediaType {
+        case .png: ["png"]
+        case .jpeg: ["jpg", "jpeg"]
+        case .gif: ["gif"]
+        case .webp: ["webp"]
+        }
+        guard expected.contains(fileExtension) else {
+            throw OracleImageLoadError.extensionMismatch(index: index, mediaType: mediaType)
+        }
+    }
+}
+
+private extension Data {
+    func starts(with bytes: [UInt8]) -> Bool {
+        guard count >= bytes.count else { return false }
+        return zip(prefix(bytes.count), bytes).allSatisfy { $0 == $1 }
+    }
+}
+
+enum OracleImageRouteAdmission {
+    static func supports(_ model: AIModel) -> Bool {
+        if case let .openAIServiceTierVariant(base, _) = model {
+            return supports(base)
+        }
+        guard case .anthropicCustom = model else {
+            return model.providerType == .anthropic
+        }
+        return false
+    }
+
+    static func supportsCurrentRoute(_ model: AIModel) -> Bool {
+        supports(model)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Darwin
 import Foundation
 
@@ -8,9 +7,52 @@ struct OracleImageRequest: Equatable {
     let title: String?
 }
 
+struct OracleImageRootIdentity: Equatable {
+    let device: dev_t
+    let inode: ino_t
+    let generation: UInt32
+    let mode: mode_t
+}
+
 struct OracleImageRootProjection: Equatable {
     let logicalRootPath: String
     let physicalRootPath: String
+    let resolvedPhysicalRootPath: String
+    let rootIdentity: OracleImageRootIdentity
+
+    static func capture(
+        logicalRootPath: String,
+        physicalRootPath: String,
+        index: Int
+    ) throws -> OracleImageRootProjection {
+        let logicalRootPath = StandardizedPath.absolute(logicalRootPath)
+        let physicalRootPath = StandardizedPath.absolute(physicalRootPath)
+        let resolvedPhysicalRootPath = StandardizedPath.absolute(
+            URL(fileURLWithPath: physicalRootPath).resolvingSymlinksInPath().path
+        )
+        let descriptor = resolvedPhysicalRootPath.withCString {
+            Darwin.open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        }
+        guard descriptor >= 0 else {
+            throw OracleImageLoadError.missingOrUnreadable(index: index)
+        }
+        defer { Darwin.close(descriptor) }
+        var info = stat()
+        guard fstat(descriptor, &info) == 0 else {
+            throw OracleImageLoadError.missingOrUnreadable(index: index)
+        }
+        return OracleImageRootProjection(
+            logicalRootPath: logicalRootPath,
+            physicalRootPath: physicalRootPath,
+            resolvedPhysicalRootPath: resolvedPhysicalRootPath,
+            rootIdentity: OracleImageRootIdentity(
+                device: info.st_dev,
+                inode: info.st_ino,
+                generation: info.st_gen,
+                mode: info.st_mode
+            )
+        )
+    }
 }
 
 struct OracleImageWorkspaceAuthority: Equatable {
@@ -84,10 +126,6 @@ struct OracleImageAttachmentLoader {
         self.afterFirstRead = afterFirstRead
     }
 
-    static func duplicateDirectoryDescriptor(_ descriptor: Int32) -> Int32 {
-        fcntl(descriptor, F_DUPFD_CLOEXEC, 0)
-    }
-
     static func loadDetached(
         requests: [OracleImageRequest],
         authority: OracleImageWorkspaceAuthority,
@@ -134,6 +172,9 @@ struct OracleImageAttachmentLoader {
             )
             do {
                 let rootIdentity = try descriptorIdentity(rootDescriptor, index: request.index)
+                guard rootIdentity == resolution.expectedRootIdentity else {
+                    throw OracleImageLoadError.unsafePath(index: request.index)
+                }
                 let fileDescriptor = try openFileWithoutSymlinks(
                     from: rootDescriptor,
                     relativePath: resolution.relativePath,
@@ -167,7 +208,6 @@ struct OracleImageAttachmentLoader {
                         rootDescriptor: rootDescriptor,
                         fileDescriptor: fileDescriptor,
                         resolution: resolution,
-                        rootIdentity: rootIdentity,
                         identity: identity,
                         byteCount: byteCount
                     ))
@@ -195,15 +235,6 @@ struct OracleImageAttachmentLoader {
             guard postReadIdentity == item.identity else {
                 throw OracleImageLoadError.changedWhileReading(index: item.request.index)
             }
-            let secondDigest = try hashExactly(
-                descriptor: item.fileDescriptor,
-                byteCount: item.byteCount,
-                index: item.request.index
-            )
-            guard Data(SHA256.hash(data: data)) == secondDigest else {
-                throw OracleImageLoadError.changedWhileReading(index: item.request.index)
-            }
-
             let reopened = try openFileWithoutSymlinks(
                 from: item.rootDescriptor,
                 relativePath: item.resolution.relativePath,
@@ -211,15 +242,7 @@ struct OracleImageAttachmentLoader {
             )
             defer { Darwin.close(reopened) }
             let reopenedIdentity = try fileIdentity(reopened, index: item.request.index)
-            let reopenedRoot = try openTrustedRootDirectory(
-                item.resolution.physicalRootPath,
-                index: item.request.index
-            )
-            defer { Darwin.close(reopenedRoot) }
-            guard reopenedIdentity == item.identity,
-                  try descriptorIdentity(item.rootDescriptor, index: item.request.index) == item.rootIdentity,
-                  try descriptorIdentity(reopenedRoot, index: item.request.index) == item.rootIdentity
-            else {
+            guard reopenedIdentity == item.identity else {
                 throw OracleImageLoadError.changedWhileReading(index: item.request.index)
             }
 
@@ -242,6 +265,7 @@ struct OracleImageAttachmentLoader {
         let physicalRootPath: String
         let physicalFilePath: String
         let relativePath: String
+        let expectedRootIdentity: OracleImageRootIdentity
     }
 
     private struct OpenedImage {
@@ -249,16 +273,8 @@ struct OracleImageAttachmentLoader {
         let rootDescriptor: Int32
         let fileDescriptor: Int32
         let resolution: Resolution
-        let rootIdentity: DescriptorIdentity
         let identity: FileIdentity
         let byteCount: Int
-    }
-
-    private struct DescriptorIdentity: Equatable {
-        let device: dev_t
-        let inode: ino_t
-        let generation: UInt32
-        let mode: mode_t
     }
 
     private struct FileIdentity: Equatable {
@@ -299,20 +315,34 @@ struct OracleImageAttachmentLoader {
         for root in authority.roots {
             let logicalRoot = StandardizedPath.absolute(root.logicalRootPath)
             let physicalRoot = StandardizedPath.absolute(root.physicalRootPath)
+            let resolvedPhysicalRoot = StandardizedPath.absolute(root.resolvedPhysicalRootPath)
             if let relative = relativePath(rawPath, under: logicalRoot) {
                 matches.append((logicalRoot.count, Resolution(
-                    physicalRootPath: physicalRoot,
-                    physicalFilePath: join(root: physicalRoot, relativePath: relative),
-                    relativePath: relative
+                    physicalRootPath: resolvedPhysicalRoot,
+                    physicalFilePath: join(root: resolvedPhysicalRoot, relativePath: relative),
+                    relativePath: relative,
+                    expectedRootIdentity: root.rootIdentity
                 )))
             }
             if logicalRoot != physicalRoot,
                let relative = relativePath(rawPath, under: physicalRoot)
             {
                 matches.append((physicalRoot.count, Resolution(
-                    physicalRootPath: physicalRoot,
-                    physicalFilePath: join(root: physicalRoot, relativePath: relative),
-                    relativePath: relative
+                    physicalRootPath: resolvedPhysicalRoot,
+                    physicalFilePath: join(root: resolvedPhysicalRoot, relativePath: relative),
+                    relativePath: relative,
+                    expectedRootIdentity: root.rootIdentity
+                )))
+            }
+            if resolvedPhysicalRoot != logicalRoot,
+               resolvedPhysicalRoot != physicalRoot,
+               let relative = relativePath(rawPath, under: resolvedPhysicalRoot)
+            {
+                matches.append((resolvedPhysicalRoot.count, Resolution(
+                    physicalRootPath: resolvedPhysicalRoot,
+                    physicalFilePath: join(root: resolvedPhysicalRoot, relativePath: relative),
+                    relativePath: relative,
+                    expectedRootIdentity: root.rootIdentity
                 )))
             }
         }
@@ -357,7 +387,7 @@ struct OracleImageAttachmentLoader {
         guard let filename = components.last else {
             throw OracleImageLoadError.notRegularFile(index: index)
         }
-        var directoryDescriptor = Self.duplicateDirectoryDescriptor(rootDescriptor)
+        var directoryDescriptor = fcntl(rootDescriptor, F_DUPFD_CLOEXEC, 0)
         guard directoryDescriptor >= 0 else {
             throw OracleImageLoadError.missingOrUnreadable(index: index)
         }
@@ -400,12 +430,12 @@ struct OracleImageAttachmentLoader {
         }
     }
 
-    private func descriptorIdentity(_ descriptor: Int32, index: Int) throws -> DescriptorIdentity {
+    private func descriptorIdentity(_ descriptor: Int32, index: Int) throws -> OracleImageRootIdentity {
         var info = stat()
         guard fstat(descriptor, &info) == 0 else {
             throw OracleImageLoadError.changedWhileReading(index: index)
         }
-        return DescriptorIdentity(
+        return OracleImageRootIdentity(
             device: info.st_dev,
             inode: info.st_ino,
             generation: info.st_gen,
@@ -441,7 +471,11 @@ struct OracleImageAttachmentLoader {
             try Task.checkCancellation()
             let count = data.withUnsafeMutableBytes { buffer -> Int in
                 guard let base = buffer.baseAddress else { return 0 }
-                return Darwin.read(descriptor, base.advanced(by: offset), byteCount - offset)
+                return Darwin.read(
+                    descriptor,
+                    base.advanced(by: offset),
+                    min(64 * 1024, byteCount - offset)
+                )
             }
             if count > 0 {
                 offset += count
@@ -451,48 +485,7 @@ struct OracleImageAttachmentLoader {
                 throw OracleImageLoadError.missingOrUnreadable(index: index)
             }
         }
-        try requireEndOfFile(descriptor: descriptor, index: index)
         return data
-    }
-
-    private func hashExactly(descriptor: Int32, byteCount: Int, index: Int) throws -> Data {
-        guard lseek(descriptor, 0, SEEK_SET) >= 0 else {
-            throw OracleImageLoadError.changedWhileReading(index: index)
-        }
-        var hasher = SHA256()
-        var buffer = Data(count: min(64 * 1024, max(byteCount, 1)))
-        var remaining = byteCount
-        while remaining > 0 {
-            try Task.checkCancellation()
-            let requested = min(buffer.count, remaining)
-            let count = buffer.withUnsafeMutableBytes { bytes -> Int in
-                Darwin.read(descriptor, bytes.baseAddress, requested)
-            }
-            if count > 0 {
-                hasher.update(data: buffer.prefix(count))
-                remaining -= count
-            } else if count == 0 {
-                throw OracleImageLoadError.changedWhileReading(index: index)
-            } else if errno != EINTR {
-                throw OracleImageLoadError.missingOrUnreadable(index: index)
-            }
-        }
-        try requireEndOfFile(descriptor: descriptor, index: index)
-        return Data(hasher.finalize())
-    }
-
-    private func requireEndOfFile(descriptor: Int32, index: Int) throws {
-        var extra: UInt8 = 0
-        while true {
-            let count = Darwin.read(descriptor, &extra, 1)
-            if count == 0 { return }
-            if count > 0 {
-                throw OracleImageLoadError.changedWhileReading(index: index)
-            }
-            if errno != EINTR {
-                throw OracleImageLoadError.missingOrUnreadable(index: index)
-            }
-        }
     }
 
     private func detectMediaType(_ data: Data, index: Int) throws -> AIImageMediaType {
@@ -544,25 +537,18 @@ struct OracleImageAttachmentLoader {
     }
 }
 
-private extension Data {
-    func starts(with bytes: [UInt8]) -> Bool {
-        guard count >= bytes.count else { return false }
-        return zip(prefix(bytes.count), bytes).allSatisfy { $0 == $1 }
-    }
-}
-
 enum OracleImageRouteAdmission {
     static func supports(_ model: AIModel) -> Bool {
-        if case let .openAIServiceTierVariant(base, _) = model {
-            return supports(base)
+        switch model {
+        case .claude45Haiku,
+             .claude4Sonnet,
+             .claude4SonnetThinking,
+             .claude4SonnetThinkingMax,
+             .claude4Opus,
+             .claude4OpusThinking:
+            true
+        default:
+            false
         }
-        guard case .anthropicCustom = model else {
-            return model.providerType == .anthropic
-        }
-        return false
-    }
-
-    static func supportsCurrentRoute(_ model: AIModel) -> Bool {
-        supports(model)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
@@ -539,16 +539,25 @@ struct OracleImageAttachmentLoader {
 
 enum OracleImageRouteAdmission {
     static func supports(_ model: AIModel) -> Bool {
-        switch model {
-        case .claude45Haiku,
-             .claude4Sonnet,
-             .claude4SonnetThinking,
-             .claude4SonnetThinkingMax,
-             .claude4Opus,
-             .claude4OpusThinking:
+        switch model.providerType {
+        case .anthropic,
+             .openAI,
+             .ollama,
+             .azure,
+             .openRouter,
+             .gemini,
+             .deepseek,
+             .customProvider,
+             .fireworks,
+             .grok,
+             .groq,
+             .zAI,
+             .claudeCode,
+             .codex,
+             .openCode,
+             .cursor,
+             .grokBuild:
             true
-        default:
-            false
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPOracleToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPOracleToolProvider.swift
@@ -60,6 +60,8 @@ final class MCPOracleToolProvider: MCPAppToolProviding {
 
             Use this to start or continue an oracle conversation in `chat`, `plan`, or `review` mode for the current agent tab. Omit `chat_id` or set `new_chat=true` to start; otherwise `chat_id` continues. The optional `model` override changes only the primary model of a new conversation.
 
+            Optional `images` sends workspace-local PNG, JPEG, GIF, or WebP files to a direct built-in Anthropic Oracle route. Each item is `{path,title?}` with a canonical absolute path inside the current loaded roots. URLs, screenshots, relative paths, and external files are rejected. Limits: 10 images, 20 MiB each, 50 MiB total.
+
             Pass `export_response: true` to write the response to a shareable file and get back shareable `oracle_export_path` / `oracle_export_instruction` values. To hand the export to a child agent, include `oracle_export_path` inside the `message` (or `messages`) you send on your next delegation call; your system prompt names the specific delegation tool available to you.
 
             Use `oracle_chat_log` after compaction to recover recent oracle messages.
@@ -85,6 +87,17 @@ final class MCPOracleToolProvider: MCPAppToolProviding {
                     "model": .string(
                         description: "Optional primary-model override for a new conversation; rejected on continuation.",
                         maxLength: OracleRosterContract.maximumModelIdentifierLength
+                    ),
+                    "images": .array(
+                        description: "Optional workspace-local images for direct built-in Anthropic Oracle routes. Each item requires canonical absolute `path` and may include `title`. PNG/JPEG/GIF/WebP only; max 10 images, 20 MiB each, 50 MiB total. URLs and screenshots are unsupported.",
+                        items: .object(
+                            properties: [
+                                "path": .string(description: "Canonical absolute path inside a currently loaded workspace root"),
+                                "title": .string(description: "Optional transient image title", maxLength: 200)
+                            ],
+                            required: ["path"]
+                        ),
+                        maxItems: OracleImageAttachmentLimits.production.maxCount
                     ),
                     "export_response": .boolean(
                         description: "When true, export the response to a file and return `oracle_export_path` plus `oracle_export_instruction`. Include `oracle_export_path` inside the `message` you send on your next delegation call; the specific delegation tool is named by your system prompt."

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPOracleToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPOracleToolProvider.swift
@@ -8,6 +8,10 @@ import RepoPromptDomainRuntime
 final class MCPOracleToolProvider: MCPAppToolProviding {
     let group: MCPAppToolGroup = .oracle
 
+    static let askOracleImageUsageDescription = "Optional `images` attaches workspace-local PNG, JPEG, GIF, or WebP files to the Oracle request when the resolved model transport supports image input. Each item is `{path,title?}` with a canonical absolute path inside the current loaded roots. Unsupported transports, URLs, screenshots, relative paths, and external files are rejected before a message is sent. Limits: \(OracleImageAttachmentLimits.production.maxCount) images, \(OracleImageAttachmentLimits.production.maxBytesPerImage / 1_048_576) MiB each, \(OracleImageAttachmentLimits.production.maxTotalBytes / 1_048_576) MiB total."
+
+    static let askOracleImagesArgumentDescription = "Optional workspace-local PNG/JPEG/GIF/WebP images for transports that support image input. Each item requires canonical absolute `path` and may include transient `title`. Unsupported transports, URLs, and screenshots are rejected. Max \(OracleImageAttachmentLimits.production.maxCount) images, \(OracleImageAttachmentLimits.production.maxBytesPerImage / 1_048_576) MiB each, \(OracleImageAttachmentLimits.production.maxTotalBytes / 1_048_576) MiB total."
+
     private let runtime: MCPAppToolBinder
     private let dependencies: MCPAppPhysicalCapabilityAdapters.Execution
 
@@ -60,7 +64,7 @@ final class MCPOracleToolProvider: MCPAppToolProviding {
 
             Use this to start or continue an oracle conversation in `chat`, `plan`, or `review` mode for the current agent tab. Omit `chat_id` or set `new_chat=true` to start; otherwise `chat_id` continues. The optional `model` override changes only the primary model of a new conversation.
 
-            Optional `images` sends workspace-local PNG, JPEG, GIF, or WebP files to a direct built-in Anthropic Oracle route. Each item is `{path,title?}` with a canonical absolute path inside the current loaded roots. URLs, screenshots, relative paths, and external files are rejected. Limits: 10 images, 20 MiB each, 50 MiB total.
+            \(Self.askOracleImageUsageDescription)
 
             Pass `export_response: true` to write the response to a shareable file and get back shareable `oracle_export_path` / `oracle_export_instruction` values. To hand the export to a child agent, include `oracle_export_path` inside the `message` (or `messages`) you send on your next delegation call; your system prompt names the specific delegation tool available to you.
 
@@ -89,7 +93,7 @@ final class MCPOracleToolProvider: MCPAppToolProviding {
                         maxLength: OracleRosterContract.maximumModelIdentifierLength
                     ),
                     "images": .array(
-                        description: "Optional workspace-local images for direct built-in Anthropic Oracle routes. Each item requires canonical absolute `path` and may include `title`. PNG/JPEG/GIF/WebP only; max 10 images, 20 MiB each, 50 MiB total. URLs and screenshots are unsupported.",
+                        description: Self.askOracleImagesArgumentDescription,
                         items: .object(
                             properties: [
                                 "path": .string(description: "Canonical absolute path inside a currently loaded workspace root"),

--- a/Sources/RepoPrompt/Infrastructure/Utilities/ErrorExtensions.swift
+++ b/Sources/RepoPrompt/Infrastructure/Utilities/ErrorExtensions.swift
@@ -62,6 +62,13 @@ extension Error {
             return apiErr.displayDescription
         }
 
+        if let localizedError = self as? LocalizedError,
+           let description = localizedError.errorDescription,
+           !description.isEmpty
+        {
+            return description
+        }
+
         // 4. Fallback to NSError bridging:
         let nsError = self as NSError
         let domain = nsError.domain

--- a/Tests/RepoPromptTests/AI/CodexCLIProviderDisposalTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexCLIProviderDisposalTests.swift
@@ -6,15 +6,17 @@ final class CodexCLIProviderDisposalTests: XCTestCase {
     func testDisposeAwaitsCancelledBridgeTaskCleanup() async {
         let provider = CodexCLIProvider()
         let gate = DisposalGate()
-        let bridgeTask = Task {
-            await withTaskCancellationHandler {
-                await gate.waitForRelease()
-            } onCancel: {
-                Task { await gate.markCancelled() }
+        let bridgeTask = provider.test_registerActiveStreamTask(id: UUID()) {
+            Task {
+                await withTaskCancellationHandler {
+                    await gate.waitForRelease()
+                } onCancel: {
+                    Task { await gate.markCancelled() }
+                }
+                await gate.markBridgeFinished()
             }
-            await gate.markBridgeFinished()
         }
-        provider.test_registerActiveStreamTask(bridgeTask, id: UUID())
+        XCTAssertNotNil(bridgeTask)
 
         let disposalTask = Task {
             await provider.dispose()
@@ -29,6 +31,33 @@ final class CodexCLIProviderDisposalTests: XCTestCase {
         await disposalTask.value
         let bridgeFinished = await gate.bridgeFinished
         XCTAssertTrue(bridgeFinished)
+    }
+
+    func testRegistrationAfterDisposeIsRefusedWithoutStartingTask() async {
+        let provider = CodexCLIProvider()
+        await provider.dispose()
+        let invocation = InvocationFlag()
+
+        let task = provider.test_registerActiveStreamTask(id: UUID()) {
+            invocation.markInvoked()
+            return Task {}
+        }
+
+        XCTAssertNil(task)
+        XCTAssertFalse(invocation.wasInvoked)
+    }
+}
+
+private final class InvocationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var invoked = false
+
+    var wasInvoked: Bool {
+        lock.withLock { invoked }
+    }
+
+    func markInvoked() {
+        lock.withLock { invoked = true }
     }
 }
 

--- a/Tests/RepoPromptTests/AI/CodexCLIProviderDisposalTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexCLIProviderDisposalTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class CodexCLIProviderDisposalTests: XCTestCase {
+    func testDisposeAwaitsCancelledBridgeTaskCleanup() async {
+        let provider = CodexCLIProvider()
+        let gate = DisposalGate()
+        let bridgeTask = Task {
+            await withTaskCancellationHandler {
+                await gate.waitForRelease()
+            } onCancel: {
+                Task { await gate.markCancelled() }
+            }
+            await gate.markBridgeFinished()
+        }
+        provider.test_registerActiveStreamTask(bridgeTask, id: UUID())
+
+        let disposalTask = Task {
+            await provider.dispose()
+            await gate.markDisposeReturned()
+        }
+
+        await gate.waitForCancellation()
+        let returnedBeforeCleanup = await gate.disposeReturned
+        XCTAssertFalse(returnedBeforeCleanup)
+
+        await gate.releaseBridge()
+        await disposalTask.value
+        let bridgeFinished = await gate.bridgeFinished
+        XCTAssertTrue(bridgeFinished)
+    }
+}
+
+private actor DisposalGate {
+    private var cancellationObserved = false
+    private var released = false
+    private(set) var bridgeFinished = false
+    private(set) var disposeReturned = false
+    private var cancellationWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func markCancelled() {
+        cancellationObserved = true
+        let waiters = cancellationWaiters
+        cancellationWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func waitForCancellation() async {
+        guard !cancellationObserved else { return }
+        await withCheckedContinuation { continuation in
+            cancellationWaiters.append(continuation)
+        }
+    }
+
+    func waitForRelease() async {
+        guard !released else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func releaseBridge() {
+        released = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func markBridgeFinished() {
+        bridgeFinished = true
+    }
+
+    func markDisposeReturned() {
+        disposeReturned = true
+    }
+}

--- a/Tests/RepoPromptTests/AI/GrokBuildModelRoutingTests.swift
+++ b/Tests/RepoPromptTests/AI/GrokBuildModelRoutingTests.swift
@@ -82,6 +82,66 @@ final class GrokBuildModelRoutingTests: XCTestCase {
         XCTAssertTrue(message.systemPrompt.contains("Do not use any tools"))
     }
 
+    func testOneShotTextPromptKeepsPromptFileArguments() throws {
+        let arguments = try GrokBuildOneShotHeadlessAgentProvider.test_promptArguments(
+            for: AgentMessage(systemPrompt: "system", userMessage: "text"),
+            promptFilePath: "/tmp/prompt.txt"
+        )
+
+        XCTAssertEqual(Array(arguments.prefix(2)), ["--prompt-file", "/tmp/prompt.txt"])
+        XCTAssertFalse(arguments.contains("--prompt-json"))
+    }
+
+    func testOneShotImagePromptUsesACPShapedPromptJSON() throws {
+        let message = AgentMessage(
+            systemPrompt: "system",
+            userMessage: "inspect",
+            transientImages: [
+                .init(bytes: Data([1, 2, 3]), mediaType: .png, title: "Diagram")
+            ]
+        )
+        let arguments = try GrokBuildOneShotHeadlessAgentProvider.test_promptArguments(
+            for: message,
+            promptFilePath: "/tmp/prompt.txt"
+        )
+        let jsonIndex = try XCTUnwrap(arguments.firstIndex(of: "--prompt-json"))
+        let json = arguments[jsonIndex + 1]
+        let blocks = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [[String: Any]]
+        )
+
+        XCTAssertFalse(arguments.contains("--prompt-file"))
+        XCTAssertEqual(blocks.first?["type"] as? String, "text")
+        XCTAssertEqual(blocks.first?["text"] as? String, "system\n\ninspect")
+        XCTAssertEqual(blocks.last?["type"] as? String, "image")
+        XCTAssertEqual(blocks.last?["mimeType"] as? String, "image/png")
+        XCTAssertEqual(blocks.last?["data"] as? String, "AQID")
+    }
+
+    func testOneShotImagePromptRejectsUnsafeArgvSize() {
+        let message = AgentMessage(
+            userMessage: "inspect",
+            transientImages: [
+                .init(
+                    bytes: Data(count: GrokBuildOneShotHeadlessAgentProvider.test_promptJSONArgumentByteLimit),
+                    mediaType: .png,
+                    title: nil
+                )
+            ]
+        )
+
+        XCTAssertThrowsError(try GrokBuildOneShotHeadlessAgentProvider.test_promptArguments(
+            for: message,
+            promptFilePath: "/tmp/prompt.txt"
+        )) { error in
+            guard case let AIProviderError.invalidConfiguration(detail) = error else {
+                return XCTFail("Expected actionable provider configuration error, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("safe macOS command-line launch"))
+            XCTAssertTrue(detail.contains("Reduce the number or size of attached images"))
+        }
+    }
+
     func testNonAgentAdapterMapsNonSuccessfulStopsToIncomplete() {
         let incompleteStopReasons = [
             "max_tokens",

--- a/Tests/RepoPromptTests/AI/GrokBuildModelRoutingTests.swift
+++ b/Tests/RepoPromptTests/AI/GrokBuildModelRoutingTests.swift
@@ -82,9 +82,8 @@ final class GrokBuildModelRoutingTests: XCTestCase {
         XCTAssertTrue(message.systemPrompt.contains("Do not use any tools"))
     }
 
-    func testOneShotTextPromptKeepsPromptFileArguments() throws {
-        let arguments = try GrokBuildOneShotHeadlessAgentProvider.test_promptArguments(
-            for: AgentMessage(systemPrompt: "system", userMessage: "text"),
+    func testOneShotTextPromptKeepsPromptFileArguments() {
+        let arguments = GrokBuildOneShotHeadlessAgentProvider.test_promptArguments(
             promptFilePath: "/tmp/prompt.txt"
         )
 
@@ -92,53 +91,27 @@ final class GrokBuildModelRoutingTests: XCTestCase {
         XCTAssertFalse(arguments.contains("--prompt-json"))
     }
 
-    func testOneShotImagePromptUsesACPShapedPromptJSON() throws {
+    func testOneShotRejectsImagesBeforeLaunchWithoutLeakingPayload() async {
+        let provider = GrokBuildOneShotHeadlessAgentProvider(
+            config: GrokBuildCLIProvider.test_makeHeadlessConfig(modelName: nil)
+        )
         let message = AgentMessage(
             systemPrompt: "system",
             userMessage: "inspect",
             transientImages: [
-                .init(bytes: Data([1, 2, 3]), mediaType: .png, title: "Diagram")
-            ]
-        )
-        let arguments = try GrokBuildOneShotHeadlessAgentProvider.test_promptArguments(
-            for: message,
-            promptFilePath: "/tmp/prompt.txt"
-        )
-        let jsonIndex = try XCTUnwrap(arguments.firstIndex(of: "--prompt-json"))
-        let json = arguments[jsonIndex + 1]
-        let blocks = try XCTUnwrap(
-            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [[String: Any]]
-        )
-
-        XCTAssertFalse(arguments.contains("--prompt-file"))
-        XCTAssertEqual(blocks.first?["type"] as? String, "text")
-        XCTAssertEqual(blocks.first?["text"] as? String, "system\n\ninspect")
-        XCTAssertEqual(blocks.last?["type"] as? String, "image")
-        XCTAssertEqual(blocks.last?["mimeType"] as? String, "image/png")
-        XCTAssertEqual(blocks.last?["data"] as? String, "AQID")
-    }
-
-    func testOneShotImagePromptRejectsUnsafeArgvSize() {
-        let message = AgentMessage(
-            userMessage: "inspect",
-            transientImages: [
-                .init(
-                    bytes: Data(count: GrokBuildOneShotHeadlessAgentProvider.test_promptJSONArgumentByteLimit),
-                    mediaType: .png,
-                    title: nil
-                )
+                .init(bytes: Data([1, 2, 3]), mediaType: .png, title: "Secret Diagram")
             ]
         )
 
-        XCTAssertThrowsError(try GrokBuildOneShotHeadlessAgentProvider.test_promptArguments(
-            for: message,
-            promptFilePath: "/tmp/prompt.txt"
-        )) { error in
-            guard case let AIProviderError.invalidConfiguration(detail) = error else {
-                return XCTFail("Expected actionable provider configuration error, got \(error)")
-            }
-            XCTAssertTrue(detail.contains("safe macOS command-line launch"))
-            XCTAssertTrue(detail.contains("Reduce the number or size of attached images"))
+        do {
+            _ = try await provider.streamAgentMessage(message)
+            XCTFail("Expected Grok Build image rejection")
+        } catch let AIProviderError.invalidConfiguration(detail) {
+            XCTAssertTrue(detail.contains("image attachments"))
+            XCTAssertFalse(detail.contains("AQID"))
+            XCTAssertFalse(detail.contains("Secret Diagram"))
+        } catch {
+            XCTFail("Expected actionable provider configuration error, got \(error)")
         }
     }
 

--- a/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
+++ b/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+@testable import RepoPromptApp
+import SwiftAnthropic
+import XCTest
+
+final class OracleImageSerializationTests: XCTestCase {
+    func testAnthropicAttachesOnlyToFinalUserTurn() throws {
+        let json = try jsonObject(AnthropicProvider.makeMessages(for: makeMessage()))
+        let text = try jsonText(json)
+
+        XCTAssertEqual(countObjects(type: "image", in: json), 1)
+        XCTAssertTrue(text.contains("Image title: Diagram"))
+        XCTAssertTrue(text.contains("AQID"))
+        XCTAssertFalse(text.contains("/Users/secret.png"))
+        let messages = try XCTUnwrap(json as? [[String: Any]])
+        XCTAssertFalse(try jsonText(messages[0]).contains("AQID"))
+        XCTAssertTrue(try jsonText(XCTUnwrap(messages.last)).contains("AQID"))
+    }
+
+    func testRouteAdmissionAllowsOnlyDirectBuiltInAnthropicRoutes() {
+        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4Sonnet))
+        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4Opus))
+
+        XCTAssertFalse(OracleImageRouteAdmission.supports(.gpt5))
+        XCTAssertFalse(OracleImageRouteAdmission.supports(
+            .openAIServiceTierVariant(base: .gpt5, tier: "flex")
+        ))
+        XCTAssertFalse(OracleImageRouteAdmission.supports(.openaiCustom(name: "custom")))
+        XCTAssertFalse(OracleImageRouteAdmission.supports(.anthropicCustom(name: "custom")))
+        XCTAssertFalse(OracleImageRouteAdmission.supports(.codexCustom(name: "codex")))
+        XCTAssertFalse(OracleImageRouteAdmission.supports(.ollama))
+    }
+
+    private func makeMessage() -> AIMessage {
+        AIMessage(
+            systemPrompt: "system",
+            conversationMessages: [
+                .init(role: .user, content: "first"),
+                .init(role: .assistant, content: "answer"),
+                .init(role: .user, content: "final")
+            ],
+            transientImages: [
+                .init(bytes: Data([1, 2, 3]), mediaType: .png, title: "Diagram")
+            ],
+            temperature: nil,
+            promptSectionsOrder: [],
+            disabledPromptSections: []
+        )
+    }
+
+    private func jsonObject(_ value: some Encodable) throws -> Any {
+        try JSONSerialization.jsonObject(with: JSONEncoder().encode(value))
+    }
+
+    private func jsonText(_ value: Any) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
+    }
+
+    private func countObjects(type: String, in value: Any) -> Int {
+        if let object = value as? [String: Any] {
+            return (object["type"] as? String == type ? 1 : 0)
+                + object.values.reduce(0) { $0 + countObjects(type: type, in: $1) }
+        }
+        if let array = value as? [Any] {
+            return array.reduce(0) { $0 + countObjects(type: type, in: $1) }
+        }
+        return 0
+    }
+}

--- a/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
+++ b/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
@@ -37,12 +37,12 @@ final class OracleImageSerializationTests: XCTestCase {
             .claudeCodeSonnet,
             .codexCustom(name: "codex"),
             .openCodeCustom(name: "opencode"),
-            .cursorCustom(name: "cursor"),
-            .grokBuildCustom(name: "grok")
+            .cursorCustom(name: "cursor")
         ]
         for model in models {
             XCTAssertTrue(OracleImageRouteAdmission.supports(model), "Expected \(model) to admit images")
         }
+        XCTAssertFalse(OracleImageRouteAdmission.supports(.grokBuildCustom(name: "grok")))
     }
 
     func testOpenAITextOnlyMessagesRemainScalar() throws {

--- a/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
+++ b/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
@@ -18,12 +18,19 @@ final class OracleImageSerializationTests: XCTestCase {
     }
 
     func testRouteAdmissionAllowsOnlyDirectBuiltInAnthropicRoutes() {
+        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude45Haiku))
         XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4Sonnet))
+        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4SonnetThinking))
+        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4SonnetThinkingMax))
         XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4Opus))
+        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4OpusThinking))
 
         XCTAssertFalse(OracleImageRouteAdmission.supports(.gpt5))
         XCTAssertFalse(OracleImageRouteAdmission.supports(
             .openAIServiceTierVariant(base: .gpt5, tier: "flex")
+        ))
+        XCTAssertFalse(OracleImageRouteAdmission.supports(
+            .openAIServiceTierVariant(base: .claude4Sonnet, tier: "flex")
         ))
         XCTAssertFalse(OracleImageRouteAdmission.supports(.openaiCustom(name: "custom")))
         XCTAssertFalse(OracleImageRouteAdmission.supports(.anthropicCustom(name: "custom")))

--- a/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
+++ b/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
@@ -17,25 +17,226 @@ final class OracleImageSerializationTests: XCTestCase {
         XCTAssertTrue(try jsonText(XCTUnwrap(messages.last)).contains("AQID"))
     }
 
-    func testRouteAdmissionAllowsOnlyDirectBuiltInAnthropicRoutes() {
-        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude45Haiku))
-        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4Sonnet))
-        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4SonnetThinking))
-        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4SonnetThinkingMax))
-        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4Opus))
-        XCTAssertTrue(OracleImageRouteAdmission.supports(.claude4OpusThinking))
+    func testRouteAdmissionAllowsEveryOracleProviderTransport() {
+        let models: [AIModel] = [
+            .claude4Sonnet,
+            .anthropicCustom(name: "custom"),
+            .gpt5,
+            .openAIServiceTierVariant(base: .gpt5, tier: "flex"),
+            .openaiCustom(name: "custom"),
+            .ollama,
+            .azureCustom(name: "azure"),
+            .openrouterCustom(name: "openrouter"),
+            .geminiFlash25,
+            .deepseekChat,
+            .customProviderUser(name: "custom"),
+            .fireworksDeepseekV3p1Terminus,
+            .grokCodeFast1,
+            .groqKimi,
+            .zaiGLM45,
+            .claudeCodeSonnet,
+            .codexCustom(name: "codex"),
+            .openCodeCustom(name: "opencode"),
+            .cursorCustom(name: "cursor"),
+            .grokBuildCustom(name: "grok")
+        ]
+        for model in models {
+            XCTAssertTrue(OracleImageRouteAdmission.supports(model), "Expected \(model) to admit images")
+        }
+    }
 
-        XCTAssertFalse(OracleImageRouteAdmission.supports(.gpt5))
-        XCTAssertFalse(OracleImageRouteAdmission.supports(
-            .openAIServiceTierVariant(base: .gpt5, tier: "flex")
-        ))
-        XCTAssertFalse(OracleImageRouteAdmission.supports(
-            .openAIServiceTierVariant(base: .claude4Sonnet, tier: "flex")
-        ))
-        XCTAssertFalse(OracleImageRouteAdmission.supports(.openaiCustom(name: "custom")))
-        XCTAssertFalse(OracleImageRouteAdmission.supports(.anthropicCustom(name: "custom")))
-        XCTAssertFalse(OracleImageRouteAdmission.supports(.codexCustom(name: "codex")))
-        XCTAssertFalse(OracleImageRouteAdmission.supports(.ollama))
+    func testOpenAITextOnlyMessagesRemainScalar() throws {
+        let message = AIMessage(systemPrompt: "system", userMessage: "plain")
+        let chat = try XCTUnwrap(try jsonObject(
+            message.openAIChatMessages(embedSystemPrompt: false)
+        ) as? [[String: Any]])
+        XCTAssertTrue(chat.allSatisfy { $0["content"] is String })
+
+        let provider = CustomOpenAIProvider(
+            baseURL: "https://example.test/v1",
+            apiKey: "key",
+            defaultModel: "text-model"
+        )
+        let custom = try XCTUnwrap(try jsonObject(
+            provider.serializedMessagesForTesting(message)
+        ) as? [[String: Any]])
+        XCTAssertTrue(custom.allSatisfy { $0["content"] is String })
+
+        let assistantOnly = AIMessage(
+            systemPrompt: "",
+            fileTree: "root",
+            conversationMessages: [.init(role: .assistant, content: "answer")],
+            temperature: nil,
+            promptSectionsOrder: [.fileMap],
+            disabledPromptSections: []
+        )
+        let responses = try XCTUnwrap(try jsonObject(
+            assistantOnly.openAIResponsesInput()
+        ) as? [[String: Any]])
+        XCTAssertEqual(responses.count, 1)
+        XCTAssertEqual(responses.first?["role"] as? String, "assistant")
+    }
+
+    func testOpenAIChatAttachesOnlyToFinalUserTurn() throws {
+        let json = try jsonObject(makeMessage().openAIChatMessages(embedSystemPrompt: false))
+        let text = try jsonText(json)
+        let messages = try XCTUnwrap(json as? [[String: Any]])
+
+        XCTAssertEqual(countObjects(type: "image_url", in: json), 1)
+        XCTAssertTrue(
+            text.contains("data:image/png;base64,AQID") ||
+                text.contains("data:image\\/png;base64,AQID")
+        )
+        XCTAssertTrue(text.contains("Image title: Diagram"))
+        XCTAssertFalse(try jsonText(messages[1]).contains("AQID"))
+        XCTAssertTrue(try jsonText(XCTUnwrap(messages.last)).contains("AQID"))
+    }
+
+    func testOpenAIResponsesAttachesOnlyToFinalUserTurn() throws {
+        let json = try jsonObject(makeMessage().openAIResponsesInput())
+        let text = try jsonText(json)
+
+        XCTAssertEqual(countObjects(type: "input_image", in: json), 1)
+        XCTAssertTrue(
+            text.contains("data:image/png;base64,AQID") ||
+                text.contains("data:image\\/png;base64,AQID")
+        )
+        XCTAssertTrue(text.contains("Image title: Diagram"))
+    }
+
+    func testCustomOpenAIEncodesFinalUserAsContentArray() throws {
+        let provider = CustomOpenAIProvider(
+            baseURL: "https://example.test/v1",
+            apiKey: "key",
+            defaultModel: "vision-model"
+        )
+        let json = try jsonObject(provider.serializedMessagesForTesting(makeMessage()))
+        let messages = try XCTUnwrap(json as? [[String: Any]])
+        let earlierContent = messages[1]["content"]
+        let finalMessage = try XCTUnwrap(messages.last)
+        let finalContent = try XCTUnwrap(finalMessage["content"] as? [[String: Any]])
+
+        XCTAssertTrue(earlierContent is String)
+        XCTAssertEqual(countObjects(type: "image_url", in: finalContent), 1)
+        let finalText = try jsonText(finalContent)
+        XCTAssertTrue(
+            finalText.contains("data:image/png;base64,AQID") ||
+                finalText.contains("data:image\\/png;base64,AQID")
+        )
+    }
+
+    func testCustomOpenAISynthesizedImageTurnKeepsAdditionsBeforeImages() throws {
+        let provider = CustomOpenAIProvider(
+            baseURL: "https://example.test/v1",
+            apiKey: "key",
+            defaultModel: "vision-model"
+        )
+        let message = AIMessage(
+            systemPrompt: "system",
+            fileTree: "root",
+            conversationMessages: [.init(role: .assistant, content: "answer")],
+            transientImages: [
+                .init(bytes: Data([1, 2, 3]), mediaType: .png, title: "Diagram")
+            ],
+            temperature: nil,
+            promptSectionsOrder: [.fileMap],
+            disabledPromptSections: []
+        )
+        let json = try jsonObject(provider.serializedMessagesForTesting(message))
+        let messages = try XCTUnwrap(json as? [[String: Any]])
+        let synthesized = try XCTUnwrap(messages.last)
+        let parts = try XCTUnwrap(synthesized["content"] as? [[String: Any]])
+
+        XCTAssertEqual(synthesized["role"] as? String, "user")
+        XCTAssertEqual(parts.first?["type"] as? String, "text")
+        XCTAssertTrue((parts.first?["text"] as? String)?.contains("root") == true)
+        XCTAssertEqual(parts.last?["type"] as? String, "image_url")
+    }
+
+    func testACPEncodesTransientImagesInlineWithoutURI() throws {
+        let image = AITransientImage(bytes: Data([1, 2, 3]), mediaType: .png, title: "Diagram")
+        let blocks = try ACPPromptContentBuilder.blocks(
+            text: "Inspect",
+            attachments: [],
+            transientImages: [image]
+        )
+        let imageBlock = try XCTUnwrap(blocks.last)
+
+        XCTAssertEqual(imageBlock["type"] as? String, "image")
+        XCTAssertEqual(imageBlock["mimeType"] as? String, "image/png")
+        XCTAssertEqual(imageBlock["data"] as? String, "AQID")
+        XCTAssertNil(imageBlock["uri"])
+    }
+
+    func testACPCLIAdaptersPreserveTransientImages() {
+        let message = makeMessage()
+        let openCode = OpenCodeCLIProvider.test_makeAgentMessage(from: message)
+        let cursor = CursorCLIProvider.test_makeAgentMessage(from: message)
+
+        XCTAssertEqual(openCode.transientImages, message.transientImages)
+        XCTAssertEqual(cursor.transientImages, message.transientImages)
+    }
+
+    func testCodexStagesTransientImagesWithOwnerOnlyPermissionsAndCleansUp() async throws {
+        let bytes = Data([0xFF, 0xD8, 0xFF])
+        var stagedFileURL: URL?
+        var stagedDirectoryURL: URL?
+
+        try await CodexCLIProvider.test_withStagedTransientImages([
+            .init(bytes: bytes, mediaType: .jpeg, title: "  Reference  ")
+        ]) { attachments in
+            let attachment = try XCTUnwrap(attachments.first)
+            XCTAssertEqual(attachments.count, 1)
+            XCTAssertEqual(attachment.title, "Reference")
+            guard case let .localFile(path) = attachment.source else {
+                return XCTFail("Expected Codex staging to produce a local-file attachment")
+            }
+
+            let fileURL = URL(fileURLWithPath: path)
+            let directoryURL = fileURL.deletingLastPathComponent()
+            stagedFileURL = fileURL
+            stagedDirectoryURL = directoryURL
+
+            XCTAssertTrue(directoryURL.lastPathComponent.hasPrefix("RepoPromptOracleImages-"))
+            XCTAssertEqual(fileURL.pathExtension, "jpg")
+            XCTAssertEqual(try Data(contentsOf: fileURL), bytes)
+
+            let directoryAttributes = try FileManager.default.attributesOfItem(atPath: directoryURL.path)
+            let fileAttributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+            XCTAssertEqual((directoryAttributes[.posixPermissions] as? NSNumber)?.intValue, 0o700)
+            XCTAssertEqual((fileAttributes[.posixPermissions] as? NSNumber)?.intValue, 0o600)
+        }
+
+        let fileURL = try XCTUnwrap(stagedFileURL)
+        let directoryURL = try XCTUnwrap(stagedDirectoryURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directoryURL.path))
+    }
+
+    func testClaudeStreamJSONEncodesTransientImages() throws {
+        let line = try ClaudeCodeProvider.makeStreamJSONInput(
+            prompt: "Inspect",
+            images: [.init(bytes: Data([1, 2, 3]), mediaType: .png, title: "Diagram")]
+        )
+        XCTAssertTrue(line.hasSuffix("\n"))
+        let data = try XCTUnwrap(line.dropLast().data(using: .utf8))
+        let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let message = try XCTUnwrap(payload["message"] as? [String: Any])
+        let content = try XCTUnwrap(message["content"] as? [[String: Any]])
+        let image = try XCTUnwrap(content.last)
+        let source = try XCTUnwrap(image["source"] as? [String: Any])
+
+        XCTAssertEqual(payload["type"] as? String, "user")
+        XCTAssertEqual(image["type"] as? String, "image")
+        XCTAssertEqual(source["type"] as? String, "base64")
+        XCTAssertEqual(source["media_type"] as? String, "image/png")
+        XCTAssertEqual(source["data"] as? String, "AQID")
+
+        var options = ClaudeCLIOptions()
+        XCTAssertFalse(options.toTokens().contains("--input-format"))
+        options.inputFormat = "stream-json"
+        XCTAssertTrue(options.toTokens().contains("--input-format"))
+        XCTAssertTrue(options.toTokens().contains("stream-json"))
     }
 
     private func makeMessage() -> AIMessage {

--- a/Tests/RepoPromptTests/MCP/OracleImageAttachmentLoaderTests.swift
+++ b/Tests/RepoPromptTests/MCP/OracleImageAttachmentLoaderTests.swift
@@ -1,0 +1,278 @@
+import Darwin
+import Dispatch
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class OracleImageAttachmentLoaderTests: XCTestCase {
+    private var testRoot: URL!
+
+    override func setUpWithError() throws {
+        testRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent(".build/oracle-image-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: testRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let testRoot {
+            try? FileManager.default.removeItem(at: testRoot)
+        }
+    }
+
+    func testLoadsClassicFormatsAndPreservesOrderWithoutPaths() throws {
+        let fixtures: [(String, Data, AIImageMediaType)] = [
+            ("one.png", Self.pngData, .png),
+            ("two.JPG", Self.jpegData, .jpeg),
+            ("three.gif", Self.gifData, .gif),
+            ("four.webp", Self.webpData, .webp)
+        ]
+        let requests = try fixtures.enumerated().map { index, fixture in
+            let url = testRoot.appendingPathComponent(fixture.0)
+            try fixture.1.write(to: url)
+            return OracleImageRequest(index: index, path: url.path, title: "Image \(index + 1)")
+        }
+
+        let images = try OracleImageAttachmentLoader().load(
+            requests: requests,
+            authority: authority(logical: testRoot, physical: testRoot)
+        )
+
+        XCTAssertEqual(images.map(\.mediaType), fixtures.map(\.2))
+        XCTAssertEqual(images.map(\.bytes), fixtures.map(\.1))
+        XCTAssertEqual(images.map(\.title), ["Image 1", "Image 2", "Image 3", "Image 4"])
+    }
+
+    func testLogicalPathReadsBoundPhysicalWorktreeFile() throws {
+        let logicalRoot = testRoot.appendingPathComponent("logical", isDirectory: true)
+        let physicalRoot = testRoot.appendingPathComponent("worktree", isDirectory: true)
+        try FileManager.default.createDirectory(at: logicalRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: physicalRoot, withIntermediateDirectories: true)
+        try Data("not an image".utf8).write(to: logicalRoot.appendingPathComponent("asset.png"))
+        try Self.pngData.write(to: physicalRoot.appendingPathComponent("asset.png"))
+
+        let images = try OracleImageAttachmentLoader().load(
+            requests: [.init(
+                index: 0,
+                path: logicalRoot.appendingPathComponent("asset.png").path,
+                title: nil
+            )],
+            authority: authority(logical: logicalRoot, physical: physicalRoot)
+        )
+
+        XCTAssertEqual(images.first?.bytes, Self.pngData)
+    }
+
+    func testRejectsNonCanonicalOutsideAndSymlinkPathsWithoutLeakingThem() throws {
+        let imageURL = testRoot.appendingPathComponent("image.png")
+        try Self.pngData.write(to: imageURL)
+        let linkURL = testRoot.appendingPathComponent("link.png")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: imageURL)
+        let siblingURL = testRoot.deletingLastPathComponent().appendingPathComponent("outside-\(UUID()).png")
+        try Self.pngData.write(to: siblingURL)
+        defer { try? FileManager.default.removeItem(at: siblingURL) }
+
+        let cases = [
+            "relative.png",
+            testRoot.appendingPathComponent("folder/../image.png").path,
+            siblingURL.path,
+            linkURL.path
+        ]
+        for path in cases {
+            XCTAssertThrowsError(try OracleImageAttachmentLoader().load(
+                requests: [.init(index: 0, path: path, title: nil)],
+                authority: authority(logical: testRoot, physical: testRoot)
+            )) { error in
+                XCTAssertFalse(error.localizedDescription.contains(testRoot.path))
+                XCTAssertFalse(error.localizedDescription.contains("image.png"))
+                XCTAssertFalse(error.localizedDescription.contains("link.png"))
+            }
+        }
+    }
+
+    func testAllowsSymlinkedTrustedRootButRejectsSymlinksBelowIt() throws {
+        let actualRoot = testRoot.appendingPathComponent("actual", isDirectory: true)
+        try FileManager.default.createDirectory(at: actualRoot, withIntermediateDirectories: true)
+        try Self.gifData.write(to: actualRoot.appendingPathComponent("image.gif"))
+
+        let trustedRoot = testRoot.appendingPathComponent("trusted-root", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: trustedRoot, withDestinationURL: actualRoot)
+        let images = try OracleImageAttachmentLoader().load(
+            requests: [.init(
+                index: 0,
+                path: trustedRoot.appendingPathComponent("image.gif").path,
+                title: nil
+            )],
+            authority: authority(logical: trustedRoot, physical: trustedRoot)
+        )
+        XCTAssertEqual(images.first?.bytes, Self.gifData)
+
+        let realDirectory = actualRoot.appendingPathComponent("real-directory", isDirectory: true)
+        try FileManager.default.createDirectory(at: realDirectory, withIntermediateDirectories: true)
+        try Self.gifData.write(to: realDirectory.appendingPathComponent("nested.gif"))
+        try FileManager.default.createSymbolicLink(
+            at: actualRoot.appendingPathComponent("linked-directory", isDirectory: true),
+            withDestinationURL: realDirectory
+        )
+        XCTAssertThrowsError(try OracleImageAttachmentLoader().load(
+            requests: [.init(
+                index: 0,
+                path: trustedRoot.appendingPathComponent("linked-directory/nested.gif").path,
+                title: nil
+            )],
+            authority: authority(logical: trustedRoot, physical: trustedRoot)
+        )) { error in
+            guard let loadError = error as? OracleImageLoadError else {
+                return XCTFail("Expected OracleImageLoadError, got \(error)")
+            }
+            XCTAssertTrue(
+                loadError == .unsafePath(index: 0)
+                    || loadError == .missingOrUnreadable(index: 0)
+            )
+        }
+    }
+
+    func testDirectoryDescriptorDuplicationSetsCloseOnExec() {
+        let descriptor = testRoot.path.withCString {
+            Darwin.open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        }
+        XCTAssertGreaterThanOrEqual(descriptor, 0)
+        defer { if descriptor >= 0 { Darwin.close(descriptor) } }
+
+        let duplicate = OracleImageAttachmentLoader.duplicateDirectoryDescriptor(descriptor)
+        XCTAssertGreaterThanOrEqual(duplicate, 0)
+        defer { if duplicate >= 0 { Darwin.close(duplicate) } }
+        XCTAssertNotEqual(fcntl(duplicate, F_GETFD) & FD_CLOEXEC, 0)
+    }
+
+    func testParentCancellationCancelsDetachedLoad() async throws {
+        let imageURL = testRoot.appendingPathComponent("cancel.gif")
+        try Self.gifData.write(to: imageURL)
+        let authority = authority(logical: testRoot, physical: testRoot)
+        let started = DispatchSemaphore(value: 0)
+        let loader = OracleImageAttachmentLoader(afterFirstRead: { _ in
+            started.signal()
+            let deadline = Date().addingTimeInterval(2)
+            while !Task.isCancelled, Date() < deadline {
+                Darwin.usleep(1000)
+            }
+            guard Task.isCancelled else {
+                throw CancellationProbeError.notPropagated
+            }
+            throw CancellationError()
+        })
+        let task = Task {
+            try await OracleImageAttachmentLoader.loadDetached(
+                requests: [.init(index: 0, path: imageURL.path, title: nil)],
+                authority: authority,
+                loader: loader
+            )
+        }
+
+        XCTAssertEqual(started.wait(timeout: .now() + 2), .success)
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected: parent cancellation reached detached loader work.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
+    func testEnforcesPerImageAndTotalLimitsBeforeReturningPayloads() throws {
+        let firstURL = testRoot.appendingPathComponent("first.gif")
+        let secondURL = testRoot.appendingPathComponent("second.gif")
+        try Self.gifData.write(to: firstURL)
+        try Self.gifData.write(to: secondURL)
+
+        XCTAssertThrowsError(try OracleImageAttachmentLoader(
+            limits: .init(maxCount: 10, maxBytesPerImage: Self.gifData.count - 1, maxTotalBytes: 100)
+        ).load(
+            requests: [.init(index: 0, path: firstURL.path, title: nil)],
+            authority: authority(logical: testRoot, physical: testRoot)
+        )) { error in
+            XCTAssertEqual(
+                error as? OracleImageLoadError,
+                .tooLarge(index: 0, maximumBytes: Self.gifData.count - 1)
+            )
+        }
+
+        XCTAssertThrowsError(try OracleImageAttachmentLoader(
+            limits: .init(
+                maxCount: 10,
+                maxBytesPerImage: Self.gifData.count,
+                maxTotalBytes: Self.gifData.count * 2 - 1
+            )
+        ).load(
+            requests: [
+                .init(index: 0, path: firstURL.path, title: nil),
+                .init(index: 1, path: secondURL.path, title: nil)
+            ],
+            authority: authority(logical: testRoot, physical: testRoot)
+        )) { error in
+            XCTAssertEqual(
+                error as? OracleImageLoadError,
+                .totalTooLarge(maximumBytes: Self.gifData.count * 2 - 1)
+            )
+        }
+    }
+
+    func testRejectsExtensionMismatchIncompleteJPEGAndFileReplacementDuringRead() throws {
+        let incompleteJPEGURL = testRoot.appendingPathComponent("incomplete.jpg")
+        try Self.jpegData.dropLast(2).write(to: incompleteJPEGURL)
+        XCTAssertThrowsError(try OracleImageAttachmentLoader().load(
+            requests: [.init(index: 0, path: incompleteJPEGURL.path, title: nil)],
+            authority: authority(logical: testRoot, physical: testRoot)
+        )) { error in
+            XCTAssertEqual(error as? OracleImageLoadError, .unsupportedFormat(index: 0))
+        }
+
+        let mismatchURL = testRoot.appendingPathComponent("wrong.jpg")
+        try Self.pngData.write(to: mismatchURL)
+        XCTAssertThrowsError(try OracleImageAttachmentLoader().load(
+            requests: [.init(index: 0, path: mismatchURL.path, title: nil)],
+            authority: authority(logical: testRoot, physical: testRoot)
+        )) { error in
+            XCTAssertEqual(
+                error as? OracleImageLoadError,
+                .extensionMismatch(index: 0, mediaType: .png)
+            )
+        }
+
+        let changingURL = testRoot.appendingPathComponent("changing.gif")
+        try Self.gifData.write(to: changingURL)
+        let replacement = Data(Array("GIF87a".utf8) + [2, 0, 1, 0])
+        let loader = OracleImageAttachmentLoader(afterFirstRead: { _ in
+            try replacement.write(to: changingURL, options: .atomic)
+        })
+        XCTAssertThrowsError(try loader.load(
+            requests: [.init(index: 0, path: changingURL.path, title: nil)],
+            authority: authority(logical: testRoot, physical: testRoot)
+        )) { error in
+            XCTAssertEqual(error as? OracleImageLoadError, .changedWhileReading(index: 0))
+        }
+    }
+
+    private func authority(logical: URL, physical: URL) -> OracleImageWorkspaceAuthority {
+        OracleImageWorkspaceAuthority(roots: [
+            .init(logicalRootPath: logical.path, physicalRootPath: physical.path)
+        ])
+    }
+
+    private enum CancellationProbeError: Error {
+        case notPropagated
+    }
+
+    private static let pngData: Data = {
+        var bytes: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+        bytes += [0, 0, 0, 13]
+        bytes += Array("IHDR".utf8)
+        bytes += Array(repeating: 0, count: 17)
+        return Data(bytes)
+    }()
+
+    private static let jpegData = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0xFF, 0xD9])
+    private static let gifData = Data(Array("GIF89a".utf8) + [1, 0, 1, 0])
+    private static let webpData = Data(Array("RIFF".utf8) + [0, 0, 0, 0] + Array("WEBPVP8 ".utf8))
+}

--- a/Tests/RepoPromptTests/MCP/OracleImageAttachmentLoaderTests.swift
+++ b/Tests/RepoPromptTests/MCP/OracleImageAttachmentLoaderTests.swift
@@ -258,13 +258,54 @@ final class OracleImageAttachmentLoaderTests: XCTestCase {
         }
     }
 
+    func testPhysicalRootCapturePinsEveryAliasToOneIdentity() throws {
+        let originalRoot = testRoot.appendingPathComponent("original", isDirectory: true)
+        let retargetedRoot = testRoot.appendingPathComponent("retargeted", isDirectory: true)
+        try FileManager.default.createDirectory(at: originalRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: retargetedRoot, withIntermediateDirectories: true)
+        try Self.gifData.write(to: originalRoot.appendingPathComponent("image.gif"))
+        let replacement = Data(Array("GIF87a".utf8) + [2, 0, 1, 0])
+        try replacement.write(to: retargetedRoot.appendingPathComponent("image.gif"))
+
+        let trustedRoot = testRoot.appendingPathComponent("trusted-root", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: trustedRoot, withDestinationURL: originalRoot)
+        let capture = try OracleImagePhysicalRootCapture.capture(
+            physicalRootPath: trustedRoot.path,
+            index: 0
+        )
+        let firstAlias = testRoot.appendingPathComponent("alias-a", isDirectory: true)
+        let firstProjection = capture.projection(logicalRootPath: firstAlias.path)
+
+        try FileManager.default.removeItem(at: trustedRoot)
+        try FileManager.default.createSymbolicLink(at: trustedRoot, withDestinationURL: retargetedRoot)
+        let secondAlias = testRoot.appendingPathComponent("alias-b", isDirectory: true)
+        let secondProjection = capture.projection(logicalRootPath: secondAlias.path)
+
+        XCTAssertEqual(firstProjection.rootIdentity, secondProjection.rootIdentity)
+        XCTAssertEqual(firstProjection.resolvedPhysicalRootPath, secondProjection.resolvedPhysicalRootPath)
+
+        let images = try OracleImageAttachmentLoader().load(
+            requests: [
+                .init(index: 0, path: firstAlias.appendingPathComponent("image.gif").path, title: nil),
+                .init(index: 1, path: secondAlias.appendingPathComponent("image.gif").path, title: nil),
+                .init(index: 2, path: trustedRoot.appendingPathComponent("image.gif").path, title: nil)
+            ],
+            authority: OracleImageWorkspaceAuthority(roots: [
+                firstProjection,
+                secondProjection,
+                capture.projection(logicalRootPath: trustedRoot.path)
+            ])
+        )
+        XCTAssertEqual(images.map(\.bytes), [Self.gifData, Self.gifData, Self.gifData])
+    }
+
     private func authority(logical: URL, physical: URL) throws -> OracleImageWorkspaceAuthority {
-        try OracleImageWorkspaceAuthority(roots: [
-            .capture(
-                logicalRootPath: logical.path,
-                physicalRootPath: physical.path,
-                index: 0
-            )
+        let capture = try OracleImagePhysicalRootCapture.capture(
+            physicalRootPath: physical.path,
+            index: 0
+        )
+        return OracleImageWorkspaceAuthority(roots: [
+            capture.projection(logicalRootPath: logical.path)
         ])
     }
 

--- a/Tests/RepoPromptTests/MCP/OracleImageAttachmentLoaderTests.swift
+++ b/Tests/RepoPromptTests/MCP/OracleImageAttachmentLoaderTests.swift
@@ -96,15 +96,32 @@ final class OracleImageAttachmentLoaderTests: XCTestCase {
 
         let trustedRoot = testRoot.appendingPathComponent("trusted-root", isDirectory: true)
         try FileManager.default.createSymbolicLink(at: trustedRoot, withDestinationURL: actualRoot)
+        let pinnedAuthority = try authority(logical: trustedRoot, physical: trustedRoot)
         let images = try OracleImageAttachmentLoader().load(
             requests: [.init(
                 index: 0,
                 path: trustedRoot.appendingPathComponent("image.gif").path,
                 title: nil
             )],
-            authority: authority(logical: trustedRoot, physical: trustedRoot)
+            authority: pinnedAuthority
         )
         XCTAssertEqual(images.first?.bytes, Self.gifData)
+
+        let retargetedRoot = testRoot.appendingPathComponent("retargeted", isDirectory: true)
+        try FileManager.default.createDirectory(at: retargetedRoot, withIntermediateDirectories: true)
+        let retargetedData = Data(Array("GIF87a".utf8) + [2, 0, 1, 0])
+        try retargetedData.write(to: retargetedRoot.appendingPathComponent("image.gif"))
+        try FileManager.default.removeItem(at: trustedRoot)
+        try FileManager.default.createSymbolicLink(at: trustedRoot, withDestinationURL: retargetedRoot)
+        let pinnedImages = try OracleImageAttachmentLoader().load(
+            requests: [.init(
+                index: 0,
+                path: trustedRoot.appendingPathComponent("image.gif").path,
+                title: nil
+            )],
+            authority: pinnedAuthority
+        )
+        XCTAssertEqual(pinnedImages.first?.bytes, Self.gifData)
 
         let realDirectory = actualRoot.appendingPathComponent("real-directory", isDirectory: true)
         try FileManager.default.createDirectory(at: realDirectory, withIntermediateDirectories: true)
@@ -119,7 +136,7 @@ final class OracleImageAttachmentLoaderTests: XCTestCase {
                 path: trustedRoot.appendingPathComponent("linked-directory/nested.gif").path,
                 title: nil
             )],
-            authority: authority(logical: trustedRoot, physical: trustedRoot)
+            authority: pinnedAuthority
         )) { error in
             guard let loadError = error as? OracleImageLoadError else {
                 return XCTFail("Expected OracleImageLoadError, got \(error)")
@@ -131,23 +148,10 @@ final class OracleImageAttachmentLoaderTests: XCTestCase {
         }
     }
 
-    func testDirectoryDescriptorDuplicationSetsCloseOnExec() {
-        let descriptor = testRoot.path.withCString {
-            Darwin.open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
-        }
-        XCTAssertGreaterThanOrEqual(descriptor, 0)
-        defer { if descriptor >= 0 { Darwin.close(descriptor) } }
-
-        let duplicate = OracleImageAttachmentLoader.duplicateDirectoryDescriptor(descriptor)
-        XCTAssertGreaterThanOrEqual(duplicate, 0)
-        defer { if duplicate >= 0 { Darwin.close(duplicate) } }
-        XCTAssertNotEqual(fcntl(duplicate, F_GETFD) & FD_CLOEXEC, 0)
-    }
-
     func testParentCancellationCancelsDetachedLoad() async throws {
         let imageURL = testRoot.appendingPathComponent("cancel.gif")
         try Self.gifData.write(to: imageURL)
-        let authority = authority(logical: testRoot, physical: testRoot)
+        let authority = try authority(logical: testRoot, physical: testRoot)
         let started = DispatchSemaphore(value: 0)
         let loader = OracleImageAttachmentLoader(afterFirstRead: { _ in
             started.signal()
@@ -254,9 +258,13 @@ final class OracleImageAttachmentLoaderTests: XCTestCase {
         }
     }
 
-    private func authority(logical: URL, physical: URL) -> OracleImageWorkspaceAuthority {
-        OracleImageWorkspaceAuthority(roots: [
-            .init(logicalRootPath: logical.path, physicalRootPath: physical.path)
+    private func authority(logical: URL, physical: URL) throws -> OracleImageWorkspaceAuthority {
+        try OracleImageWorkspaceAuthority(roots: [
+            .capture(
+                logicalRootPath: logical.path,
+                physicalRootPath: physical.path,
+                index: 0
+            )
         ])
     }
 

--- a/Tests/RepoPromptTests/MCP/OracleImageContractTests.swift
+++ b/Tests/RepoPromptTests/MCP/OracleImageContractTests.swift
@@ -42,6 +42,20 @@ final class OracleImageContractTests: XCTestCase {
         ])))
     }
 
+    func testAskOracleImageDocumentationIsProviderNeutralAndMatchesLimits() {
+        let documentation = [
+            MCPOracleToolProvider.askOracleImageUsageDescription,
+            MCPOracleToolProvider.askOracleImagesArgumentDescription
+        ].joined(separator: " ")
+
+        XCTAssertFalse(documentation.lowercased().contains("anthropic"))
+        XCTAssertTrue(documentation.contains("10 images"))
+        XCTAssertTrue(documentation.contains("20 MiB"))
+        XCTAssertTrue(documentation.contains("50 MiB"))
+        XCTAssertTrue(documentation.contains("PNG"))
+        XCTAssertTrue(documentation.lowercased().contains("rejected"))
+    }
+
     func testRawImagesAtOracleDispatchAreAnInternalInvariantFailure() {
         XCTAssertNoThrow(try OracleViewModel.validateRawImageDispatchInvariant([
             "message": .string("inspect")
@@ -72,6 +86,88 @@ final class OracleImageContractTests: XCTestCase {
 
         let unrelated = AgentChatItem.toolCall(name: "read_file", argsJSON: raw)
         XCTAssertEqual(unrelated.toolArgsJSON, raw)
+    }
+
+    func testPartialArgumentsFailClosedOnlyWhenImagesKeyIsPossible() {
+        let cases: [(String, String?)] = [
+            (#"{"message":"partial""#, #"{"message":"partial""#),
+            (#"{"message":"say \"images\": hi""#, #"{"message":"say \"images\": hi""#),
+            (#"{"message":"\ud83d"#, #"{"message":"\ud83d"#),
+            (#"{"message":"x","m"#, #"{"message":"x","m"#),
+            (#"{"message":"x",""#, nil),
+            (#"{"message":"x","ima"#, nil),
+            (#"{"images":[{"path":"/Users/secret.png""#, nil),
+            (#"{"\u0069mages":[{"path":"/Users/secret.png""#, nil),
+            (#"{"i\u006Dages":[{"path":"/Users/secret.png""#, nil)
+        ]
+
+        for (raw, expected) in cases {
+            XCTAssertEqual(
+                AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+                    toolName: "ask_oracle",
+                    argsJSON: raw
+                ),
+                expected,
+                raw
+            )
+            XCTAssertEqual(
+                AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+                    toolName: "read_file",
+                    argsJSON: raw
+                ),
+                raw,
+                raw
+            )
+        }
+    }
+
+    func testEscapedImagesKeysAndPersistedItemsAreSanitized() throws {
+        let raw = #"{"\u0069mages":[{"path":"/Users/secret.png"}],"message":"inspect"}"#
+        let sanitized = try XCTUnwrap(AgentToolArgumentPersistencePolicy.sanitizedArgsJSON(
+            toolName: "ask_oracle",
+            argsJSON: raw
+        ))
+        XCTAssertTrue(sanitized.contains("inspect"))
+        XCTAssertFalse(sanitized.contains("secret.png"))
+
+        let source = AgentChatItem.toolCall(name: "read_file", argsJSON: raw)
+        var persisted = AgentChatItemPersist(from: source, sanitizeToolResults: false)
+        persisted.toolName = "mcp__RepoPromptCE__ask_oracle"
+        let encoded = try JSONEncoder().encode(persisted)
+        XCTAssertFalse(String(decoding: encoded, as: UTF8.self).contains("secret.png"))
+        let decoded = try JSONDecoder().decode(AgentChatItemPersist.self, from: encoded)
+        XCTAssertFalse(decoded.toolArgsJSON?.contains("secret.png") == true)
+    }
+
+    func testLegacyImageArgumentsAreSanitizedOnDecode() throws {
+        let raw = #"{"message":"inspect","images":[{"path":"/Users/legacy-secret.png"}]}"#
+        let source = AgentChatItem.toolCall(name: "read_file", argsJSON: raw)
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(source)) as? [String: Any]
+        )
+        object["toolName"] = "ask_oracle"
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder().decode(AgentChatItem.self, from: legacyData)
+        XCTAssertFalse(decoded.toolArgsJSON?.contains("legacy-secret") == true)
+        XCTAssertFalse(try String(decoding: JSONEncoder().encode(decoded), as: UTF8.self).contains("legacy-secret"))
+    }
+
+    func testUnrelatedAndImageFreeArgumentsRoundTripUnchanged() throws {
+        let unrelatedRaw = #"{"images":[{"path":"/tmp/not-an-oracle-image.png"}]}"#
+        let unrelated = AgentChatItem.toolCall(name: "read_file", argsJSON: unrelatedRaw)
+        let unrelatedRoundTrip = try JSONDecoder().decode(
+            AgentChatItem.self,
+            from: JSONEncoder().encode(unrelated)
+        )
+        XCTAssertEqual(unrelatedRoundTrip.toolArgsJSON, unrelatedRaw)
+
+        let oracleRaw = #"{"message":"hi","mode":"plan"}"#
+        let oracle = AgentChatItem.toolCall(name: "ask_oracle", argsJSON: oracleRaw)
+        let oracleRoundTrip = try JSONDecoder().decode(
+            AgentChatItem.self,
+            from: JSONEncoder().encode(oracle)
+        )
+        XCTAssertEqual(oracleRoundTrip.toolArgsJSON, oracleRaw)
     }
 
     func testLateAndPartialToolArgumentsPreserveTextButRedactImages() throws {

--- a/Tests/RepoPromptTests/MCP/OracleImageContractTests.swift
+++ b/Tests/RepoPromptTests/MCP/OracleImageContractTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class OracleImageContractTests: XCTestCase {
     func testParserAcceptsOnlyBoundedPathAndOptionalTitleObjects() throws {
         XCTAssertEqual(try MCPOracleToolService.parseOracleImageRequests(nil), [])
+        XCTAssertEqual(try MCPOracleToolService.parseOracleImageRequests(.array([])), [])
 
         let parsed = try MCPOracleToolService.parseOracleImageRequests(.array([
             .object([
@@ -18,13 +19,12 @@ final class OracleImageContractTests: XCTestCase {
         ]))
 
         XCTAssertEqual(parsed, [
-            .init(index: 0, path: "/workspace/diagram.png", title: "Architecture"),
+            .init(index: 0, path: "  /workspace/diagram.png  ", title: "Architecture"),
             .init(index: 1, path: "/workspace/photo.jpg", title: nil)
         ])
     }
 
-    func testParserRejectsEmptyOversizedAndExpandedAttachmentShapes() {
-        XCTAssertThrowsError(try MCPOracleToolService.parseOracleImageRequests(.array([])))
+    func testParserRejectsOversizedAndExpandedAttachmentShapes() {
         XCTAssertThrowsError(try MCPOracleToolService.parseOracleImageRequests(.array(
             (0 ... 10).map { .object(["path": .string("/workspace/\($0).png")]) }
         )))
@@ -74,7 +74,7 @@ final class OracleImageContractTests: XCTestCase {
         XCTAssertEqual(unrelated.toolArgsJSON, raw)
     }
 
-    func testLateToolNameAndArgumentUpdatesRemainRedacted() throws {
+    func testLateAndPartialToolArgumentsPreserveTextButRedactImages() throws {
         let raw = #"{"message":"inspect","images":[{"path":"/Users/late-secret.png"}]}"#
         var item = AgentChatItem.toolCall(name: "read_file", argsJSON: nil)
         item.toolName = "ask_oracle"
@@ -83,5 +83,10 @@ final class OracleImageContractTests: XCTestCase {
         let sanitized = try XCTUnwrap(item.toolArgsJSON)
         XCTAssertFalse(sanitized.contains("images"))
         XCTAssertFalse(sanitized.contains("late-secret"))
+
+        item.toolArgsJSON = #"{"message":"partial"#
+        XCTAssertEqual(item.toolArgsJSON, #"{"message":"partial"#)
+        item.toolArgsJSON = #"{"images":[{"path":"/Users/partial-secret.png"#
+        XCTAssertNil(item.toolArgsJSON)
     }
 }

--- a/Tests/RepoPromptTests/MCP/OracleImageContractTests.swift
+++ b/Tests/RepoPromptTests/MCP/OracleImageContractTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MCP
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class OracleImageContractTests: XCTestCase {
+    func testParserAcceptsOnlyBoundedPathAndOptionalTitleObjects() throws {
+        XCTAssertEqual(try MCPOracleToolService.parseOracleImageRequests(nil), [])
+
+        let parsed = try MCPOracleToolService.parseOracleImageRequests(.array([
+            .object([
+                "path": .string("  /workspace/diagram.png  "),
+                "title": .string("  Architecture  "),
+                "_meta": .string("ignored")
+            ]),
+            .object(["path": .string("/workspace/photo.jpg")])
+        ]))
+
+        XCTAssertEqual(parsed, [
+            .init(index: 0, path: "/workspace/diagram.png", title: "Architecture"),
+            .init(index: 1, path: "/workspace/photo.jpg", title: nil)
+        ])
+    }
+
+    func testParserRejectsEmptyOversizedAndExpandedAttachmentShapes() {
+        XCTAssertThrowsError(try MCPOracleToolService.parseOracleImageRequests(.array([])))
+        XCTAssertThrowsError(try MCPOracleToolService.parseOracleImageRequests(.array(
+            (0 ... 10).map { .object(["path": .string("/workspace/\($0).png")]) }
+        )))
+        XCTAssertThrowsError(try MCPOracleToolService.parseOracleImageRequests(.array([
+            .object([
+                "path": .string("/workspace/image.png"),
+                "url": .string("https://example.com/image.png")
+            ])
+        ])))
+        XCTAssertThrowsError(try MCPOracleToolService.parseOracleImageRequests(.array([
+            .object([
+                "path": .string("/workspace/image.png"),
+                "title": .string(String(repeating: "x", count: 201))
+            ])
+        ])))
+    }
+
+    func testRawImagesAtOracleDispatchAreAnInternalInvariantFailure() {
+        XCTAssertNoThrow(try OracleViewModel.validateRawImageDispatchInvariant([
+            "message": .string("inspect")
+        ]))
+        XCTAssertThrowsError(try OracleViewModel.validateRawImageDispatchInvariant([
+            "images": .array([.object(["path": .string("/workspace/image.png")])])
+        ])) { error in
+            guard let toolError = error as? ChatToolError else {
+                return XCTFail("Expected ChatToolError, got \(error)")
+            }
+            XCTAssertEqual(toolError.code, .internalError)
+            XCTAssertTrue(toolError.message.contains("must be consumed before Oracle dispatch"))
+        }
+    }
+
+    func testAskOracleToolArgumentsAreRedactedBeforePersistence() throws {
+        let raw = #"{"message":"inspect","images":[{"path":"/Users/secret.png","title":"Secret"}]}"#
+        let item = AgentChatItem.toolCall(
+            name: "mcp__RepoPromptCE__ask_oracle",
+            argsJSON: raw
+        )
+
+        let sanitized = try XCTUnwrap(item.toolArgsJSON)
+        XCTAssertTrue(sanitized.contains("inspect"))
+        XCTAssertFalse(sanitized.contains("images"))
+        XCTAssertFalse(sanitized.contains("/Users/secret.png"))
+        XCTAssertFalse(try String(decoding: JSONEncoder().encode(item), as: UTF8.self).contains("secret.png"))
+
+        let unrelated = AgentChatItem.toolCall(name: "read_file", argsJSON: raw)
+        XCTAssertEqual(unrelated.toolArgsJSON, raw)
+    }
+
+    func testLateToolNameAndArgumentUpdatesRemainRedacted() throws {
+        let raw = #"{"message":"inspect","images":[{"path":"/Users/late-secret.png"}]}"#
+        var item = AgentChatItem.toolCall(name: "read_file", argsJSON: nil)
+        item.toolName = "ask_oracle"
+        item.toolArgsJSON = raw
+
+        let sanitized = try XCTUnwrap(item.toolArgsJSON)
+        XCTAssertFalse(sanitized.contains("images"))
+        XCTAssertFalse(sanitized.contains("late-secret"))
+    }
+}


### PR DESCRIPTION
## Summary
- add workspace-local image attachments to `ask_oracle`
- securely load PNG, JPEG, GIF, and WebP files within the active workspace/worktree authority
- deliver image bytes across Anthropic, OpenAI-compatible APIs, CustomOpenAI, Claude Code CLI, Codex app-server, and OpenCode/Cursor/Grok Build CLI transports
- keep image bytes and paths transient, attach images only to the final user turn, and surface provider/transport errors instead of silently dropping images
- redact image arguments from persisted agent tool records

## Provider coverage
- Anthropic and shared OpenAI Chat/Responses serializers (including Azure, OpenRouter, Ollama, Gemini, DeepSeek, Fireworks, Grok API, Groq, and Z.AI)
- CustomOpenAI multipart content
- Claude Code `stream-json` base64 image blocks
- Codex app-server owner-only temporary local-image attachments with deterministic cleanup
- OpenCode and Cursor ACP inline image blocks
- Grok Build documented one-shot `--prompt-json` image blocks; text-only requests retain the existing `--prompt-file` path, with a conservative argv-size error boundary

## Scope
- no screenshots, remote URLs, dependency upgrades, or generic attachment framework
- text-only payloads and transport selection remain unchanged

## Validation
- `make dev-test FILTER=OracleImageSerializationTests` (11 tests)
- `make dev-test FILTER=GrokBuildModelRoutingTests` (11 tests)
- `make dev-test FILTER=CodexCLIProviderDisposalTests` (1 test)
- `make dev-test FILTER=GrokBuildACPAgentProviderTests`
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`
  - strict lint
  - full root test suite
  - RepoPrompt product build
  - guardrails and outgoing-range secret scan

## Transport probes
- Grok Build 1.0.5 advertises `promptCapabilities.image=false` over ACP, so image requests deliberately use its documented one-shot JSON-content input rather than ACP
- Claude Code CLI is not installed on the validation host; its stream-json framing is covered deterministically against the documented CLI contract
