### PR TITLE
Allow selecting a local Codex runtime

### DIFF
--- a/Sources/RepoPrompt/App/RepoPromptApp.swift
+++ b/Sources/RepoPrompt/App/RepoPromptApp.swift
@@ -199,6 +199,11 @@ public enum RepoPromptApplication {
                 "preserved": defaultsReport.preservedKeyCount
             ]
         )
+
+        // Capture after the defaults migration attempt because it may copy a persisted Codex
+        // selection, but before bootstrap can create Settings or provider clients.
+        CodexRuntimeAuthority.initializeLaunchSnapshot()
+
         SecureStorageIdentityMigrationBootstrap.prepareIfConfigured()
         RepoPromptSwiftUIApp.main()
     }

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -1665,7 +1665,7 @@ struct CLIProvidersSettingsView: View {
                     .hoverTooltip(codexSelectedExecutablePath)
             }
 
-            Text("Restart RepoPrompt to apply this choice and refresh the model list.")
+            Text("After changing this option, restart RepoPrompt to apply it and refresh the model list.")
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -64,6 +64,8 @@ struct CLIProvidersSettingsView: View {
     @State private var isCustomCompatibleExpanded: Bool = false
     @State private var isCodexExpanded: Bool = false
     @State private var codexRuntimeSelection = CodexRuntimePreferences.selection()
+    @State private var codexRuntimePreflight: CodexProviderHelpers.CodexRuntimeSettingsPreflight?
+    @State private var isLoadingCodexRuntimePreflight = false
     @State private var isOpenCodeExpanded: Bool = false
     @State private var isCursorExpanded: Bool = false
     @State private var isGrokBuildExpanded: Bool = false
@@ -1575,6 +1577,21 @@ struct CLIProvidersSettingsView: View {
                         }
                     }
 
+                    if let systemCandidate = codexRuntimePreflight?.systemCandidate,
+                       let runtime = systemCandidate.runtime
+                    {
+                        Button {
+                            setCodexRuntimeSelection(.external(path: systemCandidate.resolvedCommand))
+                        } label: {
+                            let title = "System Codex " + runtime.version.description
+                            if codexSelectedExecutablePath == systemCandidate.resolvedCommand {
+                                Label(title, systemImage: "checkmark")
+                            } else {
+                                Text(title)
+                            }
+                        }
+                    }
+
                     Button {
                         setCodexRuntimeSelection(.inherited)
                     } label: {
@@ -1586,7 +1603,9 @@ struct CLIProvidersSettingsView: View {
                         }
                     }
 
-                    if case let .external(path) = codexRuntimeSelection {
+                    if case let .external(path) = codexRuntimeSelection,
+                       path != codexRuntimePreflight?.systemCandidate?.resolvedCommand
+                    {
                         Button {
                             setCodexRuntimeSelection(.external(path: path))
                         } label: {
@@ -1605,7 +1624,39 @@ struct CLIProvidersSettingsView: View {
                 Spacer()
             }
 
-            if let codexSelectedExecutablePath {
+            if isLoadingCodexRuntimePreflight {
+                Text("Resolving selected runtime…")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else if let resolution = codexRuntimePreflight?.effectiveResolution {
+                if resolution.status == .available,
+                   let description = resolution.displayDescription,
+                   let executablePath = resolution.runtime?.executableURL.path
+                {
+                    Text("Selection resolves to \(description)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(executablePath)
+                        .font(.caption.monospaced())
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .hoverTooltip(executablePath)
+                } else {
+                    if let codexSelectedExecutablePath {
+                        Text(codexSelectedExecutablePath)
+                            .font(.caption.monospaced())
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .hoverTooltip(codexSelectedExecutablePath)
+                    }
+                    Text(resolution.userMessage)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } else if let codexSelectedExecutablePath {
                 Text(codexSelectedExecutablePath)
                     .font(.caption.monospaced())
                     .foregroundColor(.secondary)
@@ -1618,6 +1669,9 @@ struct CLIProvidersSettingsView: View {
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+        .task(id: codexRuntimeSelectionTaskID) {
+            await refreshCodexRuntimePreflight()
         }
     }
 
@@ -1641,9 +1695,29 @@ struct CLIProvidersSettingsView: View {
         }
     }
 
+    private var codexRuntimeSelectionTaskID: String {
+        switch codexRuntimeSelection {
+        case .inherited:
+            "inherited"
+        case .bundled:
+            "bundled"
+        case let .external(path):
+            "external:\(path)"
+        }
+    }
+
     private func setCodexRuntimeSelection(_ selection: CodexRuntimePreferences.Selection) {
         CodexRuntimePreferences.setSelection(selection)
         codexRuntimeSelection = CodexRuntimePreferences.selection()
+    }
+
+    private func refreshCodexRuntimePreflight() async {
+        let selection = codexRuntimeSelection
+        isLoadingCodexRuntimePreflight = true
+        let preflight = await CodexProviderHelpers.preflightCodexRuntimeSettings()
+        guard !Task.isCancelled, codexRuntimeSelection == selection else { return }
+        codexRuntimePreflight = preflight
+        isLoadingCodexRuntimePreflight = false
     }
 
     private var codexCard: some View {
@@ -2338,6 +2412,7 @@ struct CLIProvidersSettingsView: View {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
+        panel.resolvesAliases = false
         if let codexSelectedExecutablePath {
             panel.directoryURL = URL(fileURLWithPath: codexSelectedExecutablePath).deletingLastPathComponent()
         }

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -1665,7 +1665,7 @@ struct CLIProvidersSettingsView: View {
                     .hoverTooltip(codexSelectedExecutablePath)
             }
 
-            Text("Restart RepoPrompt to apply this choice everywhere; no rebuild is required.")
+            Text("Restart RepoPrompt to apply this choice and refresh the model list.")
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -63,6 +63,7 @@ struct CLIProvidersSettingsView: View {
     @State private var isKimiCodeExpanded: Bool = false
     @State private var isCustomCompatibleExpanded: Bool = false
     @State private var isCodexExpanded: Bool = false
+    @State private var codexRuntimeSelection = CodexRuntimePreferences.selection()
     @State private var isOpenCodeExpanded: Bool = false
     @State private var isCursorExpanded: Bool = false
     @State private var isGrokBuildExpanded: Bool = false
@@ -1556,6 +1557,95 @@ struct CLIProvidersSettingsView: View {
         .fixedSize(horizontal: false, vertical: true)
     }
 
+    private var codexRuntimeSelectionControl: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 8) {
+                Text("Runtime")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Menu {
+                    Button {
+                        setCodexRuntimeSelection(.bundled)
+                    } label: {
+                        if codexRuntimeSelection == .bundled {
+                            Label("Bundled Codex \(CodexRuntimeAuthority.bundledVersion)", systemImage: "checkmark")
+                        } else {
+                            Text("Bundled Codex \(CodexRuntimeAuthority.bundledVersion)")
+                        }
+                    }
+
+                    Button {
+                        setCodexRuntimeSelection(.inherited)
+                    } label: {
+                        let title = "Environment override, otherwise bundled"
+                        if codexRuntimeSelection == .inherited {
+                            Label(title, systemImage: "checkmark")
+                        } else {
+                            Text(title)
+                        }
+                    }
+
+                    if case let .external(path) = codexRuntimeSelection {
+                        Button {
+                            setCodexRuntimeSelection(.external(path: path))
+                        } label: {
+                            Label("Local Codex (\(URL(fileURLWithPath: path).lastPathComponent))", systemImage: "checkmark")
+                        }
+                    }
+
+                    Divider()
+
+                    Button("Choose Local Executable…", action: chooseLocalCodexExecutable)
+                } label: {
+                    Text(codexRuntimeSelectionLabel)
+                }
+                .fixedSize()
+
+                Spacer()
+            }
+
+            if let codexSelectedExecutablePath {
+                Text(codexSelectedExecutablePath)
+                    .font(.caption.monospaced())
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .hoverTooltip(codexSelectedExecutablePath)
+            }
+
+            Text("Restart RepoPrompt to apply this choice everywhere; no rebuild is required.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var codexRuntimeSelectionLabel: String {
+        switch codexRuntimeSelection {
+        case .bundled:
+            "Bundled Codex \(CodexRuntimeAuthority.bundledVersion)"
+        case let .external(path):
+            "Local Codex (\(URL(fileURLWithPath: path).lastPathComponent))"
+        case .inherited:
+            "Environment override, otherwise bundled"
+        }
+    }
+
+    private var codexSelectedExecutablePath: String? {
+        switch codexRuntimeSelection {
+        case let .external(path):
+            path
+        case .inherited, .bundled:
+            nil
+        }
+    }
+
+    private func setCodexRuntimeSelection(_ selection: CodexRuntimePreferences.Selection) {
+        CodexRuntimePreferences.setSelection(selection)
+        codexRuntimeSelection = CodexRuntimePreferences.selection()
+    }
+
     private var codexCard: some View {
         providerCard(
             title: "Codex CLI",
@@ -1577,6 +1667,9 @@ struct CLIProvidersSettingsView: View {
                     }
                     .buttonStyle(PlainButtonStyle())
                 }
+
+                Divider()
+                codexRuntimeSelectionControl
 
                 if viewModel.isCodexConnected {
                     Divider()
@@ -1722,7 +1815,7 @@ struct CLIProvidersSettingsView: View {
                             .foregroundColor(.red)
                             .fixedSize(horizontal: false, vertical: true)
                         if viewModel.isCodexExecutableUnavailable {
-                            Text("Reinstall RepoPrompt CE, or fix/remove REPOPROMPT_CODEX_EXECUTABLE, then click Connect to check again.")
+                            Text("Choose another runtime above, or fix/remove REPOPROMPT_CODEX_EXECUTABLE, then click Connect to check again.")
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
@@ -2235,6 +2328,21 @@ struct CLIProvidersSettingsView: View {
                 }
             }
         }
+    }
+
+    private func chooseLocalCodexExecutable() {
+        let panel = NSOpenPanel()
+        panel.title = "Choose Codex Executable"
+        panel.message = "Select an installed Codex CLI executable. RepoPrompt validates its version before use."
+        panel.prompt = "Choose"
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        if let codexSelectedExecutablePath {
+            panel.directoryURL = URL(fileURLWithPath: codexSelectedExecutablePath).deletingLastPathComponent()
+        }
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        setCodexRuntimeSelection(.external(path: url.path))
     }
 
     private func startCodexManagedChatgptLogin() {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -119,7 +119,7 @@ actor CodexAppServerClient {
             else {
                 return message
             }
-            return "\(message) The active Codex runtime rejected RepoPrompt's required \(method) request shape. Reinstall or update RepoPrompt CE; if REPOPROMPT_CODEX_EXECUTABLE is set, update or remove that explicit override."
+            return "\(message) The active Codex runtime rejected RepoPrompt's required \(method) request shape. Reinstall or update RepoPrompt CE; if a local Codex executable is configured, update it or switch back to the bundled runtime."
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -444,6 +444,7 @@ actor CodexAppServerClient {
     private let processSpawnPreparation: @Sendable () async throws -> Void
     private let processEnvironmentBuilder: @Sendable (ProcessEnvironmentRequest) async -> ProcessEnvironmentResult
     private let runtimeStatePreparer: @Sendable (CodexRuntimeAuthority.Runtime) throws -> Void
+    private let launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot
     private let provisionsRepoPromptMCPOnStart: Bool
     private let processExitObserverFactory: @Sendable (pid_t) -> ChildProcessExitObserver
     private let expectedAgentPIDRegistrar: ExpectedAgentPIDRegistrar
@@ -470,6 +471,7 @@ actor CodexAppServerClient {
         runtimeStatePreparer: @escaping @Sendable (CodexRuntimeAuthority.Runtime) throws -> Void = {
             try $0.prepareState()
         },
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot = CodexRuntimeAuthority.currentLaunchSnapshot(),
         provisionsRepoPromptMCPOnStart: Bool = true,
         processExitObserverFactory: @escaping @Sendable (pid_t) -> ChildProcessExitObserver = {
             ChildProcessExitObserver(pid: $0)
@@ -482,6 +484,7 @@ actor CodexAppServerClient {
         self.processSpawnPreparation = processSpawnPreparation
         self.processEnvironmentBuilder = processEnvironmentBuilder
         self.runtimeStatePreparer = runtimeStatePreparer
+        self.launchSnapshot = launchSnapshot
         self.provisionsRepoPromptMCPOnStart = provisionsRepoPromptMCPOnStart
         self.processExitObserverFactory = processExitObserverFactory
         self.expectedAgentPIDRegistrar = expectedAgentPIDRegistrar
@@ -519,6 +522,7 @@ actor CodexAppServerClient {
             commandName: config.commandName,
             environment: environment,
             additionalPathHints: config.additionalPathHints,
+            launchSnapshot: launchSnapshot,
             logger: config.enableDebugLogging ? { print("[CodexAppServer] \($0)") } : nil
         )
         guard resolution.status == .available else {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
@@ -80,6 +80,7 @@ final class CodexCLIProvider: AIProvider {
     }
 
     private let workingDirectory: String?
+    private let launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot
     private let enableDebugLogging: Bool
     private let defaultRequestTimeout: TimeInterval
     private let testRequestTimeout: TimeInterval
@@ -101,6 +102,7 @@ final class CodexCLIProvider: AIProvider {
 
     init(
         workingDirectory: String? = nil,
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot = CodexRuntimeAuthority.currentLaunchSnapshot(),
         enableDebugLogging: Bool = false,
         defaultRequestTimeout: TimeInterval? = nil,
         testRequestTimeout: TimeInterval? = nil,
@@ -112,6 +114,7 @@ final class CodexCLIProvider: AIProvider {
         sessionControllerFactory: ((Set<String>, TimeInterval) -> CodexSessionControlling)? = nil
     ) {
         self.workingDirectory = workingDirectory
+        self.launchSnapshot = launchSnapshot
         self.enableDebugLogging = enableDebugLogging
         self.defaultRequestTimeout = defaultRequestTimeout ?? (45 * 60)
         self.testRequestTimeout = testRequestTimeout ?? 30
@@ -126,7 +129,7 @@ final class CodexCLIProvider: AIProvider {
         _ = logCollector
 
         // Ensure RepoPrompt MCP server entry exists before building overrides.
-        _ = MCPIntegrationHelper.ensureCodexServerForDiscovery()
+        _ = MCPIntegrationHelper.ensureCodexServerForDiscovery(launchSnapshot: launchSnapshot)
     }
 
     func streamMessage(_ aiMessage: AIMessage, model: AIModel, maxTokens _: Int? = nil) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
@@ -931,7 +934,7 @@ final class CodexCLIProvider: AIProvider {
 
     private func makeRequestAppServerClient() -> CodexAppServerClient? {
         guard sessionControllerFactory == nil else { return nil }
-        return CodexProviderHelpers.makeOwnedNonAgentAppServerClient()
+        return CodexProviderHelpers.makeOwnedNonAgentAppServerClient(launchSnapshot: launchSnapshot)
     }
 
     private func withActiveRequestAppServerClient<T>(

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
@@ -11,6 +11,7 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
 
     private var runner: CLIProcessRunner?
     private let config: CodexExecAgentConfig
+    private let launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot
     private let runtimeStatePreparer: @Sendable (CodexRuntimeAuthority.Runtime) throws -> Void
     private let configService = MCPConfigExportService.shared
     private let toolTracking = AgentToolTrackingController()
@@ -23,11 +24,13 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
 
     init(
         config: CodexExecAgentConfig,
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot = CodexRuntimeAuthority.currentLaunchSnapshot(),
         runtimeStatePreparer: @escaping @Sendable (CodexRuntimeAuthority.Runtime) throws -> Void = {
             try $0.prepareState()
         }
     ) {
         self.config = config
+        self.launchSnapshot = launchSnapshot
         self.runtimeStatePreparer = runtimeStatePreparer
         if enableDebugLogging {
             print("[DEBUG] CodexExec: Initialized provider with model: \(config.modelString ?? "default")")
@@ -115,7 +118,8 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
         let resolution = await CodexProviderHelpers.preflightCodexExecutable(
             commandName: config.commandName,
             additionalPathHints: config.additionalPathHints,
-            enableDebugLogging: enableDebugLogging
+            enableDebugLogging: enableDebugLogging,
+            launchSnapshot: launchSnapshot
         )
         if enableDebugLogging {
             print("[DEBUG] CodexExec: \(resolution.debugMessage)")

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexIntegrationConfiguration.swift
@@ -177,7 +177,7 @@ enum CodexIntegrationConfiguration {
     @discardableResult
     static func installPersistentMCPConfig() -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
         let runtime: CodexRuntimeAuthority.Runtime
-        switch CodexRuntimeAuthority.resolve() {
+        switch CodexRuntimeAuthority.resolveConfigured() {
         case let .success(resolved):
             runtime = resolved
         case let .failure(failure):
@@ -224,7 +224,7 @@ enum CodexIntegrationConfiguration {
     /// `-c` overrides.
     @discardableResult
     static func ensureServerForDiscovery() -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
-        switch CodexRuntimeAuthority.resolve() {
+        switch CodexRuntimeAuthority.resolveConfigured() {
         case let .success(resolved):
             ensureServerForDiscovery(runtime: resolved)
         case let .failure(failure):

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexIntegrationConfiguration.swift
@@ -175,9 +175,13 @@ enum CodexIntegrationConfiguration {
     /// Invoked from the UI when users opt-in to the integration. Ensures our MCP server exists and is
     /// enabled globally so Codex can use it outside of discovery runs.
     @discardableResult
-    static func installPersistentMCPConfig() -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
+    static func installPersistentMCPConfig(
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot? = nil
+    ) -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
         let runtime: CodexRuntimeAuthority.Runtime
-        switch CodexRuntimeAuthority.resolveConfigured() {
+        switch CodexRuntimeAuthority.resolveConfigured(
+            launchSnapshot: launchSnapshot ?? CodexRuntimeAuthority.currentLaunchSnapshot()
+        ) {
         case let .success(resolved):
             runtime = resolved
         case let .failure(failure):
@@ -223,8 +227,12 @@ enum CodexIntegrationConfiguration {
     /// `enabled = false` so normal Codex usage stays opt-in, while the agent enables it at runtime via
     /// `-c` overrides.
     @discardableResult
-    static func ensureServerForDiscovery() -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
-        switch CodexRuntimeAuthority.resolveConfigured() {
+    static func ensureServerForDiscovery(
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot? = nil
+    ) -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
+        switch CodexRuntimeAuthority.resolveConfigured(
+            launchSnapshot: launchSnapshot ?? CodexRuntimeAuthority.currentLaunchSnapshot()
+        ) {
         case let .success(resolved):
             ensureServerForDiscovery(runtime: resolved)
         case let .failure(failure):

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexProviderHelpers.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexProviderHelpers.swift
@@ -25,8 +25,12 @@ enum CodexProviderHelpers {
     /// Returns a fresh app-server client for non-agent Codex flows.
     /// These flows should not share transport/process state across chat, health checks,
     /// and model polling because failures become sticky across otherwise unrelated work.
-    static func makeOwnedNonAgentAppServerClient() -> CodexAppServerClient {
-        CodexAppServerClient()
+    static func makeOwnedNonAgentAppServerClient(
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot? = nil
+    ) -> CodexAppServerClient {
+        CodexAppServerClient(
+            launchSnapshot: launchSnapshot ?? CodexRuntimeAuthority.currentLaunchSnapshot()
+        )
     }
 
     struct CodexExecutableResolution: Equatable {
@@ -69,13 +73,15 @@ enum CodexProviderHelpers {
         commandName: String = CLILaunchProfiles.codex.commandName,
         environment: [String: String],
         additionalPathHints: [String] = CLILaunchProfiles.codex.supplementalSearchPaths,
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot? = nil,
         logger: ((String) -> Void)? = nil
     ) -> CodexExecutableResolution {
         _ = additionalPathHints // Kept for source compatibility; PATH fallback is intentionally disabled.
         let injectedOverride = commandName == CLILaunchProfiles.codex.commandName ? nil : commandName
         switch CodexRuntimeAuthority.resolveConfigured(
             environment: environment,
-            explicitExecutableOverride: injectedOverride
+            explicitExecutableOverride: injectedOverride,
+            launchSnapshot: launchSnapshot
         ) {
         case let .success(runtime):
             let debugMessage = runtime.redactedDiagnosticSummary
@@ -121,7 +127,8 @@ enum CodexProviderHelpers {
         enableDebugLogging: Bool = false,
         logCollector: CLIProcessLogCollector? = nil,
         inheritedEnvironment: [String: String] = ProcessInfo.processInfo.environment,
-        shellEnvironmentProvider: ProcessEnvironmentBuilder.ShellEnvironmentProvider? = nil
+        shellEnvironmentProvider: ProcessEnvironmentBuilder.ShellEnvironmentProvider? = nil,
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot? = nil
     ) async -> CodexExecutableResolution {
         let environment = await codexPreflightEnvironment(
             enableDebugLogging: enableDebugLogging,
@@ -132,7 +139,8 @@ enum CodexProviderHelpers {
             resolveCodexExecutable(
                 commandName: commandName,
                 environment: environment,
-                additionalPathHints: additionalPathHints
+                additionalPathHints: additionalPathHints,
+                launchSnapshot: launchSnapshot
             )
         }.value
         logPreflightResolution(

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexProviderHelpers.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexProviderHelpers.swift
@@ -69,13 +69,15 @@ enum CodexProviderHelpers {
         commandName: String = CLILaunchProfiles.codex.commandName,
         environment: [String: String],
         additionalPathHints: [String] = CLILaunchProfiles.codex.supplementalSearchPaths,
-        logger: ((String) -> Void)? = nil
+        logger: ((String) -> Void)? = nil,
+        selection: CodexRuntimePreferences.Selection = CodexRuntimePreferences.activeSelection
     ) -> CodexExecutableResolution {
         _ = additionalPathHints // Kept for source compatibility; PATH fallback is intentionally disabled.
         let injectedOverride = commandName == CLILaunchProfiles.codex.commandName ? nil : commandName
         switch CodexRuntimeAuthority.resolveConfigured(
             environment: environment,
-            explicitExecutableOverride: injectedOverride
+            explicitExecutableOverride: injectedOverride,
+            selection: selection
         ) {
         case let .success(runtime):
             let debugMessage = runtime.redactedDiagnosticSummary
@@ -154,8 +156,9 @@ enum CodexProviderHelpers {
             inheritedEnvironment: inheritedEnvironment,
             shellEnvironmentProvider: shellEnvironmentProvider
         )
+        let selection = CodexRuntimePreferences.selection()
         let preflight = await Task.detached(priority: .utility) {
-            let effectiveResolution = resolveCodexExecutable(environment: environment)
+            let effectiveResolution = resolveCodexExecutable(environment: environment, selection: selection)
             let discoveredCommand = CommandPathResolver.resolve(
                 CLILaunchProfiles.codex.commandName,
                 environment: environment,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexProviderHelpers.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexProviderHelpers.swift
@@ -60,6 +60,11 @@ enum CodexProviderHelpers {
         }
     }
 
+    struct CodexRuntimeSettingsPreflight: Equatable {
+        let effectiveResolution: CodexExecutableResolution
+        let systemCandidate: CodexExecutableResolution?
+    }
+
     static func resolveCodexExecutable(
         commandName: String = CLILaunchProfiles.codex.commandName,
         environment: [String: String],
@@ -118,6 +123,69 @@ enum CodexProviderHelpers {
         inheritedEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         shellEnvironmentProvider: ProcessEnvironmentBuilder.ShellEnvironmentProvider? = nil
     ) async -> CodexExecutableResolution {
+        let environment = await codexPreflightEnvironment(
+            enableDebugLogging: enableDebugLogging,
+            inheritedEnvironment: inheritedEnvironment,
+            shellEnvironmentProvider: shellEnvironmentProvider
+        )
+        let resolution = await Task.detached(priority: .utility) {
+            resolveCodexExecutable(
+                commandName: commandName,
+                environment: environment,
+                additionalPathHints: additionalPathHints
+            )
+        }.value
+        logPreflightResolution(
+            resolution,
+            enableDebugLogging: enableDebugLogging,
+            logCollector: logCollector
+        )
+        return resolution
+    }
+
+    static func preflightCodexRuntimeSettings(
+        enableDebugLogging: Bool = false,
+        logCollector: CLIProcessLogCollector? = nil,
+        inheritedEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        shellEnvironmentProvider: ProcessEnvironmentBuilder.ShellEnvironmentProvider? = nil
+    ) async -> CodexRuntimeSettingsPreflight {
+        let environment = await codexPreflightEnvironment(
+            enableDebugLogging: enableDebugLogging,
+            inheritedEnvironment: inheritedEnvironment,
+            shellEnvironmentProvider: shellEnvironmentProvider
+        )
+        let preflight = await Task.detached(priority: .utility) {
+            let effectiveResolution = resolveCodexExecutable(environment: environment)
+            let discoveredCommand = CommandPathResolver.resolve(
+                CLILaunchProfiles.codex.commandName,
+                environment: environment,
+                additionalPaths: CLILaunchProfiles.codex.supplementalSearchPaths,
+                preferredBasenames: CLILaunchProfiles.codex.preferredBasenames,
+                shellLookupMode: .disabled
+            )
+            let systemCandidate: CodexExecutableResolution? = if CommandPathResolver.launchability(of: discoveredCommand) == .launchable {
+                resolveCodexExecutable(commandName: discoveredCommand, environment: environment)
+            } else {
+                nil
+            }
+            return CodexRuntimeSettingsPreflight(
+                effectiveResolution: effectiveResolution,
+                systemCandidate: systemCandidate?.status == .available ? systemCandidate : nil
+            )
+        }.value
+        logPreflightResolution(
+            preflight.effectiveResolution,
+            enableDebugLogging: enableDebugLogging,
+            logCollector: logCollector
+        )
+        return preflight
+    }
+
+    private static func codexPreflightEnvironment(
+        enableDebugLogging: Bool,
+        inheritedEnvironment: [String: String],
+        shellEnvironmentProvider: ProcessEnvironmentBuilder.ShellEnvironmentProvider?
+    ) async -> [String: String] {
         let request = ProcessEnvironmentRequest(
             purpose: .codexPreflight,
             inheritedEnvironment: inheritedEnvironment,
@@ -131,18 +199,18 @@ enum CodexProviderHelpers {
         } else {
             await ProcessEnvironmentBuilder.build(request)
         }
-        let logger: ((String) -> Void)? = { message in
-            logCollector?.append(message)
-            if enableDebugLogging {
-                print("[CodexPreflight] \(message)")
-            }
+        return environmentResult.environment
+    }
+
+    private static func logPreflightResolution(
+        _ resolution: CodexExecutableResolution,
+        enableDebugLogging: Bool,
+        logCollector: CLIProcessLogCollector?
+    ) {
+        logCollector?.append(resolution.debugMessage)
+        if enableDebugLogging {
+            print("[CodexPreflight] \(resolution.debugMessage)")
         }
-        return resolveCodexExecutable(
-            commandName: commandName,
-            environment: environmentResult.environment,
-            additionalPathHints: additionalPathHints,
-            logger: logger
-        )
     }
 
     static func isCodexExecutableUnavailableMessage(_ message: String) -> Bool {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexProviderHelpers.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexProviderHelpers.swift
@@ -55,7 +55,7 @@ enum CodexProviderHelpers {
             case let .bundled(target):
                 "Bundled Codex \(runtime.version) (\(target))"
             case .externalOverride:
-                "External Codex override \(runtime.version) (\(runtime.executableURL.lastPathComponent))"
+                "Local Codex \(runtime.version) (\(runtime.executableURL.lastPathComponent))"
             }
         }
     }
@@ -68,7 +68,7 @@ enum CodexProviderHelpers {
     ) -> CodexExecutableResolution {
         _ = additionalPathHints // Kept for source compatibility; PATH fallback is intentionally disabled.
         let injectedOverride = commandName == CLILaunchProfiles.codex.commandName ? nil : commandName
-        switch CodexRuntimeAuthority.resolve(
+        switch CodexRuntimeAuthority.resolveConfigured(
             environment: environment,
             explicitExecutableOverride: injectedOverride
         ) {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
@@ -193,6 +193,7 @@ enum CodexRuntimeAuthority {
 
     private struct ExternalVersionCacheKey: Hashable {
         let path: String
+        let environment: [String: String]
         let modificationDate: Date?
         let fileSize: UInt64?
     }
@@ -249,6 +250,7 @@ enum CodexRuntimeAuthority {
             return resolveExternalOverride(
                 configuredOverride,
                 statePaths: state,
+                environment: environment,
                 versionReader: externalVersionReader
             )
         }
@@ -334,7 +336,7 @@ enum CodexRuntimeAuthority {
         architectureTarget: String? = currentArchitectureTarget,
         applicationSupportURL: URL? = nil,
         explicitExecutableOverride: String? = nil,
-        defaults: UserDefaults = .standard,
+        selection: CodexRuntimePreferences.Selection = CodexRuntimePreferences.activeSelection,
         externalVersionReader: ((URL) -> String?)? = nil
     ) -> Result<Runtime, Failure> {
         if let explicitExecutableOverride {
@@ -350,7 +352,7 @@ enum CodexRuntimeAuthority {
 
         var configuredEnvironment = environment
         let configuredOverride: String?
-        switch CodexRuntimePreferences.selection(defaults: defaults) {
+        switch selection {
         case .inherited:
             configuredOverride = nil
         case .bundled:
@@ -373,6 +375,7 @@ enum CodexRuntimeAuthority {
     private static func resolveExternalOverride(
         _ rawPath: String,
         statePaths: StatePaths,
+        environment: [String: String],
         versionReader: ((URL) -> String?)?
     ) -> Result<Runtime, Failure> {
         let expandedPath = (rawPath as NSString).expandingTildeInPath
@@ -390,7 +393,7 @@ enum CodexRuntimeAuthority {
         let version: Version? = if let versionReader {
             versionReader(url).flatMap(Version.parse)
         } else {
-            cachedExternalVersion(executableURL: url)
+            cachedExternalVersion(executableURL: url, environment: environment)
         }
         guard let version else {
             return .failure(.externalOverrideVersionUnreadable(url.path))
@@ -408,10 +411,11 @@ enum CodexRuntimeAuthority {
         )
     }
 
-    private static func cachedExternalVersion(executableURL: URL) -> Version? {
+    private static func cachedExternalVersion(executableURL: URL, environment: [String: String]) -> Version? {
         let attributes = try? FileManager.default.attributesOfItem(atPath: executableURL.path)
         let key = ExternalVersionCacheKey(
             path: executableURL.path,
+            environment: environment,
             modificationDate: attributes?[.modificationDate] as? Date,
             fileSize: (attributes?[.size] as? NSNumber)?.uint64Value
         )
@@ -434,7 +438,7 @@ enum CodexRuntimeAuthority {
         // Version probing may launch an invalid or hanging executable. Never hold the global
         // cache lock while waiting for that child; cache identity-bound failures briefly so
         // repeated callers do not serialize behind the same bad override.
-        let version = readExternalVersion(executableURL: executableURL).flatMap(Version.parse)
+        let version = readExternalVersion(executableURL: executableURL, environment: environment).flatMap(Version.parse)
 
         externalVersionCacheLock.lock()
         if let version {
@@ -449,11 +453,12 @@ enum CodexRuntimeAuthority {
         return version
     }
 
-    private static func readExternalVersion(executableURL: URL) -> String? {
+    private static func readExternalVersion(executableURL: URL, environment: [String: String]) -> String? {
         let process = Process()
         let output = Pipe()
         process.executableURL = executableURL
         process.arguments = ["--version"]
+        process.environment = environment
         process.standardOutput = output
         process.standardError = output
         let completed = DispatchSemaphore(value: 0)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
@@ -10,6 +10,57 @@ enum CodexRuntimeAuthority {
     static let minimumExternalVersion = bundledVersion
     static let externalExecutableOverrideEnvironmentKey = "REPOPROMPT_CODEX_EXECUTABLE"
 
+    /// The persisted preference captured for this application process. Settings writes remain
+    /// pending until the next process launch; runtime consumers never reread UserDefaults after
+    /// this snapshot has been initialized.
+    struct LaunchSnapshot: Equatable {
+        let selection: CodexRuntimePreferences.Selection
+
+        init(selection: CodexRuntimePreferences.Selection) {
+            self.selection = selection
+        }
+    }
+
+    private static let launchSnapshotLock = NSLock()
+    private static var storedLaunchSnapshot: LaunchSnapshot?
+
+    /// Builds a deterministic launch snapshot without touching process-global state. Tests inject
+    /// these values into runtime consumers instead of resetting the process snapshot.
+    static func makeLaunchSnapshot(defaults: UserDefaults = .standard) -> LaunchSnapshot {
+        LaunchSnapshot(selection: CodexRuntimePreferences.selection(defaults: defaults))
+    }
+
+    /// Captures the persisted runtime choice once, before the app creates settings or provider
+    /// clients. Repeated calls are intentionally no-ops so a settings write cannot retarget this
+    /// process; the next app launch captures the new persisted value.
+    @discardableResult
+    static func initializeLaunchSnapshot(defaults: UserDefaults = .standard) -> LaunchSnapshot {
+        let candidate = makeLaunchSnapshot(defaults: defaults)
+        launchSnapshotLock.lock()
+        if let storedLaunchSnapshot {
+            launchSnapshotLock.unlock()
+            return storedLaunchSnapshot
+        }
+        storedLaunchSnapshot = candidate
+        launchSnapshotLock.unlock()
+        return candidate
+    }
+
+    /// Returns the immutable process launch choice. Production initializes this explicitly from
+    /// `RepoPromptApplication.main`; the fallback keeps non-app callers safe without exposing a
+    /// reset API.
+    static func currentLaunchSnapshot() -> LaunchSnapshot {
+        launchSnapshotLock.lock()
+        if let storedLaunchSnapshot {
+            launchSnapshotLock.unlock()
+            return storedLaunchSnapshot
+        }
+        let snapshot = makeLaunchSnapshot()
+        storedLaunchSnapshot = snapshot
+        launchSnapshotLock.unlock()
+        return snapshot
+    }
+
     enum Source: Equatable {
         case bundled(target: String)
         case externalOverride
@@ -195,6 +246,7 @@ enum CodexRuntimeAuthority {
         let path: String
         let modificationDate: Date?
         let fileSize: UInt64?
+        let environmentFingerprint: Int
     }
 
     private struct ExternalVersionCacheEntry {
@@ -249,6 +301,7 @@ enum CodexRuntimeAuthority {
             return resolveExternalOverride(
                 configuredOverride,
                 statePaths: state,
+                environment: environment,
                 versionReader: externalVersionReader
             )
         }
@@ -325,9 +378,10 @@ enum CodexRuntimeAuthority {
     }
 
     /// Resolves the production configuration without making persistence part of the pure
-    /// validation path. A call-site override wins, followed by the Settings choice, environment,
-    /// and finally the bundled runtime. An explicitly bundled selection suppresses the legacy
-    /// environment override so the visible choice remains authoritative.
+    /// validation path. A call-site override wins, followed by the launch snapshot when supplied,
+    /// then the current Settings choice for preflight-only callers, environment, and finally the
+    /// bundled runtime. An explicitly bundled selection suppresses the legacy environment override
+    /// so the visible choice remains authoritative.
     static func resolveConfigured(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         resourcesURL: URL? = Bundle.main.resourceURL,
@@ -335,6 +389,7 @@ enum CodexRuntimeAuthority {
         applicationSupportURL: URL? = nil,
         explicitExecutableOverride: String? = nil,
         defaults: UserDefaults = .standard,
+        launchSnapshot: LaunchSnapshot? = nil,
         externalVersionReader: ((URL) -> String?)? = nil
     ) -> Result<Runtime, Failure> {
         if let explicitExecutableOverride {
@@ -350,7 +405,8 @@ enum CodexRuntimeAuthority {
 
         var configuredEnvironment = environment
         let configuredOverride: String?
-        switch CodexRuntimePreferences.selection(defaults: defaults) {
+        let selection = launchSnapshot?.selection ?? CodexRuntimePreferences.selection(defaults: defaults)
+        switch selection {
         case .inherited:
             configuredOverride = nil
         case .bundled:
@@ -373,6 +429,7 @@ enum CodexRuntimeAuthority {
     private static func resolveExternalOverride(
         _ rawPath: String,
         statePaths: StatePaths,
+        environment: [String: String],
         versionReader: ((URL) -> String?)?
     ) -> Result<Runtime, Failure> {
         let expandedPath = (rawPath as NSString).expandingTildeInPath
@@ -390,7 +447,7 @@ enum CodexRuntimeAuthority {
         let version: Version? = if let versionReader {
             versionReader(url).flatMap(Version.parse)
         } else {
-            cachedExternalVersion(executableURL: url)
+            cachedExternalVersion(executableURL: url, environment: environment)
         }
         guard let version else {
             return .failure(.externalOverrideVersionUnreadable(url.path))
@@ -408,12 +465,16 @@ enum CodexRuntimeAuthority {
         )
     }
 
-    private static func cachedExternalVersion(executableURL: URL) -> Version? {
+    private static func cachedExternalVersion(
+        executableURL: URL,
+        environment: [String: String]
+    ) -> Version? {
         let attributes = try? FileManager.default.attributesOfItem(atPath: executableURL.path)
         let key = ExternalVersionCacheKey(
             path: executableURL.path,
             modificationDate: attributes?[.modificationDate] as? Date,
-            fileSize: (attributes?[.size] as? NSNumber)?.uint64Value
+            fileSize: (attributes?[.size] as? NSNumber)?.uint64Value,
+            environmentFingerprint: environmentFingerprint(environment)
         )
         let now = Date()
 
@@ -434,7 +495,10 @@ enum CodexRuntimeAuthority {
         // Version probing may launch an invalid or hanging executable. Never hold the global
         // cache lock while waiting for that child; cache identity-bound failures briefly so
         // repeated callers do not serialize behind the same bad override.
-        let version = readExternalVersion(executableURL: executableURL).flatMap(Version.parse)
+        let version = readExternalVersion(
+            executableURL: executableURL,
+            environment: environment
+        ).flatMap(Version.parse)
 
         externalVersionCacheLock.lock()
         if let version {
@@ -449,10 +513,14 @@ enum CodexRuntimeAuthority {
         return version
     }
 
-    private static func readExternalVersion(executableURL: URL) -> String? {
+    private static func readExternalVersion(
+        executableURL: URL,
+        environment: [String: String]
+    ) -> String? {
         let process = Process()
         let output = Pipe()
         process.executableURL = executableURL
+        process.environment = environment
         process.arguments = ["--version"]
         process.standardOutput = output
         process.standardError = output
@@ -470,6 +538,15 @@ enum CodexRuntimeAuthority {
         }
         guard process.terminationStatus == 0 else { return nil }
         return String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+    }
+
+    private static func environmentFingerprint(_ environment: [String: String]) -> Int {
+        var hasher = Hasher()
+        for key in environment.keys.sorted() {
+            hasher.combine(key)
+            hasher.combine(environment[key])
+        }
+        return hasher.finalize()
     }
 
     private static func redactedStateDescription(_ paths: StatePaths) -> String {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// The single source of truth for RepoPrompt-managed Codex runtime selection and state.
 ///
-/// Production defaults to the verified bundled package for the running architecture. The
-/// only user-configurable external fallback is an absolute path supplied through
+/// Production defaults to the verified bundled package for the running architecture. Advanced
+/// users may explicitly select an absolute executable in Settings or supply one through
 /// `REPOPROMPT_CODEX_EXECUTABLE`; ordinary PATH lookup is intentionally not consulted.
 enum CodexRuntimeAuthority {
     static let bundledVersion = Version(major: 0, minor: 149, patch: 0)
@@ -87,15 +87,15 @@ enum CodexRuntimeAuthority {
             case let .bundledLayoutIncomplete(target, component):
                 "RepoPrompt could not start Codex: the bundled \(target) package is incomplete at `\(component)`. Reinstall RepoPrompt CE."
             case .externalOverrideMustBeAbsolute:
-                "RepoPrompt could not start Codex: \(externalExecutableOverrideEnvironmentKey) must be an absolute executable path. PATH lookup is not used."
+                "RepoPrompt could not start Codex: the local executable configured in Settings or \(externalExecutableOverrideEnvironmentKey) must use an absolute path. PATH lookup is not used."
             case let .externalOverrideMissing(path):
-                "RepoPrompt could not start Codex: the configured external override does not exist at `\(path)`. Fix or remove \(externalExecutableOverrideEnvironmentKey)."
+                "RepoPrompt could not start Codex: the configured local executable does not exist at `\(path)`. Choose another in Settings, or fix/remove \(externalExecutableOverrideEnvironmentKey)."
             case let .externalOverrideNotExecutable(path):
-                "RepoPrompt could not start Codex: the configured external override is not an executable file at `\(path)`. Fix or remove \(externalExecutableOverrideEnvironmentKey)."
+                "RepoPrompt could not start Codex: the configured local executable is not executable at `\(path)`. Choose another in Settings, or fix/remove \(externalExecutableOverrideEnvironmentKey)."
             case let .externalOverrideVersionUnreadable(path):
-                "RepoPrompt could not start Codex: the external override at `\(path)` did not report a compatible Codex version. Version \(minimumExternalVersion) or newer is required by RepoPrompt's app-server contract."
+                "RepoPrompt could not start Codex: the local executable at `\(path)` did not report a compatible Codex version. Version \(minimumExternalVersion) or newer is required by RepoPrompt's app-server contract."
             case let .externalOverrideTooOld(actual, minimum):
-                "RepoPrompt could not start Codex: external override version \(actual) is too old. Version \(minimum) or newer is required by RepoPrompt's app-server contract; update the explicit override or remove \(externalExecutableOverrideEnvironmentKey) to use bundled Codex \(bundledVersion)."
+                "RepoPrompt could not start Codex: local version \(actual) is too old. Version \(minimum) or newer is required by RepoPrompt's app-server contract; update the configured executable or remove it to use bundled Codex \(bundledVersion)."
             }
         }
     }
@@ -321,6 +321,52 @@ enum CodexRuntimeAuthority {
                 source: .bundled(target: architectureTarget),
                 statePaths: state
             )
+        )
+    }
+
+    /// Resolves the production configuration without making persistence part of the pure
+    /// validation path. A call-site override wins, followed by the Settings choice, environment,
+    /// and finally the bundled runtime. An explicitly bundled selection suppresses the legacy
+    /// environment override so the visible choice remains authoritative.
+    static func resolveConfigured(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        resourcesURL: URL? = Bundle.main.resourceURL,
+        architectureTarget: String? = currentArchitectureTarget,
+        applicationSupportURL: URL? = nil,
+        explicitExecutableOverride: String? = nil,
+        defaults: UserDefaults = .standard,
+        externalVersionReader: ((URL) -> String?)? = nil
+    ) -> Result<Runtime, Failure> {
+        if let explicitExecutableOverride {
+            return resolve(
+                environment: environment,
+                resourcesURL: resourcesURL,
+                architectureTarget: architectureTarget,
+                applicationSupportURL: applicationSupportURL,
+                explicitExecutableOverride: explicitExecutableOverride,
+                externalVersionReader: externalVersionReader
+            )
+        }
+
+        var configuredEnvironment = environment
+        let configuredOverride: String?
+        switch CodexRuntimePreferences.selection(defaults: defaults) {
+        case .inherited:
+            configuredOverride = nil
+        case .bundled:
+            configuredEnvironment.removeValue(forKey: externalExecutableOverrideEnvironmentKey)
+            configuredOverride = nil
+        case let .external(path):
+            configuredOverride = path
+        }
+
+        return resolve(
+            environment: configuredEnvironment,
+            resourcesURL: resourcesURL,
+            architectureTarget: architectureTarget,
+            applicationSupportURL: applicationSupportURL,
+            explicitExecutableOverride: configuredOverride,
+            externalVersionReader: externalVersionReader
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimePreferences.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimePreferences.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Persists the Codex runtime source explicitly selected in Settings.
+///
+/// An absent selection preserves the existing environment-override behavior. The runtime authority
+/// owns executable validation; this type only normalizes and stores the user's choice.
+enum CodexRuntimePreferences {
+    enum Selection: Equatable {
+        case inherited
+        case bundled
+        case external(path: String)
+    }
+
+    private static let selectionModeKey = "codexRuntimeSelectionMode"
+    private static let executablePathKey = "codexRuntimeExecutablePath"
+
+    static func selection(defaults: UserDefaults = .standard) -> Selection {
+        switch defaults.string(forKey: selectionModeKey) {
+        case "bundled":
+            .bundled
+        case "external":
+            normalizedPath(defaults.string(forKey: executablePathKey)).map { .external(path: $0) }
+                ?? .inherited
+        default:
+            .inherited
+        }
+    }
+
+    static func setSelection(_ selection: Selection, defaults: UserDefaults = .standard) {
+        switch selection {
+        case .inherited:
+            defaults.removeObject(forKey: selectionModeKey)
+            defaults.removeObject(forKey: executablePathKey)
+        case .bundled:
+            defaults.set("bundled", forKey: selectionModeKey)
+            defaults.removeObject(forKey: executablePathKey)
+        case let .external(path):
+            guard let path = normalizedPath(path) else {
+                setSelection(.inherited, defaults: defaults)
+                return
+            }
+            defaults.set("external", forKey: selectionModeKey)
+            defaults.set(path, forKey: executablePathKey)
+        }
+    }
+
+    private static func normalizedPath(_ path: String?) -> String? {
+        guard let path = path?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+            return nil
+        }
+        return path
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimePreferences.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimePreferences.swift
@@ -11,6 +11,10 @@ enum CodexRuntimePreferences {
         case external(path: String)
     }
 
+    /// Capture before the first runtime resolution or Settings write. Pending choices only
+    /// become active in the next process, including when Settings opens before any client.
+    static let activeSelection = selection()
+
     private static let selectionModeKey = "codexRuntimeSelectionMode"
     private static let executablePathKey = "codexRuntimeExecutablePath"
 
@@ -27,6 +31,7 @@ enum CodexRuntimePreferences {
     }
 
     static func setSelection(_ selection: Selection, defaults: UserDefaults = .standard) {
+        _ = activeSelection
         switch selection {
         case .inherited:
             defaults.removeObject(forKey: selectionModeKey)

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPIntegrationHelper.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPIntegrationHelper.swift
@@ -579,8 +579,10 @@ enum MCPIntegrationHelper {
     /// Invoked from the UI when users opt-in to the integration. Ensures our MCP server exists and is
     /// enabled globally so Codex can use it outside of discovery runs.
     @discardableResult
-    static func installInCodex() -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
-        let result = CodexIntegrationConfiguration.installPersistentMCPConfig()
+    static func installInCodex(
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot? = nil
+    ) -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
+        let result = CodexIntegrationConfiguration.installPersistentMCPConfig(launchSnapshot: launchSnapshot)
         if result.success {
             // Also install Codex slash commands for MCP tool usage.
             installCodexCommands(useCLIVariant: false)
@@ -593,8 +595,10 @@ enum MCPIntegrationHelper {
     /// `enabled = false` so normal Codex usage stays opt-in, while the agent enables it at runtime via
     /// `-c` overrides.
     @discardableResult
-    static func ensureCodexServerForDiscovery() -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
-        CodexIntegrationConfiguration.ensureServerForDiscovery()
+    static func ensureCodexServerForDiscovery(
+        launchSnapshot: CodexRuntimeAuthority.LaunchSnapshot? = nil
+    ) -> (success: Bool, wasAlreadyPresent: Bool, errorMessage: String?) {
+        CodexIntegrationConfiguration.ensureServerForDiscovery(launchSnapshot: launchSnapshot)
     }
 
     static func codexConfigContainsRepoPrompt() -> Bool {

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -163,7 +163,7 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
             )
         )
         XCTAssertTrue(
-            failure(from: old)?.localizedDescription?.contains("update the configured executable") == true
+            failure(from: old)?.localizedDescription.contains("update the configured executable") == true
         )
 
         let prerelease = CodexRuntimeAuthority.resolve(
@@ -201,7 +201,7 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         )
         XCTAssertEqual(failure(from: missingResult), .externalOverrideMissing(missing.path))
         XCTAssertTrue(
-            failure(from: missingResult)?.localizedDescription?.contains("Choose another in Settings") == true
+            failure(from: missingResult)?.localizedDescription.contains("Choose another in Settings") == true
         )
     }
 
@@ -232,7 +232,7 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
                 environment: environmentValues,
                 resourcesURL: resources,
                 architectureTarget: "aarch64-apple-darwin",
-                applicationSupportURL: temporaryDirectory,
+                applicationSupportURL: self.temporaryDirectory,
                 defaults: defaults,
                 launchSnapshot: snapshot,
                 externalVersionReader: { url in

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -162,6 +162,9 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
                 minimum: .init(major: 0, minor: 149, patch: 0)
             )
         )
+        XCTAssertTrue(
+            failure(from: old)?.localizedDescription?.contains("update the configured executable") == true
+        )
 
         let prerelease = CodexRuntimeAuthority.resolve(
             resourcesURL: nil,
@@ -190,17 +193,138 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         )
 
         let missing = temporaryDirectory.appendingPathComponent("external/missing-codex")
-        XCTAssertEqual(
-            failure(
-                from: CodexRuntimeAuthority.resolve(
-                    resourcesURL: nil,
-                    applicationSupportURL: temporaryDirectory,
-                    explicitExecutableOverride: missing.path,
-                    externalVersionReader: { _ in "codex-cli 0.149.0" }
-                )
-            ),
-            .externalOverrideMissing(missing.path)
+        let missingResult = CodexRuntimeAuthority.resolve(
+            resourcesURL: nil,
+            applicationSupportURL: temporaryDirectory,
+            explicitExecutableOverride: missing.path,
+            externalVersionReader: { _ in "codex-cli 0.149.0" }
         )
+        XCTAssertEqual(failure(from: missingResult), .externalOverrideMissing(missing.path))
+        XCTAssertTrue(
+            failure(from: missingResult)?.localizedDescription?.contains("Choose another in Settings") == true
+        )
+    }
+
+    func testInjectedLaunchSnapshotsPreserveBundledLocalBundledChoices() throws {
+        let resources = temporaryDirectory.appendingPathComponent("Resources", isDirectory: true)
+        let environment = temporaryDirectory.appendingPathComponent("environment/codex")
+        let selected = temporaryDirectory.appendingPathComponent("selected/codex")
+        try makeExecutable(at: environment, content: "#!/bin/sh\necho 'codex 0.153.3'\n")
+        try makeExecutable(at: selected, content: "#!/bin/sh\necho 'codex 0.154.0'\n")
+        let bundledExecutable = try makePackage(in: resources, target: "aarch64-apple-darwin")
+        let suiteName = "CodexRuntimeLaunchSnapshotTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        CodexRuntimePreferences.setSelection(.bundled, defaults: defaults)
+        let bundledSnapshot = CodexRuntimeAuthority.makeLaunchSnapshot(defaults: defaults)
+        CodexRuntimePreferences.setSelection(.external(path: selected.path), defaults: defaults)
+        let localSnapshot = CodexRuntimeAuthority.makeLaunchSnapshot(defaults: defaults)
+        CodexRuntimePreferences.setSelection(.bundled, defaults: defaults)
+        let bundledAgainSnapshot = CodexRuntimeAuthority.makeLaunchSnapshot(defaults: defaults)
+
+        let environmentValues = [
+            "PATH": temporaryDirectory.path,
+            CodexRuntimeAuthority.externalExecutableOverrideEnvironmentKey: environment.path
+        ]
+        let resolve: (CodexRuntimeAuthority.LaunchSnapshot) throws -> CodexRuntimeAuthority.Runtime = { snapshot in
+            try CodexRuntimeAuthority.resolveConfigured(
+                environment: environmentValues,
+                resourcesURL: resources,
+                architectureTarget: "aarch64-apple-darwin",
+                applicationSupportURL: temporaryDirectory,
+                defaults: defaults,
+                launchSnapshot: snapshot,
+                externalVersionReader: { url in
+                    url == selected ? "codex 0.154.0" : nil
+                }
+            ).get()
+        }
+
+        XCTAssertEqual(try resolve(bundledSnapshot).executableURL, bundledExecutable)
+        XCTAssertEqual(try resolve(localSnapshot).executableURL, selected)
+        XCTAssertEqual(try resolve(bundledAgainSnapshot).executableURL, bundledExecutable)
+    }
+
+    func testDefaultsMigrationFeedsIsolatedLaunchSnapshotForBundledAndExternalSelections() throws {
+        let externalPath = temporaryDirectory.appendingPathComponent("legacy/codex").path
+        let cases: [(expected: CodexRuntimePreferences.Selection, legacyDomain: [String: Any])] = [
+            (
+                expected: .bundled,
+                legacyDomain: ["codexRuntimeSelectionMode": "bundled"]
+            ),
+            (
+                expected: .external(path: externalPath),
+                legacyDomain: [
+                    "codexRuntimeSelectionMode": "external",
+                    "codexRuntimeExecutablePath": externalPath
+                ]
+            )
+        ]
+
+        for testCase in cases {
+            let successorDomainName = "CodexRuntimeMigrationSnapshotTests-\(UUID().uuidString)"
+            let legacyDomainName = "\(successorDomainName).legacy"
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: successorDomainName))
+            defer {
+                defaults.removePersistentDomain(forName: successorDomainName)
+                defaults.removePersistentDomain(forName: legacyDomainName)
+            }
+            defaults.removePersistentDomain(forName: successorDomainName)
+            defaults.removePersistentDomain(forName: legacyDomainName)
+            defaults.setPersistentDomain(testCase.legacyDomain, forName: legacyDomainName)
+
+            let report = BundleIdentityDefaultsMigration.migrateIfNeeded(
+                bundleIdentifier: RuntimeCodeSigningPolicy.successorDeveloperIDBundleIdentifier,
+                defaults: defaults,
+                legacyDomainName: legacyDomainName,
+                successorDomainName: successorDomainName
+            )
+            XCTAssertEqual(report.outcome, .migrated)
+
+            let snapshot = CodexRuntimeAuthority.makeLaunchSnapshot(defaults: defaults)
+            XCTAssertEqual(snapshot.selection, testCase.expected)
+        }
+    }
+
+    func testNewlyPreparedClientsKeepLaunchAuthorityAfterPendingPreferenceWrite() async throws {
+        let environment = temporaryDirectory.appendingPathComponent("environment/codex")
+        let pending = temporaryDirectory.appendingPathComponent("pending/codex")
+        try makeExecutable(at: environment, content: "#!/bin/sh\necho 'codex 0.153.3'\n")
+        try makeExecutable(at: pending, content: "#!/bin/sh\necho 'codex 0.154.0'\n")
+        let suiteName = "CodexRuntimeClientSnapshotTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        CodexRuntimePreferences.setSelection(.inherited, defaults: defaults)
+        let launchSnapshot = CodexRuntimeAuthority.makeLaunchSnapshot(defaults: defaults)
+        CodexRuntimePreferences.setSelection(.external(path: pending.path), defaults: defaults)
+
+        let environmentValues = [
+            "HOME": temporaryDirectory.path,
+            CodexRuntimeAuthority.externalExecutableOverrideEnvironmentKey: environment.path
+        ]
+        func makeClient() -> CodexAppServerClient {
+            CodexAppServerClient(
+                processEnvironmentBuilder: { _ in
+                    ProcessEnvironmentResult(
+                        environment: environmentValues,
+                        launchContext: .detect(from: environmentValues),
+                        shellEnvironmentSource: .capturedLoginShell
+                    )
+                },
+                runtimeStatePreparer: { _ in },
+                launchSnapshot: launchSnapshot,
+                provisionsRepoPromptMCPOnStart: false
+            )
+        }
+
+        let first = try await makeClient().prepareRuntimeForLaunch()
+        let newlyPrepared = try await makeClient().prepareRuntimeForLaunch()
+        XCTAssertEqual(first, newlyPrepared)
+        XCTAssertEqual(first.executableURL, environment)
+        XCTAssertEqual(first.version, .init(major: 0, minor: 153, patch: 3))
+        XCTAssertNotEqual(first.executableURL, pending)
     }
 
     func testOverrideEnvironmentIsTheOnlyFallbackWhenBundleIsMissing() throws {
@@ -308,6 +432,72 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         XCTAssertEqual(
             execProcessConfiguration.environment["CODEX_SQLITE_HOME"],
             resolution.runtime?.statePaths.sqliteHome.path
+        )
+    }
+
+    func testCapturedShellEnvironmentIsUsedByVersionProbeForInterpreterScripts() async throws {
+        let bin = temporaryDirectory.appendingPathComponent("shell-bin", isDirectory: true)
+        let node = bin.appendingPathComponent("node")
+        let codex = bin.appendingPathComponent("codex")
+        try makeExecutable(at: node, content: "#!/bin/sh\necho 'codex-cli 0.149.0'\n")
+        try makeExecutable(at: codex, content: "#!/usr/bin/env node\n")
+
+        let temporaryPath = temporaryDirectory.path
+        let resolution = await CodexProviderHelpers.preflightCodexExecutable(
+            inheritedEnvironment: ["HOME": temporaryPath],
+            shellEnvironmentProvider: { _, _ in
+                CLIEnvironmentSnapshot(
+                    environment: [
+                        "HOME": temporaryPath,
+                        "PATH": bin.path,
+                        CodexRuntimeAuthority.externalExecutableOverrideEnvironmentKey: codex.path
+                    ],
+                    source: .capturedLoginShell
+                )
+            }
+        )
+
+        XCTAssertEqual(resolution.status, .available)
+        XCTAssertEqual(resolution.resolvedCommand, codex.path)
+        XCTAssertEqual(resolution.runtime?.version, .init(major: 0, minor: 149, patch: 0))
+    }
+
+    func testVersionProbeCacheSeparatesCapturedPATHForSameExecutableMetadata() throws {
+        let firstBin = temporaryDirectory.appendingPathComponent("first-shell-bin", isDirectory: true)
+        let secondBin = temporaryDirectory.appendingPathComponent("second-shell-bin", isDirectory: true)
+        let firstInterpreter = firstBin.appendingPathComponent("node")
+        let secondInterpreter = secondBin.appendingPathComponent("node")
+        let codex = temporaryDirectory.appendingPathComponent("codex")
+        try makeExecutable(at: firstInterpreter, content: "#!/bin/sh\necho 'codex-cli 0.149.0'\n")
+        try makeExecutable(at: secondInterpreter, content: "#!/bin/sh\necho 'codex-cli 0.150.0'\n")
+        try makeExecutable(at: codex, content: "#!/usr/bin/env node\n")
+        let metadataBefore = try FileManager.default.attributesOfItem(atPath: codex.path)
+
+        let first = try CodexRuntimeAuthority.resolve(
+            environment: ["PATH": firstBin.path],
+            resourcesURL: nil,
+            applicationSupportURL: temporaryDirectory,
+            explicitExecutableOverride: codex.path
+        ).get()
+        let second = try CodexRuntimeAuthority.resolve(
+            environment: ["PATH": secondBin.path],
+            resourcesURL: nil,
+            applicationSupportURL: temporaryDirectory,
+            explicitExecutableOverride: codex.path
+        ).get()
+        let metadataAfter = try FileManager.default.attributesOfItem(atPath: codex.path)
+
+        XCTAssertEqual(first.executableURL.path, codex.path)
+        XCTAssertEqual(second.executableURL.path, codex.path)
+        XCTAssertEqual(first.version, .init(major: 0, minor: 149, patch: 0))
+        XCTAssertEqual(second.version, .init(major: 0, minor: 150, patch: 0))
+        XCTAssertEqual(
+            (metadataBefore[.size] as? NSNumber)?.uint64Value,
+            (metadataAfter[.size] as? NSNumber)?.uint64Value
+        )
+        XCTAssertEqual(
+            metadataBefore[.modificationDate] as? Date,
+            metadataAfter[.modificationDate] as? Date
         )
     }
 

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -238,7 +238,7 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
             environment: [CodexRuntimeAuthority.externalExecutableOverrideEnvironmentKey: environment.path],
             resourcesURL: nil,
             applicationSupportURL: temporaryDirectory,
-            defaults: defaults,
+            selection: CodexRuntimePreferences.selection(defaults: defaults),
             externalVersionReader: { _ in "codex 0.153.3" }
         ).get()
         XCTAssertEqual(configured.executableURL, selected)
@@ -251,7 +251,7 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
             resourcesURL: resources,
             architectureTarget: "aarch64-apple-darwin",
             applicationSupportURL: temporaryDirectory,
-            defaults: defaults,
+            selection: CodexRuntimePreferences.selection(defaults: defaults),
             externalVersionReader: { _ in "codex 0.153.3" }
         ).get()
         XCTAssertEqual(bundled.executableURL, bundledExecutable)
@@ -261,7 +261,7 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
             environment: [CodexRuntimeAuthority.externalExecutableOverrideEnvironmentKey: environment.path],
             resourcesURL: nil,
             applicationSupportURL: temporaryDirectory,
-            defaults: defaults,
+            selection: CodexRuntimePreferences.selection(defaults: defaults),
             externalVersionReader: { _ in "codex 0.153.3" }
         ).get()
         XCTAssertEqual(fallback.executableURL, environment)
@@ -351,6 +351,51 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         )
 
         XCTAssertNil(rejected.systemCandidate)
+    }
+
+    func testExternalVersionProbeUsesEnvironmentAndSeparatesCachedResults() throws {
+        let bin = temporaryDirectory.appendingPathComponent("interpreter-bin", isDirectory: true)
+        let interpreter = bin.appendingPathComponent("rpce-test-codex-interpreter")
+        let codex = temporaryDirectory.appendingPathComponent("launcher/codex")
+        try makeExecutable(at: interpreter, content: "#!/bin/sh\necho codex-cli 0.153.3\n")
+        try makeExecutable(at: codex, content: "#!/usr/bin/env rpce-test-codex-interpreter\n")
+        let absentEnvironment = ["PATH": "/usr/bin:/bin"]
+        let capturedEnvironment = ["PATH": bin.path + ":/usr/bin:/bin"]
+
+        func resolve(_ environment: [String: String]) -> Result<CodexRuntimeAuthority.Runtime, CodexRuntimeAuthority.Failure> {
+            CodexRuntimeAuthority.resolve(
+                environment: environment,
+                applicationSupportURL: temporaryDirectory,
+                explicitExecutableOverride: codex.path
+            )
+        }
+
+        XCTAssertEqual(failure(from: resolve(absentEnvironment)), .externalOverrideVersionUnreadable(codex.path))
+        XCTAssertEqual(try resolve(capturedEnvironment).get().version, .init(major: 0, minor: 153, patch: 3))
+        XCTAssertEqual(failure(from: resolve(absentEnvironment)), .externalOverrideVersionUnreadable(codex.path))
+    }
+
+    func testPendingSelectionDoesNotChangeRuntimeUntilNextProcess() throws {
+        let original = CodexRuntimePreferences.selection()
+        defer { CodexRuntimePreferences.setSelection(original) }
+        let pending = temporaryDirectory.appendingPathComponent("pending/codex")
+        try makeExecutable(at: pending)
+        let active = CodexRuntimePreferences.activeSelection
+        let before = CodexRuntimeAuthority.resolveConfigured(externalVersionReader: { _ in "codex-cli 0.153.3" })
+
+        CodexRuntimePreferences.setSelection(.external(path: pending.path))
+
+        XCTAssertEqual(CodexRuntimePreferences.selection(), .external(path: pending.path))
+        XCTAssertEqual(CodexRuntimePreferences.activeSelection, active)
+        XCTAssertEqual(
+            CodexRuntimeAuthority.resolveConfigured(externalVersionReader: { _ in "codex-cli 0.153.3" }),
+            before
+        )
+        let preview = try CodexRuntimeAuthority.resolveConfigured(
+            selection: CodexRuntimePreferences.selection(),
+            externalVersionReader: { _ in "codex-cli 0.153.3" }
+        ).get()
+        XCTAssertEqual(preview.executableURL.path, pending.path)
     }
 
     func testManagedAuthGuidanceUsesRepoPromptOwnedLoginFlow() {

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -311,6 +311,48 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         )
     }
 
+    func testSettingsPreflightPreservesVersionManagerSymlinkAndRejectsOldSystemCodex() async throws {
+        let bin = temporaryDirectory.appendingPathComponent("bin", isDirectory: true)
+        let shim = bin.appendingPathComponent("volta-shim")
+        let codex = bin.appendingPathComponent("codex")
+        try makeExecutable(
+            at: shim,
+            content: "#!/bin/sh\n[ \"${0##*/}\" = codex ] || exit 126\necho 'codex-cli 0.153.3'\n"
+        )
+        try FileManager.default.createSymbolicLink(at: codex, withDestinationURL: shim)
+
+        let temporaryPath = temporaryDirectory.path
+        let shellEnvironmentProvider: ProcessEnvironmentBuilder.ShellEnvironmentProvider = { _, _ in
+            CLIEnvironmentSnapshot(
+                environment: ["HOME": temporaryPath, "PATH": bin.path],
+                source: .capturedLoginShell
+            )
+        }
+        let accepted = await CodexProviderHelpers.preflightCodexRuntimeSettings(
+            inheritedEnvironment: ["HOME": temporaryPath],
+            shellEnvironmentProvider: shellEnvironmentProvider
+        )
+
+        XCTAssertEqual(accepted.systemCandidate?.resolvedCommand, codex.path)
+        XCTAssertEqual(accepted.systemCandidate?.runtime?.executableURL.path, codex.path)
+        XCTAssertEqual(accepted.systemCandidate?.runtime?.source, .externalOverride)
+        XCTAssertEqual(accepted.systemCandidate?.runtime?.version, .init(major: 0, minor: 153, patch: 3))
+
+        let oldShim = bin.appendingPathComponent("volta-shim-old")
+        try makeExecutable(
+            at: oldShim,
+            content: "#!/bin/sh\n[ \"${0##*/}\" = codex ] || exit 126\necho 'codex-cli 0.142.0 (too old)'\n"
+        )
+        try FileManager.default.removeItem(at: codex)
+        try FileManager.default.createSymbolicLink(at: codex, withDestinationURL: oldShim)
+        let rejected = await CodexProviderHelpers.preflightCodexRuntimeSettings(
+            inheritedEnvironment: ["HOME": temporaryPath],
+            shellEnvironmentProvider: shellEnvironmentProvider
+        )
+
+        XCTAssertNil(rejected.systemCandidate)
+    }
+
     func testManagedAuthGuidanceUsesRepoPromptOwnedLoginFlow() {
         let guidance = CodexManagedAuthRecoveryClassifier.manualLoginGuidanceMessage
 

--- a/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexRuntimeAuthorityTests.swift
@@ -221,6 +221,52 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         XCTAssertEqual(runtime.source, .externalOverride)
     }
 
+    func testConfiguredRuntimePrefersAndClearsPersistedExecutable() throws {
+        let suiteName = "CodexRuntimePreferencesTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let selected = temporaryDirectory.appendingPathComponent("selected/codex")
+        let environment = temporaryDirectory.appendingPathComponent("environment/codex")
+        try makeExecutable(at: selected)
+        try makeExecutable(at: environment)
+
+        CodexRuntimePreferences.setSelection(.external(path: "   "), defaults: defaults)
+        XCTAssertEqual(CodexRuntimePreferences.selection(defaults: defaults), .inherited)
+        CodexRuntimePreferences.setSelection(.external(path: "  \(selected.path)  "), defaults: defaults)
+
+        let configured = try CodexRuntimeAuthority.resolveConfigured(
+            environment: [CodexRuntimeAuthority.externalExecutableOverrideEnvironmentKey: environment.path],
+            resourcesURL: nil,
+            applicationSupportURL: temporaryDirectory,
+            defaults: defaults,
+            externalVersionReader: { _ in "codex 0.153.3" }
+        ).get()
+        XCTAssertEqual(configured.executableURL, selected)
+
+        CodexRuntimePreferences.setSelection(.bundled, defaults: defaults)
+        let resources = temporaryDirectory.appendingPathComponent("Resources", isDirectory: true)
+        let bundledExecutable = try makePackage(in: resources, target: "aarch64-apple-darwin")
+        let bundled = try CodexRuntimeAuthority.resolveConfigured(
+            environment: [CodexRuntimeAuthority.externalExecutableOverrideEnvironmentKey: environment.path],
+            resourcesURL: resources,
+            architectureTarget: "aarch64-apple-darwin",
+            applicationSupportURL: temporaryDirectory,
+            defaults: defaults,
+            externalVersionReader: { _ in "codex 0.153.3" }
+        ).get()
+        XCTAssertEqual(bundled.executableURL, bundledExecutable)
+
+        CodexRuntimePreferences.setSelection(.inherited, defaults: defaults)
+        let fallback = try CodexRuntimeAuthority.resolveConfigured(
+            environment: [CodexRuntimeAuthority.externalExecutableOverrideEnvironmentKey: environment.path],
+            resourcesURL: nil,
+            applicationSupportURL: temporaryDirectory,
+            defaults: defaults,
+            externalVersionReader: { _ in "codex 0.153.3" }
+        ).get()
+        XCTAssertEqual(fallback.executableURL, environment)
+    }
+
     func testCodexPreflightUsesCapturedLoginShellOverrideInsteadOfInheritedAppEnvironment() async throws {
         let inheritedOverride = temporaryDirectory.appendingPathComponent("inherited/codex")
         let loginShellOverride = temporaryDirectory.appendingPathComponent("login-shell/codex")
@@ -248,7 +294,7 @@ final class CodexRuntimeAuthorityTests: XCTestCase {
         XCTAssertEqual(resolution.resolvedCommand, loginShellOverride.path)
         XCTAssertEqual(resolution.runtime?.source, .externalOverride)
         XCTAssertEqual(resolution.runtime?.version, .init(major: 0, minor: 149, patch: 0))
-        XCTAssertEqual(resolution.displayDescription, "External Codex override 0.149.0 (codex)")
+        XCTAssertEqual(resolution.displayDescription, "Local Codex 0.149.0 (codex)")
         XCTAssertFalse(resolution.displayDescription?.contains(temporaryDirectory.path) == true)
 
         let execProcessConfiguration = CodexExecAgentProvider.processConfiguration(

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -96,8 +96,9 @@ notarization remains enforced by the protected release workflow; if Apple ever
 rejects this policy, stop rather than silently re-signing the upstream payload.
 
 The bundled package is RepoPrompt's default Codex runtime authority; runtime
-selection never falls through to the user's shell `PATH`. Advanced users may set
-one explicit absolute external override with `REPOPROMPT_CODEX_EXECUTABLE`.
+selection never falls through to the user's shell `PATH`. Advanced users may select
+one explicit local executable in Settings or set an absolute override with
+`REPOPROMPT_CODEX_EXECUTABLE`; the Settings choice takes precedence.
 RepoPrompt rejects overrides older than 0.149.0, matching the bundled runtime and
 the documented app-server contract floor. Bundled and external runtimes both use
 RepoPrompt-owned `CODEX_HOME` and `CODEX_SQLITE_HOME` directories under

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -96,8 +96,10 @@ notarization remains enforced by the protected release workflow; if Apple ever
 rejects this policy, stop rather than silently re-signing the upstream payload.
 
 The bundled package is RepoPrompt's default Codex runtime authority; runtime
-selection never falls through to the user's shell `PATH`. Advanced users may select
-one explicit local executable in Settings or set an absolute override with
+selection never falls through to the user's shell `PATH`. Settings shows the
+effective executable and version, and offers a compatible `codex` found in the
+captured login-shell `PATH` as a one-click local selection. Advanced users may also
+select one explicit local executable or set an absolute override with
 `REPOPROMPT_CODEX_EXECUTABLE`; the Settings choice takes precedence.
 RepoPrompt rejects overrides older than 0.149.0, matching the bundled runtime and
 the documented app-server contract floor. Bundled and external runtimes both use

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -100,7 +100,10 @@ selection never falls through to the user's shell `PATH`. Settings shows the
 effective executable and version, and offers a compatible `codex` found in the
 captured login-shell `PATH` as a one-click local selection. Advanced users may also
 select one explicit local executable or set an absolute override with
-`REPOPROMPT_CODEX_EXECUTABLE`; the Settings choice takes precedence.
+`REPOPROMPT_CODEX_EXECUTABLE`; the Settings choice takes precedence. Settings saves
+the next-launch choice while all runtime consumers retain the process-wide active
+selection until relaunch. Version validation uses the captured launch environment,
+including its interpreter search path.
 RepoPrompt rejects overrides older than 0.149.0, matching the bundled runtime and
 the documented app-server contract floor. Bundled and external runtimes both use
 RepoPrompt-owned `CODEX_HOME` and `CODEX_SQLITE_HOME` directories under


### PR DESCRIPTION
## Summary

- add a Runtime selector to Settings → CLI Providers → Codex CLI
- allow choosing the bundled runtime, preserving the existing environment override behavior, or selecting one explicit compatible local executable
- discover a compatible system `codex` from the captured login-shell environment as a one-click choice while preserving version-manager symlink paths such as Volta's
- show the effective executable path and version before restart, and refresh the dynamic model list after restart
- route RepoPrompt's existing Codex runtime consumers through the same configured authority

## Motivation

RepoPrompt bundles a known-compatible Codex build, but advanced users may already have a newer compatible Codex CLI installed. Selecting that executable allows them to use newly advertised models and capabilities without rebuilding RepoPrompt, while retaining the bundled build as the safe default.

Existing installations require no migration: an absent preference keeps the previous `REPOPROMPT_CODEX_EXECUTABLE`-or-bundled behavior.

## Design

The selector keeps three intentionally distinct persisted states:

- **Bundled** — use RepoPrompt's packaged Codex and explicitly ignore the environment override
- **Environment override, otherwise bundled** — preserve the legacy behavior
- **Local executable** — use the selected absolute path

`CodexRuntimePreferences` owns the persisted choice and the process-wide active selection. `CodexRuntimeAuthority.resolveConfigured` remains the single validation/precedence authority. Settings uses the existing captured login-shell environment and path resolver to offer a compatible system Codex, but never auto-selects it or silently falls through to PATH.

Discovery preserves the path under the `codex` basename rather than canonicalizing it to a shared version-manager shim. This is required for launchers such as Volta that dispatch according to the invoked basename. Blocking version probes run off the main actor.

The active selection is frozen before the first runtime resolution or Settings write. Saving a choice stages it for the next launch; existing and newly created clients continue using the same active selection until restart. Settings explicitly previews the pending choice. External version probes receive the captured caller environment, and their cache separates results by environment so interpreter-based launchers are validated correctly. After restart, the existing `CodexModelPollingService` fetches the selected runtime's paginated `model/list`.

## Scope

This PR does not add model constants or special-case GPT-6 Astra. Discovery-driven Max/Ultra parsing remains owned by #953, so the two PRs can merge independently.

## Validation

- live Volta failure reproduced: invoking `~/.volta/bin/codex` reports 0.153.3 while invoking its `volta-shim` target directly fails
- `CodexRuntimeAuthorityTests`: 13/13, including symlink/argv[0] preservation, incompatible-system-version rejection, interpreter-launcher environment/cache separation, and active-versus-pending selection
- full root test suite: passed for the final two-finding remediation at `71478614`
- strict SwiftFormat/SwiftLint: passed
- `RepoPrompt` and `repoprompt-mcp` product builds: passed
- repository commit, push, and PR-ready safety preflights: passed
- two independent exact-patch Oracle reviews: APPROVE; the final two-finding remediation was also approved by both reviewers under YAGNI/KISS and the engineering doctrine
