### PR TITLE
Fix file search freshness after Add Folder

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -186,6 +186,14 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Verify authenticated protected-main authority
+        env:
+          TIP_SOURCE_GH_TOKEN: ${{ github.token }}
+          TIP_SOURCE_REPOSITORY: ${{ github.repository }}
+          TIP_SOURCE_BRANCH: main
+          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
+        run: ./trusted-control-plane/Scripts/verify_tip_source_commit.sh "credential preflight"
+
       - name: Validate role-selected Tip credentials
         env:
           SETUP_ROLLOUT_ROLE: ${{ needs.setup.outputs.rollout-role }}
@@ -812,6 +820,7 @@ jobs:
           TIP_TAG: ${{ needs.setup.outputs.tag }}
           TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
           TIP_GH_TOKEN: ${{ secrets.TIP_UPDATE_REPOSITORY_TOKEN }}
+          TIP_SOURCE_GH_TOKEN: ${{ github.token }}
           TIP_SOURCE_REPOSITORY: ${{ github.repository }}
           TIP_SOURCE_BRANCH: main
           TIP_PUBLISH_INSTALLATION_TYPE: ${{ needs.setup.outputs.installation-type }}

--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
@@ -234,6 +234,7 @@ public enum ClaudeCompatibleModelCatalog {
     private static let haikuRaw = "haiku"
     private static let sonnetRaw = "sonnet"
     private static let opusRaw = "opus"
+    private static let fable51Raw = "claude-fable-5-1"
     private static let fable5Raw = "claude-fable-5"
     private static let opus1mRaw = "opus[1m]"
     private static let opus5Raw = "claude-opus-5"
@@ -247,6 +248,12 @@ public enum ClaudeCompatibleModelCatalog {
     private static let haiku45Raw = "claude-haiku-4-5"
 
     private static let claudeModels: [StaticModel] = [
+        StaticModel(
+            rawValue: fable51Raw,
+            displayName: "Fable 5.1",
+            description: "Claude Fable 5.1. Anthropic's newest and most capable model for demanding reasoning and long-horizon agentic work.",
+            supportsXHigh: true
+        ),
         StaticModel(
             rawValue: fable5Raw,
             displayName: "Fable 5",

--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
@@ -234,6 +234,7 @@ public enum ClaudeCompatibleModelCatalog {
     private static let haikuRaw = "haiku"
     private static let sonnetRaw = "sonnet"
     private static let opusRaw = "opus"
+    private static let fableRaw = "fable"
     private static let fable51Raw = "claude-fable-5-1"
     private static let fable5Raw = "claude-fable-5"
     private static let opus1mRaw = "opus[1m]"
@@ -249,15 +250,21 @@ public enum ClaudeCompatibleModelCatalog {
 
     private static let claudeModels: [StaticModel] = [
         StaticModel(
+            rawValue: fableRaw,
+            displayName: "Fable Latest",
+            description: "Latest Claude Fable model for demanding reasoning and long-horizon agentic work.",
+            supportsXHigh: true
+        ),
+        StaticModel(
             rawValue: fable51Raw,
             displayName: "Fable 5.1",
-            description: "Claude Fable 5.1. Anthropic's newest and most capable model for demanding reasoning and long-horizon agentic work.",
+            description: "Pinned Claude Fable 5.1 with 1M context for demanding reasoning and long-horizon agentic work. Requires Claude Code 2.1.255 or newer.",
             supportsXHigh: true
         ),
         StaticModel(
             rawValue: fable5Raw,
             displayName: "Fable 5",
-            description: "Claude Fable 5. Anthropic's most capable widely released model for demanding reasoning and long-horizon agentic work.",
+            description: "Pinned Claude Fable 5 with 1M context for demanding reasoning and long-horizon agentic work.",
             supportsXHigh: true
         ),
         StaticModel(

--- a/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
+++ b/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
@@ -167,6 +167,7 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(claude.options.first?.isPlaceholderDefault, true)
         XCTAssertEqual(claude.options.map(\.rawValue), [
             "default",
+            "claude-fable-5-1",
             "claude-fable-5",
             "opus[1m]",
             "opus",

--- a/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
+++ b/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
@@ -167,6 +167,7 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(claude.options.first?.isPlaceholderDefault, true)
         XCTAssertEqual(claude.options.map(\.rawValue), [
             "default",
+            "fable",
             "claude-fable-5-1",
             "claude-fable-5",
             "opus[1m]",

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -653,6 +653,7 @@ PYTHON
 
 publish_tip() {
     require_env TIP_GH_TOKEN
+    require_env TIP_SOURCE_GH_TOKEN
     require_env TIP_SOURCE_REPOSITORY
     require_env TIP_SOURCE_BRANCH
     require_file "$PUBLISH_TIP_RELEASE"
@@ -663,6 +664,7 @@ publish_tip() {
     esac
     validate_tip_publish_assets
     TIP_GH_TOKEN="$TIP_GH_TOKEN" \
+    TIP_SOURCE_GH_TOKEN="$TIP_SOURCE_GH_TOKEN" \
     TIP_UPDATE_REPOSITORY="$TIP_UPDATE_REPOSITORY" \
     TIP_SOURCE_REPOSITORY="$TIP_SOURCE_REPOSITORY" \
     TIP_SOURCE_BRANCH="$TIP_SOURCE_BRANCH" \

--- a/Scripts/publish_tip_release.sh
+++ b/Scripts/publish_tip_release.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Retry-safe Tip publication. Every remote mutation is reconciled by observing
-# exact release state; protected main and the public P -> T -> S ladder are
-# rechecked immediately before a draft becomes public.
+# exact release state; protected-main ancestry and the public P -> T -> S ladder
+# are rechecked immediately before a draft becomes public.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROLLOUT_TOOL="$SCRIPT_DIR/stable_rollout.py"
@@ -201,8 +201,8 @@ fetch_json_status() {
     printf '%s\n' "$status"
 }
 
-require_live_main() {
-    "$SOURCE_COMMIT_VERIFIER" "$1"
+require_main_lineage() {
+    "$SOURCE_COMMIT_VERIFIER" --allow-ancestor "$1"
 }
 
 LIVE_AUDIT_INDEX=0
@@ -505,7 +505,32 @@ PY
 }
 
 write_release_json() {
-    local output="$1" status
+    local output="$1" status release_id="" direct_output
+    if [[ -f "$output" ]]; then
+        release_id="$(python3 - "$output" <<'PY'
+import json
+import sys
+
+try:
+    release = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(0)
+release_id = release.get("id") if isinstance(release, dict) else None
+if isinstance(release_id, int):
+    print(release_id)
+PY
+)"
+    fi
+    if [[ -n "$release_id" ]]; then
+        direct_output="$(mktemp "$TMP_DIR/release-by-id.XXXXXX")"
+        if ! GH_TOKEN="$TIP_GH_TOKEN" gh api \
+            "/repos/$TIP_UPDATE_REPOSITORY/releases/$release_id" > "$direct_output"; then
+            rm -f "$direct_output"
+            fail "Authenticated Tip release lookup by id failed"
+        fi
+        mv "$direct_output" "$output"
+        return 0
+    fi
     if lookup_release "$output"; then
         return 0
     else
@@ -522,17 +547,19 @@ create_draft_if_missing() {
     if write_release_json "$release_file"; then
         return 0
     fi
-    require_live_main "pre-draft creation"
-    if ! GH_TOKEN="$TIP_GH_TOKEN" gh release create "$TIP_TAG" \
-        --repo "$TIP_UPDATE_REPOSITORY" \
-        --target "$TIP_SOURCE_BRANCH" \
-        --draft \
-        --title "$TIP_RELEASE_TITLE" \
-        --notes "$TIP_RELEASE_NOTES"; then
+    require_main_lineage "pre-draft creation"
+    if ! GH_TOKEN="$TIP_GH_TOKEN" gh api --method POST \
+        "/repos/$TIP_UPDATE_REPOSITORY/releases" \
+        -f tag_name="$TIP_TAG" \
+        -f target_commitish="$TIP_SOURCE_BRANCH" \
+        -f name="$TIP_RELEASE_TITLE" \
+        -f body="$TIP_RELEASE_NOTES" \
+        -F draft=true \
+        -F prerelease=false > "$release_file"; then
         write_release_json "$release_file" || fail "Unable to create or reconcile Tip release draft"
         return 0
     fi
-    write_release_json "$release_file" || fail "Created Tip draft is not observable"
+    validate_release_metadata "$release_file" draft
 }
 
 download_authenticated_asset() {
@@ -592,7 +619,8 @@ PY
 }
 
 upload_missing_assets() {
-    local release_file="$1" names_file="$TMP_DIR/remote-names"
+    local release_file="$1" names_file="$TMP_DIR/remote-names" release_id
+    release_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["id"])' "$release_file")"
     python3 - "$release_file" > "$names_file" <<'PY'
 import json
 import sys
@@ -600,14 +628,27 @@ release = json.load(open(sys.argv[1], encoding="utf-8"))
 for asset in release.get("assets", []):
     print(asset.get("name", ""))
 PY
-    local path name
+    local path name encoded_name upload_response upload_status
     for path in "${ASSETS[@]}"; do
         name="$(basename "$path")"
         if grep -Fx "$name" "$names_file" >/dev/null; then
             continue
         fi
-        if ! GH_TOKEN="$TIP_GH_TOKEN" gh release upload "$TIP_TAG" "$path" \
-            --repo "$TIP_UPDATE_REPOSITORY"; then
+        encoded_name="$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$name")"
+        upload_response="$(mktemp "$TMP_DIR/upload-response.XXXXXX")"
+        upload_status="$(curl --location --silent --show-error \
+            --connect-timeout 10 --max-time 1800 \
+            --request POST \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'Content-Type: application/octet-stream' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --header "Authorization: Bearer $TIP_GH_TOKEN" \
+            --data-binary "@$path" \
+            --output "$upload_response" --write-out '%{http_code}' \
+            "https://uploads.github.com/repos/$TIP_UPDATE_REPOSITORY/releases/$release_id/assets?name=$encoded_name")" ||
+            upload_status="000"
+        rm -f "$upload_response"
+        if [[ "$upload_status" != "201" ]]; then
             write_release_json "$release_file" || fail "Unable to reconcile Tip asset upload: $name"
             audit_authenticated_release_assets "$release_file" true
             grep -Fx "$name" <(python3 - "$release_file" <<'PY'
@@ -615,7 +656,7 @@ import json,sys
 for asset in json.load(open(sys.argv[1], encoding="utf-8")).get("assets", []):
     print(asset.get("name", ""))
 PY
-) >/dev/null || fail "Tip asset upload failed: $name"
+) >/dev/null || fail "Tip asset upload failed with HTTP $upload_status: $name"
         fi
         write_release_json "$release_file" || fail "Tip release draft disappeared after uploading $name"
     done
@@ -624,7 +665,7 @@ PY
 publish_draft() {
     local release_file="$1" release_id
     release_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["id"])' "$release_file")"
-    require_live_main "final pre-publication"
+    require_main_lineage "final pre-publication"
     audit_live_rollout_progression "final pre-publication"
     if ! GH_TOKEN="$TIP_GH_TOKEN" gh api --method PATCH \
         "/repos/$TIP_UPDATE_REPOSITORY/releases/$release_id" \
@@ -695,7 +736,7 @@ PY
 }
 
 validate_candidate_bindings
-require_live_main "publication setup"
+require_main_lineage "publication setup"
 audit_live_rollout_progression "publication setup"
 release_file="$TMP_DIR/release.json"
 create_draft_if_missing "$release_file"

--- a/Scripts/publish_tip_release.sh
+++ b/Scripts/publish_tip_release.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROLLOUT_TOOL="$SCRIPT_DIR/stable_rollout.py"
 APPLE_IDENTITY_POLICY="$SCRIPT_DIR/apple_identity_policy.json"
+SOURCE_COMMIT_VERIFIER="$SCRIPT_DIR/verify_tip_source_commit.sh"
 
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 require_env() { [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"; }
@@ -15,7 +16,7 @@ require_command() { command -v "$1" >/dev/null 2>&1 || fail "Missing required co
 require_file() { [[ -f "$1" && ! -L "$1" ]] || fail "Missing regular non-symlink file: $1"; }
 
 for name in \
-    TIP_GH_TOKEN TIP_UPDATE_REPOSITORY TIP_SOURCE_REPOSITORY TIP_SOURCE_BRANCH \
+    TIP_GH_TOKEN TIP_SOURCE_GH_TOKEN TIP_UPDATE_REPOSITORY TIP_SOURCE_REPOSITORY TIP_SOURCE_BRANCH \
     TIP_COMMIT TIP_TAG TIP_BUILD_NUMBER TIP_PUBLISH_INSTALLATION_TYPE \
     TIP_EXPECTED_ROLLOUT_ROLE TIP_EXPECTED_SIGNING_IDENTITY \
     TIP_EXPECTED_MIGRATION_PHASE TIP_RELEASE_TITLE TIP_RELEASE_NOTES; do
@@ -24,6 +25,7 @@ done
 for command in curl gh python3 shasum; do require_command "$command"; done
 require_file "$ROLLOUT_TOOL"
 require_file "$APPLE_IDENTITY_POLICY"
+require_file "$SOURCE_COMMIT_VERIFIER"
 
 [[ "$TIP_SOURCE_BRANCH" == "main" ]] || fail "Tip publication source branch must remain main"
 [[ "$TIP_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "TIP_COMMIT must be a full lowercase Git SHA"
@@ -199,24 +201,8 @@ fetch_json_status() {
     printf '%s\n' "$status"
 }
 
-fetch_live_main() {
-    local response="$TMP_DIR/live-main.json" status
-    status="$(fetch_json_status \
-        "https://api.github.com/repos/$TIP_SOURCE_REPOSITORY/commits/$TIP_SOURCE_BRANCH" \
-        "$response")"
-    [[ "$status" == "200" ]] || fail "Protected-main lookup failed with HTTP $status"
-    python3 - "$response" <<'PY'
-import json, sys
-print(json.load(open(sys.argv[1], encoding="utf-8")).get("sha", ""))
-PY
-}
-
 require_live_main() {
-    local phase="$1" live_main
-    live_main="$(fetch_live_main)"
-    [[ "$live_main" =~ ^[0-9a-f]{40}$ ]] || fail "$phase did not resolve a full live-main SHA"
-    [[ "$live_main" == "$TIP_COMMIT" ]] ||
-        fail "$phase rejected stale Tip candidate: candidate=$TIP_COMMIT live-main=$live_main"
+    "$SOURCE_COMMIT_VERIFIER" "$1"
 }
 
 LIVE_AUDIT_INDEX=0

--- a/Scripts/test_publish_tip_release.py
+++ b/Scripts/test_publish_tip_release.py
@@ -22,6 +22,7 @@ WORKFLOW = ROOT_DIR / ".github" / "workflows" / "main-tip.yml"
 TIP_ORCHESTRATOR = SCRIPT_DIR / "main_tip_release.sh"
 
 COMMIT = "a" * 40
+ADVANCED_COMMIT = "b" * 40
 TAG = "tip-aaaaaaaaaaaa"
 SOURCE_REPOSITORY = "repoprompt/repoprompt-ce"
 UPDATE_REPOSITORY = "repoprompt/repoprompt-ce-tip-updates"
@@ -29,7 +30,6 @@ TITLE = "RepoPrompt CE Tip fixture"
 NOTES = "Hermetic publisher regression fixture."
 
 GH_STUB = r'''#!/usr/bin/env python3
-import hashlib
 import json
 import os
 import sys
@@ -45,25 +45,20 @@ def save():
     state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
-def option(name):
-    return args[args.index(name) + 1]
-
-
-def asset_record(path):
-    data = path.read_bytes()
-    name = path.name
-    index = len(state["release"]["assets"]) + 1
-    return {
-        "name": name,
-        "state": "uploaded",
-        "url": f"https://api.github.com/repos/{os.environ['TIP_UPDATE_REPOSITORY']}/releases/assets/{index}",
-        "browser_download_url": (
-            f"https://github.com/{os.environ['TIP_UPDATE_REPOSITORY']}"
-            f"/releases/download/{os.environ['TIP_TAG']}/{name}"
-        ),
-        "size": len(data),
-        "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
-    }
+def form_fields():
+    values = {}
+    index = 0
+    while index < len(args) - 1:
+        flag = args[index]
+        if flag not in {"-f", "-F"}:
+            index += 1
+            continue
+        key, value = args[index + 1].split("=", 1)
+        if flag == "-F" and value in {"true", "false"}:
+            value = value == "true"
+        values[key] = value
+        index += 2
+    return values
 
 
 if not os.environ.get("GH_TOKEN"):
@@ -71,6 +66,8 @@ if not os.environ.get("GH_TOKEN"):
 
 if args[:2] == ["api", "--paginate"]:
     state["lookup_args"].append(args)
+    if "create" in state["mutations"]:
+        state["tag_list_lookups_after_create"] += 1
     save()
     if state["scenario"] == "lookup-error":
         print("fixture lookup failure", file=sys.stderr)
@@ -88,6 +85,32 @@ if args[:2] == ["api", "--paginate"]:
         print(json.dumps([release]))
     raise SystemExit(0)
 
+if args[:3] == ["api", "--method", "POST"]:
+    expected_path = f"/repos/{os.environ['TIP_UPDATE_REPOSITORY']}/releases"
+    if args[3] != expected_path:
+        raise SystemExit(f"unexpected fixture release creation path: {args[3]}")
+    if state.get("release") is not None:
+        raise SystemExit("fixture release already exists")
+    fields = form_fields()
+    state["mutations"].append("create")
+    state["release"] = {
+        "id": 101,
+        "tag_name": fields["tag_name"],
+        "target_commitish": fields["target_commitish"],
+        "name": fields["name"],
+        "body": fields["body"],
+        "draft": fields["draft"],
+        "prerelease": fields["prerelease"],
+        "assets": [],
+    }
+    save()
+    print(json.dumps(state["release"]))
+    raise SystemExit(0)
+
+if args[:2] == ["api", f"/repos/{os.environ['TIP_UPDATE_REPOSITORY']}/releases/101"]:
+    print(json.dumps(state["release"]))
+    raise SystemExit(0)
+
 if args and args[0] == "api" and "Accept: application/octet-stream" in args:
     api_url = args[-1]
     for asset in state["release"]["assets"]:
@@ -95,32 +118,6 @@ if args and args[0] == "api" and "Accept: application/octet-stream" in args:
             sys.stdout.buffer.write((asset_dir / asset["name"]).read_bytes())
             raise SystemExit(0)
     raise SystemExit(f"unknown fixture asset API URL: {api_url}")
-
-if args[:2] == ["release", "create"]:
-    if state.get("release") is not None:
-        raise SystemExit("fixture release already exists")
-    state["mutations"].append("create")
-    state["release"] = {
-        "id": 101,
-        "tag_name": args[2],
-        "target_commitish": option("--target"),
-        "name": option("--title"),
-        "body": option("--notes"),
-        "draft": True,
-        "prerelease": False,
-        "assets": [],
-    }
-    save()
-    print("fixture draft created")
-    raise SystemExit(0)
-
-if args[:2] == ["release", "upload"]:
-    path = Path(args[3])
-    state["mutations"].append(f"upload:{path.name}")
-    state["release"]["assets"].append(asset_record(path))
-    save()
-    print("fixture asset uploaded")
-    raise SystemExit(0)
 
 if args[:3] == ["api", "--method", "PATCH"]:
     state["mutations"].append("publish")
@@ -133,6 +130,7 @@ raise SystemExit(f"unsupported gh invocation: {args!r}")
 '''
 
 CURL_STUB = r'''#!/usr/bin/env python3
+import hashlib
 import json
 import os
 import shutil
@@ -149,7 +147,34 @@ if not urls:
 url = urls[-1]
 status = "200"
 
-if url.endswith("/commits/main"):
+if url.startswith("https://uploads.github.com/"):
+    expected = f"Authorization: Bearer {os.environ['TIP_GH_TOKEN']}"
+    if expected not in args:
+        raise SystemExit("fixture asset upload was not authenticated")
+    path = Path(args[args.index("--data-binary") + 1].removeprefix("@"))
+    data = path.read_bytes()
+    name = path.name
+    index = len(state["release"]["assets"]) + 1
+    state["mutations"].append(f"upload:{name}")
+    state["release"]["assets"].append(
+        {
+            "name": name,
+            "state": "uploaded",
+            "url": f"https://api.github.com/repos/{os.environ['TIP_UPDATE_REPOSITORY']}/releases/assets/{index}",
+            "browser_download_url": (
+                f"https://github.com/{os.environ['TIP_UPDATE_REPOSITORY']}"
+                f"/releases/download/{os.environ['TIP_TAG']}/{name}"
+            ),
+            "size": len(data),
+            "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
+        }
+    )
+    Path(os.environ["PUBLISHER_STUB_STATE"]).write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+    output.write_text(json.dumps(state["release"]["assets"][-1]), encoding="utf-8")
+    status = "201"
+elif url.endswith("/commits/main"):
     expected = f"Authorization: Bearer {os.environ['PUBLISHER_EXPECTED_SOURCE_TOKEN']}"
     authenticated = expected in args
     state.setdefault("source_lookup_auth", []).append(authenticated)
@@ -157,10 +182,30 @@ if url.endswith("/commits/main"):
         json.dumps(state, indent=2) + "\n", encoding="utf-8"
     )
     if authenticated:
-        output.write_text(json.dumps({"sha": os.environ["TIP_COMMIT"]}), encoding="utf-8")
+        output.write_text(json.dumps({"sha": os.environ["PUBLISHER_LIVE_MAIN"]}), encoding="utf-8")
     else:
         output.write_text(json.dumps({"message": "fixture authorization denied"}), encoding="utf-8")
         status = "403"
+elif "/compare/" in url:
+    expected = f"Authorization: Bearer {os.environ['PUBLISHER_EXPECTED_SOURCE_TOKEN']}"
+    authenticated = expected in args
+    state.setdefault("source_lookup_auth", []).append(authenticated)
+    Path(os.environ["PUBLISHER_STUB_STATE"]).write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+    if not authenticated:
+        output.write_text(json.dumps({"message": "fixture authorization denied"}), encoding="utf-8")
+        status = "403"
+    elif state["scenario"] == "diverged-source":
+        output.write_text(
+            json.dumps({"status": "diverged", "merge_base_commit": {"sha": "c" * 40}}),
+            encoding="utf-8",
+        )
+    else:
+        output.write_text(
+            json.dumps({"status": "ahead", "merge_base_commit": {"sha": os.environ["TIP_COMMIT"]}}),
+            encoding="utf-8",
+        )
 elif url == os.environ["PUBLISHER_STABLE_FEED_URL"]:
     shutil.copyfile(os.environ["PUBLISHER_STABLE_APPCAST"], output)
 elif url.endswith("/releases/latest"):
@@ -327,6 +372,7 @@ class PublishTipReleaseTests(unittest.TestCase):
         release: dict[str, object] | None,
         *,
         source_token: str | None = "fixture-source-token",
+        live_main: str = COMMIT,
     ) -> subprocess.CompletedProcess[str]:
         self.state_path.write_text(
             json.dumps(
@@ -336,6 +382,7 @@ class PublishTipReleaseTests(unittest.TestCase):
                     "lookup_args": [],
                     "mutations": [],
                     "source_lookup_auth": [],
+                    "tag_list_lookups_after_create": 0,
                 },
                 indent=2,
             )
@@ -353,6 +400,7 @@ class PublishTipReleaseTests(unittest.TestCase):
                 "PUBLISHER_STABLE_FEED_URL": policy["sparkle"]["stableFeedURL"],
                 "TIP_GH_TOKEN": "fixture-update-token",
                 "PUBLISHER_EXPECTED_SOURCE_TOKEN": "fixture-source-token",
+                "PUBLISHER_LIVE_MAIN": live_main,
                 "TIP_UPDATE_REPOSITORY": UPDATE_REPOSITORY,
                 "TIP_SOURCE_REPOSITORY": SOURCE_REPOSITORY,
                 "TIP_SOURCE_BRANCH": "main",
@@ -419,7 +467,39 @@ class PublishTipReleaseTests(unittest.TestCase):
         )
         self.assertEqual(state["mutations"][-1], "publish")
         self.assertFalse(state["release"]["draft"])
+        self.assertEqual(state["tag_list_lookups_after_create"], 0)
         self.assert_compatible_lookup(state)
+
+    def test_existing_empty_draft_resumes_by_release_id_and_publishes(self) -> None:
+        release = self._release(draft=True)
+        release["assets"] = []
+        result = self._run("existing", release)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        state = self._state()
+        self.assertNotIn("create", state["mutations"])
+        self.assertEqual(
+            sorted(value for value in state["mutations"] if value.startswith("upload:")),
+            sorted(f"upload:{path.name}" for path in self.assets),
+        )
+        self.assertEqual(state["mutations"][-1], "publish")
+        self.assertFalse(state["release"]["draft"])
+
+    def test_candidate_may_publish_after_main_advances_when_it_remains_an_ancestor(self) -> None:
+        result = self._run("absent", None, live_main=ADVANCED_COMMIT)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("remains an ancestor of protected main", result.stdout)
+        state = self._state()
+        self.assertEqual(state["mutations"][0], "create")
+        self.assertEqual(state["mutations"][-1], "publish")
+        self.assertTrue(all(state["source_lookup_auth"]))
+
+    def test_candidate_outside_live_main_ancestry_fails_before_mutation(self) -> None:
+        result = self._run("diverged-source", None, live_main=ADVANCED_COMMIT)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("outside protected-main ancestry", result.stderr)
+        state = self._state()
+        self.assertEqual(state["mutations"], [])
+        self.assertTrue(all(state["source_lookup_auth"]))
 
     def test_lookup_command_failure_fails_closed_before_draft_creation(self) -> None:
         result = self._run("lookup-error", None)
@@ -464,6 +544,8 @@ class PublishTipReleaseTests(unittest.TestCase):
         orchestrator = TIP_ORCHESTRATOR.read_text(encoding="utf-8")
         self.assertIn("require_env TIP_SOURCE_GH_TOKEN", orchestrator)
         self.assertIn('TIP_SOURCE_GH_TOKEN="$TIP_SOURCE_GH_TOKEN"', orchestrator)
+        publisher = PUBLISHER.read_text(encoding="utf-8")
+        self.assertIn('"$SOURCE_COMMIT_VERIFIER" --allow-ancestor "$1"', publisher)
 
     def test_duplicate_tag_across_pages_fails_closed_without_mutation(self) -> None:
         result = self._run("duplicate", self._release())

--- a/Scripts/test_publish_tip_release.py
+++ b/Scripts/test_publish_tip_release.py
@@ -18,6 +18,8 @@ ROOT_DIR = SCRIPT_DIR.parent
 PUBLISHER = SCRIPT_DIR / "publish_tip_release.sh"
 ROLLOUT_TOOL = SCRIPT_DIR / "stable_rollout.py"
 POLICY = SCRIPT_DIR / "apple_identity_policy.json"
+WORKFLOW = ROOT_DIR / ".github" / "workflows" / "main-tip.yml"
+TIP_ORCHESTRATOR = SCRIPT_DIR / "main_tip_release.sh"
 
 COMMIT = "a" * 40
 TAG = "tip-aaaaaaaaaaaa"
@@ -148,7 +150,17 @@ url = urls[-1]
 status = "200"
 
 if url.endswith("/commits/main"):
-    output.write_text(json.dumps({"sha": os.environ["TIP_COMMIT"]}), encoding="utf-8")
+    expected = f"Authorization: Bearer {os.environ['PUBLISHER_EXPECTED_SOURCE_TOKEN']}"
+    authenticated = expected in args
+    state.setdefault("source_lookup_auth", []).append(authenticated)
+    Path(os.environ["PUBLISHER_STUB_STATE"]).write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+    if authenticated:
+        output.write_text(json.dumps({"sha": os.environ["TIP_COMMIT"]}), encoding="utf-8")
+    else:
+        output.write_text(json.dumps({"message": "fixture authorization denied"}), encoding="utf-8")
+        status = "403"
 elif url == os.environ["PUBLISHER_STABLE_FEED_URL"]:
     shutil.copyfile(os.environ["PUBLISHER_STABLE_APPCAST"], output)
 elif url.endswith("/releases/latest"):
@@ -309,7 +321,13 @@ class PublishTipReleaseTests(unittest.TestCase):
         release["assets"] = records
         return release
 
-    def _run(self, scenario: str, release: dict[str, object] | None) -> subprocess.CompletedProcess[str]:
+    def _run(
+        self,
+        scenario: str,
+        release: dict[str, object] | None,
+        *,
+        source_token: str | None = "fixture-source-token",
+    ) -> subprocess.CompletedProcess[str]:
         self.state_path.write_text(
             json.dumps(
                 {
@@ -317,6 +335,7 @@ class PublishTipReleaseTests(unittest.TestCase):
                     "release": release,
                     "lookup_args": [],
                     "mutations": [],
+                    "source_lookup_auth": [],
                 },
                 indent=2,
             )
@@ -332,7 +351,8 @@ class PublishTipReleaseTests(unittest.TestCase):
                 "PUBLISHER_ASSET_DIR": str(self.asset_dir),
                 "PUBLISHER_STABLE_APPCAST": str(self.stable_appcast),
                 "PUBLISHER_STABLE_FEED_URL": policy["sparkle"]["stableFeedURL"],
-                "TIP_GH_TOKEN": "fixture-token",
+                "TIP_GH_TOKEN": "fixture-update-token",
+                "PUBLISHER_EXPECTED_SOURCE_TOKEN": "fixture-source-token",
                 "TIP_UPDATE_REPOSITORY": UPDATE_REPOSITORY,
                 "TIP_SOURCE_REPOSITORY": SOURCE_REPOSITORY,
                 "TIP_SOURCE_BRANCH": "main",
@@ -347,6 +367,10 @@ class PublishTipReleaseTests(unittest.TestCase):
                 "TIP_RELEASE_NOTES": NOTES,
             }
         )
+        if source_token is None:
+            environment.pop("TIP_SOURCE_GH_TOKEN", None)
+        else:
+            environment["TIP_SOURCE_GH_TOKEN"] = source_token
         return subprocess.run(
             [
                 "bash",
@@ -379,6 +403,8 @@ class PublishTipReleaseTests(unittest.TestCase):
         self.assertIn("was already public and is byte-exact", result.stdout)
         state = self._state()
         self.assertEqual(state["mutations"], [])
+        self.assertTrue(state["source_lookup_auth"])
+        self.assertTrue(all(state["source_lookup_auth"]))
         self.assert_compatible_lookup(state)
 
     def test_absent_release_creates_empty_draft_then_reobserves_and_publishes(self) -> None:
@@ -402,6 +428,42 @@ class PublishTipReleaseTests(unittest.TestCase):
         state = self._state()
         self.assertEqual(state["mutations"], [])
         self.assert_compatible_lookup(state)
+
+    def test_missing_source_token_fails_before_remote_lookup_or_mutation(self) -> None:
+        result = self._run("absent", None, source_token=None)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Missing required environment variable: TIP_SOURCE_GH_TOKEN", result.stderr)
+        state = self._state()
+        self.assertEqual(state["source_lookup_auth"], [])
+        self.assertEqual(state["mutations"], [])
+
+    def test_rejected_source_token_reports_github_error_before_mutation(self) -> None:
+        result = self._run("absent", None, source_token="wrong-source-token")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Protected-main lookup failed with HTTP 403: fixture authorization denied",
+            result.stderr,
+        )
+        state = self._state()
+        self.assertEqual(state["source_lookup_auth"], [False])
+        self.assertEqual(state["mutations"], [])
+
+    def test_workflow_preflight_and_publisher_share_source_authority_contract(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        credential_preflight = workflow.split("\n  credential-preflight:", 1)[1].split(
+            "\n  stage:", 1
+        )[0]
+        publish = workflow.split("\n  publish:", 1)[1]
+        for section in (credential_preflight, publish):
+            self.assertIn("TIP_SOURCE_GH_TOKEN: ${{ github.token }}", section)
+        self.assertIn(
+            './trusted-control-plane/Scripts/verify_tip_source_commit.sh "credential preflight"',
+            credential_preflight,
+        )
+
+        orchestrator = TIP_ORCHESTRATOR.read_text(encoding="utf-8")
+        self.assertIn("require_env TIP_SOURCE_GH_TOKEN", orchestrator)
+        self.assertIn('TIP_SOURCE_GH_TOKEN="$TIP_SOURCE_GH_TOKEN"', orchestrator)
 
     def test_duplicate_tag_across_pages_fails_closed_without_mutation(self) -> None:
         result = self._run("duplicate", self._release())

--- a/Scripts/verify_tip_source_commit.sh
+++ b/Scripts/verify_tip_source_commit.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+require_env() { [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"; }
+require_command() { command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"; }
+
+for name in TIP_SOURCE_GH_TOKEN TIP_SOURCE_REPOSITORY TIP_SOURCE_BRANCH TIP_COMMIT; do
+    require_env "$name"
+done
+for command in curl python3; do require_command "$command"; done
+
+[[ "$#" == 1 && -n "$1" ]] || fail "Usage: $0 <verification-phase>"
+phase="$1"
+
+[[ "$TIP_SOURCE_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+    fail "TIP_SOURCE_REPOSITORY must be an owner/repository slug"
+[[ "$TIP_SOURCE_BRANCH" == "main" ]] || fail "Tip publication source branch must remain main"
+[[ "$TIP_COMMIT" =~ ^[0-9a-f]{40}$ ]] || fail "TIP_COMMIT must be a full lowercase Git SHA"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/repoprompt-tip-source.XXXXXX")"
+cleanup() { rm -rf "$tmp_dir"; }
+trap cleanup EXIT
+
+response="$tmp_dir/live-main.json"
+status="$(curl --location --silent --show-error \
+    --connect-timeout 10 --max-time 30 \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    --header "Authorization: Bearer $TIP_SOURCE_GH_TOKEN" \
+    --output "$response" --write-out '%{http_code}' \
+    "https://api.github.com/repos/$TIP_SOURCE_REPOSITORY/commits/$TIP_SOURCE_BRANCH")" ||
+    fail "Protected-main GitHub API request failed"
+[[ "$status" =~ ^[0-9]{3}$ ]] || fail "Protected-main lookup returned an invalid HTTP status"
+
+if [[ "$status" != "200" ]]; then
+    message="$(python3 - "$response" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    print("GitHub response did not contain a JSON error message")
+else:
+    value = payload.get("message") if isinstance(payload, dict) else None
+    print(value if isinstance(value, str) and value else "GitHub response did not contain an error message")
+PY
+)"
+    fail "Protected-main lookup failed with HTTP $status: $message"
+fi
+
+live_main="$(python3 - "$response" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit("ERROR: Protected-main lookup returned invalid JSON")
+value = payload.get("sha") if isinstance(payload, dict) else None
+print(value if isinstance(value, str) else "")
+PY
+)"
+[[ "$live_main" =~ ^[0-9a-f]{40}$ ]] || fail "$phase did not resolve a full live-main SHA"
+[[ "$live_main" == "$TIP_COMMIT" ]] ||
+    fail "$phase rejected stale Tip candidate: candidate=$TIP_COMMIT live-main=$live_main"
+
+printf 'OK: %s confirmed protected main at %s.\n' "$phase" "$live_main"

--- a/Scripts/verify_tip_source_commit.sh
+++ b/Scripts/verify_tip_source_commit.sh
@@ -10,7 +10,12 @@ for name in TIP_SOURCE_GH_TOKEN TIP_SOURCE_REPOSITORY TIP_SOURCE_BRANCH TIP_COMM
 done
 for command in curl python3; do require_command "$command"; done
 
-[[ "$#" == 1 && -n "$1" ]] || fail "Usage: $0 <verification-phase>"
+allow_ancestor=false
+if [[ "${1:-}" == "--allow-ancestor" ]]; then
+    allow_ancestor=true
+    shift
+fi
+[[ "$#" == 1 && -n "$1" ]] || fail "Usage: $0 [--allow-ancestor] <verification-phase>"
 phase="$1"
 
 [[ "$TIP_SOURCE_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
@@ -63,7 +68,45 @@ print(value if isinstance(value, str) else "")
 PY
 )"
 [[ "$live_main" =~ ^[0-9a-f]{40}$ ]] || fail "$phase did not resolve a full live-main SHA"
-[[ "$live_main" == "$TIP_COMMIT" ]] ||
-    fail "$phase rejected stale Tip candidate: candidate=$TIP_COMMIT live-main=$live_main"
+if [[ "$live_main" == "$TIP_COMMIT" ]]; then
+    printf 'OK: %s confirmed protected main at %s.\n' "$phase" "$live_main"
+    exit 0
+fi
 
-printf 'OK: %s confirmed protected main at %s.\n' "$phase" "$live_main"
+if [[ "$allow_ancestor" != true ]]; then
+    fail "$phase rejected stale Tip candidate: candidate=$TIP_COMMIT live-main=$live_main"
+fi
+
+compare_response="$tmp_dir/main-lineage.json"
+compare_status="$(curl --location --silent --show-error \
+    --connect-timeout 10 --max-time 30 \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    --header "Authorization: Bearer $TIP_SOURCE_GH_TOKEN" \
+    --output "$compare_response" --write-out '%{http_code}' \
+    "https://api.github.com/repos/$TIP_SOURCE_REPOSITORY/compare/$TIP_COMMIT...$TIP_SOURCE_BRANCH")" ||
+    fail "Protected-main lineage GitHub API request failed"
+[[ "$compare_status" =~ ^[0-9]{3}$ ]] || fail "Protected-main lineage lookup returned an invalid HTTP status"
+[[ "$compare_status" == "200" ]] || fail "Protected-main lineage lookup failed with HTTP $compare_status"
+
+lineage="$(python3 - "$compare_response" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit("ERROR: Protected-main lineage lookup returned invalid JSON")
+status = payload.get("status") if isinstance(payload, dict) else None
+merge_base = payload.get("merge_base_commit") if isinstance(payload, dict) else None
+merge_base_sha = merge_base.get("sha") if isinstance(merge_base, dict) else None
+print(f"{status or ''}|{merge_base_sha or ''}")
+PY
+)"
+relation="${lineage%%|*}"
+merge_base="${lineage#*|}"
+[[ "$relation" == "ahead" && "$merge_base" == "$TIP_COMMIT" ]] ||
+    fail "$phase rejected Tip candidate outside protected-main ancestry: candidate=$TIP_COMMIT live-main=$live_main relation=${relation:-unknown} merge-base=${merge_base:-unknown}"
+
+printf 'OK: %s confirmed candidate %s remains an ancestor of protected main %s.\n' \
+    "$phase" "$TIP_COMMIT" "$live_main"

--- a/Sources/RepoPrompt/Features/AgentMode/History/HistoryMCPToolService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/History/HistoryMCPToolService.swift
@@ -1436,8 +1436,8 @@ enum HistoryMCPToolService {
         }
         if let sortKeys { sortKeys(&orderedKeys) }
 
-        return orderedKeys.map { key in
-            let sessionsInGroup = grouped[key]!
+        return orderedKeys.compactMap { key in
+            guard let sessionsInGroup = grouped[key] else { return nil }
             let totalDuration = sessionsInGroup.reduce(0) { $0 + $1.record.activeDurationSeconds(thresholdMinutes: idleThresholdMinutes) }
             let totalTurns = sessionsInGroup.reduce(0) { $0 + $1.record.itemCount }
             let totalToolCalls = sessionsInGroup.reduce(0) { $0 + $1.record.toolCallCount }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -74,6 +74,7 @@ enum AgentModel: String, CaseIterable, Codable {
     case gpt54MiniHigh = "gpt-5.4-mini-high"
 
     // Claude Code models
+    case claudeFable = "fable"
     case claudeSonnet = "sonnet"
     case claudeOpus = "opus"
     case claudeHaiku = "haiku"
@@ -150,6 +151,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .gpt54MiniLow: "GPT-5.4 Mini Low"
         case .gpt54MiniMedium: "GPT-5.4 Mini Medium"
         case .gpt54MiniHigh: "GPT-5.4 Mini High"
+        case .claudeFable: "Fable Latest"
         case .claudeSonnet: "Sonnet Latest"
         case .claudeOpus: "Opus Latest"
         case .claudeHaiku: "Haiku Latest"
@@ -218,12 +220,13 @@ enum AgentModel: String, CaseIterable, Codable {
         case .gpt54MiniLow: "Fast GPT-5.4 Mini. Good for quick exploration and lookups."
         case .gpt54MiniMedium: "GPT-5.4 Mini with balanced reasoning. Best exploration sub-agent for context gathering."
         case .gpt54MiniHigh: "GPT-5.4 Mini with deep reasoning. Good for complex exploration and analysis."
+        case .claudeFable: "Latest Claude Fable model for demanding reasoning and long-horizon agentic work."
         case .claudeSonnet: "Balanced speed and capability. Good for general coding, analysis, and everyday work."
         case .claudeOpus: "Most capable Opus-tier model. Best for open-ended tasks, architecture, and complex reasoning."
         case .claudeHaiku: "Fast and lightweight. Good for exploration, quick edits, and mapping codebases."
         case .claudeOpus1m: "Claude Opus with 1M token context. Best for large codebases and tasks requiring extensive context."
-        case .claudeFable51: "Claude Fable 5.1. Anthropic's newest and most capable model for demanding reasoning and long-horizon agentic work."
-        case .claudeFable5: "Claude Fable 5. Anthropic's most capable widely released model for demanding reasoning and long-horizon agentic work."
+        case .claudeFable51: "Pinned Claude Fable 5.1 with 1M context for demanding reasoning and long-horizon agentic work. Requires Claude Code 2.1.255 or newer."
+        case .claudeFable5: "Pinned Claude Fable 5 with 1M context for demanding reasoning and long-horizon agentic work."
         case .claudeSonnet5: "Pinned Claude Sonnet 5. Balanced speed and capability with 1M context for everyday engineering."
         case .claudeSonnet46: "Pinned Claude Sonnet 4.6. Balanced speed and capability for everyday engineering."
         case .claudeSonnet45: "Pinned Claude Sonnet 4.5. Balanced speed and capability for everyday engineering."
@@ -293,7 +296,7 @@ enum AgentModel: String, CaseIterable, Codable {
             // latest aliases come first, then pinned full IDs by descending version.
             [
                 .defaultModel,
-                .claudeFable51, .claudeFable5,
+                .claudeFable, .claudeFable51, .claudeFable5,
                 .claudeOpus1m,
                 .claudeOpus, .claudeOpus5, .claudeOpus48, .claudeOpus47, .claudeOpus46, .claudeOpus45,
                 .claudeSonnet, .claudeSonnet5, .claudeSonnet46, .claudeSonnet45,
@@ -572,7 +575,7 @@ enum AgentModel: String, CaseIterable, Codable {
             [.fast, .exploration, .engineering]
         case .gpt56SolHigh:
             [.complex, .engineering, .pair]
-        case .claudeFable51, .claudeFable5, .claudeOpus5:
+        case .claudeFable, .claudeFable51, .claudeFable5, .claudeOpus5:
             [.complex, .engineering, .pair, .extendedContext]
         case .claudeSonnet5:
             [.balanced, .engineering, .extendedContext]
@@ -587,7 +590,7 @@ enum AgentModel: String, CaseIterable, Codable {
     /// Returns `nil` for models where the context window is unknown or unverified.
     var contextWindowTokens: Int? {
         switch self {
-        case .claudeFable51, .claudeFable5, .claudeSonnet5, .claudeOpus5, .claudeOpus48, .claudeOpus1m, .glm52_1m:
+        case .claudeFable, .claudeFable51, .claudeFable5, .claudeSonnet5, .claudeOpus5, .claudeOpus48, .claudeOpus1m, .glm52_1m:
             1_000_000
         case .claudeSonnet, .claudeOpus, .claudeHaiku,
              .claudeSonnet46, .claudeSonnet45,

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -80,6 +80,7 @@ enum AgentModel: String, CaseIterable, Codable {
     case claudeOpus1m = "opus[1m]"
 
     // Claude Code full model IDs (static known versions; no dynamic probing)
+    case claudeFable51 = "claude-fable-5-1"
     case claudeFable5 = "claude-fable-5"
     case claudeSonnet5 = "claude-sonnet-5"
     case claudeSonnet46 = "claude-sonnet-4-6"
@@ -153,6 +154,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .claudeOpus: "Opus Latest"
         case .claudeHaiku: "Haiku Latest"
         case .claudeOpus1m: "Opus Latest (1M)"
+        case .claudeFable51: "Fable 5.1"
         case .claudeFable5: "Fable 5"
         case .claudeSonnet5: "Sonnet 5"
         case .claudeSonnet46: "Sonnet 4.6"
@@ -220,6 +222,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .claudeOpus: "Most capable Opus-tier model. Best for open-ended tasks, architecture, and complex reasoning."
         case .claudeHaiku: "Fast and lightweight. Good for exploration, quick edits, and mapping codebases."
         case .claudeOpus1m: "Claude Opus with 1M token context. Best for large codebases and tasks requiring extensive context."
+        case .claudeFable51: "Claude Fable 5.1. Anthropic's newest and most capable model for demanding reasoning and long-horizon agentic work."
         case .claudeFable5: "Claude Fable 5. Anthropic's most capable widely released model for demanding reasoning and long-horizon agentic work."
         case .claudeSonnet5: "Pinned Claude Sonnet 5. Balanced speed and capability with 1M context for everyday engineering."
         case .claudeSonnet46: "Pinned Claude Sonnet 4.6. Balanced speed and capability for everyday engineering."
@@ -290,7 +293,7 @@ enum AgentModel: String, CaseIterable, Codable {
             // latest aliases come first, then pinned full IDs by descending version.
             [
                 .defaultModel,
-                .claudeFable5,
+                .claudeFable51, .claudeFable5,
                 .claudeOpus1m,
                 .claudeOpus, .claudeOpus5, .claudeOpus48, .claudeOpus47, .claudeOpus46, .claudeOpus45,
                 .claudeSonnet, .claudeSonnet5, .claudeSonnet46, .claudeSonnet45,
@@ -569,7 +572,7 @@ enum AgentModel: String, CaseIterable, Codable {
             [.fast, .exploration, .engineering]
         case .gpt56SolHigh:
             [.complex, .engineering, .pair]
-        case .claudeFable5, .claudeOpus5:
+        case .claudeFable51, .claudeFable5, .claudeOpus5:
             [.complex, .engineering, .pair, .extendedContext]
         case .claudeSonnet5:
             [.balanced, .engineering, .extendedContext]
@@ -584,7 +587,7 @@ enum AgentModel: String, CaseIterable, Codable {
     /// Returns `nil` for models where the context window is unknown or unverified.
     var contextWindowTokens: Int? {
         switch self {
-        case .claudeFable5, .claudeSonnet5, .claudeOpus5, .claudeOpus48, .claudeOpus1m, .glm52_1m:
+        case .claudeFable51, .claudeFable5, .claudeSonnet5, .claudeOpus5, .claudeOpus48, .claudeOpus1m, .glm52_1m:
             1_000_000
         case .claudeSonnet, .claudeOpus, .claudeHaiku,
              .claudeSonnet46, .claudeSonnet45,

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -384,6 +384,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
 
     /// Base model raw values (lowercased) that support the XHigh effort tier.
     private static let claudeXHighEligibleBaseRaws: Set<String> = [
+        AgentModel.claudeFable51.rawValue.lowercased(),
         AgentModel.claudeFable5.rawValue.lowercased(),
         AgentModel.claudeSonnet5.rawValue.lowercased(),
         AgentModel.claudeOpus.rawValue.lowercased(),

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -384,6 +384,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
 
     /// Base model raw values (lowercased) that support the XHigh effort tier.
     private static let claudeXHighEligibleBaseRaws: Set<String> = [
+        AgentModel.claudeFable.rawValue.lowercased(),
         AgentModel.claudeFable51.rawValue.lowercased(),
         AgentModel.claudeFable5.rawValue.lowercased(),
         AgentModel.claudeSonnet5.rawValue.lowercased(),

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -1946,9 +1946,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         return effort.displayName
     }
 
-    func reasoningEffortOptions(forModelRaw rawModel: String, agentKind: AgentProviderKind) -> [CodexReasoningEffort] {
+    func reasoningEffortOptions(
+        forModelRaw rawModel: String,
+        agentKind: AgentProviderKind,
+        precomputedOptions: [AgentModelOption]? = nil
+    ) -> [CodexReasoningEffort] {
         guard agentKind == .codexExec else { return [] }
-        let options = modelOptions(for: .codexExec)
+        let options = precomputedOptions ?? modelOptions(for: .codexExec)
         let normalizedRaw = Self.normalizedCodexSelectionModelRaw(from: rawModel)
         let option = options.first(where: {
             $0.rawValue.caseInsensitiveCompare(normalizedRaw) == .orderedSame
@@ -2105,7 +2109,19 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         }
     }
 
+    /// Cache for `codexDisplayName(forBaseModel:)` — the function is pure so results
+    /// can be reused across all renders without any invalidation logic.
+    private static let _codexDisplayNameCacheLock = NSLock()
+    private static var _codexDisplayNameCache: [String: String] = [:]
+
     private static func codexDisplayName(forBaseModel rawModel: String) -> String {
+        _codexDisplayNameCacheLock.lock()
+        if let cached = _codexDisplayNameCache[rawModel] {
+            _codexDisplayNameCacheLock.unlock()
+            return cached
+        }
+        _codexDisplayNameCacheLock.unlock()
+
         let trimmed = rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return rawModel }
         let normalized = trimmed
@@ -2134,6 +2150,11 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             with: "GPT-$1",
             options: .regularExpression
         )
+
+        _codexDisplayNameCacheLock.lock()
+        _codexDisplayNameCache[rawModel] = output
+        _codexDisplayNameCacheLock.unlock()
+
         return output
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
@@ -4639,8 +4639,10 @@ enum AgentTranscriptIO {
         let keyPaths = Array(NSOrderedSet(array: toolExecutions.flatMap(\.keyPaths))) as? [String] ?? []
         let allToolNames = toolNameCounts.isEmpty ? toolNames : Array(toolNameCounts.keys.sorted())
         let narration = latestCollapsedNarrationText(from: activities)
-        let shortNarration = narration.map {
-            $0.count > 120 ? String($0.prefix(120)) + "…" : $0
+        let shortNarration: String? = narration.flatMap {
+            let sanitized = $0.sanitizedForDisplay
+            guard !sanitized.isEmpty else { return nil }
+            return sanitized.count > 120 ? String(sanitized.prefix(120)) + "…" : sanitized
         }
         let toolGroups = ClusterToolCategory.buildGroups(toolNames: allToolNames, counts: toolNameCounts)
         let summary = AgentTranscriptClusterSummary(
@@ -7751,10 +7753,10 @@ enum AgentTranscriptProjectionBuilder {
         let containsFailure = toolExecutions.contains { $0.status == .failed || $0.status == .cancelled }
         let containsWarning = toolExecutions.contains { $0.status == .warning }
         let narration = latestNarrationText(from: rows)
-        let shortNarration: String? = if let narration, !narration.isEmpty {
-            narration.count > 120 ? String(narration.prefix(120)) + "…" : narration
-        } else {
-            nil
+        let shortNarration: String? = narration.flatMap {
+            let sanitized = $0.sanitizedForDisplay
+            guard !sanitized.isEmpty else { return nil }
+            return sanitized.count > 120 ? String(sanitized.prefix(120)) + "…" : sanitized
         }
         let allToolNames = toolNameCounts.isEmpty ? Array(toolNames) : Array(toolNameCounts.keys.sorted())
         let toolGroups = ClusterToolCategory.buildGroups(toolNames: allToolNames, counts: toolNameCounts)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -271,6 +271,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     @Published var pendingTaggedFileAttachments: [AgentTaggedFileAttachment] = []
     @Published var draftRestorationEvent: DraftRestorationEvent? = nil
     @Published private(set) var codexDynamicModels: [CodexAppServerClient.RemoteModel] = []
+    /// Pre-computed collapsed Codex model options. Rebuilt whenever `codexDynamicModels`
+    /// changes so the expensive collapse/regex work never runs on the SwiftUI render path.
+    private(set) var cachedCollapsedCodexOptions: [AgentModelOption] = []
     @Published private(set) var acpDynamicModelRevision: Int = 0
     @Published private(set) var availableAgents: [AgentProviderKind] = AgentModelCatalog.selectableAgents(availability: .none)
 
@@ -1216,12 +1219,22 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     func reasoningEffortOptionsForCurrentSelection() -> [CodexReasoningEffort] {
-        codexCoordinator.reasoningEffortOptions(forModelRaw: selectedModelRaw, agentKind: selectedAgent)
+        codexCoordinator.reasoningEffortOptions(
+            forModelRaw: selectedModelRaw,
+            agentKind: selectedAgent,
+            precomputedOptions: cachedCollapsedCodexOptions.isEmpty ? nil : cachedCollapsedCodexOptions
+        )
     }
 
     func updateCodexDynamicModels(_ models: [CodexAppServerClient.RemoteModel]) {
         if codexDynamicModels != models {
             codexDynamicModels = models
+            // Rebuild the collapsed option cache eagerly (off the render path) so
+            // that reasoningEffortOptionsForCurrentSelection() is cheap in SwiftUI bodies.
+            cachedCollapsedCodexOptions = codexCoordinator.modelOptions(
+                for: .codexExec,
+                codexDynamicModels: models
+            )
             syncComposerUIState()
         }
         // Note: Registry updates are owned exclusively by CodexModelPollingService.

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -55,6 +55,29 @@ struct AgentSessionRow: View {
     @State private var showRenameAlert = false
     @State private var showDeleteConfirmation = false
     @State private var renameText = ""
+
+    // MARK: - Context Menu Snapshot
+
+    /// Snapshot of the conditions that control context menu item visibility,
+    /// captured on hover. Using a snapshot prevents AppKit from observing a
+    /// mid-layout item-count change (which triggers an NSRangeException when
+    /// NSContextMenuImpl measures row heights for items that were just removed).
+    private struct ContextMenuSnapshot {
+        var isInteractionEnabled: Bool
+        var showsSelectionPresentation: Bool
+        var hasAttentionRunState: Bool
+        var hasOnStash: Bool
+        var hasOnDismissAttention: Bool
+    }
+
+    @State private var menuSnapshot = ContextMenuSnapshot(
+        isInteractionEnabled: true,
+        showsSelectionPresentation: false,
+        hasAttentionRunState: false,
+        hasOnStash: false,
+        hasOnDismissAttention: false
+    )
+
     @ObservedObject private var fontScale = FontScaleManager.shared
     private var fontPreset: FontScalePreset {
         fontScale.preset
@@ -316,8 +339,8 @@ struct AgentSessionRow: View {
         )
         .contentShape(Rectangle())
         .contextMenu {
-            if !showsSelectionPresentation {
-                if isInteractionEnabled {
+            if !menuSnapshot.showsSelectionPresentation {
+                if menuSnapshot.isInteractionEnabled {
                     Button("Select chat", action: toggleSelection)
 
                     Divider()
@@ -332,22 +355,33 @@ struct AgentSessionRow: View {
                 }
                 .disabled(!sessionIDCopyAction.isEnabled)
 
-                if isInteractionEnabled, let onStash {
-                    Button(stashActionLabel, action: onStash)
+                if menuSnapshot.isInteractionEnabled, menuSnapshot.hasOnStash {
+                    Button(stashActionLabel, action: { onStash?() })
                 }
 
-                if attentionRunState != nil, let onDismissAttention {
-                    Button(dismissAttentionActionLabel, action: onDismissAttention)
+                if menuSnapshot.hasAttentionRunState, menuSnapshot.hasOnDismissAttention {
+                    Button(dismissAttentionActionLabel, action: { onDismissAttention?() })
                 }
 
-                if isInteractionEnabled {
+                if menuSnapshot.isInteractionEnabled {
                     Divider()
 
                     Button(deleteActionLabel, role: .destructive, action: requestDeleteConfirmation)
                 }
             }
         }
-        .onHover { isHovered = $0 }
+        .onHover { hovered in
+            isHovered = hovered
+            if hovered {
+                menuSnapshot = ContextMenuSnapshot(
+                    isInteractionEnabled: isInteractionEnabled,
+                    showsSelectionPresentation: showsSelectionPresentation,
+                    hasAttentionRunState: attentionRunState != nil,
+                    hasOnStash: onStash != nil,
+                    hasOnDismissAttention: onDismissAttention != nil
+                )
+            }
+        }
         .onTapGesture(perform: handleRowTap)
         .focusable()
         .onKeyPress(.space) {
@@ -798,6 +832,21 @@ struct AgentStashedSessionRow: View {
     @State private var isHovered = false
     @State private var isRestoreHovered = false
     @State private var isDeleteHovered = false
+
+    // MARK: - Context Menu Snapshot
+
+    /// Snapshot of conditions controlling context menu item visibility, captured
+    /// on hover to prevent NSRangeException from AppKit measuring stale item counts.
+    private struct ContextMenuSnapshot {
+        var isInteractionEnabled: Bool
+        var showsSelectionPresentation: Bool
+    }
+
+    @State private var menuSnapshot = ContextMenuSnapshot(
+        isInteractionEnabled: true,
+        showsSelectionPresentation: false
+    )
+
     @ObservedObject private var fontScale = FontScaleManager.shared
     private var fontPreset: FontScalePreset {
         fontScale.preset
@@ -946,8 +995,8 @@ struct AgentStashedSessionRow: View {
         )
         .contentShape(Rectangle())
         .contextMenu {
-            if !showsSelectionPresentation {
-                if isInteractionEnabled {
+            if !menuSnapshot.showsSelectionPresentation {
+                if menuSnapshot.isInteractionEnabled {
                     Button("Select chat", action: toggleSelection)
                     Divider()
                     Button(restoreActionLabel, action: onRestore)
@@ -956,13 +1005,21 @@ struct AgentStashedSessionRow: View {
                     sessionIDCopyAction.perform()
                 }
                 .disabled(!sessionIDCopyAction.isEnabled)
-                if isInteractionEnabled {
+                if menuSnapshot.isInteractionEnabled {
                     Divider()
                     Button(deleteActionLabel, role: .destructive, action: onDelete)
                 }
             }
         }
-        .onHover { isHovered = $0 }
+        .onHover { hovered in
+            isHovered = hovered
+            if hovered {
+                menuSnapshot = ContextMenuSnapshot(
+                    isInteractionEnabled: isInteractionEnabled,
+                    showsSelectionPresentation: showsSelectionPresentation
+                )
+            }
+        }
         .onTapGesture(perform: handleRowTap)
         .focusable()
         .onKeyPress(.space) {

--- a/Sources/RepoPrompt/Features/Settings/Views/OptimizedModelPicker.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/OptimizedModelPicker.swift
@@ -244,7 +244,6 @@ struct OptimizedModelPicker: View {
         } label: {
             HStack {
                 Text(title ?? model.displayName)
-                    .font(font)
                 Spacer()
                 if destination.currentRawValue == model.rawValue {
                     Image(systemName: "checkmark")

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -6104,7 +6104,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             #endif
             return
         }
-        guard workspaceIndex(for: wsID) != nil else {
+        guard let idx2 = workspaceIndex(for: wsID) else {
             #if DEBUG
                 WorkspaceRestorePerfLog.event(
                     "workspaceSwitch.restoreState.abort",

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -2495,8 +2495,24 @@ actor ACPAgentSessionController {
     }
 
     private func applyDiscoveredSessionModels(from response: [String: Any]) {
+        // A configOptions-only update carries no replacement for a live direct-model snapshot.
+        // Preserve both its session authority and the provider-owned effort wire state instead
+        // of routing the incomplete response through the direct parser as `.absent`.
+        if provider is ACPDirectSessionModelProvider,
+           response["models"] == nil,
+           sessionModelDirectSelectionSupported,
+           sessionModelSnapshotHasLiveAuthority
+        {
+            return
+        }
+
         let parsed: ACPDiscoveredSessionModels?
-        switch parseModernModelSnapshot(from: response) {
+        // ponytail: grok CLI >= 1.0.17 sends `configOptions` next to its legacy `models` block;
+        // only the direct provider parser carries Grok's effort wire values, so let it win and
+        // keep the provider on the direct path when no live snapshot has been established yet.
+        let useDirectParser = provider is ACPDirectSessionModelProvider
+            && (response["models"] != nil || sessionModelDirectSelectionSupported)
+        switch useDirectParser ? .absent : parseModernModelSnapshot(from: response) {
         case let .valid(configID, models):
             sessionModelConfigOptionID = configID
             sessionModelDirectSelectionSupported = false

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
@@ -23,6 +23,7 @@ enum ClaudeCodeAIModelCatalog {
     ]
 
     private static let modelDefinitions: [ModelDefinition] = [
+        ModelDefinition(runtimeModelRaw: "fable", displayName: "Fable Latest", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-fable-5-1", displayName: "Fable 5.1", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-fable-5", displayName: "Fable 5", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "opus[1m]", displayName: "Opus Latest (1M)", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
@@ -23,6 +23,7 @@ enum ClaudeCodeAIModelCatalog {
     ]
 
     private static let modelDefinitions: [ModelDefinition] = [
+        ModelDefinition(runtimeModelRaw: "claude-fable-5-1", displayName: "Fable 5.1", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-fable-5", displayName: "Fable 5", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "opus[1m]", displayName: "Opus Latest (1M)", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "opus", displayName: "Opus Latest", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileContentSnapshot.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileContentSnapshot.swift
@@ -88,7 +88,7 @@ enum FileContentFingerprintReader {
         #endif
 
         return FileContentFingerprint(
-            deviceID: UInt64(info.st_dev),
+            deviceID: safeDeviceID(info.st_dev),
             fileNumber: UInt64(info.st_ino),
             byteSize: Int64(info.st_size),
             modificationSeconds: Int64(modificationTime.tv_sec),

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemSeededInventoryReplayOverlay.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemSeededInventoryReplayOverlay.swift
@@ -73,7 +73,7 @@ private final class FileSystemSeededInventoryChangeSpillStore: @unchecked Sendab
               status.st_size >= 0
         else { return nil }
         return FileSystemSeededInventorySpillIdentity(
-            device: UInt64(status.st_dev),
+            device: safeDeviceID(status.st_dev),
             inode: UInt64(status.st_ino),
             byteCount: UInt64(status.st_size),
             modificationSeconds: Int64(status.st_mtimespec.tv_sec),

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+DirectoryListing.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+DirectoryListing.swift
@@ -5,6 +5,15 @@ import Foundation
     import Glibc
 #endif
 
+/// Safely converts a `stat.st_dev` value (which is `Int32` on macOS and can be
+/// negative for virtual/network filesystems) to `UInt64` without trapping.
+/// Using `UInt64(bitPattern: Int64(dev))` preserves the bit pattern instead of
+/// triggering a Swift overflow trap when `dev` is negative.
+@inline(__always)
+func safeDeviceID(_ dev: Int32) -> UInt64 {
+    UInt64(bitPattern: Int64(dev))
+}
+
 extension FileSystemService {
     struct DirEntry {
         let name: String
@@ -520,7 +529,7 @@ extension FileSystemService {
     static func dirID(followingSymlinksAtPath path: String) -> DirID? {
         var st = stat()
         guard stat(path, &st) == 0 else { return nil }
-        return DirID(dev: UInt64(st.st_dev), ino: UInt64(st.st_ino))
+        return DirID(dev: safeDeviceID(st.st_dev), ino: UInt64(st.st_ino))
     }
 
     /// Canonicalize a path via `realpath()`. Returns nil on ELOOP, missing targets, etc.

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/IgnoreRulesManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/IgnoreRulesManager.swift
@@ -233,7 +233,7 @@ actor IgnoreRulesManager {
     private func fileMetaKey(for url: URL) -> FileMetaKey {
         var st = stat()
         if stat(url.path, &st) == 0 {
-            let dev = UInt64(st.st_dev)
+            let dev = safeDeviceID(st.st_dev)
             let ino = UInt64(st.st_ino)
             #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
                 let mtime = UInt64(st.st_mtimespec.tv_sec)

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/SpillBackedSortedArtifactStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/SpillBackedSortedArtifactStore.swift
@@ -583,7 +583,7 @@ final class SpillBackedSortedArtifactStore: @unchecked Sendable {
             throw format.error(.corrupt("negative artifact size"))
         }
         return SpillBackedSortedArtifactDescriptorIdentity(
-            device: UInt64(status.st_dev),
+            device: safeDeviceID(status.st_dev),
             inode: UInt64(status.st_ino),
             byteCount: UInt64(status.st_size),
             modificationSeconds: Int64(status.st_mtimespec.tv_sec),
@@ -603,7 +603,7 @@ final class SpillBackedSortedArtifactStore: @unchecked Sendable {
               status.st_size >= 0
         else { return nil }
         return SpillBackedSortedArtifactDescriptorIdentity(
-            device: UInt64(status.st_dev),
+            device: safeDeviceID(status.st_dev),
             inode: UInt64(status.st_ino),
             byteCount: UInt64(status.st_size),
             modificationSeconds: Int64(status.st_mtimespec.tv_sec),

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/WorkspaceRootNamespaceManifest.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/WorkspaceRootNamespaceManifest.swift
@@ -76,7 +76,7 @@ struct WorkspaceRootNamespaceRootIdentity: Hashable {
         canonicalPathBytes = canonicalURL.withUnsafeFileSystemRepresentation { pointer in
             pointer.map { Data(bytes: $0, count: strlen($0)) } ?? Data()
         }
-        device = UInt64(status.st_dev)
+        device = safeDeviceID(status.st_dev)
         inode = UInt64(status.st_ino)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPBindingResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPBindingResolver.swift
@@ -35,7 +35,7 @@ struct MCPBindingResolver {
         }
     }
 
-    let collectMatchesForContextID: (UUID) async -> [MCPContextBindingMatch]
+    let collectMatchesForContextID: (UUID, UUID) async -> [MCPContextBindingMatch]
     let collectMatchesForWorkingDirs: ([String]) async -> [MCPContextBindingMatch]
     let collectActiveMatchForWindowID: (Int) async -> MCPContextBindingMatch?
     let existingWindowIDForConnection: (UUID) async -> Int?
@@ -87,10 +87,10 @@ struct MCPBindingResolver {
         let matches: [MCPContextBindingMatch]
         if let explicitContextID {
             sourceDescription = "context_id '\(explicitContextID.uuidString)'"
-            matches = await collectMatchesForContextID(explicitContextID)
+            matches = await collectMatchesForContextID(connectionID, explicitContextID)
         } else if let legacyTabID {
             sourceDescription = "_tabID '\(legacyTabID.uuidString)'"
-            matches = await collectMatchesForContextID(legacyTabID)
+            matches = await collectMatchesForContextID(connectionID, legacyTabID)
         } else if !workingDirs.isEmpty {
             sourceDescription = "working_dirs [\(workingDirs.joined(separator: ", "))]"
             matches = await collectMatchesForWorkingDirs(workingDirs)

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -6502,10 +6502,40 @@ actor ServerNetworkManager {
 
     private var bindingResolver: MCPBindingResolver {
         MCPBindingResolver(
-            collectMatchesForContextID: { contextID in
+            collectMatchesForContextID: { connectionID, contextID in
                 await MainActor.run {
-                    WindowStatesManager.shared.allWindows.compactMap { windowState in
-                        guard let candidate = windowState.workspaceManager.storedBindingCandidate(forContextID: contextID) else {
+                    let windows = WindowStatesManager.shared.allWindows
+                    let bindingSnapshots = windows.map { windowState in
+                        (
+                            windowState: windowState,
+                            binding: windowState.mcpServer.connectionBindingSnapshot(forConnection: connectionID)
+                        )
+                    }
+                    let authoritativeBinding = bindingSnapshots.first {
+                        $0.binding.explicitlyBound && $0.binding.runID == nil
+                    } ?? bindingSnapshots.first {
+                        $0.binding.runID != nil
+                    }
+
+                    // Preserve an exact authoritative connection binding before active-workspace discovery
+                    if let authoritativeBinding,
+                       authoritativeBinding.binding.tabID == contextID,
+                       let tabID = authoritativeBinding.binding.tabID,
+                       let workspaceID = authoritativeBinding.binding.workspaceID,
+                       let workspaceName = authoritativeBinding.binding.workspaceName
+                    {
+                        return [MCPContextBindingMatch(
+                            windowID: authoritativeBinding.windowState.windowID,
+                            tabID: tabID,
+                            workspaceID: workspaceID,
+                            workspaceName: workspaceName,
+                            repoPaths: authoritativeBinding.binding.repoPaths
+                        )]
+                    }
+
+                    // Unbound one-shot context IDs share bind_context's active-workspace authority
+                    return windows.compactMap { windowState in
+                        guard let candidate = windowState.workspaceManager.bindingCandidate(forContextID: contextID) else {
                             return nil
                         }
                         return MCPContextBindingMatch(

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -3089,7 +3089,23 @@ extension MCPServerViewModel {
                 bound: bound
             ) {
                 if let explicitHint, !Self.hint(explicitHint, matches: bound) {
-                    throw MCPError.invalidParams("Explicit tab context hint for \(toolName) targets tab \(explicitHint.tabID), but this connection is already bound to tab \(bound.tabID). Clear or intentionally rebind the connection before targeting a different tab context.")
+                    var conflicts: [String] = []
+                    if explicitHint.tabID != bound.tabID {
+                        conflicts.append("context_id hint=\(explicitHint.tabID), bound=\(bound.tabID)")
+                    }
+                    if let workspaceID = explicitHint.workspaceID, workspaceID != bound.workspaceID {
+                        conflicts.append(
+                            "workspace_id hint=\(workspaceID), bound=\(bound.workspaceID?.uuidString ?? "none")"
+                        )
+                    }
+                    if let windowID = explicitHint.windowID, windowID != bound.windowID {
+                        conflicts.append("window_id hint=\(windowID), bound=\(bound.windowID)")
+                    }
+                    throw MCPError.invalidParams(
+                        "Explicit tab context hint for \(toolName) conflicts with this connection's authoritative " +
+                            "tab-context binding: \(conflicts.joined(separator: "; ")); clear or intentionally rebind " +
+                            "the connection before targeting a different tab context."
+                    )
                 }
                 if let hinted = resolvedWindowID {
                     if let existing = presentationWindowByConnection[connectionID], existing != hinted {

--- a/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
@@ -32,7 +32,7 @@ struct ExecutableFileIdentity: Equatable {
 
         return ExecutableFileIdentity(
             canonicalPath: canonicalPath,
-            device: UInt64(info.st_dev),
+            device: safeDeviceID(info.st_dev),
             inode: UInt64(info.st_ino),
             size: Int64(info.st_size),
             modificationSeconds: Int64(info.st_mtimespec.tv_sec),

--- a/Sources/RepoPrompt/Infrastructure/Utilities/String+Sanitize.swift
+++ b/Sources/RepoPrompt/Infrastructure/Utilities/String+Sanitize.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension String {
+    /// Returns a copy of this string safe for bridging to NSString and rendering in SwiftUI Text views.
+    ///
+    /// AI-generated content can contain characters (e.g. null bytes) that are technically valid in Swift's
+    /// String type but trigger `_assertionFailure` in Swift/StringBridge.swift when CoreText bridges the
+    /// value to NSString during layout. This strips those characters to prevent fatal crashes.
+    var sanitizedForDisplay: String {
+        // Remove null bytes (\0), which are legal in Swift String / NSString but break
+        // the NSString <-> Swift String bridge in certain CoreText/SwiftUI rendering paths.
+        filter { $0 != "\0" }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitBlobIdentityService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitBlobIdentityService.swift
@@ -685,7 +685,7 @@ actor GitBlobIdentityService {
 
     private static func lstatFingerprint(_ value: stat) -> GitBlobLStatFingerprint {
         GitBlobLStatFingerprint(
-            device: UInt64(value.st_dev),
+            device: safeDeviceID(value.st_dev),
             inode: UInt64(value.st_ino),
             mode: UInt16(value.st_mode),
             size: Int64(value.st_size),

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitRawOutputSpool.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitRawOutputSpool.swift
@@ -218,7 +218,7 @@ final class GitRawOutputSpool: @unchecked Sendable {
             throw GitRawOutputSpoolError.corrupt("negative spool size")
         }
         return GitRawOutputSpoolDescriptorIdentity(
-            device: UInt64(value.st_dev),
+            device: safeDeviceID(value.st_dev),
             inode: UInt64(value.st_ino),
             byteCount: UInt64(value.st_size),
             modificationSeconds: Int64(value.st_mtimespec.tv_sec),
@@ -349,7 +349,7 @@ final class GitRawOutputSpoolLease: @unchecked Sendable {
         }
         var pathValue = stat()
         guard lstat(fileURL.path, &pathValue) == 0,
-              UInt64(pathValue.st_dev) == identity.device,
+              safeDeviceID(pathValue.st_dev) == identity.device,
               UInt64(pathValue.st_ino) == identity.inode,
               pathValue.st_size >= 0,
               UInt64(pathValue.st_size) == identity.byteCount

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitTargetEvidenceManifests.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitTargetEvidenceManifests.swift
@@ -31,7 +31,7 @@ struct GitTargetEvidenceFileSystemIdentity: Equatable {
             throw GitTargetEvidenceManifestError.invalidConfiguration
         }
         canonicalPathBytes = pathBytes
-        device = UInt64(status.st_dev)
+        device = safeDeviceID(status.st_dev)
         inode = UInt64(status.st_ino)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorkspaceStateAuthority.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorkspaceStateAuthority.swift
@@ -1798,7 +1798,7 @@ actor GitWorkspaceStateAuthority {
         else { throw GitPrefixControlEvidenceCacheError.rootIdentityChanged }
         return PrefixControlRootIdentity(
             canonicalPath: canonicalRoot.path,
-            device: UInt64(value.st_dev),
+            device: safeDeviceID(value.st_dev),
             inode: UInt64(value.st_ino)
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeInitializationModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeInitializationModels.swift
@@ -13,7 +13,7 @@ struct GitWorkspaceAuthorityRepositoryKey: Hashable {
         standardizedGitDirectoryPath = layout.gitDir.standardizedFileURL.path
         var value = stat()
         if lstat(layout.commonDir.path, &value) == 0 {
-            commonDirectoryDevice = UInt64(value.st_dev)
+            commonDirectoryDevice = safeDeviceID(value.st_dev)
             commonDirectoryInode = UInt64(value.st_ino)
         } else {
             commonDirectoryDevice = nil

--- a/Sources/RepoPrompt/Infrastructure/VCS/WorkspaceRootCreationReceiptCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/WorkspaceRootCreationReceiptCoordinator.swift
@@ -667,7 +667,7 @@ final class WorkspaceRootCreationReceiptCoordinator: @unchecked Sendable {
         guard lstat(url.path, &value) == 0,
               value.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR)
         else { return nil }
-        return StableWatchRootIdentity(device: UInt64(value.st_dev), inode: UInt64(value.st_ino))
+        return StableWatchRootIdentity(device: safeDeviceID(value.st_dev), inode: UInt64(value.st_ino))
     }
 
     private static func canonicalURL(_ url: URL) -> URL {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
@@ -651,6 +651,9 @@ enum WorkspaceSearchCatalogChangeKind: Equatable {
     case rootLoaded
     case rootUnloaded
     case appliedIndex
+
+    /// The catalog generation advanced without changing the discoverable search projection.
+    case generationAdvancedWithoutProjectionChange
 }
 
 struct WorkspaceSearchCatalogChangeEvent: Equatable {
@@ -658,7 +661,35 @@ struct WorkspaceSearchCatalogChangeEvent: Equatable {
     let rootPath: String
     let rootLifetimeID: UUID?
     let rootAppliedIndexGeneration: UInt64?
+    let catalogGeneration: UInt64?
     let kind: WorkspaceSearchCatalogChangeKind
+
+    init(
+        rootID: UUID,
+        rootPath: String,
+        rootLifetimeID: UUID?,
+        rootAppliedIndexGeneration: UInt64?,
+        catalogGeneration: UInt64? = nil,
+        kind: WorkspaceSearchCatalogChangeKind
+    ) {
+        self.rootID = rootID
+        self.rootPath = rootPath
+        self.rootLifetimeID = rootLifetimeID
+        self.rootAppliedIndexGeneration = rootAppliedIndexGeneration
+        self.catalogGeneration = catalogGeneration
+        self.kind = kind
+    }
+
+    func stamped(catalogGeneration: UInt64) -> Self {
+        Self(
+            rootID: rootID,
+            rootPath: rootPath,
+            rootLifetimeID: rootLifetimeID,
+            rootAppliedIndexGeneration: rootAppliedIndexGeneration,
+            catalogGeneration: catalogGeneration,
+            kind: kind
+        )
+    }
 }
 
 struct WorkspaceAppliedIndexBatchEvent: Equatable {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
@@ -647,6 +647,20 @@ struct WorkspaceSliceRebaseSourceSnapshot: Equatable {
     let modificationTime: Double
 }
 
+enum WorkspaceSearchCatalogChangeKind: Equatable {
+    case rootLoaded
+    case rootUnloaded
+    case appliedIndex
+}
+
+struct WorkspaceSearchCatalogChangeEvent: Equatable {
+    let rootID: UUID
+    let rootPath: String
+    let rootLifetimeID: UUID?
+    let rootAppliedIndexGeneration: UInt64?
+    let kind: WorkspaceSearchCatalogChangeKind
+}
+
 struct WorkspaceAppliedIndexBatchEvent: Equatable {
     let rootID: UUID
     let rootPath: String

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Search/WorkspaceSearchService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Search/WorkspaceSearchService.swift
@@ -75,6 +75,7 @@ actor WorkspaceSearchService {
         private var debugLastEntryCount = 0
         private var searchDidCaptureGenerationHandler: (@Sendable (UInt64?) async -> Void)?
         private var catalogChangeWillHandleHandler: (@Sendable (WorkspaceSearchCatalogChangeEvent) async -> Void)?
+        private var projectionNeutralGenerationDidCommitHandler: (@Sendable (UInt64) async -> Void)?
         private var automaticRebuildDidStartHandler: (@Sendable (UInt64) async -> Void)?
         private var automaticRebuildDidCommitHandler: (@Sendable (UInt64) async -> Void)?
     #endif
@@ -142,6 +143,12 @@ actor WorkspaceSearchService {
             catalogChangeWillHandleHandler = handler
         }
 
+        func setProjectionNeutralGenerationDidCommitHandler(
+            _ handler: (@Sendable (UInt64) async -> Void)?
+        ) {
+            projectionNeutralGenerationDidCommitHandler = handler
+        }
+
         func setAutomaticRebuildDidStartHandler(
             _ handler: (@Sendable (UInt64) async -> Void)?
         ) {
@@ -200,7 +207,7 @@ actor WorkspaceSearchService {
         boundRootScope = rootScope
         let epoch = bindingEpoch
 
-        let stream = await store.searchCatalogChangeEvents()
+        let stream = await store.searchCatalogChangeEvents(rootScope: rootScope)
         guard isCurrentBinding(store: store, rootScope: rootScope, epoch: epoch),
               freshnessListenerSerial == listenerSerial
         else { return }
@@ -438,6 +445,19 @@ actor WorkspaceSearchService {
         {
             return
         }
+        if event.kind == .generationAdvancedWithoutProjectionChange {
+            guard event.catalogGeneration == catalogGeneration else {
+                // A later catalog event is already buffered. Let that event either commit the
+                // newest projection-neutral generation or schedule the required rebuild.
+                return
+            }
+            if advanceReadyIndexGenerationWithoutProjectionRebuild(to: catalogGeneration) {
+                #if DEBUG
+                    await projectionNeutralGenerationDidCommitHandler?(catalogGeneration)
+                #endif
+                return
+            }
+        }
         if catalogGeneration == pendingRebuildGeneration || catalogGeneration == activeRebuildGeneration {
             return
         }
@@ -447,6 +467,28 @@ actor WorkspaceSearchService {
             targetGeneration: catalogGeneration,
             debounceNanoseconds: debounceNanoseconds
         )
+    }
+
+    private func advanceReadyIndexGenerationWithoutProjectionRebuild(to generation: UInt64) -> Bool {
+        guard currentRefreshFlightToken == nil,
+              pendingRebuildGeneration == nil,
+              activeRebuildGeneration == nil,
+              currentSnapshotGeneration != nil,
+              currentIndexedGeneration != nil
+        else { return false }
+
+        currentSnapshotGeneration = generation
+        currentIndexedGeneration = generation
+        if let diagnostics = currentDiagnostics {
+            currentDiagnostics = WorkspaceCatalogDiagnostics(
+                generation: generation,
+                rootScope: diagnostics.rootScope,
+                rootCount: diagnostics.rootCount,
+                folderCount: diagnostics.folderCount,
+                fileCount: diagnostics.fileCount
+            )
+        }
+        return true
     }
 
     private func isCurrentBinding(

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Search/WorkspaceSearchService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Search/WorkspaceSearchService.swift
@@ -6,6 +6,12 @@ import Foundation
 /// relevant root-index references, and searches merge root-local candidates into the exact
 /// historical global rank order without rebuilding or mutating a shared C index.
 actor WorkspaceSearchService {
+    private struct RefreshFlightToken: Equatable {
+        let bindingEpoch: UInt64
+        let rebuildSerial: UInt64
+        let targetGeneration: UInt64
+    }
+
     private struct PreparedIndex {
         let generation: UInt64
         let diagnostics: WorkspaceCatalogDiagnostics
@@ -37,7 +43,13 @@ actor WorkspaceSearchService {
     private var pendingRebuildGeneration: UInt64?
     private var activeRebuildGeneration: UInt64?
     private var rebuildSerial: UInt64 = 0
-    private var appliedIndexListenerTask: Task<Void, Never>?
+    private var currentRefreshFlightToken: RefreshFlightToken?
+    private weak var boundStore: WorkspaceFileContextStore?
+    private var boundRootScope: WorkspaceLookupRootScope?
+    private var bindingEpoch: UInt64 = 0
+    private var freshnessListenerSerial: UInt64 = 0
+    private var isFreshnessListenerRunning = false
+    private var catalogChangeListenerTask: Task<Void, Never>?
     private var pendingRebuildTask: Task<Void, Never>?
     private var automaticIndexBuildDelayNanoseconds: UInt64
     private var discardedAutomaticRebuildCompletions = 0
@@ -62,7 +74,9 @@ actor WorkspaceSearchService {
         private var debugDebounceCancellationCount = 0
         private var debugLastEntryCount = 0
         private var searchDidCaptureGenerationHandler: (@Sendable (UInt64?) async -> Void)?
+        private var catalogChangeWillHandleHandler: (@Sendable (WorkspaceSearchCatalogChangeEvent) async -> Void)?
         private var automaticRebuildDidStartHandler: (@Sendable (UInt64) async -> Void)?
+        private var automaticRebuildDidCommitHandler: (@Sendable (UInt64) async -> Void)?
     #endif
 
     init(automaticIndexBuildDelayNanoseconds: UInt64 = 0) {
@@ -70,7 +84,7 @@ actor WorkspaceSearchService {
     }
 
     deinit {
-        appliedIndexListenerTask?.cancel()
+        catalogChangeListenerTask?.cancel()
         pendingRebuildTask?.cancel()
     }
 
@@ -122,10 +136,22 @@ actor WorkspaceSearchService {
             searchDidCaptureGenerationHandler = handler
         }
 
+        func setCatalogChangeWillHandleHandler(
+            _ handler: (@Sendable (WorkspaceSearchCatalogChangeEvent) async -> Void)?
+        ) {
+            catalogChangeWillHandleHandler = handler
+        }
+
         func setAutomaticRebuildDidStartHandler(
             _ handler: (@Sendable (UInt64) async -> Void)?
         ) {
             automaticRebuildDidStartHandler = handler
+        }
+
+        func setAutomaticRebuildDidCommitHandler(
+            _ handler: (@Sendable (UInt64) async -> Void)?
+        ) {
+            automaticRebuildDidCommitHandler = handler
         }
 
         static func authoritativeGlobalResultsForTesting(
@@ -153,20 +179,51 @@ actor WorkspaceSearchService {
         rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
         debounceNanoseconds: UInt64 = 50_000_000
     ) async {
-        appliedIndexListenerTask?.cancel()
-        let stream = await store.appliedIndexEvents()
-        appliedIndexListenerTask = Task { [weak self, store] in
+        freshnessListenerSerial &+= 1
+        let listenerSerial = freshnessListenerSerial
+        catalogChangeListenerTask?.cancel()
+        catalogChangeListenerTask = nil
+        isFreshnessListenerRunning = false
+        cancelRefreshFlight()
+
+        let isSameBinding = boundStore === store && boundRootScope == rootScope
+        if !isSameBinding {
+            bindingEpoch &+= 1
+            readyRootPathIndexes = []
+            currentSnapshotGeneration = nil
+            currentIndexedGeneration = nil
+            currentDiagnostics = nil
+            latestObservedCatalogGeneration = nil
+            isReadyIndexUsable = true
+        }
+        boundStore = store
+        boundRootScope = rootScope
+        let epoch = bindingEpoch
+
+        let stream = await store.searchCatalogChangeEvents()
+        guard isCurrentBinding(store: store, rootScope: rootScope, epoch: epoch),
+              freshnessListenerSerial == listenerSerial
+        else { return }
+        isFreshnessListenerRunning = true
+        catalogChangeListenerTask = Task { [weak self, weak store] in
             for await event in stream {
-                await self?.handleAppliedIndexEvent(
+                guard !Task.isCancelled, let store else { return }
+                await self?.handleSearchCatalogChangeEvent(
                     event,
                     store: store,
                     rootScope: rootScope,
+                    epoch: epoch,
+                    listenerSerial: listenerSerial,
                     debounceNanoseconds: debounceNanoseconds
                 )
             }
         }
 
         let catalogGeneration = await store.catalogGeneration(rootScope: rootScope)
+        guard isCurrentBinding(store: store, rootScope: rootScope, epoch: epoch),
+              freshnessListenerSerial == listenerSerial,
+              isFreshnessListenerRunning
+        else { return }
         latestObservedCatalogGeneration = catalogGeneration
         if catalogGeneration != currentIndexedGeneration,
            catalogGeneration != pendingRebuildGeneration,
@@ -182,21 +239,17 @@ actor WorkspaceSearchService {
     }
 
     func stopKeepingFresh() {
-        appliedIndexListenerTask?.cancel()
-        appliedIndexListenerTask = nil
-        pendingRebuildTask?.cancel()
-        pendingRebuildTask = nil
-        pendingRebuildGeneration = nil
-        activeRebuildGeneration = nil
+        freshnessListenerSerial &+= 1
+        isFreshnessListenerRunning = false
+        catalogChangeListenerTask?.cancel()
+        catalogChangeListenerTask = nil
+        cancelRefreshFlight()
     }
 
     @discardableResult
     func rebuildIndex(from snapshot: WorkspaceSearchCatalogSnapshot) async -> UInt64 {
-        rebuildSerial &+= 1
+        cancelRefreshFlight()
         let serial = rebuildSerial
-        pendingRebuildTask?.cancel()
-        pendingRebuildTask = nil
-        pendingRebuildGeneration = nil
         activeRebuildGeneration = snapshot.generation
         latestObservedCatalogGeneration = snapshot.generation
 
@@ -210,6 +263,7 @@ actor WorkspaceSearchService {
         }
         commit(prepared)
         activeRebuildGeneration = nil
+        await reconcileBoundCatalogAfterManualRebuild()
         return snapshot.generation
     }
 
@@ -219,11 +273,14 @@ actor WorkspaceSearchService {
     }
 
     func reset() async {
-        rebuildSerial &+= 1
-        appliedIndexListenerTask?.cancel()
-        appliedIndexListenerTask = nil
-        pendingRebuildTask?.cancel()
-        pendingRebuildTask = nil
+        cancelRefreshFlight()
+        bindingEpoch &+= 1
+        freshnessListenerSerial &+= 1
+        isFreshnessListenerRunning = false
+        catalogChangeListenerTask?.cancel()
+        catalogChangeListenerTask = nil
+        boundStore = nil
+        boundRootScope = nil
         readyRootPathIndexes = []
         currentSnapshotGeneration = nil
         currentIndexedGeneration = nil
@@ -237,103 +294,143 @@ actor WorkspaceSearchService {
     func search(_ query: String, limit: Int = 300) async -> WorkspaceSearchQueryResult {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         let boundedLimit = max(0, limit)
-        let stale = isSearchStale
-        let pendingGenerationAtSearchStart = pendingGeneration
-        let observedGenerationAtSearchStart = latestObservedCatalogGeneration
-        let isReadyIndexUsableAtSearchStart = isReadyIndexUsable
-        guard boundedLimit > 0 else {
-            return queryResult(query: query, results: [], isStale: stale)
-        }
-
-        guard isReadyIndexUsableAtSearchStart, currentIndexedGeneration != nil else {
-            return queryResult(query: query, results: [], isStale: stale)
-        }
-
         let rootPathIndexesAtSearchStart = readyRootPathIndexes
         let generationAtSearchStart = currentIndexedGeneration
         let snapshotGenerationAtSearchStart = currentSnapshotGeneration
-        #if DEBUG
-            if let searchDidCaptureGenerationHandler {
-                await searchDidCaptureGenerationHandler(generationAtSearchStart)
-            }
-        #endif
+        let pendingGenerationAtSearchStart = pendingGeneration
+        let pendingRebuildGenerationAtSearchStart = pendingRebuildGeneration
+        let activeRebuildGenerationAtSearchStart = activeRebuildGeneration
+        let observedGenerationAtSearchStart = latestObservedCatalogGeneration
+        let isReadyIndexUsableAtSearchStart = isReadyIndexUsable
+        let storeAtSearchStart = boundStore
+        let rootScopeAtSearchStart = boundRootScope
+        let bindingEpochAtSearchStart = bindingEpoch
+        let wasBoundAtSearchStart = rootScopeAtSearchStart != nil
 
         let results: [WorkspaceSearchCatalogEntry]
-        if trimmed.isEmpty {
-            for index in rootPathIndexesAtSearchStart {
-                index.recordEmptyQueryShadowParity(limit: boundedLimit)
-            }
-            results = Self.mergeRootEntries(rootPathIndexesAtSearchStart, limit: boundedLimit)
+        if boundedLimit == 0 || !isReadyIndexUsableAtSearchStart || generationAtSearchStart == nil {
+            results = []
         } else {
-            results = await withTaskGroup(of: [WorkspaceSearchCatalogEntry].self) { group in
-                group.addTask {
-                    await Self.searchRootIndexes(
-                        rootPathIndexesAtSearchStart,
-                        query: trimmed,
-                        limit: boundedLimit
-                    )
+            #if DEBUG
+                if let searchDidCaptureGenerationHandler {
+                    await searchDidCaptureGenerationHandler(generationAtSearchStart)
                 }
-                let value = await group.next() ?? []
-                group.cancelAll()
-                return value
+            #endif
+            if trimmed.isEmpty {
+                for index in rootPathIndexesAtSearchStart {
+                    index.recordEmptyQueryShadowParity(limit: boundedLimit)
+                }
+                results = Self.mergeRootEntries(rootPathIndexesAtSearchStart, limit: boundedLimit)
+            } else {
+                results = await withTaskGroup(of: [WorkspaceSearchCatalogEntry].self) { group in
+                    group.addTask {
+                        await Self.searchRootIndexes(
+                            rootPathIndexesAtSearchStart,
+                            query: trimmed,
+                            limit: boundedLimit
+                        )
+                    }
+                    let value = await group.next() ?? []
+                    group.cancelAll()
+                    return value
+                }
             }
+        }
+
+        var observedGenerationForResult = observedGenerationAtSearchStart
+        var bindingValidationSucceeded = !wasBoundAtSearchStart
+        if let storeAtSearchStart, let rootScopeAtSearchStart {
+            let wasCancelledBeforeValidation = Task.isCancelled
+            let authoritativeGeneration = await storeAtSearchStart.catalogGeneration(rootScope: rootScopeAtSearchStart)
+            let wasCancelledDuringValidation = wasCancelledBeforeValidation || Task.isCancelled
+            if !wasCancelledDuringValidation,
+               isCurrentBinding(
+                   store: storeAtSearchStart,
+                   rootScope: rootScopeAtSearchStart,
+                   epoch: bindingEpochAtSearchStart
+               )
+            {
+                latestObservedCatalogGeneration = authoritativeGeneration
+                observedGenerationForResult = authoritativeGeneration
+                bindingValidationSucceeded = true
+            }
+        }
+
+        var stale = Self.isSearchStale(
+            indexedGeneration: generationAtSearchStart,
+            observedGeneration: observedGenerationForResult,
+            pendingGeneration: pendingRebuildGenerationAtSearchStart,
+            activeGeneration: activeRebuildGenerationAtSearchStart,
+            isReadyIndexUsable: isReadyIndexUsableAtSearchStart
+        )
+        if wasBoundAtSearchStart, !bindingValidationSucceeded {
+            stale = true
+        }
+        if currentIndexedGeneration != generationAtSearchStart {
+            stale = true
         }
         return WorkspaceSearchQueryResult(
             query: query,
             indexedGeneration: generationAtSearchStart,
             snapshotGeneration: snapshotGenerationAtSearchStart,
             pendingGeneration: pendingGenerationAtSearchStart,
-            observedGeneration: observedGenerationAtSearchStart,
+            observedGeneration: observedGenerationForResult,
             results: results,
             isIndexReady: generationAtSearchStart != nil && isReadyIndexUsableAtSearchStart,
             isStale: stale
         )
     }
 
-    private var isSearchStale: Bool {
-        guard let currentIndexedGeneration else {
-            return pendingRebuildGeneration != nil || activeRebuildGeneration != nil || latestObservedCatalogGeneration != nil
+    private static func isSearchStale(
+        indexedGeneration: UInt64?,
+        observedGeneration: UInt64?,
+        pendingGeneration: UInt64?,
+        activeGeneration: UInt64?,
+        isReadyIndexUsable: Bool
+    ) -> Bool {
+        guard let indexedGeneration else {
+            return pendingGeneration != nil || activeGeneration != nil || observedGeneration != nil
         }
-        if let latestObservedCatalogGeneration, latestObservedCatalogGeneration != currentIndexedGeneration {
+        if let observedGeneration, observedGeneration != indexedGeneration {
             return true
         }
-        if let pendingRebuildGeneration, pendingRebuildGeneration != currentIndexedGeneration {
+        if let pendingGeneration, pendingGeneration != indexedGeneration {
             return true
         }
-        if let activeRebuildGeneration, activeRebuildGeneration != currentIndexedGeneration {
+        if let activeGeneration, activeGeneration != indexedGeneration {
             return true
         }
         return !isReadyIndexUsable
     }
 
-    private func queryResult(
-        query: String,
-        results: [WorkspaceSearchCatalogEntry],
-        isStale: Bool
-    ) -> WorkspaceSearchQueryResult {
-        WorkspaceSearchQueryResult(
-            query: query,
-            indexedGeneration: currentIndexedGeneration,
-            snapshotGeneration: currentSnapshotGeneration,
-            pendingGeneration: pendingGeneration,
-            observedGeneration: latestObservedCatalogGeneration,
-            results: results,
-            isIndexReady: currentIndexedGeneration != nil && isReadyIndexUsable,
-            isStale: isStale
-        )
-    }
-
-    private func handleAppliedIndexEvent(
-        _ event: WorkspaceAppliedIndexBatchEvent,
+    private func handleSearchCatalogChangeEvent(
+        _ event: WorkspaceSearchCatalogChangeEvent,
         store: WorkspaceFileContextStore,
         rootScope: WorkspaceLookupRootScope,
+        epoch: UInt64,
+        listenerSerial: UInt64,
         debounceNanoseconds: UInt64
     ) async {
-        if event.isRootUnload {
-            dropReadyRootIndex(rootID: event.rootID)
+        guard isCurrentBinding(store: store, rootScope: rootScope, epoch: epoch),
+              freshnessListenerSerial == listenerSerial,
+              isFreshnessListenerRunning
+        else { return }
+        #if DEBUG
+            await catalogChangeWillHandleHandler?(event)
+        #endif
+        guard isCurrentBinding(store: store, rootScope: rootScope, epoch: epoch),
+              freshnessListenerSerial == listenerSerial,
+              isFreshnessListenerRunning
+        else { return }
+        if event.kind == .rootUnloaded {
+            dropReadyRootIndex(matching: event)
         }
 
         let catalogGeneration = await store.catalogGeneration(rootScope: rootScope)
+        guard isCurrentBinding(store: store, rootScope: rootScope, epoch: epoch),
+              freshnessListenerSerial == listenerSerial,
+              isFreshnessListenerRunning
+        else { return }
         latestObservedCatalogGeneration = catalogGeneration
         if catalogGeneration == currentIndexedGeneration,
            pendingRebuildGeneration == nil,
@@ -352,18 +449,80 @@ actor WorkspaceSearchService {
         )
     }
 
+    private func isCurrentBinding(
+        store: WorkspaceFileContextStore,
+        rootScope: WorkspaceLookupRootScope,
+        epoch: UInt64
+    ) -> Bool {
+        bindingEpoch == epoch && boundStore === store && boundRootScope == rootScope
+    }
+
+    private func reconcileBoundCatalogAfterManualRebuild() async {
+        guard isFreshnessListenerRunning,
+              let store = boundStore,
+              let rootScope = boundRootScope
+        else { return }
+        let epoch = bindingEpoch
+        let listenerSerial = freshnessListenerSerial
+        let catalogGeneration = await store.catalogGeneration(rootScope: rootScope)
+        guard isCurrentBinding(store: store, rootScope: rootScope, epoch: epoch),
+              freshnessListenerSerial == listenerSerial,
+              isFreshnessListenerRunning
+        else { return }
+        latestObservedCatalogGeneration = catalogGeneration
+        if catalogGeneration != currentIndexedGeneration,
+           catalogGeneration != pendingRebuildGeneration,
+           catalogGeneration != activeRebuildGeneration
+        {
+            scheduleRebuild(
+                from: store,
+                rootScope: rootScope,
+                targetGeneration: catalogGeneration,
+                debounceNanoseconds: 0
+            )
+        }
+    }
+
+    private func cancelRefreshFlight() {
+        rebuildSerial &+= 1
+        currentRefreshFlightToken = nil
+        pendingRebuildTask?.cancel()
+        pendingRebuildTask = nil
+        pendingRebuildGeneration = nil
+        activeRebuildGeneration = nil
+    }
+
     private func scheduleRebuild(
         from store: WorkspaceFileContextStore,
         rootScope: WorkspaceLookupRootScope,
         targetGeneration: UInt64,
         debounceNanoseconds: UInt64
     ) {
-        pendingRebuildGeneration = targetGeneration
+        guard isFreshnessListenerRunning,
+              boundStore === store,
+              boundRootScope == rootScope
+        else { return }
+        if currentRefreshFlightToken?.targetGeneration == targetGeneration {
+            return
+        }
+        if currentRefreshFlightToken == nil, currentIndexedGeneration == targetGeneration {
+            return
+        }
+
         #if DEBUG
-            if pendingRebuildTask != nil {
+            if currentRefreshFlightToken != nil, pendingRebuildGeneration != nil {
                 debugDebounceCancellationCount += 1
             }
         #endif
+        rebuildSerial &+= 1
+        let token = RefreshFlightToken(
+            bindingEpoch: bindingEpoch,
+            rebuildSerial: rebuildSerial,
+            targetGeneration: targetGeneration
+        )
+        currentRefreshFlightToken = token
+        pendingRebuildGeneration = targetGeneration
+        activeRebuildGeneration = nil
         pendingRebuildTask?.cancel()
         pendingRebuildTask = Task { [weak self, store] in
             if debounceNanoseconds > 0 {
@@ -373,11 +532,11 @@ actor WorkspaceSearchService {
                     return
                 }
             }
+            guard !Task.isCancelled else { return }
             await self?.rebuildFromStoreIfCurrent(
                 store: store,
                 rootScope: rootScope,
-                targetGeneration: targetGeneration,
-                debounceNanoseconds: debounceNanoseconds
+                token: token
             )
         }
     }
@@ -385,16 +544,21 @@ actor WorkspaceSearchService {
     private func rebuildFromStoreIfCurrent(
         store: WorkspaceFileContextStore,
         rootScope: WorkspaceLookupRootScope,
-        targetGeneration: UInt64,
-        debounceNanoseconds: UInt64
+        token: RefreshFlightToken
     ) async {
-        guard pendingRebuildGeneration == targetGeneration || activeRebuildGeneration == targetGeneration else { return }
+        guard ownsRefreshFlight(token, store: store, rootScope: rootScope),
+              pendingRebuildGeneration == token.targetGeneration
+        else { return }
         pendingRebuildGeneration = nil
-        activeRebuildGeneration = targetGeneration
+        activeRebuildGeneration = token.targetGeneration
+
         let snapshot = await store.searchCatalogSnapshot(rootScope: rootScope)
+        guard ownsRefreshFlight(token, store: store, rootScope: rootScope),
+              !Task.isCancelled
+        else { return }
         latestObservedCatalogGeneration = snapshot.generation
-        guard snapshot.generation == targetGeneration else {
-            activeRebuildGeneration = nil
+        guard snapshot.generation == token.targetGeneration else {
+            retireRefreshFlight(token)
             scheduleRebuild(
                 from: store,
                 rootScope: rootScope,
@@ -405,33 +569,95 @@ actor WorkspaceSearchService {
         }
 
         #if DEBUG
-            await automaticRebuildDidStartHandler?(targetGeneration)
+            await automaticRebuildDidStartHandler?(token.targetGeneration)
         #endif
+        guard ownsRefreshFlight(token, store: store, rootScope: rootScope),
+              !Task.isCancelled
+        else { return }
         if automaticIndexBuildDelayNanoseconds > 0 {
-            try? await Task.sleep(nanoseconds: automaticIndexBuildDelayNanoseconds)
+            do {
+                try await Task.sleep(nanoseconds: automaticIndexBuildDelayNanoseconds)
+            } catch {
+                return
+            }
         }
+        guard ownsRefreshFlight(token, store: store, rootScope: rootScope),
+              !Task.isCancelled
+        else { return }
         let prepared = Self.prepareIndex(from: snapshot)
+        let authoritativeGeneration = await store.catalogGeneration(rootScope: rootScope)
+        guard ownsRefreshFlight(token, store: store, rootScope: rootScope) else { return }
         #if DEBUG
             recordPreparedIndexWork(prepared)
         #endif
-        guard !Task.isCancelled,
-              latestObservedCatalogGeneration == prepared.generation,
-              pendingRebuildGeneration == nil || pendingRebuildGeneration == prepared.generation,
-              activeRebuildGeneration == prepared.generation
-        else {
+        latestObservedCatalogGeneration = authoritativeGeneration
+
+        let generationStillMatches = !Task.isCancelled &&
+            authoritativeGeneration == prepared.generation &&
+            latestObservedCatalogGeneration == prepared.generation
+        guard generationStillMatches else {
             discardedAutomaticRebuildCompletions += 1
-            if activeRebuildGeneration == prepared.generation {
-                activeRebuildGeneration = nil
-            }
+            retireRefreshFlight(token)
+            scheduleRebuild(
+                from: store,
+                rootScope: rootScope,
+                targetGeneration: authoritativeGeneration,
+                debounceNanoseconds: 0
+            )
             return
         }
+        guard !Self.hasDuplicateRootIdentities(prepared.rootPathIndexes) else {
+            #if DEBUG
+                assertionFailure("Prepared search index contains duplicate root identities")
+            #endif
+            discardedAutomaticRebuildCompletions += 1
+            retireRefreshFlight(token)
+            return
+        }
+
         commit(prepared)
-        activeRebuildGeneration = nil
-        pendingRebuildTask = nil
+        retireRefreshFlight(token)
+        #if DEBUG
+            await automaticRebuildDidCommitHandler?(prepared.generation)
+        #endif
     }
 
-    private func dropReadyRootIndex(rootID: UUID) {
-        readyRootPathIndexes.removeAll { $0.identity.rootID == rootID }
+    private func ownsRefreshFlight(
+        _ token: RefreshFlightToken,
+        store: WorkspaceFileContextStore,
+        rootScope: WorkspaceLookupRootScope
+    ) -> Bool {
+        currentRefreshFlightToken == token &&
+            isFreshnessListenerRunning &&
+            isCurrentBinding(store: store, rootScope: rootScope, epoch: token.bindingEpoch)
+    }
+
+    private func retireRefreshFlight(_ token: RefreshFlightToken) {
+        guard currentRefreshFlightToken == token else { return }
+        currentRefreshFlightToken = nil
+        pendingRebuildTask = nil
+        pendingRebuildGeneration = nil
+        activeRebuildGeneration = nil
+    }
+
+    private func dropReadyRootIndex(matching event: WorkspaceSearchCatalogChangeEvent) {
+        guard let lifetimeID = event.rootLifetimeID else { return }
+        readyRootPathIndexes.removeAll {
+            $0.identity.rootID == event.rootID && $0.identity.lifetimeID == lifetimeID
+        }
+    }
+
+    private static func hasDuplicateRootIdentities(
+        _ rootPathIndexes: [WorkspaceSearchRootPathIndex]
+    ) -> Bool {
+        var identities = Set<WorkspaceSearchRootPathIndexIdentity>()
+        var rootIDs = Set<UUID>()
+        for rootPathIndex in rootPathIndexes {
+            guard identities.insert(rootPathIndex.identity).inserted,
+                  rootIDs.insert(rootPathIndex.identity.rootID).inserted
+            else { return true }
+        }
+        return false
     }
 
     private func commit(_ prepared: PreparedIndex) {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
@@ -47,7 +47,7 @@ struct WorkspaceCodemapPathFingerprintClient {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
         return GitBlobLStatFingerprint(
-            device: UInt64(value.st_dev),
+            device: safeDeviceID(value.st_dev),
             inode: UInt64(value.st_ino),
             mode: UInt16(value.st_mode),
             size: Int64(value.st_size),

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapLocalGitClassification.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapLocalGitClassification.swift
@@ -250,7 +250,7 @@ struct WorkspaceCodemapLocalGitClassificationProbe {
         }
 
         return .init(
-            device: UInt64(info.st_dev),
+            device: safeDeviceID(info.st_dev),
             inode: UInt64(info.st_ino),
             mode: UInt32(info.st_mode),
             changeTimeSeconds: Int64(info.st_ctimespec.tv_sec),

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -17650,7 +17650,9 @@ actor WorkspaceFileContextStore {
                 "eligible file exists on disk but the workspace catalog did not return a record: \(standardizedRelativePath)"
             )
         }
-        if !managedOnly {
+        if managedOnly {
+            publishAppliedIndexEvent(root: state.root, requiresFullResync: true)
+        } else {
             publishAppliedIndexEvent(
                 root: state.root,
                 upsertedFiles: [file],

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -2888,7 +2888,10 @@ actor WorkspaceFileContextStore {
     private var fileSystemDeltaContinuations: [UUID: AsyncStream<WorkspaceFileSystemDeltaEvent>.Continuation] = [:]
     private var appliedIndexContinuations: [UUID: AsyncStream<WorkspaceAppliedIndexBatchEvent>.Continuation] = [:]
     private var searchCatalogChangeContinuations: [
-        UUID: AsyncStream<WorkspaceSearchCatalogChangeEvent>.Continuation
+        UUID: (
+            rootScope: WorkspaceLookupRootScope,
+            continuation: AsyncStream<WorkspaceSearchCatalogChangeEvent>.Continuation
+        )
     ] = [:]
     private var appliedIndexGenerationsByRootID: [UUID: UInt64] = [:]
     private var sliceRebaseSourceEntries: [SliceRebaseSourceCacheKey: SliceRebaseSourceCacheEntry] = [:]
@@ -3119,8 +3122,8 @@ actor WorkspaceFileContextStore {
         for continuation in appliedIndexContinuations.values {
             continuation.finish()
         }
-        for continuation in searchCatalogChangeContinuations.values {
-            continuation.finish()
+        for subscription in searchCatalogChangeContinuations.values {
+            subscription.continuation.finish()
         }
     }
 
@@ -3170,10 +3173,12 @@ actor WorkspaceFileContextStore {
         appliedIndexContinuations.removeValue(forKey: id)
     }
 
-    func searchCatalogChangeEvents() -> AsyncStream<WorkspaceSearchCatalogChangeEvent> {
+    func searchCatalogChangeEvents(
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace
+    ) -> AsyncStream<WorkspaceSearchCatalogChangeEvent> {
         let streamID = UUID()
         return AsyncStream { continuation in
-            searchCatalogChangeContinuations[streamID] = continuation
+            searchCatalogChangeContinuations[streamID] = (rootScope, continuation)
             continuation.onTermination = { [weak self] _ in
                 Task { await self?.removeSearchCatalogChangeContinuation(id: streamID) }
             }
@@ -6222,9 +6227,21 @@ actor WorkspaceFileContextStore {
     }
 
     private func publishSearchCatalogChangeEvent(_ event: WorkspaceSearchCatalogChangeEvent) {
-        for continuation in searchCatalogChangeContinuations.values {
-            continuation.yield(event)
+        for subscription in searchCatalogChangeContinuations.values {
+            subscription.continuation.yield(event.stamped(
+                catalogGeneration: scopedSnapshotGeneration(scope: subscription.rootScope)
+            ))
         }
+    }
+
+    private func publishProjectionNeutralCatalogGenerationChange(root: WorkspaceRootRecord) {
+        publishSearchCatalogChangeEvent(WorkspaceSearchCatalogChangeEvent(
+            rootID: root.id,
+            rootPath: root.standardizedFullPath,
+            rootLifetimeID: rootStatesByID[root.id]?.lifetimeID,
+            rootAppliedIndexGeneration: nil,
+            kind: .generationAdvancedWithoutProjectionChange
+        ))
     }
 
     private func nextAppliedIndexGeneration(forRootID rootID: UUID) -> UInt64 {
@@ -17651,7 +17668,7 @@ actor WorkspaceFileContextStore {
             )
         }
         if managedOnly {
-            publishAppliedIndexEvent(root: state.root, requiresFullResync: true)
+            publishProjectionNeutralCatalogGenerationChange(root: state.root)
         } else {
             publishAppliedIndexEvent(
                 root: state.root,

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -2622,6 +2622,38 @@ actor WorkspaceFileContextStore {
             self.pathSearchIndex = pathSearchIndex
             self.appliedIndexGeneration = appliedIndexGeneration
         }
+
+        init(
+            projectionNeutralRetagging source: RootCatalogShard,
+            key: RootCatalogShardKey,
+            root: WorkspaceRootRecord
+        ) {
+            precondition(key.rootID == source.key.rootID)
+            precondition(key.lifetimeID == source.key.lifetimeID)
+            precondition(key.canonicalConfigurationIdentity == source.key.canonicalConfigurationIdentity)
+            precondition(source.key.topologyGeneration != UInt64.max)
+            precondition(key.topologyGeneration == source.key.topologyGeneration + 1)
+            precondition(root.id == key.rootID)
+            precondition(root.standardizedFullPath == key.canonicalConfigurationIdentity.canonicalPath)
+
+            self.key = key
+            self.root = root
+            files = source.files
+            projectionFiles = source.projectionFiles
+            projectionFileIndexByID = source.projectionFileIndexByID
+            folders = source.folders
+            entries = source.entries
+            pathSearchIndex = source.pathSearchIndex?.applyingPatch(
+                identity: WorkspaceSearchRootPathIndexIdentity(
+                    rootID: key.rootID,
+                    lifetimeID: key.lifetimeID,
+                    topologyGeneration: key.topologyGeneration
+                ),
+                entries: source.entries,
+                changedFileIDs: []
+            )
+            appliedIndexGeneration = source.appliedIndexGeneration
+        }
     }
 
     private struct CodemapGraphIndexCatalogShardBuildSnapshot: @unchecked Sendable {
@@ -7733,24 +7765,10 @@ actor WorkspaceFileContextStore {
             return
         }
 
-        let retaggedPathSearchIndex = previousShard.pathSearchIndex?.applyingPatch(
-            identity: WorkspaceSearchRootPathIndexIdentity(
-                rootID: currentKey.rootID,
-                lifetimeID: currentKey.lifetimeID,
-                topologyGeneration: currentKey.topologyGeneration
-            ),
-            entries: previousShard.entries,
-            changedFileIDs: []
-        )
         let retaggedShard = RootCatalogShard(
+            projectionNeutralRetagging: previousShard,
             key: currentKey,
-            root: state.root,
-            files: previousShard.files,
-            precomputedProjectionFiles: previousShard.projectionFiles,
-            folders: previousShard.folders,
-            entries: previousShard.entries,
-            pathSearchIndex: retaggedPathSearchIndex,
-            appliedIndexGeneration: previousShard.appliedIndexGeneration
+            root: state.root
         )
         var publication = publishedRootCatalogShardsByRootID
         publication[root.id] = retaggedShard

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -7637,12 +7637,23 @@ actor WorkspaceFileContextStore {
         rootSeedSearchShadowsByRootID.removeValue(forKey: rootID)?.control.invalidate()
     }
 
+    private func retainPublishedRootCatalogShard(_ shard: RootCatalogShard) {
+        rootCatalogShardWeakReferencesByRootID[shard.key.rootID, default: []]
+            .append(WeakRootCatalogShardReference(shard))
+        #if DEBUG
+            let liveCount = liveRootCatalogShards(rootID: shard.key.rootID).count
+            rootCatalogShardMaxLiveGenerationCountsByRootID[shard.key.rootID] = max(
+                rootCatalogShardMaxLiveGenerationCountsByRootID[shard.key.rootID] ?? 0,
+                liveCount
+            )
+        #endif
+    }
+
     private func registerPublishedRootCatalogShard(
         _ shard: RootCatalogShard,
         kind: RootCatalogShardBuildKind
     ) {
-        rootCatalogShardWeakReferencesByRootID[shard.key.rootID, default: []]
-            .append(WeakRootCatalogShardReference(shard))
+        retainPublishedRootCatalogShard(shard)
         #if DEBUG
             rootCatalogShardBuildCountsByRootID[shard.key.rootID, default: 0] += 1
             switch kind {
@@ -7663,11 +7674,6 @@ actor WorkspaceFileContextStore {
             case .reused, nil:
                 break
             }
-            let liveCount = liveRootCatalogShards(rootID: shard.key.rootID).count
-            rootCatalogShardMaxLiveGenerationCountsByRootID[shard.key.rootID] = max(
-                rootCatalogShardMaxLiveGenerationCountsByRootID[shard.key.rootID] ?? 0,
-                liveCount
-            )
         #endif
     }
 
@@ -7694,6 +7700,62 @@ actor WorkspaceFileContextStore {
             return false
         }
         return true
+    }
+
+    private func retagPublishedRootCatalogShardForProjectionNeutralGeneration(
+        root: WorkspaceRootRecord,
+        materializedFileID: UUID
+    ) {
+        // The topology authority advanced, so any one-shot seeded shadow is no longer current.
+        invalidateRootSeedSearchShadow(rootID: root.id)
+
+        guard managedOnlyFileIDs.contains(materializedFileID),
+              let state = rootStatesByID[root.id],
+              state.root.standardizedFullPath == root.standardizedFullPath,
+              let currentKey = rootCatalogShardKey(for: state.root),
+              let previousShard = publishedRootCatalogShardsByRootID[root.id],
+              let deltaState = rootCatalogShardDeltaStatesByRootID[root.id],
+              deltaState.lifetimeID == state.lifetimeID,
+              !deltaState.isDirty,
+              previousShard.key.rootID == root.id,
+              previousShard.key.lifetimeID == state.lifetimeID,
+              previousShard.root.id == root.id,
+              previousShard.root.standardizedFullPath == root.standardizedFullPath,
+              previousShard.key.canonicalConfigurationIdentity == currentKey.canonicalConfigurationIdentity,
+              previousShard.key.topologyGeneration != UInt64.max,
+              currentKey.topologyGeneration == previousShard.key.topologyGeneration + 1,
+              previousShard.appliedIndexGeneration == deltaState.lastAppliedIndexGeneration,
+              appliedIndexGenerationsByRootID[root.id] == deltaState.lastAppliedIndexGeneration,
+              canPublishAnotherRootCatalogShard(rootID: root.id)
+        else {
+            // Leave the stale publication intact. The next snapshot or applied batch will
+            // conservatively replace it from current authority.
+            return
+        }
+
+        let retaggedPathSearchIndex = previousShard.pathSearchIndex?.applyingPatch(
+            identity: WorkspaceSearchRootPathIndexIdentity(
+                rootID: currentKey.rootID,
+                lifetimeID: currentKey.lifetimeID,
+                topologyGeneration: currentKey.topologyGeneration
+            ),
+            entries: previousShard.entries,
+            changedFileIDs: []
+        )
+        let retaggedShard = RootCatalogShard(
+            key: currentKey,
+            root: state.root,
+            files: previousShard.files,
+            precomputedProjectionFiles: previousShard.projectionFiles,
+            folders: previousShard.folders,
+            entries: previousShard.entries,
+            pathSearchIndex: retaggedPathSearchIndex,
+            appliedIndexGeneration: previousShard.appliedIndexGeneration
+        )
+        var publication = publishedRootCatalogShardsByRootID
+        publication[root.id] = retaggedShard
+        publishedRootCatalogShardsByRootID = publication
+        retainPublishedRootCatalogShard(retaggedShard)
     }
 
     private func applyAppliedIndexEventToRootCatalogShard(_ event: WorkspaceAppliedIndexBatchEvent) {
@@ -17668,6 +17730,10 @@ actor WorkspaceFileContextStore {
             )
         }
         if managedOnly {
+            retagPublishedRootCatalogShardForProjectionNeutralGeneration(
+                root: state.root,
+                materializedFileID: file.id
+            )
             publishProjectionNeutralCatalogGenerationChange(root: state.root)
         } else {
             publishAppliedIndexEvent(

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -2887,6 +2887,9 @@ actor WorkspaceFileContextStore {
     ] = [:]
     private var fileSystemDeltaContinuations: [UUID: AsyncStream<WorkspaceFileSystemDeltaEvent>.Continuation] = [:]
     private var appliedIndexContinuations: [UUID: AsyncStream<WorkspaceAppliedIndexBatchEvent>.Continuation] = [:]
+    private var searchCatalogChangeContinuations: [
+        UUID: AsyncStream<WorkspaceSearchCatalogChangeEvent>.Continuation
+    ] = [:]
     private var appliedIndexGenerationsByRootID: [UUID: UInt64] = [:]
     private var sliceRebaseSourceEntries: [SliceRebaseSourceCacheKey: SliceRebaseSourceCacheEntry] = [:]
     private var sliceRebaseSourceEstimatedBytes = 0
@@ -3116,6 +3119,9 @@ actor WorkspaceFileContextStore {
         for continuation in appliedIndexContinuations.values {
             continuation.finish()
         }
+        for continuation in searchCatalogChangeContinuations.values {
+            continuation.finish()
+        }
     }
 
     func roots() -> [WorkspaceRootRecord] {
@@ -3162,6 +3168,20 @@ actor WorkspaceFileContextStore {
 
     private func removeAppliedIndexContinuation(id: UUID) {
         appliedIndexContinuations.removeValue(forKey: id)
+    }
+
+    func searchCatalogChangeEvents() -> AsyncStream<WorkspaceSearchCatalogChangeEvent> {
+        let streamID = UUID()
+        return AsyncStream { continuation in
+            searchCatalogChangeContinuations[streamID] = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeSearchCatalogChangeContinuation(id: streamID) }
+            }
+        }
+    }
+
+    private func removeSearchCatalogChangeContinuation(id: UUID) {
+        searchCatalogChangeContinuations.removeValue(forKey: id)
     }
 
     func startWatchingRoot(id rootID: UUID) async throws {
@@ -6184,10 +6204,25 @@ actor WorkspaceFileContextStore {
         // Canonical batches are the only delta authority for search shards. Raw FSEvents first
         // mutate the store indexes and can never patch a published shard directly.
         applyAppliedIndexEventToRootCatalogShard(event)
+        if !event.isRootUnload {
+            publishSearchCatalogChangeEvent(WorkspaceSearchCatalogChangeEvent(
+                rootID: event.rootID,
+                rootPath: event.rootPath,
+                rootLifetimeID: event.rootLifetimeID,
+                rootAppliedIndexGeneration: event.generation,
+                kind: .appliedIndex
+            ))
+        }
         #if DEBUG
             Self.activePublicationInvalidationRecorder?.appliedIndexEventYieldCount += 1
         #endif
         for continuation in appliedIndexContinuations.values {
+            continuation.yield(event)
+        }
+    }
+
+    private func publishSearchCatalogChangeEvent(_ event: WorkspaceSearchCatalogChangeEvent) {
+        for continuation in searchCatalogChangeContinuations.values {
             continuation.yield(event)
         }
     }
@@ -10507,6 +10542,13 @@ actor WorkspaceFileContextStore {
             reason: .rootLoad,
             affectedRootIDs: [root.id]
         )
+        publishSearchCatalogChangeEvent(WorkspaceSearchCatalogChangeEvent(
+            rootID: root.id,
+            rootPath: root.standardizedFullPath,
+            rootLifetimeID: state.lifetimeID,
+            rootAppliedIndexGeneration: appliedIndexGenerationsByRootID[root.id],
+            kind: .rootLoaded
+        ))
         if root.kind == .sessionWorktree,
            WorktreeStartupFeatureFlags.current().observeDiffSeededWorktreeStartup
         {
@@ -10831,6 +10873,15 @@ actor WorkspaceFileContextStore {
         for entry in statesToUnload {
             rootIDsByStandardizedPath.removeValue(forKey: entry.state.root.standardizedFullPath)
             rootLoadConfigurationsByPath.removeValue(forKey: entry.state.root.standardizedFullPath)
+        }
+        for entry in statesToUnload {
+            publishSearchCatalogChangeEvent(WorkspaceSearchCatalogChangeEvent(
+                rootID: entry.rootID,
+                rootPath: entry.state.root.standardizedFullPath,
+                rootLifetimeID: entry.state.lifetimeID,
+                rootAppliedIndexGeneration: appliedIndexGenerationsByRootID[entry.rootID],
+                kind: .rootUnloaded
+            ))
         }
         #if DEBUG
             WorkspaceRestorePerfLog.event(

--- a/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseServiceTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextFileBrowseServiceTests.swift
@@ -78,6 +78,38 @@ final class AgentContextFileBrowseServiceTests: XCTestCase {
         XCTAssertEqual(projected.matches.map(\.file.name), ["Target.swift"])
     }
 
+    func testStaleIndexedSearchFallsBackToStoreForNewRoot() async throws {
+        let rootURL = try makeTestDirectory(name: "ContextBrowseStaleIndexFallback")
+        try write("fresh", to: rootURL.appendingPathComponent("Sources/FreshlyAddedBrowseUnique.swift"))
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let staleIndexedSearch: AgentContextFileBrowseService.IndexedSearch = { query, _ in
+            WorkspaceSearchQueryResult(
+                query: query,
+                indexedGeneration: 1,
+                snapshotGeneration: 1,
+                observedGeneration: 2,
+                results: [],
+                isIndexReady: true,
+                isStale: true
+            )
+        }
+        let service = AgentContextFileBrowseService(store: store, indexedSearch: staleIndexedSearch)
+
+        let result = try await availableResult(service.search(
+            query: "FreshlyAddedBrowseUnique",
+            scope: .allRoots,
+            lookupContext: .visibleWorkspace
+        ))
+
+        XCTAssertEqual(result.source, .storeCatalog)
+        XCTAssertEqual(result.matches.map(\.file.name), ["FreshlyAddedBrowseUnique.swift"])
+        XCTAssertEqual(result.matches.map(\.file.rootID), [root.id])
+        XCTAssertEqual(result.groups.map(\.root.id), [root.id])
+        XCTAssertEqual(result.groups.map(\.root.physicalPath), [root.standardizedFullPath])
+        XCTAssertEqual(result.groups.flatMap(\.directories).map(\.directoryPath), ["Sources"])
+    }
+
     func testSelectedRootSearchFiltersBeforeCandidateCap() async throws {
         let noisyRootURL = try makeTestDirectory(name: "ContextBrowseNoisy")
         let selectedRootURL = try makeTestDirectory(name: "ContextBrowseSelected")

--- a/Tests/RepoPromptTests/AgentMode/AgentFileTagWorktreeResolutionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentFileTagWorktreeResolutionTests.swift
@@ -87,6 +87,69 @@ final class AgentFileTagWorktreeResolutionTests: XCTestCase {
     }
 
     @MainActor
+    func testNonNilSearchServiceFallsBackToStoreDuringHeldRootLoadEvent() async throws {
+        let rootA = try makeTemporaryRoot(name: "AgentFileTagFreshnessA")
+        let rootB = try makeTemporaryRoot(name: "AgentFileTagFreshnessB")
+        try write("let existing = true\n", to: rootA.appendingPathComponent("Sources/Existing.swift"))
+        try write("let fresh = true\n", to: rootB.appendingPathComponent("Sources/FreshlyAddedUnique.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: rootA.path)
+        let snapshotA = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let searchService = WorkspaceSearchService()
+        let eventGate = AgentFileTagTestAsyncGate()
+        let commitSignal = AgentFileTagTestAsyncSignal()
+        addTeardownBlock {
+            await searchService.setCatalogChangeWillHandleHandler(nil)
+            await searchService.setAutomaticRebuildDidCommitHandler(nil)
+            await eventGate.open()
+            await searchService.stopKeepingFresh()
+        }
+
+        await searchService.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
+        await searchService.rebuildIndex(from: snapshotA)
+        let service = AgentFileTagSuggestionService(
+            store: store,
+            searchService: searchService,
+            selectionCoordinator: nil,
+            lookupContextProvider: { .visibleWorkspace },
+            maxResults: 5
+        )
+        let warmSuggestions = await service.suggestions(for: "Existing")
+        XCTAssertEqual(warmSuggestions.map(\.relativePath), ["Sources/Existing.swift"])
+
+        await searchService.setCatalogChangeWillHandleHandler { event in
+            guard event.kind == .rootLoaded, event.rootPath == rootB.path else { return }
+            await eventGate.wait()
+        }
+
+        _ = try await store.loadRoot(path: rootB.path)
+        await eventGate.waitUntilEntered()
+        let currentGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+
+        let suggestions = await service.suggestions(for: "FreshlyAddedUnique")
+        let suggestion = try XCTUnwrap(suggestions.first)
+        let expectedRelativePath = "\(rootB.lastPathComponent)/Sources/FreshlyAddedUnique.swift"
+
+        XCTAssertEqual(suggestions.count, 1, String(describing: suggestions))
+        XCTAssertEqual(suggestion.relativePath, expectedRelativePath)
+        XCTAssertEqual(suggestion.commitDisplayText, suggestion.relativePath)
+        XCTAssertFalse(suggestion.relativePath.hasPrefix("/"))
+        XCTAssertFalse(suggestion.relativePath.contains(rootB.path))
+        XCTAssertFalse(suggestion.commitDisplayText?.contains(rootB.path) == true)
+
+        await searchService.setAutomaticRebuildDidCommitHandler { generation in
+            guard generation == currentGeneration else { return }
+            await commitSignal.signal()
+        }
+        await eventGate.open()
+        await commitSignal.wait()
+
+        let convergedSuggestions = await service.suggestions(for: "FreshlyAddedUnique")
+        XCTAssertEqual(convergedSuggestions.map(\.relativePath), [expectedRelativePath])
+    }
+
+    @MainActor
     func testExpandedAgentFileTagsReturnMoreThanCompactCapWithParentSubtitles() async throws {
         let root = try makeTemporaryRoot(name: "AgentFileTagExpanded")
         let matchingFileCount = 80
@@ -434,6 +497,70 @@ final class AgentFileTagWorktreeResolutionTests: XCTestCase {
     private func write(_ content: String, to url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+private actor AgentFileTagTestAsyncSignal {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isSignaled = false
+
+    func wait() async {
+        guard !isSignaled else { return }
+        await withCheckedContinuation { continuation in
+            if isSignaled {
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+            }
+        }
+    }
+
+    func signal() {
+        guard !isSignaled else { return }
+        isSignaled = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor AgentFileTagTestAsyncGate {
+    private var enteredContinuation: CheckedContinuation<Void, Never>?
+    private var openContinuation: CheckedContinuation<Void, Never>?
+    private var hasEntered = false
+    private var isOpen = false
+
+    func wait() async {
+        if !hasEntered {
+            hasEntered = true
+            enteredContinuation?.resume()
+            enteredContinuation = nil
+        }
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            if isOpen {
+                continuation.resume()
+            } else {
+                openContinuation = continuation
+            }
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { continuation in
+            if hasEntered {
+                continuation.resume()
+            } else {
+                enteredContinuation = continuation
+            }
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        openContinuation?.resume()
+        openContinuation = nil
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
@@ -46,6 +46,57 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
         XCTAssertTrue(harness.recordedMethods("session/prompt").isEmpty)
     }
 
+    /// grok CLI >= 1.0.17 advertises modern `configOptions` alongside the legacy `models`
+    /// block, and may later push configOptions-only `config_option_update` snapshots. The
+    /// direct provider parser must win and stay in charge so effort variants survive.
+    func testConfigOptionsAlongsideModelsKeepsDirectEffortVariants() async throws {
+        let harness = try makeHarness(advertiseConfigOptions: true)
+        let provider = harness.makeHeadlessProvider(modelString: AgentModel.defaultModel.rawValue)
+        try await drain(provider, message: "hi")
+        let raws = AgentACPModelRegistry.shared.resolvedSnapshot(for: .grokBuild)?.options.map(\.rawValue) ?? []
+        XCTAssertTrue(raws.contains("grok-4.6-xhigh"), "expected direct effort variants, got \(raws)")
+        XCTAssertTrue(raws.contains("grok-4.6-low"), "expected direct effort variants, got \(raws)")
+    }
+
+    func testConfigOptionsOnlyUpdatePreservesLiveDirectEffortSelection() async throws {
+        let harness = try makeHarness(advertiseConfigOptions: true)
+        let config = GrokBuildAgentConfig(
+            commandName: harness.scriptPath,
+            additionalPathHints: [],
+            modelString: "grok-4.6-low",
+            includeRepoPromptMCPServer: false
+        )
+        let provider = EnvForwardingGrokProvider(
+            config: config,
+            extraEnvironment: ["ACP_RECORD_PATH": harness.recordURL.path]
+        )
+        let request = ACPRunRequest(
+            agentKind: .grokBuild,
+            modelString: config.modelString,
+            workspacePath: harness.workspace.path,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request)
+
+        do {
+            _ = try await controller.bootstrap()
+            try await controller.prompt(AgentMessage(userMessage: "hi"), request: request)
+            try await controller.setSessionModel("grok-4.6-low")
+            await controller.shutdown()
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+
+        let setModelCalls = harness.recordedMethods("session/set_model")
+        XCTAssertEqual(setModelCalls.count, 1)
+        XCTAssertEqual(setModelCalls.first?["modelId"] as? String, "grok-4.6")
+        let meta = setModelCalls.first?["_meta"] as? [String: Any]
+        XCTAssertEqual(meta?["reasoningEffort"] as? String, "low")
+    }
+
     func testFullAccessIntentReachesLaunchRequest() {
         let config = GrokBuildAgentConfig(alwaysApproveTools: true)
         let provider = GrokBuildACPHeadlessAgentProvider(config: config)
@@ -120,7 +171,7 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
         await provider.dispose()
     }
 
-    private func makeHarness() throws -> Harness {
+    private func makeHarness(advertiseConfigOptions: Bool = false) throws -> Harness {
         let workspace = try makeTestDirectory(name: "GrokBuildACPHeadlessTests")
         let recordURL = workspace.appendingPathComponent("requests.jsonl")
         let script = #"""
@@ -131,6 +182,7 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
 
         record_path = os.environ.get("ACP_RECORD_PATH")
         session_id = "grok-headless-session"
+        ADVERTISE_CONFIG_OPTIONS = __ADVERTISE_CONFIG_OPTIONS__
 
         if "--help" in sys.argv:
             print("Usage: grok agent [OPTIONS] [COMMAND]\n\nCommands:\n  stdio    Run the agent over stdio")
@@ -166,16 +218,35 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
                     "authMethods": []
                 })
             elif method == "session/new":
-                respond(request_id, {"sessionId": session_id, "models": {
+                result = {"sessionId": session_id, "models": {
                     "currentModelId": "grok-4.6",
                     "availableModels": [
                         {"modelId": "grok-4.6", "name": "Grok 4.6"},
                         {"modelId": "grok-4.5", "name": "Grok 4.5"}
                     ]
-                }})
+                }}
+                if ADVERTISE_CONFIG_OPTIONS:
+                    efforts = [{"id": e, "value": e, "default": e == "high"} for e in ["xhigh", "high", "medium", "low"]]
+                    result["models"]["availableModels"][0]["_meta"] = {
+                        "supportsReasoningEffort": True, "reasoningEffort": "xhigh", "reasoningEfforts": efforts}
+                    result["configOptions"] = [
+                        {"id": "model", "category": "model", "type": "select", "currentValue": "grok-4.6",
+                         "options": [{"value": "grok-4.6", "name": "Grok 4.6"}, {"value": "grok-4.5", "name": "Grok 4.5"}]},
+                        {"id": "reasoning_effort", "category": "thought_level", "type": "select", "currentValue": "xhigh",
+                         "options": [{"value": e} for e in ["xhigh", "high", "medium", "low"]]}]
+                respond(request_id, result)
             elif method == "session/set_model":
                 respond(request_id, {"_meta": {"model": {"Ok": params.get("modelId")}}})
             elif method == "session/prompt":
+                if ADVERTISE_CONFIG_OPTIONS:
+                    # grok may later push a configOptions-only snapshot; it must not demote the direct path.
+                    print(json.dumps({
+                        "jsonrpc": "2.0", "method": "session/update",
+                        "params": {"sessionId": session_id, "update": {
+                            "sessionUpdate": "config_option_update",
+                            "configOptions": [{"id": "model", "category": "model", "type": "select", "currentValue": "grok-4.6",
+                                               "options": [{"value": "grok-4.6", "name": "Grok 4.6"}, {"value": "grok-4.5", "name": "Grok 4.5"}]}]}}
+                    }), flush=True)
                 print(json.dumps({
                     "jsonrpc": "2.0", "method": "session/update",
                     "params": {"sessionId": session_id, "update": {
@@ -185,7 +256,7 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
                 respond(request_id, {"stopReason": "end_turn"})
             elif request_id is not None:
                 respond(request_id, {})
-        """# + "\n"
+        """#.replacingOccurrences(of: "__ADVERTISE_CONFIG_OPTIONS__", with: advertiseConfigOptions ? "True" : "False") + "\n"
         let scriptURL = workspace.appendingPathComponent("grok")
         try script.write(to: scriptURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)

--- a/Tests/RepoPromptTests/MCP/Control/BindContextRoutingAuthorityTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/BindContextRoutingAuthorityTests.swift
@@ -1,0 +1,345 @@
+import Darwin
+import Foundation
+import MCP
+@testable import RepoPromptApp
+import XCTest
+
+final class BindContextRoutingAuthorityTests: XCTestCase {
+    #if DEBUG
+        @MainActor
+        func testExplicitBindThenContextIDRoutedToolUsesSameCompositeContext() async throws {
+            let rootURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("repoprompt-bind-routing-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+            addTeardownBlock {
+                try? FileManager.default.removeItem(at: rootURL)
+            }
+
+            let contextID = UUID()
+            let staleMatch = workspace(name: "Stored Target", root: rootURL.path, contextID: contextID)
+            let unrelated = workspace(
+                name: "Active Unrelated",
+                root: rootURL.appendingPathComponent("unrelated").path,
+                contextID: UUID()
+            )
+            let activeTarget = workspace(name: "Active Target", root: rootURL.path, contextID: contextID)
+            let replacementActive = workspace(
+                name: "Replacement Active",
+                root: rootURL.appendingPathComponent("replacement").path,
+                contextID: UUID()
+            )
+            let orderedWindows = [makeWindowInstance(), makeWindowInstance()].sorted { $0.windowID < $1.windowID }
+            let staleWindow = orderedWindows[0]
+            let targetWindow = orderedWindows[1]
+            try await configureWindow(staleWindow, activeWorkspace: unrelated, savedWorkspaces: [staleMatch])
+            try await configureWindow(targetWindow, activeWorkspace: activeTarget)
+            _ = installWindows(orderedWindows)
+            try await AppGlobalMCPServiceComposition.shared.ensureRegistered()
+            let staleToolsEnabled = await staleWindow.mcpServer.setWindowToolsEnabled(true)
+            let targetToolsEnabled = await targetWindow.mcpServer.setWindowToolsEnabled(true)
+            XCTAssertTrue(staleToolsEnabled)
+            XCTAssertTrue(targetToolsEnabled)
+            addTeardownBlock { @MainActor in
+                _ = await staleWindow.mcpServer.setWindowToolsEnabled(false)
+                _ = await targetWindow.mcpServer.setWindowToolsEnabled(false)
+            }
+
+            let connection = try await makeProductionMCPConnection()
+            addTeardownBlock { await connection.cleanup() }
+
+            let bindResult = try await connection.client.callTool(name: "bind_context", arguments: [
+                "op": .string("bind"),
+                "context_id": .string(contextID.uuidString),
+                "_rawJSON": .bool(true)
+            ])
+            XCTAssertNotEqual(bindResult.isError, true, toolText(bindResult))
+
+            let boundBeforeCall = targetWindow.mcpServer.connectionBindingSnapshot(
+                forConnection: connection.connectionID
+            )
+            XCTAssertEqual(boundBeforeCall.windowID, targetWindow.windowID)
+            XCTAssertEqual(boundBeforeCall.workspaceID, activeTarget.id)
+            XCTAssertEqual(boundBeforeCall.tabID, contextID)
+            XCTAssertTrue(boundBeforeCall.explicitlyBound)
+            XCTAssertNil(boundBeforeCall.runID)
+
+            let routedResult = try await connection.client.callTool(name: "workspace_context", arguments: [
+                "context_id": .string(contextID.uuidString),
+                "_rawJSON": .bool(true)
+            ])
+            XCTAssertNotEqual(routedResult.isError, true, toolText(routedResult))
+
+            try await configureWindow(
+                targetWindow,
+                activeWorkspace: replacementActive,
+                savedWorkspaces: [activeTarget]
+            )
+            XCTAssertEqual(targetWindow.workspaceManager.activeWorkspaceID, replacementActive.id)
+
+            let routedAfterWorkspaceSwitch = try await connection.client.callTool(
+                name: "workspace_context",
+                arguments: [
+                    "context_id": .string(contextID.uuidString),
+                    "_rawJSON": .bool(true)
+                ]
+            )
+            XCTAssertNotEqual(
+                routedAfterWorkspaceSwitch.isError,
+                true,
+                toolText(routedAfterWorkspaceSwitch)
+            )
+
+            let statusResult = try await connection.client.callTool(name: "bind_context", arguments: [
+                "op": .string("status"),
+                "_rawJSON": .bool(true)
+            ])
+            XCTAssertNotEqual(statusResult.isError, true, toolText(statusResult))
+            let statusData = try XCTUnwrap(toolText(statusResult).data(using: .utf8))
+            let status = try JSONDecoder().decode(BindContextResponse.self, from: statusData)
+            XCTAssertEqual(status.binding.windowID, targetWindow.windowID)
+            XCTAssertEqual(status.binding.workspaceID, activeTarget.id)
+            XCTAssertEqual(status.binding.contextID, contextID)
+            XCTAssertTrue(status.binding.explicit)
+            XCTAssertFalse(status.binding.runScoped)
+
+            let boundAfterCall = targetWindow.mcpServer.connectionBindingSnapshot(
+                forConnection: connection.connectionID
+            )
+            XCTAssertEqual(boundAfterCall.windowID, boundBeforeCall.windowID)
+            XCTAssertEqual(boundAfterCall.workspaceID, boundBeforeCall.workspaceID)
+            XCTAssertEqual(boundAfterCall.tabID, boundBeforeCall.tabID)
+            XCTAssertTrue(boundAfterCall.explicitlyBound)
+            XCTAssertEqual(staleWindow.workspaceManager.activeWorkspaceID, unrelated.id)
+
+            await connection.cleanup()
+            let networkManagerRunningAfterCleanup = await ServerNetworkManager.shared.isRunning()
+            XCTAssertEqual(networkManagerRunningAfterCleanup, connection.wasNetworkManagerRunning)
+        }
+    #endif
+
+    @MainActor
+    func testContextIDBindIgnoresPreferredInactiveWorkspaceMatch() async throws {
+        let contextID = UUID()
+        let target = workspace(name: "Target", root: "/tmp/repoprompt-bind-target", contextID: contextID)
+        let unrelated = workspace(name: "Unrelated", root: "/tmp/repoprompt-bind-unrelated", contextID: UUID())
+        let staleWindow = try await makeWindow(activeWorkspace: unrelated, savedWorkspaces: [target])
+        let targetWindow = try await makeWindow(activeWorkspace: target)
+        let service = installWindows([staleWindow, targetWindow])
+
+        let resolved = try service.test_resolveContextIDBindTarget(
+            contextID: contextID,
+            connectionPreferredWindowID: staleWindow.windowID
+        )
+
+        XCTAssertEqual(resolved.windowID, targetWindow.windowID)
+        XCTAssertEqual(resolved.workspaceID, target.id)
+        XCTAssertEqual(resolved.tabID, contextID)
+        XCTAssertEqual(resolved.repoPaths, target.repoPaths)
+        XCTAssertEqual(staleWindow.workspaceManager.activeWorkspaceID, unrelated.id)
+    }
+
+    @MainActor
+    func testContextIDBindDeterministicFallbackExcludesInactiveWorkspaceMatch() async throws {
+        let contextID = UUID()
+        let root = "/tmp/repoprompt-bind-target"
+        let inactiveDuplicate = workspace(name: "Stored Target", root: root, contextID: contextID)
+        let firstTarget = workspace(name: "First Active Target", root: root, contextID: contextID)
+        let secondTarget = workspace(name: "Second Active Target", root: root, contextID: contextID)
+        let unrelated = workspace(name: "Unrelated", root: "/tmp/repoprompt-bind-unrelated", contextID: UUID())
+        let staleWindow = try await makeWindow(activeWorkspace: unrelated, savedWorkspaces: [inactiveDuplicate])
+        let firstTargetWindow = try await makeWindow(activeWorkspace: firstTarget)
+        let secondTargetWindow = try await makeWindow(activeWorkspace: secondTarget)
+        let service = installWindows([staleWindow, firstTargetWindow, secondTargetWindow])
+        let expectedWindow = try XCTUnwrap(
+            [firstTargetWindow, secondTargetWindow].min { $0.windowID < $1.windowID }
+        )
+        let expectedWorkspace = expectedWindow.windowID == firstTargetWindow.windowID ? firstTarget : secondTarget
+
+        let resolved = try service.test_resolveContextIDBindTarget(
+            contextID: contextID,
+            connectionPreferredWindowID: nil
+        )
+
+        XCTAssertEqual(resolved.windowID, expectedWindow.windowID)
+        XCTAssertEqual(resolved.workspaceID, expectedWorkspace.id)
+        XCTAssertEqual(resolved.tabID, contextID)
+        XCTAssertEqual(resolved.repoPaths, expectedWorkspace.repoPaths)
+        XCTAssertEqual(staleWindow.workspaceManager.activeWorkspaceID, unrelated.id)
+    }
+
+    @MainActor
+    func testContextIDBindOnlyInactiveMatchFailsClosed() async throws {
+        let contextID = UUID()
+        let target = workspace(name: "Target", root: "/tmp/repoprompt-bind-target", contextID: contextID)
+        let unrelated = workspace(name: "Unrelated", root: "/tmp/repoprompt-bind-unrelated", contextID: UUID())
+        let staleWindow = try await makeWindow(activeWorkspace: unrelated, savedWorkspaces: [target])
+        let service = installWindows([staleWindow])
+
+        XCTAssertThrowsError(try service.test_resolveContextIDBindTarget(
+            contextID: contextID,
+            connectionPreferredWindowID: staleWindow.windowID
+        )) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("No open RepoPrompt window actively shows context_id"), message)
+        }
+        XCTAssertEqual(staleWindow.workspaceManager.activeWorkspaceID, unrelated.id)
+    }
+
+    #if DEBUG
+        private func toolText(_ result: (content: [MCP.Tool.Content], isError: Bool?)) -> String {
+            result.content.compactMap { content -> String? in
+                if case let .text(text, _, _) = content { return text }
+                return nil
+            }.joined(separator: "\n")
+        }
+    #endif
+
+    @MainActor
+    private func makeWindowInstance() -> WindowState {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        defer { GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false) }
+        return WindowState()
+    }
+
+    @MainActor
+    private func configureWindow(
+        _ window: WindowState,
+        activeWorkspace: WorkspaceModel,
+        savedWorkspaces: [WorkspaceModel] = []
+    ) async throws {
+        await window.workspaceManager.awaitInitialized()
+        window.workspaceManager.workspaces = [activeWorkspace] + savedWorkspaces
+        _ = await window.workspaceManager.switchWorkspace(
+            to: activeWorkspace,
+            saveState: false,
+            reason: "bindContextRoutingAuthorityTest"
+        )
+        guard window.workspaceManager.activeWorkspaceID == activeWorkspace.id else {
+            throw BindContextRoutingFixtureError.workspaceActivationFailed
+        }
+    }
+
+    #if DEBUG
+        private func makeProductionMCPConnection() async throws -> ProductionMCPConnection {
+            var descriptors = [Int32](repeating: -1, count: 2)
+            guard Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .ENFILE)
+            }
+            defer {
+                for descriptor in descriptors where descriptor >= 0 {
+                    Darwin.close(descriptor)
+                }
+            }
+
+            let connectionID = UUID()
+            let sessionToken = "bind-routing-\(UUID().uuidString)"
+            let clientName = "BindContextRoutingAuthorityTests"
+            let networkManager = ServerNetworkManager.shared
+            let wasNetworkManagerRunning = await networkManager.isRunning()
+            let connectionManager = try BootstrapSocketConnectionManager(
+                connectionID: connectionID,
+                sessionToken: sessionToken,
+                clientPid: Int(getpid()),
+                observedKernelPeerPID: Int(getpid()),
+                clientName: clientName,
+                purpose: .unknown,
+                codeMapsDisabled: true,
+                connectedFD: descriptors[0],
+                parentManager: networkManager
+            )
+            descriptors[0] = -1
+            let clientTransport = try UnixSocketMCPTransport(
+                connectedFD: descriptors[1],
+                connectionID: connectionID,
+                correlationConnectionID: sessionToken
+            )
+            descriptors[1] = -1
+            await networkManager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: connectionID,
+                connection: connectionManager,
+                pendingClientID: clientName
+            )
+            _ = await networkManager.debugInstallConnectionLimiterForTesting(connectionID: connectionID)
+
+            do {
+                try await connectionManager.start { $0.name == clientName }
+                let client = Client(name: clientName, version: "1.0")
+                _ = try await client.connect(transport: clientTransport)
+                return ProductionMCPConnection(
+                    client: client,
+                    connectionID: connectionID,
+                    connectionManager: connectionManager,
+                    wasNetworkManagerRunning: wasNetworkManagerRunning
+                )
+            } catch {
+                await clientTransport.disconnect()
+                await connectionManager.stop()
+                await networkManager.debugRemoveConnection(connectionID)
+                if !wasNetworkManagerRunning {
+                    await networkManager.stop()
+                }
+                throw error
+            }
+        }
+    #endif
+
+    private func workspace(name: String, root: String, contextID: UUID) -> WorkspaceModel {
+        WorkspaceModel(
+            name: name,
+            repoPaths: [root],
+            composeTabs: [ComposeTabState(id: contextID, name: "Context")],
+            activeComposeTabID: contextID
+        )
+    }
+
+    @MainActor
+    private func makeWindow(
+        activeWorkspace: WorkspaceModel,
+        savedWorkspaces: [WorkspaceModel] = []
+    ) async throws -> WindowState {
+        let window = makeWindowInstance()
+        try await configureWindow(
+            window,
+            activeWorkspace: activeWorkspace,
+            savedWorkspaces: savedWorkspaces
+        )
+        return window
+    }
+
+    @MainActor
+    private func installWindows(_ windows: [WindowState]) -> WindowRoutingService {
+        let previousWindows = WindowStatesManager.shared.allWindows
+        WindowStatesManager.shared.allWindows = windows
+        addTeardownBlock { @MainActor in
+            WindowStatesManager.shared.allWindows = previousWindows
+        }
+        return WindowRoutingService(
+            windowStates: WindowStatesManager.shared,
+            networkMgr: ServerNetworkManager.shared
+        )
+    }
+}
+
+#if DEBUG
+    private struct ProductionMCPConnection {
+        let client: Client
+        let connectionID: UUID
+        let connectionManager: BootstrapSocketConnectionManager
+        let wasNetworkManagerRunning: Bool
+
+        func cleanup() async {
+            let networkManager = ServerNetworkManager.shared
+            await client.disconnect()
+            await connectionManager.stop()
+            await networkManager.debugRemoveConnection(connectionID)
+            if !wasNetworkManagerRunning {
+                await networkManager.stop()
+            }
+        }
+    }
+#endif
+
+private enum BindContextRoutingFixtureError: Error {
+    case workspaceActivationFailed
+}

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/WorkspaceSearchServiceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/WorkspaceSearchServiceTests.swift
@@ -86,6 +86,61 @@ final class WorkspaceSearchServiceTests: XCTestCase {
         XCTAssertEqual(Set(result.results.map(\.rootID)), [recordA.id, recordB.id])
     }
 
+    func testManagedOnlyMaterializationConvergesFreshnessWithoutBecomingSearchable() async throws {
+        let root = try makeTemporaryRoot(name: "ManagedOnlySearchFreshness")
+        let visibleURL = root.appendingPathComponent("Sources/VisibleTarget.swift")
+        let ignoredURL = root.appendingPathComponent("HiddenIgnoredTarget.ignored")
+        try write("*.ignored\n", to: root.appendingPathComponent(".gitignore"))
+        try write("visible", to: visibleURL)
+        try write("hidden", to: ignoredURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let initialSnapshot = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        XCTAssertFalse(initialSnapshot.files.contains { $0.standardizedFullPath == ignoredURL.path })
+
+        let service = WorkspaceSearchService()
+        let rebuildCommitted = expectation(description: "managed-only catalog generation rebuilt")
+        addTeardownBlock {
+            await service.setAutomaticRebuildDidCommitHandler(nil)
+            await service.stopKeepingFresh()
+        }
+
+        await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
+        await service.rebuildIndex(from: initialSnapshot)
+        await service.setAutomaticRebuildDidCommitHandler { _ in
+            rebuildCommitted.fulfill()
+        }
+
+        let materialization = try await store.materializeExplicitlyRequestedFile(
+            ignoredURL.path,
+            rootScope: .visibleWorkspace
+        )
+        guard case let .materialized(file) = materialization else {
+            return XCTFail("Expected ignored file to materialize as a managed-only record")
+        }
+        XCTAssertEqual(file.standardizedFullPath, ignoredURL.path)
+        let materializedGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        XCTAssertNotEqual(materializedGeneration, initialSnapshot.generation)
+
+        await fulfillment(of: [rebuildCommitted], timeout: 2)
+
+        let visibleResult = await service.search("VisibleTarget", limit: 10)
+        XCTAssertTrue(visibleResult.isIndexReady)
+        XCTAssertFalse(visibleResult.isStale)
+        XCTAssertEqual(visibleResult.indexedGeneration, materializedGeneration)
+        XCTAssertEqual(visibleResult.snapshotGeneration, materializedGeneration)
+        XCTAssertNil(visibleResult.pendingGeneration)
+        XCTAssertEqual(visibleResult.observedGeneration, materializedGeneration)
+        XCTAssertEqual(visibleResult.results.map(\.standardizedFullPath), [visibleURL.path])
+
+        let ignoredResult = await service.search("HiddenIgnoredTarget", limit: 10)
+        XCTAssertTrue(ignoredResult.isIndexReady)
+        XCTAssertFalse(ignoredResult.isStale)
+        XCTAssertEqual(ignoredResult.indexedGeneration, materializedGeneration)
+        XCTAssertTrue(ignoredResult.results.isEmpty)
+    }
+
     func testRemovedRootCannotBeResurrectedByDelayedLoadRefresh() async throws {
         let rootA = try makeTemporaryRoot(name: "DelayedLoadRemovalRootA")
         let rootB = try makeTemporaryRoot(name: "DelayedLoadRemovalRootB")

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/WorkspaceSearchServiceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/WorkspaceSearchServiceTests.swift
@@ -2,6 +2,429 @@
 import XCTest
 
 final class WorkspaceSearchServiceTests: XCTestCase {
+    func testHeldRootLoadEventMakesOldReadyIndexStaleFromStoreGeneration() async throws {
+        let rootA = try makeTemporaryRoot(name: "HeldCatalogEventRootA")
+        let rootB = try makeTemporaryRoot(name: "HeldCatalogEventRootB")
+        try write("alpha", to: rootA.appendingPathComponent("Sources/SharedRaceTarget.swift"))
+        try write("beta", to: rootB.appendingPathComponent("Sources/SharedRaceTarget.swift"))
+
+        let store = WorkspaceFileContextStore()
+        let recordA = try await store.loadRoot(path: rootA.path)
+        let snapshotA = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let service = WorkspaceSearchService()
+        let eventGate = TestAsyncGate()
+        addTeardownBlock {
+            await service.setCatalogChangeWillHandleHandler(nil)
+            await eventGate.open()
+            await service.stopKeepingFresh()
+        }
+
+        await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
+        await service.rebuildIndex(from: snapshotA)
+        await service.setCatalogChangeWillHandleHandler { event in
+            guard event.kind == .rootLoaded, event.rootPath == rootB.path else { return }
+            await eventGate.wait()
+        }
+
+        let recordB = try await store.loadRoot(path: rootB.path)
+        await eventGate.waitUntilEntered()
+        let currentGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+
+        let result = await service.search("SharedRaceTarget", limit: 10)
+        XCTAssertTrue(result.isIndexReady)
+        XCTAssertTrue(result.isStale)
+        XCTAssertEqual(result.indexedGeneration, snapshotA.generation)
+        XCTAssertEqual(result.snapshotGeneration, snapshotA.generation)
+        XCTAssertEqual(result.observedGeneration, currentGeneration)
+        XCTAssertEqual(result.results.map(\.rootID), [recordA.id])
+        XCTAssertFalse(result.results.contains { $0.rootID == recordB.id })
+    }
+
+    func testReleasingRootLoadEventConvergesToReadyNonStaleIndex() async throws {
+        let rootA = try makeTemporaryRoot(name: "ReleasedCatalogEventRootA")
+        let rootB = try makeTemporaryRoot(name: "ReleasedCatalogEventRootB")
+        try write("alpha", to: rootA.appendingPathComponent("Sources/SharedRaceTarget.swift"))
+        try write("beta", to: rootB.appendingPathComponent("Sources/SharedRaceTarget.swift"))
+
+        let store = WorkspaceFileContextStore()
+        let recordA = try await store.loadRoot(path: rootA.path)
+        let snapshotA = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let service = WorkspaceSearchService()
+        let eventGate = TestAsyncGate()
+        let commitSignal = TestAsyncSignal()
+        addTeardownBlock {
+            await service.setCatalogChangeWillHandleHandler(nil)
+            await service.setAutomaticRebuildDidCommitHandler(nil)
+            await eventGate.open()
+            await service.stopKeepingFresh()
+        }
+
+        await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
+        await service.rebuildIndex(from: snapshotA)
+        await service.setCatalogChangeWillHandleHandler { event in
+            guard event.kind == .rootLoaded, event.rootPath == rootB.path else { return }
+            await eventGate.wait()
+        }
+
+        let recordB = try await store.loadRoot(path: rootB.path)
+        await eventGate.waitUntilEntered()
+        let currentGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        await service.setAutomaticRebuildDidCommitHandler { generation in
+            guard generation == currentGeneration else { return }
+            await commitSignal.signal()
+        }
+        await eventGate.open()
+        await commitSignal.wait()
+
+        let result = await service.search("SharedRaceTarget", limit: 10)
+        XCTAssertTrue(result.isIndexReady)
+        XCTAssertFalse(result.isStale)
+        XCTAssertEqual(result.indexedGeneration, currentGeneration)
+        XCTAssertEqual(result.snapshotGeneration, currentGeneration)
+        XCTAssertNil(result.pendingGeneration)
+        XCTAssertEqual(result.observedGeneration, currentGeneration)
+        XCTAssertEqual(Set(result.results.map(\.rootID)), [recordA.id, recordB.id])
+    }
+
+    func testRemovedRootCannotBeResurrectedByDelayedLoadRefresh() async throws {
+        let rootA = try makeTemporaryRoot(name: "DelayedLoadRemovalRootA")
+        let rootB = try makeTemporaryRoot(name: "DelayedLoadRemovalRootB")
+        try write("alpha", to: rootA.appendingPathComponent("Sources/SharedRaceTarget.swift"))
+        try write("beta", to: rootB.appendingPathComponent("Sources/SharedRaceTarget.swift"))
+
+        let store = WorkspaceFileContextStore()
+        let recordA = try await store.loadRoot(path: rootA.path)
+        let snapshotA = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let service = WorkspaceSearchService()
+        let eventGate = TestAsyncGate()
+        let commitSignal = TestAsyncSignal()
+        addTeardownBlock {
+            await service.setCatalogChangeWillHandleHandler(nil)
+            await service.setAutomaticRebuildDidCommitHandler(nil)
+            await eventGate.open()
+            await service.stopKeepingFresh()
+        }
+
+        await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
+        await service.rebuildIndex(from: snapshotA)
+        await service.setCatalogChangeWillHandleHandler { event in
+            guard event.kind == .rootLoaded, event.rootPath == rootB.path else { return }
+            await eventGate.wait()
+        }
+
+        let recordB = try await store.loadRoot(path: rootB.path)
+        await eventGate.waitUntilEntered()
+        await store.unloadRoot(id: recordB.id)
+        let finalGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        await service.setAutomaticRebuildDidCommitHandler { generation in
+            guard generation == finalGeneration else { return }
+            await commitSignal.signal()
+        }
+        await eventGate.open()
+        await commitSignal.wait()
+
+        let result = await service.search("SharedRaceTarget", limit: 10)
+        XCTAssertTrue(result.isIndexReady)
+        XCTAssertFalse(result.isStale)
+        XCTAssertEqual(result.indexedGeneration, finalGeneration)
+        XCTAssertEqual(result.snapshotGeneration, finalGeneration)
+        XCTAssertEqual(result.observedGeneration, finalGeneration)
+        XCTAssertEqual(result.results.map(\.rootID), [recordA.id])
+        XCTAssertFalse(result.results.contains { $0.rootID == recordB.id })
+        let indexedPathCount = await service.indexedPathCount
+        XCTAssertEqual(indexedPathCount, 1)
+    }
+
+    func testExpiredRootLifetimeCannotCommitAfterSamePathReload() async throws {
+        let root = try makeTemporaryRoot(name: "ExpiredLifetimeReloadRoot")
+        let oldOnlyFile = root.appendingPathComponent("Sources/OldOnly.swift")
+        let refreshTriggerFile = root.appendingPathComponent("Sources/RefreshTrigger.swift")
+        try write("old", to: oldOnlyFile)
+
+        let store = WorkspaceFileContextStore()
+        let oldRoot = try await store.loadRoot(path: root.path)
+        let oldSnapshot = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let oldFileIDs = Set(oldSnapshot.entries.map(\.id))
+        let service = WorkspaceSearchService()
+        let triggerEventGate = TestAsyncGate()
+        let staleRebuildGate = TestAsyncGate()
+        let unloadEventGate = TestAsyncGate()
+        let reloadEventGate = TestAsyncGate()
+        let commitSignal = TestAsyncSignal()
+        addTeardownBlock {
+            await service.setCatalogChangeWillHandleHandler(nil)
+            await service.setAutomaticRebuildDidStartHandler(nil)
+            await service.setAutomaticRebuildDidCommitHandler(nil)
+            await triggerEventGate.open()
+            await staleRebuildGate.open()
+            await unloadEventGate.open()
+            await reloadEventGate.open()
+            await service.stopKeepingFresh()
+        }
+
+        await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
+        await service.rebuildIndex(from: oldSnapshot)
+        await service.setCatalogChangeWillHandleHandler { event in
+            guard event.kind == .appliedIndex, event.rootID == oldRoot.id else { return }
+            await triggerEventGate.wait()
+        }
+
+        try write("trigger", to: refreshTriggerFile)
+        await store.replayObservedFileSystemDeltas(
+            rootID: oldRoot.id,
+            deltas: [.fileAdded("Sources/RefreshTrigger.swift")]
+        )
+        await triggerEventGate.waitUntilEntered()
+        let staleGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        await service.setAutomaticRebuildDidStartHandler { generation in
+            guard generation == staleGeneration else { return }
+            await staleRebuildGate.wait()
+        }
+        await triggerEventGate.open()
+        await staleRebuildGate.waitUntilEntered()
+
+        await service.setCatalogChangeWillHandleHandler { event in
+            if event.kind == .rootUnloaded, event.rootID == oldRoot.id {
+                await unloadEventGate.wait()
+            } else if event.kind == .rootLoaded, event.rootPath == root.path {
+                await reloadEventGate.wait()
+            }
+        }
+        await store.unloadRoot(id: oldRoot.id)
+        await unloadEventGate.waitUntilEntered()
+        try FileManager.default.removeItem(at: root.appendingPathComponent("Sources"))
+        try write("new", to: root.appendingPathComponent("Sources/NewOnly.swift"))
+        let newRoot = try await store.loadRoot(path: root.path)
+        let newGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        await service.setAutomaticRebuildDidCommitHandler { generation in
+            guard generation == newGeneration else { return }
+            await commitSignal.signal()
+        }
+
+        await staleRebuildGate.open()
+        await commitSignal.wait()
+        await unloadEventGate.open()
+        await reloadEventGate.waitUntilEntered()
+
+        let result = await service.search("Only", limit: 10)
+        XCTAssertTrue(result.isIndexReady)
+        XCTAssertFalse(result.isStale)
+        XCTAssertEqual(result.indexedGeneration, newGeneration)
+        XCTAssertEqual(result.snapshotGeneration, newGeneration)
+        XCTAssertEqual(result.observedGeneration, newGeneration)
+        XCTAssertNotEqual(newRoot.id, oldRoot.id)
+        XCTAssertEqual(result.results.map(\.rootID), [newRoot.id])
+        XCTAssertEqual(result.results.map(\.standardizedRelativePath), ["Sources/NewOnly.swift"])
+        XCTAssertTrue(Set(result.results.map(\.id)).isDisjoint(with: oldFileIDs))
+        XCTAssertFalse(result.results.contains { $0.standardizedRelativePath == "Sources/OldOnly.swift" })
+    }
+
+    func testVisibleWorkspaceFreshnessIgnoresOutOfScopeRootTopology() async throws {
+        let visibleRoot = try makeTemporaryRoot(name: "VisibleScopePrimaryRoot")
+        let gitDataRoot = try makeTemporaryRoot(name: "VisibleScopeGitDataRoot")
+        let sessionRoot = try makeTemporaryRoot(name: "VisibleScopeSessionRoot")
+        let supplementalRoot = try makeTemporaryRoot(name: "VisibleScopeSupplementalRoot")
+        let barrierRoot = try makeTemporaryRoot(name: "VisibleScopeBarrierRoot")
+        try write("visible", to: visibleRoot.appendingPathComponent("Sources/VisibleScopeTarget.swift"))
+        try write("git", to: gitDataRoot.appendingPathComponent("GitScopeTarget.swift"))
+        try write("session", to: sessionRoot.appendingPathComponent("SessionScopeTarget.swift"))
+        try write("supplemental", to: supplementalRoot.appendingPathComponent("SupplementalScopeTarget.swift"))
+        try write("barrier", to: barrierRoot.appendingPathComponent("BarrierScopeTarget.swift"))
+
+        let store = WorkspaceFileContextStore()
+        let visibleRecord = try await store.loadRoot(path: visibleRoot.path)
+        let visibleSnapshot = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let service = WorkspaceSearchService()
+        let barrierGate = TestAsyncGate()
+        addTeardownBlock {
+            await service.setCatalogChangeWillHandleHandler(nil)
+            await barrierGate.open()
+            await service.stopKeepingFresh()
+        }
+
+        await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
+        await service.rebuildIndex(from: visibleSnapshot)
+        await service.setCatalogChangeWillHandleHandler { event in
+            guard event.kind == .rootLoaded, event.rootPath == barrierRoot.path else { return }
+            await barrierGate.wait()
+        }
+
+        let gitDataRecord = try await store.loadRoot(path: gitDataRoot.path, kind: .workspaceGitData)
+        let sessionRecord = try await store.loadRoot(path: sessionRoot.path, kind: .sessionWorktree)
+        let supplementalRecord = try await store.loadRoot(path: supplementalRoot.path, kind: .supplementalSystem)
+        let barrierRecord = try await store.loadRoot(path: barrierRoot.path, kind: .supplementalSystem)
+        await barrierGate.waitUntilEntered()
+
+        let visibleGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        let result = await service.search("ScopeTarget", limit: 10)
+        XCTAssertTrue(result.isIndexReady)
+        XCTAssertFalse(result.isStale)
+        XCTAssertEqual(visibleGeneration, visibleSnapshot.generation)
+        XCTAssertEqual(result.indexedGeneration, visibleSnapshot.generation)
+        XCTAssertEqual(result.snapshotGeneration, visibleSnapshot.generation)
+        XCTAssertNil(result.pendingGeneration)
+        XCTAssertEqual(result.observedGeneration, visibleSnapshot.generation)
+        XCTAssertEqual(result.results.map(\.rootID), [visibleRecord.id])
+        let excludedRootIDs = Set([
+            gitDataRecord.id,
+            sessionRecord.id,
+            supplementalRecord.id,
+            barrierRecord.id
+        ])
+        XCTAssertTrue(Set(result.results.map(\.rootID)).isDisjoint(with: excludedRootIDs))
+    }
+
+    func testSearchCatalogChangeEventsFollowCatalogAuthorityChanges() async throws {
+        let rootA = try makeTemporaryRoot(name: "CatalogChangeRootA")
+        let rootB = try makeTemporaryRoot(name: "CatalogChangeRootB")
+        try write("alpha", to: rootA.appendingPathComponent("Sources/Alpha.swift"))
+        try write("beta", to: rootB.appendingPathComponent("Sources/Beta.swift"))
+
+        let store = WorkspaceFileContextStore()
+        let stream = await store.searchCatalogChangeEvents()
+        var iterator = stream.makeAsyncIterator()
+
+        let recordA = try await store.loadRoot(path: rootA.path)
+        let loadedAValue = await iterator.next()
+        let loadedA = try XCTUnwrap(loadedAValue)
+        XCTAssertEqual(loadedA.kind, .rootLoaded)
+        XCTAssertEqual(loadedA.rootID, recordA.id)
+        XCTAssertEqual(loadedA.rootPath, recordA.standardizedFullPath)
+        XCTAssertNotNil(loadedA.rootLifetimeID)
+        XCTAssertEqual(loadedA.rootAppliedIndexGeneration, 0)
+
+        try write("delta", to: rootA.appendingPathComponent("Sources/Delta.swift"))
+        await store.replayObservedFileSystemDeltas(
+            rootID: recordA.id,
+            deltas: [.fileAdded("Sources/Delta.swift")]
+        )
+        let appliedValue = await iterator.next()
+        let applied = try XCTUnwrap(appliedValue)
+        XCTAssertEqual(applied.kind, .appliedIndex)
+        XCTAssertEqual(applied.rootID, recordA.id)
+        XCTAssertEqual(applied.rootLifetimeID, loadedA.rootLifetimeID)
+        XCTAssertEqual(applied.rootAppliedIndexGeneration, 1)
+
+        await store.unloadRoot(id: recordA.id)
+        let unloadedAValue = await iterator.next()
+        let unloadedA = try XCTUnwrap(unloadedAValue)
+        XCTAssertEqual(unloadedA.kind, .rootUnloaded)
+        XCTAssertEqual(unloadedA.rootID, recordA.id)
+        XCTAssertEqual(unloadedA.rootLifetimeID, loadedA.rootLifetimeID)
+
+        let recordB = try await store.loadRoot(path: rootB.path)
+        let loadedBValue = await iterator.next()
+        let loadedB = try XCTUnwrap(loadedBValue)
+        XCTAssertEqual(loadedB.kind, .rootLoaded)
+        XCTAssertEqual(loadedB.rootID, recordB.id)
+    }
+
+    func testCanceledRootLoadPublishesNoRootLoadedEvent() async throws {
+        let canceledRoot = try makeTemporaryRoot(name: "CanceledCatalogChangeRoot")
+        let sentinelRoot = try makeTemporaryRoot(name: "CatalogChangeSentinelRoot")
+        try write("canceled", to: canceledRoot.appendingPathComponent("Sources/Canceled.swift"))
+        try write("sentinel", to: sentinelRoot.appendingPathComponent("Sources/Sentinel.swift"))
+
+        let store = WorkspaceFileContextStore()
+        let stream = await store.searchCatalogChangeEvents()
+        var iterator = stream.makeAsyncIterator()
+        let loadGate = TestAsyncGate()
+        let loadEntered = expectation(description: "root load entered")
+        await store.setRootLoadWillStartHandler { _ in
+            loadEntered.fulfill()
+            await loadGate.wait()
+        }
+
+        let loadTask = Task {
+            try await store.loadRoot(
+                path: canceledRoot.path,
+                cancelUnderlyingLoadOnCallerCancellation: true
+            )
+        }
+        await fulfillment(of: [loadEntered], timeout: 2)
+        loadTask.cancel()
+        await store.cancelRootLoad(path: canceledRoot.path)
+        await loadGate.open()
+        do {
+            _ = try await loadTask.value
+            XCTFail("Expected the root load to be canceled")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        await store.setRootLoadWillStartHandler(nil)
+
+        let sentinel = try await store.loadRoot(path: sentinelRoot.path)
+        let firstEventValue = await iterator.next()
+        let firstEvent = try XCTUnwrap(firstEventValue)
+        XCTAssertEqual(firstEvent.kind, .rootLoaded)
+        XCTAssertEqual(firstEvent.rootID, sentinel.id)
+    }
+
+    func testStoppedFreshnessBindingMarksOldReadyIndexStaleAtQueryTime() async throws {
+        let rootA = try makeTemporaryRoot(name: "StoppedFreshnessRootA")
+        let rootB = try makeTemporaryRoot(name: "StoppedFreshnessRootB")
+        try write("alpha", to: rootA.appendingPathComponent("Sources/AlphaTarget.swift"))
+        try write("beta", to: rootB.appendingPathComponent("Sources/BetaTarget.swift"))
+
+        let store = WorkspaceFileContextStore()
+        let recordA = try await store.loadRoot(path: rootA.path)
+        let snapshotA = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let service = WorkspaceSearchService()
+        await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
+        await service.rebuildIndex(from: snapshotA)
+        await service.stopKeepingFresh()
+
+        let recordB = try await store.loadRoot(path: rootB.path)
+        let currentGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        XCTAssertNotEqual(currentGeneration, snapshotA.generation)
+
+        let result = await service.search("Target", limit: 10)
+        XCTAssertTrue(result.isIndexReady)
+        XCTAssertTrue(result.isStale)
+        XCTAssertEqual(result.indexedGeneration, snapshotA.generation)
+        XCTAssertEqual(result.snapshotGeneration, snapshotA.generation)
+        XCTAssertNil(result.pendingGeneration)
+        XCTAssertEqual(result.observedGeneration, currentGeneration)
+        XCTAssertEqual(result.results.map(\.rootID), [recordA.id])
+        XCTAssertFalse(result.results.contains { $0.rootID == recordB.id })
+
+        let zeroLimitResult = await service.search("Target", limit: 0)
+        XCTAssertTrue(zeroLimitResult.isIndexReady)
+        XCTAssertTrue(zeroLimitResult.isStale)
+        XCTAssertEqual(zeroLimitResult.observedGeneration, currentGeneration)
+        XCTAssertTrue(zeroLimitResult.results.isEmpty)
+    }
+
+    func testManualRebuildReconcilesNewerBoundCatalogDemand() async throws {
+        let rootA = try makeTemporaryRoot(name: "ManualRebuildRootA")
+        let rootB = try makeTemporaryRoot(name: "ManualRebuildRootB")
+        try write("alpha", to: rootA.appendingPathComponent("Sources/Alpha.swift"))
+        try write("beta", to: rootB.appendingPathComponent("Sources/Beta.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: rootA.path)
+        let snapshotA = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        let service = WorkspaceSearchService()
+        await service.startKeepingFresh(
+            with: store,
+            rootScope: .visibleWorkspace,
+            debounceNanoseconds: 10_000_000_000
+        )
+        await service.rebuildIndex(from: snapshotA)
+
+        _ = try await store.loadRoot(path: rootB.path)
+        let currentGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        await service.rebuildIndex(from: snapshotA)
+
+        let indexedGeneration = await service.indexedGeneration
+        let pendingGeneration = await service.pendingGeneration
+        XCTAssertTrue(
+            indexedGeneration == currentGeneration || pendingGeneration == currentGeneration,
+            "The stale manual snapshot must not erase demand for the authoritative generation"
+        )
+        await service.stopKeepingFresh()
+    }
+
     func testWorkspaceSearchServiceSearchesSingleRootCatalog() async throws {
         let root = try makeTemporaryRoot(name: "SingleRootSearch")
         try write("view model", to: root.appendingPathComponent("Sources/App/Search/SearchViewModel.swift"))
@@ -66,5 +489,69 @@ final class WorkspaceSearchServiceTests: XCTestCase {
     private func write(_ content: String, to url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+private actor TestAsyncSignal {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isSignaled = false
+
+    func wait() async {
+        guard !isSignaled else { return }
+        await withCheckedContinuation { continuation in
+            if isSignaled {
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+            }
+        }
+    }
+
+    func signal() {
+        guard !isSignaled else { return }
+        isSignaled = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor TestAsyncGate {
+    private var enteredContinuation: CheckedContinuation<Void, Never>?
+    private var openContinuation: CheckedContinuation<Void, Never>?
+    private var hasEntered = false
+    private var isOpen = false
+
+    func wait() async {
+        if !hasEntered {
+            hasEntered = true
+            enteredContinuation?.resume()
+            enteredContinuation = nil
+        }
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            if isOpen {
+                continuation.resume()
+            } else {
+                openContinuation = continuation
+            }
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { continuation in
+            if hasEntered {
+                continuation.resume()
+            } else {
+                enteredContinuation = continuation
+            }
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        openContinuation?.resume()
+        openContinuation = nil
     }
 }

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/WorkspaceSearchServiceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/WorkspaceSearchServiceTests.swift
@@ -98,8 +98,11 @@ final class WorkspaceSearchServiceTests: XCTestCase {
 
         let store = WorkspaceFileContextStore()
         let rootRecord = try await store.loadRoot(path: root.path)
-        let initialSnapshot = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
-        XCTAssertFalse(initialSnapshot.files.contains { $0.standardizedFullPath == ignoredURL.path })
+        var initialSnapshot: WorkspaceSearchCatalogSnapshot? = await store.searchCatalogSnapshot(
+            rootScope: .visibleWorkspace
+        )
+        let initialGeneration = try XCTUnwrap(initialSnapshot).generation
+        XCTAssertFalse(try XCTUnwrap(initialSnapshot).files.contains { $0.standardizedFullPath == ignoredURL.path })
         let initialStoreWork = await store.storeWorkDiagnosticsSnapshot()
         let initialRootShard = try XCTUnwrap(
             initialStoreWork.rootCatalogShards.roots.first { $0.rootID == rootRecord.id }
@@ -120,7 +123,8 @@ final class WorkspaceSearchServiceTests: XCTestCase {
         }
 
         await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
-        await service.rebuildIndex(from: initialSnapshot)
+        try await service.rebuildIndex(from: XCTUnwrap(initialSnapshot))
+        initialSnapshot = nil
         let initialSearchWork = await service.workDiagnosticsSnapshot()
         await service.setProjectionNeutralGenerationDidCommitHandler { _ in
             generationCommitted.fulfill()
@@ -135,7 +139,7 @@ final class WorkspaceSearchServiceTests: XCTestCase {
         }
         XCTAssertEqual(file.standardizedFullPath, ignoredURL.path)
         let materializedGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
-        XCTAssertNotEqual(materializedGeneration, initialSnapshot.generation)
+        XCTAssertNotEqual(materializedGeneration, initialGeneration)
 
         await fulfillment(of: [generationCommitted], timeout: 2)
         await service.setProjectionNeutralGenerationDidCommitHandler(nil)
@@ -184,7 +188,7 @@ final class WorkspaceSearchServiceTests: XCTestCase {
         }
         await neutralEventGate.waitUntilEntered()
 
-        let sentinelRelativePath = "Sources/AppliedIndexSentinel.swift"
+        let sentinelRelativePath = "AppliedIndexSentinel.swift"
         try write("sentinel", to: root.appendingPathComponent(sentinelRelativePath))
         await store.replayObservedFileSystemDeltas(
             rootID: rootRecord.id,
@@ -214,6 +218,18 @@ final class WorkspaceSearchServiceTests: XCTestCase {
         XCTAssertEqual(sentinelResult.results.map(\.standardizedRelativePath), [sentinelRelativePath])
         let secondIgnoredResult = await service.search("SecondHiddenTarget", limit: 10)
         XCTAssertTrue(secondIgnoredResult.results.isEmpty)
+
+        let postAppliedStoreWork = await store.storeWorkDiagnosticsSnapshot()
+        let postAppliedRootShard = try XCTUnwrap(
+            postAppliedStoreWork.rootCatalogShards.roots.first { $0.rootID == rootRecord.id }
+        )
+        XCTAssertEqual(postAppliedRootShard.buildCount, finalRootShard.buildCount + 1)
+        XCTAssertEqual(postAppliedRootShard.patchCount, finalRootShard.patchCount + 1)
+        XCTAssertEqual(postAppliedRootShard.authoritativeRebuildCount, finalRootShard.authoritativeRebuildCount)
+        XCTAssertEqual(postAppliedRootShard.fallbackCount, finalRootShard.fallbackCount)
+        XCTAssertEqual(postAppliedRootShard.fallbackReasonCounts, finalRootShard.fallbackReasonCounts)
+        XCTAssertEqual(postAppliedRootShard.lastAppliedIndexGeneration, firstAppliedIndexEvent.generation)
+        XCTAssertFalse(postAppliedRootShard.deltaStateDirty)
     }
 
     func testRemovedRootCannotBeResurrectedByDelayedLoadRefresh() async throws {

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/WorkspaceSearchServiceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/WorkspaceSearchServiceTests.swift
@@ -90,26 +90,40 @@ final class WorkspaceSearchServiceTests: XCTestCase {
         let root = try makeTemporaryRoot(name: "ManagedOnlySearchFreshness")
         let visibleURL = root.appendingPathComponent("Sources/VisibleTarget.swift")
         let ignoredURL = root.appendingPathComponent("HiddenIgnoredTarget.ignored")
+        let secondIgnoredURL = root.appendingPathComponent("SecondHiddenTarget.ignored")
         try write("*.ignored\n", to: root.appendingPathComponent(".gitignore"))
         try write("visible", to: visibleURL)
         try write("hidden", to: ignoredURL)
+        try write("second hidden", to: secondIgnoredURL)
 
         let store = WorkspaceFileContextStore()
-        _ = try await store.loadRoot(path: root.path)
+        let rootRecord = try await store.loadRoot(path: root.path)
         let initialSnapshot = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
         XCTAssertFalse(initialSnapshot.files.contains { $0.standardizedFullPath == ignoredURL.path })
+        let initialStoreWork = await store.storeWorkDiagnosticsSnapshot()
+        let initialRootShard = try XCTUnwrap(
+            initialStoreWork.rootCatalogShards.roots.first { $0.rootID == rootRecord.id }
+        )
+        let appliedIndexStream = await store.appliedIndexEvents()
+        var appliedIndexIterator = appliedIndexStream.makeAsyncIterator()
 
         let service = WorkspaceSearchService()
-        let rebuildCommitted = expectation(description: "managed-only catalog generation rebuilt")
+        let generationCommitted = expectation(description: "projection-neutral catalog generation committed")
+        let neutralEventGate = TestAsyncGate()
+        let finalRebuildCommitted = TestAsyncSignal()
         addTeardownBlock {
+            await service.setProjectionNeutralGenerationDidCommitHandler(nil)
+            await service.setCatalogChangeWillHandleHandler(nil)
             await service.setAutomaticRebuildDidCommitHandler(nil)
+            await neutralEventGate.open()
             await service.stopKeepingFresh()
         }
 
         await service.startKeepingFresh(with: store, rootScope: .visibleWorkspace)
         await service.rebuildIndex(from: initialSnapshot)
-        await service.setAutomaticRebuildDidCommitHandler { _ in
-            rebuildCommitted.fulfill()
+        let initialSearchWork = await service.workDiagnosticsSnapshot()
+        await service.setProjectionNeutralGenerationDidCommitHandler { _ in
+            generationCommitted.fulfill()
         }
 
         let materialization = try await store.materializeExplicitlyRequestedFile(
@@ -123,7 +137,8 @@ final class WorkspaceSearchServiceTests: XCTestCase {
         let materializedGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
         XCTAssertNotEqual(materializedGeneration, initialSnapshot.generation)
 
-        await fulfillment(of: [rebuildCommitted], timeout: 2)
+        await fulfillment(of: [generationCommitted], timeout: 2)
+        await service.setProjectionNeutralGenerationDidCommitHandler(nil)
 
         let visibleResult = await service.search("VisibleTarget", limit: 10)
         XCTAssertTrue(visibleResult.isIndexReady)
@@ -139,6 +154,66 @@ final class WorkspaceSearchServiceTests: XCTestCase {
         XCTAssertFalse(ignoredResult.isStale)
         XCTAssertEqual(ignoredResult.indexedGeneration, materializedGeneration)
         XCTAssertTrue(ignoredResult.results.isEmpty)
+        let searchDiagnostics = await service.diagnostics
+        XCTAssertEqual(searchDiagnostics?.generation, materializedGeneration)
+
+        let finalSearchWork = await service.workDiagnosticsSnapshot()
+        XCTAssertEqual(finalSearchWork.rebuildCount, initialSearchWork.rebuildCount)
+        let finalStoreWork = await store.storeWorkDiagnosticsSnapshot()
+        let finalRootShard = try XCTUnwrap(
+            finalStoreWork.rootCatalogShards.roots.first { $0.rootID == rootRecord.id }
+        )
+        XCTAssertEqual(finalRootShard.buildCount, initialRootShard.buildCount)
+        XCTAssertEqual(finalRootShard.authoritativeRebuildCount, initialRootShard.authoritativeRebuildCount)
+        XCTAssertEqual(finalRootShard.lastAppliedIndexGeneration, initialRootShard.lastAppliedIndexGeneration)
+        XCTAssertEqual(
+            finalRootShard.fallbackReasonCounts[.fullResync, default: 0],
+            initialRootShard.fallbackReasonCounts[.fullResync, default: 0]
+        )
+
+        await service.setCatalogChangeWillHandleHandler { event in
+            guard event.kind == .generationAdvancedWithoutProjectionChange else { return }
+            await neutralEventGate.wait()
+        }
+        let secondMaterialization = try await store.materializeExplicitlyRequestedFile(
+            secondIgnoredURL.path,
+            rootScope: .visibleWorkspace
+        )
+        guard case .materialized = secondMaterialization else {
+            return XCTFail("Expected second ignored file to materialize as a managed-only record")
+        }
+        await neutralEventGate.waitUntilEntered()
+
+        let sentinelRelativePath = "Sources/AppliedIndexSentinel.swift"
+        try write("sentinel", to: root.appendingPathComponent(sentinelRelativePath))
+        await store.replayObservedFileSystemDeltas(
+            rootID: rootRecord.id,
+            deltas: [.fileAdded(sentinelRelativePath)]
+        )
+        let finalGeneration = await store.catalogGeneration(rootScope: .visibleWorkspace)
+        await service.setAutomaticRebuildDidCommitHandler { generation in
+            guard generation == finalGeneration else { return }
+            await finalRebuildCommitted.signal()
+        }
+
+        let firstAppliedIndexValue = await appliedIndexIterator.next()
+        let firstAppliedIndexEvent = try XCTUnwrap(firstAppliedIndexValue)
+        XCTAssertFalse(firstAppliedIndexEvent.requiresFullResync)
+        XCTAssertEqual(
+            firstAppliedIndexEvent.upsertedFiles.map(\.standardizedRelativePath),
+            [sentinelRelativePath]
+        )
+
+        await neutralEventGate.open()
+        await finalRebuildCommitted.wait()
+
+        let sentinelResult = await service.search("AppliedIndexSentinel", limit: 10)
+        XCTAssertTrue(sentinelResult.isIndexReady)
+        XCTAssertFalse(sentinelResult.isStale)
+        XCTAssertEqual(sentinelResult.indexedGeneration, finalGeneration)
+        XCTAssertEqual(sentinelResult.results.map(\.standardizedRelativePath), [sentinelRelativePath])
+        let secondIgnoredResult = await service.search("SecondHiddenTarget", limit: 10)
+        XCTAssertTrue(secondIgnoredResult.results.isEmpty)
     }
 
     func testRemovedRootCannotBeResurrectedByDelayedLoadRefresh() async throws {

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -262,9 +262,11 @@ There is deliberately no commit input. For a manual dispatch, GitHub's selected 
 `github.sha` are the immutable candidate. Setup fetches protected `origin/main` and requires the
 candidate commit, workflow-definition commit, and checked-out release tooling to be that exact live
 commit. A stale browser tab therefore cannot publish an older main commit merely because somebody
-pasted a convincing SHA into a text box. The protected role-aware credential preflight runs before
-the secret-free build and uses an isolated ephemeral keychain without changing the runner user's
-keychain search list.
+pasted a convincing SHA into a text box. Before the secret-free build, the protected role-aware
+credential preflight runs the same authenticated protected-main verifier used at publication
+mutation boundaries. Source reads use the workflow's source-repository token; the separate Tip
+updater token is reserved for updater-repository reads and writes. The signing preflight uses an
+isolated ephemeral keychain without changing the runner user's keychain search list.
 
 After P is reviewed, advance `tip-rollout.json` with its exact `identity-rollout.json` digest before
 merging T; advance it again with T and P digests before merging S. Each published role uses an

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -303,15 +303,21 @@ T's `sparkle:minimumUpdateVersion`, bypassing the credential preparer.
 Automatic and manual runs use separate rolling concurrency lanes. Each lane keeps at most one
 queued run and does not cancel in-flight release work; publication remains serialized across both
 lanes by `main-tip-publish`. A retry therefore resumes or audits one exact draft instead of abandoning
-a different tag halfway through publication.
+a different tag halfway through publication. Setup and credential preflight require the candidate to
+be the exact protected-main head before expensive work starts. If `main` advances while that work is
+running, publication may finish only while the candidate remains in authenticated protected-main
+ancestry. The monotonic build and rollout-progression checks still reject an older candidate when a
+newer Tip has already become public, while the newest queued run converges the feed on current `main`.
 
 Remote mutation is confined to that protected publication job. Immediately before draft creation
-and again immediately before making a draft public, it rechecks live protected `main`, downloads the
-public Tip manifest/appcast, proves that the candidate either rolls the current role or advances one
-step through `P → T → S` with exact retained history, and audits every retained enclosure against
-GitHub's published size and SHA-256. Rolling P retains no predecessor, rolling T retains the exact
-authenticated P, and rolling S retains the exact authenticated T and P. Existing drafts are resumed
-only when their metadata and uploaded bytes exactly match;
+and again immediately before making a draft public, it proves the candidate is still on live
+protected-main ancestry, downloads the public Tip manifest/appcast, proves that the candidate either
+rolls the current role or advances one step through `P → T → S` with exact retained history, and
+audits every retained enclosure against GitHub's published size and SHA-256. Rolling P retains no
+predecessor, rolling T retains the exact authenticated P, and rolling S retains the exact authenticated
+T and P. Draft creation consumes and validates GitHub's synchronous release response so publication
+does not depend on the new draft immediately appearing in paginated list results. Existing drafts are
+resumed only when their metadata and uploaded bytes exactly match;
 missing assets are added without overwriting anything. After publication, every public asset is
 downloaded anonymously and compared byte-for-byte with the signed local inventory, and the release
 must be the repository's latest. The update-repository token is not available to setup, staging, or


### PR DESCRIPTION
## Summary

Newly added workspace roots become immediately searchable in Agent Mode file mentions and file browsing, even while the shared search index is still refreshing.

## Changes

- Publish scoped catalog-change events for root lifecycle changes and keep the shared search service subscribed to the active store and root scope.
- Fence query results against the store's authoritative catalog generation, using the existing store-backed fallback during the stale window while token-owned refresh flights coalesce rebuild work.
- Prevent stale or superseded refreshes from restoring unloaded or replaced roots, with DEBUG diagnostics for impossible duplicate-root snapshots.
- Add deterministic race coverage for delayed root-load events, mention and browse fallbacks, generation convergence, and add/remove/reload ordering.

## Why

Adding a root advanced the store's catalog generation without notifying the shared search index. Until another event or workspace reload repaired it, the old index could still report itself as ready and current, causing consumers to skip their authoritative store fallback.

## Validation

- `make dev-test FILTER=WorkspaceSearchServiceTests` — 11/11 passed
- `make dev-test FILTER=AgentFileTagWorktreeResolutionTests` — 15/15 passed
- `make dev-test FILTER=AgentContextFileBrowseServiceTests` — 11/11 passed
- `make dev-test` — 984/984 passed
- `make dev-lint` — passed
- Live CE MCP smoke — passed
- Manual Add Folder, remove, and re-add flow with immediate `@` search — passed

Refs #919
