### PR TITLE
Prefer Grok's direct model parser when configOptions accompany models

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -2497,9 +2497,11 @@ actor ACPAgentSessionController {
     private func applyDiscoveredSessionModels(from response: [String: Any]) {
         let parsed: ACPDiscoveredSessionModels?
         // ponytail: grok CLI >= 1.0.17 sends `configOptions` next to its legacy `models` block;
-        // only the direct provider parser carries Grok's effort wire values, so let it win.
-        let hasDirectModels = provider is ACPDirectSessionModelProvider && response["models"] != nil
-        switch hasDirectModels ? .absent : parseModernModelSnapshot(from: response) {
+        // only the direct provider parser carries Grok's effort wire values, so let it win and
+        // stay on the direct path for later `config_option_update` snapshots that omit `models`.
+        let useDirectParser = provider is ACPDirectSessionModelProvider
+            && (response["models"] != nil || sessionModelDirectSelectionSupported)
+        switch useDirectParser ? .absent : parseModernModelSnapshot(from: response) {
         case let .valid(configID, models):
             sessionModelConfigOptionID = configID
             sessionModelDirectSelectionSupported = false

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -2496,7 +2496,10 @@ actor ACPAgentSessionController {
 
     private func applyDiscoveredSessionModels(from response: [String: Any]) {
         let parsed: ACPDiscoveredSessionModels?
-        switch parseModernModelSnapshot(from: response) {
+        // ponytail: grok CLI >= 1.0.17 sends `configOptions` next to its legacy `models` block;
+        // only the direct provider parser carries Grok's effort wire values, so let it win.
+        let hasDirectModels = provider is ACPDirectSessionModelProvider && response["models"] != nil
+        switch hasDirectModels ? .absent : parseModernModelSnapshot(from: response) {
         case let .valid(configID, models):
             sessionModelConfigOptionID = configID
             sessionModelDirectSelectionSupported = false

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -2495,10 +2495,21 @@ actor ACPAgentSessionController {
     }
 
     private func applyDiscoveredSessionModels(from response: [String: Any]) {
+        // A configOptions-only update carries no replacement for a live direct-model snapshot.
+        // Preserve both its session authority and the provider-owned effort wire state instead
+        // of routing the incomplete response through the direct parser as `.absent`.
+        if provider is ACPDirectSessionModelProvider,
+           response["models"] == nil,
+           sessionModelDirectSelectionSupported,
+           sessionModelSnapshotHasLiveAuthority
+        {
+            return
+        }
+
         let parsed: ACPDiscoveredSessionModels?
         // ponytail: grok CLI >= 1.0.17 sends `configOptions` next to its legacy `models` block;
         // only the direct provider parser carries Grok's effort wire values, so let it win and
-        // stay on the direct path for later `config_option_update` snapshots that omit `models`.
+        // keep the provider on the direct path when no live snapshot has been established yet.
         let useDirectParser = provider is ACPDirectSessionModelProvider
             && (response["models"] != nil || sessionModelDirectSelectionSupported)
         switch useDirectParser ? .absent : parseModernModelSnapshot(from: response) {

--- a/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
@@ -47,7 +47,8 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
     }
 
     /// grok CLI >= 1.0.17 advertises modern `configOptions` alongside the legacy `models`
-    /// block. The direct provider parser must still win so effort variants survive.
+    /// block, and may later push configOptions-only `config_option_update` snapshots. The
+    /// direct provider parser must win and stay in charge so effort variants survive.
     func testConfigOptionsAlongsideModelsKeepsDirectEffortVariants() async throws {
         let harness = try makeHarness(advertiseConfigOptions: true)
         let provider = harness.makeHeadlessProvider(modelString: AgentModel.defaultModel.rawValue)
@@ -198,6 +199,15 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
             elif method == "session/set_model":
                 respond(request_id, {"_meta": {"model": {"Ok": params.get("modelId")}}})
             elif method == "session/prompt":
+                if ADVERTISE_CONFIG_OPTIONS:
+                    # grok may later push a configOptions-only snapshot; it must not demote the direct path.
+                    print(json.dumps({
+                        "jsonrpc": "2.0", "method": "session/update",
+                        "params": {"sessionId": session_id, "update": {
+                            "sessionUpdate": "config_option_update",
+                            "configOptions": [{"id": "model", "category": "model", "type": "select", "currentValue": "grok-4.6",
+                                               "options": [{"value": "grok-4.6", "name": "Grok 4.6"}, {"value": "grok-4.5", "name": "Grok 4.5"}]}]}}
+                    }), flush=True)
                 print(json.dumps({
                     "jsonrpc": "2.0", "method": "session/update",
                     "params": {"sessionId": session_id, "update": {

--- a/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
@@ -46,6 +46,17 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
         XCTAssertTrue(harness.recordedMethods("session/prompt").isEmpty)
     }
 
+    /// grok CLI >= 1.0.17 advertises modern `configOptions` alongside the legacy `models`
+    /// block. The direct provider parser must still win so effort variants survive.
+    func testConfigOptionsAlongsideModelsKeepsDirectEffortVariants() async throws {
+        let harness = try makeHarness(advertiseConfigOptions: true)
+        let provider = harness.makeHeadlessProvider(modelString: AgentModel.defaultModel.rawValue)
+        try await drain(provider, message: "hi")
+        let raws = AgentACPModelRegistry.shared.resolvedSnapshot(for: .grokBuild)?.options.map(\.rawValue) ?? []
+        XCTAssertTrue(raws.contains("grok-4.6-xhigh"), "expected direct effort variants, got \(raws)")
+        XCTAssertTrue(raws.contains("grok-4.6-low"), "expected direct effort variants, got \(raws)")
+    }
+
     func testFullAccessIntentReachesLaunchRequest() {
         let config = GrokBuildAgentConfig(alwaysApproveTools: true)
         let provider = GrokBuildACPHeadlessAgentProvider(config: config)
@@ -120,7 +131,7 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
         await provider.dispose()
     }
 
-    private func makeHarness() throws -> Harness {
+    private func makeHarness(advertiseConfigOptions: Bool = false) throws -> Harness {
         let workspace = try makeTestDirectory(name: "GrokBuildACPHeadlessTests")
         let recordURL = workspace.appendingPathComponent("requests.jsonl")
         let script = #"""
@@ -131,6 +142,7 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
 
         record_path = os.environ.get("ACP_RECORD_PATH")
         session_id = "grok-headless-session"
+        ADVERTISE_CONFIG_OPTIONS = __ADVERTISE_CONFIG_OPTIONS__
 
         if "--help" in sys.argv:
             print("Usage: grok agent [OPTIONS] [COMMAND]\n\nCommands:\n  stdio    Run the agent over stdio")
@@ -166,13 +178,23 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
                     "authMethods": []
                 })
             elif method == "session/new":
-                respond(request_id, {"sessionId": session_id, "models": {
+                result = {"sessionId": session_id, "models": {
                     "currentModelId": "grok-4.6",
                     "availableModels": [
                         {"modelId": "grok-4.6", "name": "Grok 4.6"},
                         {"modelId": "grok-4.5", "name": "Grok 4.5"}
                     ]
-                }})
+                }}
+                if ADVERTISE_CONFIG_OPTIONS:
+                    efforts = [{"id": e, "value": e, "default": e == "high"} for e in ["xhigh", "high", "medium", "low"]]
+                    result["models"]["availableModels"][0]["_meta"] = {
+                        "supportsReasoningEffort": True, "reasoningEffort": "xhigh", "reasoningEfforts": efforts}
+                    result["configOptions"] = [
+                        {"id": "model", "category": "model", "type": "select", "currentValue": "grok-4.6",
+                         "options": [{"value": "grok-4.6", "name": "Grok 4.6"}, {"value": "grok-4.5", "name": "Grok 4.5"}]},
+                        {"id": "reasoning_effort", "category": "thought_level", "type": "select", "currentValue": "xhigh",
+                         "options": [{"value": e} for e in ["xhigh", "high", "medium", "low"]]}]
+                respond(request_id, result)
             elif method == "session/set_model":
                 respond(request_id, {"_meta": {"model": {"Ok": params.get("modelId")}}})
             elif method == "session/prompt":
@@ -185,7 +207,7 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
                 respond(request_id, {"stopReason": "end_turn"})
             elif request_id is not None:
                 respond(request_id, {})
-        """# + "\n"
+        """#.replacingOccurrences(of: "__ADVERTISE_CONFIG_OPTIONS__", with: advertiseConfigOptions ? "True" : "False") + "\n"
         let scriptURL = workspace.appendingPathComponent("grok")
         try script.write(to: scriptURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)

--- a/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/GrokBuildACPHeadlessAgentProviderTests.swift
@@ -58,6 +58,45 @@ final class GrokBuildACPHeadlessAgentProviderTests: XCTestCase {
         XCTAssertTrue(raws.contains("grok-4.6-low"), "expected direct effort variants, got \(raws)")
     }
 
+    func testConfigOptionsOnlyUpdatePreservesLiveDirectEffortSelection() async throws {
+        let harness = try makeHarness(advertiseConfigOptions: true)
+        let config = GrokBuildAgentConfig(
+            commandName: harness.scriptPath,
+            additionalPathHints: [],
+            modelString: "grok-4.6-low",
+            includeRepoPromptMCPServer: false
+        )
+        let provider = EnvForwardingGrokProvider(
+            config: config,
+            extraEnvironment: ["ACP_RECORD_PATH": harness.recordURL.path]
+        )
+        let request = ACPRunRequest(
+            agentKind: .grokBuild,
+            modelString: config.modelString,
+            workspacePath: harness.workspace.path,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request)
+
+        do {
+            _ = try await controller.bootstrap()
+            try await controller.prompt(AgentMessage(userMessage: "hi"), request: request)
+            try await controller.setSessionModel("grok-4.6-low")
+            await controller.shutdown()
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+
+        let setModelCalls = harness.recordedMethods("session/set_model")
+        XCTAssertEqual(setModelCalls.count, 1)
+        XCTAssertEqual(setModelCalls.first?["modelId"] as? String, "grok-4.6")
+        let meta = setModelCalls.first?["_meta"] as? [String: Any]
+        XCTAssertEqual(meta?["reasoningEffort"] as? String, "low")
+    }
+
     func testFullAccessIntentReachesLaunchRequest() {
         let config = GrokBuildAgentConfig(alwaysApproveTools: true)
         let provider = GrokBuildACPHeadlessAgentProvider(config: config)


### PR DESCRIPTION
## Summary
grok CLI **1.0.17** (alpha channel) now returns both the legacy `models` block and a modern `configOptions` array from `session/new`. `ACPAgentSessionController.applyDiscoveredSessionModels` treats `configOptions` as authoritative whenever present, and that parser only reads the `category: "model"` selector. The `ACPDirectSessionModelProvider` path from #825, which is the only one that carries Grok's exact reasoning-effort wire values, was never reached, so `Grok 4.6 Low/Medium/High/XHigh` (and 4.5 Low/Medium/High) disappeared from the Agent Mode picker, `agent_manage list_agents`, and Oracle rosters. The base-only snapshot was then persisted, so it survived restarts.

Fix: when the provider is an `ACPDirectSessionModelProvider` and the response carries `models`, skip the modern parser and fall into the existing direct branch (which already handles valid / absent / malformed). Three-line change, no impact on Cursor / OpenCode / other ACP providers.

Closes #930

## Test
`GrokBuildACPHeadlessAgentProviderTests.testConfigOptionsAlongsideModelsKeepsDirectEffortVariants` extends the fake ACP server to advertise both blocks with `_meta.reasoningEfforts`, then asserts `grok-4.6-xhigh` / `grok-4.6-low` land in the registry.

- Fails on `main` (assertion at lines 56–57), passes with the fix.
- `make dev-test FILTER=GrokBuildACPHeadlessAgentProviderTests` ✅ 5 tests, 0 failures
- `make guardrails` ✅ · `make dev-lint` ✅
- Local release build installed: `list_agents` shows `grokBuild:grok-4.6-{low|medium|high|xhigh}` and `grok-4.5-{low|medium|high}` again with grok 1.0.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)