### PR TITLE
Resolve advertised Codex Max and Ultra effort selections

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/CodexAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/CodexAIModelCatalog.swift
@@ -90,6 +90,7 @@ enum CodexDynamicModelMapper {
     static func options(from records: [CodexDynamicModelRecord]) -> [CodexDynamicModelOption] {
         var options: [CodexDynamicModelOption] = []
         var seen = Set<String>()
+        let advertisedIDs = Set(records.map { normalizeID($0.id).lowercased() })
 
         for record in records {
             let baseID = normalizeID(record.id)
@@ -101,7 +102,12 @@ enum CodexDynamicModelMapper {
                 fallbackID: baseID
             )
             let baseDescription = record.description.trimmingCharacters(in: .whitespacesAndNewlines)
-            let effortEntries = normalizedEfforts(for: record, fallbackDescription: baseDescription)
+            // Extended effort parsing preserves exact model identities. Do not offer a
+            // synthetic option that would resolve to another advertised model instead.
+            let effortEntries = normalizedEfforts(for: record, fallbackDescription: baseDescription).filter { entry in
+                ![CodexReasoningEffort.max, .ultra].contains(entry.effort)
+                    || !advertisedIDs.contains("\(baseID)-\(entry.effort.rawValue)".lowercased())
+            }
 
             if effortEntries.isEmpty {
                 appendOption(
@@ -312,6 +318,9 @@ enum CodexDynamicModelMapper {
 
 enum CodexDynamicModelStore {
     private static let storageKey = "CodexDynamicModelRecords"
+    private static let cacheLock = NSLock()
+    private static var cachedData: Data?
+    private static var cachedRecords: [CodexDynamicModelRecord] = []
 
     static func canonicalRecords(from models: [CodexAppServerClient.RemoteModel]) -> [CodexDynamicModelRecord] {
         models
@@ -326,8 +335,16 @@ enum CodexDynamicModelStore {
     }
 
     static func load(defaults: UserDefaults = .standard) -> [CodexDynamicModelRecord] {
-        guard let data = defaults.data(forKey: storageKey) else { return [] }
-        return (try? JSONDecoder().decode([CodexDynamicModelRecord].self, from: data)) ?? []
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        // Parsing and picker ordering share this store. Decode only when the persisted
+        // payload changes, including writes from other windows or defaults suites.
+        let data = defaults.data(forKey: storageKey)
+        if data != cachedData {
+            cachedData = data
+            cachedRecords = data.flatMap { try? JSONDecoder().decode([CodexDynamicModelRecord].self, from: $0) } ?? []
+        }
+        return cachedRecords
     }
 
     static func modelOptions(defaults: UserDefaults = .standard) -> [CodexDynamicModelOption] {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexModelSpecifier.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexModelSpecifier.swift
@@ -18,12 +18,15 @@ struct CodexModelSpecifier: Equatable {
         self.serviceTier = self.baseModel == nil ? nil : serviceTier
     }
 
-    init(raw: String?) {
-        let parts = Self.splitLegacyModelID(raw)
+    init(raw: String?, discoveredRecords: @autoclosure () -> [CodexDynamicModelRecord] = CodexDynamicModelStore.load()) {
+        let parts = Self.splitLegacyModelID(raw, discoveredRecords: discoveredRecords())
         self.init(baseModel: parts.baseModel, reasoningEffort: parts.reasoningEffort, serviceTier: parts.serviceTier)
     }
 
-    static func splitLegacyModelID(_ raw: String?) -> (baseModel: String?, reasoningEffort: ReasoningEffort?, serviceTier: String?) {
+    static func splitLegacyModelID(
+        _ raw: String?,
+        discoveredRecords: @autoclosure () -> [CodexDynamicModelRecord] = CodexDynamicModelStore.load()
+    ) -> (baseModel: String?, reasoningEffort: ReasoningEffort?, serviceTier: String?) {
         guard
             let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
             !raw.isEmpty,
@@ -34,8 +37,8 @@ struct CodexModelSpecifier: Equatable {
 
         // First strip any reasoning effort suffix. Legacy efforts remain broadly decoded for
         // stored selections such as `gpt-5.5-xhigh` and `gpt-5.1-codex-max-low`.
-        // Extended efforts are gated to known GPT-5.6 families so the legitimate base ID
-        // `gpt-5.1-codex-max` is not misread as `gpt-5.1-codex` + max effort.
+        // Extended efforts require discovery metadata or a known legacy family, so a
+        // legitimate base ID such as `gpt-5.1-codex-max` is not split by its name alone.
         let suffixes: [(suffix: String, effort: ReasoningEffort, requiresKnownFamilySupport: Bool)] = [
             ("-xhigh", .xhigh, false),
             ("-maximum", .max, true),
@@ -54,7 +57,12 @@ struct CodexModelSpecifier: Equatable {
             let candidate = String(raw.dropLast(suffix.count))
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard !candidate.isEmpty else { break }
-            if !requiresKnownFamilySupport || Self.supportsExtendedEffort(candidateEffort, forBaseCandidate: candidate) {
+            if !requiresKnownFamilySupport || Self.supportsExtendedEffort(
+                candidateEffort,
+                forBaseCandidate: candidate,
+                rawModel: raw,
+                records: discoveredRecords()
+            ) {
                 base = candidate
                 effort = candidateEffort
             }
@@ -81,8 +89,27 @@ struct CodexModelSpecifier: Equatable {
         return (base, effort, tier)
     }
 
-    private static func supportsExtendedEffort(_ effort: ReasoningEffort, forBaseCandidate candidate: String) -> Bool {
+    private static func supportsExtendedEffort(
+        _ effort: ReasoningEffort,
+        forBaseCandidate candidate: String,
+        rawModel: String,
+        records: [CodexDynamicModelRecord]
+    ) -> Bool {
+        // Exact advertised identities take precedence over synthetic effort suffixes.
+        if records.contains(where: { $0.id.caseInsensitiveCompare(rawModel) == .orderedSame }) {
+            return false
+        }
         let supportBase = serviceTierStrippedBase(candidate).lowercased()
+        if let record = records.first(where: { $0.id.lowercased() == supportBase }) {
+            let advertisedEfforts = record.supportedReasoningEfforts.map(\.reasoningEffort)
+                + [record.defaultReasoningEffort].compactMap(\.self)
+            if advertisedEfforts.compactMap(ReasoningEffort.parse).contains(effort) {
+                return true
+            }
+        }
+
+        // Keep decoding saved and backfilled legacy selections when discovery is
+        // unavailable or omits capabilities previously supported by those families.
         let supported: Set<ReasoningEffort>
         switch supportBase {
         case "gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra":

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexServiceTierVariantCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexServiceTierVariantCatalog.swift
@@ -67,12 +67,20 @@ enum CodexServiceTierVariantCatalog {
 
     static func fastVariantID(
         baseModelID: String,
-        reasoningEffort: CodexReasoningEffort?
+        reasoningEffort: CodexReasoningEffort?,
+        discoveredRecords: @autoclosure () -> [CodexDynamicModelRecord] = CodexDynamicModelStore.load()
     ) -> String? {
         let baseModelID = baseModelID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !baseModelID.isEmpty, isFastEligible(baseModelID: baseModelID) else { return nil }
         if let reasoningEffort {
-            return "\(baseModelID)-\(fastServiceTier)-\(reasoningEffort.rawValue)"
+            let variantID = "\(baseModelID)-\(fastServiceTier)-\(reasoningEffort.rawValue)"
+            // Exact discovered model IDs take precedence during extended-effort parsing.
+            if [CodexReasoningEffort.max, .ultra].contains(reasoningEffort),
+               discoveredRecords().contains(where: { $0.id.caseInsensitiveCompare(variantID) == .orderedSame })
+            {
+                return nil
+            }
+            return variantID
         }
         return "\(baseModelID)-\(fastServiceTier)"
     }

--- a/Tests/RepoPromptTests/AI/CodexDiscoveredEffortTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexDiscoveredEffortTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@_spi(TestSupport) @testable import RepoPromptApp
+
+final class CodexDiscoveredEffortTests: XCTestCase {
+    func testDiscoveredPickerEffortsBecomeRequestParameters() throws {
+        let records = [record("gpt-future", efforts: ["high", "max", "ultra"])]
+        let options = CodexDynamicModelMapper.options(from: records)
+        XCTAssertEqual(Set(options.map(\.id)), ["gpt-future-high", "gpt-future-max", "gpt-future-ultra"])
+        for option in options {
+            let effort = try XCTUnwrap(option.reasoningEffort)
+            let selection = CodexModelSpecifier(raw: option.id, discoveredRecords: records)
+            XCTAssertEqual(selection.appServerModelParam, "gpt-future", option.id)
+            XCTAssertEqual(selection.appServerEffortParam, effort.rawValue, option.id)
+            XCTAssertEqual(selection.cliModelArgs, ["--model", "gpt-future"], option.id)
+            XCTAssertEqual(selection.cliReasoningConfigArgs, ["-c", "model_reasoning_effort=\(effort.rawValue)"], option.id)
+        }
+    }
+
+    func testOnlyAdvertisedExtendedEffortsAreDecoded() {
+        let records = [record("gpt-future", efforts: ["max"])]
+        let unsupported = CodexModelSpecifier(raw: "gpt-future-ultra", discoveredRecords: records)
+        XCTAssertEqual(unsupported.appServerModelParam, "gpt-future-ultra")
+        XCTAssertNil(unsupported.appServerEffortParam)
+
+        let exact = CodexModelSpecifier(
+            raw: "gpt-future-max",
+            discoveredRecords: records + [record("gpt-future-max", efforts: ["high"])]
+        )
+        XCTAssertEqual(exact.appServerModelParam, "gpt-future-max")
+        XCTAssertNil(exact.appServerEffortParam)
+    }
+
+    func testAdvertisedDefaultEffortAndFastVariantAreDecoded() {
+        let records = [record("gpt-5.5", efforts: [], defaultEffort: "ultra")]
+        let selection = CodexModelSpecifier(raw: "gpt-5.5-fast-ultra", discoveredRecords: records)
+        XCTAssertEqual(selection.appServerModelParam, "gpt-5.5")
+        XCTAssertEqual(selection.appServerEffortParam, "ultra")
+        XCTAssertEqual(selection.appServerServiceTierParam, "fast")
+    }
+
+    func testExtendedEffortCollisionKeepsBothAdvertisedModelsSelectable() {
+        let records = [record("gpt-future", efforts: ["max"]), record("gpt-future-max", efforts: ["high"])]
+        let options = CodexDynamicModelMapper.options(from: records)
+        XCTAssertEqual(Set(options.map(\.id)), ["gpt-future", "gpt-future-max-high"])
+        for option in options {
+            let selection = CodexModelSpecifier(raw: option.id, discoveredRecords: records)
+            XCTAssertEqual(selection.appServerModelParam, option.baseID)
+            XCTAssertEqual(selection.appServerEffortParam, option.reasoningEffort?.rawValue)
+        }
+    }
+
+    func testPersistedCapabilityRefreshAndRemovalReachTheParser() throws {
+        let suite = "CodexDiscoveredEffortTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        for effort in ["max", "ultra"] {
+            CodexDynamicModelStore.save([
+                .init(
+                    id: "gpt-future", model: "gpt-future", displayName: "Future", description: "", isDefault: false,
+                    supportedReasoningEfforts: [.init(reasoningEffort: effort, description: "")], defaultReasoningEffort: effort
+                )
+            ], defaults: defaults)
+            let records = CodexDynamicModelStore.load(defaults: defaults)
+            let options = CodexDynamicModelMapper.options(from: records)
+            XCTAssertEqual(options.map(\.id), ["gpt-future-\(effort)"])
+            let selection = CodexModelSpecifier(raw: options.first?.id, discoveredRecords: records)
+            XCTAssertEqual(selection.appServerModelParam, "gpt-future")
+            XCTAssertEqual(selection.appServerEffortParam, effort)
+        }
+        defaults.removePersistentDomain(forName: suite)
+        XCTAssertTrue(CodexDynamicModelStore.load(defaults: defaults).isEmpty)
+    }
+
+    func testFastEffortVariantCannotShadowAnAdvertisedModel() {
+        let records = [record("gpt-5.5", efforts: ["max", "ultra"]), record("gpt-5.5-fast-max", efforts: ["high"])]
+        XCTAssertNil(CodexServiceTierVariantCatalog.fastVariantID(baseModelID: "gpt-5.5", reasoningEffort: .max, discoveredRecords: records))
+        XCTAssertEqual(
+            CodexServiceTierVariantCatalog.fastVariantID(baseModelID: "gpt-5.5", reasoningEffort: .ultra, discoveredRecords: records),
+            "gpt-5.5-fast-ultra"
+        )
+        let exact = CodexModelSpecifier(raw: "gpt-5.5-fast-max", discoveredRecords: records)
+        XCTAssertEqual(exact.appServerModelParam, "gpt-5.5-fast-max")
+        XCTAssertNil(exact.appServerEffortParam)
+        XCTAssertNil(exact.appServerServiceTierParam)
+    }
+
+    func testPartialDiscoveryRetainsLegacyEffortSelections() {
+        let records = [record("gpt-5.6-sol", efforts: ["high"])]
+        let selection = CodexModelSpecifier(raw: "gpt-5.6-sol-ultra", discoveredRecords: records)
+        XCTAssertEqual(selection.appServerModelParam, "gpt-5.6-sol")
+        XCTAssertEqual(selection.appServerEffortParam, "ultra")
+    }
+
+    func testMissingDiscoveryRetainsLegacySelections() {
+        for (raw, base, effort) in [
+            ("gpt-5.6-sol-ultra", "gpt-5.6-sol", "ultra"),
+            ("gpt-5.6-luna-max", "gpt-5.6-luna", "max"),
+            ("gpt-5.1-codex-max-high", "gpt-5.1-codex-max", "high")
+        ] {
+            let selection = CodexModelSpecifier(raw: raw, discoveredRecords: [])
+            XCTAssertEqual(selection.appServerModelParam, base)
+            XCTAssertEqual(selection.appServerEffortParam, effort)
+        }
+        let base = CodexModelSpecifier(raw: "gpt-5.1-codex-max", discoveredRecords: [])
+        XCTAssertEqual(base.appServerModelParam, "gpt-5.1-codex-max")
+        XCTAssertNil(base.appServerEffortParam)
+    }
+
+    private func record(_ id: String, efforts: [String], defaultEffort: String? = nil) -> CodexDynamicModelRecord {
+        CodexDynamicModelRecord(
+            id: id, model: id, displayName: id, description: "", isDefault: false,
+            supportedReasoningEfforts: efforts.map { .init(reasoningEffort: $0, description: "") },
+            defaultReasoningEffort: defaultEffort
+        )
+    }
+}


### PR DESCRIPTION
When `model/list` advertises Max or Ultra for a model outside the hardcoded GPT-5.6 families, the picker creates an effort option but the request parser treats its suffix as part of the model name. For example, selecting an advertised `gpt-future-ultra` sends that string as the model with no reasoning effort.

Resolve extended effort suffixes using the existing Codex discovery metadata, while preserving legacy saved selections and exact model identities ending in `-max` or `-ultra`. Suppress ordinary and Fast effort variants whose IDs would collide with an advertised model. Reuse decoded catalogue data between reads and invalidate it when the stored catalogue changes.

This is the focused Codex parsing follow-up to closed #952. Catalogue availability still depends on the selected runtime and account; this change does not add model constants, change runtime selection, or alter recommended defaults.

Validation: reproduced the malformed Max/Ultra request parameters before the fix; all 1,007 root tests pass afterward, including eight focused regression cases. Coordinated formatting, strict lint, the RepoPrompt product build, and commit/push safety preflights pass. Independent review is clear. No live-app smoke was run; validation covers the catalogue-to-request transformation and persisted metadata refreshes, not a live provider turn.
