### PR TITLE
Fix Context Builder shutdown during app termination

### DIFF
--- a/Sources/RepoPrompt/App/AppDelegate.swift
+++ b/Sources/RepoPrompt/App/AppDelegate.swift
@@ -24,6 +24,13 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate {
     /// Prevents re-entrant termination (Cmd+Q twice, menu + dock quit, etc.)
     private var terminationInProgress = false
     private let dockMenuController = DockMenuController()
+    /// The app delegate retains signal routing so its Dispatch sources remain active for the
+    /// entire application lifetime.
+    private lazy var terminationSignalRouter = AppTerminationSignalRouter(
+        observer: DispatchTerminationSignalObserver()
+    ) {
+        NSApp.terminate(nil)
+    }
 
     /// App startup owns one explicit registration attempt; readiness only observes it.
     private var domainRuntimeStartupTask: Task<Void, Never>?
@@ -124,6 +131,7 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         let launchConfiguration = AppLaunchConfiguration.current
         ProcessTermination.resetAppTerminationFastPath()
+        terminationSignalRouter.install()
 
         if launchConfiguration.isUITestSession {
             NSApp.setActivationPolicy(.regular)

--- a/Sources/RepoPrompt/App/AppTerminationSignalRouter.swift
+++ b/Sources/RepoPrompt/App/AppTerminationSignalRouter.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Observes process signals on behalf of `AppTerminationSignalRouter`.
+///
+/// Disposition suppression is a router responsibility rather than an implementation detail so
+/// that its ordering against observation stays verifiable without delivering real signals.
+protocol TerminationSignalObserving: AnyObject {
+    /// Suppresses `signal`'s default disposition. Without this the kernel terminates the process
+    /// the moment the signal arrives, before any observer can run.
+    func ignoreDefaultDisposition(for signal: Int32)
+
+    /// Delivers subsequent occurrences of `signal` to `handler`.
+    func observe(_ signal: Int32, handler: @escaping () -> Void)
+}
+
+/// Bridges POSIX signals onto the main queue where AppKit lifecycle work is serialized.
+final class DispatchTerminationSignalObserver: TerminationSignalObserving {
+    /// Dispatch sources only remain active while retained, so the observer owns them for its
+    /// lifetime rather than relying on the caller to preserve an implementation detail.
+    private var sources: [Int32: any DispatchSourceSignal] = [:]
+
+    func ignoreDefaultDisposition(for signal: Int32) {
+        Darwin.signal(signal, SIG_IGN)
+    }
+
+    func observe(_ signal: Int32, handler: @escaping () -> Void) {
+        let source = DispatchSource.makeSignalSource(signal: signal, queue: .main)
+        source.setEventHandler(handler: handler)
+        sources[signal] = source
+        source.activate()
+    }
+}
+
+/// Routes externally delivered termination signals into the app's graceful quit sequence, so
+/// tooling that stops the app with a signal still runs `applicationShouldTerminate` — the only
+/// path that joins in-flight agent processes and releases their launch-config leases.
+final class AppTerminationSignalRouter {
+    /// Signals ordinary process tooling uses to stop the app.
+    static let routedSignals: [Int32] = [SIGTERM]
+
+    private let observer: any TerminationSignalObserving
+    private let requestGracefulTermination: () -> Void
+    private var isInstalled = false
+    private var hasRequestedTermination = false
+
+    init(
+        observer: any TerminationSignalObserving,
+        requestGracefulTermination: @escaping () -> Void
+    ) {
+        self.observer = observer
+        self.requestGracefulTermination = requestGracefulTermination
+    }
+
+    /// Suppresses each routed signal's default disposition, then routes its delivery into
+    /// graceful termination.
+    func install() {
+        guard !isInstalled else { return }
+        isInstalled = true
+
+        for signal in Self.routedSignals {
+            observer.ignoreDefaultDisposition(for: signal)
+            observer.observe(signal) { [weak self] in
+                guard let self, !hasRequestedTermination else { return }
+                hasRequestedTermination = true
+                requestGracefulTermination()
+            }
+        }
+    }
+}

--- a/Sources/RepoPrompt/App/WindowStateManager.swift
+++ b/Sources/RepoPrompt/App/WindowStateManager.swift
@@ -400,9 +400,13 @@ class WindowStatesManager: ObservableObject {
         fileURL: WindowSessionStore.sessionFileURL()
     )
     private var explicitlyClosingWindowIDs: Set<Int> = []
-    // A closing window may leave `allWindows` before app termination starts. Weak retention
-    // lets termination join any still-live teardown without extending the window's lifetime.
+    /// A closing window may leave `allWindows` before app termination starts. Weak retention
+    /// lets termination join any still-live teardown without extending the window's lifetime.
     private var closingWindowReferences: [WeakWindowState] = []
+    // AppKit can unregister and release windows before the asynchronous termination task starts.
+    // Capture participants at the synchronous termination fence so their process owners survive
+    // until Context Builder and Agent Mode teardown have both joined.
+    private var terminationWindowSnapshot: [WindowState] = []
     private var restoreQueue: [WindowSessionEntry] = []
     private var hasLoadedRestoreSession = false
     private var restorePersistenceGate = WindowSessionRestorePersistenceGate()
@@ -1011,6 +1015,12 @@ class WindowStatesManager: ObservableObject {
         // Use MainActor.assumeIsolated since this is called from applicationWillTerminate
         // which runs on the main thread, but Swift doesn't know that statically.
         MainActor.assumeIsolated {
+            self.closingWindowReferences.removeAll { $0.value == nil }
+            self.terminationWindowSnapshot = self.deduplicatedWindows(
+                self.terminationWindowSnapshot +
+                    self.allWindows +
+                    self.closingWindowReferences.compactMap(\.value)
+            )
             self.isTerminating = true
             // Cancel any pending focus/workspace change notifications that might trigger updates
             self.cancellablesDuringTermination()
@@ -1020,6 +1030,9 @@ class WindowStatesManager: ObservableObject {
     #if DEBUG
         func setTerminatingForTesting(_ isTerminating: Bool) {
             self.isTerminating = isTerminating
+            if !isTerminating {
+                terminationWindowSnapshot.removeAll()
+            }
         }
     #endif
 
@@ -1067,10 +1080,10 @@ class WindowStatesManager: ObservableObject {
     /// teardown before MCP servers stop.
     func shutdownAllAgentSessions() async {
         closingWindowReferences.removeAll { $0.value == nil }
-        var seenWindowIdentities: Set<ObjectIdentifier> = []
-        let windows = (allWindows + closingWindowReferences.compactMap(\.value)).filter { window in
-            seenWindowIdentities.insert(ObjectIdentifier(window)).inserted
-        }
+        let windows = deduplicatedWindows(
+            terminationWindowSnapshot + allWindows + closingWindowReferences.compactMap(\.value)
+        )
+        defer { terminationWindowSnapshot.removeAll() }
         let participatingWindowIdentities = Set(windows.map(ObjectIdentifier.init))
 
         // The strong snapshot owns every participant until both shutdown paths have joined.
@@ -1091,6 +1104,13 @@ class WindowStatesManager: ObservableObject {
         await OpenCodeACPModelPollingService.shared.shutdown()
         await CursorACPModelPollingService.shared.shutdown()
         await GrokBuildACPModelPollingService.shared.shutdown()
+    }
+
+    private func deduplicatedWindows(_ windows: [WindowState]) -> [WindowState] {
+        var seenWindowIdentities: Set<ObjectIdentifier> = []
+        return windows.filter { window in
+            seenWindowIdentities.insert(ObjectIdentifier(window)).inserted
+        }
     }
 
     // MARK: - Instance Number Management

--- a/Sources/RepoPrompt/App/WindowStateManager.swift
+++ b/Sources/RepoPrompt/App/WindowStateManager.swift
@@ -304,6 +304,14 @@ final class WorkspaceActivityCoordinator {
 /// find the "latest" one or broadcast to all windows if needed.
 @MainActor
 class WindowStatesManager: ObservableObject {
+    private final class WeakWindowState {
+        weak var value: WindowState?
+
+        init(_ value: WindowState) {
+            self.value = value
+        }
+    }
+
     /// 🚀 Single, shared instance for the entire app
     static let shared = WindowStatesManager()
 
@@ -392,6 +400,9 @@ class WindowStatesManager: ObservableObject {
         fileURL: WindowSessionStore.sessionFileURL()
     )
     private var explicitlyClosingWindowIDs: Set<Int> = []
+    // A closing window may leave `allWindows` before app termination starts. Weak retention
+    // lets termination join any still-live teardown without extending the window's lifetime.
+    private var closingWindowReferences: [WeakWindowState] = []
     private var restoreQueue: [WindowSessionEntry] = []
     private var hasLoadedRestoreSession = false
     private var restorePersistenceGate = WindowSessionRestorePersistenceGate()
@@ -717,6 +728,11 @@ class WindowStatesManager: ObservableObject {
     }
 
     func registerWindowState(_ state: WindowState) {
+        guard !isTerminating else {
+            state.beginClose()
+            return
+        }
+        closingWindowReferences.removeAll { $0.value == nil || $0.value === state }
         // Prevent duplicate registration
         guard !allWindows.contains(where: { $0 === state }) else { return }
 
@@ -790,6 +806,8 @@ class WindowStatesManager: ObservableObject {
         state.beginClose()
         if let idx = allWindows.firstIndex(where: { $0 === state }) {
             allWindows.remove(at: idx)
+            closingWindowReferences.removeAll { $0.value == nil || $0.value === state }
+            closingWindowReferences.append(WeakWindowState(state))
         }
         explicitlyClosingWindowIDs.remove(state.windowID)
         // A window that closes mid-restore must not leave the persistence gate held.
@@ -999,6 +1017,12 @@ class WindowStatesManager: ObservableObject {
         }
     }
 
+    #if DEBUG
+        func setTerminatingForTesting(_ isTerminating: Bool) {
+            self.isTerminating = isTerminating
+        }
+    #endif
+
     /// Cancels Combine subscriptions and clears state that could trigger updates during shutdown.
     private func cancellablesDuringTermination() {
         focusCancellables.removeAll()
@@ -1039,17 +1063,28 @@ class WindowStatesManager: ObservableObject {
 
     /// Shuts down all agent processes (Claude CLI, Codex app-server) across every window.
     /// Called during app termination to prevent orphaned child processes.
-    /// Safe to call after `signalTermination()` — only performs cancellation and process teardown,
-    /// no UI-observed state mutations.
+    /// Safe to call after `signalTermination()` — fences new work and joins provider/process
+    /// teardown before MCP servers stop.
     func shutdownAllAgentSessions() async {
-        let windowIDs = allWindows.map(\.windowID)
+        closingWindowReferences.removeAll { $0.value == nil }
+        var seenWindowIdentities: Set<ObjectIdentifier> = []
+        let windows = (allWindows + closingWindowReferences.compactMap(\.value)).filter { window in
+            seenWindowIdentities.insert(ObjectIdentifier(window)).inserted
+        }
+        let participatingWindowIdentities = Set(windows.map(ObjectIdentifier.init))
+
+        // The strong snapshot owns every participant until both shutdown paths have joined.
         await withTaskGroup(of: Void.self) { group in
-            for windowID in windowIDs {
-                group.addTask { @MainActor [weak self] in
-                    guard let self, let ws = window(withID: windowID) else { return }
-                    await ws.agentModeViewModel.prepareForWindowClose()
+            for window in windows {
+                group.addTask { @MainActor [window] in
+                    await window.contextBuilderAgentViewModel.shutdownForAppTermination()
+                    await window.agentModeViewModel.prepareForWindowClose()
                 }
             }
+        }
+        closingWindowReferences.removeAll { reference in
+            guard let window = reference.value else { return true }
+            return participatingWindowIdentities.contains(ObjectIdentifier(window))
         }
         // Stop dedicated CLI model polling so background refreshes cannot race shutdown.
         await CodexModelPollingService.shared.shutdown()

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -514,6 +514,67 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 source: "contextBuilder.testing.staleRetirement"
             )
         }
+
+        @discardableResult
+        func registerRunRecordForTesting(
+            _ record: ContextBuilderRunRecord,
+            makeCurrent: Bool,
+            releaseActiveSlot: Bool = false
+        ) -> Bool {
+            if makeCurrent {
+                sessions[record.tabID] = record.session
+            }
+            guard runRegistry.register(record) else { return false }
+            if releaseActiveSlot {
+                runRegistry.releaseActiveSlot(for: record)
+            }
+            return true
+        }
+
+        func cancelRunForTesting(
+            _ record: ContextBuilderRunRecord,
+            waiterResolution: ContextBuilderRunWaiterResolution = .snapshot
+        ) {
+            cancelRun(record, waiterResolution: waiterResolution, saveHistory: false)
+        }
+
+        @discardableResult
+        func finalizeRunForTesting(
+            _ record: ContextBuilderRunRecord,
+            outcome: ContextBuilderRunTerminalOutcome,
+            cancelExecution: Bool = false
+        ) -> Bool {
+            finalizeContextBuilderRun(
+                record,
+                outcome: outcome,
+                waiterResolution: .snapshot,
+                cancelExecution: cancelExecution,
+                saveHistory: false,
+                source: "contextBuilder.testing.finalize"
+            )
+        }
+
+        @discardableResult
+        func finishDeferredCancellationAtSafeBoundaryForTesting(
+            _ record: ContextBuilderRunRecord
+        ) -> Bool {
+            guard let policy = record.consumeDeferredCancellationAtSafeBoundary() else { return false }
+            return finalizeContextBuilderRun(
+                record,
+                outcome: .cancelled,
+                waiterResolution: policy.waiterResolution,
+                cancelExecution: false,
+                saveHistory: policy.saveHistory,
+                source: "contextBuilder.testing.safeBoundary"
+            )
+        }
+
+        func scheduleRunTeardownForTesting(
+            _ record: ContextBuilderRunRecord,
+            cancelExecution: Bool = true
+        ) {
+            scheduleRunTeardown(record, cancelExecution: cancelExecution)
+        }
     #endif
 
     // MARK: - Published session-scoped proxies
@@ -1015,6 +1076,28 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             self.tabCloseListenerToken = nil
         }
         cancellables.removeAll()
+    }
+
+    func shutdownForAppTermination() async {
+        prepareForWindowClose()
+        let records = runRegistry.retainedRecordsSnapshot()
+        for record in records where !record.isTerminal {
+            cancelRun(
+                record,
+                waiterResolution: record.origin.isMCP ? .cancellationError : .snapshot,
+                deferredWaiterResolution: .snapshot,
+                saveHistory: true
+            )
+        }
+        // Sweeps records that were already terminal with no teardown scheduled; such a record would
+        // otherwise never settle and would hang the join below. Records settled by the cancellation
+        // pass above are revisited harmlessly because starting teardown is idempotent.
+        for record in records where record.isTerminal {
+            scheduleRunTeardown(record, cancelExecution: true)
+        }
+        for record in records {
+            await record.awaitTeardownSettlement()
+        }
     }
 
     private var agentAvailabilityContext: AgentModelCatalog.AvailabilityContext {
@@ -1744,6 +1827,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         progressReporter: ContextBuilderMCPProgressReporter? = nil,
         activityReporter: ContextBuilderMCPActivityReporter? = nil
     ) async throws -> MCPContextBuilderRunCompletion {
+        guard !hasPreparedForWindowClose else { throw CancellationError() }
         let configuration = authority.configuration
         let identity = configuration.identity
         let tabID = identity.tabID
@@ -1795,7 +1879,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         }
 
         let restoreConfiguration: () -> Void = { [weak self, weak session] in
-            guard let self, let session, sessions[tabID] === session else { return }
+            guard let self, !hasPreparedForWindowClose,
+                  let session, sessions[tabID] === session else { return }
             session.contextBuilderInstructions = savedSessionInstructions
             updateRuntimeBindings(from: session)
         }
@@ -1805,7 +1890,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         let runID = UUID()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                guard runRegistry.activeRecord(tabID: tabID) == nil,
+                guard !hasPreparedForWindowClose,
+                      runRegistry.activeRecord(tabID: tabID) == nil,
                       !session.agentRunState.isRunning,
                       !session.isAgentBusy
                 else {
@@ -2214,19 +2300,19 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             AgentModePerfDiagnostics.increment("contextBuilder.run.teardown.started", tabID: record.tabID)
         #endif
 
-        let disposalTask = Task { @MainActor [weak record] in
+        let disposalTask = Task { @MainActor [record] in
+            defer { record.markProviderDisposalFinished() }
             await payload.provider?.dispose()
-            record?.markProviderDisposalFinished()
         }
-        let executionJoinTask = Task { @MainActor [weak record] in
+        let executionJoinTask = Task { @MainActor [record] in
+            defer { record.markExecutionTaskFinished() }
             await payload.executionTask?.value
-            record?.markExecutionTaskFinished()
         }
 
-        Task { @MainActor [weak self, weak record] in
+        Task { @MainActor [weak self, record] in
             await disposalTask.value
             await executionJoinTask.value
-            guard let self, let record else { return }
+            guard let self else { return }
             if runRegistry.removeAfterTeardown(record) {
                 #if DEBUG
                     AgentModePerfDiagnostics.increment("contextBuilder.run.teardown.completed", tabID: record.tabID)
@@ -2295,7 +2381,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     }
 
     func runContextBuilderAgent() {
-        guard let tabID = currentTabID else { return }
+        guard !hasPreparedForWindowClose,
+              let tabID = currentTabID else { return }
         let session = session(for: tabID)
 
         guard session.mcpControlToken == nil,
@@ -3006,21 +3093,21 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         deferredWaiterResolution: ContextBuilderRunWaiterResolution? = nil,
         saveHistory: Bool
     ) {
-        guard acceptsEvents(from: record) else {
-            retireContextBuilderRunRecordWithoutPublishing(
-                record,
-                waiterResolution: waiterResolution,
-                cancelExecution: true,
-                source: "contextBuilder.cancel.staleRetirement"
-            )
-            return
-        }
         let deferredSettlementPolicy = ContextBuilderRunCancellationSettlementPolicy(
             waiterResolution: deferredWaiterResolution ?? waiterResolution,
             saveHistory: saveHistory
         )
         switch record.requestCancellation(deferredSettlementPolicy: deferredSettlementPolicy) {
         case .settleImmediately:
+            guard acceptsEvents(from: record) else {
+                retireContextBuilderRunRecordWithoutPublishing(
+                    record,
+                    waiterResolution: waiterResolution,
+                    cancelExecution: true,
+                    source: "contextBuilder.cancel.staleRetirement"
+                )
+                return
+            }
             _ = beginCancellation(forTabID: record.tabID)
             debugLog("Cancel requested for run \(record.runID) tab \(record.tabID)")
             finalizeContextBuilderRun(

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
@@ -237,6 +237,7 @@ final class ContextBuilderRunRecord {
     private(set) var teardownFinishedAt: Date?
     private(set) var providerDisposalFinished = false
     private(set) var executionTaskFinished = false
+    private var teardownSettlementWaiters: [CheckedContinuation<Void, Never>] = []
     private var didBeginProviderStreamProgress = false
     private var didReportRoutingConfirmed = false
     private var didObserveProviderEventAfterRouting = false
@@ -434,9 +435,23 @@ final class ContextBuilderRunRecord {
         finishTeardownIfReady()
     }
 
+    func awaitTeardownSettlement() async {
+        if teardownFinishedAt != nil { return }
+        await withCheckedContinuation { continuation in
+            if teardownFinishedAt != nil {
+                continuation.resume()
+            } else {
+                teardownSettlementWaiters.append(continuation)
+            }
+        }
+    }
+
     private func finishTeardownIfReady() {
         guard providerDisposalFinished, executionTaskFinished, teardownFinishedAt == nil else { return }
         teardownFinishedAt = Date()
+        let waiters = teardownSettlementWaiters
+        teardownSettlementWaiters.removeAll()
+        waiters.forEach { $0.resume() }
     }
 }
 
@@ -468,6 +483,10 @@ final class ContextBuilderRunRegistry {
 
     func records(tabID: UUID) -> [ContextBuilderRunRecord] {
         recordsByRunID.values.filter { $0.tabID == tabID }
+    }
+
+    func retainedRecordsSnapshot() -> [ContextBuilderRunRecord] {
+        Array(recordsByRunID.values)
     }
 
     func acceptsEvents(from record: ContextBuilderRunRecord, currentSession: ContextBuilderAgentViewModel.TabSession?) -> Bool {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeAgentProvider.swift
@@ -30,7 +30,10 @@ final class ClaudeCodeAgentProvider: HeadlessAgentProvider {
     private let runner: CLIProcessRunner
     private let config: ClaudeCodeAgentConfig
     private let environmentResolver: any ClaudeCodeLaunchEnvironmentResolving
-    private let configService = MCPConfigExportService.shared
+    private let configService: MCPConfigExportService
+    private let serverReadiness: @Sendable () async -> Bool
+    private let processStarted: @Sendable (pid_t) async -> Void
+    private let cleanupStarted: @Sendable () async -> Void
     private let toolTracking = AgentToolTrackingController()
     private var streamTask: Task<Void, Never>?
 
@@ -44,11 +47,21 @@ final class ClaudeCodeAgentProvider: HeadlessAgentProvider {
     init(
         runner: CLIProcessRunner,
         config: ClaudeCodeAgentConfig,
-        environmentResolver: any ClaudeCodeLaunchEnvironmentResolving = ClaudeCodeLaunchEnvironmentResolver()
+        environmentResolver: any ClaudeCodeLaunchEnvironmentResolving = ClaudeCodeLaunchEnvironmentResolver(),
+        configService: MCPConfigExportService = .shared,
+        serverReadiness: @escaping @Sendable () async -> Bool = {
+            await ServerNetworkManager.shared.isRunning()
+        },
+        processStarted: @escaping @Sendable (pid_t) async -> Void = { _ in },
+        cleanupStarted: @escaping @Sendable () async -> Void = {}
     ) {
         self.runner = runner
         self.config = config
         self.environmentResolver = environmentResolver
+        self.configService = configService
+        self.serverReadiness = serverReadiness
+        self.processStarted = processStarted
+        self.cleanupStarted = cleanupStarted
     }
 
     // MARK: - HeadlessAgentProvider
@@ -62,7 +75,7 @@ final class ClaudeCodeAgentProvider: HeadlessAgentProvider {
             if enableDebugLogging {
                 print("[DEBUG] ClaudeCodeAgent: Verifying MCP server is running")
             }
-            let isRunning = await ServerNetworkManager.shared.isRunning()
+            let isRunning = await serverReadiness()
             if enableDebugLogging {
                 print("[DEBUG] ClaudeCodeAgent: MCP server running: \(isRunning)")
             }
@@ -325,6 +338,7 @@ final class ClaudeCodeAgentProvider: HeadlessAgentProvider {
     }
 
     func cleanup(context: HeadlessAgentContext) async {
+        await cleanupStarted()
         if enableDebugLogging {
             print("[DEBUG] ClaudeCodeAgent: Cleaning up context \(context.runID)")
         }
@@ -384,12 +398,14 @@ final class ClaudeCodeAgentProvider: HeadlessAgentProvider {
                                 additionalEnvironment: additionalEnvironment,
                                 additionalRemovedKeys: context.launchEnvironment?.removedEnvironmentKeys ?? [],
                                 onProcessStarted: { pid in
-                                    guard let expectedPIDClientName else { return }
-                                    await ServerNetworkManager.shared.registerExpectedAgentPID(
-                                        pid,
-                                        for: expectedPIDClientName,
-                                        runID: expectedPIDRunID
-                                    )
+                                    if let expectedPIDClientName {
+                                        await ServerNetworkManager.shared.registerExpectedAgentPID(
+                                            pid,
+                                            for: expectedPIDClientName,
+                                            runID: expectedPIDRunID
+                                        )
+                                    }
+                                    await self.processStarted(pid)
                                 },
                                 onProcessTerminated: { pid in
                                     guard let expectedPIDClientName else { return }
@@ -551,8 +567,12 @@ final class ClaudeCodeAgentProvider: HeadlessAgentProvider {
         if enableDebugLogging {
             print("[DEBUG] ClaudeCodeAgent: Disposing provider, cancelling stream task & runners")
         }
-        streamTask?.cancel()
+        // Join the captured task rather than the property: a later run may reassign `streamTask`,
+        // and disposal must settle this run's stream before its launch-config lease is released.
+        let task = streamTask
+        task?.cancel()
         await runner.cancelAll()
+        await task?.value
     }
 
     // MARK: - Helpers

--- a/Sources/RepoPrompt/Infrastructure/Process/ProcessLauncher.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ProcessLauncher.swift
@@ -210,11 +210,12 @@ enum ProcessLauncher {
         }
         defer { posix_spawnattr_destroy(&attributes) }
 
-        // Parent-side write paths use no-SIGPIPE hardening; restore the default SIGPIPE
-        // disposition in spawned children so CLI/tool processes keep normal pipe semantics.
+        // App lifecycle routing ignores SIGTERM process-wide, and parent write paths harden
+        // SIGPIPE. Spawned tools need default dispositions for normal termination semantics.
         var defaultSignals = sigset_t()
         sigemptyset(&defaultSignals)
         sigaddset(&defaultSignals, SIGPIPE)
+        sigaddset(&defaultSignals, SIGTERM)
 
         var spawnFlags: Int16 = 0
         let getFlagsResult = posix_spawnattr_getflags(&attributes, &spawnFlags)

--- a/Tests/RepoPromptTests/AI/ClaudeCodeAgentProviderGracefulDisposalTests.swift
+++ b/Tests/RepoPromptTests/AI/ClaudeCodeAgentProviderGracefulDisposalTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class ClaudeCodeAgentProviderGracefulDisposalTests: XCTestCase {
+    func testDisposeWaitsForExactStreamCleanupAndReleasesOnlyOwnedLease() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ClaudeCodeAgentProviderGracefulDisposalTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let executable = root.appendingPathComponent("claude-stub")
+        try """
+        #!/bin/sh
+        printf '%s\\n' '{"type":"system","subtype":"init"}'
+        trap '' TERM
+        sleep 600
+        """.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+
+        let configDirectory = root.appendingPathComponent("MCP", isDirectory: true)
+        let configService = MCPConfigExportService(
+            identity: .repoPromptCE(.debug),
+            configDirectoryURL: configDirectory,
+            renderServerConfig: { "{\"mcpServers\":{}}" }
+        )
+        let stableConfig = try await configService.prepareStableWrapperConfigFile()
+        let siblingLease = try await configService.prepareLaunchConfig()
+        defer { siblingLease.release() }
+
+        let cleanupGate = AsyncTestGate()
+        let processStarted = AsyncTestSignal()
+        let runner = CLIProcessRunner(config: CLIProcessConfiguration(
+            command: executable.path,
+            workingDirectory: root.path,
+            environment: ProcessInfo.processInfo.environment,
+            additionalPaths: [],
+            shellLookupMode: .disabled
+        ))
+        let provider = ClaudeCodeAgentProvider(
+            runner: runner,
+            config: .discovery(commandName: executable.path),
+            configService: configService,
+            serverReadiness: { true },
+            processStarted: { _ in await processStarted.signal() },
+            cleanupStarted: { await cleanupGate.wait() }
+        )
+
+        let stream = try await provider.streamAgentMessage(AgentMessage(userMessage: "test"), runID: UUID())
+        let consumer = Task {
+            do {
+                for try await _ in stream {}
+            } catch {}
+        }
+        await processStarted.wait()
+
+        let launchDirectory = configDirectory.appendingPathComponent("LaunchConfigs", isDirectory: true)
+        let launchFilesBeforeDispose = try FileManager.default.contentsOfDirectory(at: launchDirectory, includingPropertiesForKeys: nil)
+        XCTAssertEqual(launchFilesBeforeDispose.count, 2)
+
+        let disposeFinished = AsyncTestFlag()
+        let disposal = Task {
+            await provider.dispose()
+            await disposeFinished.set()
+        }
+        await cleanupGate.waitUntilEntered()
+
+        let didDisposeBeforeCleanup = await disposeFinished.value
+        XCTAssertFalse(didDisposeBeforeCleanup)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stableConfig.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: siblingLease.url.path))
+
+        await cleanupGate.open()
+        await disposal.value
+        await consumer.value
+
+        let didDisposeAfterCleanup = await disposeFinished.value
+        XCTAssertTrue(didDisposeAfterCleanup)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stableConfig.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: siblingLease.url.path))
+        let launchFilesAfterDispose = try FileManager.default.contentsOfDirectory(at: launchDirectory, includingPropertiesForKeys: nil)
+        XCTAssertEqual(launchFilesAfterDispose.count, 1)
+        XCTAssertEqual(launchFilesAfterDispose.first?.lastPathComponent, siblingLease.url.lastPathComponent)
+    }
+}
+
+private actor AsyncTestGate {
+    private var isOpen = false
+    private var entered = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var openWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        entered = true
+        let waitingForEntry = entryWaiters
+        entryWaiters.removeAll()
+        waitingForEntry.forEach { $0.resume() }
+        guard !isOpen else { return }
+        await withCheckedContinuation { openWaiters.append($0) }
+    }
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let waiters = openWaiters
+        openWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+}
+
+private actor AsyncTestSignal {
+    private var signaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        guard !signaled else { return }
+        signaled = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        if signaled { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+private actor AsyncTestFlag {
+    private(set) var value = false
+
+    func set() {
+        value = true
+    }
+}

--- a/Tests/RepoPromptTests/App/AppTerminationSignalRoutingTests.swift
+++ b/Tests/RepoPromptTests/App/AppTerminationSignalRoutingTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class AppTerminationSignalRoutingTests: XCTestCase {
+    func testInstallSuppressesDefaultDispositionBeforeObservationAndRoutesDeliveryExactlyOnce() {
+        let observer = RecordingTerminationSignalObserver()
+        var terminationRequestCount = 0
+        let router = AppTerminationSignalRouter(observer: observer) {
+            terminationRequestCount += 1
+        }
+
+        router.install()
+        router.install()
+
+        XCTAssertEqual(observer.events, [
+            .ignoredDefaultDisposition(SIGTERM),
+            .observed(SIGTERM)
+        ])
+        XCTAssertEqual(terminationRequestCount, 0)
+
+        observer.recordedHandler?()
+        observer.recordedHandler?()
+
+        XCTAssertEqual(terminationRequestCount, 1)
+    }
+}
+
+private final class RecordingTerminationSignalObserver: TerminationSignalObserving {
+    enum Event: Equatable {
+        case ignoredDefaultDisposition(Int32)
+        case observed(Int32)
+    }
+
+    private(set) var events: [Event] = []
+    private(set) var recordedHandler: (() -> Void)?
+
+    func ignoreDefaultDisposition(for signal: Int32) {
+        events.append(.ignoredDefaultDisposition(signal))
+    }
+
+    func observe(_ signal: Int32, handler: @escaping () -> Void) {
+        events.append(.observed(signal))
+        recordedHandler = handler
+    }
+}

--- a/Tests/RepoPromptTests/App/AppTerminationSignalRoutingTests.swift
+++ b/Tests/RepoPromptTests/App/AppTerminationSignalRoutingTests.swift
@@ -1,8 +1,77 @@
+import Darwin
 import Foundation
 @testable import RepoPromptApp
 import XCTest
 
+@_silgen_name("sigaction")
+private func posixSigaction(
+    _ signal: Int32,
+    _ action: UnsafePointer<sigaction>?,
+    _ previousAction: UnsafeMutablePointer<sigaction>?
+) -> Int32
+
 final class AppTerminationSignalRoutingTests: XCTestCase {
+    func testSpawnResetsInheritedIgnoredRoutedSignalDispositions() throws {
+        for routedSignal in AppTerminationSignalRouter.routedSignals {
+            var previousAction = sigaction()
+            guard posixSigaction(routedSignal, nil, &previousAction) == 0 else {
+                XCTFail("Could not capture signal \(routedSignal) disposition: errno \(errno)")
+                return
+            }
+
+            var ignoredAction = sigaction()
+            ignoredAction.__sigaction_u.__sa_handler = SIG_IGN
+            sigemptyset(&ignoredAction.sa_mask)
+            ignoredAction.sa_flags = 0
+            guard posixSigaction(routedSignal, &ignoredAction, nil) == 0 else {
+                XCTFail("Could not ignore signal \(routedSignal): errno \(errno)")
+                return
+            }
+
+            // Restore the complete disposition before waiting so this process-wide test state
+            // cannot leak beyond the child launch boundary under test.
+            var needsDispositionRestore = true
+            defer {
+                if needsDispositionRestore {
+                    var action = previousAction
+                    _ = posixSigaction(routedSignal, &action, nil)
+                }
+            }
+
+            let sentinel = "SIGNAL_\(routedSignal)_WAS_IGNORED"
+            let spawned = try ProcessLauncher.spawn(
+                command: "/bin/sh",
+                arguments: ["-c", "kill -\(routedSignal) $$; printf \(sentinel)"],
+                environment: ProcessInfo.processInfo.environment,
+                workingDirectory: nil
+            )
+            spawned.stdin?.closeFile()
+
+            var action = previousAction
+            guard posixSigaction(routedSignal, &action, nil) == 0 else {
+                XCTFail("Could not restore signal \(routedSignal) disposition: errno \(errno)")
+                return
+            }
+            needsDispositionRestore = false
+
+            var rawStatus: Int32 = 0
+            var waitResult: pid_t
+            repeat {
+                waitResult = waitpid(spawned.pid, &rawStatus, 0)
+            } while waitResult == -1 && errno == EINTR
+
+            let stdout = String(decoding: spawned.stdout.readDataToEndOfFile(), as: UTF8.self)
+
+            XCTAssertEqual(waitResult, spawned.pid, "signal \(routedSignal)")
+            XCTAssertEqual(
+                ProcessTermination.decodeWaitStatus(rawStatus),
+                .uncaughtSignal(signal: routedSignal),
+                "signal \(routedSignal)"
+            )
+            XCTAssertFalse(stdout.contains(sentinel), "signal \(routedSignal)")
+        }
+    }
+
     func testInstallSuppressesDefaultDispositionBeforeObservationAndRoutesDeliveryExactlyOnce() {
         let observer = RecordingTerminationSignalObserver()
         var terminationRequestCount = 0

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderGracefulShutdownTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderGracefulShutdownTests.swift
@@ -152,6 +152,55 @@ final class ContextBuilderGracefulShutdownTests: XCTestCase {
         await pendingTearDown.value
     }
 
+    func testTerminationSignalRetainsMCPRunOwnerUntilManagerShutdownJoinsProvider() async {
+        let manager = WindowStatesManager.shared
+        defer { manager.setTerminatingForTesting(false) }
+        var window: WindowState? = makeWindow()
+        weak var weakWindow: WindowState?
+        weakWindow = window
+        let firstEvent = ContextBuilderTestFirstEvent()
+        let provider = GatedHeadlessAgentProvider {
+            await firstEvent.signal(.providerDisposalStarted)
+        }
+        let record = makeRecord(origin: .mcp(controlToken: UUID()))
+        XCTAssertTrue(record.installProvider(provider))
+        // The strong binding must stay scoped to this block: once `window` is cleared, the
+        // manager's termination retention is the only thing keeping the window alive, which is
+        // exactly what the deallocation assertion measures.
+        if let registeredWindow = window {
+            XCTAssertTrue(registeredWindow.contextBuilderAgentViewModel.registerRunRecordForTesting(
+                record,
+                makeCurrent: true
+            ))
+            manager.registerWindowState(registeredWindow)
+            manager.signalTermination()
+            manager.unregisterWindowState(registeredWindow)
+        } else {
+            XCTFail("Expected test window")
+            return
+        }
+        window = nil
+
+        let shutdown = Task {
+            await manager.shutdownAllAgentSessions()
+            await firstEvent.signal(.managerShutdownFinished)
+        }
+        let observedFirstEvent = await firstEvent.wait()
+        guard observedFirstEvent == .providerDisposalStarted else {
+            XCTFail("Expected provider disposal before manager shutdown finished, got \(observedFirstEvent)")
+            await shutdown.value
+            return
+        }
+
+        await provider.allowDispose()
+        await shutdown.value
+
+        let disposeCallCount = await provider.disposeCallCount()
+        XCTAssertEqual(disposeCallCount, 1)
+        XCTAssertNotNil(record.teardownFinishedAt)
+        XCTAssertNil(weakWindow)
+    }
+
     func testAppShutdownJoinsAlreadyStartedTeardownWithoutDuplicateDisposal() async {
         let window = makeWindow()
         let viewModel = window.contextBuilderAgentViewModel
@@ -333,7 +382,8 @@ final class ContextBuilderGracefulShutdownTests: XCTestCase {
     }
 
     private func makeRecord(
-        continuation: CheckedContinuation<ContextBuilderAgentViewModel.MCPContextBuilderRunCompletion, Error>? = nil
+        continuation: CheckedContinuation<ContextBuilderAgentViewModel.MCPContextBuilderRunCompletion, Error>? = nil,
+        origin: ContextBuilderRunOrigin = .ui
     ) -> ContextBuilderRunRecord {
         let tabID = UUID()
         let session = ContextBuilderAgentViewModel.TabSession(tabID: tabID)
@@ -342,7 +392,7 @@ final class ContextBuilderGracefulShutdownTests: XCTestCase {
             tabID: tabID,
             session: session,
             ownership: session.beginRunAttempt(source: "graceful-shutdown-test"),
-            origin: .ui,
+            origin: origin,
             agentKind: .claudeCode,
             modelRaw: AgentModel.defaultModel.rawValue,
             continuation: continuation

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderGracefulShutdownTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderGracefulShutdownTests.swift
@@ -1,0 +1,467 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class ContextBuilderGracefulShutdownTests: XCTestCase {
+    func testRetainedSnapshotIncludesEveryRegistryOwnedLifecycleState() {
+        let registry = ContextBuilderRunRegistry()
+        let active = makeRecord()
+        let terminal = makeRecord()
+        let activeSlotReleased = makeRecord()
+        let teardownStarted = makeRecord()
+
+        for record in [active, terminal, activeSlotReleased, teardownStarted] {
+            XCTAssertTrue(registry.register(record))
+        }
+        XCTAssertTrue(terminal.claimTerminal(.completed))
+        XCTAssertTrue(registry.releaseActiveSlot(for: activeSlotReleased))
+        XCTAssertNotNil(teardownStarted.beginTeardown())
+
+        let snapshot = registry.retainedRecordsSnapshot()
+
+        XCTAssertEqual(Set(snapshot.map(\.runID)), Set([
+            active.runID,
+            terminal.runID,
+            activeSlotReleased.runID,
+            teardownStarted.runID
+        ]))
+    }
+
+    func testTeardownSettlementSupportsConcurrentAndLateWaitersExactlyOnce() async {
+        let record = makeRecord()
+        XCTAssertNotNil(record.beginTeardown())
+        let first = Task { await record.awaitTeardownSettlement() }
+        let second = Task { await record.awaitTeardownSettlement() }
+
+        record.markProviderDisposalFinished()
+        record.markProviderDisposalFinished()
+        record.markExecutionTaskFinished()
+        record.markExecutionTaskFinished()
+
+        await first.value
+        await second.value
+        await record.awaitTeardownSettlement()
+        XCTAssertNotNil(record.teardownFinishedAt)
+    }
+
+    func testAppShutdownRetiresHiddenRecordAndWaitsForProviderAndExecution() async {
+        let window = makeWindow()
+        let viewModel = window.contextBuilderAgentViewModel
+        let provider = GatedHeadlessAgentProvider()
+        let executionGate = ContextBuilderTestGate()
+        let record = makeRecord()
+        XCTAssertTrue(record.installProvider(provider))
+        record.executionTask = Task { await executionGate.wait() }
+        XCTAssertTrue(viewModel.registerRunRecordForTesting(record, makeCurrent: false, releaseActiveSlot: true))
+
+        let shutdownFinished = ContextBuilderTestFlag()
+        let shutdown = Task {
+            await viewModel.shutdownForAppTermination()
+            await shutdownFinished.set()
+        }
+        await provider.waitUntilDisposeStarted()
+        await executionGate.waitUntilEntered()
+
+        XCTAssertEqual(record.terminalOutcome, .cancelled)
+        let finishedBeforeDisposal = await shutdownFinished.current()
+        XCTAssertFalse(finishedBeforeDisposal)
+        await provider.allowDispose()
+        let finishedBeforeExecution = await shutdownFinished.current()
+        XCTAssertFalse(finishedBeforeExecution)
+        await executionGate.open()
+        await shutdown.value
+
+        let finishedAfterSettlement = await shutdownFinished.current()
+        XCTAssertTrue(finishedAfterSettlement)
+        XCTAssertNotNil(record.teardownFinishedAt)
+    }
+
+    func testWindowRegistrationIsRejectedAfterTerminationSignal() {
+        let manager = WindowStatesManager.shared
+        let window = makeWindow()
+        manager.setTerminatingForTesting(true)
+        defer {
+            if manager.allWindows.contains(where: { $0 === window }) {
+                manager.unregisterWindowState(window)
+            }
+            manager.setTerminatingForTesting(false)
+        }
+
+        manager.registerWindowState(window)
+
+        XCTAssertTrue(window.isClosing)
+        XCTAssertFalse(manager.allWindows.contains { $0 === window })
+    }
+
+    func testManagerShutdownIncludesWindowUnregisteredBeforeTerminationSignal() async {
+        let manager = WindowStatesManager.shared
+        let window = makeWindow()
+        let viewModel = window.contextBuilderAgentViewModel
+        let firstEvent = ContextBuilderTestFirstEvent()
+        let provider = GatedHeadlessAgentProvider {
+            await firstEvent.signal(.providerDisposalStarted)
+        }
+        let executionGate = ContextBuilderTestGate()
+        let closingCaptureGate = ContextBuilderTestGate()
+        let record = makeRecord()
+        XCTAssertTrue(record.installProvider(provider))
+        record.executionTask = Task { await executionGate.wait() }
+        XCTAssertTrue(viewModel.registerRunRecordForTesting(record, makeCurrent: false, releaseActiveSlot: true))
+
+        manager.registerWindowState(window)
+        let pendingTearDown = Task { @MainActor [window] in
+            await closingCaptureGate.wait()
+            _ = window.windowID
+        }
+        await closingCaptureGate.waitUntilEntered()
+        manager.unregisterWindowState(window)
+        XCTAssertFalse(manager.allWindows.contains { $0 === window })
+
+        let shutdownFinished = ContextBuilderTestFlag()
+        let shutdown = Task {
+            await manager.shutdownAllAgentSessions()
+            await shutdownFinished.set()
+            await firstEvent.signal(.managerShutdownFinished)
+        }
+
+        let observedFirstEvent = await firstEvent.wait()
+        XCTAssertEqual(observedFirstEvent, .providerDisposalStarted)
+        guard observedFirstEvent == .providerDisposalStarted else {
+            await provider.allowDispose()
+            await executionGate.open()
+            await viewModel.shutdownForAppTermination()
+            await closingCaptureGate.open()
+            await pendingTearDown.value
+            return
+        }
+
+        await executionGate.waitUntilEntered()
+        let finishedBeforeGatesOpen = await shutdownFinished.current()
+        XCTAssertFalse(finishedBeforeGatesOpen)
+        await provider.allowDispose()
+        let finishedBeforeExecution = await shutdownFinished.current()
+        XCTAssertFalse(finishedBeforeExecution)
+        await executionGate.open()
+        await shutdown.value
+
+        let disposeCallCount = await provider.disposeCallCount()
+        XCTAssertEqual(disposeCallCount, 1)
+        XCTAssertNotNil(record.teardownFinishedAt)
+        await closingCaptureGate.open()
+        await pendingTearDown.value
+    }
+
+    func testAppShutdownJoinsAlreadyStartedTeardownWithoutDuplicateDisposal() async {
+        let window = makeWindow()
+        let viewModel = window.contextBuilderAgentViewModel
+        let provider = GatedHeadlessAgentProvider()
+        let executionGate = ContextBuilderTestGate()
+        let record = makeRecord()
+        XCTAssertTrue(record.installProvider(provider))
+        record.executionTask = Task { await executionGate.wait() }
+        XCTAssertTrue(viewModel.registerRunRecordForTesting(record, makeCurrent: false))
+        viewModel.scheduleRunTeardownForTesting(record)
+        await provider.waitUntilDisposeStarted()
+        await executionGate.waitUntilEntered()
+
+        let shutdown = Task { await viewModel.shutdownForAppTermination() }
+        await provider.allowDispose()
+        await executionGate.open()
+        await shutdown.value
+
+        let disposeCallCount = await provider.disposeCallCount()
+        XCTAssertEqual(disposeCallCount, 1)
+        XCTAssertNotNil(record.teardownFinishedAt)
+    }
+
+    func testStartedTeardownSettlesAfterViewModelDeallocationWithoutDuplicateDisposal() async {
+        var window: WindowState? = makeWindow()
+        weak var weakViewModel = window?.contextBuilderAgentViewModel
+        let provider = GatedHeadlessAgentProvider()
+        let executionGate = ContextBuilderTestGate()
+        let record = makeRecord()
+        XCTAssertTrue(record.installProvider(provider))
+        record.executionTask = Task { await executionGate.wait() }
+        XCTAssertTrue(weakViewModel?.registerRunRecordForTesting(record, makeCurrent: false) == true)
+        weakViewModel?.scheduleRunTeardownForTesting(record)
+        await provider.waitUntilDisposeStarted()
+        await executionGate.waitUntilEntered()
+
+        window?.beginClose()
+        window = nil
+        XCTAssertNil(weakViewModel)
+
+        await provider.allowDispose()
+        await executionGate.open()
+        await record.awaitTeardownSettlement()
+        let disposeCallCount = await provider.disposeCallCount()
+        XCTAssertEqual(disposeCallCount, 1)
+    }
+
+    func testClaimedFinalContextReachesSafeBoundaryBeforeShutdownDisposal() async {
+        let window = makeWindow()
+        let viewModel = window.contextBuilderAgentViewModel
+        let provider = GatedHeadlessAgentProvider()
+        let safeBoundaryGate = ContextBuilderTestGate()
+        let record = makeRecord()
+        XCTAssertTrue(record.installProvider(provider))
+        record.executionTask = Task { @MainActor [weak viewModel, record] in
+            await safeBoundaryGate.wait()
+            _ = viewModel?.finishDeferredCancellationAtSafeBoundaryForTesting(record)
+        }
+        XCTAssertTrue(viewModel.registerRunRecordForTesting(record, makeCurrent: true))
+        XCTAssertTrue(record.claimFinalContextCommit())
+
+        let shutdown = Task { await viewModel.shutdownForAppTermination() }
+        while record.cancellationState == .none {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(record.cancellationState, .deferredUntilFinalContextCommitCompletes)
+        let disposeCallCountBeforeSafeBoundary = await provider.disposeCallCount()
+        XCTAssertEqual(disposeCallCountBeforeSafeBoundary, 0)
+        await safeBoundaryGate.open()
+        await provider.waitUntilDisposeStarted()
+        await provider.allowDispose()
+        await shutdown.value
+
+        XCTAssertEqual(record.terminalOutcome, .cancelled)
+        XCTAssertNotNil(record.teardownFinishedAt)
+    }
+
+    func testStaleClaimedFinalContextDefersShutdownUntilSafeBoundary() async {
+        let window = makeWindow()
+        let viewModel = window.contextBuilderAgentViewModel
+        let provider = GatedHeadlessAgentProvider()
+        let safeBoundaryGate = ContextBuilderTestGate()
+        let record = makeRecord()
+        XCTAssertTrue(record.installProvider(provider))
+        record.executionTask = Task { @MainActor [weak viewModel, record] in
+            await safeBoundaryGate.wait()
+            _ = viewModel?.finishDeferredCancellationAtSafeBoundaryForTesting(record)
+        }
+        XCTAssertTrue(viewModel.registerRunRecordForTesting(record, makeCurrent: true, releaseActiveSlot: true))
+        XCTAssertTrue(record.claimFinalContextCommit())
+
+        let shutdown = Task { await viewModel.shutdownForAppTermination() }
+        while record.cancellationState == .none, await provider.disposeCallCount() == 0 {
+            await Task.yield()
+        }
+
+        XCTAssertEqual(record.cancellationState, .deferredUntilFinalContextCommitCompletes)
+        guard record.cancellationState == .deferredUntilFinalContextCommitCompletes else {
+            await provider.allowDispose()
+            await safeBoundaryGate.open()
+            await shutdown.value
+            return
+        }
+
+        let disposeCallCountBeforeSafeBoundary = await provider.disposeCallCount()
+        XCTAssertEqual(disposeCallCountBeforeSafeBoundary, 0)
+        await safeBoundaryGate.open()
+        await provider.waitUntilDisposeStarted()
+        await provider.allowDispose()
+        await shutdown.value
+
+        let disposeCallCount = await provider.disposeCallCount()
+        XCTAssertEqual(disposeCallCount, 1)
+        XCTAssertNotNil(record.teardownFinishedAt)
+    }
+
+    func testExplicitCancellationAndNormalCompletionResolveBeforeGatedTeardown() async throws {
+        let window = makeWindow()
+        let viewModel = window.contextBuilderAgentViewModel
+
+        try await assertWaiterResolvesBeforeTeardown(
+            viewModel: viewModel,
+            terminalOutcome: .cancelled,
+            settle: { viewModel.cancelRunForTesting($0) }
+        )
+        try await assertWaiterResolvesBeforeTeardown(
+            viewModel: viewModel,
+            terminalOutcome: .completed,
+            settle: { _ = viewModel.finalizeRunForTesting($0, outcome: .completed) }
+        )
+    }
+
+    private func assertWaiterResolvesBeforeTeardown(
+        viewModel: ContextBuilderAgentViewModel,
+        terminalOutcome: ContextBuilderRunTerminalOutcome,
+        settle: (ContextBuilderRunRecord) -> Void
+    ) async throws {
+        var capturedContinuation: CheckedContinuation<ContextBuilderAgentViewModel.MCPContextBuilderRunCompletion, Error>?
+        let waiter = Task { @MainActor in
+            try await withCheckedThrowingContinuation { continuation in
+                capturedContinuation = continuation
+            }
+        }
+        while capturedContinuation == nil {
+            await Task.yield()
+        }
+
+        let provider = GatedHeadlessAgentProvider()
+        let executionGate = ContextBuilderTestGate()
+        let record = makeRecord(
+            continuation: capturedContinuation
+        )
+        XCTAssertTrue(record.installProvider(provider))
+        record.executionTask = Task { await executionGate.wait() }
+        XCTAssertTrue(viewModel.registerRunRecordForTesting(record, makeCurrent: true))
+
+        settle(record)
+        let completion = try await waiter.value
+        XCTAssertEqual(completion.terminalDisposition, terminalOutcome)
+        XCTAssertNil(record.teardownFinishedAt)
+
+        await provider.waitUntilDisposeStarted()
+        await executionGate.waitUntilEntered()
+        await provider.allowDispose()
+        await executionGate.open()
+        await record.awaitTeardownSettlement()
+        let disposeCallCount = await provider.disposeCallCount()
+        XCTAssertEqual(disposeCallCount, 1)
+    }
+
+    private func makeWindow() -> WindowState {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        defer { GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false) }
+        return WindowState(contextBuilderProviderFactory: { _, _, _ in
+            UnsupportedHeadlessAgentProvider(reason: "Unused by synthetic lifecycle tests")
+        })
+    }
+
+    private func makeRecord(
+        continuation: CheckedContinuation<ContextBuilderAgentViewModel.MCPContextBuilderRunCompletion, Error>? = nil
+    ) -> ContextBuilderRunRecord {
+        let tabID = UUID()
+        let session = ContextBuilderAgentViewModel.TabSession(tabID: tabID)
+        return ContextBuilderRunRecord(
+            runID: UUID(),
+            tabID: tabID,
+            session: session,
+            ownership: session.beginRunAttempt(source: "graceful-shutdown-test"),
+            origin: .ui,
+            agentKind: .claudeCode,
+            modelRaw: AgentModel.defaultModel.rawValue,
+            continuation: continuation
+        )
+    }
+}
+
+private final class GatedHeadlessAgentProvider: HeadlessAgentProvider, @unchecked Sendable {
+    private let disposeGate = ContextBuilderTestGate()
+    private let state = GatedHeadlessAgentProviderState()
+    private let onDisposeStarted: @Sendable () async -> Void
+
+    init(onDisposeStarted: @escaping @Sendable () async -> Void = {}) {
+        self.onDisposeStarted = onDisposeStarted
+    }
+
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID?
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+
+    func dispose() async {
+        await state.noteDisposeStarted()
+        await onDisposeStarted()
+        await disposeGate.wait()
+    }
+
+    func waitUntilDisposeStarted() async {
+        await state.waitUntilDisposeStarted()
+    }
+
+    func allowDispose() async {
+        await disposeGate.open()
+    }
+
+    func disposeCallCount() async -> Int {
+        await state.disposeCallCount
+    }
+}
+
+private actor GatedHeadlessAgentProviderState {
+    private(set) var disposeCallCount = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func noteDisposeStarted() {
+        disposeCallCount += 1
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func waitUntilDisposeStarted() async {
+        if disposeCallCount > 0 { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+private actor ContextBuilderTestGate {
+    private var isOpen = false
+    private var entered = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var openWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        entered = true
+        let pendingEntryWaiters = entryWaiters
+        entryWaiters.removeAll()
+        pendingEntryWaiters.forEach { $0.resume() }
+        guard !isOpen else { return }
+        await withCheckedContinuation { openWaiters.append($0) }
+    }
+
+    func waitUntilEntered() async {
+        if entered { return }
+        await withCheckedContinuation { entryWaiters.append($0) }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pending = openWaiters
+        openWaiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+private actor ContextBuilderTestFirstEvent {
+    enum Event: Equatable {
+        case providerDisposalStarted
+        case managerShutdownFinished
+    }
+
+    private var firstEvent: Event?
+    private var waiters: [CheckedContinuation<Event, Never>] = []
+
+    func signal(_ event: Event) {
+        guard firstEvent == nil else { return }
+        firstEvent = event
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume(returning: event) }
+    }
+
+    func wait() async -> Event {
+        if let firstEvent { return firstEvent }
+        return await withCheckedContinuation { waiters.append($0) }
+    }
+}
+
+private actor ContextBuilderTestFlag {
+    private var value = false
+
+    func set() {
+        value = true
+    }
+
+    func current() -> Bool {
+        value
+    }
+}


### PR DESCRIPTION
## Summary

- Wait for active Context Builder runs to cancel and settle during application termination.
- Retain window shutdown participants strongly until Context Builder and Agent Mode joins finish, including windows unregistered immediately before the termination snapshot.
- Make Claude provider disposal wait for stream cleanup so the owned discovery configuration lease is released before shutdown completes.
- Add deterministic coverage for provider disposal, concurrent shutdown waiters, Context Builder-before-Agent Mode ordering, and the unregister-before-snapshot race.

## Root cause

Application termination could lose the last strong reference to a window that still owned an active Context Builder run. The shutdown coordinator would then miss that participant, while Claude-compatible provider disposal could return before stream cleanup removed its discovery lease.

## Verification

- `make dev-format`
- `make dev-lint`
- `make dev-test FILTER=ContextBuilderGracefulShutdownTests` — 11 tests passed
- `make dev-test FILTER=ClaudeCodeAgentProviderGracefulDisposalTests` — 1 test passed
- `make dev-test` — 1,011 tests passed
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-swift-build PRODUCT=repoprompt-mcp`

Packaged live acceptance is pending a separate exclusive lifecycle lease and is not claimed by this submission.

Closes #954
