### PR TITLE
Derive session deletion targets from validated files

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Darwin)
+    import Darwin
+#else
+    import Glibc
+#endif
 
 // MARK: - Agent Session Data Error
 
@@ -518,6 +523,46 @@ actor AgentSessionDataService {
         let start = filename.index(filename.startIndex, offsetBy: prefixLength)
         let end = filename.index(filename.endIndex, offsetBy: -suffixLength)
         return UUID(uuidString: String(filename[start ..< end]))
+    }
+
+    /// Returns only a canonical, real session file directly under `folder`.
+    /// The metadata index is not an authority for this path: callers must discover the URL from the
+    /// folder scan, then validate the filename, filesystem object, canonical parent, and decoded ID.
+    private func canonicalAgentSessionFile(
+        _ fileURL: URL,
+        in folder: URL
+    ) -> (fileURL: URL, sessionID: UUID)? {
+        let standardizedFolder = folder.standardizedFileURL
+        let standardizedFile = fileURL.standardizedFileURL
+        guard standardizedFile.deletingLastPathComponent().path == standardizedFolder.path,
+              let sessionID = agentSessionID(fromFilename: standardizedFile.lastPathComponent),
+              standardizedFile.lastPathComponent == agentSessionFilename(for: sessionID),
+              isRealDirectory(at: standardizedFolder),
+              isRegularFileWithoutSymlinks(at: standardizedFile)
+        else {
+            return nil
+        }
+
+        let canonicalFolder = standardizedFolder.resolvingSymlinksInPath().standardizedFileURL
+        let canonicalFile = standardizedFile.resolvingSymlinksInPath().standardizedFileURL
+        guard canonicalFile.deletingLastPathComponent().path == canonicalFolder.path,
+              canonicalFile.lastPathComponent == standardizedFile.lastPathComponent
+        else {
+            return nil
+        }
+        return (standardizedFile, sessionID)
+    }
+
+    private func isRealDirectory(at url: URL) -> Bool {
+        var info = stat()
+        guard lstat(url.path, &info) == 0 else { return false }
+        return info.st_mode & S_IFMT == S_IFDIR
+    }
+
+    private func isRegularFileWithoutSymlinks(at url: URL) -> Bool {
+        var info = stat()
+        guard lstat(url.path, &info) == 0 else { return false }
+        return info.st_mode & S_IFMT == S_IFREG
     }
 
     private func metadataResourceValues(for fileURL: URL) -> (size: Int64?, modified: Date?) {
@@ -1526,14 +1571,6 @@ actor AgentSessionDataService {
         }
 
         var candidateByPath: [String: (fileURL: URL, tabID: UUID)] = [:]
-        if let index = await readMetadataIndexIfAvailable(folder: agentSessionsFolder) {
-            for record in index.entries {
-                guard let tabID = record.composeTabID, tabIDs.contains(tabID) else { continue }
-                let fileURL = agentSessionsFolder.appendingPathComponent(record.filename)
-                candidateByPath[fileURL.path] = (fileURL, tabID)
-            }
-        }
-
         let files: [URL]
         do {
             files = try await listAgentSessions(for: workspace)
@@ -1542,15 +1579,17 @@ actor AgentSessionDataService {
         }
         for fileURL in files {
             guard
+                let canonicalFile = canonicalAgentSessionFile(fileURL, in: agentSessionsFolder),
                 let stub = try? await loadAgentSessionStub(
-                    from: fileURL,
+                    from: canonicalFile.fileURL,
                     recoverMissingMetadata: false,
                     persistRecoveredMetadata: false
                 ),
+                stub.id == canonicalFile.sessionID,
                 let tabID = stub.composeTabID,
                 tabIDs.contains(tabID)
             else { continue }
-            candidateByPath[fileURL.path] = (fileURL, tabID)
+            candidateByPath[canonicalFile.fileURL.path] = (canonicalFile.fileURL, tabID)
         }
 
         var failures: [UUID: Error] = [:]

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionDataServiceDeletionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionDataServiceDeletionTests.swift
@@ -1,0 +1,235 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class AgentSessionDataServiceDeletionTests: XCTestCase {
+    func testBatchDeleteIgnoresTraversalAndAbsoluteMetadataIndexFilenames() async throws {
+        let cases: [(String, (URL) -> String)] = [
+            ("traversal", { _ in "../external-sentinel.json" }),
+            ("absolute", { storageURL in
+                storageURL.appendingPathComponent("external-sentinel.json").path
+            })
+        ]
+
+        for (label, filenameForStorageURL) in cases {
+            let fixture = try makeFixture()
+            defer { try? FileManager.default.removeItem(at: fixture.storageURL) }
+            let sentinelURL = fixture.storageURL.appendingPathComponent("external-sentinel.json")
+            try Data("sentinel-\(label)".utf8).write(to: sentinelURL, options: .atomic)
+            try writeMetadataIndex(filename: filenameForStorageURL(fixture.storageURL), fixture: fixture)
+
+            let failures = await fixture.service.deleteAgentSessions(
+                forComposeTabIDs: [fixture.tabID],
+                for: fixture.workspace
+            )
+
+            XCTAssertTrue(failures.isEmpty, "\(label): \(failures)")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: sentinelURL.path), label)
+        }
+    }
+
+    func testBatchDeleteIgnoresNestedAndMalformedMetadataIndexFilenames() async throws {
+        let cases: [(String, String, String)] = [
+            ("nested", "nested/nested-sentinel.json", "nested/nested-sentinel.json"),
+            ("malformed", "AgentSession-not-a-uuid.json", "AgentSession-not-a-uuid.json")
+        ]
+
+        for (label, indexFilename, targetRelativePath) in cases {
+            let fixture = try makeFixture()
+            defer { try? FileManager.default.removeItem(at: fixture.storageURL) }
+            let targetURL = fixture.agentSessionsFolder.appendingPathComponent(targetRelativePath)
+            try FileManager.default.createDirectory(
+                at: targetURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("sentinel-\(label)".utf8).write(to: targetURL, options: .atomic)
+            try writeMetadataIndex(filename: indexFilename, fixture: fixture)
+
+            let failures = await fixture.service.deleteAgentSessions(
+                forComposeTabIDs: [fixture.tabID],
+                for: fixture.workspace
+            )
+
+            XCTAssertTrue(failures.isEmpty, "\(label): \(failures)")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: targetURL.path), label)
+        }
+    }
+
+    func testBatchDeleteRejectsMismatchedFilenameAndDecodedSessionID() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.storageURL) }
+        let otherSessionID = UUID()
+        let mismatchedFilename = agentSessionFilename(for: otherSessionID)
+        let mismatchedURL = fixture.agentSessionsFolder.appendingPathComponent(mismatchedFilename)
+        try writeSession(
+            AgentSession(
+                id: fixture.sessionID,
+                workspaceID: fixture.workspace.id,
+                composeTabID: fixture.tabID,
+                name: "Mismatched session identity",
+                itemCount: 0
+            ),
+            to: mismatchedURL
+        )
+        try writeMetadataIndex(filename: mismatchedFilename, fixture: fixture)
+
+        let failures = await fixture.service.deleteAgentSessions(
+            forComposeTabIDs: [fixture.tabID],
+            for: fixture.workspace
+        )
+
+        XCTAssertTrue(failures.isEmpty, "\(failures)")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mismatchedURL.path))
+    }
+
+    func testBatchDeleteRejectsMismatchedComposeTabID() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.storageURL) }
+        let otherTabID = UUID()
+        let sessionURL = fixture.agentSessionsFolder.appendingPathComponent(agentSessionFilename(for: fixture.sessionID))
+        try writeSession(
+            AgentSession(
+                id: fixture.sessionID,
+                workspaceID: fixture.workspace.id,
+                composeTabID: otherTabID,
+                name: "Mismatched tab identity",
+                itemCount: 0
+            ),
+            to: sessionURL
+        )
+        try writeMetadataIndex(filename: sessionURL.lastPathComponent, fixture: fixture)
+
+        let failures = await fixture.service.deleteAgentSessions(
+            forComposeTabIDs: [fixture.tabID],
+            for: fixture.workspace
+        )
+
+        XCTAssertTrue(failures.isEmpty, "\(failures)")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sessionURL.path))
+    }
+
+    func testBatchDeleteRejectsSymlinkedSessionFileAndPreservesExternalSentinel() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.storageURL) }
+        let sentinelURL = fixture.storageURL.appendingPathComponent("symlink-sentinel.json")
+        try writeSession(
+            AgentSession(
+                id: fixture.sessionID,
+                workspaceID: fixture.workspace.id,
+                composeTabID: fixture.tabID,
+                name: "Symlink sentinel",
+                itemCount: 0
+            ),
+            to: sentinelURL
+        )
+        let symlinkURL = fixture.agentSessionsFolder.appendingPathComponent(agentSessionFilename(for: fixture.sessionID))
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: sentinelURL)
+        try writeMetadataIndex(filename: symlinkURL.lastPathComponent, fixture: fixture)
+
+        let failures = await fixture.service.deleteAgentSessions(
+            forComposeTabIDs: [fixture.tabID],
+            for: fixture.workspace
+        )
+
+        XCTAssertTrue(failures.isEmpty, "\(failures)")
+        XCTAssertNotNil(try? FileManager.default.destinationOfSymbolicLink(atPath: symlinkURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sentinelURL.path))
+    }
+
+    func testBatchDeleteRemovesValidIndexedSessionFile() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.storageURL) }
+        let sessionURL = fixture.agentSessionsFolder.appendingPathComponent(agentSessionFilename(for: fixture.sessionID))
+        try writeSession(
+            AgentSession(
+                id: fixture.sessionID,
+                workspaceID: fixture.workspace.id,
+                composeTabID: fixture.tabID,
+                name: "Valid session",
+                itemCount: 0
+            ),
+            to: sessionURL
+        )
+        try writeMetadataIndex(filename: sessionURL.lastPathComponent, fixture: fixture)
+
+        let failures = await fixture.service.deleteAgentSessions(
+            forComposeTabIDs: [fixture.tabID],
+            for: fixture.workspace
+        )
+
+        XCTAssertTrue(failures.isEmpty, "\(failures)")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sessionURL.path))
+    }
+
+    private struct BatchDeleteFixture {
+        let service: AgentSessionDataService
+        let workspace: WorkspaceModel
+        let storageURL: URL
+        let agentSessionsFolder: URL
+        let sessionID: UUID
+        let tabID: UUID
+    }
+
+    private func makeFixture() throws -> BatchDeleteFixture {
+        let storageURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentSessionDataServiceDeletionTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let agentSessionsFolder = storageURL.appendingPathComponent("AgentSessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: agentSessionsFolder, withIntermediateDirectories: true)
+        let workspace = WorkspaceModel(
+            name: "Agent Session Deletion",
+            repoPaths: ["/tmp/repo"],
+            customStoragePath: storageURL
+        )
+        return BatchDeleteFixture(
+            service: AgentSessionDataService(),
+            workspace: workspace,
+            storageURL: storageURL,
+            agentSessionsFolder: agentSessionsFolder,
+            sessionID: UUID(),
+            tabID: UUID()
+        )
+    }
+
+    private func writeMetadataIndex(filename: String, fixture: BatchDeleteFixture) throws {
+        let timestamp = Date(timeIntervalSinceReferenceDate: 1)
+        let record = AgentSessionMetadataRecord(
+            id: fixture.sessionID,
+            filename: filename,
+            workspaceID: fixture.workspace.id,
+            composeTabID: fixture.tabID,
+            name: "Indexed session",
+            savedAt: timestamp,
+            lastUserMessageAt: nil,
+            itemCount: 0,
+            transcriptProjectionCounts: nil,
+            hasUnknownConversationContent: false,
+            agentKindRaw: nil,
+            agentModelRaw: nil,
+            agentReasoningEffortRaw: nil,
+            lastRunStateRaw: nil,
+            autoEditEnabled: true,
+            parentSessionID: nil,
+            isMCPOriginated: false,
+            serializationVersion: nil,
+            observedFileSize: nil,
+            observedFileModificationDate: nil,
+            lastIndexedAt: timestamp
+        )
+        let index = AgentSessionMetadataIndex(entries: [record])
+        let indexURL = fixture.agentSessionsFolder.appendingPathComponent("AgentSessionIndex.json")
+        try JSONEncoder().encode(index).write(to: indexURL, options: .atomic)
+    }
+
+    private func writeSession(_ session: AgentSession, to fileURL: URL) throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try JSONEncoder().encode(session).write(to: fileURL, options: .atomic)
+    }
+
+    private func agentSessionFilename(for id: UUID) -> String {
+        "AgentSession-\(id.uuidString).json"
+    }
+}


### PR DESCRIPTION
A corrupt conversation index can provide an arbitrary deletion filename when its compose tab is removed. Derive deletion candidates from direct session-folder entries instead, require a canonical UUID filename with matching decoded session/tab identity, and reject a symlinked session directory or leaf. The index remains a projection and no longer supplies destructive paths.

Fixes #861.

Validation: coordinated formatting, strict lint, six focused deletion tests and the RepoPrompt product build passed. The same tests fail on unchanged production code with six safety assertion failures across five methods, including deletion of a traversal sentinel; valid deletion passes on both versions. Independent engineer and pair reviews completed; the ancestor-of-configured-root finding was adjudicated as existing trusted custom-storage behavior, outside the index-controlled path defect. This does not claim protection against concurrent replacement of the trusted storage root. Fixtures use isolated temporary storage; no user data was modified. Hosted integration and packaged deletion/upgrade acceptance remain pending.
