### PR TITLE
Fix Tip release publication races

### DIFF
--- a/Scripts/publish_tip_release.sh
+++ b/Scripts/publish_tip_release.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # Retry-safe Tip publication. Every remote mutation is reconciled by observing
-# exact release state; protected main and the public P -> T -> S ladder are
-# rechecked immediately before a draft becomes public.
+# exact release state; protected-main ancestry and the public P -> T -> S ladder
+# are rechecked immediately before a draft becomes public.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROLLOUT_TOOL="$SCRIPT_DIR/stable_rollout.py"
@@ -201,8 +201,8 @@ fetch_json_status() {
     printf '%s\n' "$status"
 }
 
-require_live_main() {
-    "$SOURCE_COMMIT_VERIFIER" "$1"
+require_main_lineage() {
+    "$SOURCE_COMMIT_VERIFIER" --allow-ancestor "$1"
 }
 
 LIVE_AUDIT_INDEX=0
@@ -505,7 +505,32 @@ PY
 }
 
 write_release_json() {
-    local output="$1" status
+    local output="$1" status release_id="" direct_output
+    if [[ -f "$output" ]]; then
+        release_id="$(python3 - "$output" <<'PY'
+import json
+import sys
+
+try:
+    release = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(0)
+release_id = release.get("id") if isinstance(release, dict) else None
+if isinstance(release_id, int):
+    print(release_id)
+PY
+)"
+    fi
+    if [[ -n "$release_id" ]]; then
+        direct_output="$(mktemp "$TMP_DIR/release-by-id.XXXXXX")"
+        if ! GH_TOKEN="$TIP_GH_TOKEN" gh api \
+            "/repos/$TIP_UPDATE_REPOSITORY/releases/$release_id" > "$direct_output"; then
+            rm -f "$direct_output"
+            fail "Authenticated Tip release lookup by id failed"
+        fi
+        mv "$direct_output" "$output"
+        return 0
+    fi
     if lookup_release "$output"; then
         return 0
     else
@@ -522,17 +547,19 @@ create_draft_if_missing() {
     if write_release_json "$release_file"; then
         return 0
     fi
-    require_live_main "pre-draft creation"
-    if ! GH_TOKEN="$TIP_GH_TOKEN" gh release create "$TIP_TAG" \
-        --repo "$TIP_UPDATE_REPOSITORY" \
-        --target "$TIP_SOURCE_BRANCH" \
-        --draft \
-        --title "$TIP_RELEASE_TITLE" \
-        --notes "$TIP_RELEASE_NOTES"; then
+    require_main_lineage "pre-draft creation"
+    if ! GH_TOKEN="$TIP_GH_TOKEN" gh api --method POST \
+        "/repos/$TIP_UPDATE_REPOSITORY/releases" \
+        -f tag_name="$TIP_TAG" \
+        -f target_commitish="$TIP_SOURCE_BRANCH" \
+        -f name="$TIP_RELEASE_TITLE" \
+        -f body="$TIP_RELEASE_NOTES" \
+        -F draft=true \
+        -F prerelease=false > "$release_file"; then
         write_release_json "$release_file" || fail "Unable to create or reconcile Tip release draft"
         return 0
     fi
-    write_release_json "$release_file" || fail "Created Tip draft is not observable"
+    validate_release_metadata "$release_file" draft
 }
 
 download_authenticated_asset() {
@@ -592,7 +619,8 @@ PY
 }
 
 upload_missing_assets() {
-    local release_file="$1" names_file="$TMP_DIR/remote-names"
+    local release_file="$1" names_file="$TMP_DIR/remote-names" release_id
+    release_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["id"])' "$release_file")"
     python3 - "$release_file" > "$names_file" <<'PY'
 import json
 import sys
@@ -600,14 +628,27 @@ release = json.load(open(sys.argv[1], encoding="utf-8"))
 for asset in release.get("assets", []):
     print(asset.get("name", ""))
 PY
-    local path name
+    local path name encoded_name upload_response upload_status
     for path in "${ASSETS[@]}"; do
         name="$(basename "$path")"
         if grep -Fx "$name" "$names_file" >/dev/null; then
             continue
         fi
-        if ! GH_TOKEN="$TIP_GH_TOKEN" gh release upload "$TIP_TAG" "$path" \
-            --repo "$TIP_UPDATE_REPOSITORY"; then
+        encoded_name="$(python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$name")"
+        upload_response="$(mktemp "$TMP_DIR/upload-response.XXXXXX")"
+        upload_status="$(curl --location --silent --show-error \
+            --connect-timeout 10 --max-time 1800 \
+            --request POST \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'Content-Type: application/octet-stream' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --header "Authorization: Bearer $TIP_GH_TOKEN" \
+            --data-binary "@$path" \
+            --output "$upload_response" --write-out '%{http_code}' \
+            "https://uploads.github.com/repos/$TIP_UPDATE_REPOSITORY/releases/$release_id/assets?name=$encoded_name")" ||
+            upload_status="000"
+        rm -f "$upload_response"
+        if [[ "$upload_status" != "201" ]]; then
             write_release_json "$release_file" || fail "Unable to reconcile Tip asset upload: $name"
             audit_authenticated_release_assets "$release_file" true
             grep -Fx "$name" <(python3 - "$release_file" <<'PY'
@@ -615,7 +656,7 @@ import json,sys
 for asset in json.load(open(sys.argv[1], encoding="utf-8")).get("assets", []):
     print(asset.get("name", ""))
 PY
-) >/dev/null || fail "Tip asset upload failed: $name"
+) >/dev/null || fail "Tip asset upload failed with HTTP $upload_status: $name"
         fi
         write_release_json "$release_file" || fail "Tip release draft disappeared after uploading $name"
     done
@@ -624,7 +665,7 @@ PY
 publish_draft() {
     local release_file="$1" release_id
     release_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["id"])' "$release_file")"
-    require_live_main "final pre-publication"
+    require_main_lineage "final pre-publication"
     audit_live_rollout_progression "final pre-publication"
     if ! GH_TOKEN="$TIP_GH_TOKEN" gh api --method PATCH \
         "/repos/$TIP_UPDATE_REPOSITORY/releases/$release_id" \
@@ -695,7 +736,7 @@ PY
 }
 
 validate_candidate_bindings
-require_live_main "publication setup"
+require_main_lineage "publication setup"
 audit_live_rollout_progression "publication setup"
 release_file="$TMP_DIR/release.json"
 create_draft_if_missing "$release_file"

--- a/Scripts/test_publish_tip_release.py
+++ b/Scripts/test_publish_tip_release.py
@@ -22,6 +22,7 @@ WORKFLOW = ROOT_DIR / ".github" / "workflows" / "main-tip.yml"
 TIP_ORCHESTRATOR = SCRIPT_DIR / "main_tip_release.sh"
 
 COMMIT = "a" * 40
+ADVANCED_COMMIT = "b" * 40
 TAG = "tip-aaaaaaaaaaaa"
 SOURCE_REPOSITORY = "repoprompt/repoprompt-ce"
 UPDATE_REPOSITORY = "repoprompt/repoprompt-ce-tip-updates"
@@ -29,7 +30,6 @@ TITLE = "RepoPrompt CE Tip fixture"
 NOTES = "Hermetic publisher regression fixture."
 
 GH_STUB = r'''#!/usr/bin/env python3
-import hashlib
 import json
 import os
 import sys
@@ -45,25 +45,20 @@ def save():
     state_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
-def option(name):
-    return args[args.index(name) + 1]
-
-
-def asset_record(path):
-    data = path.read_bytes()
-    name = path.name
-    index = len(state["release"]["assets"]) + 1
-    return {
-        "name": name,
-        "state": "uploaded",
-        "url": f"https://api.github.com/repos/{os.environ['TIP_UPDATE_REPOSITORY']}/releases/assets/{index}",
-        "browser_download_url": (
-            f"https://github.com/{os.environ['TIP_UPDATE_REPOSITORY']}"
-            f"/releases/download/{os.environ['TIP_TAG']}/{name}"
-        ),
-        "size": len(data),
-        "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
-    }
+def form_fields():
+    values = {}
+    index = 0
+    while index < len(args) - 1:
+        flag = args[index]
+        if flag not in {"-f", "-F"}:
+            index += 1
+            continue
+        key, value = args[index + 1].split("=", 1)
+        if flag == "-F" and value in {"true", "false"}:
+            value = value == "true"
+        values[key] = value
+        index += 2
+    return values
 
 
 if not os.environ.get("GH_TOKEN"):
@@ -71,6 +66,8 @@ if not os.environ.get("GH_TOKEN"):
 
 if args[:2] == ["api", "--paginate"]:
     state["lookup_args"].append(args)
+    if "create" in state["mutations"]:
+        state["tag_list_lookups_after_create"] += 1
     save()
     if state["scenario"] == "lookup-error":
         print("fixture lookup failure", file=sys.stderr)
@@ -88,6 +85,32 @@ if args[:2] == ["api", "--paginate"]:
         print(json.dumps([release]))
     raise SystemExit(0)
 
+if args[:3] == ["api", "--method", "POST"]:
+    expected_path = f"/repos/{os.environ['TIP_UPDATE_REPOSITORY']}/releases"
+    if args[3] != expected_path:
+        raise SystemExit(f"unexpected fixture release creation path: {args[3]}")
+    if state.get("release") is not None:
+        raise SystemExit("fixture release already exists")
+    fields = form_fields()
+    state["mutations"].append("create")
+    state["release"] = {
+        "id": 101,
+        "tag_name": fields["tag_name"],
+        "target_commitish": fields["target_commitish"],
+        "name": fields["name"],
+        "body": fields["body"],
+        "draft": fields["draft"],
+        "prerelease": fields["prerelease"],
+        "assets": [],
+    }
+    save()
+    print(json.dumps(state["release"]))
+    raise SystemExit(0)
+
+if args[:2] == ["api", f"/repos/{os.environ['TIP_UPDATE_REPOSITORY']}/releases/101"]:
+    print(json.dumps(state["release"]))
+    raise SystemExit(0)
+
 if args and args[0] == "api" and "Accept: application/octet-stream" in args:
     api_url = args[-1]
     for asset in state["release"]["assets"]:
@@ -95,32 +118,6 @@ if args and args[0] == "api" and "Accept: application/octet-stream" in args:
             sys.stdout.buffer.write((asset_dir / asset["name"]).read_bytes())
             raise SystemExit(0)
     raise SystemExit(f"unknown fixture asset API URL: {api_url}")
-
-if args[:2] == ["release", "create"]:
-    if state.get("release") is not None:
-        raise SystemExit("fixture release already exists")
-    state["mutations"].append("create")
-    state["release"] = {
-        "id": 101,
-        "tag_name": args[2],
-        "target_commitish": option("--target"),
-        "name": option("--title"),
-        "body": option("--notes"),
-        "draft": True,
-        "prerelease": False,
-        "assets": [],
-    }
-    save()
-    print("fixture draft created")
-    raise SystemExit(0)
-
-if args[:2] == ["release", "upload"]:
-    path = Path(args[3])
-    state["mutations"].append(f"upload:{path.name}")
-    state["release"]["assets"].append(asset_record(path))
-    save()
-    print("fixture asset uploaded")
-    raise SystemExit(0)
 
 if args[:3] == ["api", "--method", "PATCH"]:
     state["mutations"].append("publish")
@@ -133,6 +130,7 @@ raise SystemExit(f"unsupported gh invocation: {args!r}")
 '''
 
 CURL_STUB = r'''#!/usr/bin/env python3
+import hashlib
 import json
 import os
 import shutil
@@ -149,7 +147,34 @@ if not urls:
 url = urls[-1]
 status = "200"
 
-if url.endswith("/commits/main"):
+if url.startswith("https://uploads.github.com/"):
+    expected = f"Authorization: Bearer {os.environ['TIP_GH_TOKEN']}"
+    if expected not in args:
+        raise SystemExit("fixture asset upload was not authenticated")
+    path = Path(args[args.index("--data-binary") + 1].removeprefix("@"))
+    data = path.read_bytes()
+    name = path.name
+    index = len(state["release"]["assets"]) + 1
+    state["mutations"].append(f"upload:{name}")
+    state["release"]["assets"].append(
+        {
+            "name": name,
+            "state": "uploaded",
+            "url": f"https://api.github.com/repos/{os.environ['TIP_UPDATE_REPOSITORY']}/releases/assets/{index}",
+            "browser_download_url": (
+                f"https://github.com/{os.environ['TIP_UPDATE_REPOSITORY']}"
+                f"/releases/download/{os.environ['TIP_TAG']}/{name}"
+            ),
+            "size": len(data),
+            "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
+        }
+    )
+    Path(os.environ["PUBLISHER_STUB_STATE"]).write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+    output.write_text(json.dumps(state["release"]["assets"][-1]), encoding="utf-8")
+    status = "201"
+elif url.endswith("/commits/main"):
     expected = f"Authorization: Bearer {os.environ['PUBLISHER_EXPECTED_SOURCE_TOKEN']}"
     authenticated = expected in args
     state.setdefault("source_lookup_auth", []).append(authenticated)
@@ -157,10 +182,30 @@ if url.endswith("/commits/main"):
         json.dumps(state, indent=2) + "\n", encoding="utf-8"
     )
     if authenticated:
-        output.write_text(json.dumps({"sha": os.environ["TIP_COMMIT"]}), encoding="utf-8")
+        output.write_text(json.dumps({"sha": os.environ["PUBLISHER_LIVE_MAIN"]}), encoding="utf-8")
     else:
         output.write_text(json.dumps({"message": "fixture authorization denied"}), encoding="utf-8")
         status = "403"
+elif "/compare/" in url:
+    expected = f"Authorization: Bearer {os.environ['PUBLISHER_EXPECTED_SOURCE_TOKEN']}"
+    authenticated = expected in args
+    state.setdefault("source_lookup_auth", []).append(authenticated)
+    Path(os.environ["PUBLISHER_STUB_STATE"]).write_text(
+        json.dumps(state, indent=2) + "\n", encoding="utf-8"
+    )
+    if not authenticated:
+        output.write_text(json.dumps({"message": "fixture authorization denied"}), encoding="utf-8")
+        status = "403"
+    elif state["scenario"] == "diverged-source":
+        output.write_text(
+            json.dumps({"status": "diverged", "merge_base_commit": {"sha": "c" * 40}}),
+            encoding="utf-8",
+        )
+    else:
+        output.write_text(
+            json.dumps({"status": "ahead", "merge_base_commit": {"sha": os.environ["TIP_COMMIT"]}}),
+            encoding="utf-8",
+        )
 elif url == os.environ["PUBLISHER_STABLE_FEED_URL"]:
     shutil.copyfile(os.environ["PUBLISHER_STABLE_APPCAST"], output)
 elif url.endswith("/releases/latest"):
@@ -327,6 +372,7 @@ class PublishTipReleaseTests(unittest.TestCase):
         release: dict[str, object] | None,
         *,
         source_token: str | None = "fixture-source-token",
+        live_main: str = COMMIT,
     ) -> subprocess.CompletedProcess[str]:
         self.state_path.write_text(
             json.dumps(
@@ -336,6 +382,7 @@ class PublishTipReleaseTests(unittest.TestCase):
                     "lookup_args": [],
                     "mutations": [],
                     "source_lookup_auth": [],
+                    "tag_list_lookups_after_create": 0,
                 },
                 indent=2,
             )
@@ -353,6 +400,7 @@ class PublishTipReleaseTests(unittest.TestCase):
                 "PUBLISHER_STABLE_FEED_URL": policy["sparkle"]["stableFeedURL"],
                 "TIP_GH_TOKEN": "fixture-update-token",
                 "PUBLISHER_EXPECTED_SOURCE_TOKEN": "fixture-source-token",
+                "PUBLISHER_LIVE_MAIN": live_main,
                 "TIP_UPDATE_REPOSITORY": UPDATE_REPOSITORY,
                 "TIP_SOURCE_REPOSITORY": SOURCE_REPOSITORY,
                 "TIP_SOURCE_BRANCH": "main",
@@ -419,7 +467,39 @@ class PublishTipReleaseTests(unittest.TestCase):
         )
         self.assertEqual(state["mutations"][-1], "publish")
         self.assertFalse(state["release"]["draft"])
+        self.assertEqual(state["tag_list_lookups_after_create"], 0)
         self.assert_compatible_lookup(state)
+
+    def test_existing_empty_draft_resumes_by_release_id_and_publishes(self) -> None:
+        release = self._release(draft=True)
+        release["assets"] = []
+        result = self._run("existing", release)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        state = self._state()
+        self.assertNotIn("create", state["mutations"])
+        self.assertEqual(
+            sorted(value for value in state["mutations"] if value.startswith("upload:")),
+            sorted(f"upload:{path.name}" for path in self.assets),
+        )
+        self.assertEqual(state["mutations"][-1], "publish")
+        self.assertFalse(state["release"]["draft"])
+
+    def test_candidate_may_publish_after_main_advances_when_it_remains_an_ancestor(self) -> None:
+        result = self._run("absent", None, live_main=ADVANCED_COMMIT)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("remains an ancestor of protected main", result.stdout)
+        state = self._state()
+        self.assertEqual(state["mutations"][0], "create")
+        self.assertEqual(state["mutations"][-1], "publish")
+        self.assertTrue(all(state["source_lookup_auth"]))
+
+    def test_candidate_outside_live_main_ancestry_fails_before_mutation(self) -> None:
+        result = self._run("diverged-source", None, live_main=ADVANCED_COMMIT)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("outside protected-main ancestry", result.stderr)
+        state = self._state()
+        self.assertEqual(state["mutations"], [])
+        self.assertTrue(all(state["source_lookup_auth"]))
 
     def test_lookup_command_failure_fails_closed_before_draft_creation(self) -> None:
         result = self._run("lookup-error", None)
@@ -464,6 +544,8 @@ class PublishTipReleaseTests(unittest.TestCase):
         orchestrator = TIP_ORCHESTRATOR.read_text(encoding="utf-8")
         self.assertIn("require_env TIP_SOURCE_GH_TOKEN", orchestrator)
         self.assertIn('TIP_SOURCE_GH_TOKEN="$TIP_SOURCE_GH_TOKEN"', orchestrator)
+        publisher = PUBLISHER.read_text(encoding="utf-8")
+        self.assertIn('"$SOURCE_COMMIT_VERIFIER" --allow-ancestor "$1"', publisher)
 
     def test_duplicate_tag_across_pages_fails_closed_without_mutation(self) -> None:
         result = self._run("duplicate", self._release())

--- a/Scripts/verify_tip_source_commit.sh
+++ b/Scripts/verify_tip_source_commit.sh
@@ -10,7 +10,12 @@ for name in TIP_SOURCE_GH_TOKEN TIP_SOURCE_REPOSITORY TIP_SOURCE_BRANCH TIP_COMM
 done
 for command in curl python3; do require_command "$command"; done
 
-[[ "$#" == 1 && -n "$1" ]] || fail "Usage: $0 <verification-phase>"
+allow_ancestor=false
+if [[ "${1:-}" == "--allow-ancestor" ]]; then
+    allow_ancestor=true
+    shift
+fi
+[[ "$#" == 1 && -n "$1" ]] || fail "Usage: $0 [--allow-ancestor] <verification-phase>"
 phase="$1"
 
 [[ "$TIP_SOURCE_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
@@ -63,7 +68,45 @@ print(value if isinstance(value, str) else "")
 PY
 )"
 [[ "$live_main" =~ ^[0-9a-f]{40}$ ]] || fail "$phase did not resolve a full live-main SHA"
-[[ "$live_main" == "$TIP_COMMIT" ]] ||
-    fail "$phase rejected stale Tip candidate: candidate=$TIP_COMMIT live-main=$live_main"
+if [[ "$live_main" == "$TIP_COMMIT" ]]; then
+    printf 'OK: %s confirmed protected main at %s.\n' "$phase" "$live_main"
+    exit 0
+fi
 
-printf 'OK: %s confirmed protected main at %s.\n' "$phase" "$live_main"
+if [[ "$allow_ancestor" != true ]]; then
+    fail "$phase rejected stale Tip candidate: candidate=$TIP_COMMIT live-main=$live_main"
+fi
+
+compare_response="$tmp_dir/main-lineage.json"
+compare_status="$(curl --location --silent --show-error \
+    --connect-timeout 10 --max-time 30 \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    --header "Authorization: Bearer $TIP_SOURCE_GH_TOKEN" \
+    --output "$compare_response" --write-out '%{http_code}' \
+    "https://api.github.com/repos/$TIP_SOURCE_REPOSITORY/compare/$TIP_COMMIT...$TIP_SOURCE_BRANCH")" ||
+    fail "Protected-main lineage GitHub API request failed"
+[[ "$compare_status" =~ ^[0-9]{3}$ ]] || fail "Protected-main lineage lookup returned an invalid HTTP status"
+[[ "$compare_status" == "200" ]] || fail "Protected-main lineage lookup failed with HTTP $compare_status"
+
+lineage="$(python3 - "$compare_response" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except (OSError, json.JSONDecodeError):
+    raise SystemExit("ERROR: Protected-main lineage lookup returned invalid JSON")
+status = payload.get("status") if isinstance(payload, dict) else None
+merge_base = payload.get("merge_base_commit") if isinstance(payload, dict) else None
+merge_base_sha = merge_base.get("sha") if isinstance(merge_base, dict) else None
+print(f"{status or ''}|{merge_base_sha or ''}")
+PY
+)"
+relation="${lineage%%|*}"
+merge_base="${lineage#*|}"
+[[ "$relation" == "ahead" && "$merge_base" == "$TIP_COMMIT" ]] ||
+    fail "$phase rejected Tip candidate outside protected-main ancestry: candidate=$TIP_COMMIT live-main=$live_main relation=${relation:-unknown} merge-base=${merge_base:-unknown}"
+
+printf 'OK: %s confirmed candidate %s remains an ancestor of protected main %s.\n' \
+    "$phase" "$TIP_COMMIT" "$live_main"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -303,15 +303,21 @@ T's `sparkle:minimumUpdateVersion`, bypassing the credential preparer.
 Automatic and manual runs use separate rolling concurrency lanes. Each lane keeps at most one
 queued run and does not cancel in-flight release work; publication remains serialized across both
 lanes by `main-tip-publish`. A retry therefore resumes or audits one exact draft instead of abandoning
-a different tag halfway through publication.
+a different tag halfway through publication. Setup and credential preflight require the candidate to
+be the exact protected-main head before expensive work starts. If `main` advances while that work is
+running, publication may finish only while the candidate remains in authenticated protected-main
+ancestry. The monotonic build and rollout-progression checks still reject an older candidate when a
+newer Tip has already become public, while the newest queued run converges the feed on current `main`.
 
 Remote mutation is confined to that protected publication job. Immediately before draft creation
-and again immediately before making a draft public, it rechecks live protected `main`, downloads the
-public Tip manifest/appcast, proves that the candidate either rolls the current role or advances one
-step through `P → T → S` with exact retained history, and audits every retained enclosure against
-GitHub's published size and SHA-256. Rolling P retains no predecessor, rolling T retains the exact
-authenticated P, and rolling S retains the exact authenticated T and P. Existing drafts are resumed
-only when their metadata and uploaded bytes exactly match;
+and again immediately before making a draft public, it proves the candidate is still on live
+protected-main ancestry, downloads the public Tip manifest/appcast, proves that the candidate either
+rolls the current role or advances one step through `P → T → S` with exact retained history, and
+audits every retained enclosure against GitHub's published size and SHA-256. Rolling P retains no
+predecessor, rolling T retains the exact authenticated P, and rolling S retains the exact authenticated
+T and P. Draft creation consumes and validates GitHub's synchronous release response so publication
+does not depend on the new draft immediately appearing in paginated list results. Existing drafts are
+resumed only when their metadata and uploaded bytes exactly match;
 missing assets are added without overwriting anything. After publication, every public asset is
 downloaded anonymously and compared byte-for-byte with the signed local inventory, and the release
 must be the repository's latest. The update-repository token is not available to setup, staging, or


### PR DESCRIPTION
## Summary

- allow an in-flight Tip candidate to publish after main advances only when authenticated GitHub history proves the candidate remains an ancestor of protected main
- preserve the exact-head gate before expensive build work and the existing monotonic build and P-to-T-to-S rollout checks
- create, re-read, and upload release assets through the numeric release ID returned by GitHub, avoiding the observed draft tag-list visibility race
- add process-level regressions for advanced-main ancestry, divergent history rejection, fresh creation, and empty-draft recovery

## Root cause

Publish Tip #349 completed its 74-minute build, signing/notarization, and packaged smoke, then rejected the valid candidate because main advanced by one commit. Other recent runs successfully created empty drafts but immediately failed because the new draft had not appeared in paginated release-list results yet.

Failed run: https://github.com/repoprompt/repoprompt-ce/actions/runs/33701576089

## Validation

- make release-selftest
- python3 Scripts/test_publish_tip_release.py (10 tests)
- make guardrails
- make dev-release-preflight (ticket 95b2df19-3ec7-4a25-81b0-d4c026d811dc)
- contribution commit, push, and pr-ready preflights