### PR TITLE
Authenticate Tip protected-main preflight

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -186,6 +186,14 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Verify authenticated protected-main authority
+        env:
+          TIP_SOURCE_GH_TOKEN: ${{ github.token }}
+          TIP_SOURCE_REPOSITORY: ${{ github.repository }}
+          TIP_SOURCE_BRANCH: main
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+        run: ./trusted-control-plane/Scripts/verify_tip_source_commit.sh "credential preflight"
+
       - name: Validate role-selected Tip credentials
         env:
           SETUP_ROLLOUT_ROLE: ${{ needs.setup.outputs.rollout-role }}
@@ -812,6 +820,7 @@ jobs:
           TIP_TAG: ${{ needs.setup.outputs.tag }}
           TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
           TIP_GH_TOKEN: ${{ secrets.TIP_UPDATE_REPOSITORY_TOKEN }}
+          TIP_SOURCE_GH_TOKEN: ${{ github.token }}
           TIP_SOURCE_REPOSITORY: ${{ github.repository }}
           TIP_SOURCE_BRANCH: main
           TIP_PUBLISH_INSTALLATION_TYPE: ${{ needs.setup.outputs.installation-type }}

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -653,6 +653,7 @@ PYTHON
 
 publish_tip() {
     require_env TIP_GH_TOKEN
+    require_env TIP_SOURCE_GH_TOKEN
     require_env TIP_SOURCE_REPOSITORY
     require_env TIP_SOURCE_BRANCH
     require_file "$PUBLISH_TIP_RELEASE"
@@ -663,6 +664,7 @@ publish_tip() {
     esac
     validate_tip_publish_assets
     TIP_GH_TOKEN="$TIP_GH_TOKEN" \
+    TIP_SOURCE_GH_TOKEN="$TIP_SOURCE_GH_TOKEN" \
     TIP_UPDATE_REPOSITORY="$TIP_UPDATE_REPOSITORY" \
     TIP_SOURCE_REPOSITORY="$TIP_SOURCE_REPOSITORY" \
     TIP_SOURCE_BRANCH="$TIP_SOURCE_BRANCH" \

--- a/Scripts/publish_tip_release.sh
+++ b/Scripts/publish_tip_release.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROLLOUT_TOOL="$SCRIPT_DIR/stable_rollout.py"
 APPLE_IDENTITY_POLICY="$SCRIPT_DIR/apple_identity_policy.json"
+SOURCE_COMMIT_VERIFIER="$SCRIPT_DIR/verify_tip_source_commit.sh"
 
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 require_env() { [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"; }
@@ -15,7 +16,7 @@ require_command() { command -v "$1" >/dev/null 2>&1 || fail "Missing required co
 require_file() { [[ -f "$1" && ! -L "$1" ]] || fail "Missing regular non-symlink file: $1"; }
 
 for name in \
-    TIP_GH_TOKEN TIP_UPDATE_REPOSITORY TIP_SOURCE_REPOSITORY TIP_SOURCE_BRANCH \
+    TIP_GH_TOKEN TIP_SOURCE_GH_TOKEN TIP_UPDATE_REPOSITORY TIP_SOURCE_REPOSITORY TIP_SOURCE_BRANCH \
     TIP_COMMIT TIP_TAG TIP_BUILD_NUMBER TIP_PUBLISH_INSTALLATION_TYPE \
     TIP_EXPECTED_ROLLOUT_ROLE TIP_EXPECTED_SIGNING_IDENTITY \
     TIP_EXPECTED_MIGRATION_PHASE TIP_RELEASE_TITLE TIP_RELEASE_NOTES; do
@@ -24,6 +25,7 @@ done
 for command in curl gh python3 shasum; do require_command "$command"; done
 require_file "$ROLLOUT_TOOL"
 require_file "$APPLE_IDENTITY_POLICY"
+require_file "$SOURCE_COMMIT_VERIFIER"
 
 [[ "$TIP_SOURCE_BRANCH" == "main" ]] || fail "Tip publication source branch must remain main"
 [[ "$TIP_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "TIP_COMMIT must be a full lowercase Git SHA"
@@ -199,24 +201,8 @@ fetch_json_status() {
     printf '%s\n' "$status"
 }
 
-fetch_live_main() {
-    local response="$TMP_DIR/live-main.json" status
-    status="$(fetch_json_status \
-        "https://api.github.com/repos/$TIP_SOURCE_REPOSITORY/commits/$TIP_SOURCE_BRANCH" \
-        "$response")"
-    [[ "$status" == "200" ]] || fail "Protected-main lookup failed with HTTP $status"
-    python3 - "$response" <<'PY'
-import json, sys
-print(json.load(open(sys.argv[1], encoding="utf-8")).get("sha", ""))
-PY
-}
-
 require_live_main() {
-    local phase="$1" live_main
-    live_main="$(fetch_live_main)"
-    [[ "$live_main" =~ ^[0-9a-f]{40}$ ]] || fail "$phase did not resolve a full live-main SHA"
-    [[ "$live_main" == "$TIP_COMMIT" ]] ||
-        fail "$phase rejected stale Tip candidate: candidate=$TIP_COMMIT live-main=$live_main"
+    "$SOURCE_COMMIT_VERIFIER" "$1"
 }
 
 LIVE_AUDIT_INDEX=0

--- a/Scripts/test_publish_tip_release.py
+++ b/Scripts/test_publish_tip_release.py
@@ -18,6 +18,8 @@ ROOT_DIR = SCRIPT_DIR.parent
 PUBLISHER = SCRIPT_DIR / "publish_tip_release.sh"
 ROLLOUT_TOOL = SCRIPT_DIR / "stable_rollout.py"
 POLICY = SCRIPT_DIR / "apple_identity_policy.json"
+WORKFLOW = ROOT_DIR / ".github" / "workflows" / "main-tip.yml"
+TIP_ORCHESTRATOR = SCRIPT_DIR / "main_tip_release.sh"
 
 COMMIT = "a" * 40
 TAG = "tip-aaaaaaaaaaaa"
@@ -148,7 +150,17 @@ url = urls[-1]
 status = "200"
 
 if url.endswith("/commits/main"):
-    output.write_text(json.dumps({"sha": os.environ["TIP_COMMIT"]}), encoding="utf-8")
+    expected = f"Authorization: Bearer {os.environ['PUBLISHER_EXPECTED_SOURCE_TOKEN']}"
+    authenticated = expected in args
+    state.setdefault("source_lookup_auth", []).append(authenticated)
+    Path(os.environ["PUBLISHER_STUB_STATE"]).write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+    if authenticated:
+        output.write_text(json.dumps({"sha": os.environ["TIP_COMMIT"]}), encoding="utf-8")
+    else:
+        output.write_text(json.dumps({"message": "fixture authorization denied"}), encoding="utf-8")
+        status = "403"
 elif url == os.environ["PUBLISHER_STABLE_FEED_URL"]:
     shutil.copyfile(os.environ["PUBLISHER_STABLE_APPCAST"], output)
 elif url.endswith("/releases/latest"):
@@ -309,7 +321,13 @@ class PublishTipReleaseTests(unittest.TestCase):
         release["assets"] = records
         return release
 
-    def _run(self, scenario: str, release: dict[str, object] | None) -> subprocess.CompletedProcess[str]:
+    def _run(
+        self,
+        scenario: str,
+        release: dict[str, object] | None,
+        *,
+        source_token: str | None = "fixture-source-token",
+    ) -> subprocess.CompletedProcess[str]:
         self.state_path.write_text(
             json.dumps(
                 {
@@ -317,6 +335,7 @@ class PublishTipReleaseTests(unittest.TestCase):
                     "release": release,
                     "lookup_args": [],
                     "mutations": [],
+                    "source_lookup_auth": [],
                 },
                 indent=2,
             )
@@ -332,7 +351,8 @@ class PublishTipReleaseTests(unittest.TestCase):
                 "PUBLISHER_ASSET_DIR": str(self.asset_dir),
                 "PUBLISHER_STABLE_APPCAST": str(self.stable_appcast),
                 "PUBLISHER_STABLE_FEED_URL": policy["sparkle"]["stableFeedURL"],
-                "TIP_GH_TOKEN": "fixture-token",
+                "TIP_GH_TOKEN": "fixture-update-token",
+                "PUBLISHER_EXPECTED_SOURCE_TOKEN": "fixture-source-token",
                 "TIP_UPDATE_REPOSITORY": UPDATE_REPOSITORY,
                 "TIP_SOURCE_REPOSITORY": SOURCE_REPOSITORY,
                 "TIP_SOURCE_BRANCH": "main",
@@ -347,6 +367,10 @@ class PublishTipReleaseTests(unittest.TestCase):
                 "TIP_RELEASE_NOTES": NOTES,
             }
         )
+        if source_token is None:
+            environment.pop("TIP_SOURCE_GH_TOKEN", None)
+        else:
+            environment["TIP_SOURCE_GH_TOKEN"] = source_token
         return subprocess.run(
             [
                 "bash",
@@ -379,6 +403,8 @@ class PublishTipReleaseTests(unittest.TestCase):
         self.assertIn("was already public and is byte-exact", result.stdout)
         state = self._state()
         self.assertEqual(state["mutations"], [])
+        self.assertTrue(state["source_lookup_auth"])
+        self.assertTrue(all(state["source_lookup_auth"]))
         self.assert_compatible_lookup(state)
 
     def test_absent_release_creates_empty_draft_then_reobserves_and_publishes(self) -> None:
@@ -402,6 +428,42 @@ class PublishTipReleaseTests(unittest.TestCase):
         state = self._state()
         self.assertEqual(state["mutations"], [])
         self.assert_compatible_lookup(state)
+
+    def test_missing_source_token_fails_before_remote_lookup_or_mutation(self) -> None:
+        result = self._run("absent", None, source_token=None)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Missing required environment variable: TIP_SOURCE_GH_TOKEN", result.stderr)
+        state = self._state()
+        self.assertEqual(state["source_lookup_auth"], [])
+        self.assertEqual(state["mutations"], [])
+
+    def test_rejected_source_token_reports_github_error_before_mutation(self) -> None:
+        result = self._run("absent", None, source_token="wrong-source-token")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Protected-main lookup failed with HTTP 403: fixture authorization denied",
+            result.stderr,
+        )
+        state = self._state()
+        self.assertEqual(state["source_lookup_auth"], [False])
+        self.assertEqual(state["mutations"], [])
+
+    def test_workflow_preflight_and_publisher_share_source_authority_contract(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        credential_preflight = workflow.split("\n  credential-preflight:", 1)[1].split(
+            "\n  stage:", 1
+        )[0]
+        publish = workflow.split("\n  publish:", 1)[1]
+        for section in (credential_preflight, publish):
+            self.assertIn("TIP_SOURCE_GH_TOKEN: ${{ github.token }}", section)
+        self.assertIn(
+            './trusted-control-plane/Scripts/verify_tip_source_commit.sh "credential preflight"',
+            credential_preflight,
+        )
+
+        orchestrator = TIP_ORCHESTRATOR.read_text(encoding="utf-8")
+        self.assertIn("require_env TIP_SOURCE_GH_TOKEN", orchestrator)
+        self.assertIn('TIP_SOURCE_GH_TOKEN="$TIP_SOURCE_GH_TOKEN"', orchestrator)
 
     def test_duplicate_tag_across_pages_fails_closed_without_mutation(self) -> None:
         result = self._run("duplicate", self._release())

--- a/Scripts/verify_tip_source_commit.sh
+++ b/Scripts/verify_tip_source_commit.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+require_env() { [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"; }
+require_command() { command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"; }
+
+for name in TIP_SOURCE_GH_TOKEN TIP_SOURCE_REPOSITORY TIP_SOURCE_BRANCH TIP_COMMIT; do
+    require_env "$name"
+done
+for command in curl python3; do require_command "$command"; done
+
+[[ "$#" == 1 && -n "$1" ]] || fail "Usage: $0 <verification-phase>"
+phase="$1"
+
+[[ "$TIP_SOURCE_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+    fail "TIP_SOURCE_REPOSITORY must be an owner/repository slug"
+[[ "$TIP_SOURCE_BRANCH" == "main" ]] || fail "Tip publication source branch must remain main"
+[[ "$TIP_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "TIP_COMMIT must be a full lowercase Git SHA"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/repoprompt-tip-source.XXXXXX")"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT
+
+response="$tmp_dir/live-main.json"
+status="$(curl --location --silent --show-error \
+    --connect-timeout 10 --max-time 30 \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    --header "Authorization: Bearer $TIP_SOURCE_GH_TOKEN" \
+    --output "$response" --write-out '%{http_code}' \
+    "https://api.github.com/repos/$TIP_SOURCE_REPOSITORY/commits/$TIP_SOURCE_BRANCH")" ||
+    fail "Protected-main GitHub API request failed"
+[[ "$status" =~ ^[0-9]{3}$ ]] || fail "Protected-main lookup returned an invalid HTTP status"
+
+if [[ "$status" != "200" ]]; then
+    message="$(python3 - "$response" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    print("GitHub response did not contain a JSON error message")
+else:
+    value = payload.get("message") if isinstance(payload, dict) else None
+    print(value if isinstance(value, str) and value else "GitHub response did not contain an error message")
+PY
+)"
+    fail "Protected-main lookup failed with HTTP $status: $message"
+fi
+
+live_main="$(python3 - "$response" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit("ERROR: Protected-main lookup returned invalid JSON")
+value = payload.get("sha") if isinstance(payload, dict) else None
+print(value if isinstance(value, str) else "")
+PY
+)"
+[[ "$live_main" =~ ^[0-9a-f]{40}$ ]] || fail "$phase did not resolve a full live-main SHA"
+[[ "$live_main" == "$TIP_COMMIT" ]] ||
+    fail "$phase rejected stale Tip candidate: candidate=$TIP_COMMIT live-main=$live_main"
+
+printf 'OK: %s confirmed protected main at %s.\n' "$phase" "$live_main"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -262,9 +262,11 @@ There is deliberately no commit input. For a manual dispatch, GitHub's selected 
 `github.sha` are the immutable candidate. Setup fetches protected `origin/main` and requires the
 candidate commit, workflow-definition commit, and checked-out release tooling to be that exact live
 commit. A stale browser tab therefore cannot publish an older main commit merely because somebody
-pasted a convincing SHA into a text box. The protected role-aware credential preflight runs before
-the secret-free build and uses an isolated ephemeral keychain without changing the runner user's
-keychain search list.
+pasted a convincing SHA into a text box. Before the secret-free build, the protected role-aware
+credential preflight runs the same authenticated protected-main verifier used at publication
+mutation boundaries. Source reads use the workflow's source-repository token; the separate Tip
+updater token is reserved for updater-repository reads and writes. The signing preflight uses an
+isolated ephemeral keychain without changing the runner user's keychain search list.
 
 After P is reviewed, advance `tip-rollout.json` with its exact `identity-rollout.json` digest before
 merging T; advance it again with T and P digests before merging S. Each published role uses an


### PR DESCRIPTION
## Summary
- add one authenticated protected-main verifier shared by early credential preflight and publication mutation boundaries
- use the workflow source-repository token for source reads while keeping the Tip updater token scoped to updater release operations
- report GitHub's sanitized API error message and fail before build or release mutation when source authorization is rejected
- add hermetic coverage for missing/rejected source tokens and workflow/orchestrator wiring

## Root cause addressed
Run 33494119370 reached publication after build/sign/smoke, then used an unauthenticated source-repository API request and received HTTP 403. The prior credential preflight did not exercise that request path.

## Validation
- `python3 Scripts/test_publish_tip_release.py` (7 tests)
- `python3 Scripts/test_release_tooling.py`
- `python3 Scripts/test_codex_runtime_artifact.py` (28 tests)
- `python3 Scripts/test_codex_update_candidate.py` (9 tests)
- `python3 Scripts/test_codex_update_workflow.py` (2 tests)
- `./Scripts/test_release_split_metadata_root.sh`
- `make dev-release-preflight`
- `make guardrails`
- `shellcheck Scripts/verify_tip_source_commit.sh`
- live authenticated read-only verification of `repoprompt/repoprompt-ce` protected `main` at `a3654a8db4b1402d2c8e4234b1561650d945a943`
- contribution `commit`, `pr-ready`, and `push` preflights
