### PR TITLE
Add GPT-6 Astra to all Codex CLI model pickers

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -25,7 +25,13 @@ enum AgentModel: String, CaseIterable, Codable {
     /// GPT-5.1 Codex Mini (separate fast model)
     case codexMini = "gpt-5.1-codex-mini"
 
-    // GPT-5.6 models exposed through Codex CLI
+    // GPT models exposed through Codex CLI
+    case gpt6AstraLow = "gpt-6-astra-low"
+    case gpt6AstraMedium = "gpt-6-astra-medium"
+    case gpt6AstraHigh = "gpt-6-astra-high"
+    case gpt6AstraXHigh = "gpt-6-astra-xhigh"
+    case gpt6AstraMax = "gpt-6-astra-max"
+    case gpt6AstraUltra = "gpt-6-astra-ultra"
     case gpt56SolLow = "gpt-5.6-sol-low"
     case gpt56SolMedium = "gpt-5.6-sol-medium"
     case gpt56SolHigh = "gpt-5.6-sol-high"
@@ -115,6 +121,12 @@ enum AgentModel: String, CaseIterable, Codable {
     var displayName: String {
         switch self {
         case .codexMini: "GPT-5.1 Codex Mini"
+        case .gpt6AstraLow: "GPT-6 Astra Low"
+        case .gpt6AstraMedium: "GPT-6 Astra Medium"
+        case .gpt6AstraHigh: "GPT-6 Astra High"
+        case .gpt6AstraXHigh: "GPT-6 Astra XHigh"
+        case .gpt6AstraMax: "GPT-6 Astra Max"
+        case .gpt6AstraUltra: "GPT-6 Astra Ultra"
         case .gpt56SolLow: "GPT-5.6 Sol Low"
         case .gpt56SolMedium: "GPT-5.6 Sol Medium"
         case .gpt56SolHigh: "GPT-5.6 Sol High"
@@ -184,6 +196,12 @@ enum AgentModel: String, CaseIterable, Codable {
     var description: String {
         switch self {
         case .codexMini: "Ultra-fast. Good for quick lookups, simple edits, and surface-level exploration."
+        case .gpt6AstraLow: "Low GPT-6 Astra reasoning through Codex."
+        case .gpt6AstraMedium: "Medium GPT-6 Astra reasoning through Codex."
+        case .gpt6AstraHigh: "High GPT-6 Astra reasoning through Codex."
+        case .gpt6AstraXHigh: "Extra-high GPT-6 Astra reasoning through Codex."
+        case .gpt6AstraMax: "Maximum GPT-6 Astra reasoning through Codex."
+        case .gpt6AstraUltra: "Ultra GPT-6 Astra reasoning through Codex."
         case .gpt56SolLow: "Fast GPT-5.6 Sol reasoning through Codex. Recommended for explore, discovery, and lightweight implementation."
         case .gpt56SolMedium: "Balanced GPT-5.6 Sol reasoning through Codex. Good for Engineer defaults when you want more reasoning than Low without jumping to High."
         case .gpt56SolHigh: "Deep GPT-5.6 Sol reasoning through Codex. Recommended for planning, review, and pair-agent work."
@@ -256,6 +274,12 @@ enum AgentModel: String, CaseIterable, Codable {
         case .codexExec:
             [
                 .defaultModel,
+                .gpt6AstraLow,
+                .gpt6AstraMedium,
+                .gpt6AstraHigh,
+                .gpt6AstraXHigh,
+                .gpt6AstraMax,
+                .gpt6AstraUltra,
                 .gpt56SolLow,
                 .gpt56SolMedium,
                 .gpt56SolHigh,
@@ -412,6 +436,25 @@ enum AgentModel: String, CaseIterable, Codable {
             }
         }
 
+        func gpt6Astra(for effort: CodexReasoningEffort?) -> AgentModel {
+            switch effort {
+            case .some(.low):
+                .gpt6AstraLow
+            case .some(.high):
+                .gpt6AstraHigh
+            case .some(.xhigh):
+                .gpt6AstraXHigh
+            case .some(.max):
+                .gpt6AstraMax
+            case .some(.ultra):
+                .gpt6AstraUltra
+            case .some(.none), .some(.minimal), .some(.medium):
+                .gpt6AstraMedium
+            case nil, .some:
+                .gpt6AstraMedium
+            }
+        }
+
         func gpt56Sol(for effort: CodexReasoningEffort?) -> AgentModel {
             switch effort {
             case .some(.low):
@@ -500,6 +543,9 @@ enum AgentModel: String, CaseIterable, Codable {
         }
         if base.contains("gpt-5.3-codex") {
             return codex53(for: effort)
+        }
+        if base == "gpt-6-astra" {
+            return gpt6Astra(for: effort)
         }
         if base == "gpt-5.6-terra" {
             return gpt56Terra(for: effort)

--- a/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
@@ -79,6 +79,12 @@ public enum AIModel: Equatable, Hashable {
     case gpt5CodexXHigh
 
     // Codex CLI Provider Models
+    case codexCliGpt6AstraLow
+    case codexCliGpt6AstraMedium
+    case codexCliGpt6AstraHigh
+    case codexCliGpt6AstraXHigh
+    case codexCliGpt6AstraMax
+    case codexCliGpt6AstraUltra
     case codexCliGpt56SolLow
     case codexCliGpt56SolMedium
     case codexCliGpt56SolHigh
@@ -314,6 +320,12 @@ public enum AIModel: Equatable, Hashable {
         ModelInfo(model: .gpt54ProXHigh, rawValue: "gpt-5.4-pro-xhigh", actualName: "gpt-5.4-pro", displayName: "GPT-5.4 Pro XHigh", provider: ProviderIndex.openAI),
 
         // Codex CLI Provider Models
+        ModelInfo(model: .codexCliGpt6AstraLow, rawValue: "codex_cli_gpt-6-astra-low", actualName: "gpt-6-astra", displayName: "CLI·GPT-6 Astra Low", provider: ProviderIndex.codex),
+        ModelInfo(model: .codexCliGpt6AstraMedium, rawValue: "codex_cli_gpt-6-astra-medium", actualName: "gpt-6-astra", displayName: "CLI·GPT-6 Astra Medium", provider: ProviderIndex.codex),
+        ModelInfo(model: .codexCliGpt6AstraHigh, rawValue: "codex_cli_gpt-6-astra-high", actualName: "gpt-6-astra", displayName: "CLI·GPT-6 Astra High", provider: ProviderIndex.codex),
+        ModelInfo(model: .codexCliGpt6AstraXHigh, rawValue: "codex_cli_gpt-6-astra-xhigh", actualName: "gpt-6-astra", displayName: "CLI·GPT-6 Astra XHigh", provider: ProviderIndex.codex),
+        ModelInfo(model: .codexCliGpt6AstraMax, rawValue: "codex_cli_gpt-6-astra-max", actualName: "gpt-6-astra", displayName: "CLI·GPT-6 Astra Max", provider: ProviderIndex.codex),
+        ModelInfo(model: .codexCliGpt6AstraUltra, rawValue: "codex_cli_gpt-6-astra-ultra", actualName: "gpt-6-astra", displayName: "CLI·GPT-6 Astra Ultra", provider: ProviderIndex.codex),
         ModelInfo(model: .codexCliGpt56SolLow, rawValue: "codex_cli_gpt-5.6-sol-low", actualName: "gpt-5.6-sol", displayName: "CLI·GPT-5.6 Sol Low", provider: ProviderIndex.codex),
         ModelInfo(model: .codexCliGpt56SolMedium, rawValue: "codex_cli_gpt-5.6-sol-medium", actualName: "gpt-5.6-sol", displayName: "CLI·GPT-5.6 Sol Medium", provider: ProviderIndex.codex),
         ModelInfo(model: .codexCliGpt56SolHigh, rawValue: "codex_cli_gpt-5.6-sol-high", actualName: "gpt-5.6-sol", displayName: "CLI·GPT-5.6 Sol High", provider: ProviderIndex.codex),
@@ -1117,15 +1129,15 @@ public enum AIModel: Equatable, Hashable {
         case .gpt5, .gpt54, .gpt5CodexMed, .o3: return "medium"
         case .gpt5Low, .gpt54Low, .gpt5CodexLow, .o3Low: return "low"
         // Codex CLI models
-        case .codexCliGpt56SolUltra, .codexCliGpt56TerraUltra: return "ultra"
-        case .codexCliGpt56SolMax, .codexCliGpt56TerraMax, .codexCliGpt56LunaMax: return "max"
-        case .codexCliGpt56SolXHigh, .codexCliGpt56TerraXHigh, .codexCliGpt56LunaXHigh,
+        case .codexCliGpt6AstraUltra, .codexCliGpt56SolUltra, .codexCliGpt56TerraUltra: return "ultra"
+        case .codexCliGpt6AstraMax, .codexCliGpt56SolMax, .codexCliGpt56TerraMax, .codexCliGpt56LunaMax: return "max"
+        case .codexCliGpt6AstraXHigh, .codexCliGpt56SolXHigh, .codexCliGpt56TerraXHigh, .codexCliGpt56LunaXHigh,
              .codexCliGpt5XHigh, .codexCliGpt54XHigh, .codexCliGpt5CodexXHigh: return "xhigh"
-        case .codexCliGpt56SolHigh, .codexCliGpt56TerraHigh, .codexCliGpt56LunaHigh,
+        case .codexCliGpt6AstraHigh, .codexCliGpt56SolHigh, .codexCliGpt56TerraHigh, .codexCliGpt56LunaHigh,
              .codexCliGpt5High, .codexCliGpt54High, .codexCliGpt5CodexHigh: return "high"
-        case .codexCliGpt56SolMedium, .codexCliGpt56TerraMedium, .codexCliGpt56LunaMedium,
+        case .codexCliGpt6AstraMedium, .codexCliGpt56SolMedium, .codexCliGpt56TerraMedium, .codexCliGpt56LunaMedium,
              .codexCliGpt5Medium, .codexCliGpt54Medium, .codexCliGpt5CodexMedium: return "medium"
-        case .codexCliGpt56SolLow, .codexCliGpt56TerraLow, .codexCliGpt56LunaLow,
+        case .codexCliGpt6AstraLow, .codexCliGpt56SolLow, .codexCliGpt56TerraLow, .codexCliGpt56LunaLow,
              .codexCliGpt5Low, .codexCliGpt54Low, .codexCliGpt5CodexLow: return "low"
         case let .codexCustom(name):
             return CodexModelSpecifier(raw: name).reasoningEffort?.rawValue
@@ -1634,6 +1646,8 @@ public enum AIModel: Equatable, Hashable {
         let normalizedBase = normalizedSemanticText(base)
         let canonicalBase: String
         switch normalizedBase {
+        case "gpt-6-astra":
+            canonicalBase = "GPT-6 Astra"
         case "gpt-5.6", "gpt-5.6-sol":
             canonicalBase = "GPT-5.6 Sol"
         case "gpt-5.6-terra":
@@ -2006,6 +2020,12 @@ public enum AIModel: Equatable, Hashable {
         case gpt5CodexMed
         case gpt5CodexHigh
         case gpt5CodexXHigh
+        case codexCliGpt6AstraLow
+        case codexCliGpt6AstraMedium
+        case codexCliGpt6AstraHigh
+        case codexCliGpt6AstraXHigh
+        case codexCliGpt6AstraMax
+        case codexCliGpt6AstraUltra
         case codexCliGpt56SolLow
         case codexCliGpt56SolMedium
         case codexCliGpt56SolHigh
@@ -2179,6 +2199,18 @@ public enum AIModel: Equatable, Hashable {
             .staticCase(.gpt5CodexHigh)
         case .gpt5CodexXHigh:
             .staticCase(.gpt5CodexXHigh)
+        case .codexCliGpt6AstraLow:
+            .staticCase(.codexCliGpt6AstraLow)
+        case .codexCliGpt6AstraMedium:
+            .staticCase(.codexCliGpt6AstraMedium)
+        case .codexCliGpt6AstraHigh:
+            .staticCase(.codexCliGpt6AstraHigh)
+        case .codexCliGpt6AstraXHigh:
+            .staticCase(.codexCliGpt6AstraXHigh)
+        case .codexCliGpt6AstraMax:
+            .staticCase(.codexCliGpt6AstraMax)
+        case .codexCliGpt6AstraUltra:
+            .staticCase(.codexCliGpt6AstraUltra)
         case .codexCliGpt56SolLow:
             .staticCase(.codexCliGpt56SolLow)
         case .codexCliGpt56SolMedium:

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexModelSpecifier.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexModelSpecifier.swift
@@ -34,7 +34,7 @@ struct CodexModelSpecifier: Equatable {
 
         // First strip any reasoning effort suffix. Legacy efforts remain broadly decoded for
         // stored selections such as `gpt-5.5-xhigh` and `gpt-5.1-codex-max-low`.
-        // Extended efforts are gated to known GPT-5.6 families so the legitimate base ID
+        // Extended efforts are gated to known model families so the legitimate base ID
         // `gpt-5.1-codex-max` is not misread as `gpt-5.1-codex` + max effort.
         let suffixes: [(suffix: String, effort: ReasoningEffort, requiresKnownFamilySupport: Bool)] = [
             ("-xhigh", .xhigh, false),
@@ -85,7 +85,7 @@ struct CodexModelSpecifier: Equatable {
         let supportBase = serviceTierStrippedBase(candidate).lowercased()
         let supported: Set<ReasoningEffort>
         switch supportBase {
-        case "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra":
+        case "gpt-6-astra", "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra":
             supported = [.max, .ultra]
         case "gpt-5.6-luna":
             supported = [.max]

--- a/Tests/RepoPromptTests/AI/ModelPickerStringOrderingTests.swift
+++ b/Tests/RepoPromptTests/AI/ModelPickerStringOrderingTests.swift
@@ -47,4 +47,71 @@ final class ModelPickerStringOrderingTests: XCTestCase {
         XCTAssertEqual(AIModel.stripCodexReasoningSuffix(from: "GPT-5.1 Codex Max"), "GPT-5.1 Codex Max")
         XCTAssertEqual(AIModel.stripCodexReasoningSuffix(from: "GPT-5.1 Codex Max High"), "GPT-5.1 Codex Max")
     }
+
+    func testAstraSelectionsRoundTripAndProduceSeparateModelAndEffortArguments() throws {
+        let efforts: [CodexReasoningEffort] = [.low, .medium, .high, .xhigh, .max, .ultra]
+        for effort in efforts {
+            let raw = "gpt-6-astra-\(effort.rawValue)"
+            let agentModel = try XCTUnwrap(AgentModel.resolvedModel(forRaw: raw, agentKind: .codexExec))
+            XCTAssertEqual(agentModel.rawValue, raw)
+            XCTAssertTrue(AgentModel.modelsForAgent(.codexExec).contains(agentModel))
+            XCTAssertEqual(try JSONDecoder().decode(AgentModel.self, from: JSONEncoder().encode(agentModel)), agentModel)
+
+            let model = try XCTUnwrap(AIModel.fromModelName("codex_cli_\(raw)"))
+            XCTAssertEqual(model.providerType, .codex)
+            XCTAssertEqual(model.modelName, "gpt-6-astra")
+            XCTAssertEqual(model.defaultReasoningEffort, effort.rawValue)
+            XCTAssertEqual(AIModel.fromModelName(model.rawValue), model)
+
+            for tier in ["", "-fast"] {
+                let specifier = CodexModelSpecifier(raw: "gpt-6-astra\(tier)-\(effort.rawValue)")
+                XCTAssertEqual(specifier.cliModelArgs, ["--model", "gpt-6-astra"])
+                XCTAssertEqual(specifier.cliReasoningConfigArgs, ["-c", "model_reasoning_effort=\(effort.rawValue)"])
+                XCTAssertEqual(specifier.appServerModelParam, "gpt-6-astra")
+                XCTAssertEqual(specifier.appServerEffortParam, effort.rawValue)
+                XCTAssertEqual(specifier.appServerServiceTierParam, tier.isEmpty ? nil : "fast")
+            }
+        }
+        XCTAssertEqual(AgentModel.resolvedModel(forRaw: "gpt-6-astra", agentKind: .codexExec), .gpt6AstraMedium)
+        XCTAssertNil(CodexModelSpecifier(raw: "gpt-6-astra-preview-ultra").reasoningEffort)
+    }
+
+    func testAstraPickerGroupsKeepAllEffortsTogetherAndSortBeforeGPT5() {
+        let efforts = ["low", "medium", "high", "xhigh", "max", "ultra"]
+        let models: [AIModel] = efforts.reversed().flatMap { effort in
+            [AIModel.codexCustom(name: "gpt-6-astra-\(effort)"), .codexCustom(name: "gpt-6-astra-fast-\(effort)")]
+        } + [.codexCliGpt56SolHigh]
+        let groups = AIModel.codexMenuGroups(for: models)
+        XCTAssertEqual(groups.map(\.baseModelID), ["gpt-6-astra", "gpt-6-astra-fast", "gpt-5.6-sol"])
+        XCTAssertEqual(groups[0].displayName, "GPT-6 Astra")
+        XCTAssertEqual(groups[1].displayName, "GPT-6 Astra Fast")
+        XCTAssertEqual(groups[0].models.map(\.defaultReasoningEffort), efforts)
+
+        let options = models.map { model in
+            AgentModelOption(rawValue: model.modelName, displayName: model.displayName, description: nil, isDefault: false)
+        }
+        let menu = AgentModelCatalog.codexMenu(for: options)
+        XCTAssertEqual(menu.groups.map(\.baseModelID), ["gpt-6-astra", "gpt-6-astra-fast", "gpt-5.6-sol"])
+        XCTAssertEqual(menu.groups[0].options.map(\.rawValue), efforts.map { "gpt-6-astra-\($0)" })
+        XCTAssertEqual(menu.groups[1].options.map(\.rawValue), efforts.map { "gpt-6-astra-fast-\($0)" })
+    }
+
+    func testLiveAstraCataloguePreservesDefaultAndSynthesizesFastEfforts() {
+        let efforts = ["low", "medium", "high", "xhigh", "max", "ultra"]
+        let remote = CodexAppServerClient.RemoteModel(
+            id: "gpt-6-astra", model: "gpt-6-astra", displayName: "GPT-6-Astra",
+            description: "Astra", isDefault: true,
+            supportedReasoningEfforts: efforts.map {
+                CodexAppServerClient.RemoteReasoningEffort(reasoningEffort: $0, description: $0)
+            },
+            defaultReasoningEffort: "medium"
+        )
+        let options = AgentCodexModelRegistry.shared.resolvedOptions(staticOptions: [], preferredLiveModels: [remote])
+        let menu = AgentModelCatalog.codexMenu(for: options)
+        XCTAssertEqual(menu.groups.map(\.baseModelID), ["gpt-6-astra", "gpt-6-astra-fast"])
+        XCTAssertEqual(menu.groups[0].options.map(\.rawValue), efforts.map { "gpt-6-astra-\($0)" })
+        XCTAssertEqual(menu.groups[1].options.map(\.rawValue), efforts.map { "gpt-6-astra-fast-\($0)" })
+        XCTAssertEqual(options.filter(\.isProviderDefault).map(\.rawValue), ["gpt-6-astra-medium"])
+        XCTAssertEqual(menu.groups[0].displayName, "GPT-6 Astra")
+    }
 }


### PR DESCRIPTION
Adds GPT-6 Astra (Low, Medium, High, XHigh, Max and Ultra) to the shared Codex CLI catalogues used by Chat/Oracle model settings, Context Builder, Agent Mode, role settings and MCP model discovery. Existing recommendation defaults are unchanged.

Registers stable selections and display names, resolves the base model to Medium, and recognises Max/Ultra suffixes so normal and generated Fast selections send `gpt-6-astra` with a separate reasoning effort. Regression coverage checks saved selections, CLI/app-server parameters, both picker groupings, ordering and live catalogue defaults.

Validation:
- `make dev-test FILTER='ModelPickerStringOrderingTests|AIModelPreferenceRegressionTests'`: 14 tests passed.
- `make dev-swift-build PRODUCT=RepoPrompt` and `make dev-lint`: passed.
- Commit/push contribution preflights, including guardrails and redacted secret scans: passed.
- Independent diff review: no material findings.

Live smoke was attempted but could not connect to the installed debug app (app unavailable or MCP disabled). No visible app was launched or restarted.
