### PR TITLE
Add Oh My Pi ACP agent provider

### DIFF
--- a/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
+++ b/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
@@ -41,4 +41,7 @@ extension Notification.Name {
     /// Posted when Grok Build CLI connection status changes
     /// userInfo mirrors `claudeCodeConnectionChanged`
     static let grokBuildConnectionChanged = Notification.Name("grokBuildConnectionChanged")
+    /// Posted when Oh My Pi CLI connection status changes
+    /// userInfo mirrors `claudeCodeConnectionChanged`
+    static let ompConnectionChanged = Notification.Name("ompConnectionChanged")
 }

--- a/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
+++ b/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
@@ -44,4 +44,6 @@ extension Notification.Name {
     /// Posted when Oh My Pi CLI connection status changes
     /// userInfo mirrors `claudeCodeConnectionChanged`
     static let ompConnectionChanged = Notification.Name("ompConnectionChanged")
+    /// Posted when ACP model discovery changes (`userInfo["providerID"]`) or persisted catalogs finish warming.
+    static let acpDiscoveredModelsChanged = Notification.Name("acpDiscoveredModelsChanged")
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentACPModelRegistry.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentACPModelRegistry.swift
@@ -2,6 +2,7 @@ import Foundation
 
 final class AgentACPModelRegistry {
     static let shared = AgentACPModelRegistry()
+    static let providerIDUserInfoKey = "providerID"
 
     private let lock = NSLock()
     private var liveSnapshotsByProvider: [ACPProviderID: ACPDiscoveredSessionModels] = [:]
@@ -38,6 +39,11 @@ final class AgentACPModelRegistry {
 
         guard didChange else { return false }
         ACPDynamicModelStore.save(normalizedSnapshot, for: providerID)
+        NotificationCenter.default.post(
+            name: .acpDiscoveredModelsChanged,
+            object: nil,
+            userInfo: [Self.providerIDUserInfoKey: providerID.rawValue]
+        )
         return true
     }
 
@@ -74,12 +80,17 @@ final class AgentACPModelRegistry {
         guard let plan else { return }
         let loadedSnapshots = await plan.task.value
 
-        lock.withLock {
-            guard plan.generation == standardStoreWarmGeneration else { return }
+        let didApply: Bool = lock.withLock {
+            guard plan.generation == standardStoreWarmGeneration,
+                  !didWarmStandardStore
+            else { return false }
             persistedSnapshotsByProvider = loadedSnapshots
             didWarmStandardStore = true
             standardStoreWarmTask = nil
+            return true
         }
+        guard didApply else { return }
+        NotificationCenter.default.post(name: .acpDiscoveredModelsChanged, object: nil)
     }
 
     private struct StandardStoreWarmPlan {

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -304,7 +304,7 @@ enum AgentModel: String, CaseIterable, Codable {
             ]
         case .openCode:
             [.defaultModel]
-        case .grokBuild:
+        case .grokBuild, .omp:
             [.defaultModel]
         case .antigravity:
             []

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -8,6 +8,7 @@ enum AgentModelCatalog {
         let cursorAvailable: Bool
         let grokBuildAvailable: Bool
         let antigravityAvailable: Bool
+        let ompAvailable: Bool
         let zaiConfigured: Bool
         let kimiConfigured: Bool
         let customClaudeCompatibleConfigured: Bool
@@ -19,6 +20,7 @@ enum AgentModelCatalog {
             cursorAvailable: false,
             grokBuildAvailable: false,
             antigravityAvailable: false,
+            ompAvailable: false,
             zaiConfigured: false,
             kimiConfigured: false,
             customClaudeCompatibleConfigured: false
@@ -32,6 +34,7 @@ enum AgentModelCatalog {
                 cursorAvailable: cursorAvailable && providers.contains(.cursor),
                 grokBuildAvailable: grokBuildAvailable && providers.contains(.grokBuild),
                 antigravityAvailable: antigravityAvailable,
+                ompAvailable: false,
                 zaiConfigured: zaiConfigured && providers.contains(.claudeCode),
                 kimiConfigured: kimiConfigured && providers.contains(.claudeCode),
                 customClaudeCompatibleConfigured: customClaudeCompatibleConfigured && providers.contains(.claudeCode)
@@ -47,6 +50,7 @@ enum AgentModelCatalog {
                 cursorAvailable: false,
                 grokBuildAvailable: false,
                 antigravityAvailable: AntigravityRuntimeManager.installedRuntimeSync() != nil,
+                ompAvailable: false,
                 zaiConfigured: backendIsAvailable(.glmZAI, store: store),
                 kimiConfigured: backendIsAvailable(.kimi, store: store),
                 customClaudeCompatibleConfigured: backendIsAvailable(.custom, store: store)
@@ -60,6 +64,7 @@ enum AgentModelCatalog {
             cursorAvailable: Bool = false,
             grokBuildAvailable: Bool = false,
             antigravityAvailable: Bool = false,
+            ompAvailable: Bool = false,
             zaiConfigured: Bool = false,
             kimiConfigured: Bool = false,
             customClaudeCompatibleConfigured: Bool = false
@@ -70,6 +75,7 @@ enum AgentModelCatalog {
             self.cursorAvailable = cursorAvailable
             self.grokBuildAvailable = grokBuildAvailable
             self.antigravityAvailable = antigravityAvailable
+            self.ompAvailable = ompAvailable
             self.zaiConfigured = zaiConfigured
             self.kimiConfigured = kimiConfigured
             self.customClaudeCompatibleConfigured = customClaudeCompatibleConfigured
@@ -94,6 +100,7 @@ enum AgentModelCatalog {
                 cursorAvailable: cursorAvailable || agentKind == .cursor,
                 grokBuildAvailable: grokBuildAvailable || agentKind == .grokBuild,
                 antigravityAvailable: antigravityAvailable || agentKind == .antigravity,
+                ompAvailable: ompAvailable || agentKind == .omp,
                 zaiConfigured: zaiConfigured || agentKind == .claudeCodeGLM,
                 kimiConfigured: kimiConfigured || agentKind == .kimiCode,
                 customClaudeCompatibleConfigured: customClaudeCompatibleConfigured || agentKind == .customClaudeCompatible
@@ -201,14 +208,15 @@ enum AgentModelCatalog {
         .openCode,
         .cursor,
         .grokBuild,
-        .antigravity
+        .antigravity,
+        .omp
     ]
 
     static func selectableAgents(
         availability: AvailabilityContext = .current,
         surface: AgentSelectionSurface = .general
     ) -> [AgentProviderKind] {
-        [.codexExec, .claudeCode, .openCode, .cursor, .grokBuild, .antigravity, .claudeCodeGLM, .kimiCode, .customClaudeCompatible]
+        [.codexExec, .claudeCode, .openCode, .cursor, .grokBuild, .antigravity, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible]
             .filter { surface.allows($0) && isAgentAvailable($0, availability: availability) }
     }
 
@@ -242,6 +250,8 @@ enum AgentModelCatalog {
             availability.grokBuildAvailable
         case .antigravity:
             availability.antigravityAvailable
+        case .omp:
+            availability.ompAvailable
         }
     }
 
@@ -254,8 +264,9 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return AgentModel.cursorAuto.rawValue
         }
-        if agentKind == .grokBuild {
-            // Grok's default follows its own configuration.
+        if agentKind == .grokBuild || agentKind == .omp {
+            // Provider-managed default must never become a discovered session's current model:
+            // "default" sends no model mutation and follows the provider's own configuration.
             return AgentModel.defaultModel.rawValue
         }
         if agentKind == .antigravity {
@@ -272,7 +283,7 @@ enum AgentModelCatalog {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             return ClaudeCompatibleModelCatalogAdapter.defaultModelRaw(for: agentKind, availability: availability)
                 ?? AgentModel.defaultModel.rawValue
-        case .codexExec, .openCode, .grokBuild:
+        case .codexExec, .openCode, .grokBuild, .omp:
             return AgentModel.defaultModel.rawValue
         case .antigravity:
             return ""
@@ -355,6 +366,9 @@ enum AgentModelCatalog {
         if agentKind == .antigravity {
             return resolvedACPDiscoveredModels(for: .antigravity)?.options ?? []
         }
+        if agentKind == .omp {
+            return [staticOption(.defaultModel, for: .omp)]
+        }
         if agentKind == .grokBuild {
             let fallback = staticOption(.defaultModel, for: .grokBuild)
             guard let discoveredOptions = resolvedACPDiscoveredModels(for: agentKind)?.options,
@@ -385,7 +399,7 @@ enum AgentModelCatalog {
                 availability: availability,
                 includeClaudeEffortVariants: includeClaudeEffortVariants
             ) ?? []
-        case .openCode, .cursor, .grokBuild:
+        case .openCode, .cursor, .grokBuild, .omp:
             return AgentModel.modelsForAgent(agentKind)
                 .filter { isAvailable($0, for: agentKind, availability: availability) }
                 .map { staticOption($0, for: agentKind) }
@@ -407,7 +421,7 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return CursorAIModelCatalog.contains(modelRaw: normalized)
         }
-        if agentKind == .grokBuild,
+        if agentKind == .grokBuild || agentKind == .omp,
            normalized.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame
         {
             return true
@@ -1367,6 +1381,7 @@ enum AgentModelCatalog {
     private static func resolvedACPDiscoveredModels(
         for agentKind: AgentProviderKind
     ) -> ACPDiscoveredSessionModels? {
+        guard agentKind != .omp else { return nil }
         guard let providerID = agentKind.acpProviderID,
               let snapshot = AgentACPModelRegistry.shared.resolvedSnapshot(for: providerID),
               !snapshot.options.isEmpty
@@ -1406,7 +1421,7 @@ enum AgentModelCatalog {
             .kimi
         case .customClaudeCompatible:
             .custom
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             nil
         }
     }
@@ -1609,7 +1624,7 @@ enum AgentModelCatalog {
             availability.kimiConfigured
         case .customClaudeCompatible:
             availability.customClaudeCompatibleConfigured
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             true
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -264,9 +264,9 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return AgentModel.cursorAuto.rawValue
         }
-        if agentKind == .grokBuild || agentKind == .omp {
-            // Provider-managed default must never become a discovered session's current model:
-            // "default" sends no model mutation and follows the provider's own configuration.
+        if agentKind == .grokBuild {
+            // Grok's default must never become a discovered session's current model:
+            // "default" sends no model mutation and follows Grok's own configuration.
             return AgentModel.defaultModel.rawValue
         }
         if agentKind == .antigravity {
@@ -366,9 +366,6 @@ enum AgentModelCatalog {
         if agentKind == .antigravity {
             return resolvedACPDiscoveredModels(for: .antigravity)?.options ?? []
         }
-        if agentKind == .omp {
-            return [staticOption(.defaultModel, for: .omp)]
-        }
         if agentKind == .grokBuild {
             let fallback = staticOption(.defaultModel, for: .grokBuild)
             guard let discoveredOptions = resolvedACPDiscoveredModels(for: agentKind)?.options,
@@ -421,7 +418,7 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return CursorAIModelCatalog.contains(modelRaw: normalized)
         }
-        if agentKind == .grokBuild || agentKind == .omp,
+        if agentKind == .grokBuild,
            normalized.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame
         {
             return true

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -264,9 +264,9 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return AgentModel.cursorAuto.rawValue
         }
-        if agentKind == .grokBuild {
-            // Grok's default must never become a discovered session's current model:
-            // "default" sends no model mutation and follows Grok's own configuration.
+        if agentKind == .grokBuild || agentKind == .omp {
+            // Provider-managed defaults must never become a discovered session's current
+            // model: "default" sends no mutation and follows the provider configuration.
             return AgentModel.defaultModel.rawValue
         }
         if agentKind == .antigravity {
@@ -366,8 +366,8 @@ enum AgentModelCatalog {
         if agentKind == .antigravity {
             return resolvedACPDiscoveredModels(for: .antigravity)?.options ?? []
         }
-        if agentKind == .grokBuild {
-            let fallback = staticOption(.defaultModel, for: .grokBuild)
+        if agentKind == .grokBuild || agentKind == .omp {
+            let fallback = staticOption(.defaultModel, for: agentKind)
             guard let discoveredOptions = resolvedACPDiscoveredModels(for: agentKind)?.options,
                   !discoveredOptions.isEmpty
             else {
@@ -418,7 +418,7 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return CursorAIModelCatalog.contains(modelRaw: normalized)
         }
-        if agentKind == .grokBuild,
+        if agentKind == .grokBuild || agentKind == .omp,
            normalized.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame
         {
             return true
@@ -1378,7 +1378,6 @@ enum AgentModelCatalog {
     private static func resolvedACPDiscoveredModels(
         for agentKind: AgentProviderKind
     ) -> ACPDiscoveredSessionModels? {
-        guard agentKind != .omp else { return nil }
         guard let providerID = agentKind.acpProviderID,
               let snapshot = AgentACPModelRegistry.shared.resolvedSnapshot(for: providerID),
               !snapshot.options.isEmpty

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -530,6 +530,31 @@ enum AgentModelCatalog {
         return baseDisplayName(for: effectiveRaw)
     }
 
+    struct OMPProviderModelGroup: Identifiable {
+        let providerID: String?
+        let options: [AgentModelOption]
+
+        var id: String {
+            providerID ?? ""
+        }
+    }
+
+    /// OMP's ACP advertisement already applies its authentication and enabled-model
+    /// filters. Group that exact set; don't synthesize models or interpret opaque
+    /// model suffixes as OpenCode reasoning variants.
+    static func ompModelGroups(for options: [AgentModelOption]) -> [OMPProviderModelGroup] {
+        let grouped = Dictionary(grouping: options) { option -> String in
+            guard !option.isPlaceholderDefault,
+                  let slash = option.rawValue.firstIndex(of: "/"),
+                  slash != option.rawValue.startIndex,
+                  option.rawValue.index(after: slash) != option.rawValue.endIndex else { return "" }
+            return String(option.rawValue[..<slash])
+        }
+        return grouped.keys.sorted().map { provider in
+            OMPProviderModelGroup(providerID: provider.isEmpty ? nil : provider, options: grouped[provider] ?? [])
+        }
+    }
+
     static func openCodeMenu(for options: [AgentModelOption]) -> OpenCodeMenu {
         struct Entry {
             let option: AgentModelOption

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
@@ -5,6 +5,7 @@ enum ACPProviderID: String, Codable, Hashable {
     case cursor
     case grokBuild
     case antigravity
+    case omp
 }
 
 enum ACPSupportResult: Equatable {

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -362,7 +362,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
             .kimi
         case .customClaudeCompatible:
             .custom
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             nil
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatiblePluginBridge.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatiblePluginBridge.swift
@@ -18,7 +18,7 @@ enum ClaudeCompatiblePluginBridge {
             .kimiClaudeCode
         case .customClaudeCompatible:
             .customClaudeCompatible
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             nil
         }
     }
@@ -208,7 +208,7 @@ enum ClaudeCompatiblePluginBridge {
             "Claude Code is unavailable."
         case .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             "Claude-compatible backend is not configured."
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             "Not a Claude-compatible provider."
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
@@ -386,7 +386,7 @@ final class AutoRecommendationEngine {
                 enabledRecommendationProviders.contains(.cursor)
             case .grokBuild:
                 enabledRecommendationProviders.contains(.grokBuild)
-            case .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+            case .openCode, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
                 true
             case .antigravity:
                 false

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
@@ -386,7 +386,9 @@ final class AutoRecommendationEngine {
                 enabledRecommendationProviders.contains(.cursor)
             case .grokBuild:
                 enabledRecommendationProviders.contains(.grokBuild)
-            case .openCode, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+            case .omp:
+                false
+            case .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
                 true
             case .antigravity:
                 false

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModePermissionPreferences.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModePermissionPreferences.swift
@@ -48,7 +48,6 @@ enum AgentModePermissionPreferences {
         defaults: UserDefaults = .standard,
         secureStore: AgentPermissionSecureStore? = nil
     ) -> AgentProviderPermissionLevelID {
-        if providerID == .omp { return .omp }
         if let secureStore = resolvedSecureStore(defaults: defaults, secureStore: secureStore) {
             return secureStore.providerSubagentPermissionLevel(for: providerID)
         }
@@ -61,7 +60,6 @@ enum AgentModePermissionPreferences {
         defaults: UserDefaults = .standard,
         secureStore: AgentPermissionSecureStore? = nil
     ) {
-        guard providerID != .omp else { return }
         let normalizedLevel = level.providerID == providerID
             ? level
             : AgentProviderPermissionLevelID.subagentDefault(for: providerID)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModePermissionPreferences.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModePermissionPreferences.swift
@@ -48,6 +48,7 @@ enum AgentModePermissionPreferences {
         defaults: UserDefaults = .standard,
         secureStore: AgentPermissionSecureStore? = nil
     ) -> AgentProviderPermissionLevelID {
+        if providerID == .omp { return .omp }
         if let secureStore = resolvedSecureStore(defaults: defaults, secureStore: secureStore) {
             return secureStore.providerSubagentPermissionLevel(for: providerID)
         }
@@ -60,6 +61,7 @@ enum AgentModePermissionPreferences {
         defaults: UserDefaults = .standard,
         secureStore: AgentPermissionSecureStore? = nil
     ) {
+        guard providerID != .omp else { return }
         let normalizedLevel = level.providerID == providerID
             ? level
             : AgentProviderPermissionLevelID.subagentDefault(for: providerID)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSkillCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSkillCatalog.swift
@@ -423,7 +423,7 @@ final class AgentSkillCatalog {
                 precedenceRank: 7
             )
 
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             // Codex, OpenCode, and Cursor continue to share only the generic `.agents` namespace.
             appendWorkspaceRoots(
                 relativeRoot: ".agents/skills",

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
@@ -239,6 +239,9 @@ final class AgentModeProviderBindingService {
                         updateActiveBindings(session)
                     }
                 }
+            case .omp:
+                // OMP owns its internal tool permissions; RepoPrompt exposes no mutable provider preference.
+                break
             case .grokBuild:
                 // Grok full access is a launch-time `--always-approve` flag; it applies to
                 // newly launched processes and never mutates a running controller. The next

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
@@ -206,7 +206,7 @@ final class AgentModeProviderBindingService {
                 // Claude launch settings are revalidated immediately before dispatch.
                 // Avoid an eager untracked shutdown that could race a newly started run.
                 break
-            case .openCode, .antigravity:
+            case .openCode, .antigravity, .omp:
                 let runtime = runtimePermission(for: session.selectedAgent, profile: session.permissionProfile)
                 guard let sessionModeID = runtime.acpSessionModeID,
                       session.runState.isActive,
@@ -239,9 +239,6 @@ final class AgentModeProviderBindingService {
                         updateActiveBindings(session)
                     }
                 }
-            case .omp:
-                // OMP owns its internal tool permissions; RepoPrompt exposes no mutable provider preference.
-                break
             case .grokBuild:
                 // Grok full access is a launch-time `--always-approve` flag; it applies to
                 // newly launched processes and never mutates a running controller. The next

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingID.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingID.swift
@@ -7,6 +7,7 @@ enum AgentProviderBindingID: String, CaseIterable, Hashable {
     case cursor
     case grokBuild
     case antigravity
+    case omp
 
     var displayName: String {
         switch self {
@@ -22,6 +23,8 @@ enum AgentProviderBindingID: String, CaseIterable, Hashable {
             "Grok Build"
         case .antigravity:
             "Google Antigravity"
+        case .omp:
+            "Oh My Pi"
         }
     }
 }
@@ -41,6 +44,8 @@ extension AgentProviderKind {
             .grokBuild
         case .antigravity:
             .antigravity
+        case .omp:
+            .omp
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
@@ -20,6 +20,7 @@ enum AgentProviderPermissionLevelID: Hashable {
     case antigravity(AntigravityAgentToolPreferences.PermissionLevel)
     case cursor(CursorAgentToolPreferences.PermissionLevel)
     case grokBuild(GrokBuildAgentToolPreferences.PermissionLevel)
+    case omp
 
     var providerID: AgentProviderBindingID {
         switch self {
@@ -35,6 +36,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             .cursor
         case .grokBuild:
             .grokBuild
+        case .omp:
+            .omp
         }
     }
 
@@ -52,6 +55,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             .cursor(.managedDefault)
         case .grokBuild:
             .grokBuild(.managedDefault)
+        case .omp:
+            .omp
         }
     }
 
@@ -69,6 +74,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             CursorAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.cursor)
         case .grokBuild:
             GrokBuildAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.grokBuild)
+        case .omp:
+            [.omp]
         }
     }
 
@@ -93,6 +100,9 @@ enum AgentProviderPermissionLevelID: Hashable {
         case .grokBuild:
             guard let level = GrokBuildAgentToolPreferences.PermissionLevel(rawValue: raw) else { return nil }
             self = .grokBuild(level)
+        case .omp:
+            guard raw == "providerManaged" else { return nil }
+            self = .omp
         }
     }
 
@@ -110,6 +120,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.rawValue
         case let .grokBuild(level):
             level.rawValue
+        case .omp:
+            "providerManaged"
         }
     }
 
@@ -127,6 +139,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.displayName
         case let .grokBuild(level):
             level.displayName
+        case .omp:
+            "Provider Managed"
         }
     }
 
@@ -144,6 +158,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.iconName
         case let .grokBuild(level):
             level.iconName
+        case .omp:
+            "shield"
         }
     }
 
@@ -161,6 +177,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.detailText
         case let .grokBuild(level):
             level.detailText
+        case .omp:
+            "OMP controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools."
         }
     }
 
@@ -178,6 +196,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.isWarning
         case let .grokBuild(level):
             level.isWarning
+        case .omp:
+            false
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
@@ -20,7 +20,7 @@ enum AgentProviderPermissionLevelID: Hashable {
     case antigravity(AntigravityAgentToolPreferences.PermissionLevel)
     case cursor(CursorAgentToolPreferences.PermissionLevel)
     case grokBuild(GrokBuildAgentToolPreferences.PermissionLevel)
-    case omp
+    case omp(OMPAgentToolPreferences.PermissionLevel)
 
     var providerID: AgentProviderBindingID {
         switch self {
@@ -56,7 +56,7 @@ enum AgentProviderPermissionLevelID: Hashable {
         case .grokBuild:
             .grokBuild(.managedDefault)
         case .omp:
-            .omp
+            .omp(.providerManaged)
         }
     }
 
@@ -75,7 +75,7 @@ enum AgentProviderPermissionLevelID: Hashable {
         case .grokBuild:
             GrokBuildAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.grokBuild)
         case .omp:
-            [.omp]
+            OMPAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.omp)
         }
     }
 
@@ -101,8 +101,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             guard let level = GrokBuildAgentToolPreferences.PermissionLevel(rawValue: raw) else { return nil }
             self = .grokBuild(level)
         case .omp:
-            guard raw == "providerManaged" else { return nil }
-            self = .omp
+            guard let level = OMPAgentToolPreferences.PermissionLevel(rawValue: raw) else { return nil }
+            self = .omp(level)
         }
     }
 
@@ -120,8 +120,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.rawValue
         case let .grokBuild(level):
             level.rawValue
-        case .omp:
-            "providerManaged"
+        case let .omp(level):
+            level.rawValue
         }
     }
 
@@ -139,8 +139,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.displayName
         case let .grokBuild(level):
             level.displayName
-        case .omp:
-            "Provider Managed"
+        case let .omp(level):
+            level.displayName
         }
     }
 
@@ -158,8 +158,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.iconName
         case let .grokBuild(level):
             level.iconName
-        case .omp:
-            "shield"
+        case let .omp(level):
+            level.iconName
         }
     }
 
@@ -177,8 +177,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.detailText
         case let .grokBuild(level):
             level.detailText
-        case .omp:
-            "OMP controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools."
+        case let .omp(level):
+            level.detailText
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
@@ -155,11 +155,24 @@ extension AgentProviderPermissionProfile {
         }
     }
 
+    func ompPermissionLevel(
+        userConfigured: OMPAgentToolPreferences.PermissionLevel = OMPAgentToolPreferences.permissionLevel()
+    ) -> OMPAgentToolPreferences.PermissionLevel {
+        switch self {
+        case .userConfigured: userConfigured
+        case .mcpSafeDefaults: .providerManaged
+        case let .providerOverride(.omp(level)): level
+        case .providerOverride: .providerManaged
+        }
+    }
+
     func acpSessionModeID(for agent: AgentProviderKind) -> String? {
         switch agent {
         case .openCode:
             openCodeSessionModeID
-        case .cursor, .grokBuild, .antigravity, .omp:
+        case .omp:
+            ompPermissionLevel().sessionModeID
+        case .cursor, .grokBuild, .antigravity:
             nil
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .codexExec:
             nil

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
@@ -159,7 +159,7 @@ extension AgentProviderPermissionProfile {
         switch agent {
         case .openCode:
             openCodeSessionModeID
-        case .cursor, .grokBuild, .antigravity:
+        case .cursor, .grokBuild, .antigravity, .omp:
             nil
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .codexExec:
             nil

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
@@ -147,7 +147,8 @@ final class AgentProviderPreferenceSnapshotStore {
                 acceptsPendingACPApprovalWhenActivated: level.autoApprovesACPToolPermissions
             )
         case .omp:
-            return AgentProviderRuntimePermissionBinding()
+            let level = effectiveOMPPermissionLevel(profile: profile)
+            return AgentProviderRuntimePermissionBinding(acpSessionModeID: level.sessionModeID)
         case .grokBuild:
             let level = effectiveGrokBuildPermissionLevel(profile: profile)
             // For Grok this flag becomes a launch-time `--always-approve` argument in the
@@ -174,8 +175,8 @@ final class AgentProviderPreferenceSnapshotStore {
             CursorAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .grokBuild(level):
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
-        case .omp:
-            break
+        case let .omp(level):
+            OMPAgentToolPreferences.setPermissionLevel(level, defaults: defaults)
         }
         bumpRevision(for: id.providerID)
         return id.providerID
@@ -422,24 +423,24 @@ final class AgentProviderPreferenceSnapshotStore {
                 }
             )
         case .omp:
-            let level = AgentProviderPermissionLevelID.omp
+            let effective = effectiveOMPPermissionLevel(profile: profile)
             return AgentPermissionChromeBinding(
                 providerID: providerID,
-                displayName: level.displayName,
-                iconName: level.iconName,
-                isWarning: level.isWarning,
-                externallyManagedReason: level.detailText,
-                options: [
+                displayName: effective.displayName,
+                iconName: effective.iconName,
+                isWarning: false,
+                externallyManagedReason: externallyManagedReason,
+                options: OMPAgentToolPreferences.PermissionLevel.allCases.map { level in
                     AgentPermissionOptionBinding(
-                        id: level,
+                        id: .omp(level),
                         title: level.displayName,
                         iconName: level.iconName,
                         detailText: level.detailText,
-                        isWarning: level.isWarning,
-                        isSelected: true,
-                        isEnabled: false
+                        isWarning: false,
+                        isSelected: level == effective,
+                        isEnabled: externallyManagedReason == nil
                     )
-                ]
+                }
             )
         case .grokBuild:
             let effective = effectiveGrokBuildPermissionLevel(profile: profile)
@@ -682,6 +683,14 @@ final class AgentProviderPreferenceSnapshotStore {
         case .providerOverride:
             .managedDefault
         }
+    }
+
+    private func effectiveOMPPermissionLevel(
+        profile: AgentProviderPermissionProfile
+    ) -> OMPAgentToolPreferences.PermissionLevel {
+        profile.ompPermissionLevel(
+            userConfigured: OMPAgentToolPreferences.permissionLevel(defaults: defaults)
+        )
     }
 
     private static func representativeAgent(for providerID: AgentProviderBindingID) -> AgentProviderKind {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
@@ -146,6 +146,8 @@ final class AgentProviderPreferenceSnapshotStore {
                 autoApproveAllACPToolPermissions: level.autoApprovesACPToolPermissions,
                 acceptsPendingACPApprovalWhenActivated: level.autoApprovesACPToolPermissions
             )
+        case .omp:
+            return AgentProviderRuntimePermissionBinding()
         case .grokBuild:
             let level = effectiveGrokBuildPermissionLevel(profile: profile)
             // For Grok this flag becomes a launch-time `--always-approve` argument in the
@@ -172,6 +174,8 @@ final class AgentProviderPreferenceSnapshotStore {
             CursorAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .grokBuild(level):
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
+        case .omp:
+            break
         }
         bumpRevision(for: id.providerID)
         return id.providerID
@@ -416,6 +420,25 @@ final class AgentProviderPreferenceSnapshotStore {
                         isEnabled: externallyManagedReason == nil
                     )
                 }
+            )
+        case .omp:
+            return AgentPermissionChromeBinding(
+                providerID: providerID,
+                displayName: "Provider Managed",
+                iconName: "shield",
+                isWarning: false,
+                externallyManagedReason: externallyManagedReason ?? "OMP controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools.",
+                options: [
+                    AgentPermissionOptionBinding(
+                        id: .omp,
+                        title: "Provider Managed",
+                        iconName: "shield",
+                        detailText: "OMP controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools.",
+                        isWarning: false,
+                        isSelected: true,
+                        isEnabled: false
+                    )
+                ]
             )
         case .grokBuild:
             let effective = effectiveGrokBuildPermissionLevel(profile: profile)
@@ -668,6 +691,7 @@ final class AgentProviderPreferenceSnapshotStore {
         case .cursor: .cursor
         case .grokBuild: .grokBuild
         case .antigravity: .antigravity
+        case .omp: .omp
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
@@ -422,19 +422,20 @@ final class AgentProviderPreferenceSnapshotStore {
                 }
             )
         case .omp:
+            let level = AgentProviderPermissionLevelID.omp
             return AgentPermissionChromeBinding(
                 providerID: providerID,
-                displayName: "Provider Managed",
-                iconName: "shield",
-                isWarning: false,
-                externallyManagedReason: externallyManagedReason ?? "OMP controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools.",
+                displayName: level.displayName,
+                iconName: level.iconName,
+                isWarning: level.isWarning,
+                externallyManagedReason: level.detailText,
                 options: [
                     AgentPermissionOptionBinding(
-                        id: .omp,
-                        title: "Provider Managed",
-                        iconName: "shield",
-                        detailText: "OMP controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools.",
-                        isWarning: false,
+                        id: level,
+                        title: level.displayName,
+                        iconName: level.iconName,
+                        detailText: level.detailText,
+                        isWarning: level.isWarning,
                         isSelected: true,
                         isEnabled: false
                     )

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderConversationCleanupRegistry.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderConversationCleanupRegistry.swift
@@ -33,7 +33,8 @@ struct ProviderConversationCleanupRegistry {
 
         case Self.normalizedProvider(AgentProviderKind.openCode.rawValue),
              Self.normalizedProvider(AgentProviderKind.cursor.rawValue),
-             Self.normalizedProvider(AgentProviderKind.grokBuild.rawValue):
+             Self.normalizedProvider(AgentProviderKind.grokBuild.rawValue),
+             Self.normalizedProvider(AgentProviderKind.omp.rawValue):
             return .unsupported(message: "ACP provider \(handle.provider) has session metadata but no verified conversation cleanup API.")
 
         default:

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
@@ -328,7 +328,10 @@ final class AgentRuntimeProviderService {
             }
             return CursorACPHeadlessAgentProvider(config: config, workspacePath: workspacePath)
         case .omp:
-            let config = OMPAgentConfig(enableDebugLogging: Self.enableDebugLogging)
+            let config = OMPAgentConfig(
+                enableDebugLogging: Self.enableDebugLogging,
+                modelString: modelString
+            )
             if Self.enableDebugLogging {
                 Self.logger.debug("Created OMPACPHeadlessAgentProvider")
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
@@ -42,6 +42,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
     case cursor
     case grokBuild
     case antigravity
+    case omp
     case claudeCodeGLM
     case kimiCode
     case customClaudeCompatible
@@ -50,6 +51,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
     static let codexMCPClientID = "codex-mcp-client"
     static let openCodeMCPClientID = "opencode"
     static let cursorMCPClientID = "cursor"
+    static let ompMCPClientID = "omp-coding-agent"
     /// Grok Build presents `grok-shell-<injected server name>` (e.g. `grok-shell-RepoPromptCE`)
     /// to MCP servers. The hint must equal that exact registered name: the pending run-scoped
     /// tab-context store keys are raw client names (no family canonicalization), so a
@@ -71,6 +73,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "grok"
         case .antigravity:
             "agy_acp_server.par"
+        case .omp:
+            "omp"
         }
     }
 
@@ -88,6 +92,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "Grok Build"
         case .antigravity:
             "Google Antigravity"
+        case .omp:
+            "Oh My Pi"
         case .claudeCodeGLM:
             ClaudeCodeCompatibleBackendStore.shared.config(for: .glmZAI).normalizedDisplayName
         case .kimiCode:
@@ -111,6 +117,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             Self.grokBuildMCPClientID
         case .antigravity:
             "antigravity"
+        case .omp:
+            Self.ompMCPClientID
         }
     }
 
@@ -124,6 +132,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             .grokBuild
         case .antigravity:
             .antigravity
+        case .omp:
+            .omp
         case .claudeCode, .codexExec, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             nil
         }
@@ -133,7 +143,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
         switch self {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             false
         }
     }
@@ -144,7 +154,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
 
     var requiresExpectedPIDOwnedAgentModeMCPRouting: Bool {
         switch self {
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
         }
     }
@@ -153,7 +163,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
         switch self {
         case .cursor, .grokBuild, .antigravity:
             false
-        case .claudeCode, .codexExec, .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+        case .claudeCode, .codexExec, .openCode, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
         }
     }
@@ -173,6 +183,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             return "Cursor CLI ACP agent. Uses Cursor's ACP runtime and injects RepoPrompt MCP tools through ACP session configuration."
         case .grokBuild:
             return "xAI Grok Build ACP agent. Uses Grok Build's ACP runtime (`grok agent stdio`) and injects RepoPrompt MCP tools through ACP session configuration."
+        case .omp:
+            return "Installed Oh My Pi ACP agent. OMP owns authentication, provider and model selection, fallbacks, memory, compaction, and internal tools; RepoPrompt injects its MCP tools."
         case .claudeCodeGLM:
             let config = ClaudeCodeCompatibleBackendStore.shared.config(for: .glmZAI)
             if case let .claudeSlotMapping(mapping) = config.modelBehavior {
@@ -209,6 +221,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "cursor_acp"
         case .grokBuild:
             "grok_build_acp"
+        case .omp:
+            "omp_acp"
         }
     }
 
@@ -222,7 +236,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             .kimi
         case .customClaudeCompatible:
             .customCompatible
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             nil
         }
     }
@@ -313,6 +327,12 @@ final class AgentRuntimeProviderService {
                 Self.logger.debug("Created CursorACPHeadlessAgentProvider")
             }
             return CursorACPHeadlessAgentProvider(config: config, workspacePath: workspacePath)
+        case .omp:
+            let config = OMPAgentConfig(enableDebugLogging: Self.enableDebugLogging)
+            if Self.enableDebugLogging {
+                Self.logger.debug("Created OMPACPHeadlessAgentProvider")
+            }
+            return OMPACPHeadlessAgentProvider(config: config, workspacePath: workspacePath)
         case .grokBuild:
             let config = GrokBuildAgentConfig(
                 enableDebugLogging: Self.enableDebugLogging,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -632,7 +632,7 @@ final class ACPIntegratedAgentModeRunner {
                 let parameterReport = try await controller.applySessionModelParameterSelections(runRequest.modelParameterSelections)
                 try Self.validateModelParameterApplicationReport(parameterReport)
                 await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
-                try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
+                try await applyRequestedSessionModeIfNeeded(runRequest, controller: controller, runID: runID)
                 setRunningStatus(waitingForConnectionStatusText(for: runRequest.agentKind), source: .transport, session: session, urgent: true)
 
                 if runRequest.agentKind.requiresPrePromptAgentModeMCPRouting {
@@ -713,7 +713,7 @@ final class ACPIntegratedAgentModeRunner {
                 let parameterReport = try await controller.applySessionModelParameterSelections(runRequest.modelParameterSelections)
                 try Self.validateModelParameterApplicationReport(parameterReport)
                 await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
-                try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
+                try await applyRequestedSessionModeIfNeeded(runRequest, controller: controller, runID: runID)
 
                 if let deferredLease {
                     let acquired = await deferredLease.acquire()
@@ -893,11 +893,12 @@ final class ACPIntegratedAgentModeRunner {
     }
 
     private func applyRequestedSessionModeIfNeeded(
-        _ requestedMode: String?,
+        _ runRequest: ACPRunRequest,
         controller: ACPAgentSessionController,
         runID: UUID
     ) async throws {
-        if let requestedMode = requestedMode?.trimmingCharacters(in: .whitespacesAndNewlines), !requestedMode.isEmpty {
+        guard runRequest.agentKind != .omp else { return }
+        if let requestedMode = runRequest.sessionModeID?.trimmingCharacters(in: .whitespacesAndNewlines), !requestedMode.isEmpty {
             try await controller.setSessionMode(requestedMode)
         }
     }
@@ -1828,6 +1829,7 @@ final class ACPIntegratedAgentModeRunner {
         agentKind: AgentProviderKind,
         session: AgentTabSession
     ) -> Bool {
+        guard agentKind != .omp else { return false }
         guard let providerID = agentKind.acpProviderID,
               providerID != .cursor,
               let snapshot = AgentACPModelRegistry.shared.resolvedSnapshot(for: providerID)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -921,7 +921,7 @@ final class ACPIntegratedAgentModeRunner {
         agentKind: AgentProviderKind,
         modelString: String?
     ) throws -> String? {
-        guard agentKind == .openCode || agentKind == .cursor || agentKind == .grokBuild || agentKind == .antigravity else { return nil }
+        guard agentKind == .openCode || agentKind == .cursor || agentKind == .grokBuild || agentKind == .antigravity || agentKind == .omp else { return nil }
         guard let model = modelString?.trimmingCharacters(in: .whitespacesAndNewlines),
               !model.isEmpty,
               model.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) != .orderedSame
@@ -1828,6 +1828,8 @@ final class ACPIntegratedAgentModeRunner {
         agentKind: AgentProviderKind,
         session: AgentTabSession
     ) -> Bool {
+        // Keep OMP's explicit Default selection sticky instead of replacing it with the
+        // current model reported by the provider.
         guard agentKind != .omp else { return false }
         guard let providerID = agentKind.acpProviderID,
               providerID != .cursor,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -632,7 +632,7 @@ final class ACPIntegratedAgentModeRunner {
                 let parameterReport = try await controller.applySessionModelParameterSelections(runRequest.modelParameterSelections)
                 try Self.validateModelParameterApplicationReport(parameterReport)
                 await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
-                try await applyRequestedSessionModeIfNeeded(runRequest, controller: controller, runID: runID)
+                try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
                 setRunningStatus(waitingForConnectionStatusText(for: runRequest.agentKind), source: .transport, session: session, urgent: true)
 
                 if runRequest.agentKind.requiresPrePromptAgentModeMCPRouting {
@@ -713,7 +713,7 @@ final class ACPIntegratedAgentModeRunner {
                 let parameterReport = try await controller.applySessionModelParameterSelections(runRequest.modelParameterSelections)
                 try Self.validateModelParameterApplicationReport(parameterReport)
                 await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
-                try await applyRequestedSessionModeIfNeeded(runRequest, controller: controller, runID: runID)
+                try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
 
                 if let deferredLease {
                     let acquired = await deferredLease.acquire()
@@ -893,12 +893,11 @@ final class ACPIntegratedAgentModeRunner {
     }
 
     private func applyRequestedSessionModeIfNeeded(
-        _ runRequest: ACPRunRequest,
+        _ requestedMode: String?,
         controller: ACPAgentSessionController,
         runID: UUID
     ) async throws {
-        guard runRequest.agentKind != .omp else { return }
-        if let requestedMode = runRequest.sessionModeID?.trimmingCharacters(in: .whitespacesAndNewlines), !requestedMode.isEmpty {
+        if let requestedMode = requestedMode?.trimmingCharacters(in: .whitespacesAndNewlines), !requestedMode.isEmpty {
             try await controller.setSessionMode(requestedMode)
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ContextUsage.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ContextUsage.swift
@@ -6,7 +6,7 @@ extension AgentModeViewModel {
         switch agent {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             claudeContextUsageEstimator
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             nil
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -5404,7 +5404,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     modelContextWindow: session.codexContextUsage?.modelContextWindow
                 )
             }
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
             break
         }
         session.contextUsageSnapshot = ContextUsageSnapshot.fromAgentContextUsage(
@@ -17108,7 +17108,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         switch agent {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .openCode, .cursor, .antigravity:
             return renderAtPathAttachmentMessage(text: text, attachments: attachments)
-        case .codexExec, .grokBuild:
+        case .codexExec, .grokBuild, .omp:
             return text
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
@@ -172,6 +172,18 @@ struct AgentPermissionCapabilitySummaryBuilder {
                 approvalModeDescription: level.autoApprovesACPToolPermissions ? "Auto-approve: on" : "Auto-approve: off",
                 warnings: warnings
             )
+        case .omp:
+            return AgentPermissionCapabilitySummary(
+                providerID: providerID,
+                providerName: providerID.displayName,
+                isAvailable: isAvailable,
+                fileMutation: "Managed by OMP",
+                shell: "Managed by OMP",
+                externalMCP: "RepoPrompt MCP: run-scoped policy",
+                search: "Managed by OMP",
+                approvalModeDescription: "Provider managed",
+                warnings: []
+            )
         case .grokBuild:
             let level = grokBuildPermissionLevel(profile: profile)
             let warnings = level == .fullAccess
@@ -229,6 +241,7 @@ struct AgentPermissionCapabilitySummaryBuilder {
         case .cursor: availability.cursorAvailable
         case .grokBuild: availability.grokBuildAvailable
         case .antigravity: availability.antigravityAvailable
+        case .omp: availability.ompAvailable
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
@@ -191,6 +191,8 @@ final class AgentProviderPermissionsSettingsViewModel: ObservableObject {
             CursorAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .grokBuild(level):
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
+        case .omp:
+            break
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
@@ -191,8 +191,8 @@ final class AgentProviderPermissionsSettingsViewModel: ObservableObject {
             CursorAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .grokBuild(level):
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
-        case .omp:
-            break
+        case let .omp(level):
+            OMPAgentToolPreferences.setPermissionLevel(level, defaults: defaults)
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
@@ -61,7 +61,7 @@ final class AgentRuntimeSidebarViewModel: ObservableObject {
             case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible: return 200_000
             case .openCode, .cursor, .antigravity: return 200_000
             case .grokBuild: return 500_000 // grok 4.5/4.6 advertise totalContextTokens 500000
-            case .codexExec, .none: return 200_000
+            case .codexExec, .omp, .none: return 200_000
             }
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -1546,6 +1546,7 @@ extension AgentProviderKind {
         case .openCode, .antigravity: "curlybraces.square"
         case .cursor: "cursorarrow"
         case .grokBuild: "bolt.circle.fill"
+        case .omp: "pi"
         }
     }
 }

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+Groups.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+Groups.swift
@@ -80,6 +80,7 @@ enum AppOracleGroupRouting {
         case .openCode: "openCode"
         case .cursor: "cursor"
         case .grokBuild: "grokBuild"
+        case .omp: "omp"
         }
     }
 }

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -6408,6 +6408,8 @@ class PromptViewModel: ObservableObject {
             return api.isCursorConnected
         case .grokBuild:
             return api.isGrokBuildConnected
+        case .omp:
+            return api.isOMPConnected
         }
     }
 
@@ -6429,7 +6431,7 @@ class PromptViewModel: ObservableObject {
             // Custom models are always valid (user explicitly configured them)
             if model.isCustom { return true }
             switch model.providerType {
-            case .claudeCode, .codex, .openCode, .cursor, .grokBuild:
+            case .claudeCode, .codex, .openCode, .cursor, .grokBuild, .omp:
                 return true
             default:
                 // Check if the model's provider has an API key configured

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -577,6 +577,16 @@ public class APISettingsViewModel: ObservableObject {
             }
         }
         .store(in: &cliConnectionCancellables)
+
+        NotificationCenter.default.publisher(for: .acpDiscoveredModelsChanged)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard let self, !self.hasPreparedForWindowClose else { return }
+                let changedProviderID = notification.userInfo?[AgentACPModelRegistry.providerIDUserInfoKey] as? String
+                guard changedProviderID == nil || changedProviderID == ACPProviderID.omp.rawValue else { return }
+                Task { await self.updateAvailableModels() }
+            }
+            .store(in: &cliConnectionCancellables)
     }
 
     private func applyAuthoritativeCodexDisconnectedState() {
@@ -600,6 +610,7 @@ public class APISettingsViewModel: ObservableObject {
     private func reloadCLIConnectionFlagsFromDefaults() {
         let wasCursorConnected = isCursorConnected
         let wasGrokBuildConnected = isGrokBuildConnected
+        let wasOMPConnected = isOMPConnected
         isClaudeCodeConnected = UserDefaults.standard.bool(forKey: "ClaudeCodeConnected")
         if isClaudeCodeConnected {
             claudeCodeCLIStatus = .binaryPresent
@@ -625,6 +636,9 @@ public class APISettingsViewModel: ObservableObject {
             } else {
                 stopCursorModelsSubscription(clearModels: true)
             }
+            Task { await updateAvailableModels() }
+        }
+        if wasOMPConnected != isOMPConnected {
             Task { await updateAvailableModels() }
         }
     }
@@ -1885,6 +1899,10 @@ public class APISettingsViewModel: ObservableObject {
             modelSet.formUnion(AIModel.modelsForProvider(.grokBuild))
         }
 
+        if isOMPConnected {
+            modelSet.formUnion(AIModel.modelsForProvider(.omp))
+        }
+
         // ── Custom provider (OpenAI compatible) ────────────────────────────────
         if isCustomProviderValid,
            let config = try? CustomProviderConfiguration.load()
@@ -1954,6 +1972,7 @@ public class APISettingsViewModel: ObservableObject {
         case .claudeCode: "claude_code"
         case .codex: "codex"
         case .openCode: "opencode"
+        case .omp: "omp"
         }
     }
 
@@ -2030,6 +2049,8 @@ public class APISettingsViewModel: ObservableObject {
                 break
             case .grokBuild:
                 break
+            case .omp:
+                break
             }
 
             await updateAvailableModels()
@@ -2091,6 +2112,8 @@ public class APISettingsViewModel: ObservableObject {
         case .cursor:
             break
         case .grokBuild:
+            break
+        case .omp:
             break
         }
         await updateAvailableModels()
@@ -3773,6 +3796,7 @@ public class APISettingsViewModel: ObservableObject {
             setContextBuilderProviderVerified(.omp, verified: true)
             ompError = nil
             UserDefaults.standard.set(true, forKey: "OMPCLIConnected")
+            await updateAvailableModels()
             collector.append("Oh My Pi CLI marked as connected")
             ompLogCollector = nil
             NotificationCenter.default.post(
@@ -3788,6 +3812,7 @@ public class APISettingsViewModel: ObservableObject {
             setContextBuilderProviderVerified(.omp, verified: false)
             ompError = message
             UserDefaults.standard.set(false, forKey: "OMPCLIConnected")
+            await updateAvailableModels()
             collector.append("User guidance: \(message)")
             NotificationCenter.default.post(
                 name: .ompConnectionChanged,
@@ -3803,6 +3828,7 @@ public class APISettingsViewModel: ObservableObject {
         setContextBuilderProviderVerified(.omp, verified: false)
         ompError = nil
         UserDefaults.standard.set(false, forKey: "OMPCLIConnected")
+        Task { await updateAvailableModels() }
         NotificationCenter.default.post(
             name: .ompConnectionChanged,
             object: nil,

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -1370,11 +1370,7 @@ public class APISettingsViewModel: ObservableObject {
 
     private func probeCachedOMPConnection(ifNeeded: Bool) async -> Bool {
         guard ifNeeded else { return false }
-        do {
-            return try await OMPACPLaunchResolver().probeSupport(for: OMPAgentConfig()) == .supported
-        } catch {
-            return false
-        }
+        return await (try? OMPACPLaunchResolver().probeSupport(for: OMPAgentConfig())) == .supported
     }
 
     private func diagnosticReason(for error: Error) -> APIKeychainAccessDiagnostic.Reason {
@@ -3777,7 +3773,6 @@ public class APISettingsViewModel: ObservableObject {
             setContextBuilderProviderVerified(.omp, verified: true)
             ompError = nil
             UserDefaults.standard.set(true, forKey: "OMPCLIConnected")
-            await updateAvailableModels()
             collector.append("Oh My Pi CLI marked as connected")
             ompLogCollector = nil
             NotificationCenter.default.post(
@@ -3787,13 +3782,13 @@ public class APISettingsViewModel: ObservableObject {
             )
             return true
         } catch {
-            collector.append("Connection test threw error: \(error.localizedDescription)")
+            let message = friendlyOMPMessage(for: error)
+            collector.append("Connection test threw error: \(message)")
             isOMPConnected = false
             setContextBuilderProviderVerified(.omp, verified: false)
-            ompError = friendlyOMPMessage(for: error)
+            ompError = message
             UserDefaults.standard.set(false, forKey: "OMPCLIConnected")
-            await updateAvailableModels()
-            collector.append("User guidance: \(ompError ?? error.localizedDescription)")
+            collector.append("User guidance: \(message)")
             NotificationCenter.default.post(
                 name: .ompConnectionChanged,
                 object: nil,
@@ -3808,9 +3803,6 @@ public class APISettingsViewModel: ObservableObject {
         setContextBuilderProviderVerified(.omp, verified: false)
         ompError = nil
         UserDefaults.standard.set(false, forKey: "OMPCLIConnected")
-        Task {
-            await updateAvailableModels()
-        }
         NotificationCenter.default.post(
             name: .ompConnectionChanged,
             object: nil,
@@ -3824,15 +3816,7 @@ public class APISettingsViewModel: ObservableObject {
         {
             return detail
         }
-        let message = error.localizedDescription
-        let lowered = message.lowercased()
-        if lowered.contains("not installed") || lowered.contains("not found") || lowered.contains("no such file") {
-            return "Oh My Pi CLI was not found. Install it and ensure `omp acp` is available."
-        }
-        if lowered.contains("permission denied") {
-            return "Permission denied. Ensure the `omp` executable is accessible."
-        }
-        return message
+        return error.localizedDescription
     }
 
     func hasOMPTrace() -> Bool {

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -307,6 +307,10 @@ public class APISettingsViewModel: ObservableObject {
     @Published var grokBuildError: String? = nil
     @Published private(set) var availableGrokBuildModelOptions: [AgentModelOption] = []
     private var grokBuildLogCollector: CLIProcessLogCollector?
+    // Oh My Pi CLI / ACP
+    @Published var isOMPConnected: Bool = UserDefaults.standard.bool(forKey: "OMPCLIConnected")
+    @Published var ompError: String? = nil
+    private var ompLogCollector: CLIProcessLogCollector?
 
     /// CLI connection flags are persisted configuration hints, not proof that the provider is
     /// usable in the current process. Context Builder restoration waits for this validation pass
@@ -390,6 +394,7 @@ public class APISettingsViewModel: ObservableObject {
             cursorAvailable: isCursorConnected,
             grokBuildAvailable: isGrokBuildConnected,
             antigravityAvailable: AntigravityRuntimeManager.installedRuntimeSync() != nil,
+            ompAvailable: isOMPConnected,
             zaiConfigured: compatibleBackendIsActive(.glmZAI),
             kimiConfigured: compatibleBackendIsActive(.kimi),
             customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
@@ -421,6 +426,7 @@ public class APISettingsViewModel: ObservableObject {
             $isOpenCodeConnected.map { _ in () }.eraseToAnyPublisher(),
             $isCursorConnected.map { _ in () }.eraseToAnyPublisher(),
             $isGrokBuildConnected.map { _ in () }.eraseToAnyPublisher(),
+            $isOMPConnected.map { _ in () }.eraseToAnyPublisher(),
             $claudeCodeCLIStatus.map { _ in () }.eraseToAnyPublisher(),
             $compatibleBackendConfigs.map { _ in () }.eraseToAnyPublisher(),
             $compatibleBackendSecretPresence.map { _ in () }.eraseToAnyPublisher()
@@ -442,6 +448,7 @@ public class APISettingsViewModel: ObservableObject {
             openCodeAvailable: isVerifiedContextBuilderProvider(.openCode) && isOpenCodeConnected,
             cursorAvailable: isVerifiedContextBuilderProvider(.cursor) && isCursorConnected,
             grokBuildAvailable: isVerifiedContextBuilderProvider(.grokBuild) && isGrokBuildConnected,
+            ompAvailable: isVerifiedContextBuilderProvider(.omp) && isOMPConnected,
             zaiConfigured: compatibleBackendIsActive(.glmZAI),
             kimiConfigured: compatibleBackendIsActive(.kimi),
             customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
@@ -499,6 +506,8 @@ public class APISettingsViewModel: ObservableObject {
             isGrokBuildConnected
         case .antigravity:
             AntigravityRuntimeManager.installedRuntimeSync() != nil
+        case .omp:
+            isOMPConnected
         case .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             false
         }
@@ -547,7 +556,8 @@ public class APISettingsViewModel: ObservableObject {
             NotificationCenter.default.publisher(for: .codexConnectionChanged).map { _ in AgentProviderKind.codexExec },
             NotificationCenter.default.publisher(for: .openCodeConnectionChanged).map { _ in AgentProviderKind.openCode },
             NotificationCenter.default.publisher(for: .cursorConnectionChanged).map { _ in AgentProviderKind.cursor },
-            NotificationCenter.default.publisher(for: .grokBuildConnectionChanged).map { _ in AgentProviderKind.grokBuild }
+            NotificationCenter.default.publisher(for: .grokBuildConnectionChanged).map { _ in AgentProviderKind.grokBuild },
+            NotificationCenter.default.publisher(for: .ompConnectionChanged).map { _ in AgentProviderKind.omp }
         ])
         .receive(on: DispatchQueue.main)
         .sink { [weak self] provider in
@@ -601,6 +611,7 @@ public class APISettingsViewModel: ObservableObject {
         isOpenCodeConnected = UserDefaults.standard.bool(forKey: "OpenCodeCLIConnected")
         isCursorConnected = UserDefaults.standard.bool(forKey: "CursorCLIConnected")
         isGrokBuildConnected = UserDefaults.standard.bool(forKey: "GrokBuildCLIConnected")
+        isOMPConnected = UserDefaults.standard.bool(forKey: "OMPCLIConnected")
         if wasGrokBuildConnected != isGrokBuildConnected {
             if isGrokBuildConnected {
                 startGrokBuildModelsSubscriptionIfNeeded(workspacePath: nil)
@@ -1223,6 +1234,7 @@ public class APISettingsViewModel: ObservableObject {
         let shouldValidateOpenCode = isOpenCodeConnected
         let shouldValidateCursor = isCursorConnected
         let shouldValidateGrokBuild = isGrokBuildConnected
+        let shouldValidateOMP = isOMPConnected
 
         let task = Task { @MainActor [weak self] in
             guard let self, !Task.isCancelled, !hasPreparedForWindowClose else { return }
@@ -1235,7 +1247,8 @@ public class APISettingsViewModel: ObservableObject {
             async let openCodeReady = probeCachedOpenCodeConnection(ifNeeded: shouldValidateOpenCode)
             async let cursorReady = probeCachedCursorConnection(ifNeeded: shouldValidateCursor)
             async let grokBuildReady = probeCachedGrokBuildConnection(ifNeeded: shouldValidateGrokBuild)
-            let readiness = await (claudeReady, codexReady, openCodeReady, cursorReady, grokBuildReady)
+            async let ompReady = probeCachedOMPConnection(ifNeeded: shouldValidateOMP)
+            let readiness = await (claudeReady, codexReady, openCodeReady, cursorReady, grokBuildReady, ompReady)
             guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
             applyContextBuilderProviderValidationResult(readiness.0, provider: .claudeCode)
@@ -1247,6 +1260,7 @@ public class APISettingsViewModel: ObservableObject {
             applyContextBuilderProviderValidationResult(readiness.2, provider: .openCode)
             applyContextBuilderProviderValidationResult(readiness.3, provider: .cursor)
             applyContextBuilderProviderValidationResult(readiness.4, provider: .grokBuild)
+            applyContextBuilderProviderValidationResult(readiness.5, provider: .omp)
             if codexPublicationAllowed,
                isCodexConnected,
                isVerifiedContextBuilderProvider(.codexExec)
@@ -1352,6 +1366,15 @@ public class APISettingsViewModel: ObservableObject {
             return true
         }
         return await GrokBuildACPModelPollingService.shared.refreshNow(workspacePath: nil)
+    }
+
+    private func probeCachedOMPConnection(ifNeeded: Bool) async -> Bool {
+        guard ifNeeded else { return false }
+        do {
+            return try await OMPACPLaunchResolver().probeSupport(for: OMPAgentConfig()) == .supported
+        } catch {
+            return false
+        }
     }
 
     private func diagnosticReason(for error: Error) -> APIKeychainAccessDiagnostic.Reason {
@@ -3731,6 +3754,104 @@ public class APISettingsViewModel: ObservableObject {
         if clearModels {
             availableCursorModelOptions = []
         }
+    }
+
+    // MARK: - Oh My Pi CLI / ACP
+
+    func testOMPConnection() async throws -> Bool {
+        let collector = CLIProcessLogCollector()
+        collector.append("Oh My Pi CLI connection test started")
+        ompLogCollector = collector
+
+        collector.append("Refreshing login-shell environment cache")
+        await CLIEnvironmentCache.shared.invalidate()
+
+        do {
+            let support = try await OMPACPLaunchResolver().probeSupport(for: OMPAgentConfig())
+            guard support == .supported else {
+                throw AIProviderError.invalidConfiguration(
+                    detail: support.reason ?? "Installed Oh My Pi CLI does not support ACP mode."
+                )
+            }
+            isOMPConnected = true
+            setContextBuilderProviderVerified(.omp, verified: true)
+            ompError = nil
+            UserDefaults.standard.set(true, forKey: "OMPCLIConnected")
+            await updateAvailableModels()
+            collector.append("Oh My Pi CLI marked as connected")
+            ompLogCollector = nil
+            NotificationCenter.default.post(
+                name: .ompConnectionChanged,
+                object: nil,
+                userInfo: ["windowID": 0]
+            )
+            return true
+        } catch {
+            collector.append("Connection test threw error: \(error.localizedDescription)")
+            isOMPConnected = false
+            setContextBuilderProviderVerified(.omp, verified: false)
+            ompError = friendlyOMPMessage(for: error)
+            UserDefaults.standard.set(false, forKey: "OMPCLIConnected")
+            await updateAvailableModels()
+            collector.append("User guidance: \(ompError ?? error.localizedDescription)")
+            NotificationCenter.default.post(
+                name: .ompConnectionChanged,
+                object: nil,
+                userInfo: ["windowID": 0]
+            )
+            throw error
+        }
+    }
+
+    func disconnectOMP() {
+        isOMPConnected = false
+        setContextBuilderProviderVerified(.omp, verified: false)
+        ompError = nil
+        UserDefaults.standard.set(false, forKey: "OMPCLIConnected")
+        Task {
+            await updateAvailableModels()
+        }
+        NotificationCenter.default.post(
+            name: .ompConnectionChanged,
+            object: nil,
+            userInfo: ["windowID": 0]
+        )
+    }
+
+    private func friendlyOMPMessage(for error: Error) -> String {
+        if let providerError = error as? AIProviderError,
+           case let .invalidConfiguration(detail) = providerError
+        {
+            return detail
+        }
+        let message = error.localizedDescription
+        let lowered = message.lowercased()
+        if lowered.contains("not installed") || lowered.contains("not found") || lowered.contains("no such file") {
+            return "Oh My Pi CLI was not found. Install it and ensure `omp acp` is available."
+        }
+        if lowered.contains("permission denied") {
+            return "Permission denied. Ensure the `omp` executable is accessible."
+        }
+        return message
+    }
+
+    func hasOMPTrace() -> Bool {
+        ompLogCollector?.isEmpty == false
+    }
+
+    func dumpOMPTrace() throws -> URL {
+        guard let collector = ompLogCollector else {
+            throw CLIProcessLogCollectorError.noEntries
+        }
+        collector.append("Exporting trace to Downloads folder")
+        let exportDate = Date()
+        let url = try collector.writeMarkdownToDownloads(
+            baseFilename: "RepoPrompt-OMPTrace",
+            title: "Oh My Pi CLI Connection Trace",
+            timestamp: exportDate
+        )
+        collector.append("Trace exported to \(url.lastPathComponent)")
+        return url
     }
 
     // MARK: - Grok Build CLI / ACP

--- a/Sources/RepoPrompt/Features/Settings/Views/AIModelDropDown.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AIModelDropDown.swift
@@ -146,6 +146,12 @@ struct AIModelDropdown: View {
                         items: group.models.map(aiModelMenuItem)
                     )
                 }
+            } else if provider == .omp {
+                AIModel.ompMenuGroups(for: models).flatMap { group in
+                    let items = group.models.map(aiModelMenuItem)
+                    guard let displayName = group.displayName else { return items }
+                    return [.submenu(displayName, items: items)]
+                }
             } else if provider == .openCode {
                 AIModel.openCodeMenu(for: models).providerGroups.flatMap { providerGroup -> [StableMenuItem] in
                     let modelItems = providerGroup.groups.map(aiModelOpenCodeMenuItem)

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -530,7 +530,7 @@ struct AgentModeGeneralSettingsView: View {
         let connected = providers.filter(isProviderConnected).count
         let total = providers.count
         if connected == 0 {
-            return "Connect a CLI agent (Claude Code, Codex, OpenCode, Cursor) to run anything in Agent Mode."
+            return "Connect a CLI agent (Claude Code, Codex, OpenCode, Cursor, Oh My Pi) to run anything in Agent Mode."
         }
         return "\(connected) of \(total) CLI providers connected. Manage auth, installs, and models in CLI Providers."
     }
@@ -583,6 +583,7 @@ struct AgentModeGeneralSettingsView: View {
         case .antigravity: AntigravityRuntimeManager.installedRuntimeSync() != nil
         case .cursor: apiSettingsVM.isCursorConnected
         case .grokBuild: apiSettingsVM.isGrokBuildConnected
+        case .omp: apiSettingsVM.isOMPConnected
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
@@ -90,7 +90,7 @@ struct AgentProviderPermissionLevelSection: View {
         case .openCode, .antigravity: "ACP Session Mode"
         case .cursor: "ACP Auto-Approve"
         case .grokBuild: "Always-Approve Launch"
-        case .omp: "Tool Permissions"
+        case .omp: "ACP Session Mode"
         }
     }
 }

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
@@ -90,6 +90,7 @@ struct AgentProviderPermissionLevelSection: View {
         case .openCode, .antigravity: "ACP Session Mode"
         case .cursor: "ACP Auto-Approve"
         case .grokBuild: "Always-Approve Launch"
+        case .omp: "Tool Permissions"
         }
     }
 }
@@ -140,7 +141,7 @@ struct AgentProviderToolsRuntimeDisclosure: View {
         switch providerID {
         case .codex: binding.codexTools != nil
         case .claude: binding.claudeTools != nil
-        case .openCode, .cursor, .grokBuild, .antigravity: false
+        case .openCode, .cursor, .grokBuild, .antigravity, .omp: false
         }
     }
 }
@@ -168,7 +169,7 @@ struct AgentProviderToolsRuntimeControls: View {
                         onApplyMutation: onApplyClaudeToolSettingMutation
                     )
                 }
-            case .openCode, .cursor, .grokBuild, .antigravity:
+            case .openCode, .cursor, .grokBuild, .antigravity, .omp:
                 EmptyView()
             }
         }

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -53,12 +53,14 @@ struct CLIProvidersSettingsView: View {
     @State private var isTestingAntigravity = false
     @State private var isAntigravityInstalled = false
     @State private var isAntigravityExpanded = false
+    @State private var isLoadingOMP = false
     @State private var isLoadingZAI = false
     @State private var showClaudeCodeTraceDump = false
     @State private var showCodexTraceDump = false
     @State private var showOpenCodeTraceDump = false
     @State private var showCursorTraceDump = false
     @State private var showGrokBuildTraceDump = false
+    @State private var showOMPTraceDump = false
     @State private var isClaudePromptSettingsExpanded = false
     @State private var claudeNativePromptMode = ClaudeAgentToolPreferences.agentModePromptDelivery()
 
@@ -76,6 +78,7 @@ struct CLIProvidersSettingsView: View {
     @State private var isOpenCodeExpanded: Bool = false
     @State private var isCursorExpanded: Bool = false
     @State private var isGrokBuildExpanded: Bool = false
+    @State private var isOMPExpanded: Bool = false
 
     // Per-backend secret text entry buffers (GLM uses viewModel.zaiApiKey directly).
     // SEARCH-HELPER: Claude-Compatible Backends settings, Kimi API key entry, Custom backend key entry
@@ -95,6 +98,7 @@ struct CLIProvidersSettingsView: View {
             || viewModel.isOpenCodeConnected
             || viewModel.isCursorConnected
             || viewModel.isGrokBuildConnected
+            || viewModel.isOMPConnected
     }
 
     private var codexStatusText: String? {
@@ -127,7 +131,7 @@ struct CLIProvidersSettingsView: View {
                         .font(.title2)
                         .fontWeight(.semibold)
 
-                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, or Cursor to leverage your existing subscriptions — OpenCode can also proxy any API key.")
+                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, Cursor, or Oh My Pi to leverage your existing subscriptions — OpenCode can also proxy any API key.")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -156,6 +160,7 @@ struct CLIProvidersSettingsView: View {
                 cursorCard
                 grokBuildCard
                 antigravityCard
+                ompCard
             }
             .padding(16)
         }
@@ -206,6 +211,13 @@ struct CLIProvidersSettingsView: View {
                     primaryButton: .default(Text("Save Trace to Downloads"), action: dumpCursorTrace),
                     secondaryButton: .cancel(Text("OK"), action: { showCursorTraceDump = false })
                 )
+            } else if showOMPTraceDump, viewModel.hasOMPTrace() {
+                Alert(
+                    title: Text("CLI Provider Management"),
+                    message: Text(alertMessage),
+                    primaryButton: .default(Text("Save Trace to Downloads"), action: dumpOMPTrace),
+                    secondaryButton: .cancel(Text("OK"), action: { showOMPTraceDump = false })
+                )
             } else {
                 Alert(
                     title: Text("CLI Provider Management"),
@@ -220,6 +232,7 @@ struct CLIProvidersSettingsView: View {
                 showCodexTraceDump = false
                 showOpenCodeTraceDump = false
                 showCursorTraceDump = false
+                showOMPTraceDump = false
                 showCodexSignOutConfirmation = false
             }
         }
@@ -2246,6 +2259,73 @@ struct CLIProvidersSettingsView: View {
         return count == 1 ? "1 model available." : "\(count) models available (including Default)."
     }
 
+    // MARK: - Oh My Pi CLI / ACP card
+
+    private var ompCard: some View {
+        providerCard(
+            title: "Oh My Pi",
+            subtitle: "Uses the installed `omp acp` runtime for Agent Mode and headless tasks. OMP keeps authority over authentication, models, fallbacks, memory, compaction, and its built-in tools.",
+            infoURL: "https://github.com/can1357/oh-my-pi",
+            isConnected: viewModel.isOMPConnected,
+            isExpanded: $isOMPExpanded
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                if viewModel.isOMPConnected {
+                    HStack(spacing: 8) {
+                        Button(action: testOMPConnection) {
+                            if isLoadingOMP {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(height: 16)
+                            } else {
+                                Label("Test Connection", systemImage: "antenna.radiowaves.left.and.right")
+                            }
+                        }
+                        .disabled(isLoadingOMP)
+                        .buttonStyle(CustomButtonStyle())
+
+                        Spacer()
+
+                        Button(action: disconnectOMP) {
+                            Text("Disconnect")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(CustomButtonStyle())
+                    }
+
+                    Text("Uses OMP's configured provider, model, and fallback behavior.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    HStack(spacing: 10) {
+                        Button(action: testOMPConnection) {
+                            if isLoadingOMP {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(height: 16)
+                            } else {
+                                Label("Connect", systemImage: "link")
+                            }
+                        }
+                        .disabled(isLoadingOMP)
+                        .buttonStyle(CustomButtonStyle())
+
+                        if let error = viewModel.ompError, !error.isEmpty {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } else {
+                            Text("Install and authenticate OMP separately, then ensure `omp acp` is available.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // MARK: - Cursor CLI / ACP card
 
     private var cursorCard: some View {
@@ -2804,6 +2884,57 @@ struct CLIProvidersSettingsView: View {
         viewModel.disconnectCursor()
         alertMessage = "Signed out from Cursor CLI"
         showCursorTraceDump = false
+        showAlert = true
+        onAPIKeyUpdated?()
+    }
+
+    private func testOMPConnection() {
+        isLoadingOMP = true
+        Task {
+            do {
+                let ok = try await viewModel.testOMPConnection()
+                await MainActor.run {
+                    isLoadingOMP = false
+                    if ok {
+                        alertMessage = "Oh My Pi connected. OMP will use its configured provider and model."
+                        showOMPTraceDump = false
+                    }
+                    showAlert = true
+                    onAPIKeyUpdated?()
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingOMP = false
+                    alertMessage = viewModel.ompError ?? error.asFriendlyString()
+                    showOMPTraceDump = viewModel.hasOMPTrace()
+                    showAlert = true
+                }
+            }
+        }
+    }
+
+    private func dumpOMPTrace() {
+        do {
+            let url = try viewModel.dumpOMPTrace()
+            alertMessage = "Trace saved to Downloads/\(url.lastPathComponent)."
+        } catch let error as CLIProcessLogCollectorError {
+            switch error {
+            case .noEntries:
+                alertMessage = "No trace data is available to export yet."
+            case .downloadsDirectoryUnavailable:
+                alertMessage = "Unable to locate the Downloads folder."
+            }
+        } catch {
+            alertMessage = "Failed to export trace: \(error.localizedDescription)"
+        }
+        showOMPTraceDump = false
+        showAlert = true
+    }
+
+    private func disconnectOMP() {
+        viewModel.disconnectOMP()
+        alertMessage = "Disconnected Oh My Pi"
+        showOMPTraceDump = false
         showAlert = true
         onAPIKeyUpdated?()
     }

--- a/Sources/RepoPrompt/Features/Settings/Views/OptimizedModelPicker.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/OptimizedModelPicker.swift
@@ -162,6 +162,20 @@ struct OptimizedModelPicker: View {
                     modelButton(option.model, title: option.displayName)
                 }
             }
+        } else if provider == .omp {
+            ForEach(AIModel.ompMenuGroups(for: models)) { group in
+                if let displayName = group.displayName {
+                    Menu(displayName) {
+                        ForEach(group.models, id: \.rawValue) { model in
+                            modelButton(model)
+                        }
+                    }
+                } else {
+                    ForEach(group.models, id: \.rawValue) { model in
+                        modelButton(model)
+                    }
+                }
+            }
         } else if provider == .openCode {
             ForEach(AIModel.openCodeMenu(for: models).providerGroups) { providerGroup in
                 if providerGroup.rendersAsSubmenu {

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentProviderFactory.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentProviderFactory.swift
@@ -33,6 +33,12 @@ enum ACPAgentProviderFactory {
                     modelString: modelString
                 )
             )
+        case .omp:
+            OMPACPAgentProvider(
+                config: OMPAgentConfig(
+                    enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging
+                )
+            )
         case .grokBuild:
             try await GrokBuildACPAgentProvider(
                 config: GrokBuildAgentConfig(

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -725,6 +725,8 @@ actor ACPAgentSessionController {
         }
 
         switch provider.providerID {
+        case .omp:
+            return
         case .openCode, .cursor, .grokBuild, .antigravity:
             if let sessionModelFailureReason {
                 throw ControllerError.protocolViolation("malformed modern model config option: \(sessionModelFailureReason)")
@@ -2302,7 +2304,9 @@ actor ACPAgentSessionController {
         if error is ExecutableFileIdentityError {
             return "executable_identity"
         }
-        if error is CursorACPLaunchResolutionError || error is OpenCodeACPLaunchResolutionError {
+        if error is CursorACPLaunchResolutionError || error is OpenCodeACPLaunchResolutionError
+            || error is OMPACPLaunchResolutionError
+        {
             return "launch_resolution"
         }
         if error is CLIProcessRunnerError {
@@ -3259,7 +3263,7 @@ actor ACPAgentSessionController {
 
     private func preferredAllowOptionID(for options: [PermissionOption], sessionScoped: Bool) -> String {
         let preferences: [PermissionOptionPreference] = switch provider.providerID {
-        case .openCode, .cursor, .antigravity:
+        case .openCode, .cursor, .antigravity, .omp:
             genericAllowOptionPreferences(sessionScoped: sessionScoped)
         case .grokBuild:
             grokBuildAllowOptionPreferences(sessionScoped: sessionScoped)
@@ -3310,7 +3314,7 @@ actor ACPAgentSessionController {
         switch provider.providerID {
         case .cursor:
             return optionID(for: options, preferences: genericAllowOptionPreferences(sessionScoped: true))
-        case .openCode, .grokBuild, .antigravity:
+        case .openCode, .grokBuild, .antigravity, .omp:
             // Grok full access is provider-native (`grok agent --always-approve stdio`); the
             // controller never auto-selects permission options for it.
             return nil
@@ -3364,9 +3368,9 @@ actor ACPAgentSessionController {
                 .optionID("allow_once"),
                 .kind("allow_once")
             ]
-        case .grokBuild:
-            // Strict RepoPrompt MCP auto-approval is per-request: never select Grok's
-            // session-scoped `allow-edits-session` here.
+        case .grokBuild, .omp:
+            // Strict RepoPrompt MCP auto-approval is per-request: never select a provider-wide
+            // or session-scoped option here.
             [
                 .optionID("allow-once"),
                 .optionID("once"),
@@ -3569,6 +3573,8 @@ actor ACPAgentSessionController {
                 "RP_GROK_BUILD_ACP_RAW_CAPTURE_PATH"
             case .antigravity:
                 "RP_ANTIGRAVITY_ACP_RAW_CAPTURE_PATH"
+            case .omp:
+                "RP_OMP_ACP_RAW_CAPTURE_PATH"
             }
             let customPath = providerSpecificKey.flatMap { key in
                 env[key]?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -725,9 +725,7 @@ actor ACPAgentSessionController {
         }
 
         switch provider.providerID {
-        case .omp:
-            return
-        case .openCode, .cursor, .grokBuild, .antigravity:
+        case .openCode, .cursor, .grokBuild, .antigravity, .omp:
             if let sessionModelFailureReason {
                 throw ControllerError.protocolViolation("malformed modern model config option: \(sessionModelFailureReason)")
             }

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPProviderSupport.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPProviderSupport.swift
@@ -629,7 +629,7 @@ enum ACPPermissionOptionPolicy {
     /// bare kind match would otherwise select it and broaden approval beyond the request.
     static func denylistedAutoSelectOptionIDs(for providerID: ACPProviderID) -> Set<String> {
         switch providerID {
-        case .openCode, .cursor, .antigravity:
+        case .openCode, .cursor, .antigravity, .omp:
             []
         case .grokBuild:
             ["enable-always-approve"]

--- a/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
@@ -180,6 +180,7 @@ public enum AIModel: Equatable, Hashable {
     case openCodeCustom(name: String)
     case cursorCustom(name: String)
     case grokBuildCustom(name: String)
+    case ompCustom(name: String)
 
     // Custom Provider Models
     case customProvider(name: String, provider: String, model: String)
@@ -539,6 +540,8 @@ public enum AIModel: Equatable, Hashable {
             return "cursor_custom_\(n)"
         case let .grokBuildCustom(n):
             return "grokbuild_custom_\(n)"
+        case let .ompCustom(n):
+            return "omp_custom_\(n)"
         case let .customProvider(_, _, model):
             return "custom_provider_\(model)"
         case let .customProviderUser(name):
@@ -609,6 +612,9 @@ public enum AIModel: Equatable, Hashable {
         if case let .grokBuildCustom(n) = self {
             return ACPAIModelCatalog.grokBuildModelOption(for: n)?.displayName ?? n
         }
+        if case let .ompCustom(n) = self {
+            return ACPAIModelCatalog.ompModelOption(for: n)?.displayName ?? n
+        }
         if case let .customProviderUser(name) = self { return "Custom/\(name)" }
         if case .ollama = self {
             return "local/" + modelName
@@ -638,6 +644,7 @@ public enum AIModel: Equatable, Hashable {
         case .openCode: OpenCodeCLIProvider.self
         case .cursor: CursorCLIProvider.self
         case .grokBuild: GrokBuildCLIProvider.self
+        case .omp: OMPCLIProvider.self
         }
     }
 
@@ -667,6 +674,7 @@ public enum AIModel: Equatable, Hashable {
         case .openCodeCustom: return .openCode
         case .cursorCustom: return .cursor
         case .grokBuildCustom: return .grokBuild
+        case .ompCustom: return .omp
         case .customProviderUser: return .customProvider
         // or, if you prefer the old modelGroups approach:
         default:
@@ -722,7 +730,8 @@ public enum AIModel: Equatable, Hashable {
              let .codexCustom(n),
              let .openCodeCustom(n),
              let .cursorCustom(n),
-             let .grokBuildCustom(n):
+             let .grokBuildCustom(n),
+             let .ompCustom(n):
             return n
         case let .customProviderUser(name):
             return name
@@ -1163,7 +1172,7 @@ public enum AIModel: Equatable, Hashable {
             return SwiftOpenAI.Model.custom(modelName)
         case .anthropic:
             return SwiftAnthropic.Model.other(modelName)
-        case .azure, .openRouter, .customProvider, .claudeCode, .codex, .openCode, .cursor, .grokBuild:
+        case .azure, .openRouter, .customProvider, .claudeCode, .codex, .openCode, .cursor, .grokBuild, .omp:
             // For these providers, use the actual model name when available
             if let modelInfo = Self.modelDefinitions.first(where: { $0.model == self }),
                let actualName = modelInfo.actualName
@@ -1257,6 +1266,9 @@ public enum AIModel: Equatable, Hashable {
         }
         if normalizedRawValue.hasPrefix("grokbuild_custom_") {
             return .grokBuildCustom(name: String(normalizedRawValue.dropFirst("grokbuild_custom_".count)))
+        }
+        if normalizedRawValue.hasPrefix("omp_custom_") {
+            return .ompCustom(name: String(normalizedRawValue.dropFirst("omp_custom_".count)))
         }
 
         if normalizedRawValue.hasPrefix("openai_custom_reasoning_") {
@@ -1372,6 +1384,8 @@ public enum AIModel: Equatable, Hashable {
             models = ACPAIModelCatalog.cursorModelsFromStore()
         case .grokBuild:
             models = ACPAIModelCatalog.grokBuildModelsFromStore()
+        case .omp:
+            models = ACPAIModelCatalog.ompModelsFromStore()
         }
 
         // Filter out models that are not yet available based on their release date
@@ -1423,6 +1437,12 @@ public enum AIModel: Equatable, Hashable {
     struct OpenCodePickerMenu: Hashable {
         let providerGroups: [OpenCodePickerProviderMenuGroup]
         let groups: [OpenCodePickerMenuGroup]
+    }
+
+    struct ACPPickerMenuGroup: Identifiable, Hashable {
+        let id: String
+        let displayName: String?
+        let models: [AIModel]
     }
 
     struct ClaudeCodePickerMenuOption: Identifiable, Hashable {
@@ -1559,6 +1579,27 @@ public enum AIModel: Equatable, Hashable {
 
     static func openCodeMenuGroups(for models: [AIModel]) -> [OpenCodePickerMenuGroup] {
         openCodeMenu(for: models).groups
+    }
+
+    static func ompMenuGroups(for models: [AIModel]) -> [ACPPickerMenuGroup] {
+        let modelsByRaw = Dictionary(
+            models
+                .filter { $0.providerType == .omp }
+                .map { ($0.modelName.lowercased(), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let options = ACPAIModelCatalog.ompModelOptionsFromStore().filter {
+            modelsByRaw[$0.rawValue.lowercased()] != nil
+        }
+        return AgentModelCatalog.ompModelGroups(for: options).compactMap { group in
+            let groupedModels = group.options.compactMap { modelsByRaw[$0.rawValue.lowercased()] }
+            guard !groupedModels.isEmpty else { return nil }
+            return ACPPickerMenuGroup(
+                id: group.id,
+                displayName: group.providerID,
+                models: groupedModels
+            )
+        }
     }
 
     static func codexMenuGroups(for models: [AIModel]) -> [CodexPickerMenuGroup] {
@@ -1981,6 +2022,7 @@ public enum AIModel: Equatable, Hashable {
         case openCodeCustom(name: String)
         case cursorCustom(name: String)
         case grokBuildCustom(name: String)
+        case ompCustom(name: String)
         case customProvider(name: String, provider: String, model: String)
         case customProviderUser(name: String)
         case claudeCodeModel(normalizedSpecifier: String)
@@ -2137,6 +2179,8 @@ public enum AIModel: Equatable, Hashable {
             .cursorCustom(name: name)
         case let .grokBuildCustom(name):
             .grokBuildCustom(name: name)
+        case let .ompCustom(name):
+            .ompCustom(name: name)
         case let .customProvider(name, provider, model):
             .customProvider(name: name, provider: provider, model: model)
         case let .customProviderUser(name):

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ACPAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ACPAIModelCatalog.swift
@@ -377,6 +377,10 @@ enum ACPAIModelCatalog {
         grokBuildModelOptionsFromStore().map { .grokBuildCustom(name: $0.rawValue) }
     }
 
+    static func ompModelsFromStore() -> [AIModel] {
+        ompModelOptionsFromStore().map { .ompCustom(name: $0.rawValue) }
+    }
+
     static func openCodeModelOption(for rawValue: String) -> AgentModelOption? {
         let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else { return nil }
@@ -393,6 +397,10 @@ enum ACPAIModelCatalog {
         guard !normalized.isEmpty else { return nil }
         return grokBuildModelOptionsFromStore()
             .first { $0.rawValue.caseInsensitiveCompare(normalized) == .orderedSame }
+    }
+
+    static func ompModelOption(for rawValue: String) -> AgentModelOption? {
+        modelOption(for: rawValue, in: ompModelOptionsFromStore())
     }
 
     static func normalizedCursorModelAlias(_ value: String) -> String {
@@ -419,5 +427,19 @@ enum ACPAIModelCatalog {
             for: .grokBuild,
             availability: AgentModelCatalog.AvailabilityContext(grokBuildAvailable: true)
         )
+    }
+
+    static func ompModelOptionsFromStore() -> [AgentModelOption] {
+        // Keep AIModel's static paths one-way: registry data only, never AgentModelCatalog.
+        AgentACPModelRegistry.shared.resolvedSnapshot(for: .omp)?.options ?? []
+    }
+
+    private static func modelOption(
+        for rawValue: String,
+        in options: [AgentModelOption]
+    ) -> AgentModelOption? {
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+        return options.first { $0.rawValue.caseInsensitiveCompare(normalized) == .orderedSame }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AIProviderFactory.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AIProviderFactory.swift
@@ -18,7 +18,7 @@ class AIProviderFactory {
         }
 
         // CLI providers don't need API keys - they leverage existing authentication
-        if providerType == .claudeCode || providerType == .codex || providerType == .openCode || providerType == .cursor || providerType == .grokBuild {
+        if providerType == .claudeCode || providerType == .codex || providerType == .openCode || providerType == .cursor || providerType == .grokBuild || providerType == .omp {
             return try await createProvider(
                 for: providerType,
                 key: "",
@@ -89,6 +89,8 @@ class AIProviderFactory {
             return CursorCLIProvider()
         case .grokBuild:
             return GrokBuildCLIProvider()
+        case .omp:
+            return OMPCLIProvider()
         case .customProvider:
             let config = try CustomProviderConfiguration.load()
 
@@ -181,6 +183,7 @@ enum AIProviderType: Codable, Equatable {
     case openCode // OpenCode CLI provider case
     case cursor // Cursor CLI provider case
     case grokBuild // Grok Build CLI provider case
+    case omp // Oh My Pi ACP provider case
 }
 
 extension AIProviderType {
@@ -203,6 +206,7 @@ extension AIProviderType {
         case .openCode: "OpenCode"
         case .cursor: "Cursor CLI"
         case .grokBuild: "Grok Build"
+        case .omp: "OMP"
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/CLIPathHints.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/CLIPathHints.swift
@@ -7,6 +7,7 @@ enum CLIPathHints {
     static let codex: [String] = CLILaunchProfiles.codex.supplementalSearchPaths
     static let openCode: [String] = CLILaunchProfiles.openCodeProviderSpecificPaths
     static let cursor: [String] = CLILaunchProfiles.cursorProviderSpecificPaths
+    static let omp: [String] = CLILaunchProfiles.ompProviderSpecificPaths
     static let grokBuild: [String] = CLILaunchProfiles.grokBuildProviderSpecificPaths
 
     static func nativeDefaultsSupplemented(with providerSpecificPaths: [String]) -> [String] {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPAgentProvider.swift
@@ -5,12 +5,6 @@ struct OMPACPAgentProvider: ACPAgentProvider {
     private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
     private let launchResolver: OMPACPLaunchResolver
 
-    #if DEBUG
-        var test_config: OMPAgentConfig {
-            config
-        }
-    #endif
-
     init(
         config: OMPAgentConfig,
         repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
@@ -58,7 +52,7 @@ struct OMPACPAgentProvider: ACPAgentProvider {
         return try ACPSessionConfiguration(
             mode: mode,
             workingDirectory: standardizedWorkingDirectory(from: request.workspacePath),
-            mcpServers: config.includeRepoPromptMCPServer ? [repoPromptMCPConfiguration] : []
+            mcpServers: [repoPromptMCPConfiguration]
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPAgentProvider.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+struct OMPACPAgentProvider: ACPAgentProvider {
+    private let config: OMPAgentConfig
+    private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
+    private let launchResolver: OMPACPLaunchResolver
+
+    #if DEBUG
+        var test_config: OMPAgentConfig {
+            config
+        }
+    #endif
+
+    init(
+        config: OMPAgentConfig,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        launchResolver: OMPACPLaunchResolver = OMPACPLaunchResolver()
+    ) {
+        self.config = config
+        self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
+        self.launchResolver = launchResolver
+    }
+
+    var providerID: ACPProviderID {
+        .omp
+    }
+
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
+        try await launchResolver.probeSupport(for: config)
+    }
+
+    func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        let workingDirectory = try standardizedWorkingDirectory(from: request.workspacePath)
+        let resolvedLaunch = try launchResolver.resolvedLaunch(for: config)
+        return ACPLaunchConfiguration(
+            providerID: providerID,
+            command: resolvedLaunch.command,
+            arguments: resolvedLaunch.arguments,
+            environment: [:],
+            workingDirectory: workingDirectory,
+            additionalPathHints: resolvedLaunch.additionalPathHints,
+            enableDebugLogging: config.enableDebugLogging,
+            expectedExecutableIdentity: resolvedLaunch.executableIdentity
+        )
+    }
+
+    func makeSessionConfiguration(
+        for request: ACPRunRequest,
+        mcpServer _: RepoPromptMCPServerConfiguration
+    ) throws -> ACPSessionConfiguration {
+        let mode: ACPSessionConfiguration.Mode = if let resume = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !resume.isEmpty
+        {
+            .load(existingSessionID: resume)
+        } else {
+            .new
+        }
+        return try ACPSessionConfiguration(
+            mode: mode,
+            workingDirectory: standardizedWorkingDirectory(from: request.workspacePath),
+            mcpServers: config.includeRepoPromptMCPServer ? [repoPromptMCPConfiguration] : []
+        )
+    }
+
+    func buildPromptBlocks(
+        for message: AgentMessage,
+        request: ACPRunRequest
+    ) throws -> [[String: Any]] {
+        let isFollowUp = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+        let systemPrompt = message.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let userMessage = message.userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text: String = if isFollowUp || systemPrompt.isEmpty {
+            userMessage.isEmpty ? message.userMessage : userMessage
+        } else if userMessage.isEmpty {
+            systemPrompt
+        } else {
+            "\(systemPrompt)\n\n\(userMessage)"
+        }
+        return try ACPPromptContentBuilder.blocks(text: text, attachments: request.attachments)
+    }
+
+    func normalizeSessionUpdate(
+        _ payload: [String: Any],
+        sessionID _: String
+    ) -> [NormalizedAgentRuntimeEvent] {
+        ACPDefaultSessionUpdateNormalizer.normalize(payload, providerID: .omp)
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        if error is AIProviderError { return error }
+        if let runnerError = error as? CLIProcessRunnerError,
+           case .commandNotFound = runnerError
+        {
+            return AIProviderError.invalidConfiguration(
+                detail: "Oh My Pi ACP server not found. Install OMP and ensure `omp acp` is available."
+            )
+        }
+        if error is OMPACPLaunchResolutionError || error is ExecutableFileIdentityError {
+            return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
+        }
+        return AIProviderError.apiError(source: error)
+    }
+
+    private func standardizedWorkingDirectory(from workspacePath: String?) throws -> String {
+        if let cwd = workspacePath?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty {
+            return URL(fileURLWithPath: cwd, isDirectory: true).standardizedFileURL.path
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPromptOMPACPPreflight", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL.path
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPHeadlessAgentProvider.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Headless/discovery adapter for the installed Oh My Pi ACP runtime.
+final class OMPACPHeadlessAgentProvider: HeadlessAgentProvider {
+    typealias ProviderFactory = @Sendable (_ config: OMPAgentConfig) -> any ACPAgentProvider
+    typealias ControllerFactory = ACPHeadlessAgentProviderBridge.ControllerFactory
+
+    private let config: OMPAgentConfig
+    private let bridge: ACPHeadlessAgentProviderBridge
+
+    #if DEBUG
+        var test_config: OMPAgentConfig {
+            config
+        }
+    #endif
+
+    init(
+        config: OMPAgentConfig,
+        workspacePath: String? = nil,
+        providerFactory: ProviderFactory? = nil,
+        controllerFactory: @escaping ControllerFactory = { provider, request, diagnosticSink in
+            try ACPAgentSessionController(
+                provider: provider,
+                runRequest: request,
+                diagnosticSink: diagnosticSink
+            )
+        }
+    ) {
+        self.config = config
+        let resolvedProviderFactory = providerFactory ?? { config in
+            OMPACPAgentProvider(config: config)
+        }
+        bridge = ACPHeadlessAgentProviderBridge(
+            providerName: "Oh My Pi",
+            makeProvider: { resolvedProviderFactory(config) },
+            makeRequest: { message, _ in
+                ACPRunRequest(
+                    agentKind: .omp,
+                    modelString: nil,
+                    workspacePath: workspacePath,
+                    resumeSessionID: message.resumeSessionID,
+                    attachments: [],
+                    taskLabelKind: nil
+                )
+            },
+            makeController: controllerFactory,
+            approvalPolicy: .declineUnsupported
+        )
+    }
+
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        try await bridge.streamAgentMessage(message, runID: runID)
+    }
+
+    func dispose() async {
+        await bridge.dispose()
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPHeadlessAgentProvider.swift
@@ -5,7 +5,14 @@ final class OMPACPHeadlessAgentProvider: HeadlessAgentProvider {
     typealias ProviderFactory = @Sendable (_ config: OMPAgentConfig) -> any ACPAgentProvider
     typealias ControllerFactory = ACPHeadlessAgentProviderBridge.ControllerFactory
 
+    private let config: OMPAgentConfig
     private let bridge: ACPHeadlessAgentProviderBridge
+
+    #if DEBUG
+        var test_config: OMPAgentConfig {
+            config
+        }
+    #endif
 
     init(
         config: OMPAgentConfig,
@@ -19,6 +26,7 @@ final class OMPACPHeadlessAgentProvider: HeadlessAgentProvider {
             )
         }
     ) {
+        self.config = config
         let resolvedProviderFactory = providerFactory ?? { config in
             OMPACPAgentProvider(config: config)
         }
@@ -28,7 +36,7 @@ final class OMPACPHeadlessAgentProvider: HeadlessAgentProvider {
             makeRequest: { message, _ in
                 ACPRunRequest(
                     agentKind: .omp,
-                    modelString: nil,
+                    modelString: config.modelString,
                     workspacePath: workspacePath,
                     resumeSessionID: message.resumeSessionID,
                     attachments: [],
@@ -36,6 +44,13 @@ final class OMPACPHeadlessAgentProvider: HeadlessAgentProvider {
                 )
             },
             makeController: controllerFactory,
+            beforePrompt: { controller, request in
+                guard let model = request.modelString?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !model.isEmpty,
+                      model.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) != .orderedSame
+                else { return }
+                try await controller.setSessionModel(model)
+            },
             approvalPolicy: .declineUnsupported
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPHeadlessAgentProvider.swift
@@ -5,14 +5,7 @@ final class OMPACPHeadlessAgentProvider: HeadlessAgentProvider {
     typealias ProviderFactory = @Sendable (_ config: OMPAgentConfig) -> any ACPAgentProvider
     typealias ControllerFactory = ACPHeadlessAgentProviderBridge.ControllerFactory
 
-    private let config: OMPAgentConfig
     private let bridge: ACPHeadlessAgentProviderBridge
-
-    #if DEBUG
-        var test_config: OMPAgentConfig {
-            config
-        }
-    #endif
 
     init(
         config: OMPAgentConfig,
@@ -26,7 +19,6 @@ final class OMPACPHeadlessAgentProvider: HeadlessAgentProvider {
             )
         }
     ) {
-        self.config = config
         let resolvedProviderFactory = providerFactory ?? { config in
             OMPACPAgentProvider(config: config)
         }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPLaunchResolver.swift
@@ -1,0 +1,354 @@
+import Foundation
+
+enum OMPACPLaunchCandidate: Equatable {
+    case ompACP
+
+    var command: String {
+        CLILaunchProfiles.omp.commandName
+    }
+
+    var launchArguments: [String] {
+        ["acp"]
+    }
+
+    var helpArguments: [String] {
+        ["acp", "--help"]
+    }
+}
+
+struct OMPACPResolvedLaunch: Equatable {
+    let command: String
+    let arguments: [String]
+    let additionalPathHints: [String]
+    let environment: [String: String]
+    let executableIdentity: ExecutableFileIdentity
+}
+
+enum OMPACPLaunchResolutionError: Error, Equatable, LocalizedError {
+    case missingConfiguredCommand
+    case unsafeConfiguredCommand(String)
+    case exactPathNotFound(String)
+    case noValidLaunchCandidate(String, [String], ShellEnvironmentSource?)
+    case environmentDiscoveryRequired(String)
+    case unsafeApplicationPath(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingConfiguredCommand:
+            "Oh My Pi CLI launch requires an exact `omp` command or absolute path."
+        case let .unsafeConfiguredCommand(command):
+            "Refusing unsafe OMP ACP command `\(command)`. Configure the installed `omp` executable."
+        case let .exactPathNotFound(command):
+            "Oh My Pi CLI was not found as a valid executable regular file for `\(command)`. Install OMP or configure its absolute `omp` path."
+        case let .noValidLaunchCandidate(command, failures, source):
+            AgentCLILaunchDiagnostics.appendFallbackEnvironmentHint(
+                to: "Oh My Pi CLI was not found as a valid executable regular file for `\(command)`. Tried: \(failures.joined(separator: "; "))",
+                source: source
+            )
+        case let .environmentDiscoveryRequired(command):
+            "Oh My Pi CLI path discovery has not completed for `\(command)`. Run the OMP ACP support preflight or configure an absolute `omp` path."
+        case let .unsafeApplicationPath(path):
+            "Refusing OMP ACP executable inside an application bundle: \(path)"
+        }
+    }
+}
+
+final class OMPACPLaunchResolver: @unchecked Sendable {
+    typealias EnvironmentProvider = @Sendable (_ enableDebugLogging: Bool) async -> ACPLaunchEnvironment
+
+    private let environmentProvider: EnvironmentProvider
+    private let probeMutex = AsyncMutex()
+    private let lock = NSLock()
+    private var cachedLaunchByKey: [String: OMPACPResolvedLaunch] = [:]
+
+    convenience init(
+        environmentProvider: @escaping @Sendable (_ enableDebugLogging: Bool) async -> [String: String]
+    ) {
+        self.init(launchEnvironmentProvider: { enableDebugLogging in
+            await ACPLaunchEnvironment(environment: environmentProvider(enableDebugLogging))
+        })
+    }
+
+    init(
+        launchEnvironmentProvider: @escaping EnvironmentProvider = { enableDebugLogging in
+            let result = await ProcessEnvironmentBuilder.build(
+                ProcessEnvironmentRequest(
+                    purpose: .acpAgent(providerID: ACPProviderID.omp.rawValue),
+                    enableDebugLogging: enableDebugLogging
+                )
+            )
+            return ACPLaunchEnvironment(
+                environment: result.environment,
+                shellEnvironmentSource: result.shellEnvironmentSource
+            )
+        }
+    ) {
+        environmentProvider = launchEnvironmentProvider
+    }
+
+    func resolvedLaunch(for config: OMPAgentConfig) throws -> OMPACPResolvedLaunch {
+        let key = cacheKey(for: config)
+        if let cached = cachedLaunch(forKey: key) {
+            do {
+                try cached.executableIdentity.validateForTrustedPathLaunch(atPath: cached.command)
+                return cached
+            } catch {
+                invalidate(key: key)
+                throw error
+            }
+        }
+
+        let launch = try resolveExplicitLaunch(for: config)
+        cache(launch, key: key)
+        return launch
+    }
+
+    func probeSupport(for config: OMPAgentConfig) async throws -> ACPSupportResult {
+        try await probeMutex.withLock { [self] in
+            try await probeSupportSerially(for: config)
+        }
+    }
+
+    private func probeSupportSerially(for config: OMPAgentConfig) async throws -> ACPSupportResult {
+        let key = cacheKey(for: config)
+        invalidate(key: key)
+        do {
+            // Resolve from the current effective environment on every support check. The cache only
+            // bridges this successful probe to the immediately following launch configuration.
+            let launch = try await resolveLaunchForProbe(for: config)
+            let processConfig = CLIProcessConfiguration(
+                command: launch.command,
+                additionalPaths: [],
+                enableDebugLogging: config.enableDebugLogging,
+                shellLookupMode: .fallbackOnly
+            )
+            let result = try await CLIProcessRunner(config: processConfig).run(
+                args: OMPACPLaunchCandidate.ompACP.helpArguments,
+                stdin: nil,
+                outputMode: .none,
+                timeout: 10,
+                cancelChildOnTaskCancellation: true
+            )
+            guard result.status == 0 else {
+                return .unsupported(
+                    reason: "Oh My Pi CLI ACP preflight failed: `omp acp --help` exited with status \(result.status)."
+                )
+            }
+
+            let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            let combined = "\(stdout)\n\(stderr)"
+            guard combined.localizedCaseInsensitiveContains("run oh my pi as an acp"),
+                  combined.localizedCaseInsensitiveContains("server over stdio")
+            else {
+                return .unsupported(
+                    reason: "Oh My Pi CLI ACP preflight failed: `omp acp --help` did not advertise ACP support."
+                )
+            }
+
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
+            cache(launch, key: key)
+            return .supported
+        } catch is CancellationError {
+            invalidate(key: key)
+            throw CancellationError()
+        } catch {
+            invalidate(key: key)
+            return .unsupported(reason: error.localizedDescription)
+        }
+    }
+
+    private func resolveLaunchForProbe(for config: OMPAgentConfig) async throws -> OMPACPResolvedLaunch {
+        let configuredCommand = try validatedConfiguredCommand(config)
+        let launchEnvironment = await environmentProvider(config.enableDebugLogging)
+        let environment = launchEnvironment.environment
+        try Task.checkCancellation()
+        if configuredCommand.contains("/") {
+            return try resolveExplicitLaunch(
+                for: config,
+                environment: environment,
+                shellEnvironmentSource: launchEnvironment.shellEnvironmentSource
+            )
+        }
+
+        let effectiveHints = CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(config.additionalPathHints)
+        return try firstValidLaunch(
+            candidates: launchCandidates(
+                additionalPathHints: effectiveHints,
+                environment: environment
+            ),
+            configuredCommand: configuredCommand,
+            additionalPathHints: effectiveHints,
+            environment: environment,
+            shellEnvironmentSource: launchEnvironment.shellEnvironmentSource
+        )
+    }
+
+    private func resolveExplicitLaunch(
+        for config: OMPAgentConfig,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        shellEnvironmentSource: ShellEnvironmentSource? = nil
+    ) throws -> OMPACPResolvedLaunch {
+        let configuredCommand = try validatedConfiguredCommand(config)
+        guard configuredCommand.contains("/") else {
+            throw OMPACPLaunchResolutionError.environmentDiscoveryRequired(configuredCommand)
+        }
+        let effectiveHints = CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(config.additionalPathHints)
+        do {
+            return try validatedLaunch(
+                entryPath: CommandPathResolver.expandPath(configuredCommand, environment: environment),
+                configuredCommand: configuredCommand,
+                additionalPathHints: effectiveHints,
+                environment: environment
+            )
+        } catch {
+            // Explicit-path failures intentionally keep their specific errors
+            // (exactPathNotFound / unsafeApplicationPath) and omit the
+            // fallback-PATH hint: an exact configured path does not depend on PATH discovery.
+            // Record the same resolution-failure telemetry as other ACP launchers.
+            AgentCLILaunchDiagnostics.recordPathResolutionFailure(
+                providerKind: .omp,
+                shellEnvironmentSource: shellEnvironmentSource,
+                candidateCount: 1
+            )
+            throw error
+        }
+    }
+
+    private func validatedConfiguredCommand(_ config: OMPAgentConfig) throws -> String {
+        let configuredCommand = config.commandName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !configuredCommand.isEmpty else {
+            throw OMPACPLaunchResolutionError.missingConfiguredCommand
+        }
+        let expectedCommand = OMPACPLaunchCandidate.ompACP.command
+        if configuredCommand.contains("/") {
+            guard (configuredCommand as NSString).lastPathComponent.caseInsensitiveCompare(expectedCommand) == .orderedSame else {
+                throw OMPACPLaunchResolutionError.unsafeConfiguredCommand(configuredCommand)
+            }
+        } else if configuredCommand.caseInsensitiveCompare(expectedCommand) != .orderedSame {
+            throw OMPACPLaunchResolutionError.unsafeConfiguredCommand(configuredCommand)
+        }
+        return configuredCommand
+    }
+
+    private func validatedLaunch(
+        entryPath: String,
+        configuredCommand: String,
+        additionalPathHints: [String],
+        environment: [String: String],
+        preserveValidationError: Bool = false
+    ) throws -> OMPACPResolvedLaunch {
+        guard entryPath.hasPrefix("/"),
+              (entryPath as NSString).lastPathComponent.caseInsensitiveCompare(OMPACPLaunchCandidate.ompACP.command) == .orderedSame
+        else {
+            throw OMPACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+
+        let identity: ExecutableFileIdentity
+        do {
+            identity = try ExecutableFileIdentity.captureForTrustedPathLaunch(atPath: entryPath)
+        } catch {
+            if preserveValidationError { throw error }
+            throw OMPACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+
+        if identity.canonicalPath.split(separator: "/").contains(where: { $0.lowercased().hasSuffix(".app") }) {
+            throw OMPACPLaunchResolutionError.unsafeApplicationPath(identity.canonicalPath)
+        }
+        return OMPACPResolvedLaunch(
+            command: identity.canonicalPath,
+            arguments: OMPACPLaunchCandidate.ompACP.launchArguments,
+            additionalPathHints: additionalPathHints,
+            environment: environment,
+            executableIdentity: identity
+        )
+    }
+
+    private func launchCandidates(
+        additionalPathHints: [String],
+        environment: [String: String]
+    ) -> [String] {
+        var candidates: [String] = []
+        var seen = Set<String>()
+
+        func append(_ candidate: String) {
+            let expanded = CommandPathResolver.expandPath(candidate, environment: environment)
+            guard !expanded.isEmpty,
+                  expanded.hasPrefix("/"),
+                  seen.insert(expanded).inserted
+            else { return }
+            candidates.append(expanded)
+        }
+
+        append(
+            CommandPathResolver.resolve(
+                OMPACPLaunchCandidate.ompACP.command,
+                environment: environment,
+                additionalPaths: additionalPathHints,
+                preferredBasenames: CLILaunchProfiles.omp.preferredBasenames,
+                shellLookupMode: .fallbackOnly
+            )
+        )
+        for directory in CommandPathResolver.mergedPathComponents(
+            environment: environment,
+            additionalPaths: additionalPathHints
+        ) {
+            append((directory as NSString).appendingPathComponent(OMPACPLaunchCandidate.ompACP.command))
+        }
+        return candidates
+    }
+
+    private func firstValidLaunch(
+        candidates: [String],
+        configuredCommand: String,
+        additionalPathHints: [String],
+        environment: [String: String],
+        shellEnvironmentSource: ShellEnvironmentSource?
+    ) throws -> OMPACPResolvedLaunch {
+        var failures: [String] = []
+        for candidate in candidates {
+            do {
+                return try validatedLaunch(
+                    entryPath: candidate,
+                    configuredCommand: configuredCommand,
+                    additionalPathHints: additionalPathHints,
+                    environment: environment,
+                    preserveValidationError: true
+                )
+            } catch {
+                failures.append("\(candidate): \(error.localizedDescription)")
+            }
+        }
+        if failures.isEmpty {
+            throw OMPACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+        AgentCLILaunchDiagnostics.recordPathResolutionFailure(
+            providerKind: .omp,
+            shellEnvironmentSource: shellEnvironmentSource,
+            candidateCount: candidates.count
+        )
+        throw OMPACPLaunchResolutionError.noValidLaunchCandidate(configuredCommand, failures, shellEnvironmentSource)
+    }
+
+    private func cachedLaunch(forKey key: String) -> OMPACPResolvedLaunch? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedLaunchByKey[key]
+    }
+
+    private func cache(_ launch: OMPACPResolvedLaunch, key: String) {
+        lock.lock()
+        cachedLaunchByKey[key] = launch
+        lock.unlock()
+    }
+
+    private func invalidate(key: String) {
+        lock.lock()
+        cachedLaunchByKey.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    private func cacheKey(for config: OMPAgentConfig) -> String {
+        ([config.commandName] + config.additionalPathHints).joined(separator: "\u{1F}")
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPLaunchResolver.swift
@@ -20,7 +20,6 @@ struct OMPACPResolvedLaunch: Equatable {
     let command: String
     let arguments: [String]
     let additionalPathHints: [String]
-    let environment: [String: String]
     let executableIdentity: ExecutableFileIdentity
 }
 
@@ -179,7 +178,6 @@ final class OMPACPLaunchResolver: @unchecked Sendable {
             ),
             configuredCommand: configuredCommand,
             additionalPathHints: effectiveHints,
-            environment: environment,
             shellEnvironmentSource: launchEnvironment.shellEnvironmentSource
         )
     }
@@ -198,8 +196,7 @@ final class OMPACPLaunchResolver: @unchecked Sendable {
             return try validatedLaunch(
                 entryPath: CommandPathResolver.expandPath(configuredCommand, environment: environment),
                 configuredCommand: configuredCommand,
-                additionalPathHints: effectiveHints,
-                environment: environment
+                additionalPathHints: effectiveHints
             )
         } catch {
             // Explicit-path failures intentionally keep their specific errors
@@ -235,7 +232,6 @@ final class OMPACPLaunchResolver: @unchecked Sendable {
         entryPath: String,
         configuredCommand: String,
         additionalPathHints: [String],
-        environment: [String: String],
         preserveValidationError: Bool = false
     ) throws -> OMPACPResolvedLaunch {
         guard entryPath.hasPrefix("/"),
@@ -259,7 +255,6 @@ final class OMPACPLaunchResolver: @unchecked Sendable {
             command: identity.canonicalPath,
             arguments: OMPACPLaunchCandidate.ompACP.launchArguments,
             additionalPathHints: additionalPathHints,
-            environment: environment,
             executableIdentity: identity
         )
     }
@@ -302,7 +297,6 @@ final class OMPACPLaunchResolver: @unchecked Sendable {
         candidates: [String],
         configuredCommand: String,
         additionalPathHints: [String],
-        environment: [String: String],
         shellEnvironmentSource: ShellEnvironmentSource?
     ) throws -> OMPACPResolvedLaunch {
         var failures: [String] = []
@@ -312,7 +306,6 @@ final class OMPACPLaunchResolver: @unchecked Sendable {
                     entryPath: candidate,
                     configuredCommand: configuredCommand,
                     additionalPathHints: additionalPathHints,
-                    environment: environment,
                     preserveValidationError: true
                 )
             } catch {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentConfig.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentConfig.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct OMPAgentConfig {
+    let commandName: String
+    let additionalPathHints: [String]
+    let enableDebugLogging: Bool
+    let includeRepoPromptMCPServer: Bool
+
+    init(
+        commandName: String = "omp",
+        additionalPathHints: [String] = CLIPathHints.omp,
+        enableDebugLogging: Bool = false,
+        includeRepoPromptMCPServer: Bool = true
+    ) {
+        self.commandName = commandName
+        self.additionalPathHints = additionalPathHints
+        self.enableDebugLogging = enableDebugLogging
+        self.includeRepoPromptMCPServer = includeRepoPromptMCPServer
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentConfig.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentConfig.swift
@@ -4,14 +4,17 @@ struct OMPAgentConfig {
     let commandName: String
     let additionalPathHints: [String]
     let enableDebugLogging: Bool
+    let modelString: String?
 
     init(
         commandName: String = "omp",
         additionalPathHints: [String] = CLIPathHints.omp,
-        enableDebugLogging: Bool = false
+        enableDebugLogging: Bool = false,
+        modelString: String? = nil
     ) {
         self.commandName = commandName
         self.additionalPathHints = additionalPathHints
         self.enableDebugLogging = enableDebugLogging
+        self.modelString = modelString
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentConfig.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentConfig.swift
@@ -4,17 +4,14 @@ struct OMPAgentConfig {
     let commandName: String
     let additionalPathHints: [String]
     let enableDebugLogging: Bool
-    let includeRepoPromptMCPServer: Bool
 
     init(
         commandName: String = "omp",
         additionalPathHints: [String] = CLIPathHints.omp,
-        enableDebugLogging: Bool = false,
-        includeRepoPromptMCPServer: Bool = true
+        enableDebugLogging: Bool = false
     ) {
         self.commandName = commandName
         self.additionalPathHints = additionalPathHints
         self.enableDebugLogging = enableDebugLogging
-        self.includeRepoPromptMCPServer = includeRepoPromptMCPServer
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentToolPreferences.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentToolPreferences.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+enum OMPAgentToolPreferences {
+    enum PermissionLevel: String, CaseIterable {
+        case providerManaged
+        case plan
+
+        var displayName: String {
+            switch self {
+            case .providerManaged: "Default"
+            case .plan: "Plan"
+            }
+        }
+
+        var detailText: String {
+            switch self {
+            case .providerManaged:
+                "Uses OMP's default ACP session mode. OMP controls its internal tools; RepoPrompt policy applies only to RepoPrompt MCP tools."
+            case .plan:
+                "Requests OMP's read-only Plan session mode. OMP still controls its internal tools; RepoPrompt policy applies only to RepoPrompt MCP tools."
+            }
+        }
+
+        var iconName: String {
+            switch self {
+            case .providerManaged: "shield"
+            case .plan: "doc.text.magnifyingglass"
+            }
+        }
+
+        var sessionModeID: String {
+            switch self {
+            case .providerManaged: "default"
+            case .plan: "plan"
+            }
+        }
+
+        static func from(rawValue: String?) -> PermissionLevel {
+            guard let rawValue else { return .providerManaged }
+            return PermissionLevel(rawValue: rawValue.trimmingCharacters(in: .whitespacesAndNewlines))
+                ?? .providerManaged
+        }
+    }
+
+    private static let permissionLevelKey = "ompACPSessionMode"
+
+    static func permissionLevel(defaults: UserDefaults = .standard) -> PermissionLevel {
+        PermissionLevel.from(rawValue: defaults.string(forKey: permissionLevelKey))
+    }
+
+    static func setPermissionLevel(
+        _ level: PermissionLevel,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(level.rawValue, forKey: permissionLevelKey)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPCLIProvider.swift
@@ -1,23 +1,27 @@
 import Foundation
 
-/// OpenCode CLI provider for non-agent use (chat, Oracle, AI queries) backed by ACP.
-/// Runs a fresh prompt-only-style ACP session per request while preserving OpenCode's raw model IDs.
-final class OpenCodeCLIProvider: AIProvider {
-    private let activeProviders = ActiveACPCLIProviderStore<OpenCodeACPHeadlessAgentProvider>()
+/// Oh My Pi provider for non-agent use (chat, Oracle, AI queries) backed by ACP.
+/// Runs a fresh ACP session per request while preserving OMP's advertised model IDs.
+final class OMPCLIProvider: AIProvider {
+    private let activeProviders = ActiveACPCLIProviderStore<OMPACPHeadlessAgentProvider>()
 
     #if DEBUG
-        static func test_makeHeadlessConfig(modelName: String?) -> OpenCodeAgentConfig {
+        static func test_makeHeadlessConfig(modelName: String?) -> OMPAgentConfig {
             makeHeadlessConfig(modelName: modelName)
         }
 
         static func test_makeAgentMessage(from aiMessage: AIMessage) -> AgentMessage {
-            OpenCodeCLIProvider().makeAgentMessage(from: aiMessage)
+            OMPCLIProvider().makeAgentMessage(from: aiMessage)
         }
     #endif
 
-    func streamMessage(_ aiMessage: AIMessage, model: AIModel, maxTokens _: Int? = nil) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
-        let provider = OpenCodeACPHeadlessAgentProvider(
-            config: Self.makeHeadlessConfig(modelName: openCodeModelName(for: model)),
+    func streamMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens _: Int? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        let provider = OMPACPHeadlessAgentProvider(
+            config: Self.makeHeadlessConfig(modelName: ompModelName(for: model)),
             workspacePath: nil
         )
         if let replacedProvider = activeProviders.replace(provider) {
@@ -68,7 +72,11 @@ final class OpenCodeCLIProvider: AIProvider {
         }
     }
 
-    func completeMessage(_ aiMessage: AIMessage, model: AIModel, maxTokens: Int? = nil) async throws -> AICompletionResult {
+    func completeMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AICompletionResult {
         let stream = try await streamMessage(aiMessage, model: model, maxTokens: maxTokens)
         var textParts: [String] = []
         var finalContent: String?
@@ -93,7 +101,9 @@ final class OpenCodeCLIProvider: AIProvider {
                 if let value = result.completionTokens { completionTokens = value }
                 if let value = result.cost { cost = value }
             case "error":
-                throw AIProviderError.invalidConfiguration(detail: result.text ?? "OpenCode ACP reported an error")
+                throw AIProviderError.invalidConfiguration(
+                    detail: result.text ?? "Oh My Pi ACP reported an error"
+                )
             default:
                 continue
             }
@@ -101,7 +111,7 @@ final class OpenCodeCLIProvider: AIProvider {
 
         let text = textParts.isEmpty ? (finalContent ?? "") : textParts.joined()
         guard sawMessageStop || !text.isEmpty else {
-            throw AIProviderError.invalidResponse(detail: "OpenCode returned no completion")
+            throw AIProviderError.invalidResponse(detail: "Oh My Pi returned no completion")
         }
 
         return AICompletionResult(
@@ -119,14 +129,10 @@ final class OpenCodeCLIProvider: AIProvider {
         }
     }
 
-    private static func makeHeadlessConfig(modelName: String?) -> OpenCodeAgentConfig {
-        OpenCodeAgentConfig(
-            modelString: modelName,
+    private static func makeHeadlessConfig(modelName: String?) -> OMPAgentConfig {
+        OMPAgentConfig(
             enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
-            includeRepoPromptMCPServer: false,
-            includeManagedConfigOverlay: true,
-            cleanupLegacyPersistentConfig: true,
-            toolProfile: .noTools
+            modelString: modelName
         )
     }
 
@@ -163,59 +169,9 @@ final class OpenCodeCLIProvider: AIProvider {
         return conversation
     }
 
-    private func openCodeModelName(for model: AIModel) -> String? {
-        guard model.providerType == .openCode else { return nil }
+    private func ompModelName(for model: AIModel) -> String? {
+        guard model.providerType == .omp else { return nil }
         let trimmed = model.modelName.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
-    }
-}
-
-final class ActiveACPCLIProviderStore<Provider: AnyObject>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var providers: [ObjectIdentifier: Provider] = [:]
-    private var currentProviderID: ObjectIdentifier?
-
-    func replace(_ provider: Provider) -> Provider? {
-        lock.lock()
-        let providerID = ObjectIdentifier(provider)
-        let previousProvider = currentProviderID.flatMap { providers[$0] }
-        providers[providerID] = provider
-        currentProviderID = providerID
-        lock.unlock()
-        guard let previousProvider,
-              previousProvider !== provider
-        else {
-            return nil
-        }
-        return previousProvider
-    }
-
-    func contains(_ provider: Provider) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-
-        return providers[ObjectIdentifier(provider)] != nil
-    }
-
-    @discardableResult
-    func remove(_ provider: Provider) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let providerID = ObjectIdentifier(provider)
-        let removedProvider = providers.removeValue(forKey: providerID)
-        if currentProviderID == providerID {
-            currentProviderID = nil
-        }
-        return removedProvider != nil
-    }
-
-    func removeAll() -> [Provider] {
-        lock.lock()
-        let currentProviders = Array(providers.values)
-        providers.removeAll()
-        currentProviderID = nil
-        lock.unlock()
-        return currentProviders
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
@@ -1445,6 +1445,7 @@ private enum AppSettingsMCPRegistry {
         case .openCode: "openCode"
         case .cursor: "cursor"
         case .grokBuild: "grokBuild"
+        case .omp: "omp"
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
@@ -1421,6 +1421,8 @@ private enum AppSettingsMCPRegistry {
             .cursor
         case .grokBuild:
             .grokBuild
+        case .omp:
+            nil
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
@@ -569,7 +569,7 @@ enum OracleImageRouteAdmission {
              .openCode,
              .cursor:
             true
-        case .grokBuild:
+        case .grokBuild, .omp:
             false
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Policies/AgentModeMCPToolPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Policies/AgentModeMCPToolPolicy.swift
@@ -48,6 +48,8 @@ enum AgentModeMCPToolPolicy {
             cursorGrantedTools
         case .grokBuild:
             grokBuildGrantedTools
+        case .omp:
+            grantedTools
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
@@ -15,6 +15,7 @@ enum CLILaunchProfiles {
         "~/.opencode/bin"
     ]
     static let cursorProviderSpecificPaths: [String] = []
+    static let ompProviderSpecificPaths: [String] = ["~/.bun/bin"]
 
     /// Official Grok Build installer location (`GROK_BIN_DIR` overrides it, but a custom
     /// value is honored through PATH or an explicitly configured absolute command only).
@@ -64,6 +65,12 @@ enum CLILaunchProfiles {
         commandName: "cursor-agent",
         preferredBasenames: ["cursor-agent"],
         supplementalSearchPaths: nativeDefaultsSupplemented(with: cursorProviderSpecificPaths)
+    )
+
+    static let omp = CLILaunchProfile(
+        commandName: "omp",
+        preferredBasenames: ["omp"],
+        supplementalSearchPaths: providerSpecificPathsSupplementedWithNativeDefaults(ompProviderSpecificPaths)
     )
 
     static let grokBuild = CLILaunchProfile(

--- a/Sources/RepoPrompt/Infrastructure/Security/KeyManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/KeyManager.swift
@@ -19,7 +19,7 @@ actor KeyManager {
             return cached
         }
 
-        let account = provider.secureStorageAccount
+        guard let account = provider.secureStorageAccount else { return nil }
         let keyFromDisk = try await secureService.getAPIKey(for: account, accessMode: accessMode)
 
         if let k = keyFromDisk {
@@ -35,8 +35,8 @@ actor KeyManager {
         for provider: AIProviderType,
         accessMode: KeychainAccessMode = .interactive
     ) throws {
+        guard let account = provider.secureStorageAccount else { return }
         cache[provider] = key
-        let account = provider.secureStorageAccount
         try secureService.saveAPIKey(key, for: account, accessMode: accessMode)
     }
 
@@ -46,14 +46,14 @@ actor KeyManager {
         accessMode: KeychainAccessMode = .interactive
     ) throws {
         cache.removeValue(forKey: provider)
-        let account = provider.secureStorageAccount
+        guard let account = provider.secureStorageAccount else { return }
         try secureService.deleteAPIKey(for: account, accessMode: accessMode)
     }
 }
 
 extension AIProviderType {
     /// Maps each provider to its frozen secure-storage account.
-    var secureStorageAccount: SecureStorageAccount {
+    var secureStorageAccount: SecureStorageAccount? {
         switch self {
         case .anthropic: .anthropicAPI
         case .openAI: .openAIAPI
@@ -71,6 +71,7 @@ extension AIProviderType {
         case .openCode: .openCodeCLIAPI
         case .cursor: .cursorCLIAPI
         case .grokBuild: .grokAPI
+        case .omp: nil
         case .zAI: .zAIAPI
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryModel.swift
@@ -199,6 +199,7 @@ extension SentryTelemetryBootstrap {
         case openCode = "opencode"
         case grokBuild = "grok_build"
         case antigravity
+        case omp
 
         init(agentKind: AgentProviderKind) {
             switch agentKind {
@@ -214,6 +215,8 @@ extension SentryTelemetryBootstrap {
                 self = .grokBuild
             case .antigravity:
                 self = .antigravity
+            case .omp:
+                self = .omp
             case .claudeCodeGLM:
                 self = .claudeCodeGLM
             case .kimiCode:

--- a/Sources/RepoPrompt/Infrastructure/UI/Agent/AgentModelOptionsMenuContent.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Agent/AgentModelOptionsMenuContent.swift
@@ -90,6 +90,20 @@ struct AgentModelOptionsMenuContent: View {
                     modelOptionButton(option)
                 }
             }
+        } else if agentKind == .omp {
+            ForEach(AgentModelCatalog.ompModelGroups(for: options)) { group in
+                if let provider = group.providerID {
+                    Menu(provider) {
+                        ForEach(group.options, id: \.rawValue) { option in
+                            modelOptionButton(option)
+                        }
+                    }
+                } else {
+                    ForEach(group.options, id: \.rawValue) { option in
+                        modelOptionButton(option)
+                    }
+                }
+            }
         } else if agentKind == .openCode {
             ForEach(AgentModelCatalog.openCodeMenu(for: options).providerGroups) { providerGroup in
                 if providerGroup.rendersAsSubmenu {
@@ -224,6 +238,21 @@ enum AgentModelStableMenuItems {
                 selectedModelRaw: selectedModelRaw,
                 onSelect: onSelect
             )
+        }
+        if agentKind == .omp {
+            return AgentModelCatalog.ompModelGroups(for: visibleOptions).flatMap { group -> [StableMenuItem] in
+                let items = group.options.map { option in
+                    modelItem(
+                        option,
+                        agentKind: agentKind,
+                        selectedAgent: selectedAgent,
+                        selectedModelRaw: selectedModelRaw,
+                        onSelect: onSelect
+                    )
+                }
+                guard let provider = group.providerID else { return items }
+                return [.submenu(provider, items: items)]
+            }
         }
         if agentKind == .openCode, groupOpenCode {
             return AgentModelCatalog.openCodeMenu(for: visibleOptions).providerGroups.flatMap { providerGroup -> [StableMenuItem] in

--- a/Tests/RepoPromptTests/AgentMode/AutoRecommendationEngineScopedSettingsTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AutoRecommendationEngineScopedSettingsTests.swift
@@ -173,6 +173,18 @@ final class AutoRecommendationEngineScopedSettingsTests: XCTestCase {
         XCTAssertNil(globalNotification.userInfo?[AgentModelsSettingsNotification.workspaceIDKey])
     }
 
+    func testContextBuilderFallbackNeverImplicitlySelectsOMP() {
+        let onlyOMP = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.omp)
+
+        let selection = AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: nil,
+            persistedModelRaw: nil,
+            availability: onlyOMP
+        )
+
+        XCTAssertNil(selection)
+    }
+
     func testContextBuilderRecommendationWritesTargetWorkspaceProfileOnly() throws {
         let fixture = try makeFixture()
         let workspaceID = UUID()

--- a/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
@@ -109,15 +109,16 @@ final class OMPACPAgentProviderTests: XCTestCase {
         XCTAssertNotNil(provider as? OMPACPAgentProvider)
     }
 
-    func testHeadlessFactoryReturnsOMPProviderWithoutModelConfiguration() {
+    func testHeadlessFactoryCarriesSelectedOMPModel() throws {
         let provider = AgentRuntimeProviderService.shared.makeProvider(
             for: .omp,
-            modelString: "ignored-model"
+            modelString: "openai-codex/gpt-5.6-luna"
         )
-        XCTAssertNotNil(provider as? OMPACPHeadlessAgentProvider)
+        let ompProvider = try XCTUnwrap(provider as? OMPACPHeadlessAgentProvider)
+        XCTAssertEqual(ompProvider.test_config.modelString, "openai-codex/gpt-5.6-luna")
     }
 
-    func testCatalogExposesOnlyProviderManagedDefaultModel() {
+    func testCatalogExposesStickyDefaultAndDiscoveredModels() {
         AgentACPModelRegistry.shared.test_reset(providerID: .omp)
         defer { AgentACPModelRegistry.shared.test_reset(providerID: .omp) }
 
@@ -139,12 +140,12 @@ final class OMPACPAgentProviderTests: XCTestCase {
         let availability = AgentModelCatalog.AvailabilityContext(ompAvailable: true)
         let options = AgentModelCatalog.options(for: .omp, availability: availability)
 
-        XCTAssertEqual(options.map(\.rawValue), [AgentModel.defaultModel.rawValue])
+        XCTAssertEqual(options.map(\.rawValue), [AgentModel.defaultModel.rawValue, "discovered-omp-model"])
         XCTAssertEqual(
             AgentModelCatalog.defaultModelRaw(for: .omp, availability: availability),
             AgentModel.defaultModel.rawValue
         )
-        XCTAssertFalse(
+        XCTAssertTrue(
             AgentModelCatalog.isValid(
                 rawModel: "discovered-omp-model",
                 for: .omp,
@@ -161,6 +162,16 @@ final class OMPACPAgentProviderTests: XCTestCase {
         XCTAssertTrue(AgentModelCatalog.isAgentAvailable(.omp, availability: availability))
     }
 
+    func testCatalogFallsBackToDefaultBeforeOMPDiscovery() {
+        AgentACPModelRegistry.shared.test_reset(providerID: .omp)
+        let availability = AgentModelCatalog.AvailabilityContext(ompAvailable: true)
+
+        XCTAssertEqual(
+            AgentModelCatalog.options(for: .omp, availability: availability).map(\.rawValue),
+            [AgentModel.defaultModel.rawValue]
+        )
+    }
+
     func testTaskLabelsDoNotSelectProviderManagedOMPImplicitly() {
         let onlyOMP = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.omp)
         for label in AgentModelCatalog.taskLabels {
@@ -168,19 +179,73 @@ final class OMPACPAgentProviderTests: XCTestCase {
         }
     }
 
-    func testPermissionBindingIsInformationalAndProviderManaged() {
-        XCTAssertEqual(AgentProviderPermissionLevelID.options(for: .omp), [.omp])
-        XCTAssertEqual(AgentProviderPermissionLevelID.subagentDefault(for: .omp), .omp)
-        XCTAssertEqual(AgentProviderPermissionLevelID.omp.subagentRawValue, "providerManaged")
+    func testSessionModeBindingExposesDefaultAndPlan() {
+        XCTAssertEqual(
+            AgentProviderPermissionLevelID.options(for: .omp),
+            [.omp(.providerManaged), .omp(.plan)]
+        )
+        XCTAssertEqual(AgentProviderPermissionLevelID.subagentDefault(for: .omp), .omp(.providerManaged))
+        XCTAssertEqual(AgentProviderPermissionLevelID.omp(.providerManaged).subagentRawValue, "providerManaged")
+        XCTAssertEqual(AgentProviderPermissionLevelID.omp(.plan).subagentRawValue, "plan")
+        XCTAssertEqual(
+            AgentProviderPermissionLevelID(providerID: .omp, subagentRawValue: "plan"),
+            .omp(.plan)
+        )
         XCTAssertTrue(ACPPermissionOptionPolicy.isAutoSelectable(optionID: "allow-once", for: .omp))
     }
 
     @MainActor
-    func testMCPSafeDefaultsLeaveOMPRuntimePermissionsProviderManaged() {
+    func testMCPSafeDefaultsUseOMPDefaultSessionModeWithoutApprovalChanges() {
         let runtimePermission = AgentProviderPreferenceSnapshotStore()
             .runtimePermission(for: .omp, profile: .mcpSafeDefaults)
 
-        XCTAssertEqual(runtimePermission, AgentProviderRuntimePermissionBinding())
+        XCTAssertEqual(runtimePermission.acpSessionModeID, "default")
+        XCTAssertFalse(runtimePermission.autoApproveAllACPToolPermissions)
+        XCTAssertFalse(runtimePermission.acceptsPendingACPApprovalWhenActivated)
+    }
+
+    @MainActor
+    func testOMPPlanOverrideUsesPlanSessionMode() {
+        let runtimePermission = AgentProviderPreferenceSnapshotStore()
+            .runtimePermission(for: .omp, profile: .providerOverride(.omp(.plan)))
+
+        XCTAssertEqual(runtimePermission.acpSessionModeID, "plan")
+        XCTAssertFalse(runtimePermission.autoApproveAllACPToolPermissions)
+        XCTAssertFalse(runtimePermission.acceptsPendingACPApprovalWhenActivated)
+    }
+
+    @MainActor
+    func testForeignOMPOverrideFallsBackToDefaultSessionMode() {
+        let runtimePermission = AgentProviderPreferenceSnapshotStore()
+            .runtimePermission(for: .omp, profile: .providerOverride(.grokBuild(.fullAccess)))
+
+        XCTAssertEqual(runtimePermission.acpSessionModeID, "default")
+    }
+
+    func testOMPSessionModePreferencePersists() throws {
+        let suiteName = "OMPACPAgentProviderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(OMPAgentToolPreferences.permissionLevel(defaults: defaults), .providerManaged)
+        OMPAgentToolPreferences.setPermissionLevel(.plan, defaults: defaults)
+        XCTAssertEqual(OMPAgentToolPreferences.permissionLevel(defaults: defaults), .plan)
+    }
+
+    @MainActor
+    func testOMPSessionModePreferenceFlowsThroughUserConfiguredBinding() throws {
+        let suiteName = "OMPACPAgentProviderTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = AgentProviderPreferenceSnapshotStore(defaults: defaults)
+
+        store.setPermissionLevel(.omp(.plan))
+
+        XCTAssertEqual(
+            store.runtimePermission(for: .omp, profile: .userConfigured).acpSessionModeID,
+            "plan"
+        )
+        XCTAssertEqual(store.revision(for: .omp), 1)
     }
 
     func testObservedOMPMCPClientIdentityMatchesRoutingHint() {

--- a/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
@@ -1,11 +1,9 @@
 import Foundation
-@testable import RepoPromptApp
+@_spi(TestSupport) @testable import RepoPromptApp
 import XCTest
 
 final class OMPACPAgentProviderTests: XCTestCase {
-    private func makeProvider(
-        includeRepoPromptMCPServer: Bool = true
-    ) throws -> (OMPACPAgentProvider, URL) {
+    private func makeProvider() throws -> (OMPACPAgentProvider, URL) {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("OMPACPAgentProviderTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -15,8 +13,7 @@ final class OMPACPAgentProviderTests: XCTestCase {
         let provider = OMPACPAgentProvider(
             config: OMPAgentConfig(
                 commandName: executable.path,
-                additionalPathHints: [],
-                includeRepoPromptMCPServer: includeRepoPromptMCPServer
+                additionalPathHints: []
             )
         )
         return (provider, directory)
@@ -60,22 +57,25 @@ final class OMPACPAgentProviderTests: XCTestCase {
         XCTAssertEqual(session.mcpServers, [.repoPrompt])
     }
 
-    func testConnectionProbeConfigurationCanDisableMCPInjection() throws {
-        let (provider, directory) = try makeProvider(includeRepoPromptMCPServer: false)
-        let session = try provider.makeSessionConfiguration(
-            for: makeRequest(workspacePath: directory.path),
-            mcpServer: .repoPrompt
-        )
-        XCTAssertTrue(session.mcpServers.isEmpty)
-    }
-
     func testPromptUsesStandardACPTextAndImageBlocks() throws {
         let (provider, directory) = try makeProvider()
+        let imageData = try XCTUnwrap(Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="))
+        let imageURL = directory.appendingPathComponent("pixel.png")
+        try imageData.write(to: imageURL)
         let first = try provider.buildPromptBlocks(
             for: AgentMessage(systemPrompt: "SYS", userMessage: "USER"),
-            request: makeRequest(workspacePath: directory.path)
+            request: makeRequest(
+                workspacePath: directory.path,
+                attachments: [AgentImageAttachment(source: .localFile(path: imageURL.path), title: "pixel.png")]
+            )
         )
-        XCTAssertEqual(first.first?["text"] as? String, "SYS\n\nUSER")
+        XCTAssertEqual(first.count, 2)
+        XCTAssertEqual(first[0]["type"] as? String, "text")
+        XCTAssertEqual(first[0]["text"] as? String, "SYS\n\nUSER")
+        XCTAssertEqual(first[1]["type"] as? String, "image")
+        XCTAssertEqual(first[1]["mimeType"] as? String, "image/png")
+        XCTAssertEqual(first[1]["data"] as? String, imageData.base64EncodedString())
+        XCTAssertEqual(first[1]["uri"] as? String, imageURL.absoluteString)
 
         let followUp = try provider.buildPromptBlocks(
             for: AgentMessage(systemPrompt: "SYS", userMessage: "NEXT"),
@@ -114,15 +114,50 @@ final class OMPACPAgentProviderTests: XCTestCase {
             for: .omp,
             modelString: "ignored-model"
         )
-        let ompProvider = provider as? OMPACPHeadlessAgentProvider
-        XCTAssertNotNil(ompProvider)
-        XCTAssertEqual(ompProvider?.test_config.commandName, "omp")
+        XCTAssertNotNil(provider as? OMPACPHeadlessAgentProvider)
     }
 
     func testCatalogExposesOnlyProviderManagedDefaultModel() {
+        AgentACPModelRegistry.shared.test_reset(providerID: .omp)
+        defer { AgentACPModelRegistry.shared.test_reset(providerID: .omp) }
+
+        XCTAssertTrue(AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [
+                    AgentModelOption(
+                        rawValue: "discovered-omp-model",
+                        displayName: "Discovered OMP Model",
+                        description: nil,
+                        isPlaceholderDefault: false,
+                        isProviderDefault: true
+                    )
+                ],
+                currentModelRaw: "discovered-omp-model"
+            ),
+            for: .omp
+        ))
         let availability = AgentModelCatalog.AvailabilityContext(ompAvailable: true)
         let options = AgentModelCatalog.options(for: .omp, availability: availability)
+
         XCTAssertEqual(options.map(\.rawValue), [AgentModel.defaultModel.rawValue])
+        XCTAssertEqual(
+            AgentModelCatalog.defaultModelRaw(for: .omp, availability: availability),
+            AgentModel.defaultModel.rawValue
+        )
+        XCTAssertFalse(
+            AgentModelCatalog.isValid(
+                rawModel: "discovered-omp-model",
+                for: .omp,
+                availability: availability
+            )
+        )
+        XCTAssertTrue(
+            AgentModelCatalog.isValid(
+                rawModel: AgentModel.defaultModel.rawValue,
+                for: .omp,
+                availability: availability
+            )
+        )
         XCTAssertTrue(AgentModelCatalog.isAgentAvailable(.omp, availability: availability))
     }
 
@@ -138,6 +173,14 @@ final class OMPACPAgentProviderTests: XCTestCase {
         XCTAssertEqual(AgentProviderPermissionLevelID.subagentDefault(for: .omp), .omp)
         XCTAssertEqual(AgentProviderPermissionLevelID.omp.subagentRawValue, "providerManaged")
         XCTAssertTrue(ACPPermissionOptionPolicy.isAutoSelectable(optionID: "allow-once", for: .omp))
+    }
+
+    @MainActor
+    func testMCPSafeDefaultsLeaveOMPRuntimePermissionsProviderManaged() {
+        let runtimePermission = AgentProviderPreferenceSnapshotStore()
+            .runtimePermission(for: .omp, profile: .mcpSafeDefaults)
+
+        XCTAssertEqual(runtimePermission, AgentProviderRuntimePermissionBinding())
     }
 
     func testObservedOMPMCPClientIdentityMatchesRoutingHint() {

--- a/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class OMPACPAgentProviderTests: XCTestCase {
+    private func makeProvider(
+        includeRepoPromptMCPServer: Bool = true
+    ) throws -> (OMPACPAgentProvider, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OMPACPAgentProviderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent("omp")
+        try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        let provider = OMPACPAgentProvider(
+            config: OMPAgentConfig(
+                commandName: executable.path,
+                additionalPathHints: [],
+                includeRepoPromptMCPServer: includeRepoPromptMCPServer
+            )
+        )
+        return (provider, directory)
+    }
+
+    private func makeRequest(
+        workspacePath: String,
+        resumeSessionID: String? = nil,
+        attachments: [AgentImageAttachment] = []
+    ) -> ACPRunRequest {
+        ACPRunRequest(
+            agentKind: .omp,
+            modelString: AgentModel.defaultModel.rawValue,
+            workspacePath: workspacePath,
+            resumeSessionID: resumeSessionID,
+            attachments: attachments,
+            taskLabelKind: nil
+        )
+    }
+
+    func testLaunchUsesInstalledOMPACPWithoutRepoPromptOwnedOverrides() throws {
+        let (provider, directory) = try makeProvider()
+        let launch = try provider.makeLaunchConfiguration(for: makeRequest(workspacePath: directory.path))
+        XCTAssertEqual(launch.providerID, .omp)
+        XCTAssertEqual(launch.arguments, ["acp"])
+        XCTAssertTrue(launch.environment.isEmpty)
+        XCTAssertNil(launch.cleanupArtifact)
+        XCTAssertNotNil(launch.expectedExecutableIdentity)
+    }
+
+    func testSessionConfigurationInjectsRepoPromptMCPAndLoadsTrimmedResumeID() throws {
+        let (provider, directory) = try makeProvider()
+        let session = try provider.makeSessionConfiguration(
+            for: makeRequest(workspacePath: directory.path, resumeSessionID: "  omp-session  "),
+            mcpServer: .repoPrompt
+        )
+        guard case let .load(existingSessionID) = session.mode else {
+            return XCTFail("expected session/load")
+        }
+        XCTAssertEqual(existingSessionID, "omp-session")
+        XCTAssertEqual(session.mcpServers, [.repoPrompt])
+    }
+
+    func testConnectionProbeConfigurationCanDisableMCPInjection() throws {
+        let (provider, directory) = try makeProvider(includeRepoPromptMCPServer: false)
+        let session = try provider.makeSessionConfiguration(
+            for: makeRequest(workspacePath: directory.path),
+            mcpServer: .repoPrompt
+        )
+        XCTAssertTrue(session.mcpServers.isEmpty)
+    }
+
+    func testPromptUsesStandardACPTextAndImageBlocks() throws {
+        let (provider, directory) = try makeProvider()
+        let first = try provider.buildPromptBlocks(
+            for: AgentMessage(systemPrompt: "SYS", userMessage: "USER"),
+            request: makeRequest(workspacePath: directory.path)
+        )
+        XCTAssertEqual(first.first?["text"] as? String, "SYS\n\nUSER")
+
+        let followUp = try provider.buildPromptBlocks(
+            for: AgentMessage(systemPrompt: "SYS", userMessage: "NEXT"),
+            request: makeRequest(workspacePath: directory.path, resumeSessionID: "session")
+        )
+        XCTAssertEqual(followUp.first?["text"] as? String, "NEXT")
+    }
+
+    func testStandardAgentMessageUpdateUsesDefaultNormalizer() throws {
+        let (provider, _) = try makeProvider()
+        let events = provider.normalizeSessionUpdate(
+            ["sessionUpdate": "agent_message_chunk", "content": ["type": "text", "text": "hello"]],
+            sessionID: "session"
+        )
+        guard case let .stream(result) = events.first else {
+            return XCTFail("expected stream event")
+        }
+        XCTAssertEqual(result.text, "hello")
+    }
+
+    func testAuthenticationRemainsOMPManaged() throws {
+        let (provider, _) = try makeProvider()
+        XCTAssertNil(provider.preferredAuthMethodID(context: ACPAuthenticationContext(
+            authMethodIDs: ["agent"],
+            environment: [:]
+        )))
+    }
+
+    func testInteractiveFactoryReturnsOMPProviderWithoutModelConfiguration() async throws {
+        let provider = try await ACPAgentProviderFactory.makeProvider(for: .omp, modelString: "ignored-model")
+        XCTAssertNotNil(provider as? OMPACPAgentProvider)
+    }
+
+    func testHeadlessFactoryReturnsOMPProviderWithoutModelConfiguration() {
+        let provider = AgentRuntimeProviderService.shared.makeProvider(
+            for: .omp,
+            modelString: "ignored-model"
+        )
+        let ompProvider = provider as? OMPACPHeadlessAgentProvider
+        XCTAssertNotNil(ompProvider)
+        XCTAssertEqual(ompProvider?.test_config.commandName, "omp")
+    }
+
+    func testCatalogExposesOnlyProviderManagedDefaultModel() {
+        let availability = AgentModelCatalog.AvailabilityContext(ompAvailable: true)
+        let options = AgentModelCatalog.options(for: .omp, availability: availability)
+        XCTAssertEqual(options.map(\.rawValue), [AgentModel.defaultModel.rawValue])
+        XCTAssertTrue(AgentModelCatalog.isAgentAvailable(.omp, availability: availability))
+    }
+
+    func testTaskLabelsDoNotSelectProviderManagedOMPImplicitly() {
+        let onlyOMP = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.omp)
+        for label in AgentModelCatalog.taskLabels {
+            XCTAssertNil(AgentModelCatalog.resolveTaskLabelKind(label.kind, availability: onlyOMP))
+        }
+    }
+
+    func testPermissionBindingIsInformationalAndProviderManaged() {
+        XCTAssertEqual(AgentProviderPermissionLevelID.options(for: .omp), [.omp])
+        XCTAssertEqual(AgentProviderPermissionLevelID.subagentDefault(for: .omp), .omp)
+        XCTAssertEqual(AgentProviderPermissionLevelID.omp.subagentRawValue, "providerManaged")
+        XCTAssertTrue(ACPPermissionOptionPolicy.isAutoSelectable(optionID: "allow-once", for: .omp))
+    }
+
+    func testObservedOMPMCPClientIdentityMatchesRoutingHint() {
+        XCTAssertEqual(AgentProviderKind.omp.mcpClientNameHint, "omp-coding-agent")
+        XCTAssertTrue(MCPClientIdentity.matches("omp-coding-agent", AgentProviderKind.omp.mcpClientNameHint))
+        XCTAssertTrue(AgentProviderKind.omp.requiresPrePromptAgentModeMCPRouting)
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 @_spi(TestSupport) @testable import RepoPromptApp
 import XCTest
@@ -118,6 +119,18 @@ final class OMPACPAgentProviderTests: XCTestCase {
         XCTAssertEqual(ompProvider.test_config.modelString, "openai-codex/gpt-5.6-luna")
     }
 
+    func testOracleProviderCarriesSelectedOMPModel() async throws {
+        let model = AIModel.ompCustom(name: "openai-codex/gpt-5.6-luna")
+        XCTAssertEqual(
+            OMPCLIProvider.test_makeHeadlessConfig(modelName: model.modelName).modelString,
+            model.modelName
+        )
+        let keyManager = KeyManager(secureService: SecureKeysService(secureStorage: TestSecureStorageBackend()))
+        let provider = try await AIProviderFactory.createProvider(for: .omp, keyManager: keyManager)
+        XCTAssertTrue(provider is OMPCLIProvider)
+        await provider.dispose()
+    }
+
     func testCatalogExposesStickyDefaultAndDiscoveredModels() {
         AgentACPModelRegistry.shared.test_reset(providerID: .omp)
         defer { AgentACPModelRegistry.shared.test_reset(providerID: .omp) }
@@ -206,6 +219,95 @@ final class OMPACPAgentProviderTests: XCTestCase {
             selectedModelRaw: advertised[0].rawValue, includePlaceholderDefault: false, groupOpenCode: false
         ) { _, _ in }
         XCTAssertEqual(withoutDefault.map(\.title), ["openai-codex", "openrouter"])
+    }
+
+    func testOracleCatalogExposesAndGroupsOnlyAdvertisedOMPModels() {
+        AgentACPModelRegistry.shared.test_reset(providerID: .omp)
+        defer { AgentACPModelRegistry.shared.test_reset(providerID: .omp) }
+        let advertised = [
+            AgentModelOption(rawValue: "openai-codex/gpt-fixture", displayName: "GPT Fixture", description: nil, isDefault: false),
+            AgentModelOption(rawValue: "openrouter/vendor/model/high", displayName: "Model High", description: nil, isDefault: false),
+            AgentModelOption(rawValue: "openai-codex/another-model", displayName: "Another Model", description: nil, isDefault: false)
+        ]
+        XCTAssertTrue(AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(options: advertised, currentModelRaw: advertised[0].rawValue),
+            for: .omp
+        ))
+
+        let models = AIModel.modelsForProvider(.omp)
+        XCTAssertEqual(Set(models.map(\.modelName)), Set(advertised.map(\.rawValue)))
+        XCTAssertEqual(AIModel.fromModelName("omp_custom_openai-codex/gpt-fixture"), .ompCustom(name: advertised[0].rawValue))
+        XCTAssertEqual(models.first { $0.modelName == advertised[0].rawValue }?.displayName, "GPT Fixture")
+
+        let groups = AIModel.ompMenuGroups(for: models)
+        XCTAssertEqual(groups.map(\.displayName), ["openai-codex", "openrouter"])
+        XCTAssertEqual(groups.map(\.models.count), [2, 1])
+        XCTAssertEqual(AIModel.ompMenuGroups(for: [models[0], models[0]]).flatMap(\.models).count, 1)
+    }
+
+    @MainActor
+    func testConnectedOMPModelsAppearInOraclePickerCatalog() async {
+        AgentACPModelRegistry.shared.test_reset(providerID: .omp)
+        defer { AgentACPModelRegistry.shared.test_reset(providerID: .omp) }
+        let model = AgentModelOption(
+            rawValue: "openai-codex/gpt-fixture",
+            displayName: "GPT Fixture",
+            description: nil,
+            isDefault: true
+        )
+        XCTAssertTrue(AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(options: [model], currentModelRaw: model.rawValue),
+            for: .omp
+        ))
+        let keyManager = KeyManager(secureService: SecureKeysService(secureStorage: TestSecureStorageBackend()))
+        let viewModel = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        defer { viewModel.prepareForWindowClose() }
+        viewModel.isOMPConnected = true
+
+        await viewModel.updateAvailableModels()
+
+        XCTAssertTrue(viewModel.availableModels.contains(.ompCustom(name: model.rawValue)))
+    }
+
+    @MainActor
+    func testOMPDiscoveryRefreshesAnOpenOraclePickerCatalog() async {
+        AgentACPModelRegistry.shared.test_reset(providerID: .omp)
+        defer { AgentACPModelRegistry.shared.test_reset(providerID: .omp) }
+        let keyManager = KeyManager(secureService: SecureKeysService(secureStorage: TestSecureStorageBackend()))
+        let viewModel = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        defer { viewModel.prepareForWindowClose() }
+        viewModel.isOMPConnected = true
+        await viewModel.updateAvailableModels()
+
+        let model = AgentModelOption(
+            rawValue: "openai-codex/live-model",
+            displayName: "Live Model",
+            description: nil,
+            isDefault: true
+        )
+        let refreshed = expectation(description: "Oracle picker refresh")
+        let cancellable = viewModel.$availableModels
+            .dropFirst()
+            .sink { models in
+                if models.contains(.ompCustom(name: model.rawValue)) {
+                    refreshed.fulfill()
+                }
+            }
+        XCTAssertTrue(AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(options: [model], currentModelRaw: model.rawValue),
+            for: .omp
+        ))
+
+        await fulfillment(of: [refreshed], timeout: 1)
+        cancellable.cancel()
     }
 
     func testTaskLabelsDoNotSelectProviderManagedOMPImplicitly() {

--- a/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OMPACPAgentProviderTests.swift
@@ -172,6 +172,42 @@ final class OMPACPAgentProviderTests: XCTestCase {
         )
     }
 
+    func testModelPickerGroupsOnlyAdvertisedProvidersAndKeepsDefaultAtRoot() {
+        AgentACPModelRegistry.shared.test_reset(providerID: .omp)
+        defer { AgentACPModelRegistry.shared.test_reset(providerID: .omp) }
+        let availability = AgentModelCatalog.AvailabilityContext(ompAvailable: true)
+        let stale = AgentModelOption(rawValue: "unavailable/old-model", displayName: "Old Model", description: nil, isDefault: false)
+        AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(options: [stale], currentModelRaw: stale.rawValue), for: .omp
+        )
+        let advertised = [
+            AgentModelOption(rawValue: "openai-codex/gpt-fixture", displayName: "GPT Fixture", description: nil, isDefault: false),
+            AgentModelOption(rawValue: "openrouter/vendor/model/high", displayName: "Model High", description: nil, isDefault: false),
+            AgentModelOption(rawValue: "openai-codex/another-model", displayName: "Another Model", description: nil, isDefault: false)
+        ]
+        AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(options: advertised, currentModelRaw: stale.rawValue), for: .omp
+        )
+        let options = AgentModelCatalog.options(for: .omp, availability: availability)
+        let items = AgentModelStableMenuItems.modelItems(
+            agentKind: .omp, options: options, selectedAgent: .omp,
+            selectedModelRaw: advertised[0].rawValue
+        ) { _, _ in }
+        XCTAssertEqual(items.map(\.title), ["Default", "openai-codex", "openrouter"])
+        let groups = AgentModelCatalog.ompModelGroups(for: options)
+        XCTAssertEqual(groups.map(\.providerID), [nil, "openai-codex", "openrouter"])
+        XCTAssertEqual(groups[1].options.map(\.rawValue), ["openai-codex/another-model", "openai-codex/gpt-fixture"])
+        XCTAssertEqual(groups[2].options.map(\.rawValue), ["openrouter/vendor/model/high"])
+        XCTAssertEqual(groups[2].options.first?.displayName, "Model High")
+        XCTAssertEqual(Set(options.filter { !$0.isPlaceholderDefault }.map(\.rawValue)), Set(advertised.map(\.rawValue)))
+        XCTAssertFalse(AgentModelCatalog.isValid(rawModel: stale.rawValue, for: .omp, availability: availability))
+        let withoutDefault = AgentModelStableMenuItems.modelItems(
+            agentKind: .omp, options: options, selectedAgent: .omp,
+            selectedModelRaw: advertised[0].rawValue, includePlaceholderDefault: false, groupOpenCode: false
+        ) { _, _ in }
+        XCTAssertEqual(withoutDefault.map(\.title), ["openai-codex", "openrouter"])
+    }
+
     func testTaskLabelsDoNotSelectProviderManagedOMPImplicitly() {
         let onlyOMP = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.omp)
         for label in AgentModelCatalog.taskLabels {

--- a/Tests/RepoPromptTests/AgentMode/OMPACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OMPACPLaunchResolverTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class OMPACPLaunchResolverTests: XCTestCase {
+    func testProviderProfileMatchesInstalledOMPConvention() {
+        XCTAssertEqual(CLILaunchProfiles.omp.commandName, "omp")
+        XCTAssertTrue(CLILaunchProfiles.omp.supplementalSearchPaths.contains("~/.bun/bin"))
+        XCTAssertTrue(CLIPathHints.omp.contains("~/.bun/bin"))
+    }
+
+    func testNonOMPCommandIsRejected() async throws {
+        let resolver = OMPACPLaunchResolver(environmentProvider: { _ in [:] })
+        let support = try await resolver.probeSupport(
+            for: OMPAgentConfig(commandName: "not-omp", additionalPathHints: [])
+        )
+        guard case let .unsupported(reason) = support else {
+            return XCTFail("expected unsupported, got \(support)")
+        }
+        XCTAssertTrue(reason.contains("Refusing unsafe OMP ACP command"))
+    }
+
+    func testSupportProbeRequiresZeroExitStatus() async throws {
+        let directory = try makeTemporaryDirectory()
+        _ = try makeExecutable(named: "omp", in: directory, exitStatus: 3)
+        let resolver = OMPACPLaunchResolver(environmentProvider: { _ in
+            ["PATH": directory.path, "SHELL": "/bin/false"]
+        })
+
+        let support = try await resolver.probeSupport(
+            for: OMPAgentConfig(commandName: "omp", additionalPathHints: [])
+        )
+
+        guard case let .unsupported(reason) = support else {
+            return XCTFail("expected unsupported, got \(support)")
+        }
+        XCTAssertTrue(reason.contains("`omp acp --help` exited with status 3"), "unexpected reason: \(reason)")
+    }
+
+    func testSupportProbeRequiresOMPACKPHelpMarkers() async throws {
+        let directory = try makeTemporaryDirectory()
+        _ = try makeExecutable(named: "omp", in: directory, output: "generic help")
+        let resolver = OMPACPLaunchResolver(environmentProvider: { _ in
+            ["PATH": directory.path, "SHELL": "/bin/false"]
+        })
+
+        let support = try await resolver.probeSupport(
+            for: OMPAgentConfig(commandName: "omp", additionalPathHints: [])
+        )
+
+        guard case let .unsupported(reason) = support else {
+            return XCTFail("expected unsupported, got \(support)")
+        }
+        XCTAssertTrue(reason.contains("did not advertise ACP support"), "unexpected reason: \(reason)")
+    }
+
+    func testBunStyleSymlinkShapeIsAcceptedAndLaunchesACP() async throws {
+        let directory = try makeTemporaryDirectory()
+        let targetDirectory = directory.appendingPathComponent("package", isDirectory: true)
+        try FileManager.default.createDirectory(at: targetDirectory, withIntermediateDirectories: true)
+        let target = try makeExecutable(named: "omp-entry", in: targetDirectory)
+        let binDirectory = directory.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        let symlink = binDirectory.appendingPathComponent("omp")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: target)
+        let resolver = OMPACPLaunchResolver(environmentProvider: { _ in
+            ["PATH": binDirectory.path, "SHELL": "/bin/false"]
+        })
+        let config = OMPAgentConfig(commandName: "omp", additionalPathHints: [])
+
+        let support = try await resolver.probeSupport(for: config)
+        XCTAssertEqual(support, .supported)
+        let launch = try resolver.resolvedLaunch(for: config)
+        XCTAssertEqual(launch.arguments, ["acp"])
+        XCTAssertTrue(launch.command.hasSuffix("omp-entry"), "unexpected command: \(launch.command)")
+        XCTAssertEqual(launch.executableIdentity.canonicalPath, launch.command)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        try makeTestDirectory(name: "OMPACPLaunchResolverTests")
+    }
+
+    @discardableResult
+    private func makeExecutable(
+        named name: String,
+        in directory: URL,
+        output: String = "Run Oh My Pi as an ACP (Agent Client Protocol) server over stdio",
+        exitStatus: Int32 = 0
+    ) throws -> URL {
+        let executable = directory.appendingPathComponent(name)
+        let script = "#!/bin/sh\nprintf '%s\\n' '\(output)'\nexit \(exitStatus)\n"
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return executable
+    }
+}


### PR DESCRIPTION
## Why this provider

RepoPrompt's native Codex Agent Mode is built on the bundled Codex app-server runtime. That path currently has an unresolved image-history failure mode: image-producing tool results can be persisted as large inline base64 payloads, replayed on later turns and compaction requests, and leave the thread permanently returning `{"detail":"Bad Request"}`. The public reports describe both poisoned resume state and the underlying mismatch between low image-token accounting and very large serialized requests:

- [Codex #18629 — inline tool images can poison persisted history and resume](https://github.com/openai/codex/issues/18629)
- [Codex #41338 — an image can be inexpensive in model tokens but several megabytes on the wire](https://github.com/openai/codex/issues/41338)

We reproduced that failure family in RepoPrompt: twelve tool images added about 53 MiB of inline PNG data to a Codex rollout; the next turn failed with HTTP 400, resume failed again, and no compaction had occurred.

OMP provides a useful alternative without changing RepoPrompt's native Codex integration. RepoPrompt launches the installed `omp acp` process and speaks standard ACP JSON-RPC over stdio. OMP's normal `AgentSession`—not Codex app server—owns provider requests, model history, image normalization, persistence, recovery, and compaction. OMP can still use a configured Codex model, but the harness and history boundary are OMP's:

```text
RepoPrompt Agent Mode
  -> standard ACP over stdio
  -> installed OMP AgentSession
  -> OMP-configured provider/model (including Codex)
```

OMP's image path is materially safer for this workload:

- [byte-aware image normalization](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/utils/image-resize.ts) targets 500 KiB and bounded dimensions, trying multiple encodings and quality/dimension fallbacks;
- [provider image budgeting](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/session/provider-image-budget.ts) drops the oldest transient images when a provider's image-count limit would be exceeded;
- [session persistence](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/session/session-persistence.ts) externalizes large image payloads to blob storage instead of repeatedly embedding them in session JSONL.

## What this adds

- installed Oh My Pi (`omp`) 18.0.3 as a standard ACP provider for interactive Agent Mode and headless/delegated runs;
- fail-closed executable discovery and support probing;
- RepoPrompt MCP injection into each OMP ACP session, including Context Builder and Oracle MCP tools;
- OMP-advertised model discovery plus a sticky `Default` choice that leaves provider/model/fallback selection with OMP;
- OMP's advertised `Default` and read-only `Plan` ACP session modes through RepoPrompt's existing generic controls;
- saved-session identity, continuation/resume, cancellation, event normalization, and provider-managed permission presentation through the shared ACP framework.

## OMP engine capabilities retained under ACP

ACP changes the host UI and transport; it does not replace OMP's engine. Because OMP's ACP server creates the same [`AgentSession`](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/session/agent-session.ts) used by its other run modes, engine-owned behavior remains active when driven by RepoPrompt:

- authentication and upstream provider/model configuration;
- provider/model fallback behavior;
- image normalization and provider image limits;
- session persistence, memory, and OMP-native tools;
- automatic recovery and advanced [context compaction](https://github.com/can1357/oh-my-pi/blob/main/docs/compaction.md), including threshold, overflow, incomplete-output, mid-turn, and optional idle maintenance;
- configured compaction methods such as context-full summarization, handoff, local `shake` artifact elision, deterministic `snapcompact`, and provider-native compaction with fallback.

This PR deliberately does not recreate those OMP settings in RepoPrompt. OMP remains their authority, so existing `~/.omp` configuration applies equally when RepoPrompt is the ACP client.

## Scope boundaries

- OMP Agent Mode can call RepoPrompt Context Builder and Oracle through the injected RepoPrompt MCP server. This PR does **not** register OMP as a backend for RepoPrompt's separate Built-in Chat/`AIProvider` pipeline or change ownership of RepoPrompt's Oracle model configuration.
- OMP TUI-specific navigation and configuration UI are not reimplemented in RepoPrompt.
- OMP installation, bundling, updating, authentication UI, model registries, compaction controls, memory controls, and native-tool settings remain out of scope.
- OMP thinking/effort selection, custom event normalization, and new generic ACP UI are not added here.
- Existing poisoned Codex app-server sessions are not repaired; OMP protects new OMP-owned sessions.

## Validation

Automated and build validation:

- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- `make dev-test FILTER=OMPACPAgentProviderTests` — 17 tests passed
- `make dev-test FILTER=ACPIntegratedAgentModeRunnerExecutionTests` — 5 tests passed
- `make dev-test FILTER=AgentRunMCPToolServiceStartDefaultTests` — 5 tests passed
- `make dev-test FILTER=AgentPermissionSecureStoreTests` — 17 tests passed
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `ALLOW_ADHOC_SIGNING=1 make dev-build`
- conductor debug app build/relaunch

Live acceptance used installed `omp/18.0.3` with Codex models and covered:

- first turn and same-thread continuation;
- injected RepoPrompt MCP routing;
- permission request, cancellation, and saved-session reactivation;
- explicit `openai-codex/gpt-5.6-luna` selection, ACP model mutation, a RepoPrompt `get_file_tree` call in a new chat, and a successful `Hi` response;
- installed OMP acceptance of both `Default` and `Plan` session-mode mutations;
- twelve large synthetic PNG tool results followed by both continuation and resume.

In the incident-shaped image test, OMP converted the images to bounded JPEG blobs of about 483 KiB each, kept the final session JSONL around 142 KiB, persisted no inline base64, and continued/resumed successfully.

## Stacked base

Draft targets `rp/agent/b71c239f-agent` (PR #923), so this stacked PR contains only the OMP provider integration commits.