### PR TITLE
Add Devin ACP agent provider

### DIFF
--- a/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
+++ b/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
@@ -46,4 +46,7 @@ extension Notification.Name {
     static let ompConnectionChanged = Notification.Name("ompConnectionChanged")
     /// Posted when ACP model discovery changes (`userInfo["providerID"]`) or persisted catalogs finish warming.
     static let acpDiscoveredModelsChanged = Notification.Name("acpDiscoveredModelsChanged")
+    /// Posted when Devin CLI connection status changes
+    /// userInfo mirrors `claudeCodeConnectionChanged`
+    static let devinConnectionChanged = Notification.Name("devinConnectionChanged")
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -304,7 +304,7 @@ enum AgentModel: String, CaseIterable, Codable {
             ]
         case .openCode:
             [.defaultModel]
-        case .grokBuild, .omp:
+        case .grokBuild, .omp, .devin:
             [.defaultModel]
         case .antigravity:
             []

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -9,6 +9,7 @@ enum AgentModelCatalog {
         let grokBuildAvailable: Bool
         let antigravityAvailable: Bool
         let ompAvailable: Bool
+        let devinAvailable: Bool
         let zaiConfigured: Bool
         let kimiConfigured: Bool
         let customClaudeCompatibleConfigured: Bool
@@ -21,6 +22,7 @@ enum AgentModelCatalog {
             grokBuildAvailable: false,
             antigravityAvailable: false,
             ompAvailable: false,
+            devinAvailable: false,
             zaiConfigured: false,
             kimiConfigured: false,
             customClaudeCompatibleConfigured: false
@@ -35,6 +37,7 @@ enum AgentModelCatalog {
                 grokBuildAvailable: grokBuildAvailable && providers.contains(.grokBuild),
                 antigravityAvailable: antigravityAvailable,
                 ompAvailable: false,
+                devinAvailable: false,
                 zaiConfigured: zaiConfigured && providers.contains(.claudeCode),
                 kimiConfigured: kimiConfigured && providers.contains(.claudeCode),
                 customClaudeCompatibleConfigured: customClaudeCompatibleConfigured && providers.contains(.claudeCode)
@@ -51,6 +54,7 @@ enum AgentModelCatalog {
                 grokBuildAvailable: false,
                 antigravityAvailable: AntigravityRuntimeManager.installedRuntimeSync() != nil,
                 ompAvailable: false,
+                devinAvailable: false,
                 zaiConfigured: backendIsAvailable(.glmZAI, store: store),
                 kimiConfigured: backendIsAvailable(.kimi, store: store),
                 customClaudeCompatibleConfigured: backendIsAvailable(.custom, store: store)
@@ -65,6 +69,7 @@ enum AgentModelCatalog {
             grokBuildAvailable: Bool = false,
             antigravityAvailable: Bool = false,
             ompAvailable: Bool = false,
+            devinAvailable: Bool = false,
             zaiConfigured: Bool = false,
             kimiConfigured: Bool = false,
             customClaudeCompatibleConfigured: Bool = false
@@ -76,6 +81,7 @@ enum AgentModelCatalog {
             self.grokBuildAvailable = grokBuildAvailable
             self.antigravityAvailable = antigravityAvailable
             self.ompAvailable = ompAvailable
+            self.devinAvailable = devinAvailable
             self.zaiConfigured = zaiConfigured
             self.kimiConfigured = kimiConfigured
             self.customClaudeCompatibleConfigured = customClaudeCompatibleConfigured
@@ -101,6 +107,7 @@ enum AgentModelCatalog {
                 grokBuildAvailable: grokBuildAvailable || agentKind == .grokBuild,
                 antigravityAvailable: antigravityAvailable || agentKind == .antigravity,
                 ompAvailable: ompAvailable || agentKind == .omp,
+                devinAvailable: devinAvailable || agentKind == .devin,
                 zaiConfigured: zaiConfigured || agentKind == .claudeCodeGLM,
                 kimiConfigured: kimiConfigured || agentKind == .kimiCode,
                 customClaudeCompatibleConfigured: customClaudeCompatibleConfigured || agentKind == .customClaudeCompatible
@@ -209,14 +216,15 @@ enum AgentModelCatalog {
         .cursor,
         .grokBuild,
         .antigravity,
-        .omp
+        .omp,
+        .devin
     ]
 
     static func selectableAgents(
         availability: AvailabilityContext = .current,
         surface: AgentSelectionSurface = .general
     ) -> [AgentProviderKind] {
-        [.codexExec, .claudeCode, .openCode, .cursor, .grokBuild, .antigravity, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible]
+        [.codexExec, .claudeCode, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin, .claudeCodeGLM, .kimiCode, .customClaudeCompatible]
             .filter { surface.allows($0) && isAgentAvailable($0, availability: availability) }
     }
 
@@ -252,6 +260,8 @@ enum AgentModelCatalog {
             availability.antigravityAvailable
         case .omp:
             availability.ompAvailable
+        case .devin:
+            availability.devinAvailable
         }
     }
 
@@ -283,7 +293,7 @@ enum AgentModelCatalog {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             return ClaudeCompatibleModelCatalogAdapter.defaultModelRaw(for: agentKind, availability: availability)
                 ?? AgentModel.defaultModel.rawValue
-        case .codexExec, .openCode, .grokBuild, .omp:
+        case .codexExec, .openCode, .grokBuild, .omp, .devin:
             return AgentModel.defaultModel.rawValue
         case .antigravity:
             return ""
@@ -396,7 +406,7 @@ enum AgentModelCatalog {
                 availability: availability,
                 includeClaudeEffortVariants: includeClaudeEffortVariants
             ) ?? []
-        case .openCode, .cursor, .grokBuild, .omp:
+        case .openCode, .cursor, .grokBuild, .omp, .devin:
             return AgentModel.modelsForAgent(agentKind)
                 .filter { isAvailable($0, for: agentKind, availability: availability) }
                 .map { staticOption($0, for: agentKind) }
@@ -418,7 +428,7 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return CursorAIModelCatalog.contains(modelRaw: normalized)
         }
-        if agentKind == .grokBuild || agentKind == .omp,
+        if agentKind == .grokBuild || agentKind == .omp || agentKind == .devin,
            normalized.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame
         {
             return true
@@ -1442,7 +1452,7 @@ enum AgentModelCatalog {
             .kimi
         case .customClaudeCompatible:
             .custom
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }
@@ -1645,7 +1655,7 @@ enum AgentModelCatalog {
             availability.kimiConfigured
         case .customClaudeCompatible:
             availability.customClaudeCompatibleConfigured
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             true
         }
     }
@@ -1956,7 +1966,7 @@ enum AgentModelCatalog {
         surface: AgentSelectionSurface = .general
     ) -> [DiscoveryAgent] {
         AgentProviderKind.allCases
-            .filter { surface.allows($0) }
+            .filter { $0 != .devin && surface.allows($0) }
             .map { agent in
                 discoveryAgent(agent, availability: availability)
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -565,6 +565,22 @@ enum AgentModelCatalog {
         }
     }
 
+    struct DevinModelFamilyGroup: Identifiable {
+        let family: AgentModelFamily?
+        let options: [AgentModelOption]
+        var id: String {
+            family?.id ?? ""
+        }
+    }
+
+    static func devinModelGroups(for options: [AgentModelOption]) -> [DevinModelFamilyGroup] {
+        let grouped = Dictionary(grouping: options, by: { $0.isPlaceholderDefault ? "" : ($0.modelFamily?.id ?? "") })
+        return grouped.keys.sorted().map { id in
+            let options = grouped[id] ?? []
+            return DevinModelFamilyGroup(family: id.isEmpty ? nil : options.first?.modelFamily, options: options)
+        }
+    }
+
     static func openCodeMenu(for options: [AgentModelOption]) -> OpenCodeMenu {
         struct Entry {
             let option: AgentModelOption
@@ -1966,7 +1982,7 @@ enum AgentModelCatalog {
         surface: AgentSelectionSurface = .general
     ) -> [DiscoveryAgent] {
         AgentProviderKind.allCases
-            .filter { $0 != .devin && surface.allows($0) }
+            .filter { surface.allows($0) }
             .map { agent in
                 discoveryAgent(agent, availability: availability)
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelOption.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelOption.swift
@@ -8,6 +8,11 @@ struct AgentModelEffortVariant: Hashable, Codable {
     let reasoningEffort: CodexReasoningEffort
 }
 
+struct AgentModelFamily: Hashable, Codable {
+    let id: String
+    let displayName: String
+}
+
 struct AgentModelOption: Identifiable, Hashable {
     let rawValue: String
     let displayName: String
@@ -17,6 +22,7 @@ struct AgentModelOption: Identifiable, Hashable {
     let supportedReasoningEfforts: [CodexReasoningEffort]
     let defaultReasoningEffort: CodexReasoningEffort?
     let effortVariant: AgentModelEffortVariant?
+    let modelFamily: AgentModelFamily?
 
     init(
         rawValue: String,
@@ -26,7 +32,8 @@ struct AgentModelOption: Identifiable, Hashable {
         isProviderDefault: Bool,
         supportedReasoningEfforts: [CodexReasoningEffort] = [],
         defaultReasoningEffort: CodexReasoningEffort? = nil,
-        effortVariant: AgentModelEffortVariant? = nil
+        effortVariant: AgentModelEffortVariant? = nil,
+        modelFamily: AgentModelFamily? = nil
     ) {
         self.rawValue = rawValue
         self.displayName = displayName
@@ -36,6 +43,7 @@ struct AgentModelOption: Identifiable, Hashable {
         self.supportedReasoningEfforts = supportedReasoningEfforts
         self.defaultReasoningEffort = defaultReasoningEffort
         self.effortVariant = effortVariant
+        self.modelFamily = modelFamily
     }
 
     init(
@@ -45,7 +53,8 @@ struct AgentModelOption: Identifiable, Hashable {
         isDefault: Bool,
         supportedReasoningEfforts: [CodexReasoningEffort] = [],
         defaultReasoningEffort: CodexReasoningEffort? = nil,
-        effortVariant: AgentModelEffortVariant? = nil
+        effortVariant: AgentModelEffortVariant? = nil,
+        modelFamily: AgentModelFamily? = nil
     ) {
         let isPlaceholder =
             rawValue.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame
@@ -57,6 +66,7 @@ struct AgentModelOption: Identifiable, Hashable {
         self.supportedReasoningEfforts = supportedReasoningEfforts
         self.defaultReasoningEffort = defaultReasoningEffort
         self.effortVariant = effortVariant
+        self.modelFamily = modelFamily
     }
 
     var isDefault: Bool {

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
@@ -321,6 +321,7 @@ protocol ACPAgentProvider: Sendable {
     ) -> [NormalizedAgentRuntimeEvent]
     func preferredAuthMethodID(context: ACPAuthenticationContext) -> String?
     func cleanupLaunchArtifacts(for configuration: ACPLaunchConfiguration) async
+    func modelFamily(for rawModel: String) -> AgentModelFamily?
     func normalizeError(_ error: Error) -> Error
 
     /// Opts a provider into ACP's parameterized model picker capability and classifies
@@ -340,6 +341,10 @@ extension ACPAgentProvider {
     }
 
     func modelParameterKind(for _: ACPModelParameterClassificationInput) -> ACPModelParameterKind? {
+        nil
+    }
+
+    func modelFamily(for _: String) -> AgentModelFamily? {
         nil
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
@@ -23,6 +23,22 @@ enum ACPSupportResult: Equatable {
     }
 }
 
+/// Complete, confirmed configuration of one live ACP session, never a provider-wide default.
+struct ACPSessionModeSnapshot: Equatable {
+    struct Option: Equatable {
+        let rawValue: String
+        let displayName: String
+        let description: String?
+    }
+
+    let configID: String
+    let currentValue: String
+    let options: [Option]
+    var availableValues: [String] {
+        options.map(\.rawValue)
+    }
+}
+
 struct ACPDiscoveredSessionModels: Equatable {
     let options: [AgentModelOption]
     let currentModelRaw: String?
@@ -128,6 +144,7 @@ struct ACPRunRequest {
     let sessionModeID: String?
     let autoApproveAllToolPermissions: Bool
     let modelParameterSelections: [ACPModelParameterSelection]
+    let requiresNonBypassSessionMode: Bool
 
     init(
         agentKind: AgentProviderKind,
@@ -138,7 +155,8 @@ struct ACPRunRequest {
         taskLabelKind: AgentModelCatalog.TaskLabelKind?,
         sessionModeID: String? = nil,
         autoApproveAllToolPermissions: Bool = false,
-        modelParameterSelections: [ACPModelParameterSelection] = []
+        modelParameterSelections: [ACPModelParameterSelection] = [],
+        requiresNonBypassSessionMode: Bool = false
     ) {
         self.agentKind = agentKind
         self.modelString = modelString
@@ -149,6 +167,7 @@ struct ACPRunRequest {
         self.sessionModeID = sessionModeID
         self.autoApproveAllToolPermissions = autoApproveAllToolPermissions
         self.modelParameterSelections = modelParameterSelections
+        self.requiresNonBypassSessionMode = requiresNonBypassSessionMode
     }
 }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
@@ -6,6 +6,7 @@ enum ACPProviderID: String, Codable, Hashable {
     case grokBuild
     case antigravity
     case omp
+    case devin
 }
 
 enum ACPSupportResult: Equatable {

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -362,7 +362,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
             .kimi
         case .customClaudeCompatible:
             .custom
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatiblePluginBridge.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatiblePluginBridge.swift
@@ -18,7 +18,7 @@ enum ClaudeCompatiblePluginBridge {
             .kimiClaudeCode
         case .customClaudeCompatible:
             .customClaudeCompatible
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }
@@ -208,7 +208,7 @@ enum ClaudeCompatiblePluginBridge {
             "Claude Code is unavailable."
         case .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             "Claude-compatible backend is not configured."
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             "Not a Claude-compatible provider."
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
@@ -386,7 +386,7 @@ final class AutoRecommendationEngine {
                 enabledRecommendationProviders.contains(.cursor)
             case .grokBuild:
                 enabledRecommendationProviders.contains(.grokBuild)
-            case .omp:
+            case .omp, .devin:
                 false
             case .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
                 true

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModePermissionPreferences.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModePermissionPreferences.swift
@@ -48,6 +48,7 @@ enum AgentModePermissionPreferences {
         defaults: UserDefaults = .standard,
         secureStore: AgentPermissionSecureStore? = nil
     ) -> AgentProviderPermissionLevelID {
+        if providerID == .devin { return .devin }
         if let secureStore = resolvedSecureStore(defaults: defaults, secureStore: secureStore) {
             return secureStore.providerSubagentPermissionLevel(for: providerID)
         }
@@ -60,6 +61,7 @@ enum AgentModePermissionPreferences {
         defaults: UserDefaults = .standard,
         secureStore: AgentPermissionSecureStore? = nil
     ) {
+        guard providerID != .devin else { return }
         let normalizedLevel = level.providerID == providerID
             ? level
             : AgentProviderPermissionLevelID.subagentDefault(for: providerID)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
@@ -51,6 +51,12 @@ final class AgentModeRunService {
     private let headlessRunner: HeadlessAgentModeRunner
     private let codexRunner: CodexIntegratedAgentModeRunner
     private let claudeRunner: ClaudeIntegratedAgentModeRunner
+    #if DEBUG
+        var testACPRunner: ACPIntegratedAgentModeRunner {
+            acpRunner
+        }
+    #endif
+
     private let acpRunner: ACPIntegratedAgentModeRunner
     private let terminalCommitBarrier: AgentRunTerminalCommitBarrier
 
@@ -148,7 +154,7 @@ final class AgentModeRunService {
                 resumeSessionID: session.providerSessionID,
                 attachments: attachments,
                 taskLabelKind: session.mcpControlContext?.taskLabelKind,
-                sessionModeID: runtimePermission.acpSessionModeID,
+                sessionModeID: selectedAgent == .devin && session.permissionProfile == .userConfigured ? session.acpSessionModeIntent : runtimePermission.acpSessionModeID,
                 autoApproveAllToolPermissions: runtimePermission.autoApproveAllACPToolPermissions,
                 modelParameterSelections: selectedAgent == .cursor
                     ? ACPModelParameterResolver.effectiveSelections(
@@ -156,7 +162,8 @@ final class AgentModeRunService {
                         selectedModelRaw: session.selectedModelRaw,
                         persistedSelections: session.acpModelParameterSelections
                     )
-                    : []
+                    : [],
+                requiresNonBypassSessionMode: selectedAgent == .devin && session.permissionProfile != .userConfigured
             )
         } else {
             nil
@@ -282,6 +289,7 @@ final class AgentModeRunService {
             resumeSessionID: session.providerSessionID,
             attachments: attachments,
             taskLabelKind: session.mcpControlContext?.taskLabelKind,
+            // Steering retains the active mode; pending intent belongs to the next normal turn.
             sessionModeID: runtimePermission.acpSessionModeID,
             autoApproveAllToolPermissions: runtimePermission.autoApproveAllACPToolPermissions,
             modelParameterSelections: selectedAgent == .cursor
@@ -290,7 +298,8 @@ final class AgentModeRunService {
                     selectedModelRaw: session.selectedModelRaw,
                     persistedSelections: session.acpModelParameterSelections
                 )
-                : []
+                : [],
+            requiresNonBypassSessionMode: selectedAgent == .devin && session.permissionProfile != .userConfigured
         )
         let sent = await acpRunner.submitActivePrompt(
             session: session,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSkillCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSkillCatalog.swift
@@ -423,7 +423,7 @@ final class AgentSkillCatalog {
                 precedenceRank: 7
             )
 
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             // Codex, OpenCode, and Cursor continue to share only the generic `.agents` namespace.
             appendWorkspaceRoots(
                 relativeRoot: ".agents/skills",

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
@@ -239,6 +239,9 @@ final class AgentModeProviderBindingService {
                         updateActiveBindings(session)
                     }
                 }
+            case .devin:
+                // Devin owns its internal tool permissions; RepoPrompt exposes no mutable provider preference.
+                break
             case .grokBuild:
                 // Grok full access is a launch-time `--always-approve` flag; it applies to
                 // newly launched processes and never mutates a running controller. The next

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
@@ -21,14 +21,18 @@ final class AgentModeProviderBindingService {
         selectedModelRaw: String? = nil,
         permissionProfile: AgentProviderPermissionProfile,
         isSubagent: Bool,
-        externallyManagedReason: String?
+        externallyManagedReason: String?,
+        acpModeSnapshot: ACPSessionModeSnapshot? = nil,
+        acpModeIntent: String? = nil
     ) -> AgentProviderControlsBinding {
         preferences.controlsBinding(
             selectedAgent: selectedAgent,
             selectedModelRaw: selectedModelRaw,
             permissionProfile: permissionProfile,
             isSubagent: isSubagent,
-            externallyManagedReason: externallyManagedReason
+            externallyManagedReason: externallyManagedReason,
+            acpModeSnapshot: acpModeSnapshot,
+            acpModeIntent: acpModeIntent
         )
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingID.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingID.swift
@@ -8,6 +8,7 @@ enum AgentProviderBindingID: String, CaseIterable, Hashable {
     case grokBuild
     case antigravity
     case omp
+    case devin
 
     var displayName: String {
         switch self {
@@ -25,6 +26,8 @@ enum AgentProviderBindingID: String, CaseIterable, Hashable {
             "Google Antigravity"
         case .omp:
             "Oh My Pi"
+        case .devin:
+            "Devin"
         }
     }
 }
@@ -46,6 +49,8 @@ extension AgentProviderKind {
             .antigravity
         case .omp:
             .omp
+        case .devin:
+            .devin
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
@@ -21,6 +21,7 @@ enum AgentProviderPermissionLevelID: Hashable {
     case cursor(CursorAgentToolPreferences.PermissionLevel)
     case grokBuild(GrokBuildAgentToolPreferences.PermissionLevel)
     case omp(OMPAgentToolPreferences.PermissionLevel)
+    case devin
 
     var providerID: AgentProviderBindingID {
         switch self {
@@ -38,6 +39,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             .grokBuild
         case .omp:
             .omp
+        case .devin:
+            .devin
         }
     }
 
@@ -57,6 +60,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             .grokBuild(.managedDefault)
         case .omp:
             .omp(.providerManaged)
+        case .devin:
+            .devin
         }
     }
 
@@ -76,6 +81,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             GrokBuildAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.grokBuild)
         case .omp:
             OMPAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.omp)
+        case .devin:
+            [.devin]
         }
     }
 
@@ -103,6 +110,9 @@ enum AgentProviderPermissionLevelID: Hashable {
         case .omp:
             guard let level = OMPAgentToolPreferences.PermissionLevel(rawValue: raw) else { return nil }
             self = .omp(level)
+        case .devin:
+            guard raw == "providerManaged" else { return nil }
+            self = .devin
         }
     }
 
@@ -122,6 +132,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.rawValue
         case let .omp(level):
             level.rawValue
+        case .devin:
+            "providerManaged"
         }
     }
 
@@ -141,6 +153,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.displayName
         case let .omp(level):
             level.displayName
+        case .devin:
+            "Provider Managed"
         }
     }
 
@@ -160,6 +174,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.iconName
         case let .omp(level):
             level.iconName
+        case .devin:
+            "shield"
         }
     }
 
@@ -179,6 +195,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.detailText
         case let .omp(level):
             level.detailText
+        case .devin:
+            "Devin controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools."
         }
     }
 
@@ -196,7 +214,7 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.isWarning
         case let .grokBuild(level):
             level.isWarning
-        case .omp:
+        case .omp, .devin:
             false
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
@@ -22,6 +22,8 @@ enum AgentProviderPermissionLevelID: Hashable {
     case grokBuild(GrokBuildAgentToolPreferences.PermissionLevel)
     case omp(OMPAgentToolPreferences.PermissionLevel)
     case devin
+    /// Ephemeral live-advertised choice; never a stored provider preference.
+    case devinMode(String)
 
     var providerID: AgentProviderBindingID {
         switch self {
@@ -39,7 +41,7 @@ enum AgentProviderPermissionLevelID: Hashable {
             .grokBuild
         case .omp:
             .omp
-        case .devin:
+        case .devin, .devinMode:
             .devin
         }
     }
@@ -132,7 +134,7 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.rawValue
         case let .omp(level):
             level.rawValue
-        case .devin:
+        case .devin, .devinMode:
             "providerManaged"
         }
     }
@@ -153,7 +155,7 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.displayName
         case let .omp(level):
             level.displayName
-        case .devin:
+        case .devin, .devinMode:
             "Provider Managed"
         }
     }
@@ -174,7 +176,7 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.iconName
         case let .omp(level):
             level.iconName
-        case .devin:
+        case .devin, .devinMode:
             "shield"
         }
     }
@@ -195,7 +197,7 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.detailText
         case let .omp(level):
             level.detailText
-        case .devin:
+        case .devin, .devinMode:
             "Devin controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools."
         }
     }
@@ -216,6 +218,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.isWarning
         case .omp, .devin:
             false
+        case let .devinMode(raw):
+            raw == "bypass"
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
@@ -172,7 +172,7 @@ extension AgentProviderPermissionProfile {
             openCodeSessionModeID
         case .omp:
             ompPermissionLevel().sessionModeID
-        case .cursor, .grokBuild, .antigravity:
+        case .cursor, .grokBuild, .antigravity, .devin:
             nil
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .codexExec:
             nil

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
@@ -149,6 +149,8 @@ final class AgentProviderPreferenceSnapshotStore {
         case .omp:
             let level = effectiveOMPPermissionLevel(profile: profile)
             return AgentProviderRuntimePermissionBinding(acpSessionModeID: level.sessionModeID)
+        case .devin:
+            return AgentProviderRuntimePermissionBinding()
         case .grokBuild:
             let level = effectiveGrokBuildPermissionLevel(profile: profile)
             // For Grok this flag becomes a launch-time `--always-approve` argument in the
@@ -177,6 +179,8 @@ final class AgentProviderPreferenceSnapshotStore {
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .omp(level):
             OMPAgentToolPreferences.setPermissionLevel(level, defaults: defaults)
+        case .devin:
+            break
         }
         bumpRevision(for: id.providerID)
         return id.providerID
@@ -442,6 +446,26 @@ final class AgentProviderPreferenceSnapshotStore {
                     )
                 }
             )
+        case .devin:
+            let level = AgentProviderPermissionLevelID.devin
+            return AgentPermissionChromeBinding(
+                providerID: providerID,
+                displayName: level.displayName,
+                iconName: level.iconName,
+                isWarning: level.isWarning,
+                externallyManagedReason: level.detailText,
+                options: [
+                    AgentPermissionOptionBinding(
+                        id: level,
+                        title: level.displayName,
+                        iconName: level.iconName,
+                        detailText: level.detailText,
+                        isWarning: level.isWarning,
+                        isSelected: true,
+                        isEnabled: false
+                    )
+                ]
+            )
         case .grokBuild:
             let effective = effectiveGrokBuildPermissionLevel(profile: profile)
             return AgentPermissionChromeBinding(
@@ -702,6 +726,7 @@ final class AgentProviderPreferenceSnapshotStore {
         case .grokBuild: .grokBuild
         case .antigravity: .antigravity
         case .omp: .omp
+        case .devin: .devin
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
@@ -48,10 +48,12 @@ final class AgentProviderPreferenceSnapshotStore {
         selectedModelRaw: String? = nil,
         permissionProfile: AgentProviderPermissionProfile,
         isSubagent _: Bool,
-        externallyManagedReason: String?
+        externallyManagedReason: String?,
+        acpModeSnapshot: ACPSessionModeSnapshot? = nil,
+        acpModeIntent: String? = nil
     ) -> AgentProviderControlsBinding {
         let providerID = selectedAgent.providerBindingID
-        let permission = permissionChromeBinding(
+        let permission = providerID == .devin ? Self.devinModeBinding(snapshot: acpModeSnapshot, intent: acpModeIntent, lockReason: externallyManagedReason) : permissionChromeBinding(
             for: providerID,
             profile: permissionProfile,
             externallyManagedReason: externallyManagedReason
@@ -72,6 +74,43 @@ final class AgentProviderPreferenceSnapshotStore {
                     selectedModelRaw: selectedModelRaw
                 )
                 : nil
+        )
+    }
+
+    static func devinModeBinding(snapshot: ACPSessionModeSnapshot?, intent: String?, lockReason: String?) -> AgentPermissionChromeBinding {
+        guard let snapshot else {
+            return AgentPermissionChromeBinding(
+                providerID: .devin, displayName: "Provider Managed", iconName: "shield", isWarning: false,
+                externallyManagedReason: lockReason,
+                options: [.init(
+                    id: .devin,
+                    title: "Mode unavailable",
+                    iconName: "shield",
+                    detailText: "Live ACP modes appear after Devin opens a session. Selections apply before the next normal turn and are not restored by RepoPrompt after reopening.",
+                    isWarning: false,
+                    isSelected: true,
+                    isEnabled: false
+                )]
+            )
+        }
+        let currentName = snapshot.options.first { $0.rawValue == snapshot.currentValue }?.displayName ?? snapshot.currentValue
+        return AgentPermissionChromeBinding(
+            providerID: .devin, displayName: currentName, iconName: "shield",
+            isWarning: snapshot.currentValue == "bypass", externallyManagedReason: lockReason,
+            options: snapshot.options.map { option in
+                let pending = intent == option.rawValue && intent != snapshot.currentValue
+                let warning = option.rawValue == "bypass"
+                let detail = [
+                    option.description,
+                    warning ? "Eligible Devin tools may run without approval. Organization restrictions and RepoPrompt MCP policy still apply; this is not an OS sandbox setting." : nil,
+                    pending ? "Requested: applies before the next normal turn." : nil
+                ].compactMap(\.self).joined(separator: "\n")
+                return AgentPermissionOptionBinding(
+                    id: .devinMode(option.rawValue), title: option.displayName + (pending ? " (requested)" : ""),
+                    iconName: warning ? "exclamationmark.shield" : "shield", detailText: detail,
+                    isWarning: warning, isSelected: option.rawValue == snapshot.currentValue, isEnabled: lockReason == nil
+                )
+            }
         )
     }
 
@@ -179,7 +218,7 @@ final class AgentProviderPreferenceSnapshotStore {
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .omp(level):
             OMPAgentToolPreferences.setPermissionLevel(level, defaults: defaults)
-        case .devin:
+        case .devin, .devinMode:
             break
         }
         bumpRevision(for: id.providerID)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderConversationCleanupRegistry.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderConversationCleanupRegistry.swift
@@ -34,7 +34,8 @@ struct ProviderConversationCleanupRegistry {
         case Self.normalizedProvider(AgentProviderKind.openCode.rawValue),
              Self.normalizedProvider(AgentProviderKind.cursor.rawValue),
              Self.normalizedProvider(AgentProviderKind.grokBuild.rawValue),
-             Self.normalizedProvider(AgentProviderKind.omp.rawValue):
+             Self.normalizedProvider(AgentProviderKind.omp.rawValue),
+             Self.normalizedProvider(AgentProviderKind.devin.rawValue):
             return .unsupported(message: "ACP provider \(handle.provider) has session metadata but no verified conversation cleanup API.")
 
         default:

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
@@ -43,6 +43,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
     case grokBuild
     case antigravity
     case omp
+    case devin
     case claudeCodeGLM
     case kimiCode
     case customClaudeCompatible
@@ -52,6 +53,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
     static let openCodeMCPClientID = "opencode"
     static let cursorMCPClientID = "cursor"
     static let ompMCPClientID = "omp-coding-agent"
+    /// Devin's built-in Rust MCP client reports this exact initialize name.
+    static let devinMCPClientID = "rmcp"
     /// Grok Build presents `grok-shell-<injected server name>` (e.g. `grok-shell-RepoPromptCE`)
     /// to MCP servers. The hint must equal that exact registered name: the pending run-scoped
     /// tab-context store keys are raw client names (no family canonicalization), so a
@@ -75,6 +78,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "agy_acp_server.par"
         case .omp:
             "omp"
+        case .devin:
+            "devin"
         }
     }
 
@@ -94,6 +99,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "Google Antigravity"
         case .omp:
             "Oh My Pi"
+        case .devin:
+            "Devin"
         case .claudeCodeGLM:
             ClaudeCodeCompatibleBackendStore.shared.config(for: .glmZAI).normalizedDisplayName
         case .kimiCode:
@@ -119,6 +126,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "antigravity"
         case .omp:
             Self.ompMCPClientID
+        case .devin:
+            Self.devinMCPClientID
         }
     }
 
@@ -134,6 +143,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             .antigravity
         case .omp:
             .omp
+        case .devin:
+            .devin
         case .claudeCode, .codexExec, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             nil
         }
@@ -143,7 +154,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
         switch self {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             false
         }
     }
@@ -154,7 +165,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
 
     var requiresExpectedPIDOwnedAgentModeMCPRouting: Bool {
         switch self {
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .devin:
             true
         }
     }
@@ -163,7 +174,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
         switch self {
         case .cursor, .grokBuild, .antigravity:
             false
-        case .claudeCode, .codexExec, .openCode, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+        case .claudeCode, .codexExec, .openCode, .omp, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .devin:
             true
         }
     }
@@ -185,6 +196,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             return "xAI Grok Build ACP agent. Uses Grok Build's ACP runtime (`grok agent stdio`) and injects RepoPrompt MCP tools through ACP session configuration."
         case .omp:
             return "Installed Oh My Pi ACP agent. OMP owns authentication, provider and model selection, fallbacks, memory, compaction, and internal tools; RepoPrompt injects its MCP tools."
+        case .devin:
+            return "Installed Devin ACP agent for interactive Agent Mode. Devin owns authentication, model selection, modes, and internal tools; RepoPrompt injects its MCP tools."
         case .claudeCodeGLM:
             let config = ClaudeCodeCompatibleBackendStore.shared.config(for: .glmZAI)
             if case let .claudeSlotMapping(mapping) = config.modelBehavior {
@@ -223,6 +236,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "grok_build_acp"
         case .omp:
             "omp_acp"
+        case .devin:
+            "devin_acp"
         }
     }
 
@@ -236,7 +251,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             .kimi
         case .customClaudeCompatible:
             .customCompatible
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }
@@ -336,6 +351,10 @@ final class AgentRuntimeProviderService {
                 Self.logger.debug("Created OMPACPHeadlessAgentProvider")
             }
             return OMPACPHeadlessAgentProvider(config: config, workspacePath: workspacePath)
+        case .devin:
+            return UnsupportedHeadlessAgentProvider(
+                reason: "Devin CLI is currently supported only in interactive Agent Mode."
+            )
         case .grokBuild:
             let config = GrokBuildAgentConfig(
                 enableDebugLogging: Self.enableDebugLogging,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -921,7 +921,7 @@ final class ACPIntegratedAgentModeRunner {
         agentKind: AgentProviderKind,
         modelString: String?
     ) throws -> String? {
-        guard agentKind == .openCode || agentKind == .cursor || agentKind == .grokBuild || agentKind == .antigravity || agentKind == .omp else { return nil }
+        guard agentKind == .openCode || agentKind == .cursor || agentKind == .grokBuild || agentKind == .antigravity || agentKind == .omp || agentKind == .devin else { return nil }
         guard let model = modelString?.trimmingCharacters(in: .whitespacesAndNewlines),
               !model.isEmpty,
               model.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) != .orderedSame

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -628,7 +628,7 @@ final class ACPIntegratedAgentModeRunner {
                 hooks.persistence.scheduleSave(session)
                 hooks.bindingObservation.updateBindings(session)
 
-                try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
+                try await Self.applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
                 let parameterReport = try await controller.applySessionModelParameterSelections(runRequest.modelParameterSelections)
                 try Self.validateModelParameterApplicationReport(parameterReport)
                 await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
@@ -709,7 +709,7 @@ final class ACPIntegratedAgentModeRunner {
                     return .failed(errorText: "\(runRequest.agentKind.displayName) ACP session is no longer reusable.")
                 }
 
-                try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
+                try await Self.applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
                 let parameterReport = try await controller.applySessionModelParameterSelections(runRequest.modelParameterSelections)
                 try Self.validateModelParameterApplicationReport(parameterReport)
                 await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
@@ -902,7 +902,7 @@ final class ACPIntegratedAgentModeRunner {
         }
     }
 
-    private func applyExplicitSelectedModelIfNeeded(
+    static func applyExplicitSelectedModelIfNeeded(
         _ runRequest: ACPRunRequest,
         controller: ACPAgentSessionController,
         runID: UUID
@@ -913,7 +913,9 @@ final class ACPIntegratedAgentModeRunner {
         ) else {
             return
         }
-        log("applying \(runRequest.agentKind.displayName) selected model=\(model)", runID: runID)
+        if AgentRuntimeProviderService.enableDebugLogging {
+            print("[ACP-Runner] run=\(runID) applying \(runRequest.agentKind.displayName) selected model=\(model)")
+        }
         try await controller.setSessionModel(model)
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -925,7 +925,7 @@ final class ACPIntegratedAgentModeRunner {
         controller: ACPAgentSessionController,
         runID: UUID
     ) async throws {
-        guard let model = try Self.explicitSelectedModel(
+        guard let model = try explicitSelectedModel(
             agentKind: runRequest.agentKind,
             modelString: runRequest.modelString
         ) else {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -48,8 +48,18 @@ final class ACPIntegratedAgentModeRunner {
     private let controllerFactory: AgentModeViewModel.ACPControllerFactory
     private var toolTrackingByTabID: [UUID: AgentToolTrackingController] = [:]
     private var toolTrackingRunIDByTabID: [UUID: UUID] = [:]
-    private var acpProviderInvocationByTrackerInvocationIDByTabID: [UUID: [UUID: UUID]] = [:]
-    private var acpProviderPlaceholderInvocationIDsByTabID: [UUID: Set<UUID>] = [:]
+    private enum ToolSource { case tracker, provider }
+    private struct ToolCorrelation {
+        var providerByTracker: [UUID: UUID] = [:]
+        var sources: [UUID: ToolSource] = [:]
+        var placeholders: Set<UUID> = []
+        // Item IDs survive the tracker-to-provider invocation ID remap.
+        var trackerResults: Set<UUID> = []
+        var providerFailures: Set<UUID> = []
+        var notedFailures: Set<UUID> = []
+    }
+
+    private var toolCorrelation: [UUID: ToolCorrelation] = [:]
 
     private func log(_ message: String, runID: UUID) {
         guard AgentRuntimeProviderService.enableDebugLogging else { return }
@@ -316,6 +326,10 @@ final class ACPIntegratedAgentModeRunner {
 
         await controller.setExpectedMCPRunID(runID)
         session.acpController = controller
+        session.observeACPSessionModes(from: controller) { [weak self, weak session] in
+            guard let self, let session else { return }
+            hooks.bindingObservation.updateBindings(session)
+        }
         let requiresPrePromptMCPRouting = runRequest.agentKind.requiresPrePromptAgentModeMCPRouting
         session.installRunAttemptTerminalResources(ownership: ownership) { [weak self] terminalState in
             let trackerTeardown = self?.prepareToolTrackingTeardown(for: session, matchingRunID: runID)
@@ -632,7 +646,7 @@ final class ACPIntegratedAgentModeRunner {
                 let parameterReport = try await controller.applySessionModelParameterSelections(runRequest.modelParameterSelections)
                 try Self.validateModelParameterApplicationReport(parameterReport)
                 await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
-                try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
+                try await Self.applyRequestedSessionModeIfNeeded(runRequest, controller: controller)
                 setRunningStatus(waitingForConnectionStatusText(for: runRequest.agentKind), source: .transport, session: session, urgent: true)
 
                 if runRequest.agentKind.requiresPrePromptAgentModeMCPRouting {
@@ -713,7 +727,7 @@ final class ACPIntegratedAgentModeRunner {
                 let parameterReport = try await controller.applySessionModelParameterSelections(runRequest.modelParameterSelections)
                 try Self.validateModelParameterApplicationReport(parameterReport)
                 await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
-                try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
+                try await Self.applyRequestedSessionModeIfNeeded(runRequest, controller: controller)
 
                 if let deferredLease {
                     let acquired = await deferredLease.acquire()
@@ -892,14 +906,18 @@ final class ACPIntegratedAgentModeRunner {
         hooks.bindingObservation.updateBindings(session)
     }
 
-    private func applyRequestedSessionModeIfNeeded(
-        _ requestedMode: String?,
-        controller: ACPAgentSessionController,
-        runID: UUID
+    static func applyRequestedSessionModeIfNeeded(
+        _ request: ACPRunRequest,
+        controller: ACPAgentSessionController
     ) async throws {
-        if let requestedMode = requestedMode?.trimmingCharacters(in: .whitespacesAndNewlines), !requestedMode.isEmpty {
-            try await controller.setSessionMode(requestedMode)
+        guard let requested = request.sessionModeID else { return }
+        if request.agentKind == .devin {
+            let snapshot = await controller.currentSessionModeSnapshot()
+            guard snapshot?.availableValues.contains(requested) == true else {
+                throw AIProviderError.invalidConfiguration(detail: "Devin does not advertise the requested session mode.")
+            }
         }
+        try await controller.setSessionMode(requested)
     }
 
     static func applyExplicitSelectedModelIfNeeded(
@@ -1241,11 +1259,13 @@ final class ACPIntegratedAgentModeRunner {
         toolTrackingHooks.flushPendingAssistantDelta(session)
         toolTrackingHooks.endActiveAssistantSegment(session)
         toolTrackingHooks.endActiveReasoningSegment(session)
+        toolCorrelation[session.tabID, default: ToolCorrelation()].sources[invocationID] = .tracker
         let argsJSON = AgentToolTrackingController.encodeArgsToJSON(args)
         let storedToolName = MCPIntegrationHelper.canonicalRepoPromptToolName(toolName) ?? toolName
         if let index = correlatedToolCallItemIndex(
             in: session,
             storedToolName: storedToolName,
+            source: .tracker,
             invocationID: invocationID,
             argsJSON: argsJSON,
             allowNameOnlyFallback: false
@@ -1272,6 +1292,7 @@ final class ACPIntegratedAgentModeRunner {
         } else if let index = correlatedToolResultItemIndex(
             in: session,
             storedToolName: storedToolName,
+            source: .tracker,
             invocationID: invocationID,
             argsJSON: argsJSON,
             allowNameOnlyFallback: false
@@ -1326,12 +1347,14 @@ final class ACPIntegratedAgentModeRunner {
         toolTrackingHooks.flushPendingAssistantDelta(session)
         toolTrackingHooks.endActiveAssistantSegment(session)
         toolTrackingHooks.endActiveReasoningSegment(session)
+        toolCorrelation[session.tabID, default: ToolCorrelation()].sources[invocationID] = .tracker
         let argsJSON = AgentToolTrackingController.encodeArgsToJSON(args)
         let storedToolName = MCPIntegrationHelper.canonicalRepoPromptToolName(toolName) ?? toolName
-        let resolvedInvocationID = consumeProviderInvocation(forTrackerInvocationID: invocationID, tabID: session.tabID) ?? invocationID
+        let resolvedInvocationID = resolvedProviderInvocation(forTrackerInvocationID: invocationID, tabID: session.tabID) ?? invocationID
         if let index = correlatedToolResultItemIndex(
             in: session,
             storedToolName: storedToolName,
+            source: .tracker,
             invocationID: resolvedInvocationID,
             argsJSON: argsJSON,
             allowNameOnlyFallback: true
@@ -1354,7 +1377,9 @@ final class ACPIntegratedAgentModeRunner {
             if !hadResult, hasNonEmptyPayload(resultJSON) {
                 toolTrackingHooks.addToolOutputTokens(resultJSON, session)
             }
+            toolCorrelation[session.tabID, default: ToolCorrelation()].trackerResults.insert(updated.id)
             session.replaceItem(at: index, with: updated)
+            reportProviderContradiction(for: updated, session: session)
         } else {
             if hasNonEmptyPayload(resultJSON) {
                 toolTrackingHooks.addToolOutputTokens(resultJSON, session)
@@ -1367,6 +1392,7 @@ final class ACPIntegratedAgentModeRunner {
                 sequenceIndex: session.nextSequenceIndex
             )
             toolResultItem.toolArgsJSON = argsJSON
+            toolCorrelation[session.tabID, default: ToolCorrelation()].trackerResults.insert(toolResultItem.id)
             session.appendItem(toolResultItem)
         }
         toolTrackingHooks.requestUIRefresh(session.tabID, false)
@@ -1393,10 +1419,12 @@ final class ACPIntegratedAgentModeRunner {
     private func correlatedToolCallItemIndex(
         in session: AgentTabSession,
         storedToolName: String,
+        source: ToolSource,
         invocationID: UUID?,
         argsJSON: String?,
         allowNameOnlyFallback: Bool
     ) -> Int? {
+        let invocationID = invocationID.map { source == .tracker ? resolvedProviderInvocation(forTrackerInvocationID: $0, tabID: session.tabID) ?? $0 : $0 }
         var inspectedItemCount = 0
         if let invocationID {
             let candidates = indexedThenActiveTurnToolCandidates(
@@ -1405,12 +1433,6 @@ final class ACPIntegratedAgentModeRunner {
                 where: {
                     $0.kind == .toolCall
                         && $0.toolInvocationID == invocationID
-                        && self.shouldUpdateExistingToolCall(
-                            $0,
-                            storedToolName: storedToolName,
-                            argsJSON: argsJSON,
-                            tabID: session.tabID
-                        )
                 }
             )
             inspectedItemCount += candidates.inspectedItemCount
@@ -1432,11 +1454,12 @@ final class ACPIntegratedAgentModeRunner {
                 session: session,
                 where: {
                     $0.kind == .toolCall
+                        && self.canAssociate($0, incoming: invocationID, source: source, tabID: session.tabID)
                         && self.toolInvocationSignature(toolName: $0.toolName, argsJSON: $0.toolArgsJSON) == signature
                 }
             )
             inspectedItemCount += candidates.inspectedItemCount
-            if let index = candidates.indices.last {
+            if candidates.indices.count == 1, let index = candidates.indices.first {
                 MCPToolObserverAttributionContext.record(
                     correlationPath: candidates.usedFallbackScan ? "signature_active_turn_scan" : "signature",
                     scannedItemCount: inspectedItemCount
@@ -1450,6 +1473,7 @@ final class ACPIntegratedAgentModeRunner {
             let normalizedToolName = AgentTabSession.normalizedToolCorrelationName(storedToolName)
             let placeholderCandidates = session.activeTurnToolItemIndices(where: { item in
                 item.kind == .toolCall
+                    && self.canAssociate(item, incoming: invocationID, source: source, tabID: session.tabID)
                     && self.isProviderPlaceholderInvocation(item.toolInvocationID, tabID: session.tabID)
                     && self.isPlaceholderToolArgs(item.toolArgsJSON)
                     && AgentTabSession.normalizedToolCorrelationName(item.toolName) == normalizedToolName
@@ -1467,6 +1491,7 @@ final class ACPIntegratedAgentModeRunner {
             let normalizedToolName = AgentTabSession.normalizedToolCorrelationName(storedToolName)
             let fallback = session.activeTurnToolItemIndices(where: {
                 $0.kind == .toolCall
+                    && self.canAssociate($0, incoming: invocationID, source: source, tabID: session.tabID)
                     && AgentTabSession.normalizedToolCorrelationName($0.toolName) == normalizedToolName
             })
             inspectedItemCount += fallback.scannedItemCount
@@ -1474,7 +1499,7 @@ final class ACPIntegratedAgentModeRunner {
                 correlationPath: fallback.lastIndex == nil ? "none" : "name_active_turn_scan",
                 scannedItemCount: inspectedItemCount
             )
-            return fallback.lastIndex
+            return fallback.indices.count == 1 ? fallback.indices.first : nil
         }
         MCPToolObserverAttributionContext.record(
             correlationPath: "none",
@@ -1486,10 +1511,12 @@ final class ACPIntegratedAgentModeRunner {
     private func correlatedToolResultItemIndex(
         in session: AgentTabSession,
         storedToolName: String,
+        source: ToolSource,
         invocationID: UUID?,
         argsJSON: String?,
         allowNameOnlyFallback: Bool
     ) -> Int? {
+        let invocationID = invocationID.map { source == .tracker ? resolvedProviderInvocation(forTrackerInvocationID: $0, tabID: session.tabID) ?? $0 : $0 }
         var inspectedItemCount = 0
         if let invocationID {
             let callCandidates = indexedThenActiveTurnToolCandidates(
@@ -1498,12 +1525,6 @@ final class ACPIntegratedAgentModeRunner {
                 where: {
                     $0.kind == .toolCall
                         && $0.toolInvocationID == invocationID
-                        && self.shouldUpdateExistingToolCall(
-                            $0,
-                            storedToolName: storedToolName,
-                            argsJSON: argsJSON,
-                            tabID: session.tabID
-                        )
                 }
             )
             inspectedItemCount += callCandidates.inspectedItemCount
@@ -1522,12 +1543,6 @@ final class ACPIntegratedAgentModeRunner {
                 where: {
                     $0.kind == .toolResult
                         && $0.toolInvocationID == invocationID
-                        && self.shouldUpdateExistingToolResult(
-                            $0,
-                            storedToolName: storedToolName,
-                            argsJSON: argsJSON,
-                            tabID: session.tabID
-                        )
                 }
             )
             inspectedItemCount += resultCandidates.inspectedItemCount
@@ -1549,11 +1564,12 @@ final class ACPIntegratedAgentModeRunner {
                 session: session,
                 where: {
                     $0.kind == .toolCall
+                        && self.canAssociate($0, incoming: invocationID, source: source, tabID: session.tabID)
                         && self.toolInvocationSignature(toolName: $0.toolName, argsJSON: $0.toolArgsJSON) == signature
                 }
             )
             inspectedItemCount += callCandidates.inspectedItemCount
-            if let index = callCandidates.indices.last {
+            if callCandidates.indices.count == 1, let index = callCandidates.indices.first {
                 MCPToolObserverAttributionContext.record(
                     correlationPath: callCandidates.usedFallbackScan
                         ? "signature_call_active_turn_scan"
@@ -1567,11 +1583,12 @@ final class ACPIntegratedAgentModeRunner {
                 session: session,
                 where: {
                     $0.kind == .toolResult
+                        && self.canAssociate($0, incoming: invocationID, source: source, tabID: session.tabID)
                         && self.toolInvocationSignature(toolName: $0.toolName, argsJSON: $0.toolArgsJSON) == signature
                 }
             )
             inspectedItemCount += resultCandidates.inspectedItemCount
-            if let index = resultCandidates.indices.last {
+            if resultCandidates.indices.count == 1, let index = resultCandidates.indices.first {
                 MCPToolObserverAttributionContext.record(
                     correlationPath: resultCandidates.usedFallbackScan
                         ? "signature_result_active_turn_scan"
@@ -1585,6 +1602,7 @@ final class ACPIntegratedAgentModeRunner {
             let normalizedToolName = AgentTabSession.normalizedToolCorrelationName(storedToolName)
             let fallback = session.activeTurnToolItemIndices(where: {
                 $0.kind == .toolCall
+                    && self.canAssociate($0, incoming: invocationID, source: source, tabID: session.tabID)
                     && AgentTabSession.normalizedToolCorrelationName($0.toolName) == normalizedToolName
             })
             inspectedItemCount += fallback.scannedItemCount
@@ -1592,7 +1610,7 @@ final class ACPIntegratedAgentModeRunner {
                 correlationPath: fallback.lastIndex == nil ? "none" : "name_active_turn_scan",
                 scannedItemCount: inspectedItemCount
             )
-            return fallback.lastIndex
+            return fallback.indices.count == 1 ? fallback.indices.first : nil
         }
         MCPToolObserverAttributionContext.record(
             correlationPath: "none",
@@ -1601,92 +1619,49 @@ final class ACPIntegratedAgentModeRunner {
         return nil
     }
 
-    private func shouldUpdateExistingToolCall(
-        _ item: AgentChatItem,
-        storedToolName: String,
-        argsJSON: String?,
-        tabID: UUID
-    ) -> Bool {
-        guard item.kind == .toolCall else { return false }
-        return hasExactToolInvocationSignature(item, storedToolName: storedToolName, argsJSON: argsJSON)
-            || hasSameNormalizedToolName(item.toolName, storedToolName)
-            || isKnownProviderPlaceholder(item, tabID: tabID)
-    }
-
-    private func shouldUpdateExistingToolResult(
-        _ item: AgentChatItem,
-        storedToolName: String,
-        argsJSON: String?,
-        tabID: UUID
-    ) -> Bool {
-        guard item.kind == .toolResult else { return false }
-        if hasExactToolInvocationSignature(item, storedToolName: storedToolName, argsJSON: argsJSON) {
-            return true
-        }
-        switch AgentTranscriptToolNormalizer.status(for: item) {
-        case .pending, .running:
-            return hasSameNormalizedToolName(item.toolName, storedToolName)
-                || isKnownProviderPlaceholder(item, tabID: tabID)
-        case .success, .warning, .failed, .cancelled, .unknown:
-            return false
-        }
-    }
-
-    private func hasExactToolInvocationSignature(
-        _ item: AgentChatItem,
-        storedToolName: String,
-        argsJSON: String?
-    ) -> Bool {
-        toolInvocationSignature(toolName: item.toolName, argsJSON: item.toolArgsJSON)
-            == toolInvocationSignature(toolName: storedToolName, argsJSON: argsJSON)
-    }
-
-    private func hasSameNormalizedToolName(_ existingToolName: String?, _ incomingToolName: String) -> Bool {
-        let existing = MCPIntegrationHelper.normalizedRepoPromptToolName(existingToolName ?? "")
-        let incoming = MCPIntegrationHelper.normalizedRepoPromptToolName(incomingToolName)
-        return !existing.isEmpty && existing == incoming
-    }
-
-    private func isKnownProviderPlaceholder(_ item: AgentChatItem, tabID: UUID) -> Bool {
-        isProviderPlaceholderInvocation(item.toolInvocationID, tabID: tabID)
-            && isPlaceholderToolArgs(item.toolArgsJSON)
+    private func canAssociate(_ item: AgentChatItem, incoming: UUID?, source: ToolSource, tabID: UUID) -> Bool {
+        guard let existing = item.toolInvocationID, let incoming else { return true }
+        let state = toolCorrelation[tabID, default: ToolCorrelation()]
+        guard state.sources[existing] != source else { return false }
+        // Once paired, only exact identity/alias lookup may find this execution.
+        return state.providerByTracker[existing] == nil && !state.providerByTracker.values.contains(existing)
+            && state.providerByTracker[incoming] == nil && !state.providerByTracker.values.contains(incoming)
     }
 
     private func recordProviderInvocation(_ providerInvocationID: UUID, forTrackerInvocationID trackerInvocationID: UUID, tabID: UUID) {
-        var mappings = acpProviderInvocationByTrackerInvocationIDByTabID[tabID, default: [:]]
-        mappings[trackerInvocationID] = providerInvocationID
-        acpProviderInvocationByTrackerInvocationIDByTabID[tabID] = mappings
+        toolCorrelation[tabID, default: ToolCorrelation()].providerByTracker[trackerInvocationID] = providerInvocationID
     }
 
     private func recordProviderPlaceholderInvocationIfNeeded(_ invocationID: UUID?, argsJSON: String?, tabID: UUID) {
         guard let invocationID, isPlaceholderToolArgs(argsJSON) else { return }
-        var placeholders = acpProviderPlaceholderInvocationIDsByTabID[tabID, default: []]
-        placeholders.insert(invocationID)
-        acpProviderPlaceholderInvocationIDsByTabID[tabID] = placeholders
+        toolCorrelation[tabID, default: ToolCorrelation()].placeholders.insert(invocationID)
     }
 
     private func removeProviderPlaceholderInvocation(_ invocationID: UUID?, tabID: UUID) {
-        guard let invocationID,
-              var placeholders = acpProviderPlaceholderInvocationIDsByTabID[tabID] else { return }
-        placeholders.remove(invocationID)
-        acpProviderPlaceholderInvocationIDsByTabID[tabID] = placeholders.isEmpty ? nil : placeholders
+        guard let invocationID else { return }
+        toolCorrelation[tabID]?.placeholders.remove(invocationID)
     }
 
     private func isProviderPlaceholderInvocation(_ invocationID: UUID?, tabID: UUID) -> Bool {
         guard let invocationID else { return false }
-        return acpProviderPlaceholderInvocationIDsByTabID[tabID]?.contains(invocationID) == true
+        return toolCorrelation[tabID]?.placeholders.contains(invocationID) == true
     }
 
-    private func consumeProviderInvocation(forTrackerInvocationID trackerInvocationID: UUID, tabID: UUID) -> UUID? {
-        guard var mappings = acpProviderInvocationByTrackerInvocationIDByTabID[tabID] else { return nil }
-        let providerInvocationID = mappings.removeValue(forKey: trackerInvocationID)
-        acpProviderInvocationByTrackerInvocationIDByTabID[tabID] = mappings.isEmpty ? nil : mappings
-        return providerInvocationID
+    private func resolvedProviderInvocation(forTrackerInvocationID trackerInvocationID: UUID, tabID: UUID) -> UUID? {
+        toolCorrelation[tabID]?.providerByTracker[trackerInvocationID]
+    }
+
+    private func reportProviderContradiction(for item: AgentChatItem, session: AgentTabSession) {
+        guard item.toolIsError != true,
+              toolCorrelation[session.tabID]?.trackerResults.contains(item.id) == true,
+              toolCorrelation[session.tabID]?.providerFailures.contains(item.id) == true,
+              toolCorrelation[session.tabID]?.notedFailures.contains(item.id) != true else { return }
+        toolCorrelation[session.tabID, default: ToolCorrelation()].notedFailures.insert(item.id)
+        session.appendItem(.error("The provider reported \(item.toolName ?? "tool") as failed, but RepoPrompt completed it successfully. The actual RepoPrompt result is retained.", sequenceIndex: session.nextSequenceIndex))
     }
 
     private func resetACPToolCorrelation(for tabID: UUID) {
-        acpProviderInvocationByTrackerInvocationIDByTabID[tabID] = nil
-        acpProviderPlaceholderInvocationIDsByTabID[tabID] = nil
+        toolCorrelation[tabID] = nil
     }
 
     private func toolInvocationSignature(toolName: String?, argsJSON: String?) -> String {
@@ -1878,10 +1853,12 @@ final class ACPIntegratedAgentModeRunner {
             toolTrackingHooks.flushPendingAssistantDelta(session)
             toolTrackingHooks.endActiveAssistantSegment(session)
             toolTrackingHooks.endActiveReasoningSegment(session)
+            if let id = call.invocationID { toolCorrelation[session.tabID, default: ToolCorrelation()].sources[id] = .provider }
             let storedToolName = MCPIntegrationHelper.canonicalRepoPromptToolName(call.toolName) ?? call.toolName
             if let index = correlatedToolCallItemIndex(
                 in: session,
                 storedToolName: storedToolName,
+                source: .provider,
                 invocationID: call.invocationID,
                 argsJSON: call.argsJSON,
                 allowNameOnlyFallback: false
@@ -1898,7 +1875,9 @@ final class ACPIntegratedAgentModeRunner {
                     updated.toolInvocationID = updated.toolInvocationID ?? call.invocationID
                 }
                 updated.toolName = storedToolName
-                updated.toolArgsJSON = call.argsJSON ?? updated.toolArgsJSON
+                if toolCorrelation[session.tabID]?.trackerResults.contains(updated.id) != true {
+                    updated.toolArgsJSON = call.argsJSON ?? updated.toolArgsJSON
+                }
                 if updated.kind == .toolCall {
                     updated.text = call.argsJSON ?? ""
                 }
@@ -1909,6 +1888,7 @@ final class ACPIntegratedAgentModeRunner {
             } else if let index = correlatedToolResultItemIndex(
                 in: session,
                 storedToolName: storedToolName,
+                source: .provider,
                 invocationID: call.invocationID,
                 argsJSON: call.argsJSON,
                 allowNameOnlyFallback: false
@@ -1925,7 +1905,9 @@ final class ACPIntegratedAgentModeRunner {
                     updated.toolInvocationID = updated.toolInvocationID ?? call.invocationID
                 }
                 updated.toolName = storedToolName
-                updated.toolArgsJSON = call.argsJSON ?? updated.toolArgsJSON
+                if toolCorrelation[session.tabID]?.trackerResults.contains(updated.id) != true {
+                    updated.toolArgsJSON = call.argsJSON ?? updated.toolArgsJSON
+                }
                 if !hadArgs, hasAccountableToolPayload(call.argsJSON) {
                     toolTrackingHooks.addToolInputTokens(call.argsJSON, session)
                 }
@@ -1959,15 +1941,33 @@ final class ACPIntegratedAgentModeRunner {
             toolTrackingHooks.endActiveAssistantSegment(session)
             toolTrackingHooks.endActiveReasoningSegment(session)
             removeProviderPlaceholderInvocation(result.invocationID, tabID: session.tabID)
+            if let id = result.invocationID { toolCorrelation[session.tabID, default: ToolCorrelation()].sources[id] = .provider }
             let storedToolName = MCPIntegrationHelper.canonicalRepoPromptToolName(result.toolName) ?? result.toolName
             if let index = correlatedToolResultItemIndex(
                 in: session,
                 storedToolName: storedToolName,
+                source: .provider,
                 invocationID: result.invocationID,
                 argsJSON: result.argsJSON,
                 allowNameOnlyFallback: true
             ) {
                 var updated = session.items[index]
+                if let trackerID = updated.toolInvocationID, let providerID = result.invocationID, trackerID != providerID {
+                    recordProviderInvocation(providerID, forTrackerInvocationID: trackerID, tabID: session.tabID)
+                    updated.toolInvocationID = providerID
+                    session.replaceItem(at: index, with: updated)
+                }
+                if result.isError == true {
+                    toolCorrelation[session.tabID, default: ToolCorrelation()].providerFailures.insert(updated.id)
+                } else {
+                    toolCorrelation[session.tabID]?.providerFailures.remove(updated.id)
+                }
+                if toolCorrelation[session.tabID]?.trackerResults.contains(updated.id) == true {
+                    reportProviderContradiction(for: updated, session: session)
+                    toolTrackingHooks.requestUIRefresh(session.tabID, false)
+                    toolTrackingHooks.scheduleSave(session.tabID)
+                    return true
+                }
                 let hadResult = hasNonEmptyPayload(updated.toolResultJSON)
                 updated.kind = .toolResult
                 updated.toolName = storedToolName
@@ -1992,6 +1992,9 @@ final class ACPIntegratedAgentModeRunner {
                     sequenceIndex: session.nextSequenceIndex
                 )
                 toolResultItem.toolArgsJSON = result.argsJSON
+                if result.isError == true {
+                    toolCorrelation[session.tabID, default: ToolCorrelation()].providerFailures.insert(toolResultItem.id)
+                }
                 session.appendItem(toolResultItem)
             }
             toolTrackingHooks.requestUIRefresh(session.tabID, false)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ContextUsage.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ContextUsage.swift
@@ -6,7 +6,7 @@ extension AgentModeViewModel {
         switch agent {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             claudeContextUsageEstimator
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ProviderBindings.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ProviderBindings.swift
@@ -91,6 +91,16 @@ extension AgentModeViewModel {
     }
 
     func setProviderPermissionLevel(_ id: AgentProviderPermissionLevelID) {
+        if case let .devinMode(raw) = id {
+            guard let session = activeSession, session.selectedAgent == .devin,
+                  session.permissionProfile == .userConfigured,
+                  permissionControlsExternallyManagedReason(for: session) == nil,
+                  session.acpSessionModeSnapshot?.availableValues.contains(raw) == true else { return }
+            // Intent only: never mutate a running turn or persist native observed state as consent.
+            session.acpSessionModeIntent = raw
+            updatePermissionBindingState(from: session)
+            return
+        }
         let providerID = providerBindingService.setPermissionLevel(id)
         providerPreferenceDidChange(providerID, bumpProviderBindingRevision: false)
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -5404,7 +5404,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     modelContextWindow: session.codexContextUsage?.modelContextWindow
                 )
             }
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             break
         }
         session.contextUsageSnapshot = ContextUsageSnapshot.fromAgentContextUsage(
@@ -17108,7 +17108,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         switch agent {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .openCode, .cursor, .antigravity:
             return renderAtPathAttachmentMessage(text: text, attachments: attachments)
-        case .codexExec, .grokBuild, .omp:
+        case .codexExec, .grokBuild, .omp, .devin:
             return text
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -700,6 +700,12 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     let clearConsumedAttachmentsAfterProviderConsumption: Bool
     let applyEditsApprovalStore: ApplyEditsApprovalStore
     private lazy var runService: AgentModeRunService = makeRunService()
+
+    #if DEBUG
+        var testACPRunner: ACPIntegratedAgentModeRunner {
+            runService.testACPRunner
+        }
+    #endif
     private let sessionLifecycleAuthority = AgentSessionLifecycleAuthority()
 
     private var isRestoringState = false
@@ -11094,7 +11100,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
     }
 
-    private func permissionControlsExternallyManagedReason(for session: TabSession) -> String? {
+    func permissionControlsExternallyManagedReason(for session: TabSession) -> String? {
         providerBindingService.externallyManagedPermissionReason(
             isSubagent: usesSubagentPermissionPolicy(session),
             isMCPControlled: session.mcpControlContext != nil,
@@ -11122,7 +11128,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             selectedModelRaw: session.selectedModelRaw,
             permissionProfile: session.permissionProfile,
             isSubagent: usesSubagentPolicy,
-            externallyManagedReason: externallyManagedReason
+            externallyManagedReason: externallyManagedReason,
+            acpModeSnapshot: session.acpSessionModeSnapshot,
+            acpModeIntent: session.acpSessionModeIntent
         )
         if activeProviderControlsBinding != nextControlsBinding {
             activeProviderControlsBinding = nextControlsBinding

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentTabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentTabSession.swift
@@ -826,7 +826,32 @@ final class AgentTabSession: ObservableObject {
     }
 
     var claudeController: (any NativeAgentRuntimeControlling)?
-    var acpController: ACPAgentSessionController?
+    var acpSessionModeSnapshot: ACPSessionModeSnapshot?
+    var acpSessionModeIntent: String?
+    var acpModeObservationTask: Task<Void, Never>?
+    func observeACPSessionModes(from controller: ACPAgentSessionController, onChange: @escaping @MainActor () -> Void) {
+        acpModeObservationTask?.cancel()
+        let binding = persistentSessionBindingIdentity
+        acpModeObservationTask = Task { [weak self] in
+            for await snapshot in await controller.sessionModeUpdates() {
+                guard !Task.isCancelled, let self, acpController === controller,
+                      persistentSessionBindingIdentity == binding else { return }
+                acpSessionModeSnapshot = snapshot
+                onChange()
+            }
+        }
+    }
+
+    var acpController: ACPAgentSessionController? {
+        didSet {
+            if oldValue !== acpController {
+                acpModeObservationTask?.cancel()
+                acpModeObservationTask = nil
+                acpSessionModeSnapshot = nil
+            }
+        }
+    }
+
     var codexEventTask: Task<Void, Never>?
     var codexEventTaskRunID: UUID?
     var codexLastEventAt: Date?
@@ -875,8 +900,18 @@ final class AgentTabSession: ObservableObject {
         hasSentFirstMessage && !pendingHandoff.defersProviderLockUntilSend
     }
 
-    // Persistence
-    private(set) var persistentSessionBindingIdentity: AgentPersistentSessionBindingIdentity?
+    /// Persistence
+    private(set) var persistentSessionBindingIdentity: AgentPersistentSessionBindingIdentity? {
+        didSet {
+            if oldValue != persistentSessionBindingIdentity {
+                acpModeObservationTask?.cancel()
+                acpModeObservationTask = nil
+                acpSessionModeSnapshot = nil
+                acpSessionModeIntent = nil
+            }
+        }
+    }
+
     var activeAgentSessionID: UUID? {
         persistentSessionBindingIdentity?.sessionID
     }
@@ -960,6 +995,7 @@ final class AgentTabSession: ObservableObject {
     }
 
     deinit {
+        acpModeObservationTask?.cancel()
         applyEditsApprovalSubscriptionTask?.cancel()
         oversight.snoozeDeadlineTask?.cancel()
         oversight.periodicDeadlineTask?.cancel()
@@ -975,6 +1011,10 @@ final class AgentTabSession: ObservableObject {
     /// instruction, applyEditsReview, MCP control, run cancellation) remain
     /// on the VM and are called separately by each teardown path.
     func cancelEphemeralRuntimeState() {
+        acpModeObservationTask?.cancel()
+        acpModeObservationTask = nil
+        acpSessionModeSnapshot = nil
+        acpSessionModeIntent = nil
         derivedTranscriptRefreshTask?.cancel()
         derivedTranscriptRefreshTask = nil
         pendingDerivedTranscriptRefreshReason = nil

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
@@ -184,6 +184,18 @@ struct AgentPermissionCapabilitySummaryBuilder {
                 approvalModeDescription: "Provider managed",
                 warnings: []
             )
+        case .devin:
+            return AgentPermissionCapabilitySummary(
+                providerID: providerID,
+                providerName: providerID.displayName,
+                isAvailable: isAvailable,
+                fileMutation: "Managed by Devin",
+                shell: "Managed by Devin",
+                externalMCP: "RepoPrompt MCP: run-scoped policy",
+                search: "Managed by Devin",
+                approvalModeDescription: "Provider managed",
+                warnings: []
+            )
         case .grokBuild:
             let level = grokBuildPermissionLevel(profile: profile)
             let warnings = level == .fullAccess
@@ -242,6 +254,7 @@ struct AgentPermissionCapabilitySummaryBuilder {
         case .grokBuild: availability.grokBuildAvailable
         case .antigravity: availability.antigravityAvailable
         case .omp: availability.ompAvailable
+        case .devin: availability.devinAvailable
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
@@ -193,6 +193,8 @@ final class AgentProviderPermissionsSettingsViewModel: ObservableObject {
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .omp(level):
             OMPAgentToolPreferences.setPermissionLevel(level, defaults: defaults)
+        case .devin:
+            break
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
@@ -193,7 +193,7 @@ final class AgentProviderPermissionsSettingsViewModel: ObservableObject {
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .omp(level):
             OMPAgentToolPreferences.setPermissionLevel(level, defaults: defaults)
-        case .devin:
+        case .devin, .devinMode:
             break
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
@@ -61,8 +61,7 @@ final class AgentRuntimeSidebarViewModel: ObservableObject {
             case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible: return 200_000
             case .openCode, .cursor, .antigravity: return 200_000
             case .grokBuild: return 500_000 // grok 4.5/4.6 advertise totalContextTokens 500000
-            case .codexExec, .omp, .none: return 200_000
-            case .codexExec, .devin, .none: return 200_000
+            case .codexExec, .omp, .devin, .none: return 200_000
             }
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
@@ -62,6 +62,7 @@ final class AgentRuntimeSidebarViewModel: ObservableObject {
             case .openCode, .cursor, .antigravity: return 200_000
             case .grokBuild: return 500_000 // grok 4.5/4.6 advertise totalContextTokens 500000
             case .codexExec, .omp, .none: return 200_000
+            case .codexExec, .devin, .none: return 200_000
             }
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
@@ -257,6 +257,7 @@ struct AgentComposerView: View, Equatable {
 
     @FocusState var isFocused: Bool
 
+    @State private var confirmsDevinBypass = false
     @State private var localInputText: String = ""
     @State private var submissionLatch = AgentComposerSubmissionLatch()
     @State private var lastAppliedDraftRestorationEventIDByTab: [UUID: UUID] = [:]
@@ -1173,6 +1174,13 @@ struct AgentComposerView: View, Equatable {
         .hoverTooltip("Permissions & approval settings")
         .popover(isPresented: $showPermissionPopover, arrowEdge: .bottom) {
             approvalPopoverContent
+                .confirmationDialog("Enable Devin Bypass Permissions?", isPresented: $confirmsDevinBypass, titleVisibility: .visible) {
+                    Button("Request Bypass Permissions", role: .destructive) {
+                        actions.setProviderPermissionLevel(.devinMode("bypass"))
+                    }
+                } message: {
+                    Text("Eligible Devin tools may run without approval on the next turn. Organization restrictions and RepoPrompt MCP policy still apply.")
+                }
         }
     }
 
@@ -1203,7 +1211,7 @@ struct AgentComposerView: View, Equatable {
             managedPermissionInfoBlock
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("Sandbox Level")
+                Text(permissionBinding?.providerID == .devin ? "ACP Session Mode" : "Sandbox Level")
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
                     .foregroundStyle(.secondary)
 
@@ -1215,7 +1223,17 @@ struct AgentComposerView: View, Equatable {
                             isSelected: option.isSelected,
                             disabled: !option.isEnabled
                         ) {
-                            actions.setProviderPermissionLevel(option.id)
+                            if case .devinMode("bypass") = option.id {
+                                confirmsDevinBypass = true
+                            } else {
+                                actions.setProviderPermissionLevel(option.id)
+                            }
+                        }
+                        if permissionBinding.providerID == .devin, let detail = option.detailText, !detail.isEmpty {
+                            Text(detail)
+                                .font(fontPreset.swiftUIFont(sizeAtNormal: 10))
+                                .foregroundStyle(option.isWarning ? .orange : .secondary)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -1547,6 +1547,7 @@ extension AgentProviderKind {
         case .cursor: "cursorarrow"
         case .grokBuild: "bolt.circle.fill"
         case .omp: "pi"
+        case .devin: "terminal.fill"
         }
     }
 }

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -311,6 +311,10 @@ public class APISettingsViewModel: ObservableObject {
     @Published var isOMPConnected: Bool = UserDefaults.standard.bool(forKey: "OMPCLIConnected")
     @Published var ompError: String? = nil
     private var ompLogCollector: CLIProcessLogCollector?
+    // Devin CLI / ACP
+    @Published var isDevinConnected: Bool = UserDefaults.standard.bool(forKey: "DevinCLIConnected")
+    @Published var devinError: String? = nil
+    private var devinLogCollector: CLIProcessLogCollector?
 
     /// CLI connection flags are persisted configuration hints, not proof that the provider is
     /// usable in the current process. Context Builder restoration waits for this validation pass
@@ -395,6 +399,7 @@ public class APISettingsViewModel: ObservableObject {
             grokBuildAvailable: isGrokBuildConnected,
             antigravityAvailable: AntigravityRuntimeManager.installedRuntimeSync() != nil,
             ompAvailable: isOMPConnected,
+            devinAvailable: isDevinConnected,
             zaiConfigured: compatibleBackendIsActive(.glmZAI),
             kimiConfigured: compatibleBackendIsActive(.kimi),
             customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
@@ -427,6 +432,7 @@ public class APISettingsViewModel: ObservableObject {
             $isCursorConnected.map { _ in () }.eraseToAnyPublisher(),
             $isGrokBuildConnected.map { _ in () }.eraseToAnyPublisher(),
             $isOMPConnected.map { _ in () }.eraseToAnyPublisher(),
+            $isDevinConnected.map { _ in () }.eraseToAnyPublisher(),
             $claudeCodeCLIStatus.map { _ in () }.eraseToAnyPublisher(),
             $compatibleBackendConfigs.map { _ in () }.eraseToAnyPublisher(),
             $compatibleBackendSecretPresence.map { _ in () }.eraseToAnyPublisher()
@@ -449,6 +455,7 @@ public class APISettingsViewModel: ObservableObject {
             cursorAvailable: isVerifiedContextBuilderProvider(.cursor) && isCursorConnected,
             grokBuildAvailable: isVerifiedContextBuilderProvider(.grokBuild) && isGrokBuildConnected,
             ompAvailable: isVerifiedContextBuilderProvider(.omp) && isOMPConnected,
+            devinAvailable: false,
             zaiConfigured: compatibleBackendIsActive(.glmZAI),
             kimiConfigured: compatibleBackendIsActive(.kimi),
             customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
@@ -508,6 +515,8 @@ public class APISettingsViewModel: ObservableObject {
             AntigravityRuntimeManager.installedRuntimeSync() != nil
         case .omp:
             isOMPConnected
+        case .devin:
+            isDevinConnected
         case .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             false
         }
@@ -557,7 +566,8 @@ public class APISettingsViewModel: ObservableObject {
             NotificationCenter.default.publisher(for: .openCodeConnectionChanged).map { _ in AgentProviderKind.openCode },
             NotificationCenter.default.publisher(for: .cursorConnectionChanged).map { _ in AgentProviderKind.cursor },
             NotificationCenter.default.publisher(for: .grokBuildConnectionChanged).map { _ in AgentProviderKind.grokBuild },
-            NotificationCenter.default.publisher(for: .ompConnectionChanged).map { _ in AgentProviderKind.omp }
+            NotificationCenter.default.publisher(for: .ompConnectionChanged).map { _ in AgentProviderKind.omp },
+            NotificationCenter.default.publisher(for: .devinConnectionChanged).map { _ in AgentProviderKind.devin }
         ])
         .receive(on: DispatchQueue.main)
         .sink { [weak self] provider in
@@ -623,6 +633,7 @@ public class APISettingsViewModel: ObservableObject {
         isCursorConnected = UserDefaults.standard.bool(forKey: "CursorCLIConnected")
         isGrokBuildConnected = UserDefaults.standard.bool(forKey: "GrokBuildCLIConnected")
         isOMPConnected = UserDefaults.standard.bool(forKey: "OMPCLIConnected")
+        isDevinConnected = UserDefaults.standard.bool(forKey: "DevinCLIConnected")
         if wasGrokBuildConnected != isGrokBuildConnected {
             if isGrokBuildConnected {
                 startGrokBuildModelsSubscriptionIfNeeded(workspacePath: nil)
@@ -3858,6 +3869,97 @@ public class APISettingsViewModel: ObservableObject {
         let url = try collector.writeMarkdownToDownloads(
             baseFilename: "RepoPrompt-OMPTrace",
             title: "Oh My Pi CLI Connection Trace",
+            timestamp: exportDate
+        )
+        collector.append("Trace exported to \(url.lastPathComponent)")
+        return url
+    }
+
+    // MARK: - Devin CLI / ACP
+
+    func testDevinConnection() async throws -> Bool {
+        let collector = CLIProcessLogCollector()
+        collector.append("Devin CLI connection test started")
+        devinLogCollector = collector
+
+        collector.append("Refreshing login-shell environment cache")
+        await CLIEnvironmentCache.shared.invalidate()
+
+        do {
+            guard let models = try await DevinACPModelDiscoveryService.discoverModels(),
+                  !models.options.isEmpty
+            else {
+                throw AIProviderError.invalidConfiguration(
+                    detail: "Devin CLI ACP did not advertise any selectable models."
+                )
+            }
+            isDevinConnected = true
+            devinError = nil
+            UserDefaults.standard.set(true, forKey: "DevinCLIConnected")
+            collector.append("Devin CLI marked as connected with \(models.options.count) model(s)")
+            devinLogCollector = nil
+            NotificationCenter.default.post(
+                name: .devinConnectionChanged,
+                object: nil,
+                userInfo: ["windowID": 0]
+            )
+            return true
+        } catch {
+            collector.append("Connection test threw error: \(error.localizedDescription)")
+            isDevinConnected = false
+            devinError = friendlyDevinMessage(for: error)
+            UserDefaults.standard.set(false, forKey: "DevinCLIConnected")
+            collector.append("User guidance: \(devinError ?? error.localizedDescription)")
+            NotificationCenter.default.post(
+                name: .devinConnectionChanged,
+                object: nil,
+                userInfo: ["windowID": 0]
+            )
+            throw error
+        }
+    }
+
+    func disconnectDevin() {
+        isDevinConnected = false
+        devinError = nil
+        UserDefaults.standard.set(false, forKey: "DevinCLIConnected")
+        NotificationCenter.default.post(
+            name: .devinConnectionChanged,
+            object: nil,
+            userInfo: ["windowID": 0]
+        )
+    }
+
+    private func friendlyDevinMessage(for error: Error) -> String {
+        if let providerError = error as? AIProviderError,
+           case let .invalidConfiguration(detail) = providerError
+        {
+            return detail
+        }
+        let message = error.localizedDescription
+        let lowered = message.lowercased()
+        if lowered.contains("not installed") || lowered.contains("not found") || lowered.contains("no such file") {
+            return "Devin CLI was not found. Install it and ensure `devin acp` is available."
+        }
+        if lowered.contains("permission denied") {
+            return "Permission denied. Ensure the `devin` executable is accessible."
+        }
+        return message
+    }
+
+    func hasDevinTrace() -> Bool {
+        devinLogCollector?.isEmpty == false
+    }
+
+    func dumpDevinTrace() throws -> URL {
+        guard let collector = devinLogCollector else {
+            throw CLIProcessLogCollectorError.noEntries
+        }
+        collector.append("Exporting trace to Downloads folder")
+        let exportDate = Date()
+        let url = try collector.writeMarkdownToDownloads(
+            baseFilename: "RepoPrompt-DevinTrace",
+            title: "Devin CLI Connection Trace",
             timestamp: exportDate
         )
         collector.append("Trace exported to \(url.lastPathComponent)")

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -530,8 +530,7 @@ struct AgentModeGeneralSettingsView: View {
         let connected = providers.filter(isProviderConnected).count
         let total = providers.count
         if connected == 0 {
-            return "Connect a CLI agent (Claude Code, Codex, OpenCode, Cursor, Oh My Pi) to run anything in Agent Mode."
-            return "Connect a CLI agent (Claude Code, Codex, OpenCode, Cursor, Devin) to run anything in Agent Mode."
+            return "Connect a CLI agent (Claude Code, Codex, OpenCode, Cursor, Oh My Pi, Devin) to run anything in Agent Mode."
         }
         return "\(connected) of \(total) CLI providers connected. Manage auth, installs, and models in CLI Providers."
     }

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -531,6 +531,7 @@ struct AgentModeGeneralSettingsView: View {
         let total = providers.count
         if connected == 0 {
             return "Connect a CLI agent (Claude Code, Codex, OpenCode, Cursor, Oh My Pi) to run anything in Agent Mode."
+            return "Connect a CLI agent (Claude Code, Codex, OpenCode, Cursor, Devin) to run anything in Agent Mode."
         }
         return "\(connected) of \(total) CLI providers connected. Manage auth, installs, and models in CLI Providers."
     }
@@ -584,6 +585,7 @@ struct AgentModeGeneralSettingsView: View {
         case .cursor: apiSettingsVM.isCursorConnected
         case .grokBuild: apiSettingsVM.isGrokBuildConnected
         case .omp: apiSettingsVM.isOMPConnected
+        case .devin: apiSettingsVM.isDevinConnected
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
@@ -91,6 +91,7 @@ struct AgentProviderPermissionLevelSection: View {
         case .cursor: "ACP Auto-Approve"
         case .grokBuild: "Always-Approve Launch"
         case .omp: "ACP Session Mode"
+        case .devin: "Tool Permissions"
         }
     }
 }
@@ -141,7 +142,7 @@ struct AgentProviderToolsRuntimeDisclosure: View {
         switch providerID {
         case .codex: binding.codexTools != nil
         case .claude: binding.claudeTools != nil
-        case .openCode, .cursor, .grokBuild, .antigravity, .omp: false
+        case .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin: false
         }
     }
 }
@@ -169,7 +170,7 @@ struct AgentProviderToolsRuntimeControls: View {
                         onApplyMutation: onApplyClaudeToolSettingMutation
                     )
                 }
-            case .openCode, .cursor, .grokBuild, .antigravity, .omp:
+            case .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
                 EmptyView()
             }
         }

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -135,8 +135,7 @@ struct CLIProvidersSettingsView: View {
                         .font(.title2)
                         .fontWeight(.semibold)
 
-                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, Cursor, or Oh My Pi to leverage your existing subscriptions — OpenCode can also proxy any API key.")
-                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, Cursor, or Devin to leverage your existing subscriptions — OpenCode can also proxy any API key.")
+                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, Cursor, Oh My Pi, or Devin to leverage your existing subscriptions — OpenCode can also proxy any API key.")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -2372,6 +2371,7 @@ struct CLIProvidersSettingsView: View {
                                 .foregroundColor(.secondary)
                         }
                         .buttonStyle(CustomButtonStyle())
+                        .disabled(isLoadingDevin)
                     }
 
                     Text("Models are discovered live from `devin acp`.")

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -54,6 +54,7 @@ struct CLIProvidersSettingsView: View {
     @State private var isAntigravityInstalled = false
     @State private var isAntigravityExpanded = false
     @State private var isLoadingOMP = false
+    @State private var isLoadingDevin = false
     @State private var isLoadingZAI = false
     @State private var showClaudeCodeTraceDump = false
     @State private var showCodexTraceDump = false
@@ -61,6 +62,7 @@ struct CLIProvidersSettingsView: View {
     @State private var showCursorTraceDump = false
     @State private var showGrokBuildTraceDump = false
     @State private var showOMPTraceDump = false
+    @State private var showDevinTraceDump = false
     @State private var isClaudePromptSettingsExpanded = false
     @State private var claudeNativePromptMode = ClaudeAgentToolPreferences.agentModePromptDelivery()
 
@@ -79,6 +81,7 @@ struct CLIProvidersSettingsView: View {
     @State private var isCursorExpanded: Bool = false
     @State private var isGrokBuildExpanded: Bool = false
     @State private var isOMPExpanded: Bool = false
+    @State private var isDevinExpanded: Bool = false
 
     // Per-backend secret text entry buffers (GLM uses viewModel.zaiApiKey directly).
     // SEARCH-HELPER: Claude-Compatible Backends settings, Kimi API key entry, Custom backend key entry
@@ -99,6 +102,7 @@ struct CLIProvidersSettingsView: View {
             || viewModel.isCursorConnected
             || viewModel.isGrokBuildConnected
             || viewModel.isOMPConnected
+            || viewModel.isDevinConnected
     }
 
     private var codexStatusText: String? {
@@ -132,6 +136,7 @@ struct CLIProvidersSettingsView: View {
                         .fontWeight(.semibold)
 
                     Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, Cursor, or Oh My Pi to leverage your existing subscriptions — OpenCode can also proxy any API key.")
+                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, Cursor, or Devin to leverage your existing subscriptions — OpenCode can also proxy any API key.")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -161,6 +166,7 @@ struct CLIProvidersSettingsView: View {
                 grokBuildCard
                 antigravityCard
                 ompCard
+                devinCard
             }
             .padding(16)
         }
@@ -218,6 +224,13 @@ struct CLIProvidersSettingsView: View {
                     primaryButton: .default(Text("Save Trace to Downloads"), action: dumpOMPTrace),
                     secondaryButton: .cancel(Text("OK"), action: { showOMPTraceDump = false })
                 )
+            } else if showDevinTraceDump, viewModel.hasDevinTrace() {
+                Alert(
+                    title: Text("CLI Provider Management"),
+                    message: Text(alertMessage),
+                    primaryButton: .default(Text("Save Trace to Downloads"), action: dumpDevinTrace),
+                    secondaryButton: .cancel(Text("OK"), action: { showDevinTraceDump = false })
+                )
             } else {
                 Alert(
                     title: Text("CLI Provider Management"),
@@ -233,6 +246,7 @@ struct CLIProvidersSettingsView: View {
                 showOpenCodeTraceDump = false
                 showCursorTraceDump = false
                 showOMPTraceDump = false
+                showDevinTraceDump = false
                 showCodexSignOutConfirmation = false
             }
         }
@@ -2326,6 +2340,73 @@ struct CLIProvidersSettingsView: View {
         }
     }
 
+    // MARK: - Devin CLI / ACP card
+
+    private var devinCard: some View {
+        providerCard(
+            title: "Devin",
+            subtitle: "Uses the installed `devin acp` runtime for interactive Agent Mode. Devin keeps authority over authentication, models, modes, and built-in tools.",
+            infoURL: "https://docs.devin.ai/cli/acp/zed",
+            isConnected: viewModel.isDevinConnected,
+            isExpanded: $isDevinExpanded
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                if viewModel.isDevinConnected {
+                    HStack(spacing: 8) {
+                        Button(action: testDevinConnection) {
+                            if isLoadingDevin {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(height: 16)
+                            } else {
+                                Label("Test Connection", systemImage: "antenna.radiowaves.left.and.right")
+                            }
+                        }
+                        .disabled(isLoadingDevin)
+                        .buttonStyle(CustomButtonStyle())
+
+                        Spacer()
+
+                        Button(action: disconnectDevin) {
+                            Text("Disconnect")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(CustomButtonStyle())
+                    }
+
+                    Text("Models are discovered live from `devin acp`.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    HStack(spacing: 10) {
+                        Button(action: testDevinConnection) {
+                            if isLoadingDevin {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(height: 16)
+                            } else {
+                                Label("Connect", systemImage: "link")
+                            }
+                        }
+                        .disabled(isLoadingDevin)
+                        .buttonStyle(CustomButtonStyle())
+
+                        if let error = viewModel.devinError, !error.isEmpty {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } else {
+                            Text("Install and authenticate Devin separately, then ensure `devin acp` is available.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // MARK: - Cursor CLI / ACP card
 
     private var cursorCard: some View {
@@ -2935,6 +3016,57 @@ struct CLIProvidersSettingsView: View {
         viewModel.disconnectOMP()
         alertMessage = "Disconnected Oh My Pi"
         showOMPTraceDump = false
+        showAlert = true
+        onAPIKeyUpdated?()
+    }
+
+    private func testDevinConnection() {
+        isLoadingDevin = true
+        Task {
+            do {
+                let ok = try await viewModel.testDevinConnection()
+                await MainActor.run {
+                    isLoadingDevin = false
+                    if ok {
+                        alertMessage = "Devin connected. Devin will use its configured provider and model."
+                        showDevinTraceDump = false
+                    }
+                    showAlert = true
+                    onAPIKeyUpdated?()
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingDevin = false
+                    alertMessage = viewModel.devinError ?? error.asFriendlyString()
+                    showDevinTraceDump = viewModel.hasDevinTrace()
+                    showAlert = true
+                }
+            }
+        }
+    }
+
+    private func dumpDevinTrace() {
+        do {
+            let url = try viewModel.dumpDevinTrace()
+            alertMessage = "Trace saved to Downloads/\(url.lastPathComponent)."
+        } catch let error as CLIProcessLogCollectorError {
+            switch error {
+            case .noEntries:
+                alertMessage = "No trace data is available to export yet."
+            case .downloadsDirectoryUnavailable:
+                alertMessage = "Unable to locate the Downloads folder."
+            }
+        } catch {
+            alertMessage = "Failed to export trace: \(error.localizedDescription)"
+        }
+        showDevinTraceDump = false
+        showAlert = true
+    }
+
+    private func disconnectDevin() {
+        viewModel.disconnectDevin()
+        alertMessage = "Disconnected Devin"
+        showDevinTraceDump = false
         showAlert = true
         onAPIKeyUpdated?()
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentProviderFactory.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentProviderFactory.swift
@@ -39,6 +39,12 @@ enum ACPAgentProviderFactory {
                     enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging
                 )
             )
+        case .devin:
+            DevinACPAgentProvider(
+                config: DevinAgentConfig(
+                    enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging
+                )
+            )
         case .grokBuild:
             try await GrokBuildACPAgentProvider(
                 config: GrokBuildAgentConfig(

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -2964,7 +2964,8 @@ actor ACPAgentSessionController {
             displayName: displayName,
             description: normalizedACPModelString(rawOption["description"] as? String),
             isPlaceholderDefault: false,
-            isProviderDefault: rawOption["isDefault"] as? Bool ?? false
+            isProviderDefault: rawOption["isDefault"] as? Bool ?? false,
+            modelFamily: provider.modelFamily(for: rawValue)
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -725,7 +725,7 @@ actor ACPAgentSessionController {
         }
 
         switch provider.providerID {
-        case .openCode, .cursor, .grokBuild, .antigravity, .omp:
+        case .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             if let sessionModelFailureReason {
                 throw ControllerError.protocolViolation("malformed modern model config option: \(sessionModelFailureReason)")
             }
@@ -2304,6 +2304,7 @@ actor ACPAgentSessionController {
         }
         if error is CursorACPLaunchResolutionError || error is OpenCodeACPLaunchResolutionError
             || error is OMPACPLaunchResolutionError
+            || error is DevinACPLaunchResolutionError
         {
             return "launch_resolution"
         }
@@ -3261,7 +3262,7 @@ actor ACPAgentSessionController {
 
     private func preferredAllowOptionID(for options: [PermissionOption], sessionScoped: Bool) -> String {
         let preferences: [PermissionOptionPreference] = switch provider.providerID {
-        case .openCode, .cursor, .antigravity, .omp:
+        case .openCode, .cursor, .antigravity, .omp, .devin:
             genericAllowOptionPreferences(sessionScoped: sessionScoped)
         case .grokBuild:
             grokBuildAllowOptionPreferences(sessionScoped: sessionScoped)
@@ -3312,7 +3313,7 @@ actor ACPAgentSessionController {
         switch provider.providerID {
         case .cursor:
             return optionID(for: options, preferences: genericAllowOptionPreferences(sessionScoped: true))
-        case .openCode, .grokBuild, .antigravity, .omp:
+        case .openCode, .grokBuild, .antigravity, .omp, .devin:
             // Grok full access is provider-native (`grok agent --always-approve stdio`); the
             // controller never auto-selects permission options for it.
             return nil
@@ -3366,7 +3367,7 @@ actor ACPAgentSessionController {
                 .optionID("allow_once"),
                 .kind("allow_once")
             ]
-        case .grokBuild, .omp:
+        case .grokBuild, .omp, .devin:
             // Strict RepoPrompt MCP auto-approval is per-request: never select a provider-wide
             // or session-scoped option here.
             [
@@ -3573,6 +3574,8 @@ actor ACPAgentSessionController {
                 "RP_ANTIGRAVITY_ACP_RAW_CAPTURE_PATH"
             case .omp:
                 "RP_OMP_ACP_RAW_CAPTURE_PATH"
+            case .devin:
+                "RP_DEVIN_ACP_RAW_CAPTURE_PATH"
             }
             let customPath = providerSpecificKey.flatMap { key in
                 env[key]?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -149,12 +149,6 @@ actor ACPAgentSessionController {
         var timeoutTask: Task<Void, Never>?
     }
 
-    private struct SessionModeSnapshot {
-        let configID: String
-        let currentValue: String
-        let availableValues: [String]
-    }
-
     private struct ParsedSelectConfigOption {
         let id: String
         let currentValue: String
@@ -169,7 +163,7 @@ actor ACPAgentSessionController {
 
     private enum ParsedModernModeSnapshot {
         case absent
-        case valid(SessionModeSnapshot)
+        case valid(ACPSessionModeSnapshot)
         case malformed(String)
     }
 
@@ -285,7 +279,23 @@ actor ACPAgentSessionController {
     /// registry data to live authority — effort-bearing selections require this.
     private var sessionModelSnapshotHasLiveAuthority = false
     private var sessionModelFailureReason: String?
-    private var sessionModeSnapshot: SessionModeSnapshot?
+    private let modeChannel = AsyncStream<ACPSessionModeSnapshot?>.makeStream(bufferingPolicy: .bufferingNewest(1))
+    private var sessionModeSnapshot: ACPSessionModeSnapshot? {
+        didSet {
+            if oldValue != sessionModeSnapshot { modeChannel.continuation.yield(sessionModeSnapshot) }
+        }
+    }
+
+    func currentSessionModeSnapshot() -> ACPSessionModeSnapshot? {
+        sessionModeSnapshot
+    }
+
+    /// Single subscriber owned by the runner, independent of per-prompt event streams.
+    func sessionModeUpdates() -> AsyncStream<ACPSessionModeSnapshot?> {
+        modeChannel.continuation.yield(sessionModeSnapshot)
+        return modeChannel.stream
+    }
+
     private var sessionModeFailureReason: String?
     private var lastAppliedConfigurationSequence: UInt64 = 0
     private var bufferedConfigOptionUpdates: [BufferedConfigOptionUpdate] = []
@@ -603,6 +613,18 @@ actor ACPAgentSessionController {
         let response: [String: Any]
         do {
             let promptRequest = effectivePromptRunRequest(override: overrideRunRequest)
+            if promptRequest.agentKind == .devin {
+                if promptRequest.requiresNonBypassSessionMode {
+                    guard let current = sessionModeSnapshot?.currentValue, current != "bypass" else {
+                        throw ControllerError.requestFailed("Devin session mode is Bypass or unconfirmed. This managed session cannot send a prompt without confirmed non-Bypass authority.")
+                    }
+                }
+                if let requested = promptRequest.sessionModeID {
+                    guard sessionModeSnapshot?.currentValue == requested else {
+                        throw ControllerError.requestFailed("Devin has not confirmed the requested ACP session mode. No prompt was sent.")
+                    }
+                }
+            }
             let promptBlocks = try provider.buildPromptBlocks(for: message, request: promptRequest)
             #if DEBUG
                 if isRawACPCaptureEnabled {
@@ -1049,19 +1071,28 @@ actor ACPAgentSessionController {
             return
         }
 
-        let response = try await sendRequestResponse(
-            method: "session/set_config_option",
-            params: [
-                "sessionId": sessionID,
-                "configId": snapshot.configID,
-                "value": canonicalModeID
-            ]
-        )
-        try await applyVerifiedConfigOptionsMutationResponse(
-            response,
-            requiredModeValue: canonicalModeID,
-            requiredModelValue: nil
-        )
+        let previousSequence = lastAppliedConfigurationSequence
+        do {
+            let response = try await sendRequestResponse(
+                method: "session/set_config_option",
+                params: [
+                    "sessionId": sessionID,
+                    "configId": snapshot.configID,
+                    "value": canonicalModeID
+                ]
+            )
+            try await applyVerifiedConfigOptionsMutationResponse(
+                response,
+                requiredModeValue: canonicalModeID,
+                requiredModelValue: nil
+            )
+        } catch {
+            if provider.providerID == .devin, lastAppliedConfigurationSequence == previousSequence {
+                sessionModeSnapshot = nil
+                sessionModeFailureReason = "Session mode could not be confirmed after the request."
+            }
+            throw error
+        }
     }
 
     func respondToPermissionRequest(
@@ -1340,6 +1371,7 @@ actor ACPAgentSessionController {
         sessionModelSnapshotHasLiveAuthority = false
         sessionModelFailureReason = nil
         sessionModeSnapshot = nil
+        modeChannel.continuation.finish()
         sessionModeFailureReason = nil
         lastAppliedConfigurationSequence = 0
         bufferedConfigOptionUpdates.removeAll()
@@ -2068,7 +2100,8 @@ actor ACPAgentSessionController {
             taskLabelKind: request.taskLabelKind,
             sessionModeID: request.sessionModeID,
             autoApproveAllToolPermissions: request.autoApproveAllToolPermissions,
-            modelParameterSelections: request.modelParameterSelections
+            modelParameterSelections: request.modelParameterSelections,
+            requiresNonBypassSessionMode: request.requiresNonBypassSessionMode
         )
     }
 
@@ -2402,10 +2435,17 @@ actor ACPAgentSessionController {
             guard let currentValue = canonicalAdvertisedValue(option.currentValue, in: values) else {
                 return .malformed("mode selector '\(option.id)' currentValue is not one of its advertised values")
             }
-            return .valid(SessionModeSnapshot(
+            return .valid(ACPSessionModeSnapshot(
                 configID: option.id,
                 currentValue: currentValue,
-                availableValues: values
+                options: values.map { value in
+                    let choice = option.choices.first { normalizedConfigValue($0["value"] as? String) == value }
+                    return ACPSessionModeSnapshot.Option(
+                        rawValue: value,
+                        displayName: choice?["name"] as? String ?? value,
+                        description: choice?["description"] as? String
+                    )
+                }
             ))
         }
     }
@@ -2514,7 +2554,7 @@ actor ACPAgentSessionController {
 
     private func canonicalSessionModeValue(
         _ requestedValue: String,
-        in snapshot: SessionModeSnapshot
+        in snapshot: ACPSessionModeSnapshot
     ) throws -> String {
         if let exact = snapshot.availableValues.first(where: { $0 == requestedValue }) {
             return exact
@@ -2529,7 +2569,7 @@ actor ACPAgentSessionController {
         throw ControllerError.requestFailed("ACP runtime does not advertise session mode '\(requestedValue)'. Available modes: \(advertisedSessionModeDescription(snapshot)).")
     }
 
-    private func advertisedSessionModeDescription(_ snapshot: SessionModeSnapshot) -> String {
+    private func advertisedSessionModeDescription(_ snapshot: ACPSessionModeSnapshot) -> String {
         snapshot.availableValues.isEmpty ? "none" : snapshot.availableValues.joined(separator: ", ")
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPProviderSupport.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPProviderSupport.swift
@@ -629,7 +629,7 @@ enum ACPPermissionOptionPolicy {
     /// bare kind match would otherwise select it and broaden approval beyond the request.
     static func denylistedAutoSelectOptionIDs(for providerID: ACPProviderID) -> Set<String> {
         switch providerID {
-        case .openCode, .cursor, .antigravity, .omp:
+        case .openCode, .cursor, .antigravity, .omp, .devin:
             []
         case .grokBuild:
             ["enable-always-approve"]

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ACPAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ACPAIModelCatalog.swift
@@ -11,6 +11,7 @@ struct ACPDynamicModelRecord: Codable, Hashable {
     /// Variant provenance for synthesized effort options. Optional so records persisted
     /// before effort support decode unchanged.
     var effortVariant: AgentModelEffortVariant? = nil
+    var modelFamily: AgentModelFamily? = nil
 }
 
 struct ACPDynamicProviderRecord: Codable, Hashable {
@@ -206,7 +207,8 @@ enum ACPDynamicModelStore {
             isProviderDefault: option.isProviderDefault,
             supportedReasoningEfforts: supportedReasoningEfforts,
             defaultReasoningEffort: option.defaultReasoningEffort?.rawValue,
-            effortVariant: option.effortVariant
+            effortVariant: option.effortVariant,
+            modelFamily: option.modelFamily
         )
     }
 
@@ -224,7 +226,8 @@ enum ACPDynamicModelStore {
             isProviderDefault: record.isProviderDefault,
             supportedReasoningEfforts: supportedReasoningEfforts,
             defaultReasoningEffort: CodexReasoningEffort.parse(record.defaultReasoningEffort),
-            effortVariant: record.effortVariant
+            effortVariant: record.effortVariant,
+            modelFamily: record.modelFamily
         )
     }
 
@@ -278,7 +281,8 @@ enum ACPDynamicModelStore {
             defaultReasoningEffort: metadataRecord.defaultReasoningEffort ?? fallbackRecord.defaultReasoningEffort,
             // Variant provenance is semantic identity, not metadata: keep it only when both
             // records agree, so a real base (nil) never inherits stale variant provenance.
-            effortVariant: existing.effortVariant == candidate.effortVariant ? existing.effortVariant : nil
+            effortVariant: existing.effortVariant == candidate.effortVariant ? existing.effortVariant : nil,
+            modelFamily: metadataRecord.modelFamily ?? fallbackRecord.modelFamily
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Prompts/AgentModePrompts.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Prompts/AgentModePrompts.swift
@@ -104,7 +104,7 @@ enum AgentModePrompts {
         - Providing implementation code when asked for analysis — explain and point, don't write code
         - Continuing to explore after you have enough to answer the question
         """
-        return Fragments.codexQualifiedToolReferences(prompt, agentKind: agentKind)
+        return Fragments.providerQualifiedToolReferences(prompt, agentKind: agentKind)
     }
 
     // MARK: - Engineer
@@ -203,7 +203,7 @@ enum AgentModePrompts {
         - Do not continue work after the task is complete
         - If something goes wrong, explain what happened and offer to fix it
         """
-        return Fragments.codexQualifiedToolReferences(prompt, agentKind: agentKind)
+        return Fragments.providerQualifiedToolReferences(prompt, agentKind: agentKind)
     }
 
     // MARK: - Shared Fragments
@@ -354,9 +354,14 @@ enum AgentModePrompts {
         /// Qualify RepoPrompt MCP tool references for providers whose model-visible
         /// tool names include the server namespace (Codex exposes them as
         /// `mcp__RepoPrompt__<tool>`). Keep authoring prompts with canonical names
-        /// and qualify the rendered Codex prompt at the boundary.
-        static func codexQualifiedToolReferences(_ prompt: String, agentKind: AgentProviderKind?) -> String {
-            guard agentKind == .codexExec else { return prompt }
+        /// and qualify the rendered host prompt at the provider boundary.
+        static func providerQualifiedToolReferences(_ prompt: String, agentKind: AgentProviderKind?) -> String {
+            let namespace: String
+            switch agentKind {
+            case .codexExec: namespace = MCPIntegrationHelper.repoPromptMCPServerName
+            case .devin: namespace = RepoPromptMCPServerConfiguration.defaultServerName
+            default: return prompt
+            }
             var qualified = prompt
             let toolNames = MCPIntegrationHelper.repoPromptToolNames
                 .union(["RepoPrompt__read_file"])
@@ -365,7 +370,7 @@ enum AgentModePrompts {
                 let canonical = toolName == "RepoPrompt__read_file" ? "read_file" : toolName
                 qualified = qualified.replacingOccurrences(
                     of: "`\(toolName)`",
-                    with: "`mcp__\(MCPIntegrationHelper.repoPromptMCPServerName)__\(canonical)`"
+                    with: "`mcp__\(namespace)__\(canonical)`"
                 )
             }
             return qualified

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/CLIPathHints.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/CLIPathHints.swift
@@ -8,6 +8,7 @@ enum CLIPathHints {
     static let openCode: [String] = CLILaunchProfiles.openCodeProviderSpecificPaths
     static let cursor: [String] = CLILaunchProfiles.cursorProviderSpecificPaths
     static let omp: [String] = CLILaunchProfiles.ompProviderSpecificPaths
+    static let devin: [String] = CLILaunchProfiles.devinProviderSpecificPaths
     static let grokBuild: [String] = CLILaunchProfiles.grokBuildProviderSpecificPaths
 
     static func nativeDefaultsSupplemented(with providerSpecificPaths: [String]) -> [String] {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPAgentProvider.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+struct DevinACPAgentProvider: ACPAgentProvider {
+    private let config: DevinAgentConfig
+    private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
+    private let launchResolver: DevinACPLaunchResolver
+
+    init(
+        config: DevinAgentConfig,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        launchResolver: DevinACPLaunchResolver = DevinACPLaunchResolver()
+    ) {
+        self.config = config
+        self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
+        self.launchResolver = launchResolver
+    }
+
+    var providerID: ACPProviderID {
+        .devin
+    }
+
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
+        try await launchResolver.probeSupport(for: config)
+    }
+
+    func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        let workingDirectory = try standardizedWorkingDirectory(from: request.workspacePath)
+        let resolvedLaunch = try launchResolver.resolvedLaunch(for: config)
+        let integration: DevinIntegrationConfiguration.PreparedConfiguration? = if config.includeRepoPromptMCPServer {
+            try DevinIntegrationConfiguration.prepare(
+                workingDirectory: workingDirectory,
+                repoPromptMCPConfiguration: repoPromptMCPConfiguration
+            )
+        } else {
+            nil
+        }
+        return ACPLaunchConfiguration(
+            providerID: providerID,
+            command: resolvedLaunch.command,
+            arguments: resolvedLaunch.arguments,
+            environment: integration?.environment ?? [:],
+            workingDirectory: workingDirectory,
+            additionalPathHints: resolvedLaunch.additionalPathHints,
+            enableDebugLogging: config.enableDebugLogging,
+            cleanupArtifact: integration?.cleanupArtifact,
+            expectedExecutableIdentity: resolvedLaunch.executableIdentity
+        )
+    }
+
+    func makeSessionConfiguration(
+        for request: ACPRunRequest,
+        mcpServer _: RepoPromptMCPServerConfiguration
+    ) throws -> ACPSessionConfiguration {
+        let mode: ACPSessionConfiguration.Mode = if let resume = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !resume.isEmpty
+        {
+            .load(existingSessionID: resume)
+        } else {
+            .new
+        }
+        return try ACPSessionConfiguration(
+            mode: mode,
+            workingDirectory: standardizedWorkingDirectory(from: request.workspacePath),
+            // Devin 3000.6.11 accepts ACP mcpServers but does not start them. The isolated
+            // XDG config prepared for this launch is the effective RepoPrompt MCP injection.
+            mcpServers: []
+        )
+    }
+
+    func buildPromptBlocks(
+        for message: AgentMessage,
+        request: ACPRunRequest
+    ) throws -> [[String: Any]] {
+        let isFollowUp = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+        let systemPrompt = message.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let userMessage = message.userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text: String = if isFollowUp || systemPrompt.isEmpty {
+            userMessage.isEmpty ? message.userMessage : userMessage
+        } else if userMessage.isEmpty {
+            systemPrompt
+        } else {
+            "\(systemPrompt)\n\n\(userMessage)"
+        }
+        return try ACPPromptContentBuilder.blocks(text: text, attachments: request.attachments)
+    }
+
+    func normalizeSessionUpdate(
+        _ payload: [String: Any],
+        sessionID _: String
+    ) -> [NormalizedAgentRuntimeEvent] {
+        ACPDefaultSessionUpdateNormalizer.normalize(payload, providerID: .devin)
+    }
+
+    func cleanupLaunchArtifacts(for configuration: ACPLaunchConfiguration) async {
+        guard let artifact = configuration.cleanupArtifact else { return }
+        DevinIntegrationConfiguration.cleanup(artifact: artifact)
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        if error is AIProviderError { return error }
+        if let runnerError = error as? CLIProcessRunnerError,
+           case .commandNotFound = runnerError
+        {
+            return AIProviderError.invalidConfiguration(
+                detail: "Devin ACP server not found. Install Devin and ensure `devin acp` is available."
+            )
+        }
+        if error is DevinACPLaunchResolutionError || error is ExecutableFileIdentityError {
+            return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
+        }
+        return AIProviderError.apiError(source: error)
+    }
+
+    private func standardizedWorkingDirectory(from workspacePath: String?) throws -> String {
+        if let cwd = workspacePath?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty {
+            return URL(fileURLWithPath: cwd, isDirectory: true).standardizedFileURL.path
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPromptDevinACPPreflight", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL.path
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPAgentProvider.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 struct DevinACPAgentProvider: ACPAgentProvider {
+    private let modelFamilies = DevinModelFamilyCatalog()
     private let config: DevinAgentConfig
     private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
     private let launchResolver: DevinACPLaunchResolver
@@ -20,7 +21,15 @@ struct DevinACPAgentProvider: ACPAgentProvider {
     }
 
     func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
-        try await launchResolver.probeSupport(for: config)
+        let result = try await launchResolver.probeSupport(for: config)
+        if result == .supported {
+            try await modelFamilies.refresh(launch: launchResolver.resolvedLaunch(for: config))
+        }
+        return result
+    }
+
+    func modelFamily(for rawModel: String) -> AgentModelFamily? {
+        modelFamilies.family(for: rawModel)
     }
 
     func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPAgentProvider.swift
@@ -29,7 +29,8 @@ struct DevinACPAgentProvider: ACPAgentProvider {
         let integration: DevinIntegrationConfiguration.PreparedConfiguration? = if config.includeRepoPromptMCPServer {
             try DevinIntegrationConfiguration.prepare(
                 workingDirectory: workingDirectory,
-                repoPromptMCPConfiguration: repoPromptMCPConfiguration
+                repoPromptMCPConfiguration: repoPromptMCPConfiguration,
+                sourceEnvironment: resolvedLaunch.environment
             )
         } else {
             nil
@@ -38,7 +39,7 @@ struct DevinACPAgentProvider: ACPAgentProvider {
             providerID: providerID,
             command: resolvedLaunch.command,
             arguments: resolvedLaunch.arguments,
-            environment: integration?.environment ?? [:],
+            environment: resolvedLaunch.environment.merging(integration?.environment ?? [:]) { _, overlay in overlay },
             workingDirectory: workingDirectory,
             additionalPathHints: resolvedLaunch.additionalPathHints,
             enableDebugLogging: config.enableDebugLogging,
@@ -61,8 +62,8 @@ struct DevinACPAgentProvider: ACPAgentProvider {
         return try ACPSessionConfiguration(
             mode: mode,
             workingDirectory: standardizedWorkingDirectory(from: request.workspacePath),
-            // Devin 3000.6.11 accepts ACP mcpServers but does not start them. The isolated
-            // XDG config prepared for this launch is the effective RepoPrompt MCP injection.
+            // Use only the isolated XDG configuration for RepoPrompt MCP injection.
+            // Native ACP injection needs new/load/tool proof before replacing this route.
             mcpServers: []
         )
     }
@@ -90,12 +91,35 @@ struct DevinACPAgentProvider: ACPAgentProvider {
         _ payload: [String: Any],
         sessionID _: String
     ) -> [NormalizedAgentRuntimeEvent] {
-        ACPDefaultSessionUpdateNormalizer.normalize(payload, providerID: .devin)
+        var projected = payload
+        if let update = (payload["sessionUpdate"] as? String)?.lowercased(),
+           update == "tool_call" || update == "tool_call_update",
+           let metadata = payload["_meta"] as? [String: Any],
+           let toolName = ACPRuntimeEventParsing.firstMachineIdentifier(
+               in: metadata,
+               keys: ["cognition.ai/toolName", "cognition.ai/inferenceToolName"]
+           ),
+           toolName != "mcp_call_tool"
+        {
+            // Replay can replace inferenceToolName with a generic dispatcher; prefer
+            // toolName when present, and leave generic-only partial records unresolved.
+            projected["toolName"] = toolName
+        }
+        return ACPDefaultSessionUpdateNormalizer.normalize(projected, providerID: .devin)
     }
 
     func cleanupLaunchArtifacts(for configuration: ACPLaunchConfiguration) async {
         guard let artifact = configuration.cleanupArtifact else { return }
         DevinIntegrationConfiguration.cleanup(artifact: artifact)
+    }
+
+    func shouldEmitStderrLine(_ line: String) -> Bool {
+        // The controller records diagnostics and strips ANSI before this presentation gate.
+        // Only the observed tracing INFO prefix is noise; retain unknown formats and failures.
+        line.range(
+            of: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+INFO\s+"#,
+            options: .regularExpression
+        ) == nil
     }
 
     func normalizeError(_ error: Error) -> Error {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPLaunchResolver.swift
@@ -1,0 +1,352 @@
+import Foundation
+
+enum DevinACPLaunchCandidate: Equatable {
+    case devinACP
+
+    var command: String {
+        CLILaunchProfiles.devin.commandName
+    }
+
+    var launchArguments: [String] {
+        ["acp"]
+    }
+
+    var helpArguments: [String] {
+        ["acp", "--help"]
+    }
+}
+
+struct DevinACPResolvedLaunch: Equatable {
+    let command: String
+    let arguments: [String]
+    let additionalPathHints: [String]
+    let executableIdentity: ExecutableFileIdentity
+}
+
+enum DevinACPLaunchResolutionError: Error, Equatable, LocalizedError {
+    case missingConfiguredCommand
+    case unsafeConfiguredCommand(String)
+    case exactPathNotFound(String)
+    case noValidLaunchCandidate(String, [String], ShellEnvironmentSource?)
+    case environmentDiscoveryRequired(String)
+    case unsafeApplicationPath(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingConfiguredCommand:
+            "Devin CLI launch requires an exact `devin` command or absolute path."
+        case let .unsafeConfiguredCommand(command):
+            "Refusing unsafe Devin ACP command `\(command)`. Configure the installed `devin` executable."
+        case let .exactPathNotFound(command):
+            "Devin CLI was not found as a valid executable regular file for `\(command)`. Install Devin or configure its absolute `devin` path."
+        case let .noValidLaunchCandidate(command, failures, source):
+            AgentCLILaunchDiagnostics.appendFallbackEnvironmentHint(
+                to: "Devin CLI was not found as a valid executable regular file for `\(command)`. Tried: \(failures.joined(separator: "; "))",
+                source: source
+            )
+        case let .environmentDiscoveryRequired(command):
+            "Devin CLI path discovery has not completed for `\(command)`. Run the Devin ACP support preflight or configure an absolute `devin` path."
+        case let .unsafeApplicationPath(path):
+            "Refusing Devin ACP executable inside an application bundle: \(path)"
+        }
+    }
+}
+
+final class DevinACPLaunchResolver: @unchecked Sendable {
+    typealias EnvironmentProvider = @Sendable (_ enableDebugLogging: Bool) async -> ACPLaunchEnvironment
+
+    private let environmentProvider: EnvironmentProvider
+    private let probeMutex = AsyncMutex()
+    private let lock = NSLock()
+    private var cachedLaunchByKey: [String: DevinACPResolvedLaunch] = [:]
+
+    convenience init(
+        environmentProvider: @escaping @Sendable (_ enableDebugLogging: Bool) async -> [String: String]
+    ) {
+        self.init(launchEnvironmentProvider: { enableDebugLogging in
+            await ACPLaunchEnvironment(environment: environmentProvider(enableDebugLogging))
+        })
+    }
+
+    init(
+        launchEnvironmentProvider: @escaping EnvironmentProvider = { enableDebugLogging in
+            let result = await ProcessEnvironmentBuilder.build(
+                ProcessEnvironmentRequest(
+                    purpose: .acpAgent(providerID: ACPProviderID.devin.rawValue),
+                    enableDebugLogging: enableDebugLogging
+                )
+            )
+            return ACPLaunchEnvironment(
+                environment: result.environment,
+                shellEnvironmentSource: result.shellEnvironmentSource
+            )
+        }
+    ) {
+        environmentProvider = launchEnvironmentProvider
+    }
+
+    func resolvedLaunch(for config: DevinAgentConfig) throws -> DevinACPResolvedLaunch {
+        let key = cacheKey(for: config)
+        if let cached = cachedLaunch(forKey: key) {
+            do {
+                try cached.executableIdentity.validateForTrustedPathLaunch(atPath: cached.command)
+                return cached
+            } catch {
+                invalidate(key: key)
+                throw error
+            }
+        }
+
+        let launch = try resolveExplicitLaunch(for: config)
+        cache(launch, key: key)
+        return launch
+    }
+
+    func probeSupport(for config: DevinAgentConfig) async throws -> ACPSupportResult {
+        try await probeMutex.withLock { [self] in
+            try await probeSupportSerially(for: config)
+        }
+    }
+
+    private func probeSupportSerially(for config: DevinAgentConfig) async throws -> ACPSupportResult {
+        let key = cacheKey(for: config)
+        invalidate(key: key)
+        do {
+            // Resolve from the current effective environment on every support check. The cache only
+            // bridges this successful probe to the immediately following launch configuration.
+            let launch = try await resolveLaunchForProbe(for: config)
+            let processConfig = CLIProcessConfiguration(
+                command: launch.command,
+                additionalPaths: [],
+                enableDebugLogging: config.enableDebugLogging,
+                shellLookupMode: .fallbackOnly
+            )
+            let result = try await CLIProcessRunner(config: processConfig).run(
+                args: DevinACPLaunchCandidate.devinACP.helpArguments,
+                stdin: nil,
+                outputMode: .none,
+                timeout: 10,
+                cancelChildOnTaskCancellation: true
+            )
+            guard result.status == 0 else {
+                return .unsupported(
+                    reason: "Devin CLI ACP preflight failed: `devin acp --help` exited with status \(result.status)."
+                )
+            }
+
+            let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            let combined = "\(stdout)\n\(stderr)"
+            guard combined.localizedCaseInsensitiveContains("run as an acp"),
+                  combined.localizedCaseInsensitiveContains("server over stdio")
+            else {
+                return .unsupported(
+                    reason: "Devin CLI ACP preflight failed: `devin acp --help` did not advertise ACP support."
+                )
+            }
+
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
+            cache(launch, key: key)
+            return .supported
+        } catch is CancellationError {
+            invalidate(key: key)
+            throw CancellationError()
+        } catch {
+            invalidate(key: key)
+            return .unsupported(reason: error.localizedDescription)
+        }
+    }
+
+    private func resolveLaunchForProbe(for config: DevinAgentConfig) async throws -> DevinACPResolvedLaunch {
+        let configuredCommand = try validatedConfiguredCommand(config)
+        let launchEnvironment = await environmentProvider(config.enableDebugLogging)
+        let environment = launchEnvironment.environment
+        try Task.checkCancellation()
+        if configuredCommand.contains("/") {
+            return try resolveExplicitLaunch(
+                for: config,
+                environment: environment,
+                shellEnvironmentSource: launchEnvironment.shellEnvironmentSource
+            )
+        }
+
+        let effectiveHints = CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(config.additionalPathHints)
+        return try firstValidLaunch(
+            candidates: launchCandidates(
+                additionalPathHints: effectiveHints,
+                environment: environment
+            ),
+            configuredCommand: configuredCommand,
+            additionalPathHints: effectiveHints,
+            environment: environment,
+            shellEnvironmentSource: launchEnvironment.shellEnvironmentSource
+        )
+    }
+
+    private func resolveExplicitLaunch(
+        for config: DevinAgentConfig,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        shellEnvironmentSource: ShellEnvironmentSource? = nil
+    ) throws -> DevinACPResolvedLaunch {
+        let configuredCommand = try validatedConfiguredCommand(config)
+        guard configuredCommand.contains("/") else {
+            throw DevinACPLaunchResolutionError.environmentDiscoveryRequired(configuredCommand)
+        }
+        let effectiveHints = CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(config.additionalPathHints)
+        do {
+            return try validatedLaunch(
+                entryPath: CommandPathResolver.expandPath(configuredCommand, environment: environment),
+                configuredCommand: configuredCommand,
+                additionalPathHints: effectiveHints,
+                environment: environment
+            )
+        } catch {
+            // Explicit-path failures intentionally keep their specific errors
+            // (exactPathNotFound / unsafeApplicationPath) and omit the
+            // fallback-PATH hint: an exact configured path does not depend on PATH discovery.
+            // Record the same resolution-failure telemetry as other ACP launchers.
+            AgentCLILaunchDiagnostics.recordPathResolutionFailure(
+                providerKind: .devin,
+                shellEnvironmentSource: shellEnvironmentSource,
+                candidateCount: 1
+            )
+            throw error
+        }
+    }
+
+    private func validatedConfiguredCommand(_ config: DevinAgentConfig) throws -> String {
+        let configuredCommand = config.commandName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !configuredCommand.isEmpty else {
+            throw DevinACPLaunchResolutionError.missingConfiguredCommand
+        }
+        let expectedCommand = DevinACPLaunchCandidate.devinACP.command
+        if configuredCommand.contains("/") {
+            guard (configuredCommand as NSString).lastPathComponent.caseInsensitiveCompare(expectedCommand) == .orderedSame else {
+                throw DevinACPLaunchResolutionError.unsafeConfiguredCommand(configuredCommand)
+            }
+        } else if configuredCommand.caseInsensitiveCompare(expectedCommand) != .orderedSame {
+            throw DevinACPLaunchResolutionError.unsafeConfiguredCommand(configuredCommand)
+        }
+        return configuredCommand
+    }
+
+    private func validatedLaunch(
+        entryPath: String,
+        configuredCommand: String,
+        additionalPathHints: [String],
+        environment: [String: String],
+        preserveValidationError: Bool = false
+    ) throws -> DevinACPResolvedLaunch {
+        guard entryPath.hasPrefix("/"),
+              (entryPath as NSString).lastPathComponent.caseInsensitiveCompare(DevinACPLaunchCandidate.devinACP.command) == .orderedSame
+        else {
+            throw DevinACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+
+        let identity: ExecutableFileIdentity
+        do {
+            identity = try ExecutableFileIdentity.captureForTrustedPathLaunch(atPath: entryPath)
+        } catch {
+            if preserveValidationError { throw error }
+            throw DevinACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+
+        if identity.canonicalPath.split(separator: "/").contains(where: { $0.lowercased().hasSuffix(".app") }) {
+            throw DevinACPLaunchResolutionError.unsafeApplicationPath(identity.canonicalPath)
+        }
+        return DevinACPResolvedLaunch(
+            command: identity.canonicalPath,
+            arguments: DevinACPLaunchCandidate.devinACP.launchArguments,
+            additionalPathHints: additionalPathHints,
+            executableIdentity: identity
+        )
+    }
+
+    private func launchCandidates(
+        additionalPathHints: [String],
+        environment: [String: String]
+    ) -> [String] {
+        var candidates: [String] = []
+        var seen = Set<String>()
+
+        func append(_ candidate: String) {
+            let expanded = CommandPathResolver.expandPath(candidate, environment: environment)
+            guard !expanded.isEmpty,
+                  expanded.hasPrefix("/"),
+                  seen.insert(expanded).inserted
+            else { return }
+            candidates.append(expanded)
+        }
+
+        append(
+            CommandPathResolver.resolve(
+                DevinACPLaunchCandidate.devinACP.command,
+                environment: environment,
+                additionalPaths: additionalPathHints,
+                preferredBasenames: CLILaunchProfiles.devin.preferredBasenames,
+                shellLookupMode: .fallbackOnly
+            )
+        )
+        for directory in CommandPathResolver.mergedPathComponents(
+            environment: environment,
+            additionalPaths: additionalPathHints
+        ) {
+            append((directory as NSString).appendingPathComponent(DevinACPLaunchCandidate.devinACP.command))
+        }
+        return candidates
+    }
+
+    private func firstValidLaunch(
+        candidates: [String],
+        configuredCommand: String,
+        additionalPathHints: [String],
+        environment: [String: String],
+        shellEnvironmentSource: ShellEnvironmentSource?
+    ) throws -> DevinACPResolvedLaunch {
+        var failures: [String] = []
+        for candidate in candidates {
+            do {
+                return try validatedLaunch(
+                    entryPath: candidate,
+                    configuredCommand: configuredCommand,
+                    additionalPathHints: additionalPathHints,
+                    environment: environment,
+                    preserveValidationError: true
+                )
+            } catch {
+                failures.append("\(candidate): \(error.localizedDescription)")
+            }
+        }
+        if failures.isEmpty {
+            throw DevinACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+        AgentCLILaunchDiagnostics.recordPathResolutionFailure(
+            providerKind: .devin,
+            shellEnvironmentSource: shellEnvironmentSource,
+            candidateCount: candidates.count
+        )
+        throw DevinACPLaunchResolutionError.noValidLaunchCandidate(configuredCommand, failures, shellEnvironmentSource)
+    }
+
+    private func cachedLaunch(forKey key: String) -> DevinACPResolvedLaunch? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedLaunchByKey[key]
+    }
+
+    private func cache(_ launch: DevinACPResolvedLaunch, key: String) {
+        lock.lock()
+        cachedLaunchByKey[key] = launch
+        lock.unlock()
+    }
+
+    private func invalidate(key: String) {
+        lock.lock()
+        cachedLaunchByKey.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    private func cacheKey(for config: DevinAgentConfig) -> String {
+        ([config.commandName] + config.additionalPathHints).joined(separator: "\u{1F}")
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPLaunchResolver.swift
@@ -20,6 +20,7 @@ struct DevinACPResolvedLaunch: Equatable {
     let command: String
     let arguments: [String]
     let additionalPathHints: [String]
+    let environment: [String: String]
     let executableIdentity: ExecutableFileIdentity
 }
 
@@ -258,6 +259,7 @@ final class DevinACPLaunchResolver: @unchecked Sendable {
             command: identity.canonicalPath,
             arguments: DevinACPLaunchCandidate.devinACP.launchArguments,
             additionalPathHints: additionalPathHints,
+            environment: environment,
             executableIdentity: identity
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPModelDiscoveryService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPModelDiscoveryService.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum DevinACPModelDiscoveryService {
+    static func discoverModels(workspacePath: String? = nil) async throws -> ACPDiscoveredSessionModels? {
+        let request = ACPRunRequest(
+            agentKind: .devin,
+            modelString: nil,
+            workspacePath: workspacePath,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+        let provider = DevinACPAgentProvider(
+            config: DevinAgentConfig(
+                enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
+                includeRepoPromptMCPServer: false
+            )
+        )
+        let support = try await provider.support(for: request)
+        guard support == .supported else {
+            throw AIProviderError.invalidConfiguration(
+                detail: support.reason ?? "Installed Devin CLI does not support ACP mode."
+            )
+        }
+
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request)
+        do {
+            _ = try await controller.bootstrap()
+            let snapshot = AgentACPModelRegistry.shared.currentSnapshot(for: .devin)
+            await controller.shutdown()
+            return snapshot
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinAgentConfig.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinAgentConfig.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct DevinAgentConfig {
+    let commandName: String
+    let additionalPathHints: [String]
+    let enableDebugLogging: Bool
+    let includeRepoPromptMCPServer: Bool
+
+    init(
+        commandName: String = "devin",
+        additionalPathHints: [String] = CLIPathHints.devin,
+        enableDebugLogging: Bool = false,
+        includeRepoPromptMCPServer: Bool = true
+    ) {
+        self.commandName = commandName
+        self.additionalPathHints = additionalPathHints
+        self.enableDebugLogging = enableDebugLogging
+        self.includeRepoPromptMCPServer = includeRepoPromptMCPServer
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinIntegrationConfiguration.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+enum DevinIntegrationConfiguration {
+    static let cleanupArtifactKind = "devinIsolatedMCPConfiguration"
+    private static let directoryPrefix = "RepoPromptDevinACP-"
+
+    struct PreparedConfiguration {
+        let environment: [String: String]
+        let cleanupArtifact: ACPLaunchCleanupArtifact
+    }
+
+    static func prepare(
+        workingDirectory: String,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration,
+        sourceConfigurationRoot: URL? = nil
+    ) throws -> PreparedConfiguration {
+        try repoPromptMCPConfiguration.validateACPLaunchCommand(workingDirectory: workingDirectory)
+
+        let id = UUID()
+        let root = configurationRoot(id: id)
+        let devinDirectory = root.appendingPathComponent("devin", isDirectory: true)
+        let configURL = devinDirectory.appendingPathComponent("mcp_config.json")
+        do {
+            try FileManager.default.createDirectory(
+                at: devinDirectory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let sourceRoot = sourceConfigurationRoot ?? defaultSourceConfigurationRoot()
+            let sourceDevinDirectory = sourceRoot.appendingPathComponent("devin", isDirectory: true)
+            try linkExistingConfiguration(
+                from: sourceDevinDirectory,
+                to: devinDirectory
+            )
+
+            let sourceMCPURL = sourceDevinDirectory.appendingPathComponent("mcp_config.json")
+            var rootObject = try existingMCPRootObject(at: sourceMCPURL)
+            var servers = rootObject["mcpServers"] as? [String: Any] ?? [:]
+            var server: [String: Any] = [
+                "transport": "stdio",
+                "command": repoPromptMCPConfiguration.command,
+                "args": repoPromptMCPConfiguration.args
+            ]
+            if !repoPromptMCPConfiguration.env.isEmpty {
+                server["env"] = repoPromptMCPConfiguration.environmentDictionary
+            }
+            servers[repoPromptMCPConfiguration.name] = server
+            rootObject["mcpServers"] = servers
+            let data = try JSONSerialization.data(
+                withJSONObject: rootObject,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            )
+            try data.write(to: configURL, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: configURL.path
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: root)
+            throw AIProviderError.invalidConfiguration(
+                detail: "Unable to prepare Devin MCP configuration: \(error.localizedDescription)"
+            )
+        }
+
+        return PreparedConfiguration(
+            environment: ["XDG_CONFIG_HOME": root.path],
+            cleanupArtifact: ACPLaunchCleanupArtifact(
+                providerID: .devin,
+                id: id,
+                kind: cleanupArtifactKind
+            )
+        )
+    }
+
+    static func cleanup(artifact: ACPLaunchCleanupArtifact) {
+        guard artifact.providerID == .devin,
+              artifact.kind == cleanupArtifactKind
+        else {
+            return
+        }
+        try? FileManager.default.removeItem(at: configurationRoot(id: artifact.id))
+    }
+
+    private static func configurationRoot(id: UUID) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(directoryPrefix)\(id.uuidString)", isDirectory: true)
+            .standardizedFileURL
+    }
+
+    private static func defaultSourceConfigurationRoot() -> URL {
+        let environment = ProcessInfo.processInfo.environment
+        if let configured = environment["XDG_CONFIG_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !configured.isEmpty
+        {
+            let expanded = (configured as NSString).expandingTildeInPath
+            return URL(fileURLWithPath: expanded, isDirectory: true).standardizedFileURL
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config", isDirectory: true)
+            .standardizedFileURL
+    }
+
+    private static func linkExistingConfiguration(from source: URL, to destination: URL) throws {
+        guard FileManager.default.fileExists(atPath: source.path) else { return }
+        for entry in try FileManager.default.contentsOfDirectory(
+            at: source,
+            includingPropertiesForKeys: nil
+        ) where entry.lastPathComponent != "mcp_config.json" {
+            try FileManager.default.createSymbolicLink(
+                at: destination.appendingPathComponent(entry.lastPathComponent),
+                withDestinationURL: entry
+            )
+        }
+    }
+
+    private static func existingMCPRootObject(at url: URL) throws -> [String: Any] {
+        guard FileManager.default.fileExists(atPath: url.path) else { return [:] }
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        guard let root = object as? [String: Any] else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Unable to merge Devin MCP configuration at \(url.path): expected a JSON object."
+            )
+        }
+        if let servers = root["mcpServers"], !(servers is [String: Any]) {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Unable to merge Devin MCP configuration at \(url.path): expected mcpServers to be a JSON object."
+            )
+        }
+        return root
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinIntegrationConfiguration.swift
@@ -12,7 +12,7 @@ enum DevinIntegrationConfiguration {
     static func prepare(
         workingDirectory: String,
         repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration,
-        sourceConfigurationRoot: URL? = nil
+        sourceEnvironment: [String: String]
     ) throws -> PreparedConfiguration {
         try repoPromptMCPConfiguration.validateACPLaunchCommand(workingDirectory: workingDirectory)
 
@@ -26,7 +26,7 @@ enum DevinIntegrationConfiguration {
                 withIntermediateDirectories: true,
                 attributes: [.posixPermissions: 0o700]
             )
-            let sourceRoot = sourceConfigurationRoot ?? defaultSourceConfigurationRoot()
+            let sourceRoot = sourceConfigurationRoot(environment: sourceEnvironment)
             let sourceDevinDirectory = sourceRoot.appendingPathComponent("devin", isDirectory: true)
             try linkExistingConfiguration(
                 from: sourceDevinDirectory,
@@ -45,6 +45,22 @@ enum DevinIntegrationConfiguration {
                 server["env"] = repoPromptMCPConfiguration.environmentDictionary
             }
             servers[repoPromptMCPConfiguration.name] = server
+            // The overlay is for Devin, not for its MCP children. Preserve the native
+            // config root for known stdio entries without overriding explicit server env.
+            for (name, value) in servers {
+                guard var child = value as? [String: Any],
+                      child["transport"] as? String == "stdio",
+                      child["env"] == nil || child["env"] is [String: String]
+                else { continue }
+                var environment = child["env"] as? [String: String] ?? [:]
+                if environment["XDG_CONFIG_HOME"] == nil {
+                    // A child HOME override owns the fallback when native XDG is unset.
+                    let nativeEnvironment = sourceEnvironment.merging(environment) { _, child in child }
+                    environment["XDG_CONFIG_HOME"] = sourceConfigurationRoot(environment: nativeEnvironment).path
+                }
+                child["env"] = environment
+                servers[name] = child
+            }
             rootObject["mcpServers"] = servers
             let data = try JSONSerialization.data(
                 withJSONObject: rootObject,
@@ -87,16 +103,17 @@ enum DevinIntegrationConfiguration {
             .standardizedFileURL
     }
 
-    private static func defaultSourceConfigurationRoot() -> URL {
-        let environment = ProcessInfo.processInfo.environment
+    private static func sourceConfigurationRoot(environment: [String: String]) -> URL {
         if let configured = environment["XDG_CONFIG_HOME"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !configured.isEmpty
         {
-            let expanded = (configured as NSString).expandingTildeInPath
+            let expanded = CommandPathResolver.expandPath(configured, environment: environment)
             return URL(fileURLWithPath: expanded, isDirectory: true).standardizedFileURL
         }
-        return FileManager.default.homeDirectoryForCurrentUser
+        let home = environment["HOME"].flatMap { $0.isEmpty ? nil : $0 }
+            ?? FileManager.default.homeDirectoryForCurrentUser.path
+        return URL(fileURLWithPath: home, isDirectory: true)
             .appendingPathComponent(".config", isDirectory: true)
             .standardizedFileURL
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinModelFamilyCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinModelFamilyCatalog.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Advisory presentation metadata from Devin's account catalog. It never adds a
+/// selectable model: the controller annotates only IDs its ACP session advertises.
+final class DevinModelFamilyCatalog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var familiesByModel: [String: AgentModelFamily] = [:]
+
+    func family(for rawModel: String) -> AgentModelFamily? {
+        lock.withLock { familiesByModel[rawModel] }
+    }
+
+    func refresh(launch: DevinACPResolvedLaunch) async throws {
+        lock.withLock { familiesByModel = [:] }
+        do {
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
+            let runner = CLIProcessRunner(config: CLIProcessConfiguration(
+                command: launch.command,
+                environment: launch.environment,
+                additionalPaths: [],
+                enableDebugLogging: false,
+                shellLookupMode: .fallbackOnly
+            ))
+            let result = try await runner.run(
+                args: ["models", "list", "--format", "json"], stdin: nil,
+                outputMode: .none, timeout: 10, cancelChildOnTaskCancellation: true
+            )
+            try Task.checkCancellation()
+            guard result.status == 0 else { return }
+            let parsed = try Self.parse(result.stdout)
+            lock.withLock { familiesByModel = parsed }
+        } catch {
+            // Older CLI versions or unavailable catalog metadata leave an ordinary
+            // flat picker. Never block a valid ACP session or infer family from an ID.
+            try Task.checkCancellation()
+        }
+    }
+
+    static func parse(_ data: Data) throws -> [String: AgentModelFamily] {
+        struct Catalog: Decodable {
+            struct Family: Decodable {
+                struct Variant: Decodable {
+                    let modelID: String
+                    enum CodingKeys: String, CodingKey { case modelID = "model_uid" }
+                }
+
+                let familyID: String
+                let familyLabel: String
+                let variants: [Variant]
+                enum CodingKeys: String, CodingKey {
+                    case familyID = "family_uid"
+                    case familyLabel = "family_label"
+                    case variants
+                }
+            }
+
+            let families: [Family]
+        }
+        enum InvalidCatalog: Error { case invalidOrDuplicateIdentity }
+        let catalog = try JSONDecoder().decode(Catalog.self, from: data)
+        var result: [String: AgentModelFamily] = [:]
+        var familyIDs = Set<String>()
+        for family in catalog.families {
+            guard !family.familyID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  !family.familyLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  familyIDs.insert(family.familyID).inserted else { throw InvalidCatalog.invalidOrDuplicateIdentity }
+            for variant in family.variants {
+                guard !variant.modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                      result[variant.modelID] == nil else { throw InvalidCatalog.invalidOrDuplicateIdentity }
+                result[variant.modelID] = AgentModelFamily(id: family.familyID, displayName: family.familyLabel)
+            }
+        }
+        return result
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/SystemPromptService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/SystemPromptService.swift
@@ -900,7 +900,7 @@ class SystemPromptService {
         \(agentDelegationFinalNote)
         - If something goes wrong, explain what happened and offer to fix it\(askForHelpNote)
         """
-        return AgentModePrompts.Fragments.codexQualifiedToolReferences(prompt, agentKind: agentKind)
+        return AgentModePrompts.Fragments.providerQualifiedToolReferences(prompt, agentKind: agentKind)
     }
 
     private static func mcpPairProgramPrompt() -> String {

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
@@ -1421,7 +1421,7 @@ private enum AppSettingsMCPRegistry {
             .cursor
         case .grokBuild:
             .grokBuild
-        case .omp:
+        case .omp, .devin:
             nil
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Policies/AgentModeMCPToolPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Policies/AgentModeMCPToolPolicy.swift
@@ -48,7 +48,7 @@ enum AgentModeMCPToolPolicy {
             cursorGrantedTools
         case .grokBuild:
             grokBuildGrantedTools
-        case .omp:
+        case .omp, .devin:
             grantedTools
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
@@ -16,6 +16,7 @@ enum CLILaunchProfiles {
     ]
     static let cursorProviderSpecificPaths: [String] = []
     static let ompProviderSpecificPaths: [String] = ["~/.bun/bin"]
+    static let devinProviderSpecificPaths: [String] = ["~/.local/bin"]
 
     /// Official Grok Build installer location (`GROK_BIN_DIR` overrides it, but a custom
     /// value is honored through PATH or an explicitly configured absolute command only).
@@ -71,6 +72,12 @@ enum CLILaunchProfiles {
         commandName: "omp",
         preferredBasenames: ["omp"],
         supplementalSearchPaths: providerSpecificPathsSupplementedWithNativeDefaults(ompProviderSpecificPaths)
+    )
+
+    static let devin = CLILaunchProfile(
+        commandName: "devin",
+        preferredBasenames: ["devin"],
+        supplementalSearchPaths: providerSpecificPathsSupplementedWithNativeDefaults(devinProviderSpecificPaths)
     )
 
     static let grokBuild = CLILaunchProfile(

--- a/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryModel.swift
@@ -200,6 +200,7 @@ extension SentryTelemetryBootstrap {
         case grokBuild = "grok_build"
         case antigravity
         case omp
+        case devin
 
         init(agentKind: AgentProviderKind) {
             switch agentKind {
@@ -217,6 +218,8 @@ extension SentryTelemetryBootstrap {
                 self = .antigravity
             case .omp:
                 self = .omp
+            case .devin:
+                self = .devin
             case .claudeCodeGLM:
                 self = .claudeCodeGLM
             case .kimiCode:

--- a/Sources/RepoPrompt/Infrastructure/UI/Agent/AgentModelOptionsMenuContent.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Agent/AgentModelOptionsMenuContent.swift
@@ -90,6 +90,16 @@ struct AgentModelOptionsMenuContent: View {
                     modelOptionButton(option)
                 }
             }
+        } else if agentKind == .devin {
+            ForEach(AgentModelCatalog.devinModelGroups(for: options)) { group in
+                if let family = group.family {
+                    Menu(family.displayName) {
+                        ForEach(group.options, id: \.rawValue) { option in modelOptionButton(option) }
+                    }
+                } else {
+                    ForEach(group.options, id: \.rawValue) { option in modelOptionButton(option) }
+                }
+            }
         } else if agentKind == .omp {
             ForEach(AgentModelCatalog.ompModelGroups(for: options)) { group in
                 if let provider = group.providerID {
@@ -238,6 +248,21 @@ enum AgentModelStableMenuItems {
                 selectedModelRaw: selectedModelRaw,
                 onSelect: onSelect
             )
+        }
+        if agentKind == .devin {
+            return AgentModelCatalog.devinModelGroups(for: visibleOptions).flatMap { group -> [StableMenuItem] in
+                let items = group.options.map { option in
+                    modelItem(
+                        option,
+                        agentKind: agentKind,
+                        selectedAgent: selectedAgent,
+                        selectedModelRaw: selectedModelRaw,
+                        onSelect: onSelect
+                    )
+                }
+                guard let family = group.family else { return items }
+                return [.submenu(family.displayName, items: items)]
+            }
         }
         if agentKind == .omp {
             return AgentModelCatalog.ompModelGroups(for: visibleOptions).flatMap { group -> [StableMenuItem] in

--- a/Tests/RepoPromptTests/AgentMode/ACPIntegratedAgentModeRunnerModelSelectionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPIntegratedAgentModeRunnerModelSelectionTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class ACPIntegratedAgentModeRunnerModelSelectionTests: XCTestCase {
+    func testOMPSelectedModelReachesControllerBeforeInitialAndRetainedPrompts() async throws {
+        try await verifySelections(agentKind: .omp)
+    }
+
+    func testDevinSelectedModelReachesControllerBeforeInitialAndRetainedPrompts() async throws {
+        try await verifySelections(agentKind: .devin)
+    }
+
+    private func verifySelections(agentKind: AgentProviderKind) async throws {
+        let providerID: ACPProviderID = agentKind == .omp ? .omp : .devin
+        defer { AgentACPModelRegistry.shared.test_reset(providerID: providerID) }
+        let directory = try makeTestDirectory(name: "ACPIntegratedRunnerModels")
+        let provider = try ACPModelSelectionFixtureProvider(directory: directory, providerID: providerID)
+        func request(_ model: String, resume: String? = nil) -> ACPRunRequest {
+            ACPRunRequest(
+                agentKind: agentKind,
+                modelString: model,
+                workspacePath: directory.path,
+                resumeSessionID: resume,
+                attachments: [],
+                taskLabelKind: nil
+            )
+        }
+        // Bootstrap with the provider default so bootstrap's own model application cannot
+        // mask a skipped runner call. Both production runner paths call this same method.
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request("default"))
+        do {
+            _ = try await controller.bootstrap()
+            let initial = request("model-b")
+            try await ACPIntegratedAgentModeRunner.applyExplicitSelectedModelIfNeeded(initial, controller: controller, runID: UUID())
+            try await controller.prompt(AgentMessage(userMessage: "initial"), request: initial)
+            let continuation = request("model-c", resume: "fixture-session")
+            try await ACPIntegratedAgentModeRunner.applyExplicitSelectedModelIfNeeded(continuation, controller: controller, runID: UUID())
+            let reusable = await controller.prepareForNextTurn()
+            XCTAssertTrue(reusable)
+            try await controller.prompt(AgentMessage(userMessage: "follow-up"), request: continuation)
+            // Rejection must propagate from the controller, not silently use the old model.
+            do {
+                try await ACPIntegratedAgentModeRunner.applyExplicitSelectedModelIfNeeded(request("rejected"), controller: controller, runID: UUID())
+                XCTFail("Expected model-selection rejection")
+            } catch {
+                XCTAssertTrue(String(describing: error).contains("fixture rejection"), "\(error)")
+            }
+            await controller.shutdown()
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+        let records = try provider.records()
+        XCTAssertEqual(records.compactMap { $0["selected"] as? String }, ["model-b", "model-c", "rejected"])
+        let prompts = records.filter { $0["method"] as? String == "session/prompt" }
+        XCTAssertEqual(prompts.compactMap { $0["model"] as? String }, ["model-b", "model-c"])
+        XCTAssertEqual(prompts.compactMap { $0["mode"] as? String }, ["ask", "ask"])
+        XCTAssertEqual(records.count(where: { $0["method"] as? String == "session/new" }), 1)
+        XCTAssertFalse(records.contains { $0["method"] as? String == "session/load" })
+    }
+}
+
+/// Disposable wire fixture, not evidence about an installed provider's protocol behavior.
+struct ACPModelSelectionFixtureProvider: ACPAgentProvider {
+    let directory: URL
+    let providerID: ACPProviderID
+
+    init(directory: URL, providerID: ACPProviderID) throws {
+        self.directory = directory
+        self.providerID = providerID
+        let script = #"""
+        #!/usr/bin/env python3
+        import json, sys
+        from pathlib import Path
+        root = Path(__file__).parent
+        model, mode = 'model-a', 'ask'
+        def options():
+            return [
+                {'id':'model','name':'Model','category':'model','type':'select','currentValue':model,
+                 'options':[{'value':v,'name':v} for v in ['model-a','model-b','model-c','rejected']]},
+                {'id':'mode','name':'Mode','category':'mode','type':'select','currentValue':mode,
+                 'options':[{'value':v,'name':v} for v in ['ask','code']]}]
+        def reply(i, result):
+            print(json.dumps({'jsonrpc':'2.0','id':i,'result':result}),flush=True)
+        for line in sys.stdin:
+            m=json.loads(line); method=m.get('method'); params=m.get('params',{}); i=m.get('id')
+            record={'method':method,'model':model,'mode':mode}
+            if method=='session/set_config_option': record['selected']=params['value']
+            with (root/'requests.jsonl').open('a') as f: f.write(json.dumps(record)+'\n')
+            if method=='initialize':
+                reply(i,{'protocolVersion':1,'agentCapabilities':{'loadSession':True},'authMethods':[]})
+            elif method in ['session/new','session/load']:
+                reply(i,{'sessionId':'fixture-session','configOptions':options()})
+            elif method=='session/set_config_option':
+                if params['value']=='rejected':
+                    print(json.dumps({'jsonrpc':'2.0','id':i,'error':{'code':-32602,'message':'fixture rejection'}}),flush=True)
+                else:
+                    if params['configId']=='model': model=params['value']
+                    else: mode=params['value']
+                    reply(i,{'configOptions':options()})
+            elif method=='session/prompt':
+                stderr=root/'stderr.txt'
+                if stderr.exists(): print(stderr.read_text(),file=sys.stderr,flush=True)
+                print(json.dumps({'jsonrpc':'2.0','method':'session/update','params':{'sessionId':'fixture-session',
+                    'update':{'sessionUpdate':'agent_message_chunk','content':{'type':'text','text':'answer'}}}}),flush=True)
+                reply(i,{'stopReason':'end_turn'})
+            elif i is not None: reply(i,{})
+        """# + "\n"
+        let executable = directory.appendingPathComponent("acp-fixture")
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+    }
+
+    func records() throws -> [[String: Any]] {
+        try String(contentsOf: directory.appendingPathComponent("requests.jsonl"), encoding: .utf8)
+            .split(separator: "\n").map { try XCTUnwrap(JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any]) }
+    }
+
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
+        .supported
+    }
+
+    func makeLaunchConfiguration(for _: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        ACPLaunchConfiguration(
+            providerID: providerID,
+            command: directory.appendingPathComponent("acp-fixture").path,
+            arguments: [],
+            environment: [:],
+            workingDirectory: directory.path,
+            additionalPathHints: [],
+            enableDebugLogging: false
+        )
+    }
+
+    func makeSessionConfiguration(for _: ACPRunRequest, mcpServer _: RepoPromptMCPServerConfiguration) throws -> ACPSessionConfiguration {
+        ACPSessionConfiguration(mode: .new, workingDirectory: directory.path, mcpServers: [])
+    }
+
+    func buildPromptBlocks(for message: AgentMessage, request _: ACPRunRequest) throws -> [[String: Any]] {
+        [["type": "text", "text": message.userMessage]]
+    }
+
+    func normalizeSessionUpdate(_ payload: [String: Any], sessionID _: String) -> [NormalizedAgentRuntimeEvent] {
+        ACPDefaultSessionUpdateNormalizer.normalize(payload, providerID: providerID)
+    }
+
+    func shouldEmitStderrLine(_ line: String) -> Bool {
+        if providerID == .devin {
+            return DevinACPAgentProvider(config: DevinAgentConfig(includeRepoPromptMCPServer: false)).shouldEmitStderrLine(line)
+        }
+        return true
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        error
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/ACPIntegratedAgentModeRunnerModelSelectionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPIntegratedAgentModeRunnerModelSelectionTests.swift
@@ -75,31 +75,38 @@ struct ACPModelSelectionFixtureProvider: ACPAgentProvider {
         import json, sys
         from pathlib import Path
         root = Path(__file__).parent
-        model, mode = 'model-a', 'ask'
+        model, mode = 'model-a', (root/'initial-mode.txt').read_text() if (root/'initial-mode.txt').exists() else 'ask'
         def options():
             return [
                 {'id':'model','name':'Model','category':'model','type':'select','currentValue':model,
                  'options':[{'value':v,'name':v} for v in ['model-a','model-b','model-c','rejected']]},
-                {'id':'mode','name':'Mode','category':'mode','type':'select','currentValue':mode,
-                 'options':[{'value':v,'name':v} for v in ['ask','code']]}]
+                {'id':'permission-profile','name':'Mode','category':'mode','type':'select','currentValue':mode,
+                 'options':[{'value':v,'name':'Mode '+v,'description':'Description '+v} for v in ['ask','code','novel-mode','bypass','unconfirmed']]}]
         def reply(i, result):
             print(json.dumps({'jsonrpc':'2.0','id':i,'result':result}),flush=True)
         for line in sys.stdin:
             m=json.loads(line); method=m.get('method'); params=m.get('params',{}); i=m.get('id')
             record={'method':method,'model':model,'mode':mode}
-            if method=='session/set_config_option': record['selected']=params['value']
+            if method=='session/set_config_option': record.update(selected=params['value'],configId=params['configId'])
             with (root/'requests.jsonl').open('a') as f: f.write(json.dumps(record)+'\n')
             if method=='initialize':
                 reply(i,{'protocolVersion':1,'agentCapabilities':{'loadSession':True},'authMethods':[]})
             elif method in ['session/new','session/load']:
                 reply(i,{'sessionId':'fixture-session','configOptions':options()})
             elif method=='session/set_config_option':
-                if params['value']=='rejected':
+                if params['value']=='unconfirmed':
+                    reply(i,{})
+                elif params['value']=='rejected':
                     print(json.dumps({'jsonrpc':'2.0','id':i,'error':{'code':-32602,'message':'fixture rejection'}}),flush=True)
                 else:
                     if params['configId']=='model': model=params['value']
                     else: mode=params['value']
                     reply(i,{'configOptions':options()})
+                    pushed=root/'push-mode.txt'
+                    if pushed.exists():
+                        mode=pushed.read_text()
+                        print(json.dumps({'jsonrpc':'2.0','method':'session/update','params':{'sessionId':'fixture-session',
+                            'update':{'sessionUpdate':'config_option_update','configOptions':options()}}}),flush=True)
             elif method=='session/prompt':
                 stderr=root/'stderr.txt'
                 if stderr.exists(): print(stderr.read_text(),file=sys.stderr,flush=True)
@@ -134,8 +141,8 @@ struct ACPModelSelectionFixtureProvider: ACPAgentProvider {
         )
     }
 
-    func makeSessionConfiguration(for _: ACPRunRequest, mcpServer _: RepoPromptMCPServerConfiguration) throws -> ACPSessionConfiguration {
-        ACPSessionConfiguration(mode: .new, workingDirectory: directory.path, mcpServers: [])
+    func makeSessionConfiguration(for request: ACPRunRequest, mcpServer _: RepoPromptMCPServerConfiguration) throws -> ACPSessionConfiguration {
+        ACPSessionConfiguration(mode: request.resumeSessionID.map { ACPSessionConfiguration.Mode.load(existingSessionID: $0) } ?? .new, workingDirectory: directory.path, mcpServers: [])
     }
 
     func buildPromptBlocks(for message: AgentMessage, request _: ACPRunRequest) throws -> [[String: Any]] {

--- a/Tests/RepoPromptTests/AgentMode/ACPRunnerToolConvergenceTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPRunnerToolConvergenceTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import MCP
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class ACPRunnerToolConvergenceTests: XCTestCase {
+    private let provider = DevinACPAgentProvider(config: .init(includeRepoPromptMCPServer: false))
+    private let toolName = "mcp__RepoPromptCE__get_file_tree"
+    private let rich = #"{"status":"success","content":"fixture tree"}"#
+
+    func testBothCompletionOrdersPreserveOneTrackerOwnedExecution() throws {
+        for trackerFirst in [true, false] {
+            for input in [nil, [:], ["type": "different"]] as [[String: String]?] {
+                let vm = AgentModeViewModel(codexControllerFactory: { _, _, _, _, _, _ in fatalError("Unused") })
+                let runner = vm.testACPRunner
+                let session = AgentTabSession(tabID: UUID())
+                session.appendItem(.user("fixture", sequenceIndex: 0))
+                session.runState = .running
+                let tracker = UUID()
+                try emit("tool_call", id: "one", input: ["type": "roots"], runner: runner, session: session)
+                runner.testHandleTrackerToolCall(invocationID: tracker, toolName: "get_file_tree", args: ["type": .string("roots")], session: session)
+                let itemID = try XCTUnwrap(session.items.last?.id)
+                if !trackerFirst { try emit("tool_call_update", id: "one", status: "completed", input: input, runner: runner, session: session) }
+                runner.testHandleTrackerToolResult(invocationID: tracker, toolName: "get_file_tree", args: ["type": .string("roots")], resultJSON: rich, isError: false, session: session)
+                try emit("tool_call_update", id: "one", status: "in_progress", runner: runner, session: session)
+                try emit("tool_call_update", id: "one", status: "completed", input: input, runner: runner, session: session)
+                let tools = session.items.filter { $0.kind == .toolResult || $0.kind == .toolCall }
+                XCTAssertEqual(tools.count, 1)
+                XCTAssertEqual(tools.first?.id, itemID)
+                XCTAssertEqual(tools.first?.toolResultJSON, rich)
+                XCTAssertEqual(tools.first?.toolInvocationID, ACPRuntimeEventParsing.stableInvocationUUID(rawValue: "one"))
+                let transcript = AgentTranscriptIO.importLegacyItems(session.items, terminalState: .completed)
+                let roundTrip = try JSONDecoder().decode(AgentTranscript.self, from: JSONEncoder().encode(transcript))
+                let executions = roundTrip.turns.flatMap(\.responseSpans).flatMap(\.activities).compactMap(\.toolExecution)
+                XCTAssertEqual(executions.count, 1)
+                XCTAssertEqual(executions.first?.status, .success)
+                XCTAssertEqual(executions.first?.stableExecutionID, tools.first?.toolInvocationID?.uuidString.lowercased())
+                session.testAssertSourceItemDerivedStateIsConsistent()
+            }
+        }
+    }
+
+    func testParallelSameSourceCallsRemainDistinct() throws {
+        let vm = AgentModeViewModel(codexControllerFactory: { _, _, _, _, _, _ in fatalError("Unused") })
+        let session = AgentTabSession(tabID: UUID())
+        session.appendItem(.user("fixture", sequenceIndex: 0))
+        session.runState = .running
+        for id in ["one", "two"] {
+            try emit("tool_call", id: id, input: ["type": "roots"], runner: vm.testACPRunner, session: session)
+        }
+        XCTAssertEqual(session.items.count(where: { $0.kind == .toolCall }), 2)
+    }
+
+    func testTrackerErrorsAndContradictoryProviderFailuresRemainTruthful() throws {
+        for trackerError in [true, false] {
+            let vm = AgentModeViewModel(codexControllerFactory: { _, _, _, _, _, _ in fatalError("Unused") })
+            let runner = vm.testACPRunner
+            let session = AgentTabSession(tabID: UUID())
+            session.appendItem(.user("fixture", sequenceIndex: 0))
+            session.runState = .running
+            let tracker = UUID()
+            try emit("tool_call", id: "failure", input: ["type": "roots"], runner: runner, session: session)
+            runner.testHandleTrackerToolCall(invocationID: tracker, toolName: "get_file_tree", args: ["type": .string("roots")], session: session)
+            let payload = trackerError ? #"{"status":"failed","error":"fixture failure"}"# : rich
+            runner.testHandleTrackerToolResult(invocationID: tracker, toolName: "get_file_tree", args: ["type": .string("roots")], resultJSON: payload, isError: trackerError, session: session)
+            for _ in 0 ..< 2 {
+                try emit("tool_call_update", id: "failure", status: trackerError ? "completed" : "failed", runner: runner, session: session)
+            }
+            let tools = session.items.filter { $0.kind == .toolResult }
+            XCTAssertEqual(tools.count, 1)
+            XCTAssertEqual(tools.first?.toolResultJSON, payload)
+            XCTAssertEqual(tools.first?.toolIsError, trackerError)
+            XCTAssertEqual(session.items.count(where: { $0.kind == .error }), trackerError ? 0 : 1)
+        }
+    }
+
+    func testResultFirstAssociationRetainsAliasForInputlessUpdates() throws {
+        let vm = AgentModeViewModel(codexControllerFactory: { _, _, _, _, _, _ in fatalError("Unused") })
+        let session = AgentTabSession(tabID: UUID())
+        session.appendItem(.user("fixture", sequenceIndex: 0))
+        session.runState = .running
+        let tracker = UUID()
+        vm.testACPRunner.testHandleTrackerToolCall(invocationID: tracker, toolName: "get_file_tree", args: ["type": .string("roots")], session: session)
+        vm.testACPRunner.testHandleTrackerToolResult(invocationID: tracker, toolName: "get_file_tree", args: ["type": .string("roots")], resultJSON: rich, isError: false, session: session)
+        try emit("tool_call_update", id: "result-first", status: "completed", input: ["type": "roots"], runner: vm.testACPRunner, session: session)
+        try emit("tool_call_update", id: "result-first", status: "completed", runner: vm.testACPRunner, session: session)
+        let tools = session.items.filter { $0.kind == .toolResult }
+        XCTAssertEqual(tools.count, 1)
+        XCTAssertEqual(tools.first?.toolInvocationID, ACPRuntimeEventParsing.stableInvocationUUID(rawValue: "result-first"))
+        XCTAssertEqual(tools.first?.toolResultJSON, rich)
+    }
+
+    func testInitiallyAppendedProviderFailureSurvivesTrackerSuccessAsSeparateFailure() throws {
+        let vm = AgentModeViewModel(codexControllerFactory: { _, _, _, _, _, _ in fatalError("Unused") })
+        let session = AgentTabSession(tabID: UUID())
+        session.appendItem(.user("fixture", sequenceIndex: 0))
+        session.runState = .running
+        try emit("tool_call_update", id: "failure-first", status: "failed", input: ["type": "roots"], runner: vm.testACPRunner, session: session)
+        let tracker = UUID()
+        vm.testACPRunner.testHandleTrackerToolCall(invocationID: tracker, toolName: "get_file_tree", args: ["type": .string("roots")], session: session)
+        vm.testACPRunner.testHandleTrackerToolResult(invocationID: tracker, toolName: "get_file_tree", args: ["type": .string("roots")], resultJSON: rich, isError: false, session: session)
+        XCTAssertEqual(session.items.count(where: { $0.kind == .toolResult }), 1)
+        XCTAssertEqual(session.items.count(where: { $0.kind == .error }), 1)
+    }
+
+    private func emit(_ kind: String, id: String, status: String? = nil, input: [String: String]? = nil, runner: ACPIntegratedAgentModeRunner, session: AgentTabSession) throws {
+        var payload: [String: Any] = ["sessionUpdate": kind, "toolCallId": id, "_meta": ["cognition.ai/toolName": toolName]]
+        payload["status"] = status
+        payload["rawInput"] = input
+        for event in provider.normalizeSessionUpdate(payload, sessionID: "fixture") {
+            if case let .stream(stream) = event, let tool = AgentToolStreamEvent.from(stream) {
+                XCTAssertTrue(runner.handleToolStreamEvent(tool, session: session))
+            }
+        }
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/DevinACPAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinACPAgentProviderTests.swift
@@ -1,0 +1,251 @@
+import Foundation
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+final class DevinACPAgentProviderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AgentACPModelRegistry.shared.test_reset(providerID: .devin)
+    }
+
+    override func tearDown() {
+        AgentACPModelRegistry.shared.test_reset(providerID: .devin)
+        super.tearDown()
+    }
+
+    private func makeProvider(
+        includeRepoPromptMCPServer: Bool = true
+    ) throws -> (DevinACPAgentProvider, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DevinACPAgentProviderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let executable = directory.appendingPathComponent("devin")
+        try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        let provider = DevinACPAgentProvider(
+            config: DevinAgentConfig(
+                commandName: executable.path,
+                additionalPathHints: [],
+                includeRepoPromptMCPServer: includeRepoPromptMCPServer
+            ),
+            repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(
+                command: "/bin/echo",
+                args: ["--backend", "app"]
+            )
+        )
+        return (provider, directory)
+    }
+
+    private func makeRequest(
+        workspacePath: String,
+        resumeSessionID: String? = nil,
+        attachments: [AgentImageAttachment] = []
+    ) -> ACPRunRequest {
+        ACPRunRequest(
+            agentKind: .devin,
+            modelString: AgentModel.defaultModel.rawValue,
+            workspacePath: workspacePath,
+            resumeSessionID: resumeSessionID,
+            attachments: attachments,
+            taskLabelKind: nil
+        )
+    }
+
+    func testLaunchUsesInstalledDevinACPWithIsolatedRepoPromptMCPConfig() async throws {
+        let (provider, directory) = try makeProvider()
+        let launch = try provider.makeLaunchConfiguration(for: makeRequest(workspacePath: directory.path))
+        XCTAssertEqual(launch.providerID, .devin)
+        XCTAssertEqual(launch.arguments, ["acp"])
+        let configRoot = try XCTUnwrap(launch.environment["XDG_CONFIG_HOME"])
+        let configURL = URL(fileURLWithPath: configRoot)
+            .appendingPathComponent("devin/mcp_config.json")
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: configURL)) as? [String: Any]
+        )
+        let servers = try XCTUnwrap(object["mcpServers"] as? [String: Any])
+        XCTAssertNotNil(servers[RepoPromptMCPServerConfiguration.defaultServerName])
+        XCTAssertNotNil(launch.cleanupArtifact)
+        XCTAssertNotNil(launch.expectedExecutableIdentity)
+        await provider.cleanupLaunchArtifacts(for: launch)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: configRoot))
+    }
+
+    func testSessionConfigurationUsesIsolatedMCPConfigAndLoadsTrimmedResumeID() throws {
+        let (provider, directory) = try makeProvider()
+        let session = try provider.makeSessionConfiguration(
+            for: makeRequest(workspacePath: directory.path, resumeSessionID: "  devin-session  "),
+            mcpServer: .repoPrompt
+        )
+        guard case let .load(existingSessionID) = session.mode else {
+            return XCTFail("expected session/load")
+        }
+        XCTAssertEqual(existingSessionID, "devin-session")
+        XCTAssertTrue(session.mcpServers.isEmpty)
+    }
+
+    func testModelDiscoveryLaunchDoesNotInjectRepoPromptMCP() throws {
+        let (provider, directory) = try makeProvider(includeRepoPromptMCPServer: false)
+        let launch = try provider.makeLaunchConfiguration(for: makeRequest(workspacePath: directory.path))
+
+        XCTAssertTrue(launch.environment.isEmpty)
+        XCTAssertNil(launch.cleanupArtifact)
+    }
+
+    func testIsolatedMCPConfigPreservesExistingDevinConfigAndMergesServers() throws {
+        let sourceRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DevinSourceConfig-\(UUID().uuidString)", isDirectory: true)
+        let sourceDevin = sourceRoot.appendingPathComponent("devin", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDevin, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sourceRoot) }
+
+        let settingsURL = sourceDevin.appendingPathComponent("config.json")
+        try Data("{\"theme\":\"dark\"}".utf8).write(to: settingsURL)
+        let existingMCPURL = sourceDevin.appendingPathComponent("mcp_config.json")
+        try Data("""
+        {"mcpServers":{"Existing":{"transport":"stdio","command":"/bin/echo","args":["existing"]}}}
+        """.utf8).write(to: existingMCPURL)
+
+        let prepared = try DevinIntegrationConfiguration.prepare(
+            workingDirectory: sourceRoot.path,
+            repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(
+                command: "/bin/echo",
+                args: ["repo-prompt"]
+            ),
+            sourceConfigurationRoot: sourceRoot
+        )
+        defer { DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact) }
+
+        let isolatedRoot = try XCTUnwrap(prepared.environment["XDG_CONFIG_HOME"])
+        let isolatedDevin = URL(fileURLWithPath: isolatedRoot).appendingPathComponent("devin")
+        let linkedSettings = isolatedDevin.appendingPathComponent("config.json")
+        let values = try linkedSettings.resourceValues(forKeys: [.isSymbolicLinkKey])
+        XCTAssertEqual(values.isSymbolicLink, true)
+        XCTAssertEqual(try Data(contentsOf: linkedSettings), try Data(contentsOf: settingsURL))
+
+        let isolatedMCP = isolatedDevin.appendingPathComponent("mcp_config.json")
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: isolatedMCP)) as? [String: Any]
+        )
+        let servers = try XCTUnwrap(object["mcpServers"] as? [String: Any])
+        XCTAssertNotNil(servers["Existing"])
+        XCTAssertNotNil(servers[RepoPromptMCPServerConfiguration.defaultServerName])
+        let attributes = try FileManager.default.attributesOfItem(atPath: isolatedMCP.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(permissions.intValue & 0o777, 0o600)
+    }
+
+    func testPromptUsesStandardACPTextAndImageBlocks() throws {
+        let (provider, directory) = try makeProvider()
+        let first = try provider.buildPromptBlocks(
+            for: AgentMessage(systemPrompt: "SYS", userMessage: "USER"),
+            request: makeRequest(workspacePath: directory.path)
+        )
+        XCTAssertEqual(first.first?["text"] as? String, "SYS\n\nUSER")
+
+        let followUp = try provider.buildPromptBlocks(
+            for: AgentMessage(systemPrompt: "SYS", userMessage: "NEXT"),
+            request: makeRequest(workspacePath: directory.path, resumeSessionID: "session")
+        )
+        XCTAssertEqual(followUp.first?["text"] as? String, "NEXT")
+    }
+
+    func testStandardAgentMessageUpdateUsesDefaultNormalizer() throws {
+        let (provider, _) = try makeProvider()
+        let events = provider.normalizeSessionUpdate(
+            ["sessionUpdate": "agent_message_chunk", "content": ["type": "text", "text": "hello"]],
+            sessionID: "session"
+        )
+        guard case let .stream(result) = events.first else {
+            return XCTFail("expected stream event")
+        }
+        XCTAssertEqual(result.text, "hello")
+    }
+
+    func testAuthenticationRemainsDevinManaged() throws {
+        let (provider, _) = try makeProvider()
+        XCTAssertNil(provider.preferredAuthMethodID(context: ACPAuthenticationContext(
+            authMethodIDs: ["agent"],
+            environment: [:]
+        )))
+    }
+
+    func testInteractiveFactoryReturnsDevinProviderWithoutModelConfiguration() async throws {
+        let provider = try await ACPAgentProviderFactory.makeProvider(for: .devin, modelString: "ignored-model")
+        XCTAssertNotNil(provider as? DevinACPAgentProvider)
+    }
+
+    func testHeadlessFactoryFailsClosed() {
+        let provider = AgentRuntimeProviderService.shared.makeProvider(
+            for: .devin,
+            modelString: "ignored-model"
+        )
+        XCTAssertTrue(provider is UnsupportedHeadlessAgentProvider)
+    }
+
+    func testCatalogUsesModelsAdvertisedByDevinACP() {
+        let availability = AgentModelCatalog.AvailabilityContext(devinAvailable: true)
+        XCTAssertEqual(
+            AgentModelCatalog.options(for: .devin, availability: availability).map(\.rawValue),
+            [AgentModel.defaultModel.rawValue]
+        )
+
+        _ = AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [
+                    AgentModelOption(
+                        rawValue: "gpt-5.6",
+                        displayName: "GPT-5.6",
+                        description: nil,
+                        isPlaceholderDefault: false,
+                        isProviderDefault: true
+                    ),
+                    AgentModelOption(
+                        rawValue: "claude-opus-4.6",
+                        displayName: "Claude Opus 4.6",
+                        description: nil,
+                        isPlaceholderDefault: false,
+                        isProviderDefault: false
+                    )
+                ],
+                currentModelRaw: "gpt-5.6"
+            ),
+            for: .devin
+        )
+
+        let options = AgentModelCatalog.options(for: .devin, availability: availability)
+        XCTAssertEqual(Set(options.map(\.rawValue)), ["gpt-5.6", "claude-opus-4.6"])
+        XCTAssertEqual(AgentModelCatalog.defaultModelRaw(for: .devin, availability: availability), "gpt-5.6")
+        XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-opus-4.6", for: .devin, availability: availability))
+        XCTAssertTrue(AgentModelCatalog.isAgentAvailable(.devin, availability: availability))
+    }
+
+    func testTaskLabelsDoNotSelectProviderManagedDevinImplicitly() {
+        let onlyDevin = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.devin)
+        for label in AgentModelCatalog.taskLabels {
+            XCTAssertNil(AgentModelCatalog.resolveTaskLabelKind(label.kind, availability: onlyDevin))
+        }
+    }
+
+    @MainActor
+    func testContextBuilderFallbackDoesNotSelectDevinImplicitly() {
+        let onlyDevin = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.devin)
+        XCTAssertNil(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: nil,
+            persistedModelRaw: nil,
+            availability: onlyDevin
+        ))
+    }
+
+    func testPermissionBindingIsInformationalAndProviderManaged() {
+        XCTAssertEqual(AgentProviderPermissionLevelID.options(for: .devin), [.devin])
+        XCTAssertEqual(AgentProviderPermissionLevelID.subagentDefault(for: .devin), .devin)
+        XCTAssertEqual(AgentProviderPermissionLevelID.devin.subagentRawValue, "providerManaged")
+        XCTAssertTrue(ACPPermissionOptionPolicy.isAutoSelectable(optionID: "allow-once", for: .devin))
+    }
+
+    func testObservedDevinMCPClientIdentityMatchesRoutingHint() {
+        XCTAssertEqual(AgentProviderKind.devin.mcpClientNameHint, "rmcp")
+        XCTAssertTrue(MCPClientIdentity.matches("rmcp", AgentProviderKind.devin.mcpClientNameHint))
+        XCTAssertTrue(AgentProviderKind.devin.requiresPrePromptAgentModeMCPRouting)
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/DevinACPAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinACPAgentProviderTests.swift
@@ -246,6 +246,95 @@ final class DevinACPAgentProviderTests: XCTestCase {
         XCTAssertTrue(AgentModelCatalog.isAgentAvailable(.devin, availability: availability))
     }
 
+    func testDiscoveryIncludesDevinCurrentModelAndAdvertisedAlternatives() throws {
+        let availability = AgentModelCatalog.AvailabilityContext(devinAvailable: true)
+        _ = AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [
+                    AgentModelOption(
+                        rawValue: "gpt-5-6-sol-medium",
+                        displayName: "GPT-5.6 Sol Medium Thinking",
+                        description: nil,
+                        isPlaceholderDefault: false,
+                        isProviderDefault: false
+                    ),
+                    AgentModelOption(
+                        rawValue: "claude-opus-5-medium",
+                        displayName: "Claude Opus 5 Medium",
+                        description: nil,
+                        isPlaceholderDefault: false,
+                        isProviderDefault: false
+                    )
+                ],
+                currentModelRaw: "gpt-5-6-sol-medium"
+            ),
+            for: .devin
+        )
+
+        let devin = try XCTUnwrap(
+            AgentModelCatalog.discoveryAgents(availability: availability)
+                .first(where: { $0.agent == .devin })
+        )
+        XCTAssertTrue(devin.available)
+        XCTAssertEqual(devin.defaults.modelRaw, "gpt-5-6-sol-medium")
+        XCTAssertEqual(
+            devin.models.map(\.name),
+            ["Claude Opus 5 Medium", "GPT-5.6 Sol Medium Thinking"]
+        )
+    }
+
+    @MainActor
+    func testNativeFamilyMetadataAnnotatesOnlyACPModelsAndSurvivesStorage() async throws {
+        let directory = try makeTestDirectory(name: "DevinModelFamilies")
+        _ = try ACPModelSelectionFixtureProvider(directory: directory, providerID: .devin)
+        let catalog = #"{"families":[{"family_uid":"fixture","family_label":"Fixture Family","variants":[{"model_uid":"model-a"},{"model_uid":"model-b"},{"model_uid":"not-advertised-by-acp"}]}]}"#
+        try catalog.write(to: directory.appendingPathComponent("catalog.json"), atomically: true, encoding: .utf8)
+        let executable = directory.appendingPathComponent("devin")
+        let script = """
+        #!/bin/sh
+        if [ "$1" = "models" ]; then cat '\(directory.path)/catalog.json'; exit 0; fi
+        if [ "$2" = "--help" ]; then echo 'Run as an ACP server over stdio'; exit 0; fi
+        exec '\(directory.path)/acp-fixture'
+        """
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        let provider = DevinACPAgentProvider(config: DevinAgentConfig(commandName: executable.path, additionalPathHints: [], includeRepoPromptMCPServer: false))
+        let request = makeRequest(workspacePath: directory.path)
+        let support = try await provider.support(for: request)
+        XCTAssertEqual(support, .supported)
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request)
+        do {
+            _ = try await controller.bootstrap()
+            let snapshot = try XCTUnwrap(AgentACPModelRegistry.shared.currentSnapshot(for: .devin))
+            XCTAssertFalse(snapshot.options.contains { $0.rawValue == "not-advertised-by-acp" })
+            let family = try XCTUnwrap(snapshot.options.first { $0.rawValue == "model-a" }?.modelFamily)
+            XCTAssertEqual(family.displayName, "Fixture Family")
+            let groups = AgentModelCatalog.devinModelGroups(for: snapshot.options)
+            XCTAssertEqual(groups.map(\.id), ["", "fixture"])
+            XCTAssertEqual(Set(groups[1].options.map(\.rawValue)), ["model-a", "model-b"])
+            let items = AgentModelStableMenuItems.modelItems(
+                agentKind: .devin,
+                options: snapshot.options,
+                selectedAgent: .devin,
+                selectedModelRaw: "model-a"
+            ) { _, _ in }
+            XCTAssertEqual(items.last?.title, "Fixture Family")
+            let record = try XCTUnwrap(ACPDynamicModelStore.canonicalProviderRecord(from: snapshot, providerID: .devin))
+            let decoded = try JSONDecoder().decode(ACPDynamicProviderRecord.self, from: JSONEncoder().encode(record))
+            XCTAssertEqual(ACPDynamicModelStore.snapshot(from: decoded)?.options.first { $0.rawValue == "model-a" }?.modelFamily, family)
+            await controller.shutdown()
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+    }
+
+    func testFamilyCatalogRejectsConflictingModelAssignments() throws {
+        let invalid = #"{"families":[{"family_uid":"one","family_label":"One","variants":[{"model_uid":"same"}]},{"family_uid":"two","family_label":"Two","variants":[{"model_uid":"same"}]}]}"#
+        XCTAssertThrowsError(try DevinModelFamilyCatalog.parse(Data(invalid.utf8)))
+        XCTAssertThrowsError(try DevinModelFamilyCatalog.parse(Data(#"{"families":[{"family_uid":"","family_label":"Missing ID","variants":[]}]}"#.utf8)))
+    }
+
     func testTaskLabelsDoNotSelectProviderManagedDevinImplicitly() {
         let onlyDevin = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.devin)
         for label in AgentModelCatalog.taskLabels {

--- a/Tests/RepoPromptTests/AgentMode/DevinACPAgentProviderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinACPAgentProviderTests.swift
@@ -16,11 +16,12 @@ final class DevinACPAgentProviderTests: XCTestCase {
     private func makeProvider(
         includeRepoPromptMCPServer: Bool = true
     ) throws -> (DevinACPAgentProvider, URL) {
-        let directory = FileManager.default.temporaryDirectory
-            .appendingPathComponent("DevinACPAgentProviderTests-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let executable = directory.appendingPathComponent("devin")
-        try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+        let directory = try makeTestDirectory(name: "DevinACPAgentProviderTests")
+        let bin = directory.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        let executable = bin.appendingPathComponent("devin")
+        try "#!/bin/sh\ncase \"$*\" in *--help*) echo 'Run as an ACP server over stdio';; *) printf '%s' \"$HOME\";; esac\n"
+            .write(to: executable, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
         let provider = DevinACPAgentProvider(
             config: DevinAgentConfig(
@@ -31,7 +32,10 @@ final class DevinACPAgentProviderTests: XCTestCase {
             repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(
                 command: "/bin/echo",
                 args: ["--backend", "app"]
-            )
+            ),
+            launchResolver: DevinACPLaunchResolver(environmentProvider: { _ in
+                ["PATH": "/usr/bin:/bin", "XDG_CONFIG_HOME": directory.path, "HOME": directory.path]
+            })
         )
         return (provider, directory)
     }
@@ -51,9 +55,17 @@ final class DevinACPAgentProviderTests: XCTestCase {
         )
     }
 
-    func testLaunchUsesInstalledDevinACPWithIsolatedRepoPromptMCPConfig() async throws {
+    func testFixtureLaunchUsesResolvedDevinACPWithIsolatedRepoPromptMCPConfig() async throws {
         let (provider, directory) = try makeProvider()
-        let launch = try provider.makeLaunchConfiguration(for: makeRequest(workspacePath: directory.path))
+        let sourceDevin = directory.appendingPathComponent("devin", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDevin, withIntermediateDirectories: true)
+        try Data(#"{"mcpServers":{"Fixture":{"transport":"stdio","command":"/bin/echo","args":["fixture"]}}}"#.utf8)
+            .write(to: sourceDevin.appendingPathComponent("mcp_config.json"))
+        let request = makeRequest(workspacePath: directory.path)
+        let support = try await provider.support(for: request)
+        XCTAssertEqual(support, .supported)
+        let launch = try provider.makeLaunchConfiguration(for: request)
+        addTeardownBlock { await provider.cleanupLaunchArtifacts(for: launch) }
         XCTAssertEqual(launch.providerID, .devin)
         XCTAssertEqual(launch.arguments, ["acp"])
         let configRoot = try XCTUnwrap(launch.environment["XDG_CONFIG_HOME"])
@@ -63,9 +75,23 @@ final class DevinACPAgentProviderTests: XCTestCase {
             JSONSerialization.jsonObject(with: Data(contentsOf: configURL)) as? [String: Any]
         )
         let servers = try XCTUnwrap(object["mcpServers"] as? [String: Any])
-        XCTAssertNotNil(servers[RepoPromptMCPServerConfiguration.defaultServerName])
+        XCTAssertEqual(Set(servers.keys), ["Fixture", RepoPromptMCPServerConfiguration.defaultServerName])
+        XCTAssertEqual(launch.environment["HOME"], directory.path)
+        let fixture = try XCTUnwrap(servers["Fixture"] as? [String: Any])
+        XCTAssertEqual((fixture["env"] as? [String: String])?["XDG_CONFIG_HOME"], directory.path)
         XCTAssertNotNil(launch.cleanupArtifact)
         XCTAssertNotNil(launch.expectedExecutableIdentity)
+        let child = Process()
+        child.executableURL = URL(fileURLWithPath: launch.command)
+        child.arguments = launch.arguments
+        child.environment = launch.environment
+        let output = Pipe()
+        child.standardOutput = output
+        try child.run()
+        let childData = output.fileHandleForReading.readDataToEndOfFile()
+        child.waitUntilExit()
+        XCTAssertEqual(child.terminationStatus, 0)
+        XCTAssertEqual(String(decoding: childData, as: UTF8.self), directory.path)
         await provider.cleanupLaunchArtifacts(for: launch)
         XCTAssertFalse(FileManager.default.fileExists(atPath: configRoot))
     }
@@ -83,20 +109,21 @@ final class DevinACPAgentProviderTests: XCTestCase {
         XCTAssertTrue(session.mcpServers.isEmpty)
     }
 
-    func testModelDiscoveryLaunchDoesNotInjectRepoPromptMCP() throws {
+    func testModelDiscoveryLaunchDoesNotInjectRepoPromptMCP() async throws {
         let (provider, directory) = try makeProvider(includeRepoPromptMCPServer: false)
-        let launch = try provider.makeLaunchConfiguration(for: makeRequest(workspacePath: directory.path))
+        let request = makeRequest(workspacePath: directory.path)
+        let support = try await provider.support(for: request)
+        XCTAssertEqual(support, .supported)
+        let launch = try provider.makeLaunchConfiguration(for: request)
 
-        XCTAssertTrue(launch.environment.isEmpty)
+        XCTAssertEqual(launch.environment["XDG_CONFIG_HOME"], directory.path)
         XCTAssertNil(launch.cleanupArtifact)
     }
 
     func testIsolatedMCPConfigPreservesExistingDevinConfigAndMergesServers() throws {
-        let sourceRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent("DevinSourceConfig-\(UUID().uuidString)", isDirectory: true)
+        let sourceRoot = try makeTestDirectory(name: "DevinSourceConfig")
         let sourceDevin = sourceRoot.appendingPathComponent("devin", isDirectory: true)
         try FileManager.default.createDirectory(at: sourceDevin, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: sourceRoot) }
 
         let settingsURL = sourceDevin.appendingPathComponent("config.json")
         try Data("{\"theme\":\"dark\"}".utf8).write(to: settingsURL)
@@ -111,7 +138,7 @@ final class DevinACPAgentProviderTests: XCTestCase {
                 command: "/bin/echo",
                 args: ["repo-prompt"]
             ),
-            sourceConfigurationRoot: sourceRoot
+            sourceEnvironment: ["XDG_CONFIG_HOME": sourceRoot.path]
         )
         defer { DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact) }
 
@@ -134,7 +161,7 @@ final class DevinACPAgentProviderTests: XCTestCase {
         XCTAssertEqual(permissions.intValue & 0o777, 0o600)
     }
 
-    func testPromptUsesStandardACPTextAndImageBlocks() throws {
+    func testPromptPrependsSystemTextOnlyOnInitialTurn() throws {
         let (provider, directory) = try makeProvider()
         let first = try provider.buildPromptBlocks(
             for: AgentMessage(systemPrompt: "SYS", userMessage: "USER"),
@@ -243,7 +270,7 @@ final class DevinACPAgentProviderTests: XCTestCase {
         XCTAssertTrue(ACPPermissionOptionPolicy.isAutoSelectable(optionID: "allow-once", for: .devin))
     }
 
-    func testObservedDevinMCPClientIdentityMatchesRoutingHint() {
+    func testDevinMCPClientRoutingPolicyPinsRmcpHint() {
         XCTAssertEqual(AgentProviderKind.devin.mcpClientNameHint, "rmcp")
         XCTAssertTrue(MCPClientIdentity.matches("rmcp", AgentProviderKind.devin.mcpClientNameHint))
         XCTAssertTrue(AgentProviderKind.devin.requiresPrePromptAgentModeMCPRouting)

--- a/Tests/RepoPromptTests/AgentMode/DevinACPAgentProviderToolMetadataTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinACPAgentProviderToolMetadataTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class DevinACPAgentProviderToolMetadataTests: XCTestCase {
+    private let provider = DevinACPAgentProvider(config: DevinAgentConfig(includeRepoPromptMCPServer: false))
+    private let canonicalName = "mcp__RepoPromptCE__read_file"
+    private let callID = "synthetic-devin-read"
+
+    /// Minimal metadata/title/status shapes from installed Devin 3000.6.14 captures.
+    /// IDs, arguments and content below are synthetic; no private session/prompt data.
+    func testCapturedInitialToolMetadataPreservesCanonicalNameAndArguments() throws {
+        let payload: [String: Any] = [
+            "sessionUpdate": "tool_call", "toolCallId": callID,
+            "title": "Calling read_file from RepoPromptCE",
+            "rawInput": ["path": "fixture.txt"],
+            "_meta": [
+                "cognition.ai/eventType": "mcp_tool_call",
+                "cognition.ai/toolName": canonicalName,
+                "cognition.ai/inferenceToolName": canonicalName
+            ]
+        ]
+        let result = try normalize(payload)
+        XCTAssertEqual(result.type, "tool_call")
+        XCTAssertEqual(result.toolName, canonicalName)
+        XCTAssertEqual(result.toolInvocationID, ACPRuntimeEventParsing.stableInvocationUUID(rawValue: callID))
+        XCTAssertEqual(try jsonObject(result.toolArgsJSON), ["path": "fixture.txt"] as NSDictionary)
+        XCTAssertEqual(result.toolArgs, result.toolArgsJSON)
+        XCTAssertNil(result.toolResultJSON)
+    }
+
+    func testCapturedTitlelessUpdatesKeepCanonicalNameStatusErrorsAndContent() throws {
+        for status in ["in_progress", "completed", "failed"] {
+            let payload: [String: Any] = [
+                "sessionUpdate": "tool_call_update", "toolCallId": callID, "status": status,
+                "rawInput": ["path": "fixture.txt"],
+                "content": [["type": "content", "content": ["type": "text", "text": "synthetic result"]]],
+                "_meta": ["cognition.ai/inferenceToolName": canonicalName]
+            ]
+            let result = try normalize(payload)
+            let baseline = try stream(ACPDefaultSessionUpdateNormalizer.normalize(payload, providerID: .devin))
+            XCTAssertEqual(result.toolName, canonicalName, status)
+            XCTAssertEqual(result.type, "tool_result")
+            XCTAssertEqual(result.toolInvocationID, ACPRuntimeEventParsing.stableInvocationUUID(rawValue: callID))
+            XCTAssertEqual(result.toolIsError, status == "failed")
+            XCTAssertEqual(try jsonObject(result.toolArgsJSON), try jsonObject(baseline.toolArgsJSON))
+            XCTAssertEqual(try jsonObject(result.toolResultJSON), try jsonObject(baseline.toolResultJSON))
+            XCTAssertEqual(result.toolOutput, result.toolResultJSON)
+            if status == "in_progress" {
+                XCTAssertEqual(try (jsonObject(result.toolResultJSON) as? NSDictionary)?["status"] as? String, "running")
+            }
+        }
+    }
+
+    func testLoadedCanonicalToolNameWinsButGenericOnlyReplayDoesNotInventIdentity() throws {
+        let initial: [String: Any] = [
+            "sessionUpdate": "tool_call", "toolCallId": callID,
+            "title": "Calling read_file from RepoPromptCE",
+            "_meta": ["cognition.ai/toolName": canonicalName, "cognition.ai/inferenceToolName": "mcp_call_tool"]
+        ]
+        let loaded = try normalize(initial)
+        XCTAssertEqual(loaded.toolName, canonicalName)
+        // Recorded replay updates carry only the generic dispatcher. Stateless projection
+        // must not pretend it can reconstruct the omitted canonical name from that field.
+        for status in ["completed", "failed"] {
+            let partial: [String: Any] = [
+                "sessionUpdate": "tool_call_update", "toolCallId": callID, "status": status,
+                "_meta": ["cognition.ai/inferenceToolName": "mcp_call_tool"]
+            ]
+            let result = try normalize(partial)
+            XCTAssertEqual(result.toolName, "tool")
+            XCTAssertEqual(result.toolInvocationID, loaded.toolInvocationID)
+            XCTAssertEqual(result.toolIsError, status == "failed")
+        }
+    }
+
+    func testMetadataFreeAndMalformedMetadataRetainExistingFallback() throws {
+        let metadata: [Any] = [
+            NSNull(), "not-an-object", [:] as [String: Any],
+            ["cognition.ai/toolName": " ", "cognition.ai/inferenceToolName": 42],
+            ["cognition.ai/toolName": "not a machine name", "cognition.ai/inferenceToolName": "mcp_call_tool"]
+        ]
+        for meta in metadata {
+            for title in [nil, "Calling read_file from RepoPromptCE"] as [String?] {
+                var payload: [String: Any] = ["sessionUpdate": "tool_call_update", "toolCallId": callID, "status": "failed"]
+                payload["title"] = title
+                let expected = try normalize(payload)
+                payload["_meta"] = meta
+                let result = try normalize(payload)
+                XCTAssertEqual(result.toolName, title ?? "tool")
+                XCTAssertEqual(result.toolName, expected.toolName)
+                XCTAssertEqual(result.toolInvocationID, expected.toolInvocationID)
+                XCTAssertEqual(result.toolIsError, expected.toolIsError)
+            }
+        }
+    }
+
+    func testCapturedNativeInferenceNamesUseExistingMachineIdentifierParsing() throws {
+        for name in ["read", "mcp_list_tools"] {
+            let result = try normalize([
+                "sessionUpdate": "tool_call_update", "toolCallId": callID, "status": "in_progress",
+                "_meta": ["cognition.ai/inferenceToolName": "  \(name)  "]
+            ])
+            XCTAssertEqual(result.toolName, name)
+        }
+    }
+
+    func testNonToolUpdatesAndOMPDoNotAdoptDevinMetadata() throws {
+        let message: [String: Any] = [
+            "sessionUpdate": "agent_message_chunk", "content": ["type": "text", "text": "synthetic greeting"],
+            "_meta": ["cognition.ai/toolName": canonicalName]
+        ]
+        let result = try normalize(message)
+        XCTAssertEqual(result.type, "content")
+        XCTAssertEqual(result.text, "synthetic greeting")
+        XCTAssertNil(result.toolName)
+        let omp = OMPACPAgentProvider(config: OMPAgentConfig())
+        let events = omp.normalizeSessionUpdate([
+            "sessionUpdate": "tool_call", "toolCallId": callID, "title": "Calling read_file from RepoPromptCE",
+            "_meta": ["cognition.ai/toolName": canonicalName]
+        ], sessionID: "synthetic-session")
+        XCTAssertEqual(try stream(events).toolName, "Calling read_file from RepoPromptCE")
+    }
+
+    private func normalize(_ payload: [String: Any]) throws -> AIStreamResult {
+        try stream(provider.normalizeSessionUpdate(payload, sessionID: "synthetic-session"))
+    }
+
+    private func stream(_ events: [NormalizedAgentRuntimeEvent]) throws -> AIStreamResult {
+        XCTAssertEqual(events.count, 1)
+        guard case let .stream(result) = try XCTUnwrap(events.first) else {
+            throw NSError(domain: "ExpectedStreamEvent", code: 1)
+        }
+        return result
+    }
+
+    private func jsonObject(_ text: String?) throws -> NSObject {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: Data(XCTUnwrap(text).utf8)) as? NSObject)
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/DevinACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinACPLaunchResolverTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class DevinACPLaunchResolverTests: XCTestCase {
+    func testProviderProfileMatchesInstalledDevinConvention() {
+        XCTAssertEqual(CLILaunchProfiles.devin.commandName, "devin")
+        XCTAssertTrue(CLILaunchProfiles.devin.supplementalSearchPaths.contains("~/.local/bin"))
+        XCTAssertTrue(CLIPathHints.devin.contains("~/.local/bin"))
+    }
+
+    func testNonDevinCommandIsRejected() async throws {
+        let resolver = DevinACPLaunchResolver(environmentProvider: { _ in [:] })
+        let support = try await resolver.probeSupport(
+            for: DevinAgentConfig(commandName: "not-devin", additionalPathHints: [])
+        )
+        guard case let .unsupported(reason) = support else {
+            return XCTFail("expected unsupported, got \(support)")
+        }
+        XCTAssertTrue(reason.contains("Refusing unsafe Devin ACP command"))
+    }
+
+    func testSupportProbeRequiresZeroExitStatus() async throws {
+        let directory = try makeTemporaryDirectory()
+        _ = try makeExecutable(named: "devin", in: directory, exitStatus: 3)
+        let resolver = DevinACPLaunchResolver(environmentProvider: { _ in
+            ["PATH": directory.path, "SHELL": "/bin/false"]
+        })
+
+        let support = try await resolver.probeSupport(
+            for: DevinAgentConfig(commandName: "devin", additionalPathHints: [])
+        )
+
+        guard case let .unsupported(reason) = support else {
+            return XCTFail("expected unsupported, got \(support)")
+        }
+        XCTAssertTrue(reason.contains("`devin acp --help` exited with status 3"), "unexpected reason: \(reason)")
+    }
+
+    func testSupportProbeRequiresDevinACPHelpMarkers() async throws {
+        let directory = try makeTemporaryDirectory()
+        _ = try makeExecutable(named: "devin", in: directory, output: "generic help")
+        let resolver = DevinACPLaunchResolver(environmentProvider: { _ in
+            ["PATH": directory.path, "SHELL": "/bin/false"]
+        })
+
+        let support = try await resolver.probeSupport(
+            for: DevinAgentConfig(commandName: "devin", additionalPathHints: [])
+        )
+
+        guard case let .unsupported(reason) = support else {
+            return XCTFail("expected unsupported, got \(support)")
+        }
+        XCTAssertTrue(reason.contains("did not advertise ACP support"), "unexpected reason: \(reason)")
+    }
+
+    func testBunStyleSymlinkShapeIsAcceptedAndLaunchesACP() async throws {
+        let directory = try makeTemporaryDirectory()
+        let targetDirectory = directory.appendingPathComponent("package", isDirectory: true)
+        try FileManager.default.createDirectory(at: targetDirectory, withIntermediateDirectories: true)
+        let target = try makeExecutable(named: "devin-entry", in: targetDirectory)
+        let binDirectory = directory.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        let symlink = binDirectory.appendingPathComponent("devin")
+        try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: target)
+        let resolver = DevinACPLaunchResolver(environmentProvider: { _ in
+            ["PATH": binDirectory.path, "SHELL": "/bin/false"]
+        })
+        let config = DevinAgentConfig(commandName: "devin", additionalPathHints: [])
+
+        let support = try await resolver.probeSupport(for: config)
+        XCTAssertEqual(support, .supported)
+        let launch = try resolver.resolvedLaunch(for: config)
+        XCTAssertEqual(launch.arguments, ["acp"])
+        XCTAssertTrue(launch.command.hasSuffix("devin-entry"), "unexpected command: \(launch.command)")
+        XCTAssertEqual(launch.executableIdentity.canonicalPath, launch.command)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        try makeTestDirectory(name: "DevinACPLaunchResolverTests")
+    }
+
+    @discardableResult
+    private func makeExecutable(
+        named name: String,
+        in directory: URL,
+        output: String = "Run as an ACP (Agent Client Protocol) server over stdio",
+        exitStatus: Int32 = 0
+    ) throws -> URL {
+        let executable = directory.appendingPathComponent(name)
+        let script = "#!/bin/sh\nprintf '%s\\n' '\(output)'\nexit \(exitStatus)\n"
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return executable
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/DevinACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinACPLaunchResolverTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import XCTest
 
 final class DevinACPLaunchResolverTests: XCTestCase {
-    func testProviderProfileMatchesInstalledDevinConvention() {
+    func testProviderProfilePinsDevinCommandAndSearchHints() {
         XCTAssertEqual(CLILaunchProfiles.devin.commandName, "devin")
         XCTAssertTrue(CLILaunchProfiles.devin.supplementalSearchPaths.contains("~/.local/bin"))
         XCTAssertTrue(CLIPathHints.devin.contains("~/.local/bin"))
@@ -54,7 +54,7 @@ final class DevinACPLaunchResolverTests: XCTestCase {
         XCTAssertTrue(reason.contains("did not advertise ACP support"), "unexpected reason: \(reason)")
     }
 
-    func testBunStyleSymlinkShapeIsAcceptedAndLaunchesACP() async throws {
+    func testSymlinkFixturePassesProbeAndResolvesACPArguments() async throws {
         let directory = try makeTemporaryDirectory()
         let targetDirectory = directory.appendingPathComponent("package", isDirectory: true)
         try FileManager.default.createDirectory(at: targetDirectory, withIntermediateDirectories: true)

--- a/Tests/RepoPromptTests/AgentMode/DevinACPStderrPresentationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinACPStderrPresentationTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+final class DevinACPStderrPresentationTests: XCTestCase {
+    // Normalized prefix fixtures from the archived installed 3000.6.14 plain-hi control.
+    private let info = "2026-09-06T14:56:09.512658Z  INFO run_acp_server: chisel_server::acp: Starting ACP server"
+    private let warning = "2026-09-06T14:56:09.603601Z  WARN message_forest: MessageChain tree duplication: system prefix changed (old_len=0, new_len=4, messages_to_copy=3)"
+
+    func testOnlyTimestampPrefixedINFOIsSuppressed() {
+        let provider = DevinACPAgentProvider(config: DevinAgentConfig(includeRepoPromptMCPServer: false))
+        XCTAssertFalse(provider.shouldEmitStderrLine(info))
+        XCTAssertFalse(provider.shouldEmitStderrLine("2026-09-06T14:56:09Z INFO chisel: logging initialized"))
+        for line in [
+            warning,
+            "2026-09-06T14:56:09.512658Z ERROR chisel: authentication failed",
+            "2026-09-06T14:56:09.512658Z DEBUG chisel: diagnostic",
+            "2026-09-06T14:56:09.512658Z INFOGRAPHIC unknown",
+            "INFO unrecognized prefix",
+            "connection failed: INFO unavailable",
+            "Authentication failed. Run /login.",
+            "thread 'main' panicked at startup"
+        ] {
+            XCTAssertTrue(provider.shouldEmitStderrLine(line), line)
+        }
+        XCTAssertTrue(OMPACPAgentProvider(config: OMPAgentConfig()).shouldEmitStderrLine(info))
+    }
+
+    func testControllerKeepsSuppressedINFOInDiagnosticsAndEmitsActionableStderr() async throws {
+        let directory = try makeTestDirectory(name: "DevinACPStderrPresentation")
+        let provider = try ACPModelSelectionFixtureProvider(directory: directory, providerID: .devin)
+        defer { AgentACPModelRegistry.shared.test_reset(providerID: .devin) }
+        let error = "Authentication failed. Run /login."
+        let failure = "2026-09-06T14:56:09.512658Z ERROR chisel: transport failed"
+        let stderr = ["\u{1B}[2m\(info)\u{1B}[0m", warning, failure, error]
+        try stderr.joined(separator: "\n").write(to: directory.appendingPathComponent("stderr.txt"), atomically: true, encoding: .utf8)
+        let request = ACPRunRequest(
+            agentKind: .devin,
+            modelString: "default",
+            workspacePath: directory.path,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+        let diagnostics = StderrRecords()
+        let received = expectation(description: "all stderr reaches diagnostics")
+        received.expectedFulfillmentCount = stderr.count
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request, diagnosticSink: { event in
+            if case let .stderrLine(line) = event {
+                diagnostics.append(line)
+                received.fulfill()
+            }
+        })
+        let events = await controller.events
+        let consumer = Task { () -> [String] in
+            var lines: [String] = []
+            for await event in events {
+                if case let .stream(result) = event, result.type == "system", let text = result.text {
+                    lines.append(text)
+                }
+            }
+            return lines
+        }
+        do {
+            _ = try await controller.bootstrap()
+            try await controller.prompt(AgentMessage(userMessage: "hi"), request: request)
+            await fulfillment(of: [received], timeout: 5)
+            await controller.shutdown()
+        } catch {
+            await controller.shutdown()
+            _ = await consumer.value
+            throw error
+        }
+        let lines = await consumer.value
+        XCTAssertEqual(diagnostics.snapshot(), [info, warning, failure, error])
+        XCTAssertFalse(lines.contains(info))
+        for line in [warning, failure, error] {
+            XCTAssertTrue(lines.contains(line), "Missing \(line) in \(lines)")
+        }
+    }
+}
+
+private final class StderrRecords: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lines: [String] = []
+
+    func append(_ line: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        lines.append(line)
+    }
+
+    func snapshot() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return lines
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/DevinIntegrationConfigurationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinIntegrationConfigurationTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class DevinIntegrationConfigurationTests: XCTestCase {
+    func testOverlayStdioChildrenReadNativeConfigurationUnlessExplicitlyOverridden() throws {
+        let source = try makeTestDirectory(name: "DevinChildSource")
+        let explicit = try makeTestDirectory(name: "DevinChildExplicit")
+        let devin = source.appendingPathComponent("devin")
+        try FileManager.default.createDirectory(at: devin, withIntermediateDirectories: true)
+        try Data("native-child-config".utf8).write(to: source.appendingPathComponent("child-config"))
+        try Data("explicit-child-config".utf8).write(to: explicit.appendingPathComponent("child-config"))
+        let syntheticAuth = Data("synthetic-auth-not-a-credential".utf8)
+        let auth = devin.appendingPathComponent("auth.json")
+        try syntheticAuth.write(to: auth)
+        let command = ["-c", "cat \"$XDG_CONFIG_HOME/child-config\"; printf '|%s' \"$CHILD_MARKER\""]
+        let native: [String: Any] = ["transport": "stdio", "command": "/bin/sh", "args": command, "env": ["CHILD_MARKER": "preserved"]]
+        let overridden: [String: Any] = [
+            "transport": "stdio",
+            "command": "/bin/sh",
+            "args": command,
+            "env": ["XDG_CONFIG_HOME": explicit.path, "CHILD_MARKER": "explicit"]
+        ]
+        let emptyOverride: [String: Any] = ["transport": "stdio", "command": "/bin/echo", "env": ["XDG_CONFIG_HOME": ""]]
+        let remote: [String: Any] = ["transport": "http", "url": "https://example.invalid", "env": ["KEEP": "remote"]]
+        let unknown: [String: Any] = ["transport": "future", "command": "/bin/echo", "custom": true]
+        let original = try JSONSerialization.data(withJSONObject: ["custom": "retained", "mcpServers": [
+            "Native": native, "Explicit": overridden, "Empty": emptyOverride, "Remote": remote, "Unknown": unknown
+        ]], options: [.sortedKeys])
+        let originalURL = devin.appendingPathComponent("mcp_config.json")
+        try original.write(to: originalURL)
+        XCTAssertEqual(try runChild(native, environment: ["XDG_CONFIG_HOME": source.path]), "native-child-config|preserved")
+
+        let prepared = try DevinIntegrationConfiguration.prepare(
+            workingDirectory: source.path,
+            repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(
+                command: "/bin/sh", args: command,
+                env: [.init(name: "XDG_CONFIG_HOME", value: explicit.path), .init(name: "CHILD_MARKER", value: "run-scoped")]
+            ),
+            sourceEnvironment: ["XDG_CONFIG_HOME": source.path]
+        )
+        defer { DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact) }
+        let isolated = try URL(fileURLWithPath: XCTUnwrap(prepared.environment["XDG_CONFIG_HOME"]))
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: isolated.appendingPathComponent("devin/mcp_config.json"))) as? [String: Any])
+        let servers = try XCTUnwrap(root["mcpServers"] as? [String: [String: Any]])
+        XCTAssertEqual(try runChild(XCTUnwrap(servers["Native"]), environment: prepared.environment), "native-child-config|preserved")
+        XCTAssertEqual(try runChild(XCTUnwrap(servers["Explicit"]), environment: prepared.environment), "explicit-child-config|explicit")
+        XCTAssertEqual(try runChild(XCTUnwrap(servers[RepoPromptMCPServerConfiguration.defaultServerName]), environment: prepared.environment), "explicit-child-config|run-scoped")
+        XCTAssertEqual(servers["Empty"]?["env"] as? [String: String], ["XDG_CONFIG_HOME": ""])
+        XCTAssertEqual(servers["Remote"] as NSDictionary?, remote as NSDictionary)
+        XCTAssertEqual(servers["Unknown"] as NSDictionary?, unknown as NSDictionary)
+        XCTAssertEqual(root["custom"] as? String, "retained")
+        XCTAssertEqual(try Data(contentsOf: originalURL), original)
+        let linkedAuth = isolated.appendingPathComponent("devin/auth.json")
+        XCTAssertEqual(linkedAuth.resolvingSymlinksInPath(), auth.resolvingSymlinksInPath())
+        XCTAssertEqual(try Data(contentsOf: linkedAuth), syntheticAuth)
+        // Native-owned auth writes remain linked, not copied into ephemeral configuration.
+        try Data("synthetic-native-refresh".utf8).write(to: auth)
+        XCTAssertEqual(try Data(contentsOf: linkedAuth), Data("synthetic-native-refresh".utf8))
+        DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact)
+        XCTAssertEqual(try Data(contentsOf: auth), Data("synthetic-native-refresh".utf8))
+    }
+
+    func testOverlayRespectsChildHOMEOverrideUnlessSourceXDGIsSet() throws {
+        let parentHome = try makeTestDirectory(name: "DevinParentHome")
+        let childHome = try makeTestDirectory(name: "DevinChildHome")
+        let parentRoot = parentHome.appendingPathComponent(".config", isDirectory: true)
+        let childRoot = childHome.appendingPathComponent(".config", isDirectory: true)
+        let sourceDevin = parentRoot.appendingPathComponent("devin", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDevin, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: childRoot, withIntermediateDirectories: true)
+        try Data("parent-config".utf8).write(to: parentRoot.appendingPathComponent("child-config"))
+        try Data("isolated-child-config".utf8).write(to: childRoot.appendingPathComponent("child-config"))
+        let server: [String: Any] = [
+            "transport": "stdio", "command": "/bin/sh",
+            "args": ["-c", "config=\"${XDG_CONFIG_HOME:-$HOME/.config}\"; /bin/cat \"$config/child-config\""],
+            "env": ["HOME": childHome.path]
+        ]
+        let original = try JSONSerialization.data(withJSONObject: ["mcpServers": ["IsolatedChild": server]])
+        let sourceURL = sourceDevin.appendingPathComponent("mcp_config.json")
+        try original.write(to: sourceURL)
+
+        for sourceXDG in [nil, parentRoot.path] as [String?] {
+            var sourceEnvironment = ["HOME": parentHome.path]
+            sourceEnvironment["XDG_CONFIG_HOME"] = sourceXDG
+            let expected = sourceXDG == nil ? "isolated-child-config" : "parent-config"
+            let nativeOutput = try runChild(server, environment: sourceEnvironment)
+            XCTAssertEqual(nativeOutput, expected)
+
+            let prepared = try DevinIntegrationConfiguration.prepare(
+                workingDirectory: parentHome.path,
+                repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(command: "/bin/echo"),
+                sourceEnvironment: sourceEnvironment
+            )
+            defer { DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact) }
+            let isolated = try URL(fileURLWithPath: XCTUnwrap(prepared.environment["XDG_CONFIG_HOME"]))
+            let root = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: isolated.appendingPathComponent("devin/mcp_config.json"))) as? [String: Any])
+            let servers = try XCTUnwrap(root["mcpServers"] as? [String: [String: Any]])
+            let child = try XCTUnwrap(servers["IsolatedChild"])
+            let launchEnvironment = sourceEnvironment.merging(prepared.environment) { _, overlay in overlay }
+            XCTAssertEqual(try runChild(child, environment: launchEnvironment), nativeOutput)
+            XCTAssertEqual((child["env"] as? [String: String])?["HOME"], childHome.path)
+            XCTAssertEqual(try Data(contentsOf: sourceURL), original)
+        }
+    }
+
+    func testSourceRootUsesEffectiveHOMEWhenXDGIsUnsetOrBlank() throws {
+        let home = try makeTestDirectory(name: "DevinEffectiveHome")
+        let source = home.appendingPathComponent(".config/devin", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try Data(#"{"effectiveHomeMarker":true,"mcpServers":{}}"#.utf8).write(to: source.appendingPathComponent("mcp_config.json"))
+        for xdg in [nil, "  "] as [String?] {
+            var environment = ["HOME": home.path]
+            environment["XDG_CONFIG_HOME"] = xdg
+            let prepared = try DevinIntegrationConfiguration.prepare(
+                workingDirectory: home.path,
+                repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(command: "/bin/echo"),
+                sourceEnvironment: environment
+            )
+            defer { DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact) }
+            let root = try URL(fileURLWithPath: XCTUnwrap(prepared.environment["XDG_CONFIG_HOME"]))
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: root.appendingPathComponent("devin/mcp_config.json"))) as? [String: Any])
+            XCTAssertEqual(object["effectiveHomeMarker"] as? Bool, true)
+        }
+    }
+
+    private func runChild(_ server: [String: Any], environment: [String: String]) throws -> String {
+        let process = Process()
+        process.executableURL = try URL(fileURLWithPath: XCTUnwrap(server["command"] as? String))
+        process.arguments = server["args"] as? [String] ?? []
+        process.environment = environment.merging(server["env"] as? [String: String] ?? [:]) { _, explicit in explicit }
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/DevinPromptQualificationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinPromptQualificationTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class DevinPromptQualificationTests: XCTestCase {
+    func testStandardAndRolePromptsQualifyHostReferences() {
+        for role in [nil, .explore, .engineer, .pair, .design] as [AgentModelCatalog.TaskLabelKind?] {
+            let prompt = SystemPromptService.agentModePrompt(agentKind: .devin, taskLabelKind: role)
+            XCTAssertTrue(prompt.contains("`mcp__RepoPromptCE__set_status`"))
+            XCTAssertFalse(prompt.contains("`set_status`"))
+            XCTAssertFalse(prompt.contains("`RepoPrompt__read_file`"))
+            XCTAssertFalse(prompt.contains("`get_file_tree`"))
+            XCTAssertFalse(prompt.contains("mcp__RepoPromptCE__mcp__"))
+        }
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/DevinSessionModeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinSessionModeTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class DevinSessionModeTests: XCTestCase {
+    func testAdvertisedModesApplyBeforeNewAndLoadedPrompts() async throws {
+        for resume in [nil, "fixture-session"] as [String?] {
+            let directory = try makeTestDirectory(name: "DevinModes")
+            let provider = try ACPModelSelectionFixtureProvider(directory: directory, providerID: .devin)
+            let initial = request(directory, resume: resume)
+            let controller = try ACPAgentSessionController(provider: provider, runRequest: initial)
+            do {
+                _ = try await controller.bootstrap()
+                let value = await controller.currentSessionModeSnapshot()
+                let snapshot = try XCTUnwrap(value)
+                XCTAssertEqual(snapshot.configID, "permission-profile")
+                XCTAssertEqual(snapshot.currentValue, "ask")
+                XCTAssertEqual(snapshot.options.map(\.rawValue), ["ask", "code", "novel-mode", "bypass", "unconfirmed"])
+                XCTAssertEqual(snapshot.options[2].displayName, "Mode novel-mode")
+                XCTAssertEqual(snapshot.options[2].description, "Description novel-mode")
+                // An untouched default sends no configuration RPC.
+                try await ACPIntegratedAgentModeRunner.applyRequestedSessionModeIfNeeded(initial, controller: controller)
+                XCTAssertFalse(try provider.records().contains { $0["method"] as? String == "session/set_config_option" })
+                let explicit = request(directory, resume: resume, mode: "novel-mode")
+                try await ACPIntegratedAgentModeRunner.applyRequestedSessionModeIfNeeded(explicit, controller: controller)
+                try await controller.prompt(AgentMessage(userMessage: "initial"), request: explicit)
+                let reusable = await controller.prepareForNextTurn()
+                XCTAssertTrue(reusable)
+                let followup = request(directory, resume: "fixture-session", mode: "code")
+                try await ACPIntegratedAgentModeRunner.applyRequestedSessionModeIfNeeded(followup, controller: controller)
+                try await controller.prompt(AgentMessage(userMessage: "follow-up"), request: followup)
+                await controller.shutdown()
+                let records = try provider.records()
+                XCTAssertEqual(records.filter { $0["method"] as? String == "session/prompt" }.compactMap { $0["mode"] as? String }, ["novel-mode", "code"])
+                XCTAssertEqual(records.filter { $0["method"] as? String == "session/set_config_option" }.compactMap { $0["configId"] as? String }, ["permission-profile", "permission-profile"])
+                XCTAssertEqual(records.count(where: { $0["method"] as? String == (resume == nil ? "session/new" : "session/load") }), 1)
+            } catch {
+                await controller.shutdown()
+                throw error
+            }
+        }
+    }
+
+    func testMissingAcknowledgementInvalidatesAuthorityAndBlocksPrompt() async throws {
+        let directory = try makeTestDirectory(name: "DevinUnconfirmedMode")
+        let provider = try ACPModelSelectionFixtureProvider(directory: directory, providerID: .devin)
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request(directory))
+        do {
+            _ = try await controller.bootstrap()
+            let explicit = request(directory, mode: "unconfirmed")
+            do {
+                try await ACPIntegratedAgentModeRunner.applyRequestedSessionModeIfNeeded(explicit, controller: controller)
+                XCTFail("Expected missing acknowledgement failure")
+            } catch {}
+            let snapshot = await controller.currentSessionModeSnapshot()
+            XCTAssertNil(snapshot)
+            do {
+                try await controller.prompt(AgentMessage(userMessage: "must not send"), request: explicit)
+                XCTFail("Unconfirmed selection must block the prompt")
+            } catch {}
+            XCTAssertFalse(try provider.records().contains { $0["method"] as? String == "session/prompt" })
+            await controller.shutdown()
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+    }
+
+    func testManagedBypassIsBlockedButDirectNativeDefaultIsNotChanged() async throws {
+        for restricted in [true, false] {
+            let directory = try makeTestDirectory(name: "DevinModePolicy")
+            try "bypass".write(to: directory.appendingPathComponent("initial-mode.txt"), atomically: true, encoding: .utf8)
+            let provider = try ACPModelSelectionFixtureProvider(directory: directory, providerID: .devin)
+            let run = request(directory, restricted: restricted)
+            let controller = try ACPAgentSessionController(provider: provider, runRequest: run)
+            do {
+                _ = try await controller.bootstrap()
+                do {
+                    try await controller.prompt(AgentMessage(userMessage: "fixture"), request: run)
+                    XCTAssertFalse(restricted)
+                } catch {
+                    XCTAssertTrue(restricted, "\(error)")
+                }
+                let records = try provider.records()
+                XCTAssertEqual(records.contains { $0["method"] as? String == "session/prompt" }, !restricted)
+                XCTAssertFalse(records.contains { $0["method"] as? String == "session/set_config_option" })
+                XCTAssertFalse(run.autoApproveAllToolPermissions)
+                await controller.shutdown()
+            } catch {
+                await controller.shutdown()
+                throw error
+            }
+        }
+    }
+
+    func testIdleModeUpdatesSurvivePromptStreamReplacement() async throws {
+        let directory = try makeTestDirectory(name: "DevinIdleModes")
+        let provider = try ACPModelSelectionFixtureProvider(directory: directory, providerID: .devin)
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request(directory))
+        do {
+            _ = try await controller.bootstrap()
+            var updates = await controller.sessionModeUpdates().makeAsyncIterator()
+            let initial = await updates.next()
+            XCTAssertEqual(initial??.currentValue, "ask")
+            let prepared = await controller.prepareForNextTurn()
+            XCTAssertTrue(prepared)
+            try "novel-mode".write(to: directory.appendingPathComponent("push-mode.txt"), atomically: true, encoding: .utf8)
+            try await controller.setSessionModel("model-b")
+            let pushed = await updates.next()
+            XCTAssertEqual(pushed??.currentValue, "novel-mode")
+            await controller.shutdown()
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+    }
+
+    func testRebindingInvalidatesOldControllerModeProjection() async throws {
+        let directory = try makeTestDirectory(name: "DevinReboundModes")
+        let provider = try ACPModelSelectionFixtureProvider(directory: directory, providerID: .devin)
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request(directory))
+        let session = AgentTabSession(tabID: UUID())
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
+        session.acpController = controller
+        let received = expectation(description: "Initial mode observed")
+        session.observeACPSessionModes(from: controller) {
+            if session.acpSessionModeSnapshot != nil { received.fulfill() }
+        }
+        do {
+            _ = try await controller.bootstrap()
+            await fulfillment(of: [received], timeout: 3)
+            XCTAssertEqual(session.acpSessionModeSnapshot?.currentValue, "ask")
+            session.acpSessionModeIntent = "novel-mode"
+            session.testInstallPersistentSessionBinding(sessionID: UUID())
+            XCTAssertNil(session.acpModeObservationTask)
+            XCTAssertNil(session.acpSessionModeSnapshot)
+            XCTAssertNil(session.acpSessionModeIntent)
+            try "novel-mode".write(to: directory.appendingPathComponent("push-mode.txt"), atomically: true, encoding: .utf8)
+            try await controller.setSessionModel("model-b")
+            await controller.shutdown()
+            XCTAssertNil(session.acpSessionModeSnapshot)
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+    }
+
+    func testChromeShowsActualAndRequestedModesWithInheritedLocks() {
+        let snapshot = ACPSessionModeSnapshot(configID: "arbitrary", currentValue: "ask", options: [
+            .init(rawValue: "ask", displayName: "Ask", description: "Questions"),
+            .init(rawValue: "novel", displayName: "Novel", description: "Provider description"),
+            .init(rawValue: "bypass", displayName: "Bypass", description: "Provider approvals")
+        ])
+        for lock in [nil, "Inherited policy"] as [String?] {
+            let chrome = AgentProviderPreferenceSnapshotStore.devinModeBinding(snapshot: snapshot, intent: "novel", lockReason: lock)
+            XCTAssertEqual(chrome.displayName, "Ask")
+            XCTAssertEqual(chrome.externallyManagedReason, lock)
+            XCTAssertEqual(chrome.options.map(\.id), [.devinMode("ask"), .devinMode("novel"), .devinMode("bypass")])
+            XCTAssertTrue(chrome.options[0].isSelected)
+            XCTAssertFalse(chrome.options[1].isSelected)
+            XCTAssertTrue(chrome.options[1].title.contains("requested"))
+            XCTAssertTrue(chrome.options[2].isWarning)
+            XCTAssertEqual(chrome.options.allSatisfy(\.isEnabled), lock == nil)
+        }
+    }
+
+    private func request(_ directory: URL, resume: String? = nil, mode: String? = nil, restricted: Bool = false) -> ACPRunRequest {
+        ACPRunRequest(agentKind: .devin, modelString: nil, workspacePath: directory.path, resumeSessionID: resume, attachments: [], taskLabelKind: nil, sessionModeID: mode, requiresNonBypassSessionMode: restricted)
+    }
+}


### PR DESCRIPTION
## Summary

- add Devin CLI as an interactive ACP Agent Mode provider via `devin acp`
- discover and select Devin models from live ACP `configOptions`
- preserve Devin-owned authentication, modes, tools, and configuration while injecting RepoPrompt MCP through an isolated merged config
- keep Devin out of headless agents and automatic recommendations

## Validation

- `make dev-test FILTER=DevinACP` — 19 tests passed
- `make dev-test FILTER=OMPACP` — 22 tests passed
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-lint`
- installed Devin ACP model selection, prompt, and process-restart session reload probe

## Stack

Draft stacked on #928. Review this PR after the OMP provider base.
