### PR TITLE
Preserve competing files during exclusive creation

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
@@ -387,7 +387,11 @@ extension FileSystemService {
         completeMutationWaiter(mutationID)
     }
 
-    func createFile(atRelativePath relativePath: String, content: String) async throws {
+    func createFile(
+        atRelativePath relativePath: String,
+        content: String,
+        overwrite: Bool = false
+    ) async throws {
         try Task.checkCancellation()
         let fm = fm
         let target = try mutationTarget(forRelativePath: relativePath)
@@ -399,8 +403,14 @@ extension FileSystemService {
         try physicalMutationGuard?.revalidate()
         try fm.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
         _ = try mutationTarget(forRelativePath: target.relativePath)
-        guard !fm.fileExists(atPath: fullPath, isDirectory: nil) else {
-            throw FileSystemError.fileAlreadyExists
+        var isDirectory = ObjCBool(false)
+        if fm.fileExists(atPath: fullPath, isDirectory: &isDirectory) {
+            if isDirectory.boolValue {
+                throw FileSystemError.isDirectory
+            }
+            guard overwrite else {
+                throw FileSystemError.fileAlreadyExists
+            }
         }
 
         // Materializing a large Swift String as UTF-8 is synchronous and potentially expensive.
@@ -408,8 +418,14 @@ extension FileSystemService {
         // the actor-owned waiter while preparation and the uncancellable disk write continue.
         #if DEBUG
             let dataPreparation = createFileDataPreparationForTesting
+            let exclusiveRename = createFileExclusiveRenameForTesting
+            let posixFailureAfterOpen = createFilePOSIXFailureAfterOpenForTesting
+            let fallbackPOSIXFailureAfterOpen = createFileFallbackPOSIXFailureAfterOpenForTesting
         #else
             let dataPreparation: (@Sendable (String) async throws -> Data)? = nil
+            let exclusiveRename: (@Sendable (String, String) -> Int32)? = nil
+            let posixFailureAfterOpen: Int32? = nil
+            let fallbackPOSIXFailureAfterOpen: (@Sendable (String) -> Int32)? = nil
         #endif
         let mutation = try await startUncancellableMutation(
             .create,
@@ -428,7 +444,17 @@ extension FileSystemService {
                 )
             }
             try await executor {
-                try FileSystemService.writeFileRobust(to: fullURL, data: data)
+                if overwrite {
+                    try FileSystemService.writeFileRobust(to: fullURL, data: data)
+                } else {
+                    try FileSystemService.writeFileNoClobber(
+                        to: fullURL,
+                        data: data,
+                        exclusiveRename: exclusiveRename,
+                        posixFailureAfterOpen: posixFailureAfterOpen,
+                        fallbackPOSIXFailureAfterOpen: fallbackPOSIXFailureAfterOpen
+                    )
+                }
             }
         }
         Task.detached { [weak self] in
@@ -438,6 +464,16 @@ extension FileSystemService {
                     mutationID: mutation.id,
                     relativePath: target.relativePath,
                     url: fullURL
+                )
+            } catch FileSystemError.fileAlreadyExists {
+                await self?.completeMutationWaiter(
+                    mutation.id,
+                    error: FileSystemError.fileAlreadyExists
+                )
+            } catch let error as FileSystemError {
+                await self?.completeMutationWaiter(
+                    mutation.id,
+                    error: error
                 )
             } catch {
                 await self?.completeMutationWaiter(
@@ -839,14 +875,117 @@ extension FileSystemService {
         try data.write(to: url, options: .atomic) // blocking write
     }
 
+    /// Creates a file without replacing a destination that appears after preflight.
+    ///
+    /// The temporary-file publication keeps the normal local-filesystem path atomic. The
+    /// exclusive-open fallback is for filesystems that do not support RENAME_EXCL; neither
+    /// path can replace or truncate an existing destination.
+    private static func writeFileNoClobber(
+        to url: URL,
+        data: Data,
+        exclusiveRename: (@Sendable (String, String) -> Int32)? = nil,
+        posixFailureAfterOpen: Int32? = nil,
+        fallbackPOSIXFailureAfterOpen: (@Sendable (String) -> Int32)? = nil
+    ) throws {
+        let temporaryURL = url.deletingLastPathComponent()
+            .appendingPathComponent(".repoprompt.create.\(UUID().uuidString).tmp")
+        var temporaryExists = false
+        defer {
+            if temporaryExists {
+                _ = unlink(temporaryURL.path)
+            }
+        }
+
+        try writeFilePOSIXNoClobber(
+            to: temporaryURL,
+            data: data,
+            postOpenFailure: posixFailureAfterOpen,
+            didOpen: { temporaryExists = true }
+        )
+
+        let renameError: Int32
+        if let exclusiveRename {
+            let simulatedError = exclusiveRename(temporaryURL.path, url.path)
+            if simulatedError == 0 {
+                temporaryExists = false
+                return
+            }
+            renameError = simulatedError
+        } else {
+            let renameResult = renamex_np(
+                temporaryURL.path,
+                url.path,
+                UInt32(RENAME_EXCL)
+            )
+            if renameResult == 0 {
+                temporaryExists = false
+                return
+            }
+            renameError = errno
+        }
+        if renameError == EEXIST {
+            throw FileSystemError.fileAlreadyExists
+        }
+        guard renameError == EINVAL ||
+            renameError == ENOTSUP ||
+            renameError == EOPNOTSUPP ||
+            renameError == ENOSYS
+        else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(renameError),
+                userInfo: [NSLocalizedDescriptionKey: "renamex_np(RENAME_EXCL) failed for \(url.path) (\(renameError))"]
+            )
+        }
+
+        // Some external filesystems do not implement RENAME_EXCL. Claim the destination
+        // directly with O_EXCL rather than falling back to replacement semantics. Never remove
+        // the destination here: another writer may have claimed it while rename was unsupported.
+        // Once O_EXCL succeeds, a later write/fsync/close failure retains the claimed path and
+        // reports an explicitly incomplete result instead of attempting a racy unlink.
+        try writeFilePOSIXNoClobber(
+            to: url,
+            data: data,
+            postOpenFailureProvider: fallbackPOSIXFailureAfterOpen,
+            preservePartialOutputOnFailure: true
+        )
+    }
+
+    private static func writeFilePOSIXNoClobber(
+        to url: URL,
+        data: Data,
+        postOpenFailure: Int32? = nil,
+        didOpen: (() -> Void)? = nil,
+        postOpenFailureProvider: (@Sendable (String) -> Int32)? = nil,
+        preservePartialOutputOnFailure: Bool = false
+    ) throws {
+        do {
+            try writeFilePOSIX(
+                to: url,
+                data: data,
+                openFlags: O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+                postOpenFailure: postOpenFailure,
+                didOpen: didOpen,
+                postOpenFailureProvider: postOpenFailureProvider,
+                preservePartialOutputOnFailure: preservePartialOutputOnFailure
+            )
+        } catch let error as NSError where
+            error.domain == NSPOSIXErrorDomain && error.code == Int(EEXIST)
+        {
+            throw FileSystemError.fileAlreadyExists
+        }
+    }
+
     /// Robust write that works across external/network volumes:
     /// 1) try atomic write
-    /// 2) write to temp in the same directory then move into place (delete destination if needed)
+    /// 2) write to temp in the same directory then replace with POSIX rename
     /// 3) POSIX open(O_CREAT|O_TRUNC)+write+fsync fallback
     private static func writeFileRobust(
         to url: URL,
         data: Data
     ) throws {
+        try rejectDirectory(at: url)
+
         // Fast path: try Foundation's atomic write first.
         do {
             try data.write(to: url, options: [.atomic])
@@ -859,16 +998,25 @@ extension FileSystemService {
         let dirURL = url.deletingLastPathComponent()
         let tmpURL = dirURL.appendingPathComponent(".repoprompt.tmp.\(UUID().uuidString)")
 
-        // Fallback #1: write to temp in the same directory then move/replace.
+        // Fallback #1: write to temp in the same directory then replace with rename. POSIX rename
+        // cannot remove a destination directory when the source is a regular file.
         do {
             try data.write(to: tmpURL, options: [])
-            if fm.fileExists(atPath: url.path) {
-                // Removing the destination first avoids exchange/rename restrictions on some filesystems
-                // (exFAT/SMB may reject replace semantics).
-                try? fm.removeItem(at: url)
+            guard rename(tmpURL.path, url.path) == 0 else {
+                let code = errno
+                if code == EISDIR || code == ENOTDIR || isDirectory(at: url) {
+                    throw FileSystemError.isDirectory
+                }
+                throw NSError(
+                    domain: NSPOSIXErrorDomain,
+                    code: Int(code),
+                    userInfo: [NSLocalizedDescriptionKey: "rename() failed for \(url.path) (\(code))"]
+                )
             }
-            try fm.moveItem(at: tmpURL, to: url)
             return
+        } catch FileSystemError.isDirectory {
+            try? fm.removeItem(at: tmpURL)
+            throw FileSystemError.isDirectory
         } catch {
             // Clean up temp if it remains
             try? fm.removeItem(at: tmpURL)
@@ -881,12 +1029,20 @@ extension FileSystemService {
     /// Low-level write that avoids Foundation's atomic/replace semantics entirely.
     private static func writeFilePOSIX(
         to url: URL,
-        data: Data
+        data: Data,
+        openFlags: Int32 = O_WRONLY | O_CREAT | O_TRUNC,
+        postOpenFailure: Int32? = nil,
+        didOpen: (() -> Void)? = nil,
+        postOpenFailureProvider: (@Sendable (String) -> Int32)? = nil,
+        preservePartialOutputOnFailure: Bool = false
     ) throws {
         let path = url.path
-        let fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0o644)
+        let fd = open(path, openFlags, 0o644)
         if fd == -1 {
             let code = errno
+            if code == EISDIR {
+                throw FileSystemError.isDirectory
+            }
             throw NSError(
                 domain: NSPOSIXErrorDomain,
                 code: Int(code),
@@ -894,24 +1050,27 @@ extension FileSystemService {
             )
         }
 
-        var writeError: Int32 = 0
-        data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
-            guard var base = ptr.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
-            var remaining = data.count
-            while remaining > 0 {
-                let n = Darwin.write(fd, base, remaining)
-                if n < 0 {
-                    writeError = errno
-                    break
+        didOpen?()
+        var writeError: Int32 = postOpenFailure ?? postOpenFailureProvider?(path) ?? 0
+        if writeError == 0 {
+            data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
+                guard var base = ptr.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
+                var remaining = data.count
+                while remaining > 0 {
+                    let n = Darwin.write(fd, base, remaining)
+                    if n < 0 {
+                        writeError = errno
+                        break
+                    }
+                    if n == 0 {
+                        // A zero-byte write makes no progress. Treat it as I/O failure instead of
+                        // spinning forever inside an uncancellable mutation worker.
+                        writeError = EIO
+                        break
+                    }
+                    remaining -= n
+                    base = base.advanced(by: n)
                 }
-                if n == 0 {
-                    // A zero-byte write makes no progress. Treat it as I/O failure instead of
-                    // spinning forever inside an uncancellable mutation worker.
-                    writeError = EIO
-                    break
-                }
-                remaining -= n
-                base = base.advanced(by: n)
             }
         }
 
@@ -924,19 +1083,38 @@ extension FileSystemService {
         // Always attempt to close; prefer first error if any.
         let closeResult = close(fd)
         if writeError != 0 {
-            throw NSError(
+            let error = NSError(
                 domain: NSPOSIXErrorDomain,
                 code: Int(writeError),
                 userInfo: [NSLocalizedDescriptionKey: "write/fsync failed for \(path) (\(writeError))"]
             )
+            if preservePartialOutputOnFailure {
+                throw FileSystemError.incompleteFileCreation(path: path, underlying: error)
+            }
+            throw error
         }
         if closeResult != 0 {
             let code = errno
-            throw NSError(
+            let error = NSError(
                 domain: NSPOSIXErrorDomain,
                 code: Int(code),
                 userInfo: [NSLocalizedDescriptionKey: "close() failed for \(path) (\(code))"]
             )
+            if preservePartialOutputOnFailure {
+                throw FileSystemError.incompleteFileCreation(path: path, underlying: error)
+            }
+            throw error
+        }
+    }
+
+    private static func isDirectory(at url: URL) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    private static func rejectDirectory(at url: URL) throws {
+        if isDirectory(at: url) {
+            throw FileSystemError.isDirectory
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
@@ -196,6 +196,16 @@ actor FileSystemService {
         /// Test-only replacement for UTF-8 materialization inside the detached create worker.
         var createFileDataPreparationForTesting: (@Sendable (String) async throws -> Data)?
 
+        /// Test-only result override for the exclusive create publication primitive.
+        /// Zero reports success; a non-zero value is the simulated errno.
+        var createFileExclusiveRenameForTesting: (@Sendable (String, String) -> Int32)?
+
+        /// Test-only errno injected after a successful POSIX create open and before writing.
+        var createFilePOSIXFailureAfterOpenForTesting: Int32?
+
+        /// Test-only failure/replacement hook invoked after the fallback destination O_EXCL open.
+        var createFileFallbackPOSIXFailureAfterOpenForTesting: (@Sendable (String) -> Int32)?
+
         /// Test-only replacement for the real Finder Trash operation.
         var moveItemToTrashIOForTesting: (@Sendable (URL) throws -> Void)?
 
@@ -474,6 +484,22 @@ actor FileSystemService {
             _ preparation: (@Sendable (String) async throws -> Data)?
         ) {
             createFileDataPreparationForTesting = preparation
+        }
+
+        func setCreateFileExclusiveRenameForTesting(
+            _ operation: (@Sendable (String, String) -> Int32)?
+        ) {
+            createFileExclusiveRenameForTesting = operation
+        }
+
+        func setCreateFilePOSIXFailureAfterOpenForTesting(_ errorNumber: Int32?) {
+            createFilePOSIXFailureAfterOpenForTesting = errorNumber
+        }
+
+        func setCreateFileFallbackPOSIXFailureAfterOpenForTesting(
+            _ handler: (@Sendable (String) -> Int32)?
+        ) {
+            createFileFallbackPOSIXFailureAfterOpenForTesting = handler
         }
 
         func setMoveItemToTrashIOForTesting(_ operation: (@Sendable (URL) throws -> Void)?) {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemServiceTypes.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemServiceTypes.swift
@@ -246,6 +246,7 @@ enum FileSystemError: Error {
     case fileAlreadyExists
     case fileNotFound
     case failedToCreateFile(Error)
+    case incompleteFileCreation(path: String, underlying: Error)
     case failedToEditFile(Error)
     case failedToDeleteFile(Error)
     case failedToReadFile
@@ -261,6 +262,14 @@ enum FileSystemError: Error {
 extension FileSystemError: LocalizedError {
     var errorDescription: String? {
         switch self {
+        case .fileAlreadyExists:
+            "The destination file already exists."
+        case let .failedToCreateFile(error):
+            "File creation failed: \(error.localizedDescription)"
+        case let .incompleteFileCreation(path, underlying):
+            "File creation failed after exclusively claiming '\(path)'; incomplete output may remain at that path. Inspect it before retrying and do not blindly retry. Underlying error: \(underlying.localizedDescription)"
+        case .isDirectory:
+            "The destination path is a directory."
         case .invalidRelativePath:
             "Unsafe workspace mutation path: target escapes the loaded root, contains traversal, or uses a symbolic-link component."
         case .mutationInProgress:

--- a/Sources/RepoPrompt/Infrastructure/MCP/ApplyEdits/WorkspaceFileEditHost.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ApplyEdits/WorkspaceFileEditHost.swift
@@ -81,6 +81,7 @@ struct WorkspaceFileEditHost: FileEditHost {
             let writeResult = try await mutationService.createFileWithPostcondition(
                 userPath: path,
                 content: content,
+                overwrite: overwrite,
                 rootScope: lookupRootScope,
                 selectedFileFullPaths: (path as NSString).expandingTildeInPath.hasPrefix("/") ? [] : selectedFileFullPaths(),
                 pathResolutionPolicy: createPathResolutionPolicy,

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleExportFileWriter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleExportFileWriter.swift
@@ -35,10 +35,10 @@ struct GeneratedOracleExportFileWriter {
             let writeResult = try await mutationService.createFileWithPostcondition(
                 userPath: physicalPath,
                 content: content,
+                overwrite: false,
                 rootScope: destination.lookupContext.rootScope,
                 pathResolutionPolicy: .literalPreferredIfStronger
             )
-
             if let reason = writeResult.catalogIneligibility {
                 throw MCPError.invalidParams(
                     "Generated Oracle export was written to '\(logicalPath)', but that path is not readable by read_file because \(reason.description). Remove the workspace policy/ignore exclusion for this export path and try again."
@@ -61,31 +61,14 @@ struct GeneratedOracleExportFileWriter {
                 rootScope: destination.lookupContext.rootScope
             )
             return logicalPath
-        } catch let error as MCPError {
-            await cleanupCreatedExportIfPresent(
-                physicalPath: physicalPath,
-                root: scopedRoot,
-                rootScope: destination.lookupContext.rootScope
-            )
-            throw error
-        } catch is FileManagerError {
-            await cleanupCreatedExportIfPresent(
-                physicalPath: physicalPath,
-                root: scopedRoot,
-                rootScope: destination.lookupContext.rootScope
-            )
+        } catch FileSystemError.fileAlreadyExists {
             throw MCPError.invalidParams(
-                "Cannot create generated Oracle export at '\(logicalPath)': filesystem operation failed."
+                "Cannot create generated Oracle export at '\(logicalPath)': path already exists."
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
-            await cleanupCreatedExportIfPresent(
-                physicalPath: physicalPath,
-                root: scopedRoot,
-                rootScope: destination.lookupContext.rootScope
-            )
-            throw MCPError.invalidParams(
-                "Cannot create generated Oracle export at '\(logicalPath)': export creation or verification failed."
-            )
+            throw partialCreationError(logicalPath: logicalPath, underlying: error)
         }
     }
 
@@ -106,20 +89,9 @@ struct GeneratedOracleExportFileWriter {
         return resolvedPath
     }
 
-    private func cleanupCreatedExportIfPresent(
-        physicalPath: String,
-        root: WorkspaceRootRef,
-        rootScope: WorkspaceLookupRootScope
-    ) async {
-        guard FileManager.default.fileExists(atPath: physicalPath) else { return }
-        try? FileManager.default.removeItem(atPath: physicalPath)
-        let rootPrefix = root.standardizedFullPath.hasSuffix("/") ? root.standardizedFullPath : root.standardizedFullPath + "/"
-        guard physicalPath.hasPrefix(rootPrefix) else { return }
-        let relativePath = StandardizedPath.relative(String(physicalPath.dropFirst(rootPrefix.count)))
-        await store.replayObservedFileSystemDeltas(rootID: root.id, deltas: [.fileRemoved(relativePath)])
-        _ = await store.awaitAppliedIngressForExplicitRequest(
-            userPath: physicalPath,
-            fallbackScope: rootScope
+    private func partialCreationError(logicalPath: String, underlying: Error) -> MCPError {
+        MCPError.invalidParams(
+            "Cannot create generated Oracle export at '\(logicalPath)': \(String(describing: underlying)). Output may remain at the requested path; inspect it before retrying and do not blindly retry."
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleExportFileWriter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleExportFileWriter.swift
@@ -65,6 +65,10 @@ struct GeneratedOracleExportFileWriter {
             throw MCPError.invalidParams(
                 "Cannot create generated Oracle export at '\(logicalPath)': path already exists."
             )
+        } catch is FileManagerError {
+            throw MCPError.invalidParams(
+                "Cannot create generated Oracle export at '\(logicalPath)': filesystem operation failed."
+            )
         } catch is CancellationError {
             throw CancellationError()
         } catch {

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -6489,6 +6489,10 @@ final class MCPServerViewModel: ObservableObject {
             try await host.writeText(path: path, content: content, overwrite: overwrite)
         } catch is CancellationError {
             throw CancellationError()
+        } catch FileSystemError.fileAlreadyExists {
+            throw MCPError.invalidParams("path already exists: \(path)")
+        } catch FileSystemError.isDirectory {
+            throw MCPError.invalidParams("path resolves to a directory: \(path)")
         } catch let fmErr as FileManagerError {
             throw await mapFileManagerErrorToMCP(fmErr, action: "create", path: path)
         } catch let mcpErr as MCPError {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1241,6 +1241,7 @@ actor WorkspaceFileContextStore {
         private var publishedGitArtifactIngressDidRegisterHandler: (@Sendable (UUID, String) async -> Void)?
         private var watcherSinkWillApplyHandler: (@Sendable (UUID) async -> Void)?
         private var storeEditDeferredPublicationDidRegisterHandler: (@Sendable (UUID, String) async -> Void)?
+        private var createFilePostDiskWriteHandlerForTesting: (@Sendable (UUID, String) async throws -> Void)?
         private var publisherIngressWillWaitHandler: (@Sendable (Set<UUID>) async -> Void)?
         private var watcherPublisherIngressDidOpenHandler: (@Sendable (UUID, UUID) async -> Void)?
         private var watcherInfrastructureDidJoinFlightHandler: (@Sendable (UUID, UUID) async -> Void)?
@@ -2516,6 +2517,12 @@ actor WorkspaceFileContextStore {
             _ handler: (@Sendable (UUID, String) async -> Void)?
         ) {
             storeEditDeferredPublicationDidRegisterHandler = handler
+        }
+
+        func setCreateFilePostDiskWriteHandlerForTesting(
+            _ handler: (@Sendable (UUID, String) async throws -> Void)?
+        ) {
+            createFilePostDiskWriteHandlerForTesting = handler
         }
 
         func setSearchContentReadChunkHandlerForTesting(
@@ -16459,6 +16466,7 @@ actor WorkspaceFileContextStore {
         rootID: UUID,
         relativePath: String,
         content: String,
+        overwrite: Bool = false,
         validating rootScope: WorkspaceLookupRootScope? = nil
     ) async throws -> WorkspaceFileCatalogMaterializationResult {
         if let rootScope {
@@ -16474,6 +16482,9 @@ actor WorkspaceFileContextStore {
             rootID: rootID,
             commands: [.modified([standardizedRelativePath])]
         )
+        #if DEBUG
+            let postDiskWriteHandler = createFilePostDiskWriteHandlerForTesting
+        #endif
         var didCommitCatalogMutation = false
         var retainedFenceUntilMutationDrain = false
         defer {
@@ -16485,7 +16496,11 @@ actor WorkspaceFileContextStore {
             }
         }
         do {
-            try await state.service.createFile(atRelativePath: standardizedRelativePath, content: content)
+            try await state.service.createFile(
+                atRelativePath: standardizedRelativePath,
+                content: content,
+                overwrite: overwrite
+            )
         } catch is CancellationError {
             retainedFenceUntilMutationDrain = true
             retainCodemapPathFenceUntilMutationDrain(
@@ -16495,6 +16510,11 @@ actor WorkspaceFileContextStore {
             )
             throw CancellationError()
         }
+        #if DEBUG
+            if let postDiskWriteHandler {
+                try await postDiskWriteHandler(rootID, standardizedRelativePath)
+            }
+        #endif
         let result = try await materializeCatalogFileAfterDiskWrite(
             rootID: rootID,
             relativePath: standardizedRelativePath,

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileMutationService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileMutationService.swift
@@ -123,6 +123,7 @@ struct WorkspaceFileMutationService {
     func createFile(
         userPath: String,
         content: String,
+        overwrite: Bool = false,
         rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
         selectedFileFullPaths: Set<String> = [],
         pathResolutionPolicy: WorkspaceFileCreatePathResolutionPolicy = .literalPreferredIfStronger,
@@ -131,6 +132,7 @@ struct WorkspaceFileMutationService {
         let result = try await createFileWithPostcondition(
             userPath: userPath,
             content: content,
+            overwrite: overwrite,
             rootScope: rootScope,
             selectedFileFullPaths: selectedFileFullPaths,
             pathResolutionPolicy: pathResolutionPolicy,
@@ -148,6 +150,7 @@ struct WorkspaceFileMutationService {
     func createFileWithPostcondition(
         userPath: String,
         content: String,
+        overwrite: Bool = false,
         rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
         selectedFileFullPaths: Set<String> = [],
         pathResolutionPolicy: WorkspaceFileCreatePathResolutionPolicy = .literalPreferredIfStronger,
@@ -182,6 +185,7 @@ struct WorkspaceFileMutationService {
                 using: absolute,
                 userPath: userPath,
                 content: content,
+                overwrite: overwrite,
                 rootScope: rootScope,
                 mutationRootMappings: mutationRootMappings,
                 skipCatalogExistenceChecks: true
@@ -195,6 +199,7 @@ struct WorkspaceFileMutationService {
                 using: literal,
                 userPath: userPath,
                 content: content,
+                overwrite: overwrite,
                 rootScope: rootScope,
                 mutationRootMappings: mutationRootMappings
             )
@@ -204,7 +209,7 @@ struct WorkspaceFileMutationService {
             let displayPath = await displayPath(for: folder, rootScope: rootScope)
             throw FileManagerError.fileSystemServiceNotFoundWithContext("'\(displayPath)' resolves to a folder. Provide a file path.")
         }
-        if let existing = await exactExistingFile(standardizedInput, rootScope: rootScope) {
+        if !overwrite, let existing = await exactExistingFile(standardizedInput, rootScope: rootScope) {
             throw await FileManagerError.fileSystemServiceNotFoundWithContext("path already exists: \(displayPath(for: existing, rootScope: rootScope))")
         }
 
@@ -241,6 +246,7 @@ struct WorkspaceFileMutationService {
                 using: result,
                 userPath: userPath,
                 content: content,
+                overwrite: overwrite,
                 rootScope: rootScope,
                 mutationRootMappings: mutationRootMappings
             )
@@ -251,6 +257,7 @@ struct WorkspaceFileMutationService {
         using result: FileCreationResult,
         userPath: String,
         content: String,
+        overwrite: Bool,
         rootScope: WorkspaceLookupRootScope,
         mutationRootMappings: [DomainMutationPhysicalRootMapping],
         skipCatalogExistenceChecks: Bool = false
@@ -270,7 +277,7 @@ struct WorkspaceFileMutationService {
             if let folder = await exactExistingFolder(absolutePath, rootScope: rootScope) {
                 throw await FileManagerError.fileSystemServiceNotFoundWithContext("'\(displayPath(for: folder, rootScope: rootScope))' resolves to a folder. Provide a file path.")
             }
-            if await exactExistingFile(absolutePath, rootScope: rootScope) != nil {
+            if !overwrite, await exactExistingFile(absolutePath, rootScope: rootScope) != nil {
                 throw FileManagerError.fileSystemServiceNotFoundWithContext("path already exists: \(userPath)")
             }
         }
@@ -282,6 +289,7 @@ struct WorkspaceFileMutationService {
             rootID: root.id,
             relativePath: relativePath,
             content: content,
+            overwrite: overwrite,
             validating: rootScope
         )
         return .fromCatalogMaterialization(result)

--- a/Tests/RepoPromptTests/MCP/GeneratedOracleExportFileWriterTests.swift
+++ b/Tests/RepoPromptTests/MCP/GeneratedOracleExportFileWriterTests.swift
@@ -45,6 +45,125 @@ final class GeneratedOracleExportFileWriterTests: XCTestCase {
         }
     }
 
+    func testGeneratedExportWriterCollisionPreservesCompetingWinner() async throws {
+        let root = try makeTemporaryRoot(name: "OracleExportCompetingCreator")
+        let destinationURL = root.appendingPathComponent("prompt-exports/oracle-plan-collision.md")
+        let winnerContent = "winner bytes must survive\n"
+        let loserContent = "loser bytes must never replace\n"
+        let store = WorkspaceFileContextStore()
+        let rootRecord = try await store.loadRoot(path: root.path)
+        guard let service = await store.fileSystemServiceForTesting(rootID: rootRecord.id) else {
+            return XCTFail("The isolated root must expose its filesystem service")
+        }
+        let gate = GeneratedOracleExportCreateGate()
+        await service.setCreateFileDataPreparationForTesting { content in
+            await gate.wait()
+            return Data(content.utf8)
+        }
+
+        let writeTask = Task {
+            try await GeneratedOracleExportFileWriter(store: store).write(
+                path: destinationURL.path,
+                content: loserContent,
+                destination: OracleExportDestination(
+                    workspaceID: UUID(),
+                    windowID: 1,
+                    tabID: nil,
+                    primaryRootPath: root.path
+                )
+            )
+        }
+
+        await gate.waitUntilEntered()
+        try write(winnerContent, to: destinationURL)
+        await gate.open()
+
+        do {
+            _ = try await writeTask.value
+            XCTFail("The losing generated export must fail")
+        } catch let error as MCPError {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("path already exists"), message)
+        } catch {
+            XCTFail("Expected an MCP existing-path error, got \(error)")
+        }
+        await service.setCreateFileDataPreparationForTesting(nil)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destinationURL.path))
+        XCTAssertEqual(try String(contentsOf: destinationURL, encoding: .utf8), winnerContent)
+    }
+
+    func testGeneratedExportWriterRetainsOutputAfterPostDiskCatalogFailure() async throws {
+        let root = try makeTemporaryRoot(name: "OracleExportPostDiskCatalogFailure")
+        let destinationURL = root.appendingPathComponent("prompt-exports/oracle-plan-partial.md")
+        let content = "output remains after catalog failure\n"
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        await store.setCreateFilePostDiskWriteHandlerForTesting { _, _ in
+            throw WorkspaceFileContextStoreError.catalogMaterializationFailed(
+                "injected post-disk catalog failure"
+            )
+        }
+
+        do {
+            _ = try await GeneratedOracleExportFileWriter(store: store).write(
+                path: destinationURL.path,
+                content: content,
+                destination: OracleExportDestination(
+                    workspaceID: UUID(),
+                    windowID: 1,
+                    tabID: nil,
+                    primaryRootPath: root.path
+                )
+            )
+            XCTFail("Expected the injected post-disk catalog failure")
+        } catch let error as MCPError {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("injected post-disk catalog failure"), message)
+            XCTAssertTrue(message.contains("Output may remain at the requested path"), message)
+            XCTAssertTrue(message.contains("do not blindly retry"), message)
+        } catch {
+            XCTFail("Expected a truthful partial-state MCP error, got \(error)")
+        }
+        await store.setCreateFilePostDiskWriteHandlerForTesting(nil)
+
+        XCTAssertEqual(try String(contentsOf: destinationURL, encoding: .utf8), content)
+    }
+
+    func testGeneratedExportWriterRetainsPostCreateCompetingReplacementAfterVerificationFailure() async throws {
+        let root = try makeTemporaryRoot(name: "OracleExportPostCreateReplacement")
+        let destinationURL = root.appendingPathComponent("prompt-exports/oracle-plan-replaced.md")
+        let replacement = "competing replacement must survive\n"
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        await store.setCreateFilePostDiskWriteHandlerForTesting { _, _ in
+            try replacement.write(to: destinationURL, atomically: true, encoding: .utf8)
+        }
+
+        do {
+            _ = try await GeneratedOracleExportFileWriter(store: store).write(
+                path: destinationURL.path,
+                content: "original export content\n",
+                destination: OracleExportDestination(
+                    workspaceID: UUID(),
+                    windowID: 1,
+                    tabID: nil,
+                    primaryRootPath: root.path
+                )
+            )
+            XCTFail("Expected verification to reject the competing replacement")
+        } catch let error as MCPError {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("loaded different contents"), message)
+            XCTAssertTrue(message.contains("Output may remain at the requested path"), message)
+        } catch {
+            XCTFail("Expected a truthful post-create verification error, got \(error)")
+        }
+        await store.setCreateFilePostDiskWriteHandlerForTesting(nil)
+
+        XCTAssertEqual(try String(contentsOf: destinationURL, encoding: .utf8), replacement)
+    }
+
     func testGeneratedExportWriterWritesToBoundWorktreeAndReturnsLogicalPath() async throws {
         let logicalRoot = try makeTemporaryRoot(name: "OracleExportLogical")
         let worktreeRoot = try makeTemporaryRoot(name: "OracleExportWorktree")
@@ -163,7 +282,7 @@ final class GeneratedOracleExportFileWriterTests: XCTestCase {
         XCTAssertFalse(tree.contains("oracle-plan-ignored.md"), tree)
     }
 
-    func testGeneratedExportWriterCleansUpSymlinkedExportPathFailure() async throws {
+    func testGeneratedExportWriterRejectsSymlinkedExportPathWithoutWritingOutsideWorkspace() async throws {
         let root = try makeTemporaryRoot(name: "OracleExportSymlink")
         let outside = try makeTemporaryRoot(name: "OracleExportSymlinkOutside")
         try FileManager.default.createSymbolicLink(
@@ -193,7 +312,7 @@ final class GeneratedOracleExportFileWriterTests: XCTestCase {
             XCTAssertTrue(message.contains("not readable by read_file") || message.contains("symlink"), message)
         }
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: outsideTarget), "Rejected generated exports should clean up symlinked disk artifacts")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: outsideTarget), "Rejected generated exports must not write outside the workspace")
     }
 
     private func makeBinding(logicalRoot: URL, worktreeRoot: URL) -> AgentSessionWorktreeBinding {
@@ -224,5 +343,46 @@ final class GeneratedOracleExportFileWriterTests: XCTestCase {
     private func write(_ content: String, to url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+private actor GeneratedOracleExportCreateGate {
+    private var enteredContinuation: CheckedContinuation<Void, Never>?
+    private var openContinuation: CheckedContinuation<Void, Never>?
+    private var hasEntered = false
+    private var isOpen = false
+
+    func wait() async {
+        if !hasEntered {
+            hasEntered = true
+            enteredContinuation?.resume()
+            enteredContinuation = nil
+        }
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            if isOpen {
+                continuation.resume()
+            } else {
+                openContinuation = continuation
+            }
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { continuation in
+            if hasEntered {
+                continuation.resume()
+            } else {
+                enteredContinuation = continuation
+            }
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        openContinuation?.resume()
+        openContinuation = nil
     }
 }

--- a/Tests/RepoPromptTests/MCP/MCPReadMutationPathContractTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadMutationPathContractTests.swift
@@ -1,3 +1,6 @@
+import Darwin
+import Foundation
+import MCP
 @testable import RepoPromptApp
 import RepoPromptDomainRuntime
 import XCTest
@@ -620,6 +623,570 @@ final class MCPReadMutationPathContractTests: XCTestCase {
         )
     }
 
+    /// Exercises the shared WorkspaceFileEditHost create path. The data-preparation gate leaves
+    /// the real filesystem commit pending while an external creator claims the destination.
+    func testWorkspaceFileEditHostCreateLosingCreatorReturnsFileAlreadyExistsWithoutClobberingWinner() async throws {
+        try await assertWorkspaceFileEditHostCreatePreservesCompetingWinner(
+            fixtureName: "AtomicCreateCompetingCreator",
+            forcedRenameError: nil
+        )
+    }
+
+    /// Forces the supported-filesystem fallback so the regression exercises O_EXCL directly,
+    /// rather than only observing RENAME_EXCL returning EEXIST.
+    func testWorkspaceFileEditHostCreateOEXCLFallbackPreservesCompetingWinner() async throws {
+        try await assertWorkspaceFileEditHostCreatePreservesCompetingWinner(
+            fixtureName: "AtomicCreateOEXCLFallback",
+            forcedRenameError: ENOTSUP
+        )
+    }
+
+    func testWorkspaceFileEditHostCreateNativeRenameExclPublishesNewFile() async throws {
+        let root = try makeTemporaryDirectory(name: "AtomicCreateNativeRenameExclSuccess")
+        let destination = root.appendingPathComponent("nested/NewFile.swift")
+        let content = "native RENAME_EXCL publication succeeds\n"
+        let store = WorkspaceFileContextStore()
+        let rootRecord = try await store.loadRoot(path: root.path)
+        let resolvedService = await store.fileSystemServiceForTesting(rootID: rootRecord.id)
+        let service = try XCTUnwrap(resolvedService)
+        let nativeSuccessProbe = Issue859ExclusiveRenameProbe()
+        await service.setCreateFileExclusiveRenameForTesting { source, destination in
+            let result = renamex_np(source, destination, UInt32(RENAME_EXCL))
+            if result == 0 {
+                nativeSuccessProbe.recordInvocation()
+                return 0
+            }
+            return errno
+        }
+
+        let host = WorkspaceFileEditHost(
+            store: store,
+            target: .create(path: destination.path),
+            lookupRootScope: .visibleWorkspace,
+            selectCreatedFiles: false
+        )
+        do {
+            try await host.writeText(
+                path: destination.path,
+                content: content,
+                overwrite: false
+            )
+        } catch {
+            await service.setCreateFileExclusiveRenameForTesting(nil)
+            throw error
+        }
+        await service.setCreateFileExclusiveRenameForTesting(nil)
+
+        XCTAssertTrue(nativeSuccessProbe.wasInvoked, "The local fixture must publish through native RENAME_EXCL, not its fallback")
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), content)
+    }
+
+    func testWorkspaceFileEditHostCreateOEXCLFallbackPublishesNewFile() async throws {
+        let root = try makeTemporaryDirectory(name: "AtomicCreateOEXCLFallbackSuccess")
+        let destination = root.appendingPathComponent("nested/NewFile.swift")
+        let content = "fallback publication succeeds\n"
+        let store = WorkspaceFileContextStore()
+        let rootRecord = try await store.loadRoot(path: root.path)
+        guard let service = await store.fileSystemServiceForTesting(rootID: rootRecord.id) else {
+            return XCTFail("The isolated root must expose its filesystem service")
+        }
+        let renameProbe = Issue859ExclusiveRenameProbe()
+        await service.setCreateFileExclusiveRenameForTesting { _, _ in
+            renameProbe.recordInvocation()
+            return ENOTSUP
+        }
+
+        let host = WorkspaceFileEditHost(
+            store: store,
+            target: .create(path: destination.path),
+            lookupRootScope: .visibleWorkspace,
+            selectCreatedFiles: false
+        )
+        do {
+            try await host.writeText(
+                path: destination.path,
+                content: content,
+                overwrite: false
+            )
+        } catch {
+            await service.setCreateFileExclusiveRenameForTesting(nil)
+            throw error
+        }
+        await service.setCreateFileExclusiveRenameForTesting(nil)
+
+        XCTAssertTrue(renameProbe.wasInvoked)
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), content)
+    }
+
+    func testWorkspaceFileEditHostCreateCleansOwnedTempAfterPostOpenFailure() async throws {
+        let root = try makeTemporaryDirectory(name: "AtomicCreateOwnedTempCleanup")
+        let destination = root.appendingPathComponent("nested/NewFile.swift")
+        let store = WorkspaceFileContextStore()
+        let rootRecord = try await store.loadRoot(path: root.path)
+        guard let service = await store.fileSystemServiceForTesting(rootID: rootRecord.id) else {
+            return XCTFail("The isolated root must expose its filesystem service")
+        }
+        await service.setCreateFilePOSIXFailureAfterOpenForTesting(EIO)
+
+        let host = WorkspaceFileEditHost(
+            store: store,
+            target: .create(path: destination.path),
+            lookupRootScope: .visibleWorkspace,
+            selectCreatedFiles: false
+        )
+        do {
+            try await host.writeText(
+                path: destination.path,
+                content: "the owned temporary file must be removed\n",
+                overwrite: false
+            )
+            XCTFail("Expected the injected post-open write failure")
+        } catch FileSystemError.failedToCreateFile {
+            // The detached reconciler preserves the failed-create classification.
+        } catch {
+            XCTFail("Expected failedToCreateFile, got \(error)")
+        }
+        await service.setCreateFilePOSIXFailureAfterOpenForTesting(nil)
+
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: destination.deletingLastPathComponent(),
+            includingPropertiesForKeys: nil
+        )
+        XCTAssertFalse(contents.contains { $0.lastPathComponent.hasPrefix(".repoprompt.create.") })
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.path))
+    }
+
+    func testWorkspaceFileEditHostCreateFallbackPostOpenFailurePreservesCompetingReplacement() async throws {
+        let root = try makeTemporaryDirectory(name: "AtomicCreateOEXCLFallbackPostOpenFailure")
+        let destination = root.appendingPathComponent("nested/NewFile.swift")
+        let winnerContent = "replacement after exclusive claim must survive\n"
+        let store = WorkspaceFileContextStore()
+        let rootRecord = try await store.loadRoot(path: root.path)
+        guard let service = await store.fileSystemServiceForTesting(rootID: rootRecord.id) else {
+            return XCTFail("The isolated root must expose its filesystem service")
+        }
+        let renameProbe = Issue859ExclusiveRenameProbe()
+        await service.setCreateFileExclusiveRenameForTesting { _, _ in
+            renameProbe.recordInvocation()
+            return ENOTSUP
+        }
+        await service.setCreateFileFallbackPOSIXFailureAfterOpenForTesting { path in
+            try? winnerContent.write(toFile: path, atomically: true, encoding: .utf8)
+            return EIO
+        }
+
+        let host = WorkspaceFileEditHost(
+            store: store,
+            target: .create(path: destination.path),
+            lookupRootScope: .visibleWorkspace,
+            selectCreatedFiles: false
+        )
+        do {
+            try await host.writeText(
+                path: destination.path,
+                content: "incomplete bytes must not be retried blindly\n",
+                overwrite: false
+            )
+            XCTFail("Expected the injected fallback post-open failure")
+        } catch let error as FileSystemError {
+            guard case .incompleteFileCreation = error else {
+                return XCTFail("Expected incompleteFileCreation, got \(error)")
+            }
+            let message = error.localizedDescription
+            XCTAssertTrue(message.contains("incomplete output may remain"), message)
+            XCTAssertTrue(message.contains("do not blindly retry"), message)
+        } catch {
+            XCTFail("Expected incompleteFileCreation, got \(error)")
+        }
+        await service.setCreateFileExclusiveRenameForTesting(nil)
+        await service.setCreateFileFallbackPOSIXFailureAfterOpenForTesting(nil)
+
+        XCTAssertTrue(renameProbe.wasInvoked)
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), winnerContent)
+        let contents = try FileManager.default.contentsOfDirectory(
+            at: destination.deletingLastPathComponent(),
+            includingPropertiesForKeys: nil
+        )
+        XCTAssertFalse(contents.contains { $0.lastPathComponent.hasPrefix(".repoprompt.create.") })
+    }
+
+    @MainActor
+    func testPublicMCPFileActionsCollisionReturnsExistingPathError() async throws {
+        let root = try makeTemporaryDirectory(name: "PublicMCPCreateCompetingCreator")
+        let destination = root.appendingPathComponent("nested/NewFile.swift")
+        let winnerContent = "public winner bytes must survive\n"
+        let loserContent = "public loser bytes must never replace\n"
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let (server, _) = try makeInProcessMCPFileActionsServer(store: store, root: root)
+        guard let rootID = await store.rootRefs(scope: .visibleWorkspace).first?.id,
+              let service = await store.fileSystemServiceForTesting(rootID: rootID)
+        else {
+            return XCTFail("The isolated root must expose its filesystem service")
+        }
+        let tool = try await inProcessFileActionsTool(from: server)
+        let gate = Issue859CreateGate()
+        await service.setCreateFileDataPreparationForTesting { content in
+            await gate.wait()
+            return Data(content.utf8)
+        }
+        let createTask = Task {
+            try await tool(fileActionArguments(
+                path: destination.path,
+                content: loserContent,
+                ifExists: "error"
+            ))
+        }
+        addTeardownBlock {
+            await gate.open()
+            _ = await createTask.result
+            await service.setCreateFileDataPreparationForTesting(nil)
+        }
+
+        guard await gate.waitUntilEntered() else {
+            await gate.open()
+            switch await createTask.result {
+            case .success:
+                XCTFail("The public losing create did not reach the data-preparation gate before the bounded observation expired")
+            case let .failure(error):
+                XCTFail("The public losing create failed before reaching the data-preparation gate: \(error)")
+            }
+            return
+        }
+        do {
+            try write(winnerContent, to: destination)
+        } catch {
+            await gate.open()
+            switch await createTask.result {
+            case .success:
+                XCTFail("The public losing create unexpectedly succeeded while recovering from the winner-write failure")
+            case let .failure(taskError):
+                guard let mcpError = taskError as? MCPError,
+                      String(describing: mcpError).contains("path already exists")
+                else {
+                    XCTFail("Unexpected public losing create failure while recovering from the winner-write failure: \(taskError)")
+                }
+            }
+            throw error
+        }
+        await gate.open()
+
+        do {
+            _ = try await createTask.value
+            XCTFail("The public losing create must fail")
+        } catch let error as MCPError {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("path already exists"), message)
+        } catch {
+            XCTFail("Expected a public MCP existing-path error, got \(error)")
+        }
+        await service.setCreateFileDataPreparationForTesting(nil)
+
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), winnerContent)
+    }
+
+    @MainActor
+    func testPublicMCPFileActionsOverwriteReplacesRacedMissingDestination() async throws {
+        let root = try makeTemporaryDirectory(name: "PublicMCPCreateOverwriteRace")
+        let destination = root.appendingPathComponent("nested/NewFile.swift")
+        let winnerContent = "raced winner must be replaced\n"
+        let overwriteContent = "explicit overwrite content\n"
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let (server, _) = try makeInProcessMCPFileActionsServer(store: store, root: root)
+        guard let rootID = await store.rootRefs(scope: .visibleWorkspace).first?.id,
+              let service = await store.fileSystemServiceForTesting(rootID: rootID)
+        else {
+            return XCTFail("The isolated root must expose its filesystem service")
+        }
+        let tool = try await inProcessFileActionsTool(from: server)
+        let gate = Issue859CreateGate()
+        await service.setCreateFileDataPreparationForTesting { content in
+            await gate.wait()
+            return Data(content.utf8)
+        }
+        let createTask = Task {
+            try await tool(fileActionArguments(
+                path: destination.path,
+                content: overwriteContent,
+                ifExists: "overwrite"
+            ))
+        }
+        addTeardownBlock {
+            await gate.open()
+            _ = await createTask.result
+            await service.setCreateFileDataPreparationForTesting(nil)
+        }
+
+        guard await gate.waitUntilEntered() else {
+            await gate.open()
+            switch await createTask.result {
+            case .success:
+                XCTFail("The public overwrite create did not reach the data-preparation gate before the bounded observation expired")
+            case let .failure(error):
+                XCTFail("The public overwrite create failed before reaching the data-preparation gate: \(error)")
+            }
+            return
+        }
+        do {
+            try write(winnerContent, to: destination)
+        } catch {
+            await gate.open()
+            switch await createTask.result {
+            case .success:
+                break
+            case let .failure(taskError):
+                XCTFail("The public overwrite create failed while recovering from the winner-write failure: \(taskError)")
+            }
+            throw error
+        }
+        await gate.open()
+
+        let result = try await createTask.value
+        await service.setCreateFileDataPreparationForTesting(nil)
+        let reply = try XCTUnwrap(result.decode(ToolResultDTOs.FileActionReply.self))
+        XCTAssertEqual(reply.status, "ok")
+        XCTAssertEqual(reply.mutationState, "applied")
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), overwriteContent)
+    }
+
+    @MainActor
+    func testPublicMCPFileActionsOverwritePreservesRacedDirectory() async throws {
+        let root = try makeTemporaryDirectory(name: "PublicMCPCreateOverwriteRacedDirectory")
+        let destination = root.appendingPathComponent("nested/NewFile.swift")
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let (server, _) = try makeInProcessMCPFileActionsServer(store: store, root: root)
+        guard let rootID = await store.rootRefs(scope: .visibleWorkspace).first?.id,
+              let service = await store.fileSystemServiceForTesting(rootID: rootID)
+        else {
+            return XCTFail("The isolated root must expose its filesystem service")
+        }
+        let tool = try await inProcessFileActionsTool(from: server)
+        await service.setCreateFileDataPreparationForTesting { content in
+            try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+            return Data(content.utf8)
+        }
+        addTeardownBlock {
+            await service.setCreateFileDataPreparationForTesting(nil)
+        }
+
+        do {
+            _ = try await tool(fileActionArguments(
+                path: destination.path,
+                content: "directory must survive explicit overwrite\n",
+                ifExists: "overwrite"
+            ))
+            XCTFail("Expected explicit overwrite of a raced directory to fail")
+        } catch let error as MCPError {
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("directory"), message)
+        } catch {
+            XCTFail("Expected a public MCP directory error, got \(error)")
+        }
+        await service.setCreateFileDataPreparationForTesting(nil)
+
+        var isDirectory = ObjCBool(false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destination.path, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    private func assertWorkspaceFileEditHostCreatePreservesCompetingWinner(
+        fixtureName: String,
+        forcedRenameError: Int32?
+    ) async throws {
+        let root = try makeTemporaryDirectory(name: fixtureName)
+        let destination = root.appendingPathComponent("nested/NewFile.swift")
+        let winnerContent = "winner bytes must survive\n"
+        let loserContent = "loser bytes must never replace\n"
+        let store = WorkspaceFileContextStore()
+        let rootRecord = try await store.loadRoot(path: root.path)
+        guard let service = await store.fileSystemServiceForTesting(rootID: rootRecord.id) else {
+            return XCTFail("The isolated root must expose its filesystem service")
+        }
+        let gate = Issue859CreateGate()
+        let renameProbe = Issue859ExclusiveRenameProbe()
+        let mutationService = WorkspaceFileMutationService(store: store)
+        let target: WorkspaceFileEditHost.Target = if let existing = await mutationService.exactExistingFile(
+            destination.path,
+            rootScope: .visibleWorkspace
+        ) {
+            .existing(existing)
+        } else {
+            .create(path: destination.path)
+        }
+        guard case .create = target else {
+            return XCTFail("The isolated destination must be missing before the competing create")
+        }
+        let host = WorkspaceFileEditHost(
+            store: store,
+            target: target,
+            lookupRootScope: .visibleWorkspace,
+            selectCreatedFiles: false
+        )
+        if let forcedRenameError {
+            await service.setCreateFileExclusiveRenameForTesting { _, _ in
+                renameProbe.recordInvocation()
+                return forcedRenameError
+            }
+        }
+        await service.setCreateFileDataPreparationForTesting { content in
+            await gate.wait()
+            return Data(content.utf8)
+        }
+        let createTask = Task {
+            try await host.writeText(
+                path: destination.path,
+                content: loserContent,
+                overwrite: false
+            )
+        }
+        addTeardownBlock {
+            await gate.open()
+            _ = await createTask.result
+            await service.setCreateFileDataPreparationForTesting(nil)
+            await service.setCreateFileExclusiveRenameForTesting(nil)
+        }
+
+        guard await gate.waitUntilEntered() else {
+            await gate.open()
+            switch await createTask.result {
+            case .success:
+                XCTFail("The losing create did not reach the data-preparation gate before the bounded observation expired")
+            case let .failure(error):
+                XCTFail("The losing create failed before reaching the data-preparation gate: \(error)")
+            }
+            return
+        }
+        do {
+            try write(winnerContent, to: destination)
+        } catch {
+            await gate.open()
+            switch await createTask.result {
+            case .success:
+                XCTFail("The losing create unexpectedly succeeded while recovering from the winner-write failure")
+            case let .failure(taskError):
+                guard let filesystemError = taskError as? FileSystemError,
+                      case .fileAlreadyExists = filesystemError
+                else {
+                    XCTFail("Unexpected losing create failure while recovering from the winner-write failure: \(taskError)")
+                }
+            }
+            throw error
+        }
+        await gate.open()
+
+        do {
+            try await createTask.value
+            XCTFail("The losing create must fail with fileAlreadyExists")
+        } catch FileSystemError.fileAlreadyExists {
+            // The exclusive commit reported the expected typed outcome.
+        } catch {
+            XCTFail("Expected fileAlreadyExists, got \(error)")
+        }
+        await service.setCreateFileDataPreparationForTesting(nil)
+        await service.setCreateFileExclusiveRenameForTesting(nil)
+        if forcedRenameError != nil {
+            XCTAssertTrue(
+                renameProbe.wasInvoked,
+                "The fallback regression must invoke the exclusive-rename seam"
+            )
+        }
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), winnerContent)
+    }
+
+    @MainActor
+    private func makeInProcessMCPFileActionsServer(
+        store: WorkspaceFileContextStore,
+        root: URL
+    ) throws -> (server: MCPServerViewModel, connectionID: UUID) {
+        let fileManager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+        let keyManager = KeyManager(
+            secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+        )
+        let aiQueriesService = AIQueriesService(keyManager: keyManager)
+        let apiSettings = APISettingsViewModel(
+            aiQueriesService: aiQueriesService,
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        let settingsManager = WindowSettingsManager(windowID: -859)
+        let prompt = PromptViewModel(
+            fileManager: fileManager,
+            aiQueriesService: aiQueriesService,
+            apiSettingsViewModel: apiSettings,
+            windowID: -859,
+            settingsManager: settingsManager
+        )
+        let workspaceManager = WorkspaceManagerViewModel(
+            fileManager: fileManager,
+            promptViewModel: prompt,
+            performInitialWorkspaceActivation: false
+        )
+        let workspace = WorkspaceModel(name: "Issue 859", repoPaths: [root.path])
+        workspaceManager.workspaces = [workspace]
+        workspaceManager.activeWorkspace = workspace
+        let oracle = OracleViewModel(
+            aiQueriesService: aiQueriesService,
+            promptViewModel: prompt,
+            workspaceManager: workspaceManager,
+            chatData: ChatDataService()
+        )
+        let service = MCPService(
+            hostBootstrapOperation: {},
+            controllerStartOperation: {},
+            controllerFullShutdownOperation: {}
+        )
+        let server = MCPServerViewModel(
+            service: service,
+            promptVM: prompt,
+            oracleVM: oracle,
+            workspaceManager: workspaceManager,
+            windowID: -859,
+            workspaceSearch: { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
+                throw MCPError.internalError("search is not used by the file_actions regression")
+            },
+            ensureGitDataRootLoaded: { _, _ in
+                throw MCPError.internalError("Git-data loading is not used by the file_actions regression")
+            }
+        )
+        let connectionID = UUID()
+        try server.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: nil,
+            tabID: XCTUnwrap(workspace.activeComposeTabID),
+            workspaceID: workspace.id,
+            windowID: -859
+        )
+        server.setRequestMetadataOverrideForTesting(
+            MCPServerViewModel.RequestMetadata(
+                connectionID: connectionID,
+                clientName: nil,
+                windowID: -859
+            )
+        )
+        return (server, connectionID)
+    }
+
+    @MainActor
+    private func inProcessFileActionsTool(from server: MCPServerViewModel) async throws -> Tool {
+        let tools = await server.windowMCPTools
+        return try XCTUnwrap(tools.first { $0.name == MCPWindowToolName.fileActions })
+    }
+
+    private func fileActionArguments(
+        path: String,
+        content: String,
+        ifExists: String
+    ) -> [String: Value] {
+        [
+            "action": .string("create"),
+            "path": .string(path),
+            "content": .string(content),
+            "if_exists": .string(ifExists)
+        ]
+    }
+
     func testMissingResolvedTargetFailsInsteadOfReadingEmptyContent() async throws {
         let root = try makeTemporaryDirectory(name: "MissingResolvedTarget")
         let fileURL = root.appendingPathComponent("Target.swift")
@@ -658,5 +1225,109 @@ final class MCPReadMutationPathContractTests: XCTestCase {
     private func write(_ content: String, to url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+private final class Issue859ExclusiveRenameProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var invocationCount = 0
+
+    func recordInvocation() {
+        lock.lock()
+        invocationCount += 1
+        lock.unlock()
+    }
+
+    var wasInvoked: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return invocationCount > 0
+    }
+}
+
+private actor Issue859CreateGate {
+    private enum EntryObservation: Equatable {
+        case entered
+        case timedOut
+    }
+
+    private static let entryObservationTimeoutNanoseconds: UInt64 = 1_000_000_000
+
+    private var enteredContinuation: CheckedContinuation<EntryObservation, Never>?
+    private var openContinuation: CheckedContinuation<Void, Never>?
+    private var hasEntered = false
+    private var isOpen = false
+    private var entryWaitCancelled = false
+
+    func wait() async {
+        if !hasEntered {
+            hasEntered = true
+            enteredContinuation?.resume(returning: .entered)
+            enteredContinuation = nil
+        }
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            if isOpen {
+                continuation.resume()
+            } else {
+                openContinuation = continuation
+            }
+        }
+    }
+
+    func waitUntilEntered() async -> Bool {
+        guard !hasEntered else { return true }
+        return await withTaskCancellationHandler(operation: {
+            await withTaskGroup(of: EntryObservation.self) { group in
+                group.addTask {
+                    await self.waitForEntry()
+                }
+                group.addTask {
+                    do {
+                        try await Task.sleep(nanoseconds: Self.entryObservationTimeoutNanoseconds)
+                    } catch {
+                        // Cancellation only ends the timer; entry remains event-driven.
+                    }
+                    return .timedOut
+                }
+                let observation = await group.next() ?? .timedOut
+                if observation == .timedOut {
+                    await self.cancelEntryWaiter()
+                }
+                group.cancelAll()
+                return observation == .entered
+            }
+        }, onCancel: {
+            Task { await self.cancelEntryWaiter() }
+        })
+    }
+
+    private func waitForEntry() async -> EntryObservation {
+        await withTaskCancellationHandler(operation: {
+            await withCheckedContinuation { continuation in
+                if hasEntered {
+                    continuation.resume(returning: .entered)
+                } else if entryWaitCancelled {
+                    continuation.resume(returning: .timedOut)
+                } else {
+                    enteredContinuation = continuation
+                }
+            }
+        }, onCancel: {
+            Task { await self.cancelEntryWaiter() }
+        })
+    }
+
+    private func cancelEntryWaiter() {
+        entryWaitCancelled = true
+        enteredContinuation?.resume(returning: .timedOut)
+        enteredContinuation = nil
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        openContinuation?.resume()
+        openContinuation = nil
     }
 }

--- a/Tests/RepoPromptTests/MCP/MCPReadMutationPathContractTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadMutationPathContractTests.swift
@@ -865,6 +865,7 @@ final class MCPReadMutationPathContractTests: XCTestCase {
                       String(describing: mcpError).contains("path already exists")
                 else {
                     XCTFail("Unexpected public losing create failure while recovering from the winner-write failure: \(taskError)")
+                    throw taskError
                 }
             }
             throw error
@@ -1070,6 +1071,7 @@ final class MCPReadMutationPathContractTests: XCTestCase {
                       case .fileAlreadyExists = filesystemError
                 else {
                     XCTFail("Unexpected losing create failure while recovering from the winner-write failure: \(taskError)")
+                    throw taskError
                 }
             }
             throw error
@@ -1169,7 +1171,7 @@ final class MCPReadMutationPathContractTests: XCTestCase {
     }
 
     @MainActor
-    private func inProcessFileActionsTool(from server: MCPServerViewModel) async throws -> Tool {
+    private func inProcessFileActionsTool(from server: MCPServerViewModel) async throws -> RepoPromptApp.Tool {
         let tools = await server.windowMCPTools
         return try XCTUnwrap(tools.first { $0.name == MCPWindowToolName.fileActions })
     }


### PR DESCRIPTION
A file created by another writer between RPCE's existence check and publication could be overwritten even when the request required a new file. Publish new files with exclusive rename, falling back to an exclusive create where needed, and propagate a precise collision error through workspace edits and MCP file_actions. Explicit overwrite remains supported for files and rejects a directory created during the race.

Oracle export failures no longer delete a destination by pathname. A failed fallback write preserves any partial output and reports that it may remain; temporary staging cleanup stays private to the writer. This change does not claim to close the separate protected-path authority races in #858.

Validation at `b0e6f9d283b2cf39b116013941cb511161d0142d`, integrated with main `542b111e3074ed7126c0dea8a46572fa569bf51a`:

- A test-only overlay on unchanged main reproduced the losing create overwriting another writer's bytes and explicit overwrite replacing a raced directory: three tests, four assertion failures; the allowed regular-file overwrite control passed.
- All 33 affected file-mutation and Oracle-export tests passed on the fix, including native exclusive-rename and forced fallback controls. The public file_actions fixtures invoke the tool in-process; raw socket transport is not covered by those fixtures.
- RepoPrompt app build, strict lint, formatter, and independent engineering/cleanup reviews passed. Hosted checks and packaged release acceptance remain required.

Fixes #859.
