### PR TITLE
Discover provider models from advertised capabilities

### DIFF
--- a/Sources/RepoPrompt/App/Notifications/AppNotifications.swift
+++ b/Sources/RepoPrompt/App/Notifications/AppNotifications.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 extension Notification.Name {
+    static let providerModelCatalogDidChange = Notification.Name("providerModelCatalogDidChange")
     static let showAPISettingsTab = Notification.Name("showAPISettingsTab")
     /// General request to open/focus the dedicated Settings window (Appearance / current tab).
     /// `object` should be the WindowState to target; when omitted, the focused/latest window is used.

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentCodexModelRegistry.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentCodexModelRegistry.swift
@@ -92,6 +92,7 @@ final class AgentCodexModelRegistry {
     private func synthesizedFastAgentOptions(from options: [AgentModelOption]) -> [AgentModelOption] {
         var synthesized: [AgentModelOption] = []
         var seen = Set(options.map { $0.rawValue.lowercased() })
+        seen.formUnion(CodexDynamicModelStore.reservedBaseIDs())
 
         for option in options where !option.isPlaceholderDefault {
             let specifier = CodexModelSpecifier(raw: option.rawValue)
@@ -105,7 +106,7 @@ final class AgentCodexModelRegistry {
 
             synthesized.append(AgentModelOption(
                 rawValue: fastID,
-                displayName: fastDisplayName(for: option, reasoningEffort: specifier.reasoningEffort),
+                displayName: fastDisplayName(for: option, baseModel: baseModel, reasoningEffort: specifier.reasoningEffort),
                 description: fastDescription(for: option.description),
                 isPlaceholderDefault: false,
                 isProviderDefault: false,
@@ -117,8 +118,8 @@ final class AgentCodexModelRegistry {
         return synthesized
     }
 
-    private func fastDisplayName(for option: AgentModelOption, reasoningEffort: CodexReasoningEffort?) -> String {
-        let baseLabel = AIModel.stripCodexReasoningSuffix(from: option.displayName)
+    private func fastDisplayName(for option: AgentModelOption, baseModel: String, reasoningEffort: CodexReasoningEffort?) -> String {
+        let baseLabel = AIModel.codexBaseDisplayName(for: baseModel, fallbackDisplayName: option.displayName)
         let fastLabel = baseLabel.range(of: " fast", options: [.caseInsensitive, .backwards]) == nil
             ? "\(baseLabel) Fast"
             : baseLabel

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -713,11 +713,13 @@ enum AgentModelCatalog {
             return "\(baseDisplayName) \(serviceTier.capitalized)"
         }
 
+        let discoveredBases = CodexDynamicModelStore.reservedBaseIDs()
         let entries = modelOptions.map { option -> Entry in
             let specifier = CodexModelSpecifier(raw: option.rawValue)
             let normalizedRaw = option.rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
             let baseModelID = CodexServiceTierVariantCatalog.serviceTierAwareBaseID(for: normalizedRaw)
-            let reasoningEffort = specifier.reasoningEffort ?? effortFromDisplayName(option.displayName)
+            let reasoningEffort = discoveredBases.contains(normalizedRaw.lowercased())
+                ? nil : specifier.reasoningEffort ?? effortFromDisplayName(option.displayName)
             let groupDisplayName = displayNameForBaseModel(
                 baseModelID: baseModelID,
                 fallbackDisplayName: option.displayName

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -187,6 +187,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
         {
             return false
         }
+        if agentKind == .claudeCode, ClaudeDynamicModelStore.record(for: baseModel) != nil { return true }
         guard let known = AgentModel.resolvedModel(forRaw: baseModel, agentKind: agentKind) else { return false }
         guard known.isValidFor(agentKind) else { return false }
         return known.isAvailable
@@ -197,6 +198,9 @@ enum ClaudeCompatibleModelCatalogAdapter {
         isSupportedForBaseModelRaw baseModelRaw: String?,
         agentKind: AgentProviderKind?
     ) -> Bool {
+        if agentKind == .claudeCode, let record = ClaudeDynamicModelStore.record(for: baseModelRaw) {
+            return record.efforts.contains(effort)
+        }
         if let agentKind, compatibleBackendModelBehavior(for: agentKind) == .noModel {
             return false
         }
@@ -222,10 +226,35 @@ enum ClaudeCompatibleModelCatalogAdapter {
         agentKind: AgentProviderKind,
         includeClaudeEffortVariants: Bool
     ) -> ClaudeCompatiblePluginModelCatalogSnapshot {
-        ClaudeCompatibleProviderRuntimeBridge.modelCatalogSnapshot(
+        let fallback = ClaudeCompatibleProviderRuntimeBridge.modelCatalogSnapshot(
             pluginID: pluginID,
             backendConfig: compatibleBackendConfig(for: agentKind),
             includeEffortVariants: includeClaudeEffortVariants
+        )
+        guard agentKind == .claudeCode else { return fallback }
+        let records = ClaudeDynamicModelStore.records()
+        guard !records.isEmpty else { return fallback }
+        let discovered = records.flatMap { record -> [ClaudeCompatiblePluginModelOption] in
+            let efforts: [ClaudeCodeEffortLevel?] = includeClaudeEffortVariants && !record.efforts.isEmpty
+                ? record.efforts.map(\.self) : [nil]
+            return efforts.map { effort in
+                ClaudeCompatiblePluginModelOption(
+                    rawValue: effort.map { ClaudeModelSpecifier.encodedRaw(baseModelRaw: record.value, effort: $0) } ?? record.value,
+                    displayName: record.displayName + (effort.map { " \($0.displayName)" } ?? ""),
+                    description: record.description,
+                    isPlaceholderDefault: false,
+                    isProviderDefault: false,
+                    supportedEffortLevels: record.efforts.map(\.rawValue)
+                )
+            }
+        }
+        let identities = Set(records.map { $0.value.lowercased() })
+        return ClaudeCompatiblePluginModelCatalogSnapshot(
+            pluginID: fallback.pluginID,
+            defaultModelRaw: fallback.defaultModelRaw,
+            options: discovered + fallback.options.filter {
+                !identities.contains(ClaudeModelSpecifier(raw: $0.rawValue).baseModel?.lowercased() ?? "")
+            }
         )
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -2576,6 +2576,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     private func setupObservers() {
+        NotificationCenter.default.publisher(for: .providerModelCatalogDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
         guard let promptManager else { return }
         installPromptManagerCascadeResolvers(promptManager)
         installAgentSessionLifecycleProjectionAuthority()

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModelsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModelsSettingsViewModel.swift
@@ -540,6 +540,14 @@ final class AgentModelsSettingsViewModel: ObservableObject {
     }
 
     private func observeNotifications() {
+        apiSettingsVM.$availableModels
+            .dropFirst()
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+        notificationCenter.publisher(for: .providerModelCatalogDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
         notificationCenter.publisher(for: .recommendationsShouldRefresh)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.refresh() }

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -937,6 +937,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         }
 
         // Reload agent/model when recommendations are applied
+        NotificationCenter.default.publisher(for: .providerModelCatalogDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
         NotificationCenter.default.publisher(for: .recommendationsDidApply)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -349,6 +349,7 @@ public class APISettingsViewModel: ObservableObject {
 
     // ── Model-list fetch tasks (one per provider) ───────────────────────────
     private var openAIModelsTask: Task<Void, Never>?
+    private var anthropicModelsTask: Task<Void, Never>?
     private var deepSeekModelsTask: Task<Void, Never>?
     private var fireworksModelsTask: Task<Void, Never>?
     private var grokModelsTask: Task<Void, Never>? // NEW
@@ -539,6 +540,12 @@ public class APISettingsViewModel: ObservableObject {
     }
 
     private func installCLIConnectionObservers() {
+        NotificationCenter.default.publisher(for: .providerModelCatalogDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                Task { await self?.updateAvailableModels() }
+            }
+            .store(in: &cliConnectionCancellables)
         Publishers.MergeMany([
             NotificationCenter.default.publisher(for: .claudeCodeConnectionChanged).map { _ in AgentProviderKind.claudeCode },
             NotificationCenter.default.publisher(for: .codexConnectionChanged).map { _ in AgentProviderKind.codexExec },
@@ -1056,6 +1063,7 @@ public class APISettingsViewModel: ObservableObject {
     }
 
     func prepareForWindowClose() {
+        anthropicModelsTask?.cancel()
         guard !hasPreparedForWindowClose else { return }
         hasPreparedForWindowClose = true
         initialLoadTask?.cancel()
@@ -1087,6 +1095,7 @@ public class APISettingsViewModel: ObservableObject {
     }
 
     deinit {
+        anthropicModelsTask?.cancel()
         initialLoadTask?.cancel()
         openAIModelsTask?.cancel()
         deepSeekModelsTask?.cancel()
@@ -1405,6 +1414,7 @@ public class APISettingsViewModel: ObservableObject {
         guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
         // ── 0. Cancel previous background fetches ───────────────────────────────
+        anthropicModelsTask?.cancel()
         openAIModelsTask?.cancel()
         openAIModelsTask = nil
         deepSeekModelsTask?.cancel()
@@ -1566,6 +1576,7 @@ public class APISettingsViewModel: ObservableObject {
         // ----------------------------------------------------------------
         guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
         if isOpenAIKeyValid { openAIModelsTask = Task { await self.updateOpenAIModels() } }
+        if isAnthropicKeyValid { anthropicModelsTask = Task { await self.updateAnthropicModels() } }
         if isDeepSeekKeyValid { deepSeekModelsTask = Task { await self.updateDeepSeekModels() } }
         if isFireworksKeyValid { fireworksModelsTask = Task { await self.updateFireworksModels() } }
         if isGrokKeyValid { grokModelsTask = Task { await self.updateGrokModels() } }
@@ -1949,6 +1960,8 @@ public class APISettingsViewModel: ObservableObject {
             case .anthropic:
                 anthropicApiKey = trimmedKey
                 isAnthropicKeyValid = true
+                anthropicModelsTask?.cancel()
+                anthropicModelsTask = Task { await self.updateAnthropicModels() }
                 seedPreferredComposeModelIfMissing(AIModel.claude4Sonnet, reason: "api_settings.validate_key.default_seed.anthropic")
             case .openAI:
                 openAIApiKey = trimmedKey
@@ -3955,6 +3968,21 @@ public class APISettingsViewModel: ObservableObject {
 
     // MARK: - Remote-model fetch helpers
 
+    private func updateAnthropicModels() async {
+        let key = anthropicApiKey
+        guard isAnthropicKeyValid, !key.isEmpty else { return }
+        do {
+            let records = try await AnthropicModelCatalog.fetch(apiKey: key)
+            guard !Task.isCancelled, !hasPreparedForWindowClose, key == anthropicApiKey, isAnthropicKeyValid else { return }
+            if AnthropicModelCatalog.save(records) {
+                NotificationCenter.default.post(name: .providerModelCatalogDidChange, object: nil)
+            }
+            await updateAvailableModels()
+        } catch {
+            // Preserve the last usable catalogue and the user's selections.
+        }
+    }
+
     // SEARCH-HELPER: OpenAI Base URL, Custom Base URL, Normalization
     private func normalizedOpenAIBaseURL(_ raw: String) -> String {
         let (base, _) = normalizedOpenAIBaseURLAndVersion(raw)
@@ -4096,21 +4124,17 @@ public class APISettingsViewModel: ObservableObject {
     #endif
 
     private func updateGrokModels() async {
-        guard isGrokKeyValid else { return }
+        let key = grokApiKey
+        guard isGrokKeyValid, !key.isEmpty else { return }
         do {
-            // GrokProvider inherits from OpenAIProvider, so CustomOpenAIProvider can be used for model listing
-            // if Grok's /models endpoint is OpenAI-compatible.
-            let provider = CustomOpenAIProvider(
-                baseURL: "https://api.x.ai/v1", // Grok API base URL for models
-                apiKey: grokApiKey,
-                defaultModel: "grok-3-mini-beta", // A known Grok model
-                defaultTemperature: 0.7
-            )
-            let models = try await provider.getAvailableModels()
-            await MainActor.run { availableGrokModels = models }
+            let models = try await GrokModelCatalog.fetch(apiKey: key)
+            guard !Task.isCancelled, !hasPreparedForWindowClose, key == grokApiKey, isGrokKeyValid else { return }
+            availableGrokModels = models
+            if GrokModelCatalog.save(models) {
+                NotificationCenter.default.post(name: .providerModelCatalogDidChange, object: nil)
+            }
         } catch {
-            await MainActor.run { availableGrokModels = [] }
-            print("Error fetching Grok models: \(error.asFriendlyString())")
+            // Keep the last usable snapshot on a failed or superseded refresh.
         }
         await updateAvailableModels()
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
@@ -169,6 +169,7 @@ public enum AIModel: Equatable, Hashable {
     case openaiCustomResponses(name: String)
     case openaiCustomReasoning(name: String, effort: CodexReasoningEffort)
     case anthropicCustom(name: String)
+    case anthropicCustomReasoning(name: String, effort: ClaudeCodeEffortLevel)
     case geminiCustom(name: String)
     case deepseekCustom(name: String)
     case fireworksCustom(name: String)
@@ -517,6 +518,8 @@ public enum AIModel: Equatable, Hashable {
             return "\(ClaudeCodeAIModelCatalog.rawPrefix)\(ClaudeCodeAIModelCatalog.normalizedSpecifier(specifier))"
         case let .anthropicCustom(n):
             return "anthropic_custom_\(n)"
+        case let .anthropicCustomReasoning(n, effort):
+            return "anthropic_reasoning_\(effort.rawValue)__\(n)"
         case let .geminiCustom(n):
             return "gemini_custom_\(n)"
         case let .deepseekCustom(n):
@@ -562,7 +565,10 @@ public enum AIModel: Equatable, Hashable {
         if case let .openaiCustomResponses(n) = self { return "\(n)" }
         if case let .openaiCustomReasoning(n, effort) = self { return "\(n) \(effort.displayName)" }
         if case let .claudeCodeModel(specifier) = self { return ClaudeCodeAIModelCatalog.displayName(for: specifier) }
-        if case let .anthropicCustom(n) = self { return "\(n)" }
+        if case let .anthropicCustom(n) = self { return AnthropicModelCatalog.record(for: n)?.displayName ?? n }
+        if case let .anthropicCustomReasoning(n, effort) = self {
+            return "\(AnthropicModelCatalog.record(for: n)?.displayName ?? n) \(effort.displayName)"
+        }
         if case let .geminiCustom(n) = self { return "\(n)" }
         if case let .deepseekCustom(n) = self { return "\(n)" }
         if case let .fireworksCustom(n) = self { return "\(n)" }
@@ -654,7 +660,7 @@ public enum AIModel: Equatable, Hashable {
             return .ollama
         case .openaiCustom, .openaiCustomResponses, .openaiCustomReasoning:
             return .openAI
-        case .anthropicCustom: return .anthropic
+        case .anthropicCustom, .anthropicCustomReasoning: return .anthropic
         case .geminiCustom: return .gemini
         case .deepseekCustom: return .deepseek
         case .fireworksCustom: return .fireworks
@@ -709,6 +715,8 @@ public enum AIModel: Equatable, Hashable {
             return n
         case let .claudeCodeModel(specifier):
             return ClaudeModelSpecifier(raw: specifier).runtimeModelParam ?? ""
+        case let .anthropicCustomReasoning(n, _):
+            return n
         case let .anthropicCustom(n),
              let .geminiCustom(n),
              let .deepseekCustom(n),
@@ -1019,7 +1027,7 @@ public enum AIModel: Equatable, Hashable {
              .openaiCustom(_),
              .openaiCustomResponses(_),
              .openaiCustomReasoning(_, _),
-             .anthropicCustom(_),
+             .anthropicCustom(_), .anthropicCustomReasoning,
              .geminiCustom(_),
              .deepseekCustom(_),
              .fireworksCustom(_),
@@ -1132,6 +1140,8 @@ public enum AIModel: Equatable, Hashable {
         case let .claudeCodeModel(specifier):
             return ClaudeModelSpecifier(raw: specifier).explicitEffortLevel?.rawValue
         case let .openaiCustomReasoning(_, effort):
+            return effort.rawValue
+        case let .anthropicCustomReasoning(_, effort):
             return effort.rawValue
         default: return nil
         }
@@ -1246,6 +1256,15 @@ public enum AIModel: Equatable, Hashable {
                 return nil
             }
         }
+        if normalizedRawValue.hasPrefix("anthropic_reasoning_") {
+            let rest = String(normalizedRawValue.dropFirst("anthropic_reasoning_".count))
+            if let separator = rest.range(of: "__"),
+               let effort = ClaudeCodeEffortLevel.parse(String(rest[..<separator.lowerBound]))
+            {
+                return .anthropicCustomReasoning(name: String(rest[separator.upperBound...]), effort: effort)
+            }
+            return nil
+        }
         if normalizedRawValue.hasPrefix("codex_custom_") {
             return .codexCustom(name: String(normalizedRawValue.dropFirst("codex_custom_".count)))
         }
@@ -1332,7 +1351,12 @@ public enum AIModel: Equatable, Hashable {
         let models: [AIModel]
         switch provider {
         case .anthropic:
-            models = Array(modelGroups[ProviderIndex.anthropic])
+            let fallback = Array(modelGroups[ProviderIndex.anthropic])
+            let knownNames = Set(fallback.map(\.modelName))
+            models = fallback + AnthropicModelCatalog.models().filter {
+                if case .anthropicCustomReasoning = $0 { return true }
+                return !knownNames.contains($0.modelName)
+            }
         case .openAI:
             models = Array(modelGroups[ProviderIndex.openAI])
         case .gemini:
@@ -1357,7 +1381,9 @@ public enum AIModel: Equatable, Hashable {
         case .fireworks: // <-- Add Fireworks case
             models = Array(modelGroups[ProviderIndex.fireworks])
         case .grok: // <-- Add Grok case
-            models = Array(modelGroups[ProviderIndex.grok])
+            let fallback = Array(modelGroups[ProviderIndex.grok])
+            let knownNames = Set(fallback.map(\.modelName))
+            models = fallback + GrokModelCatalog.names().filter { !knownNames.contains($0) }.map { .grokCustom(name: $0) }
         case .groq: // <-- Add Groq case
             models = Array(modelGroups[ProviderIndex.groq])
         case .zAI:
@@ -1611,7 +1637,7 @@ public enum AIModel: Equatable, Hashable {
 
     static func codexBaseDisplayName(for baseModelID: String, fallbackDisplayName: String) -> String {
         if let storeLabel = CodexDynamicModelStore.displayName(forModelID: baseModelID) {
-            let normalizedStoreLabel = normalizedCodexBaseLabel(storeLabel)
+            let normalizedStoreLabel = storeLabel.trimmingCharacters(in: .whitespacesAndNewlines)
             if !normalizedStoreLabel.isEmpty {
                 return codexPreviewDisplayAlias(for: normalizedStoreLabel) ?? normalizedStoreLabel
             }
@@ -1944,7 +1970,11 @@ public enum AIModel: Equatable, Hashable {
     static func allModels() -> [AIModel] {
         var models: [AIModel] = []
         for (providerIndex, group) in modelGroups.enumerated() {
-            if providerIndex == ProviderIndex.claudeCode {
+            if providerIndex == ProviderIndex.anthropic {
+                models.append(contentsOf: modelsForProvider(.anthropic))
+            } else if providerIndex == ProviderIndex.grok {
+                models.append(contentsOf: modelsForProvider(.grok))
+            } else if providerIndex == ProviderIndex.claudeCode {
                 models.append(contentsOf: ClaudeCodeAIModelCatalog.modelsForPicker())
             } else if providerIndex == ProviderIndex.codex {
                 models.append(contentsOf: codexModelsForPicker())
@@ -1970,6 +2000,7 @@ public enum AIModel: Equatable, Hashable {
         case openaiCustomResponses(name: String)
         case openaiCustomReasoning(name: String, effort: CodexReasoningEffort)
         case anthropicCustom(name: String)
+        case anthropicCustomReasoning(name: String, effort: ClaudeCodeEffortLevel)
         case geminiCustom(name: String)
         case deepseekCustom(name: String)
         case fireworksCustom(name: String)
@@ -2115,6 +2146,8 @@ public enum AIModel: Equatable, Hashable {
             .openaiCustomReasoning(name: name, effort: effort)
         case let .anthropicCustom(name):
             .anthropicCustom(name: name)
+        case let .anthropicCustomReasoning(name, effort):
+            .anthropicCustomReasoning(name: name, effort: effort)
         case let .geminiCustom(name):
             .geminiCustom(name: name)
         case let .deepseekCustom(name):

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/ProviderModelDiscoveryCache.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/ProviderModelDiscoveryCache.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Current discovery controls eligibility. Remembered metadata only resolves saved
+/// selections after a provider omits a model; it must not repopulate the picker.
+final class ProviderModelDiscoveryCache<Record: Codable> {
+    let key: String
+    let identity: (Record) -> String
+    private let lock = NSLock()
+    private var decoded: Snapshot?
+
+    private struct Snapshot {
+        let defaults: UserDefaults
+        let currentData: Data?
+        let historyData: Data?
+        let current: [Record]
+        let remembered: [Record]
+    }
+
+    init(key: String, identity: @escaping (Record) -> String) {
+        self.key = key
+        self.identity = identity
+    }
+
+    func current(defaults: UserDefaults = .standard) -> [Record] {
+        lock.lock()
+        defer { lock.unlock() }
+        return snapshot(defaults: defaults).current
+    }
+
+    func remembered(defaults: UserDefaults = .standard) -> [Record] {
+        lock.lock()
+        defer { lock.unlock() }
+        return snapshot(defaults: defaults).remembered
+    }
+
+    @discardableResult
+    func save(_ records: [Record], defaults: UserDefaults = .standard) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let previous = snapshot(defaults: defaults)
+        let current = merged([], records)
+        let remembered = merged(previous.remembered, current)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        guard let data = try? encoder.encode(current),
+              let history = try? encoder.encode(remembered) else { return false }
+        let changed = previous.currentData != data
+        defaults.set(history, forKey: key + ".savedSelectionMetadata")
+        defaults.set(data, forKey: key)
+        decoded = Snapshot(defaults: defaults, currentData: data, historyData: history, current: current, remembered: remembered)
+        return changed
+    }
+
+    /// Picker sorting resolves many model IDs; decode once per persisted snapshot.
+    /// Data comparison also observes writes from another window/process or test suite.
+    private func snapshot(defaults: UserDefaults) -> Snapshot {
+        let currentData = defaults.data(forKey: key)
+        let historyData = defaults.data(forKey: key + ".savedSelectionMetadata")
+        if let decoded, decoded.defaults === defaults,
+           decoded.currentData == currentData, decoded.historyData == historyData
+        {
+            return decoded
+        }
+        let current = decode(currentData)
+        let snapshot = Snapshot(
+            defaults: defaults,
+            currentData: currentData,
+            historyData: historyData,
+            current: current,
+            remembered: merged(decode(historyData), current)
+        )
+        decoded = snapshot
+        return snapshot
+    }
+
+    private func decode(_ data: Data?) -> [Record] {
+        guard let data else { return [] }
+        return (try? JSONDecoder().decode([Record].self, from: data)) ?? []
+    }
+
+    private func merged(_ old: [Record], _ new: [Record]) -> [Record] {
+        var byID = Dictionary(old.map { (identity($0), $0) }, uniquingKeysWith: { _, latest in latest })
+        for record in new {
+            byID[identity(record)] = record
+        }
+        return byID.sorted { $0.key < $1.key }.map(\.value)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/AnthropicModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/AnthropicModelCatalog.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+enum AnthropicModelCatalog {
+    struct Record: Codable, Equatable {
+        let id: String
+        let displayName: String
+        let efforts: [ClaudeCodeEffortLevel]
+        let adaptiveThinking: Bool
+    }
+
+    private static let cache = ProviderModelDiscoveryCache<Record>(key: "AnthropicDiscoveredModels", identity: { $0.id })
+
+    static func fetch(apiKey: String, client: any HTTPClient = DefaultHTTPClient.discoveryClient) async throws -> [Record] {
+        var records: [Record] = []
+        var cursor: String?
+        var seen = Set<String>()
+        repeat {
+            try Task.checkCancellation()
+            var components = URLComponents(string: "https://api.anthropic.com/v1/models")!
+            components.queryItems = [URLQueryItem(name: "limit", value: "1000")]
+            if let cursor { components.queryItems?.append(URLQueryItem(name: "after_id", value: cursor)) }
+            var request = URLRequest(url: components.url!)
+            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+            let response = try await client.data(for: request)
+            guard response.http.statusCode == 200,
+                  let page = try JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+                  let entries = page["data"] as? [[String: Any]] else { throw URLError(.badServerResponse) }
+            records.append(contentsOf: parse(entries))
+            guard page["has_more"] as? Bool == true else { break }
+            guard let next = page["last_id"] as? String, !next.isEmpty, seen.insert(next).inserted else {
+                throw URLError(.badServerResponse)
+            }
+            cursor = next
+        } while true
+        return records
+    }
+
+    static func records(defaults: UserDefaults = .standard) -> [Record] {
+        cache.current(defaults: defaults)
+    }
+
+    static func record(for id: String, defaults: UserDefaults = .standard) -> Record? {
+        cache.remembered(defaults: defaults).first { $0.id == id }
+    }
+
+    static func parse(_ entries: [[String: Any]]) -> [Record] {
+        entries.compactMap { entry in
+            guard let id = entry["id"] as? String, !id.isEmpty else { return nil }
+            let capabilities = entry["capabilities"] as? [String: Any] ?? [:]
+            let effort = capabilities["effort"] as? [String: Any] ?? [:]
+            let efforts = ["low", "medium", "high", "xhigh", "max"].compactMap { level -> ClaudeCodeEffortLevel? in
+                guard effort["supported"] as? Bool != false,
+                      (effort[level] as? [String: Any])?["supported"] as? Bool == true else { return nil }
+                return ClaudeCodeEffortLevel.parse(level)
+            }
+            let thinking = capabilities["thinking"] as? [String: Any] ?? [:]
+            let thinkingTypes = thinking["types"] as? [String: Any] ?? [:]
+            return Record(
+                id: id,
+                displayName: entry["display_name"] as? String ?? id,
+                efforts: efforts,
+                adaptiveThinking: thinking["supported"] as? Bool != false && (thinkingTypes["adaptive"] as? [String: Any])?["supported"] as? Bool == true
+            )
+        }
+    }
+
+    @discardableResult
+    static func save(_ records: [Record], defaults: UserDefaults = .standard) -> Bool {
+        cache.save(records, defaults: defaults)
+    }
+
+    static func models(defaults: UserDefaults = .standard) -> [AIModel] {
+        records(defaults: defaults).flatMap { record in
+            [.anthropicCustom(name: record.id)] + record.efforts.map {
+                .anthropicCustomReasoning(name: record.id, effort: $0)
+            }
+        }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
@@ -22,7 +22,15 @@ enum ClaudeCodeAIModelCatalog {
         .low, .medium, .high, .xhigh, .max
     ]
 
-    private static let modelDefinitions: [ModelDefinition] = [
+    private static var modelDefinitions: [ModelDefinition] {
+        let discovered = ClaudeDynamicModelStore.records().map {
+            ModelDefinition(runtimeModelRaw: $0.value, displayName: $0.displayName, supportedEfforts: $0.efforts)
+        }
+        let identities = Set(discovered.map { $0.runtimeModelRaw.lowercased() })
+        return discovered + fallbackDefinitions.filter { !identities.contains($0.runtimeModelRaw.lowercased()) }
+    }
+
+    private static let fallbackDefinitions: [ModelDefinition] = [
         ModelDefinition(runtimeModelRaw: "fable", displayName: "Fable Latest", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-fable-5-1", displayName: "Fable 5.1", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
         ModelDefinition(runtimeModelRaw: "claude-fable-5", displayName: "Fable 5", supportedEfforts: [.low, .medium, .high, .xhigh, .max]),
@@ -283,6 +291,9 @@ enum ClaudeCodeAIModelCatalog {
         guard let raw else { return nil }
         let normalized = normalizedSpecifier(raw)
         guard !normalized.isEmpty else { return nil }
+        if let record = ClaudeDynamicModelStore.record(for: normalized) {
+            return ModelDefinition(runtimeModelRaw: record.value, displayName: record.displayName, supportedEfforts: record.efforts)
+        }
         return modelDefinitions.first {
             $0.runtimeModelRaw.caseInsensitiveCompare(normalized) == .orderedSame
         }

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeDynamicModelStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeDynamicModelStore.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Claude Code's initialize response is the authority for the connected runtime.
+/// Compatible backends keep their separately configured model mappings.
+enum ClaudeDynamicModelStore {
+    struct Record: Codable, Equatable {
+        let value: String
+        let displayName: String
+        let description: String
+        let supportsEffort: Bool?
+        let supportedEffortLevels: [String]?
+
+        var efforts: [ClaudeCodeEffortLevel] {
+            guard supportsEffort != false else { return [] }
+            return (supportedEffortLevels ?? []).compactMap(ClaudeCodeEffortLevel.parse)
+        }
+    }
+
+    private static let cache = ProviderModelDiscoveryCache<Record>(key: "ClaudeCodeDiscoveredModels", identity: { $0.value })
+
+    static func records(defaults: UserDefaults = .standard) -> [Record] {
+        cache.current(defaults: defaults)
+    }
+
+    static func record(for raw: String?, defaults: UserDefaults = .standard) -> Record? {
+        guard let raw else { return nil }
+        return cache.remembered(defaults: defaults).first { $0.value.caseInsensitiveCompare(raw) == .orderedSame }
+    }
+
+    static func effort(_ requested: ClaudeCodeEffortLevel?, forModel raw: String?, defaults: UserDefaults = .standard) -> ClaudeCodeEffortLevel? {
+        guard let record = record(for: raw, defaults: defaults) else { return requested }
+        guard let requested, record.efforts.contains(requested) else { return nil }
+        return requested
+    }
+
+    @discardableResult
+    static func update(json: String, defaults: UserDefaults = .standard) -> Bool {
+        guard let data = json.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([Record].self, from: data),
+              decoded.allSatisfy({ !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+        else { return false }
+        return cache.save(decoded, defaults: defaults)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/CodexAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/CodexAIModelCatalog.swift
@@ -90,6 +90,7 @@ enum CodexDynamicModelMapper {
     static func options(from records: [CodexDynamicModelRecord]) -> [CodexDynamicModelOption] {
         var options: [CodexDynamicModelOption] = []
         var seen = Set<String>()
+        let advertisedIDs = CodexDynamicModelStore.reservedBaseIDs().union(records.flatMap { [$0.id.lowercased(), $0.model.lowercased()] })
 
         for record in records {
             let baseID = normalizeID(record.id)
@@ -101,7 +102,10 @@ enum CodexDynamicModelMapper {
                 fallbackID: baseID
             )
             let baseDescription = record.description.trimmingCharacters(in: .whitespacesAndNewlines)
-            let effortEntries = normalizedEfforts(for: record, fallbackDescription: baseDescription)
+            // A saved base identity cannot also denote a newly generated effort choice.
+            let effortEntries = normalizedEfforts(for: record, fallbackDescription: baseDescription).filter {
+                !advertisedIDs.contains("\(baseID)-\($0.effort.rawValue)".lowercased())
+            }
 
             if effortEntries.isEmpty {
                 appendOption(
@@ -161,6 +165,9 @@ enum CodexDynamicModelMapper {
         let normalizedID = normalizeID(id)
         let lookupID = normalizedID.lowercased()
         guard !lookupID.isEmpty else { return nil }
+        if let record = records.first(where: { $0.id.lowercased() == lookupID || $0.model.lowercased() == lookupID }) {
+            return formatBaseDisplayName(record.displayName, fallbackModel: record.model, fallbackID: record.id)
+        }
 
         for record in records {
             let baseID = normalizeID(record.id)
@@ -311,7 +318,7 @@ enum CodexDynamicModelMapper {
 }
 
 enum CodexDynamicModelStore {
-    private static let storageKey = "CodexDynamicModelRecords"
+    private static let cache = ProviderModelDiscoveryCache<CodexDynamicModelRecord>(key: "CodexDynamicModelRecords", identity: { $0.id })
 
     static func canonicalRecords(from models: [CodexAppServerClient.RemoteModel]) -> [CodexDynamicModelRecord] {
         models
@@ -321,13 +328,19 @@ enum CodexDynamicModelStore {
 
     static func save(_ models: [CodexAppServerClient.RemoteModel], defaults: UserDefaults = .standard) {
         let records = canonicalRecords(from: models)
-        guard let data = try? JSONEncoder().encode(records) else { return }
-        defaults.set(data, forKey: storageKey)
+        cache.save(records, defaults: defaults)
     }
 
     static func load(defaults: UserDefaults = .standard) -> [CodexDynamicModelRecord] {
-        guard let data = defaults.data(forKey: storageKey) else { return [] }
-        return (try? JSONDecoder().decode([CodexDynamicModelRecord].self, from: data)) ?? []
+        cache.current(defaults: defaults)
+    }
+
+    static func resolutionRecords(defaults: UserDefaults = .standard) -> [CodexDynamicModelRecord] {
+        cache.remembered(defaults: defaults)
+    }
+
+    static func reservedBaseIDs(defaults: UserDefaults = .standard) -> Set<String> {
+        Set(resolutionRecords(defaults: defaults).flatMap { [$0.id.lowercased(), $0.model.lowercased()] })
     }
 
     static func modelOptions(defaults: UserDefaults = .standard) -> [CodexDynamicModelOption] {
@@ -335,7 +348,7 @@ enum CodexDynamicModelStore {
     }
 
     static func displayName(forModelID id: String, defaults: UserDefaults = .standard) -> String? {
-        CodexDynamicModelMapper.displayName(forModelID: id, records: load(defaults: defaults))
+        CodexDynamicModelMapper.displayName(forModelID: id, records: resolutionRecords(defaults: defaults))
     }
 
     private static func canonicalRecord(from model: CodexAppServerClient.RemoteModel) -> CodexDynamicModelRecord? {
@@ -477,6 +490,7 @@ enum CodexAIModelCatalog {
     private static func synthesizedFastAIModels(from models: [AIModel]) -> [AIModel] {
         var synthesized: [AIModel] = []
         var seen = Set(models.map { $0.modelName.lowercased() })
+        seen.formUnion(CodexDynamicModelStore.reservedBaseIDs())
 
         for model in models {
             guard case let .codexCustom(name) = model else { continue }

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/GrokModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/GrokModelCatalog.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum GrokModelCatalog {
+    private static let cache = ProviderModelDiscoveryCache<String>(key: "GrokDiscoveredChatModels", identity: { $0 })
+
+    static func names(defaults: UserDefaults = .standard) -> [String] {
+        cache.current(defaults: defaults)
+    }
+
+    @discardableResult
+    static func save(_ names: [String], defaults: UserDefaults = .standard) -> Bool {
+        cache.save(names, defaults: defaults)
+    }
+
+    static func parse(_ models: [[String: Any]]) -> [String] {
+        models.compactMap { model in
+            guard let id = model["id"] as? String, !id.isEmpty,
+                  (model["input_modalities"] as? [String])?.contains("text") == true,
+                  (model["output_modalities"] as? [String])?.contains("text") == true else { return nil }
+            return id
+        }
+    }
+
+    static func fetch(apiKey: String, client: any HTTPClient = DefaultHTTPClient.discoveryClient) async throws -> [String] {
+        var request = URLRequest(url: URL(string: "https://api.x.ai/v1/language-models")!)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        let response = try await client.data(for: request)
+        guard response.http.statusCode == 200,
+              let body = try JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+              let models = body["models"] as? [[String: Any]] else { throw URLError(.badServerResponse) }
+        return parse(models)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicModelRequest.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicModelRequest.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftAnthropic
+
+/// Adds advertised Messages capabilities while retaining the SDK's message encoder
+/// and transport. Legacy budget-based thinking remains on the existing SDK path.
+struct AnthropicModelRequest: Encodable {
+    let parameters: MessageParameter
+    let effort: ClaudeCodeEffortLevel?
+    let adaptiveThinking: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case thinking
+        case outputConfig = "output_config"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try parameters.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if adaptiveThinking {
+            try container.encode(["type": "adaptive"], forKey: .thinking)
+        }
+        if let effort {
+            try container.encode(["effort": effort.rawValue], forKey: .outputConfig)
+        }
+    }
+
+    func request(apiKey: String, betaHeaders: [String]) throws -> URLRequest {
+        guard let url = URL(string: "https://api.anthropic.com/v1/messages") else { throw AIProviderError.invalidModel }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !betaHeaders.isEmpty { request.setValue(betaHeaders.joined(separator: ","), forHTTPHeaderField: "anthropic-beta") }
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        request.httpBody = try encoder.encode(self)
+        return request
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicProvider.swift
@@ -3,9 +3,26 @@ import SwiftAnthropic
 
 class AnthropicProvider: AIProvider {
     private let service: AnthropicService
+    private let apiKey: String
+    private let betaHeaders: [String]
 
     init(apiKey: String, betaHeaders: [String] = ["messages-2023-12-15", "prompt-caching-2024-07-31", "output-128k-2025-02-19"]) {
+        self.apiKey = apiKey
+        self.betaHeaders = betaHeaders
         service = AnthropicServiceFactory.service(apiKey: apiKey, betaHeaders: betaHeaders)
+    }
+
+    private func advertisedCapabilities(for model: AIModel?) -> (effort: ClaudeCodeEffortLevel?, adaptive: Bool)? {
+        guard let model else { return nil }
+        switch model {
+        case let .anthropicCustomReasoning(name, effort):
+            return (effort, AnthropicModelCatalog.record(for: name)?.adaptiveThinking ?? false)
+        case let .anthropicCustom(name):
+            guard let record = AnthropicModelCatalog.record(for: name) else { return nil }
+            return (nil, record.adaptiveThinking)
+        default:
+            return nil
+        }
     }
 
     static func isSuccessfulCompletionStopReason(_ stopReason: String) -> Bool {
@@ -81,7 +98,12 @@ class AnthropicProvider: AIProvider {
         let thinkingBudget: Int
         var overrideMaxTokens = 8192
 
-        if modelName.hasSuffix("-thinking-max") {
+        let capabilities = advertisedCapabilities(for: model)
+        if capabilities != nil {
+            baseModelName = modelName
+            isThinkingMode = false
+            thinkingBudget = 0
+        } else if modelName.hasSuffix("-thinking-max") {
             baseModelName = String(modelName.dropLast("-thinking-max".count))
             isThinkingMode = true
             thinkingBudget = 32000
@@ -112,7 +134,7 @@ class AnthropicProvider: AIProvider {
 
         var temperature: Double? = 0
         // Skip temperature setting for thinking models
-        if isThinkingMode {
+        if isThinkingMode || capabilities?.adaptive == true {
             temperature = nil
         }
         // Apply user-defined temperature if override is enabled (for non-thinking models)
@@ -131,7 +153,14 @@ class AnthropicProvider: AIProvider {
             thinking: isThinkingMode ? MessageParameter.Thinking(budgetTokens: thinkingBudget) : nil
         )
 
-        let stream = try await service.streamMessage(parameters)
+        let stream: AsyncThrowingStream<MessageStreamResponse, Error>
+        if let capabilities {
+            let request = try AnthropicModelRequest(parameters: parameters, effort: capabilities.effort, adaptiveThinking: capabilities.adaptive)
+                .request(apiKey: apiKey, betaHeaders: betaHeaders)
+            stream = try await service.fetchStream(type: MessageStreamResponse.self, with: request, debugEnabled: false)
+        } else {
+            stream = try await service.streamMessage(parameters)
+        }
 
         return AsyncThrowingStream { continuation in
             Task {
@@ -246,7 +275,11 @@ class AnthropicProvider: AIProvider {
         let thinkingBudget: Int
         var overrideMaxTokens = maxTokens ?? 4096
 
-        if modelName.hasSuffix("-thinking-max") {
+        if advertisedCapabilities(for: model) != nil {
+            baseModelName = modelName
+            isThinkingMode = false
+            thinkingBudget = 0
+        } else if modelName.hasSuffix("-thinking-max") {
             baseModelName = String(modelName.dropLast("-thinking-max".count))
             isThinkingMode = true
             thinkingBudget = 32000
@@ -270,10 +303,10 @@ class AnthropicProvider: AIProvider {
         }
 
         let anthropicModel = SwiftAnthropic.Model.other(baseModelName)
-        return try await completeMessage(aiMessage, model: anthropicModel, maxTokens: overrideMaxTokens, isThinkingMode: isThinkingMode, thinkingBudget: thinkingBudget)
+        return try await completeMessage(aiMessage, model: anthropicModel, maxTokens: overrideMaxTokens, isThinkingMode: isThinkingMode, thinkingBudget: thinkingBudget, selectedModel: model)
     }
 
-    private func completeMessage(_ aiMessage: AIMessage, model: SwiftAnthropic.Model, maxTokens: Int? = nil, isThinkingMode: Bool = false, thinkingBudget: Int = 0) async throws -> AICompletionResult {
+    private func completeMessage(_ aiMessage: AIMessage, model: SwiftAnthropic.Model, maxTokens: Int? = nil, isThinkingMode: Bool = false, thinkingBudget: Int = 0, selectedModel: AIModel? = nil) async throws -> AICompletionResult {
         guard !aiMessage.systemPrompt.isEmpty else {
             throw AIProviderError.invalidSystemPrompt
         }
@@ -290,7 +323,14 @@ class AnthropicProvider: AIProvider {
             thinking: isThinkingMode ? MessageParameter.Thinking(budgetTokens: thinkingBudget) : nil
         )
 
-        let response = try await service.createMessage(parameters)
+        let response: MessageResponse
+        if let capabilities = advertisedCapabilities(for: selectedModel) {
+            let request = try AnthropicModelRequest(parameters: parameters, effort: capabilities.effort, adaptiveThinking: capabilities.adaptive)
+                .request(apiKey: apiKey, betaHeaders: betaHeaders)
+            response = try await service.fetch(type: MessageResponse.self, with: request, debugEnabled: false)
+        } else {
+            response = try await service.createMessage(parameters)
+        }
 
         let text = response.content.compactMap { contentItem in
             switch contentItem {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/ClaudeAgentToolPreferences.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/ClaudeAgentToolPreferences.swift
@@ -491,7 +491,7 @@ struct ClaudeAgentToolPreferences {
 
 // MARK: - Claude Code Effort Level
 
-enum ClaudeCodeEffortLevel: String, CaseIterable {
+public enum ClaudeCodeEffortLevel: String, CaseIterable, Codable {
     // Ordered highest → lowest so UI pickers and variant menus list the
     // strongest effort first. `allCases` drives both `AgentInputBar`'s Claude
     // effort picker and `claudeEffortSortRank` in `AgentModelCatalog`.

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
@@ -654,6 +654,14 @@ final actor ClaudeNativeProcessSessionController {
 
         let snapshot = Self.parseInitializeResponseSnapshot(from: initializeResult)
         initializeResponseSnapshot = snapshot
+        if activeLaunchEnvironmentSignature?.backend == .defaultClaude,
+           let modelsJSON = snapshot.modelsJSON,
+           ClaudeDynamicModelStore.update(json: modelsJSON)
+        {
+            await MainActor.run {
+                NotificationCenter.default.post(name: .providerModelCatalogDidChange, object: nil)
+            }
+        }
 
         if config.enableDebugLogging {
             print("[ClaudeNativeSession] initialize response keys: \(initializeResult.keys.sorted())")
@@ -689,7 +697,8 @@ final actor ClaudeNativeProcessSessionController {
             : effectiveEffortLevel
         let request = Self.buildApplyFlagSettingsRequest(
             model: launchEnvironment.effectiveModel,
-            effortLevel: requestEffortLevel
+            effortLevel: requestEffortLevel,
+            useDiscoveredCapabilities: launchEnvironment.backend == .defaultClaude
         )
         return (launchEnvironment, request)
     }
@@ -709,9 +718,20 @@ final actor ClaudeNativeProcessSessionController {
     private func applyInitialFlagSettingsIfNeeded() async throws {
         while true {
             let requestGeneration = flagSettingsRequestGeneration
-            guard let request = initialFlagSettingsRequest else {
+            guard var request = initialFlagSettingsRequest else {
                 hasCompletedInitialFlagSettings = true
                 return
+            }
+            // initialize can advertise capabilities after the initial intent was built.
+            if activeLaunchEnvironmentSignature?.backend == .defaultClaude,
+               let settings = request["settings"] as? [String: Any],
+               let filtered = Self.buildApplyFlagSettingsRequest(
+                   model: settings["model"] as? String,
+                   effortLevel: ClaudeCodeEffortLevel.parse(settings["effortLevel"] as? String),
+                   useDiscoveredCapabilities: true
+               )
+            {
+                request = filtered
             }
             let flagSettingsResult = try await sendControlRequest(request: request)
             writeRawEventLogRecord(kind: "session.flagSettingsApplied", payload: [
@@ -746,12 +766,19 @@ final actor ClaudeNativeProcessSessionController {
         launchEnvironment.suppressesEffortSettings
     }
 
-    private static func buildApplyFlagSettingsRequest(model: String?, effortLevel: ClaudeCodeEffortLevel?) -> [String: Any]? {
+    private static func buildApplyFlagSettingsRequest(
+        model: String?,
+        effortLevel: ClaudeCodeEffortLevel?,
+        useDiscoveredCapabilities: Bool = false
+    ) -> [String: Any]? {
         var settings: [String: Any] = [:]
         if let model = normalizedFlagSettingsModel(model) {
             settings["model"] = model
         }
-        if let effortLevel {
+        let resolvedEffort = useDiscoveredCapabilities
+            ? ClaudeDynamicModelStore.effort(effortLevel, forModel: model)
+            : effortLevel
+        if let effortLevel = resolvedEffort {
             settings["effortLevel"] = effortLevel.rawValue
         }
         guard !settings.isEmpty else { return nil }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexModelSpecifier.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexModelSpecifier.swift
@@ -18,9 +18,46 @@ struct CodexModelSpecifier: Equatable {
         self.serviceTier = self.baseModel == nil ? nil : serviceTier
     }
 
-    init(raw: String?) {
+    init(raw: String?, records: [CodexDynamicModelRecord] = CodexDynamicModelStore.resolutionRecords()) {
+        if let resolved = Self.discoveredModel(raw, records: records) {
+            self = resolved
+            return
+        }
         let parts = Self.splitLegacyModelID(raw)
         self.init(baseModel: parts.baseModel, reasoningEffort: parts.reasoningEffort, serviceTier: parts.serviceTier)
+    }
+
+    private static func discoveredModel(_ raw: String?, records: [CodexDynamicModelRecord]) -> Self? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty, raw.lowercased() != "default" else { return nil }
+        // An exact advertised model always wins over an effort-looking family suffix.
+        if let record = records.first(where: {
+            $0.id.caseInsensitiveCompare(raw) == .orderedSame || $0.model.caseInsensitiveCompare(raw) == .orderedSame
+        }) {
+            return Self(baseModel: record.model.isEmpty ? record.id : record.model, reasoningEffort: nil)
+        }
+        for record in records {
+            let model = record.model.isEmpty ? record.id : record.model
+            let identities = Set([record.id, model])
+            let efforts = record.supportedReasoningEfforts.map(\.reasoningEffort) + [record.defaultReasoningEffort].compactMap(\.self)
+            for identity in identities {
+                for effort in efforts.compactMap(ReasoningEffort.parse) {
+                    if "\(identity)-\(effort.rawValue)".caseInsensitiveCompare(raw) == .orderedSame {
+                        return Self(baseModel: model, reasoningEffort: effort)
+                    }
+                    if CodexServiceTierVariantCatalog.isFastEligible(baseModelID: model),
+                       "\(identity)-fast-\(effort.rawValue)".caseInsensitiveCompare(raw) == .orderedSame
+                    {
+                        return Self(baseModel: model, reasoningEffort: effort, serviceTier: "fast")
+                    }
+                }
+                if CodexServiceTierVariantCatalog.isFastEligible(baseModelID: model),
+                   "\(identity)-fast".caseInsensitiveCompare(raw) == .orderedSame
+                {
+                    return Self(baseModel: model, reasoningEffort: nil, serviceTier: "fast")
+                }
+            }
+        }
+        return nil
     }
 
     static func splitLegacyModelID(_ raw: String?) -> (baseModel: String?, reasoningEffort: ReasoningEffort?, serviceTier: String?) {

--- a/Tests/RepoPromptTests/AI/ProviderModelDiscoveryTests.swift
+++ b/Tests/RepoPromptTests/AI/ProviderModelDiscoveryTests.swift
@@ -1,0 +1,285 @@
+import Foundation
+import SwiftAnthropic
+import XCTest
+@_spi(TestSupport) @testable import RepoPromptApp
+
+final class ProviderModelDiscoveryTests: XCTestCase {
+    private func isolatedDefaults() throws -> UserDefaults {
+        let name = "ProviderModelDiscoveryTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: name))
+        addTeardownBlock { defaults.removePersistentDomain(forName: name) }
+        return defaults
+    }
+
+    private func preserveSharedCatalogs() {
+        let keys = ["CodexDynamicModelRecords", "ClaudeCodeDiscoveredModels", "AnthropicDiscoveredModels", "GrokDiscoveredChatModels"]
+            .flatMap { [$0, $0 + ".savedSelectionMetadata"] }
+        let saved = keys.map { ($0, UserDefaults.standard.object(forKey: $0)) }
+        let liveModels = AgentCodexModelRegistry.shared.currentLiveModels()
+        _ = AgentCodexModelRegistry.shared.updateLiveModels([])
+        for key in keys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        addTeardownBlock {
+            _ = AgentCodexModelRegistry.shared.updateLiveModels(liveModels)
+            for (key, value) in saved {
+                if let value { UserDefaults.standard.set(value, forKey: key) }
+                else { UserDefaults.standard.removeObject(forKey: key) }
+            }
+        }
+    }
+
+    private func futureCodex(id: String = "future-choice", model: String = "gpt-9-future") -> CodexAppServerClient.RemoteModel {
+        .init(
+            id: id,
+            model: model,
+            displayName: "Future Model",
+            description: "Fixture",
+            isDefault: false,
+            supportedReasoningEfforts: [.init(reasoningEffort: "max", description: "Max"), .init(reasoningEffort: "ultra", description: "Ultra")],
+            defaultReasoningEffort: "max"
+        )
+    }
+
+    func testDecodedCacheObservesExternalWritesEmptySnapshotsAndOtherSuites() throws {
+        let first = try isolatedDefaults()
+        let second = try isolatedDefaults()
+        let cache = ProviderModelDiscoveryCache<String>(key: "models", identity: { $0 })
+        cache.save(["old"], defaults: first)
+        XCTAssertEqual(cache.current(defaults: first), ["old"])
+        try first.set(JSONEncoder().encode(["new"]), forKey: "models")
+        XCTAssertEqual(cache.current(defaults: first), ["new"])
+        XCTAssertEqual(cache.remembered(defaults: first), ["new", "old"])
+        cache.save([], defaults: first)
+        XCTAssertTrue(cache.current(defaults: first).isEmpty)
+        XCTAssertEqual(cache.remembered(defaults: first), ["new", "old"])
+        cache.save(["other"], defaults: second)
+        XCTAssertEqual(cache.remembered(defaults: second), ["other"])
+        XCTAssertTrue(cache.current(defaults: first).isEmpty)
+        XCTAssertEqual(cache.remembered(defaults: first), ["new", "old"])
+    }
+
+    func testFutureCodexIdentityEffortAndFastVariantsReachSharedMenusAndMCP() throws {
+        preserveSharedCatalogs()
+        _ = AgentCodexModelRegistry.shared.updateLiveModels([futureCodex()])
+        let available = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.codexExec)
+        let options = AgentModelCatalog.options(for: .codexExec, availability: available)
+        for raw in ["future-choice-max", "future-choice-ultra", "gpt-9-future-fast-max", "gpt-9-future-fast-ultra"] {
+            XCTAssertTrue(options.contains { $0.rawValue == raw }, raw)
+            XCTAssertTrue(AIModel.modelsForProvider(.codex).contains { $0.modelName == raw }, raw)
+            let specifier = CodexModelSpecifier(raw: raw)
+            XCTAssertEqual(specifier.cliModelArgs, ["--model", "gpt-9-future"])
+            let effort = raw.hasSuffix("ultra") ? "ultra" : "max"
+            XCTAssertEqual(specifier.appServerEffortParam, effort)
+            XCTAssertEqual(specifier.cliReasoningConfigArgs, ["-c", "model_reasoning_effort=\(effort)"])
+            XCTAssertEqual(specifier.appServerServiceTierParam, raw.contains("-fast-") ? "fast" : nil)
+        }
+        let discovery = try XCTUnwrap(AgentModelCatalog.discoveryAgents(availability: available).first { $0.agent == .codexExec })
+        let future = try XCTUnwrap(discovery.models.first { $0.id == "gpt-9-future" })
+        XCTAssertEqual(Set(future.supportedReasoningEfforts), [.max, .ultra])
+        XCTAssertEqual(Set(future.startTargets.compactMap(\.reasoningEffort)), [.max, .ultra])
+        XCTAssertEqual(future.name, "Future Model")
+        XCTAssertEqual(options.first { $0.rawValue == "gpt-9-future-fast-max" }?.displayName, "Future Model Fast Max")
+        XCTAssertEqual(CodexModelSpecifier(raw: "gpt-9-future-max").appServerEffortParam, "max")
+    }
+
+    func testAdvertisedCodexBaseWinsSuffixCollisionAndMetadataDoesNotInventEfforts() {
+        let models = [
+            futureCodex(id: "gpt-9", model: "gpt-9"),
+            CodexAppServerClient.RemoteModel(id: "gpt-9-max", model: "gpt-9-max", displayName: "Base Max", description: "", isDefault: false, supportedReasoningEfforts: [], defaultReasoningEffort: nil)
+        ]
+        let records = CodexDynamicModelStore.canonicalRecords(from: models)
+        let base = CodexModelSpecifier(raw: "gpt-9-max", records: records)
+        XCTAssertEqual(base.baseModel, "gpt-9-max")
+        XCTAssertNil(base.reasoningEffort)
+        let option = CodexDynamicModelMapper.options(from: records).filter { $0.id == "gpt-9-max" }
+        XCTAssertEqual(option.count, 1)
+        XCTAssertNil(option.first?.reasoningEffort)
+        XCTAssertNil(CodexModelSpecifier(raw: "gpt-5.1-codex-max", records: []).reasoningEffort)
+        XCTAssertNil(CodexModelSpecifier(raw: "default", records: records).baseModel)
+    }
+
+    func testCodexRefreshRemovesChoicesButRetainsSavedSelectionRouting() throws {
+        let defaults = try isolatedDefaults()
+        CodexDynamicModelStore.save([futureCodex()], defaults: defaults)
+        CodexDynamicModelStore.save([], defaults: defaults)
+        XCTAssertTrue(CodexDynamicModelStore.modelOptions(defaults: defaults).isEmpty)
+        let saved = CodexModelSpecifier(raw: "future-choice-ultra", records: CodexDynamicModelStore.resolutionRecords(defaults: defaults))
+        XCTAssertEqual(saved.appServerModelParam, "gpt-9-future")
+        XCTAssertEqual(saved.appServerEffortParam, "ultra")
+    }
+
+    func testHistoricalCodexBaseCannotBeReusedAsAnEffortChoice() {
+        preserveSharedCatalogs()
+        let old = CodexAppServerClient.RemoteModel(id: "gpt-9-max", model: "gpt-9-max", displayName: "Original Base", description: "", isDefault: false, supportedReasoningEfforts: [], defaultReasoningEffort: nil)
+        let oldFast = CodexAppServerClient.RemoteModel(id: "gpt-9-fast-ultra", model: "gpt-9-fast-ultra", displayName: "Original Fast Base", description: "", isDefault: false, supportedReasoningEfforts: [], defaultReasoningEffort: nil)
+        CodexDynamicModelStore.save([old, oldFast])
+        CodexDynamicModelStore.save([futureCodex(id: "gpt-9", model: "gpt-9")])
+        let options = CodexDynamicModelStore.modelOptions()
+        XCTAssertFalse(options.contains { $0.id == "gpt-9-max" })
+        XCTAssertTrue(options.contains { $0.id == "gpt-9-ultra" })
+        XCTAssertEqual(CodexModelSpecifier(raw: "gpt-9-max").baseModel, "gpt-9-max")
+        XCTAssertNil(CodexModelSpecifier(raw: "gpt-9-max").reasoningEffort)
+        XCTAssertFalse(AIModel.modelsForProvider(.codex).contains { $0.modelName == "gpt-9-fast-ultra" })
+        let availability = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.codexExec)
+        XCTAssertFalse(AgentModelCatalog.options(for: .codexExec, availability: availability).contains { $0.rawValue == "gpt-9-fast-ultra" })
+        XCTAssertEqual(CodexModelSpecifier(raw: "gpt-9-fast-ultra").baseModel, "gpt-9-fast-ultra")
+        XCTAssertNil(CodexModelSpecifier(raw: "gpt-9-fast-ultra").reasoningEffort)
+    }
+
+    func testCodexDisplayNameCannotAdvertiseAnUnlistedEffort() throws {
+        preserveSharedCatalogs()
+        let model = CodexAppServerClient.RemoteModel(id: "future-base", model: "future-base", displayName: "Future High", description: "", isDefault: false, supportedReasoningEfforts: [], defaultReasoningEffort: nil)
+        _ = AgentCodexModelRegistry.shared.updateLiveModels([model])
+        let availability = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.codexExec)
+        let agent = try XCTUnwrap(AgentModelCatalog.discoveryAgents(availability: availability).first { $0.agent == .codexExec })
+        let discovered = try XCTUnwrap(agent.models.first { $0.id == "future-base" })
+        XCTAssertEqual(discovered.name, "Future High")
+        XCTAssertTrue(discovered.supportedReasoningEfforts.isEmpty)
+        XCTAssertTrue(discovered.startTargets.allSatisfy { $0.reasoningEffort == nil })
+    }
+
+    func testGrokTextChatDiscoveryAddsNamesWithoutInferringEfforts() async throws {
+        preserveSharedCatalogs()
+        let client = FixtureHTTPClient(pages: [#"{"models":[{"id":"future-chat-high","input_modalities":["text","image"],"output_modalities":["text"]},{"id":"future-image","input_modalities":["text"],"output_modalities":["image"]},{"id":"unclassified"}]}"#])
+        let names = try await GrokModelCatalog.fetch(apiKey: "fixture", client: client)
+        XCTAssertEqual(names, ["future-chat-high"])
+        XCTAssertTrue(GrokModelCatalog.save(names))
+        XCTAssertFalse(GrokModelCatalog.save(names))
+        let model = try XCTUnwrap(AIModel.modelsForProvider(.grok).first { $0.modelName == "future-chat-high" })
+        XCTAssertNil(model.defaultReasoningEffort)
+        XCTAssertEqual(AIModel.fromModelName(model.rawValue), model)
+        XCTAssertTrue(AIModel.allModels().contains(model))
+        GrokModelCatalog.save([])
+        XCTAssertFalse(AIModel.modelsForProvider(.grok).contains(model))
+        XCTAssertEqual(AIModel.fromModelName(model.rawValue), model)
+    }
+
+    func testClaudeAdvertisementReachesChatAgentRoleMenusAndMCPWithoutInventedEfforts() throws {
+        preserveSharedCatalogs()
+        let json = #"[{"value":"claude-future","displayName":"Future Claude","description":"Fixture","supportsEffort":true,"supportedEffortLevels":["low","max"]}]"#
+        XCTAssertTrue(ClaudeDynamicModelStore.update(json: json))
+        XCTAssertFalse(ClaudeDynamicModelStore.update(json: json))
+        let availability = AgentModelCatalog.AvailabilityContext.none.assumingAvailable(.claudeCode)
+        let options = AgentModelCatalog.options(for: .claudeCode, availability: availability)
+        XCTAssertTrue(options.contains { $0.rawValue == "claude-future:max" })
+        XCTAssertFalse(options.contains { $0.rawValue == "claude-future:high" })
+        XCTAssertEqual(AgentModelCatalog.supportedClaudeEfforts(forSelectedModelRaw: "claude-future", agentKind: .claudeCode), [.low, .max])
+        let model = try XCTUnwrap(AIModel.modelsForProvider(.claudeCode).first { $0.claudeCodeRuntimeSpecifierRaw == "claude-future:max" })
+        XCTAssertEqual(AIModel.fromModelName(model.rawValue), model)
+        let request = try ClaudeCodeProvider.resolveCLIModelSelection(for: model)
+        XCTAssertEqual(request.modelArgument, "claude-future")
+        XCTAssertEqual(request.effortLevel, .max)
+        let discovery = try XCTUnwrap(AgentModelCatalog.discoveryAgents(availability: availability).first { $0.agent == .claudeCode })
+        XCTAssertTrue(discovery.models.contains { $0.id == "claude-future" && $0.startTargets.count == 2 })
+        XCTAssertNil(AIModel.fromModelName("claude_code__claude-future:high"))
+    }
+
+    func testClaudeMalformedRefreshRetainsSnapshotAndSuccessfulEmptyRefreshRemovesEligibility() throws {
+        let defaults = try isolatedDefaults()
+        let json = #"[{"value":"future","displayName":"Future","description":"","supportedEffortLevels":["max"]}]"#
+        XCTAssertTrue(ClaudeDynamicModelStore.update(json: json, defaults: defaults))
+        XCTAssertFalse(ClaudeDynamicModelStore.update(json: "malformed", defaults: defaults))
+        XCTAssertEqual(ClaudeDynamicModelStore.records(defaults: defaults).count, 1)
+        XCTAssertTrue(ClaudeDynamicModelStore.update(json: "[]", defaults: defaults))
+        XCTAssertTrue(ClaudeDynamicModelStore.records(defaults: defaults).isEmpty)
+        XCTAssertEqual(ClaudeDynamicModelStore.record(for: "future", defaults: defaults)?.efforts, [.max])
+    }
+
+    func testClaudeNativeRequestSuppressesUnadvertisedDefaultEffort() async throws {
+        preserveSharedCatalogs()
+        ClaudeDynamicModelStore.update(json: #"[{"value":"future","displayName":"Future","description":"","supportsEffort":false}]"#)
+        let controller = ClaudeNativeProcessSessionController(
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: nil,
+            config: .discovery(commandName: "/usr/bin/false"),
+            environmentResolver: FixtureClaudeResolver()
+        )
+        let request = try await controller.test_resolveApplyFlagSettingsRequest(model: "future", effortLevel: .high)
+        let settings = try XCTUnwrap(request?["settings"] as? [String: Any])
+        XCTAssertEqual(settings["model"] as? String, "future")
+        XCTAssertNil(settings["effortLevel"])
+        XCTAssertNil(ClaudeDynamicModelStore.effort(.high, forModel: "future"))
+    }
+
+    func testAnthropicCapabilitiesDriveTypedChoicesAndMessagesEncoding() throws {
+        preserveSharedCatalogs()
+        let records = AnthropicModelCatalog.parse([
+            ["id": "claude-future", "display_name": "Future", "capabilities": [
+                "effort": ["supported": true, "low": ["supported": true], "max": ["supported": true], "high": ["supported": false]],
+                "thinking": ["supported": true, "types": ["adaptive": ["supported": true]]]
+            ]],
+            ["id": "claude-unknown", "display_name": "Unknown"]
+        ])
+        AnthropicModelCatalog.save(records)
+        XCTAssertEqual(records.first?.efforts, [.low, .max])
+        XCTAssertEqual(records.last?.efforts, [])
+        let choice = AIModel.anthropicCustomReasoning(name: "claude-future", effort: .max)
+        XCTAssertTrue(AIModel.modelsForProvider(.anthropic).contains(choice))
+        XCTAssertTrue(AIModel.allModels().contains(choice))
+        XCTAssertEqual(AIModel.fromModelName(choice.rawValue), choice)
+        XCTAssertEqual(choice.modelName, "claude-future")
+        XCTAssertFalse(AIModel.modelsForProvider(.anthropic).contains(.anthropicCustomReasoning(name: "claude-unknown", effort: .high)))
+        for stream in [true, false] {
+            let parameters = MessageParameter(model: .other(choice.modelName), messages: [], maxTokens: 4096, stream: stream)
+            let request = try AnthropicModelRequest(parameters: parameters, effort: .max, adaptiveThinking: true).request(apiKey: "fixture", betaHeaders: [])
+            let body = try XCTUnwrap(JSONSerialization.jsonObject(with: XCTUnwrap(request.httpBody)) as? [String: Any])
+            XCTAssertEqual(body["model"] as? String, "claude-future")
+            XCTAssertEqual(body["stream"] as? Bool, stream)
+            XCTAssertEqual(body["max_tokens"] as? Int, 4096)
+            XCTAssertEqual((body["output_config"] as? [String: String])?["effort"], "max")
+            XCTAssertEqual(body["thinking"] as? [String: String], ["type": "adaptive"])
+            XCTAssertNil(body["temperature"])
+        }
+        AnthropicModelCatalog.save([])
+        XCTAssertFalse(AIModel.modelsForProvider(.anthropic).contains(choice))
+        XCTAssertEqual(AnthropicModelCatalog.record(for: "claude-future")?.efforts, [.low, .max])
+        XCTAssertEqual(AIModel.fromModelName(choice.rawValue), choice)
+    }
+
+    func testAnthropicPaginationAndFailureDoNotPublishPartialResults() async throws {
+        let client = FixtureHTTPClient(pages: [
+            #"{"data":[{"id":"future-one"}],"has_more":true,"last_id":"future-one"}"#,
+            #"{"data":[{"id":"future-two"}],"has_more":false}"#
+        ])
+        let records = try await AnthropicModelCatalog.fetch(apiKey: "fixture", client: client)
+        XCTAssertEqual(records.map(\.id), ["future-one", "future-two"])
+        let requests = await client.requests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertTrue(requests[1].url?.query?.contains("after_id=future-one") == true)
+        let failing = FixtureHTTPClient(pages: [
+            #"{"data":[{"id":"future-one"}],"has_more":true,"last_id":"future-one"}"#, "invalid"
+        ])
+        do {
+            _ = try await AnthropicModelCatalog.fetch(apiKey: "fixture", client: failing)
+            XCTFail("Malformed second page must fail the entire discovery")
+        } catch {}
+    }
+
+    private struct FixtureClaudeResolver: ClaudeCodeLaunchEnvironmentResolving {
+        func resolve(variant: ClaudeCodeRuntimeVariant, requestedModel: String?) async throws -> ClaudeCodeLaunchEnvironment {
+            .init(effectiveModel: requestedModel, environmentOverrides: [:], backend: .defaultClaude)
+        }
+    }
+
+    private actor FixtureHTTPClient: RepoPromptApp.HTTPClient {
+        let pages: [String]
+        var requests: [URLRequest] = []
+        init(pages: [String]) {
+            self.pages = pages
+        }
+
+        func data(for request: URLRequest) async throws -> RepoPromptApp.HTTPResponse {
+            let index = requests.count
+            requests.append(request)
+            guard index < pages.count else { throw URLError(.badServerResponse) }
+            return RepoPromptApp.HTTPResponse(data: Data(pages[index].utf8), http: HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        func bytes(for request: URLRequest) async throws -> (bytes: URLSession.AsyncBytes, http: HTTPURLResponse) {
+            throw URLError(.unsupportedURL)
+        }
+    }
+}


### PR DESCRIPTION
New provider models could be omitted from shared pickers, and a newly advertised Codex effort could be displayed but sent as part of the model name. This change carries advertised model identities and supported efforts through the shared Chat/Oracle/Plan, Context Builder, Agent Mode, role-default and MCP discovery catalogues.

- Resolve Codex choice IDs, wire model names and advertised efforts, including existing Fast variants. Reserve current and historical base IDs against ambiguous generated choices. Keep the shared 60-second coalesced polling unchanged.
- Consume Claude Code initialize model metadata in the existing catalogues and suppress unadvertised effort settings. Refresh subscribed menus without adding a polling loop. Compatible backends retain their own mappings.
- Discover Anthropic API models and advertised effort/adaptive-thinking capabilities, using the pinned SDK's Messages encoder and transport. Discover text-capable xAI language models through the existing settings refresh, without inventing effort variants.
- Keep current picker snapshots separate from remembered metadata for saved selections. Publish API catalogue changes across windows and cache decoded snapshots under a lock. Saved preference values and recommended defaults remain unchanged.

Providers whose listing cannot establish chat compatibility retain curated/custom choices: OpenAI, Gemini, DeepSeek and Groq. Fireworks' richer metadata requires a separate account-scoped control-plane integration. OpenRouter and custom providers retain explicit enabled-model policy; Azure, Ollama, Z.AI and ACP providers retain their existing discovery/configuration boundaries. Model names alone never establish new reasoning capabilities.

This is independent of #951: it adds no GPT-6 Astra constants and does not merge or supersede that PR.

Validation: coordinated full root suite (1,011 tests, zero failures), RepoPrompt product build, formatter, strict lint, repository guardrails, staged/outgoing secret scans, and independent review. Regressions cover unknown future IDs, advertised efforts, ordinary/Fast identity collisions, saved selections after removal, Claude effort suppression, Anthropic request encoding/pagination, xAI modality filtering, and cache invalidation. The earlier focused pass ran 45 tests successfully.

Live validation of the changed binary was not run because visible app lifecycle actions were excluded from this task. No live provider requests are represented by the fixture tests.
