### PR TITLE
Fix release provisioning profile permissions

### DIFF
--- a/Scripts/embedded_provisioning_profile.py
+++ b/Scripts/embedded_provisioning_profile.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Install and validate the embedded release provisioning profile."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import stat
+import tempfile
+from pathlib import Path
+
+DEPLOYED_MODE = 0o644
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def validate_profile(path: Path) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        fail(f"missing embedded provisioning profile: {path}")
+    if not stat.S_ISREG(mode):
+        fail(f"embedded provisioning profile must be a regular, non-symlink file: {path}")
+
+    deployed_mode = stat.S_IMODE(mode)
+    if deployed_mode != DEPLOYED_MODE:
+        fail(
+            "embedded provisioning profile must use deployed-readable mode "
+            f"0644, got {deployed_mode:04o}: {path}"
+        )
+
+
+def install_profile(source: Path, destination: Path) -> None:
+    try:
+        source_mode = source.lstat().st_mode
+    except FileNotFoundError:
+        fail(f"missing provisioning profile source: {source}")
+    if not stat.S_ISREG(source_mode):
+        fail(f"provisioning profile source must be a regular, non-symlink file: {source}")
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{destination.name}.",
+            dir=destination.parent,
+        )
+        os.close(descriptor)
+        temporary_path = Path(temporary_name)
+        shutil.copyfile(source, temporary_path)
+        os.chmod(temporary_path, DEPLOYED_MODE)
+        validate_profile(temporary_path)
+        os.replace(temporary_path, destination)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+    validate_profile(destination)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    install_parser = subparsers.add_parser(
+        "install", help="copy a profile into the app bundle using mode 0644"
+    )
+    install_parser.add_argument("source", type=Path)
+    install_parser.add_argument("destination", type=Path)
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="require a regular embedded profile with mode 0644"
+    )
+    validate_parser.add_argument("path", type=Path)
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "install":
+        install_profile(args.source, args.destination)
+    else:
+        validate_profile(args.path)
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -379,7 +379,9 @@ elif (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
         EXPECTED_PROFILE_APP_IDENTIFIER="$EXPECTED_PROVISIONING_PROFILE_APPLICATION_IDENTIFIER"
     fi
     [[ "$PROFILE_APP_IDENTIFIER" == "$EXPECTED_PROFILE_APP_IDENTIFIER" ]] || fail "Provisioning profile app identifier mismatch: expected $EXPECTED_PROFILE_APP_IDENTIFIER, got ${PROFILE_APP_IDENTIFIER:-<missing>}."
-    run cp "$REPOPROMPT_PROVISIONING_PROFILE" "$APP_BUNDLE/Contents/embedded.provisionprofile"
+    run python3 "$CONTROL_PLANE_SCRIPTS_DIR/embedded_provisioning_profile.py" install \
+        "$REPOPROMPT_PROVISIONING_PROFILE" \
+        "$APP_BUNDLE/Contents/embedded.provisionprofile"
     APP_ENTITLEMENTS="$(mktemp)"
     run python3 - <<PY
 from pathlib import Path
@@ -529,6 +531,10 @@ else
     sign_path "$APP_BUNDLE"
 fi
 run codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+if (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )) && (( ! USE_LOCAL_SELF_SIGNED_RELEASE )); then
+    run python3 "$CONTROL_PLANE_SCRIPTS_DIR/embedded_provisioning_profile.py" validate \
+        "$APP_BUNDLE/Contents/embedded.provisionprofile"
+fi
 if [[ -n "${REPOPROMPT_STABLE_RELEASE_CONTEXT:-}" ]] && (( ! USE_ADHOC_SIGNING )); then
     run codesign --verify --strict --verbose=2 -R="$EXPECTED_APP_REQUIREMENT" "$APP_BUNDLE"
 fi

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -124,6 +124,7 @@ run_preflight() {
     require_file "$ROOT_DIR/Vendor/Sparkle/PROVENANCE.md"
     require_file "$ROOT_DIR/Vendor/Sparkle/SHA256SUMS"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/embedded_provisioning_profile.py"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/upload_sentry_debug_symbols.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/release_sentry_symbols.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/build_swiftpm_release_products.sh"

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -91,7 +91,9 @@ security cms -D -i "$REPOPROMPT_PROVISIONING_PROFILE" -o "$profile_plist"
 profile_app_identifier="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$profile_plist" 2>/dev/null || true)"
 [[ "$profile_app_identifier" == "$EXPECTED_PROVISIONING_PROFILE_APPLICATION_IDENTIFIER" ]] ||
     fail "Provisioning profile app identifier mismatch: expected $EXPECTED_PROVISIONING_PROFILE_APPLICATION_IDENTIFIER, got ${profile_app_identifier:-<missing>}"
-cp "$REPOPROMPT_PROVISIONING_PROFILE" "$APP_BUNDLE/Contents/embedded.provisionprofile"
+python3 "$SCRIPT_DIR/embedded_provisioning_profile.py" install \
+    "$REPOPROMPT_PROVISIONING_PROFILE" \
+    "$APP_BUNDLE/Contents/embedded.provisionprofile"
 python3 - "$ENTITLEMENTS_TEMPLATE" "$app_entitlements" "$BUNDLE_ID" "$SIGNING_TEAM_ID" <<'PYTHON'
 import sys
 from pathlib import Path
@@ -193,6 +195,8 @@ sign_path "$APP_BUNDLE/Contents/MacOS/repoprompt-mcp"
 sign_path "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"
 codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
+python3 "$SCRIPT_DIR/embedded_provisioning_profile.py" validate \
+    "$APP_BUNDLE/Contents/embedded.provisionprofile"
 codesign --verify --strict --verbose=2 -R="$EXPECTED_APP_REQUIREMENT" "$APP_BUNDLE"
 python3 "$SCRIPT_DIR/codex_runtime_artifact.py" \
     --manifest "$CODEX_MANIFEST" verify-bundle \

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Regression coverage for the Tip Stable-build floor and reset authority."""
+"""Regression coverage for release packaging and rollout tooling."""
 
 from __future__ import annotations
 
 import copy
 import hashlib
 import json
+import stat
 import subprocess
 import sys
 import tempfile
@@ -16,6 +17,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 ROOT_DIR = SCRIPT_DIR.parent
 ROLLOUT_TOOL = SCRIPT_DIR / "stable_rollout.py"
 POLICY = SCRIPT_DIR / "apple_identity_policy.json"
+PROFILE_TOOL = SCRIPT_DIR / "embedded_provisioning_profile.py"
 
 
 class StableTipFloorTests(unittest.TestCase):
@@ -358,6 +360,85 @@ class StableTipFloorTests(unittest.TestCase):
                 with self.subTest(case=label):
                     self.assertNotEqual(result.returncode, 0)
                     self.assertIn(diagnostic, result.stderr)
+
+
+class EmbeddedProvisioningProfileTests(unittest.TestCase):
+    def run_tool(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(PROFILE_TOOL), *arguments],
+            cwd=ROOT_DIR,
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+
+    def test_install_normalizes_owner_only_source_to_deployed_readable_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "release.provisionprofile"
+            destination = root / "RepoPrompt.app" / "Contents" / "embedded.provisionprofile"
+            payload = b"fixture provisioning profile\n"
+            source.write_bytes(payload)
+            source.chmod(0o600)
+
+            result = self.run_tool("install", str(source), str(destination))
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_bytes(), payload)
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o644)
+            self.assertNotEqual(destination.stat().st_mode & stat.S_IROTH, 0)
+            self.assertEqual(stat.S_IMODE(source.stat().st_mode), 0o600)
+
+    def test_install_replaces_destination_symlink_without_mutating_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "release.provisionprofile"
+            target = root / "protected-target"
+            destination = root / "RepoPrompt.app" / "Contents" / "embedded.provisionprofile"
+            source.write_bytes(b"fixture provisioning profile\n")
+            source.chmod(0o600)
+            target.write_bytes(b"protected target\n")
+            target.chmod(0o600)
+            destination.parent.mkdir(parents=True)
+            destination.symlink_to(target)
+
+            result = self.run_tool("install", str(source), str(destination))
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(destination.is_symlink())
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o644)
+            self.assertEqual(target.read_bytes(), b"protected target\n")
+            self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o600)
+
+    def test_validate_rejects_sealed_profile_unreadable_by_non_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            profile = Path(temporary_directory) / "embedded.provisionprofile"
+            profile.write_bytes(b"fixture provisioning profile\n")
+            profile.chmod(0o600)
+
+            result = self.run_tool("validate", str(profile))
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must use deployed-readable mode 0644, got 0600", result.stderr)
+
+    def test_every_release_signing_path_installs_and_validates_profile_before_distribution(self) -> None:
+        cases = (
+            ("package_app.sh", 'phase "Signing app bundle"'),
+            ("sign_staged_release.sh", "sign_path() {"),
+        )
+        for filename, signing_marker in cases:
+            source = (SCRIPT_DIR / filename).read_text(encoding="utf-8")
+            install = source.index('embedded_provisioning_profile.py" install')
+            validate = source.index('embedded_provisioning_profile.py" validate')
+            strict_verification = source.rindex('codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"')
+            with self.subTest(script=filename):
+                self.assertLess(install, source.index(signing_marker))
+                self.assertGreater(validate, strict_verification)
+                self.assertNotIn(
+                    'cp "$REPOPROMPT_PROVISIONING_PROFILE"',
+                    source,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- install the embedded release provisioning profile atomically with exact deployed mode `0644`
- use the same helper in both direct release packaging and protected staged signing
- validate the embedded profile after strict app signature verification
- add deterministic regression coverage for the root-owned `0600` failure, symlink replacement safety, and both release paths

## Root cause

Tip build `36.15.54` preserved a source provisioning profile created under `umask 077`. Sparkle installed the app as `root`, leaving the sealed `Contents/embedded.provisionprofile` at `root:wheel` mode `0600`. The ordinary app user could not read that sealed resource, so strict self-signature validation failed during `SecureStorageIdentityMigration.prepareLegacyBridge` and updates were paused at `preparer-validation`.

The failure occurs before migration authority is opened or changed; this fix does not weaken identity, signature, catalog, journal, or Keychain guards.

## Validation

- focused embedded provisioning profile tests: 4/4 passed during implementation
- `make release-selftest`: 54 Python tests plus split metadata-root shell test passed
- `make dev-release-preflight`: passed, ticket `38d81d06-c204-470b-ac97-492c49f2367a`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`: passed
- mandatory commit and push preflights: passed; staged/outgoing secret scans found no leaks
- independent read-only review: no must-fix findings
- reviewer rerun: 5 focused tests passed, changed-shell `bash -n`, `git diff --check`, ZIP mode round-trip, and hard-link replacement probe passed

## Validation limits

No real Developer ID artifact was signed/notarized or installed through Sparkle as root. Final ZIP/PKG permission revalidation remains a defense-in-depth follow-up; current producers and a hermetic ZIP round-trip preserve `0644`.
