### PR TITLE
Add Claude Fable 5.1 to the Claude Code model catalogs

### DIFF
--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
@@ -234,6 +234,7 @@ public enum ClaudeCompatibleModelCatalog {
     private static let haikuRaw = "haiku"
     private static let sonnetRaw = "sonnet"
     private static let opusRaw = "opus"
+    private static let fable51Raw = "claude-fable-5-1"
     private static let fable5Raw = "claude-fable-5"
     private static let opus1mRaw = "opus[1m]"
     private static let opus5Raw = "claude-opus-5"
@@ -247,6 +248,12 @@ public enum ClaudeCompatibleModelCatalog {
     private static let haiku45Raw = "claude-haiku-4-5"
 
     private static let claudeModels: [StaticModel] = [
+        StaticModel(
+            rawValue: fable51Raw,
+            displayName: "Fable 5.1",
+            description: "Claude Fable 5.1. Anthropic's newest and most capable model for demanding reasoning and long-horizon agentic work.",
+            supportsXHigh: true
+        ),
         StaticModel(
             rawValue: fable5Raw,
             displayName: "Fable 5",

--- a/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
+++ b/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
@@ -167,6 +167,7 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(claude.options.first?.isPlaceholderDefault, true)
         XCTAssertEqual(claude.options.map(\.rawValue), [
             "default",
+            "claude-fable-5-1",
             "claude-fable-5",
             "opus[1m]",
             "opus",

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -80,6 +80,7 @@ enum AgentModel: String, CaseIterable, Codable {
     case claudeOpus1m = "opus[1m]"
 
     // Claude Code full model IDs (static known versions; no dynamic probing)
+    case claudeFable51 = "claude-fable-5-1"
     case claudeFable5 = "claude-fable-5"
     case claudeSonnet5 = "claude-sonnet-5"
     case claudeSonnet46 = "claude-sonnet-4-6"
@@ -153,6 +154,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .claudeOpus: "Opus Latest"
         case .claudeHaiku: "Haiku Latest"
         case .claudeOpus1m: "Opus Latest (1M)"
+        case .claudeFable51: "Fable 5.1"
         case .claudeFable5: "Fable 5"
         case .claudeSonnet5: "Sonnet 5"
         case .claudeSonnet46: "Sonnet 4.6"
@@ -220,6 +222,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .claudeOpus: "Most capable Opus-tier model. Best for open-ended tasks, architecture, and complex reasoning."
         case .claudeHaiku: "Fast and lightweight. Good for exploration, quick edits, and mapping codebases."
         case .claudeOpus1m: "Claude Opus with 1M token context. Best for large codebases and tasks requiring extensive context."
+        case .claudeFable51: "Claude Fable 5.1. Anthropic's newest and most capable model for demanding reasoning and long-horizon agentic work."
         case .claudeFable5: "Claude Fable 5. Anthropic's most capable widely released model for demanding reasoning and long-horizon agentic work."
         case .claudeSonnet5: "Pinned Claude Sonnet 5. Balanced speed and capability with 1M context for everyday engineering."
         case .claudeSonnet46: "Pinned Claude Sonnet 4.6. Balanced speed and capability for everyday engineering."
@@ -290,7 +293,7 @@ enum AgentModel: String, CaseIterable, Codable {
             // latest aliases come first, then pinned full IDs by descending version.
             [
                 .defaultModel,
-                .claudeFable5,
+                .claudeFable51, .claudeFable5,
                 .claudeOpus1m,
                 .claudeOpus, .claudeOpus5, .claudeOpus48, .claudeOpus47, .claudeOpus46, .claudeOpus45,
                 .claudeSonnet, .claudeSonnet5, .claudeSonnet46, .claudeSonnet45,
@@ -569,7 +572,7 @@ enum AgentModel: String, CaseIterable, Codable {
             [.fast, .exploration, .engineering]
         case .gpt56SolHigh:
             [.complex, .engineering, .pair]
-        case .claudeFable5, .claudeOpus5:
+        case .claudeFable51, .claudeFable5, .claudeOpus5:
             [.complex, .engineering, .pair, .extendedContext]
         case .claudeSonnet5:
             [.balanced, .engineering, .extendedContext]
@@ -584,7 +587,7 @@ enum AgentModel: String, CaseIterable, Codable {
     /// Returns `nil` for models where the context window is unknown or unverified.
     var contextWindowTokens: Int? {
         switch self {
-        case .claudeFable5, .claudeSonnet5, .claudeOpus5, .claudeOpus48, .claudeOpus1m, .glm52_1m:
+        case .claudeFable51, .claudeFable5, .claudeSonnet5, .claudeOpus5, .claudeOpus48, .claudeOpus1m, .glm52_1m:
             1_000_000
         case .claudeSonnet, .claudeOpus, .claudeHaiku,
              .claudeSonnet46, .claudeSonnet45,

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -384,6 +384,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
 
     /// Base model raw values (lowercased) that support the XHigh effort tier.
     private static let claudeXHighEligibleBaseRaws: Set<String> = [
+        AgentModel.claudeFable51.rawValue.lowercased(),
         AgentModel.claudeFable5.rawValue.lowercased(),
         AgentModel.claudeSonnet5.rawValue.lowercased(),
         AgentModel.claudeOpus.rawValue.lowercased(),

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
@@ -23,6 +23,7 @@ enum ClaudeCodeAIModelCatalog {
     ]
 
     private static let modelDefinitions: [ModelDefinition] = [
+        ModelDefinition(runtimeModelRaw: "claude-fable-5-1", displayName: "Fable 5.1", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-fable-5", displayName: "Fable 5", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "opus[1m]", displayName: "Opus Latest (1M)", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "opus", displayName: "Opus Latest", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),


### PR DESCRIPTION
## Summary
- Adds `claude-fable-5-1` ("Fable 5.1") next to the existing `claude-fable-5` entries so it is selectable in the Agent Mode picker, Oracle / built-in chat rosters, and MCP role labels.
- Four catalog sites mirrored, no behavior changes elsewhere:
  - `ClaudeCompatibleProviderPlugin.swift` static `claudeModels` (what the Agent Mode picker reads)
  - `AgentModel.swift` enum case, display name, description, ordering, capability tags, 1M context
  - `ClaudeCompatibleModelCatalogAdapter.swift` XHigh eligibility
  - `ClaudeCodeAIModelCatalog.swift` model definition

Closes #931

## Validation
- `make guardrails` ✅
- `make dev-lint` ✅
- Local release build installed and verified: `agent_manage list_agents` lists `claudeCode:claude-fable-5-1:{low|medium|high|xhigh|max}`, and a dual-Oracle request with `claude_code__claude-fable-5-1:xhigh` completed end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)