### PR TITLE
Remove artificial timeouts from Tip workflow

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -27,7 +27,6 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     runs-on: macos-26
-    timeout-minutes: 20
     outputs:
       commit: ${{ steps.tip.outputs.commit }}
       short-sha: ${{ steps.tip.outputs.short-sha }}
@@ -166,7 +165,6 @@ jobs:
     needs: setup
     environment: tip-release
     runs-on: macos-26
-    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -339,7 +337,6 @@ jobs:
       - setup
       - credential-preflight
     runs-on: macos-26
-    timeout-minutes: 90
     permissions:
       contents: read
     steps:
@@ -388,7 +385,6 @@ jobs:
       - stage
     environment: tip-release
     runs-on: macos-26
-    timeout-minutes: 120
     permissions:
       contents: read
     steps:
@@ -707,7 +703,6 @@ jobs:
       - setup
       - sign
     runs-on: macos-26
-    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -794,7 +789,6 @@ jobs:
       - smoke-no-secrets
     environment: tip-release
     runs-on: macos-26
-    timeout-minutes: 120
     permissions:
       contents: read
     steps:

--- a/Scripts/test_publish_tip_release.py
+++ b/Scripts/test_publish_tip_release.py
@@ -528,6 +528,14 @@ class PublishTipReleaseTests(unittest.TestCase):
         self.assertEqual(state["source_lookup_auth"], [False])
         self.assertEqual(state["mutations"], [])
 
+    def test_tip_workflow_does_not_set_explicit_job_timeouts(self) -> None:
+        timeout_lines = [
+            line.strip()
+            for line in WORKFLOW.read_text(encoding="utf-8").splitlines()
+            if line.split("#", 1)[0].partition(":")[0].strip() == "timeout-minutes"
+        ]
+        self.assertEqual(timeout_lines, [])
+
     def test_workflow_preflight_and_publisher_share_source_authority_contract(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         credential_preflight = workflow.split("\n  credential-preflight:", 1)[1].split(


### PR DESCRIPTION
## Why

[Tip run 33841892699](https://github.com/repoprompt/repoprompt-ce/actions/runs/33841892699) was executing a valid cold universal source build when the `stage` job reached the repository-defined 90-minute ceiling. GitHub cancelled the build even though the same source SHA completed successfully on another runner.

The explicit ceilings were introduced in #894. Recent valid Tip stages already took 87-89 minutes, so the 90-minute build limit had no meaningful safety margin.

## What changed

- remove explicit `timeout-minutes` limits from every job in the Tip publisher workflow
- add a workflow contract test preventing explicit Tip job timeouts from being reintroduced

This does not inflate a timeout or alter build/sign/publish behavior. GitHub platform limits still apply.

## Validation

- `python3 -m unittest -v Scripts.test_publish_tip_release.PublishTipReleaseTests.test_tip_workflow_does_not_set_explicit_job_timeouts`
- GitHub Actions YAML parsed successfully with Ruby Psych
- `make dev-release-preflight`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`
- independent diff review: no must-fix findings

`make release-selftest` also ran. `test_release_tooling.py` passed; three existing publisher mutation fixtures exceeded their own `subprocess.run(timeout=30)` limits. Those fixture-local timeouts are unrelated to this workflow-only policy change and are not modified here.

## Hosted validation

The PR workflow will provide the first hosted validation of the edited Actions definition. A full Tip publication remains a separate privileged release action.
