### PR TITLE
Revalidate worktree identity before alternate-root operations

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
@@ -66,6 +66,8 @@ struct AgentWorkspaceLookupContextSource: Equatable {
                         StandardizedPath.absolute((binding.logicalRootPath as NSString).expandingTildeInPath),
                         binding.worktreeID,
                         StandardizedPath.absolute((binding.worktreeRootPath as NSString).expandingTildeInPath),
+                        binding.commonGitDir.map(StandardizedPath.absolute) ?? "",
+                        binding.isMainWorktree.map { String($0) } ?? "",
                         binding.branch ?? "",
                         binding.head ?? ""
                     ].joined(separator: "\u{1F}")

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorktreeRuntimeWorkspaceResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorktreeRuntimeWorkspaceResolver.swift
@@ -1,6 +1,22 @@
 import Foundation
 
 enum AgentWorktreeRuntimeWorkspaceResolver {
+    struct Dependencies {
+        let directoryExists: (String) -> Bool
+        let resolveIdentity: (String) -> GitWorktreeIdentitySnapshot?
+
+        static let live = Dependencies(
+            directoryExists: { path in
+                var isDirectory: ObjCBool = false
+                return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+                    && isDirectory.boolValue
+            },
+            resolveIdentity: { path in
+                GitWorktreeIdentityResolver.resolve(atWorkTreeRoot: URL(fileURLWithPath: path))
+            }
+        )
+    }
+
     static func primaryExecutionBinding(
         in bindings: [AgentSessionWorktreeBinding],
         fallbackWorkspacePath: String?
@@ -15,7 +31,8 @@ enum AgentWorktreeRuntimeWorkspaceResolver {
 
     static func effectiveWorkspacePath(
         bindings: [AgentSessionWorktreeBinding],
-        fallbackWorkspacePath: String?
+        fallbackWorkspacePath: String?,
+        dependencies: Dependencies = .live
     ) throws -> String? {
         let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
         let binding = primaryExecutionBinding(
@@ -26,7 +43,7 @@ enum AgentWorktreeRuntimeWorkspaceResolver {
         guard let binding else {
             return primaryWorkspacePath
         }
-        return try validatedWorktreeRootPath(for: binding)
+        return try validatedWorktreeRootPath(for: binding, dependencies: dependencies)
     }
 
     /// Codex-specific projection of the same primary-binding selection used by
@@ -36,7 +53,8 @@ enum AgentWorktreeRuntimeWorkspaceResolver {
     /// opaque process-spawn error.
     static func codexRuntimeWorkspacePaths(
         bindings: [AgentSessionWorktreeBinding],
-        fallbackWorkspacePath: String?
+        fallbackWorkspacePath: String?,
+        dependencies: Dependencies = .live
     ) throws -> CodexRuntimeWorkspacePaths {
         let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
         let binding = primaryExecutionBinding(
@@ -47,11 +65,11 @@ enum AgentWorktreeRuntimeWorkspaceResolver {
         guard let binding else {
             return .uniform(primaryWorkspacePath)
         }
-        let executionDirectory = try validatedWorktreeRootPath(for: binding)
+        let executionDirectory = try validatedWorktreeRootPath(for: binding, dependencies: dependencies)
         guard let processLaunchDirectory = standardizedWorkspacePath(binding.logicalRootPath) else {
             throw CodexRuntimeWorkspacePathsError.emptyLogicalRoot
         }
-        guard directoryExists(atPath: processLaunchDirectory) else {
+        guard dependencies.directoryExists(processLaunchDirectory) else {
             throw CodexRuntimeWorkspacePathsError.launchDirectoryUnavailable(path: processLaunchDirectory)
         }
         return .worktreeBound(
@@ -60,27 +78,56 @@ enum AgentWorktreeRuntimeWorkspaceResolver {
         )
     }
 
-    static func validateBindingsAvailable(_ bindings: [AgentSessionWorktreeBinding]) throws {
+    static func validateBindingsAvailable(
+        _ bindings: [AgentSessionWorktreeBinding],
+        dependencies: Dependencies = .live
+    ) throws {
         for binding in bindings {
-            _ = try validatedWorktreeRootPath(for: binding)
+            _ = try validatedWorktreeRootPath(for: binding, dependencies: dependencies)
         }
     }
 
     private static func validatedWorktreeRootPath(
-        for binding: AgentSessionWorktreeBinding
+        for binding: AgentSessionWorktreeBinding,
+        dependencies: Dependencies
     ) throws -> String {
         guard let worktreePath = standardizedWorkspacePath(binding.worktreeRootPath),
-              directoryExists(atPath: worktreePath)
+              dependencies.directoryExists(worktreePath),
+              let identity = dependencies.resolveIdentity(worktreePath),
+              matchesPersistedBinding(binding, identity: identity, worktreePath: worktreePath)
         else {
             throw AgentWorktreeRuntimeWorkspaceError(binding: binding)
         }
         return worktreePath
     }
 
-    private static func directoryExists(atPath path: String) -> Bool {
-        var isDirectory: ObjCBool = false
-        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
+    private static func matchesPersistedBinding(
+        _ binding: AgentSessionWorktreeBinding,
+        identity: GitWorktreeIdentitySnapshot,
+        worktreePath: String
+    ) -> Bool {
+        guard identity.repository.repositoryID == binding.repositoryID,
+              identity.worktreeID == binding.worktreeID,
+              GitRepoRootAuthorization.isPathWithinAuthorizedRoots(
+                  worktreePath,
+                  roots: [identity.worktreeRootPath]
+              )
+        else {
+            return false
+        }
+
+        if let commonGitDir = binding.commonGitDir,
+           GitRepoRootAuthorization.canonicalPath(commonGitDir)
+           != GitRepoRootAuthorization.canonicalPath(identity.repository.commonGitDir)
+        {
+            return false
+        }
+        if let isMainWorktree = binding.isMainWorktree,
+           isMainWorktree != identity.isMain
+        {
+            return false
+        }
+        return true
     }
 
     static func standardizedWorkspacePath(_ path: String?) -> String? {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -6660,6 +6660,11 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         else { return .unavailable }
         let state = worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID)
         guard case let .hydrated(bindings) = state else { return state }
+        do {
+            try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(bindings)
+        } catch {
+            return .unavailable
+        }
         guard let store = promptManager?.workspaceFileContextStore else { return .unavailable }
         let materializer = WorkspaceRootBindingProjectionMaterializer(store: store)
         if bindings.isEmpty {
@@ -6819,6 +6824,13 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     ) async throws -> [AgentSessionWorktreeBinding] {
         guard let session = try authoritativeLiveSession(for: sessionID) else {
             throw MCPError.invalidParams("The requested agent session is not currently available.")
+        }
+        if !desiredBindings.isEmpty {
+            do {
+                try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(desiredBindings)
+            } catch {
+                throw ExecutionLocationTransitionError.unavailable(error.localizedDescription)
+            }
         }
         guard !session.worktreeBindingTransitionInProgress else {
             throw ExecutionLocationTransitionError.stale
@@ -7038,6 +7050,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 logicalRootName: context.logicalRoot.name,
                 worktreeID: worktree.worktreeID,
                 worktreeRootPath: worktree.path,
+                commonGitDir: worktree.repository.commonGitDir,
+                isMainWorktree: worktree.isMain,
                 worktreeName: worktree.name,
                 branch: worktree.branch,
                 head: worktree.head,
@@ -7808,7 +7822,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     binding.repoKey,
                     StandardizedPath.absolute((binding.logicalRootPath as NSString).expandingTildeInPath),
                     binding.worktreeID,
-                    StandardizedPath.absolute((binding.worktreeRootPath as NSString).expandingTildeInPath)
+                    StandardizedPath.absolute((binding.worktreeRootPath as NSString).expandingTildeInPath),
+                    binding.commonGitDir.map(StandardizedPath.absolute) ?? "",
+                    binding.isMainWorktree.map { String($0) } ?? ""
                 ].joined(separator: "\u{1F}")
             }.sorted()
         }
@@ -13699,6 +13715,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 logicalRootName: logicalRoot.name,
                 worktreeID: worktree.worktreeID,
                 worktreeRootPath: worktree.path,
+                commonGitDir: worktree.repository.commonGitDir,
+                isMainWorktree: worktree.isMain,
                 worktreeName: worktree.name,
                 branch: worktree.branch,
                 head: worktree.head,

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentMCPStartWorktreeCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentMCPStartWorktreeCoordinator.swift
@@ -394,6 +394,7 @@ struct AgentMCPStartWorktreeCoordinator {
         sessionID: UUID,
         targetWindow: WindowState
     ) async throws {
+        try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(bindings)
         let store = targetWindow.promptManager.workspaceFileContextStore
         let physicalRootPaths = Set(bindings.map {
             standardizedPath($0.worktreeRootPath)
@@ -665,6 +666,8 @@ struct AgentMCPStartWorktreeCoordinator {
             logicalRootName: logicalRoot.name,
             worktreeID: worktree.worktreeID,
             worktreeRootPath: physicalRootPath,
+            commonGitDir: worktree.repository.commonGitDir,
+            isMainWorktree: worktree.isMain,
             worktreeName: worktree.name,
             branch: worktree.branch,
             head: worktree.head,

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWorktreeToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWorktreeToolProvider.swift
@@ -464,6 +464,8 @@ final class MCPWorktreeToolProvider: MCPAppToolProviding {
             logicalRootName: logicalRoot.name,
             worktreeID: worktree.worktreeID,
             worktreeRootPath: worktree.path,
+            commonGitDir: worktree.repository.commonGitDir,
+            isMainWorktree: worktree.isMain,
             worktreeName: worktree.name,
             branch: worktree.branch,
             head: worktree.head,

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitDiff/GitRepoDescriptor.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitDiff/GitRepoDescriptor.swift
@@ -17,6 +17,10 @@ public struct GitRepoDescriptor: Codable, Sendable, Equatable, Hashable {
     /// Human-readable display name (typically last path component)
     public let displayName: String
 
+    /// Fresh repository/worktree identity when the root has a resolvable Git layout.
+    /// A nil value is intentionally not treated as an authorization match for external worktrees.
+    public let worktreeIdentity: GitWorktreeIdentitySnapshot?
+
     /// Initialize from a git root URL
     /// - Parameter rootURL: The canonical git repository root URL
     public init(rootURL: URL) {
@@ -24,14 +28,22 @@ public struct GitRepoDescriptor: Codable, Sendable, Equatable, Hashable {
         rootPath = (rootURL.path as NSString).standardizingPath
         displayName = rootURL.lastPathComponent
         repoKey = Self.makeRepoKey(for: rootPath, displayName: displayName)
+        worktreeIdentity = GitWorktreeIdentityResolver.resolve(atWorkTreeRoot: rootURL)
     }
 
     /// Initialize with all fields (used for decoding or testing)
-    public init(rootURL: URL, rootPath: String, repoKey: String, displayName: String) {
+    public init(
+        rootURL: URL,
+        rootPath: String,
+        repoKey: String,
+        displayName: String,
+        worktreeIdentity: GitWorktreeIdentitySnapshot? = nil
+    ) {
         self.rootURL = rootURL
         self.rootPath = rootPath
         self.repoKey = repoKey
         self.displayName = displayName
+        self.worktreeIdentity = worktreeIdentity
     }
 
     /// Generate a stable, filesystem-safe repo key from the root path.

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitRepoTargetResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitRepoTargetResolver.swift
@@ -79,7 +79,8 @@ struct GitRepoTargetResolver {
                 to: baseRepo,
                 allRepos: allRepos,
                 defaultRepo: defaultRepo,
-                hasExplicitBase: !trimmed.isEmpty
+                hasExplicitBase: !trimmed.isEmpty,
+                authorizedRoots: visibleRoots
             )
         }
 
@@ -92,7 +93,11 @@ struct GitRepoTargetResolver {
             in: candidateRepos(allRepos: allRepos, defaultRepo: defaultRepo),
             selectorKind: .branchNameOrPath
         ) {
-            return GitRepoDescriptor(rootURL: URL(fileURLWithPath: worktree.path))
+            return try await resolveAuthorizedWorktreeRepository(
+                worktree,
+                advertisingRepos: candidateRepos(allRepos: allRepos, defaultRepo: defaultRepo),
+                authorizedRoots: visibleRoots
+            )
         }
 
         let availableNames = visibleRoots.map(\.name).joined(separator: ", ")
@@ -111,38 +116,11 @@ struct GitRepoTargetResolver {
             allRepos: allRepos
         )
         if let authorizedRoots {
-            let rootPaths = authorizedRoots.map(\.standardizedFullPath)
-            let isInsideLoadedRoot = GitRepoRootAuthorization.isPathWithinAuthorizedRoots(
-                worktree.path,
-                roots: rootPaths
+            _ = try await resolveAuthorizedWorktreeRepository(
+                worktree,
+                advertisingRepos: [repo],
+                authorizedRoots: authorizedRoots
             )
-            // `worktree` was just obtained from `git worktree list`; authorize its external
-            // checkout path only when another checkout of the same repository is loaded and
-            // the target independently resolves as that exact repository root.
-            let mainRepositoryIsLoaded = worktree.repository.mainWorktreeRoot.map {
-                GitRepoRootAuthorization.isPathWithinAuthorizedRoots($0, roots: rootPaths)
-            } ?? false
-            let loadedRepositoryWorktrees = await mainRepositoryIsLoaded
-                ? []
-                : (try? dependencies.listWorktrees(repo)) ?? []
-            let matchingLinkedRepositoryIsLoaded = loadedRepositoryWorktrees.contains { candidate in
-                GitRepoRootAuthorization.isPathWithinAuthorizedRoots(candidate.path, roots: rootPaths)
-                    && candidate.repository.repositoryID == worktree.repository.repositoryID
-                    && samePath(candidate.repository.commonGitDir, worktree.repository.commonGitDir)
-            }
-            let advertisingRepositoryIsLoaded = mainRepositoryIsLoaded || matchingLinkedRepositoryIsLoaded
-            let resolvedWorktree = !isInsideLoadedRoot && advertisingRepositoryIsLoaded
-                ? await dependencies.resolveRepo(URL(fileURLWithPath: worktree.path))
-                : nil
-            let isVerifiedLinkedWorktree = resolvedWorktree.map {
-                samePath($0.rootPath, worktree.path)
-            } ?? false
-            guard isInsideLoadedRoot || isVerifiedLinkedWorktree else {
-                let rootsList = rootPaths.joined(separator: ", ")
-                throw GitRepoTargetResolverError.invalidParams(
-                    "worktree path must be inside a loaded root or advertised by a loaded repository. Received: \(worktree.path). Loaded roots: \(rootsList)"
-                )
-            }
         }
         // Fail closed on stale/prunable worktrees. Git reports a worktree as prunable when its
         // gitdir points to a non-existent location (the checkout was removed or left incomplete).
@@ -237,7 +215,11 @@ struct GitRepoTargetResolver {
                    selectorKind: .branchNameOrPath
                )
             {
-                return GitRepoDescriptor(rootURL: URL(fileURLWithPath: worktree.path))
+                return try await resolveAuthorizedWorktreeRepository(
+                    worktree,
+                    advertisingRepos: candidateRepos(allRepos: allRepos, defaultRepo: defaultRepo),
+                    authorizedRoots: visibleRoots
+                )
             }
 
             let visibleRootPaths = visibleRoots.map(\.standardizedFullPath)
@@ -254,9 +236,12 @@ struct GitRepoTargetResolver {
                 trimmed,
                 in: candidateRepos(allRepos: allRepos, defaultRepo: defaultRepo),
                 selectorKind: .path
-            ), let resolved = await dependencies.resolveRepo(URL(fileURLWithPath: worktree.path)),
-            samePath(resolved.rootPath, worktree.path) {
-                return resolved
+            ) {
+                return try await resolveAuthorizedWorktreeRepository(
+                    worktree,
+                    advertisingRepos: candidateRepos(allRepos: allRepos, defaultRepo: defaultRepo),
+                    authorizedRoots: visibleRoots
+                )
             }
 
             let rootsList = visibleRootPaths.joined(separator: ", ")
@@ -332,7 +317,8 @@ struct GitRepoTargetResolver {
         to repo: GitRepoDescriptor,
         allRepos: [GitRepoDescriptor],
         defaultRepo: GitRepoDescriptor,
-        hasExplicitBase: Bool
+        hasExplicitBase: Bool,
+        authorizedRoots: [WorkspaceRootRef]
     ) async throws -> GitRepoDescriptor {
         guard let specifier else {
             return repo
@@ -346,43 +332,101 @@ struct GitRepoTargetResolver {
         case let .main(branch):
             if let branch, !branch.isEmpty {
                 if let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: repo.rootURL),
-                   let root = resolveWorktreeRoot(forBranch: branch, layout: layout)
+                   let resolution = resolveWorktreeRoot(forBranch: branch, layout: layout),
+                   let expected = expectedWorktreeDescriptor(for: resolution, basedOn: repo)
                 {
-                    return GitRepoDescriptor(rootURL: root)
+                    return try await resolveAuthorizedWorktreeRepository(
+                        expected,
+                        advertisingRepos: [repo],
+                        authorizedRoots: authorizedRoots
+                    )
                 }
                 if let worktree = try await resolveWorktreeSelector(branch, in: [repo], selectorKind: .branch) {
-                    return GitRepoDescriptor(rootURL: URL(fileURLWithPath: worktree.path))
+                    return try await resolveAuthorizedWorktreeRepository(
+                        worktree,
+                        advertisingRepos: [repo],
+                        authorizedRoots: authorizedRoots
+                    )
                 }
                 throw GitRepoTargetResolverError.invalidParams("No worktree found for branch '\(branch)'. Use repo_root=\"@main\" for the main checkout or pass a full worktree path.")
             }
             if let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: repo.rootURL) {
                 if !layout.isLinkedWorktree {
-                    return repo
+                    guard let expected = expectedWorktreeDescriptor(
+                        for: ResolvedWorktreeRoot(root: repo.rootURL, gitDir: nil, isMain: true),
+                        basedOn: repo
+                    ) else {
+                        throw GitRepoTargetResolverError.invalidParams(
+                            "The main checkout identity could not be established for repo: \(repo.rootPath)"
+                        )
+                    }
+                    return try await resolveAuthorizedWorktreeRepository(
+                        expected,
+                        advertisingRepos: [repo],
+                        authorizedRoots: authorizedRoots
+                    )
                 }
-                if let mainRoot = Self.resolveMainWorktreeRoot(for: layout) {
-                    return GitRepoDescriptor(rootURL: mainRoot)
+                if let mainRoot = Self.resolveMainWorktreeRoot(for: layout),
+                   let expected = expectedWorktreeDescriptor(
+                       for: ResolvedWorktreeRoot(root: mainRoot, gitDir: nil, isMain: true),
+                       basedOn: repo
+                   )
+                {
+                    return try await resolveAuthorizedWorktreeRepository(
+                        expected,
+                        advertisingRepos: [repo],
+                        authorizedRoots: authorizedRoots
+                    )
                 }
                 if let main = try await mainWorktree(for: repo) {
-                    return GitRepoDescriptor(rootURL: URL(fileURLWithPath: main.path))
+                    return try await resolveAuthorizedWorktreeRepository(
+                        main,
+                        advertisingRepos: [repo],
+                        authorizedRoots: authorizedRoots
+                    )
                 }
                 throw GitRepoTargetResolverError.invalidParams("The main checkout path could not be resolved for repo: \(repo.rootPath)")
             }
-            if let main = try await mainWorktree(for: repo), !samePath(main.path, repo.rootPath) {
-                return GitRepoDescriptor(rootURL: URL(fileURLWithPath: main.path))
+            if let main = try await mainWorktree(for: repo) {
+                return try await resolveAuthorizedWorktreeRepository(
+                    main,
+                    advertisingRepos: [repo],
+                    authorizedRoots: authorizedRoots
+                )
             }
-            return repo
+            guard let expected = expectedWorktreeDescriptor(
+                for: ResolvedWorktreeRoot(root: repo.rootURL, gitDir: nil, isMain: true),
+                basedOn: repo
+            ) else {
+                throw GitRepoTargetResolverError.invalidParams(
+                    "The main checkout identity could not be established for repo: \(repo.rootPath)"
+                )
+            }
+            return try await resolveAuthorizedWorktreeRepository(
+                expected,
+                advertisingRepos: [repo],
+                authorizedRoots: authorizedRoots
+            )
         case .current:
             return repo
         case let .id(id):
             let candidates = hasExplicitBase ? [repo] : candidateRepos(allRepos: allRepos, defaultRepo: defaultRepo)
             if let worktree = try await resolveWorktreeSelector(id, in: candidates, selectorKind: .id) {
-                return GitRepoDescriptor(rootURL: URL(fileURLWithPath: worktree.path))
+                return try await resolveAuthorizedWorktreeRepository(
+                    worktree,
+                    advertisingRepos: candidates,
+                    authorizedRoots: authorizedRoots
+                )
             }
             throw GitRepoTargetResolverError.invalidParams("No worktree found for id '\(id)'.")
         case let .branch(branch):
             let candidates = hasExplicitBase ? [repo] : candidateRepos(allRepos: allRepos, defaultRepo: defaultRepo)
             if let worktree = try await resolveWorktreeSelector(branch, in: candidates, selectorKind: .branch) {
-                return GitRepoDescriptor(rootURL: URL(fileURLWithPath: worktree.path))
+                return try await resolveAuthorizedWorktreeRepository(
+                    worktree,
+                    advertisingRepos: candidates,
+                    authorizedRoots: authorizedRoots
+                )
             }
             throw GitRepoTargetResolverError.invalidParams("No worktree found for branch '\(branch)'.")
         }
@@ -493,6 +537,108 @@ struct GitRepoTargetResolver {
         return matchesBranch(requested, headRef: branch)
     }
 
+    private struct ResolvedWorktreeRoot {
+        let root: URL
+        let gitDir: URL?
+        let isMain: Bool
+    }
+
+    private func expectedWorktreeDescriptor(
+        for resolution: ResolvedWorktreeRoot,
+        basedOn repo: GitRepoDescriptor
+    ) -> GitWorktreeDescriptor? {
+        guard let repository = repo.worktreeIdentity?.repository,
+              resolution.isMain || resolution.gitDir != nil
+        else {
+            return nil
+        }
+        let root = resolution.root.standardizedFileURL
+        let worktreeID = GitWorktreeIdentity.worktreeID(
+            repositoryID: repository.repositoryID,
+            gitDir: resolution.isMain ? nil : resolution.gitDir,
+            isMain: resolution.isMain,
+            path: root
+        )
+        return GitWorktreeDescriptor(
+            worktreeID: worktreeID,
+            repository: repository,
+            path: root.path,
+            gitDir: resolution.gitDir?.standardizedFileURL.path,
+            name: root.lastPathComponent.isEmpty ? nil : root.lastPathComponent,
+            branch: nil,
+            head: nil,
+            isMain: resolution.isMain,
+            isCurrent: samePath(root.path, repo.rootPath),
+            isDetached: false,
+            isLocked: false,
+            lockReason: nil,
+            isPrunable: false,
+            prunableReason: nil
+        )
+    }
+
+    private func resolveAuthorizedWorktreeRepository(
+        _ worktree: GitWorktreeDescriptor,
+        advertisingRepos: [GitRepoDescriptor],
+        authorizedRoots: [WorkspaceRootRef]
+    ) async throws -> GitRepoDescriptor {
+        let rootPaths = authorizedRoots.map(\.standardizedFullPath)
+        let isInsideLoadedRoot = GitRepoRootAuthorization.isPathWithinAuthorizedRoots(
+            worktree.path,
+            roots: rootPaths
+        )
+        if isInsideLoadedRoot {
+            return GitRepoDescriptor(rootURL: URL(fileURLWithPath: worktree.path))
+        }
+
+        // An external checkout must still be advertised by a loaded checkout of the same
+        // repository before its fresh target identity can authorize the path.
+        let mainRepositoryIsLoaded = worktree.repository.mainWorktreeRoot.map {
+            GitRepoRootAuthorization.isPathWithinAuthorizedRoots($0, roots: rootPaths)
+        } ?? false
+        var matchingLinkedRepositoryIsLoaded = false
+        if !mainRepositoryIsLoaded {
+            for advertisingRepo in uniqueRepos(advertisingRepos) {
+                let loadedRepositoryWorktrees = await (try? dependencies.listWorktrees(advertisingRepo)) ?? []
+                if loadedRepositoryWorktrees.contains(where: { candidate in
+                    GitRepoRootAuthorization.isPathWithinAuthorizedRoots(candidate.path, roots: rootPaths)
+                        && candidate.repository.repositoryID == worktree.repository.repositoryID
+                        && samePath(candidate.repository.commonGitDir, worktree.repository.commonGitDir)
+                }) {
+                    matchingLinkedRepositoryIsLoaded = true
+                    break
+                }
+            }
+        }
+        let advertisingRepositoryIsLoaded = mainRepositoryIsLoaded || matchingLinkedRepositoryIsLoaded
+        guard advertisingRepositoryIsLoaded,
+              let resolved = await dependencies.resolveRepo(URL(fileURLWithPath: worktree.path)),
+              matchesFreshWorktreeIdentity(resolved, worktree: worktree)
+        else {
+            let rootsList = rootPaths.joined(separator: ", ")
+            throw GitRepoTargetResolverError.invalidParams(
+                "worktree path must be inside a loaded root or advertised by a loaded repository. Received: \(worktree.path). Loaded roots: \(rootsList)"
+            )
+        }
+        return resolved
+    }
+
+    private func matchesFreshWorktreeIdentity(
+        _ resolved: GitRepoDescriptor,
+        worktree: GitWorktreeDescriptor
+    ) -> Bool {
+        guard samePath(resolved.rootPath, worktree.path),
+              let identity = resolved.worktreeIdentity
+        else {
+            return false
+        }
+        return samePath(identity.worktreeRootPath, worktree.path)
+            && identity.repository.repositoryID == worktree.repository.repositoryID
+            && samePath(identity.repository.commonGitDir, worktree.repository.commonGitDir)
+            && identity.worktreeID == worktree.worktreeID
+            && identity.isMain == worktree.isMain
+    }
+
     private func samePath(_ lhs: String, _ rhs: String) -> Bool {
         GitRepoRootAuthorization.canonicalPath(lhs) == GitRepoRootAuthorization.canonicalPath(rhs)
     }
@@ -540,7 +686,7 @@ struct GitRepoTargetResolver {
         return resolvedGitdir.deletingLastPathComponent().standardizedFileURL
     }
 
-    private func resolveWorktreeRoot(forBranch branch: String, layout: GitRepositoryLayout) -> URL? {
+    private func resolveWorktreeRoot(forBranch branch: String, layout: GitRepositoryLayout) -> ResolvedWorktreeRoot? {
         let target = branch.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !target.isEmpty else { return nil }
         let fileManager = FileManager.default
@@ -556,7 +702,11 @@ struct GitRepoTargetResolver {
                         continue
                     }
                     if let root = resolveWorktreeRootFromEntry(entry) {
-                        return root
+                        return ResolvedWorktreeRoot(
+                            root: root,
+                            gitDir: entry.standardizedFileURL,
+                            isMain: false
+                        )
                     }
                 }
             }
@@ -564,7 +714,7 @@ struct GitRepoTargetResolver {
         if let mainRoot = Self.resolveMainWorktreeRoot(for: layout) {
             let headURL = layout.commonDir.appendingPathComponent("HEAD")
             if let headRef = readHeadRef(from: headURL), matchesBranch(target, headRef: headRef) {
-                return mainRoot
+                return ResolvedWorktreeRoot(root: mainRoot, gitDir: nil, isMain: true)
             }
         }
         return nil

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - Git Worktree Models
 
-public struct GitWorktreeRepositoryIdentity: Sendable, Equatable, Hashable {
+public struct GitWorktreeRepositoryIdentity: Codable, Sendable, Equatable, Hashable {
     public let repositoryID: String
     public let repoKey: String
     public let displayName: String
@@ -22,6 +22,30 @@ public struct GitWorktreeRepositoryIdentity: Sendable, Equatable, Hashable {
         self.displayName = displayName
         self.commonGitDir = commonGitDir
         self.mainWorktreeRoot = mainWorktreeRoot
+    }
+}
+
+/// Fresh identity resolved from the Git metadata at a worktree root.
+///
+/// The repository ID and key are derived from the common Git directory, while the worktree ID
+/// also incorporates the per-worktree Git directory (or the explicit main-worktree marker).
+/// Keeping those values together prevents a path-only resolution from becoming an authority.
+public struct GitWorktreeIdentitySnapshot: Codable, Sendable, Equatable, Hashable {
+    public let repository: GitWorktreeRepositoryIdentity
+    public let worktreeID: String
+    public let worktreeRootPath: String
+    public let isMain: Bool
+
+    public init(
+        repository: GitWorktreeRepositoryIdentity,
+        worktreeID: String,
+        worktreeRootPath: String,
+        isMain: Bool
+    ) {
+        self.repository = repository
+        self.worktreeID = worktreeID
+        self.worktreeRootPath = worktreeRootPath
+        self.isMain = isMain
     }
 }
 
@@ -364,6 +388,42 @@ enum GitWorktreeIdentity {
     private static func sha256Hex(_ text: String) -> String {
         let digest = SHA256.hash(data: Data(text.utf8))
         return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Resolves repository and worktree identity directly from the current Git layout.
+///
+/// This deliberately performs an uncached metadata read so callers can revalidate a persisted
+/// binding after a path has been replaced. Ancestors are considered for bindings to a logical
+/// subdirectory inside a checkout; the returned path is always the actual checkout root.
+enum GitWorktreeIdentityResolver {
+    static func resolve(atWorkTreeRoot root: URL) -> GitWorktreeIdentitySnapshot? {
+        var candidate = root.standardizedFileURL
+        while true {
+            if let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: candidate) {
+                let isMain = !layout.isLinkedWorktree
+                let repository = GitWorktreeIdentity.repositoryIdentity(
+                    commonGitDir: layout.commonDir,
+                    mainWorktreeRoot: isMain ? layout.workTreeRoot : layout.knownMainWorktreeRoot
+                )
+                let worktreeID = GitWorktreeIdentity.worktreeID(
+                    repositoryID: repository.repositoryID,
+                    gitDir: isMain ? nil : layout.gitDir,
+                    isMain: isMain,
+                    path: layout.workTreeRoot
+                )
+                return GitWorktreeIdentitySnapshot(
+                    repository: repository,
+                    worktreeID: worktreeID,
+                    worktreeRootPath: layout.workTreeRoot.standardizedFileURL.path,
+                    isMain: isMain
+                )
+            }
+
+            let parent = candidate.deletingLastPathComponent().standardizedFileURL
+            guard parent.path != candidate.path else { return nil }
+            candidate = parent
+        }
     }
 }
 

--- a/Sources/RepoPromptDomainRuntime/DomainAgentSessionWorktreeBinding.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainAgentSessionWorktreeBinding.swift
@@ -12,6 +12,10 @@ package struct AgentSessionWorktreeBinding: Codable, Equatable, Identifiable, Se
     package let logicalRootName: String?
     package let worktreeID: String
     package let worktreeRootPath: String
+    /// Common Git directory captured when the binding was created.
+    /// Legacy bindings may omit it; fresh repository/worktree IDs are still required at use time.
+    package let commonGitDir: String?
+    package let isMainWorktree: Bool?
     package let worktreeName: String?
     package let branch: String?
     package let head: String?
@@ -28,6 +32,8 @@ package struct AgentSessionWorktreeBinding: Codable, Equatable, Identifiable, Se
         logicalRootName: String? = nil,
         worktreeID: String,
         worktreeRootPath: String,
+        commonGitDir: String? = nil,
+        isMainWorktree: Bool? = nil,
         worktreeName: String? = nil,
         branch: String? = nil,
         head: String? = nil,
@@ -43,6 +49,8 @@ package struct AgentSessionWorktreeBinding: Codable, Equatable, Identifiable, Se
         self.logicalRootName = logicalRootName
         self.worktreeID = worktreeID
         self.worktreeRootPath = worktreeRootPath
+        self.commonGitDir = commonGitDir
+        self.isMainWorktree = isMainWorktree
         self.worktreeName = worktreeName
         self.branch = branch
         self.head = head
@@ -65,6 +73,8 @@ package struct AgentSessionWorktreeBinding: Codable, Equatable, Identifiable, Se
             logicalRootName: logicalRootName,
             worktreeID: worktreeID,
             worktreeRootPath: worktreeRootPath,
+            commonGitDir: commonGitDir,
+            isMainWorktree: isMainWorktree,
             worktreeName: worktreeName,
             branch: branch,
             head: head,
@@ -86,6 +96,8 @@ package struct AgentSessionWorktreeBindingSummary: Codable, Equatable, Identifia
     package let logicalRootName: String?
     package let worktreeID: String
     package let worktreeRootPath: String
+    package let commonGitDir: String?
+    package let isMainWorktree: Bool?
     package let worktreeName: String?
     package let branch: String?
     package let visualLabel: String?
@@ -100,6 +112,8 @@ package struct AgentSessionWorktreeBindingSummary: Codable, Equatable, Identifia
         logicalRootName: String? = nil,
         worktreeID: String,
         worktreeRootPath: String,
+        commonGitDir: String? = nil,
+        isMainWorktree: Bool? = nil,
         worktreeName: String? = nil,
         branch: String? = nil,
         visualLabel: String? = nil,
@@ -113,6 +127,8 @@ package struct AgentSessionWorktreeBindingSummary: Codable, Equatable, Identifia
         self.logicalRootName = logicalRootName
         self.worktreeID = worktreeID
         self.worktreeRootPath = worktreeRootPath
+        self.commonGitDir = commonGitDir
+        self.isMainWorktree = isMainWorktree
         self.worktreeName = worktreeName
         self.branch = branch
         self.visualLabel = visualLabel
@@ -129,6 +145,8 @@ package struct AgentSessionWorktreeBindingSummary: Codable, Equatable, Identifia
             logicalRootName: binding.logicalRootName,
             worktreeID: binding.worktreeID,
             worktreeRootPath: binding.worktreeRootPath,
+            commonGitDir: binding.commonGitDir,
+            isMainWorktree: binding.isMainWorktree,
             worktreeName: binding.worktreeName,
             branch: binding.branch,
             visualLabel: binding.visualLabel,
@@ -151,7 +169,7 @@ package struct AgentWorktreeRuntimeWorkspaceError: LocalizedError, Equatable, Se
             ?? binding.branch
             ?? binding.worktreeID
         let logicalRoot = binding.logicalRootName ?? binding.logicalRootPath
-        return "Agent session is bound to worktree '\(label)' for root '\(logicalRoot)', but the worktree path is unavailable: \(binding.worktreeRootPath). Recreate or repair that Git worktree, bind the session to another worktree, or unbind the session before starting the agent."
+        return "Agent session is bound to worktree '\(label)' for root '\(logicalRoot)', but the worktree path or Git identity is unavailable or changed: \(binding.worktreeRootPath). Recreate or repair that Git worktree, bind the session to another worktree, or unbind the session before starting the agent."
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/WorktreeMergeReviewStateTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/WorktreeMergeReviewStateTests.swift
@@ -303,10 +303,22 @@ final class WorktreeMergeReviewStateTests: XCTestCase {
         )
         let endpoint = try GitWorktreeMergeEndpoint(descriptor: mainDescriptor(head: endpointHead))
         let resolvedMain = mainDescriptor(head: resolvedHead)
+        let resolvedMainDescriptor = GitRepoDescriptor(
+            rootURL: URL(fileURLWithPath: mainPath),
+            rootPath: mainPath,
+            repoKey: resolvedMain.repository.repoKey,
+            displayName: resolvedMain.repository.displayName,
+            worktreeIdentity: GitWorktreeIdentitySnapshot(
+                repository: resolvedMain.repository,
+                worktreeID: resolvedMain.worktreeID,
+                worktreeRootPath: mainPath,
+                isMain: resolvedMain.isMain
+            )
+        )
         let resolver = GitRepoTargetResolver(dependencies: .init(
             resolveRepo: { url in
                 url.standardizedFileURL.path == mainPath
-                    ? GitRepoDescriptor(rootURL: URL(fileURLWithPath: mainPath))
+                    ? resolvedMainDescriptor
                     : nil
             },
             listWorktrees: { _ in [resolvedMain, linked] }

--- a/Tests/RepoPromptTests/Services/VCS/GitRepoTargetResolverTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitRepoTargetResolverTests.swift
@@ -1,0 +1,640 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class GitRepoTargetResolverTests: XCTestCase {
+    func testRejectsSamePathWhenFinalExternalResolutionUsesDifferentRepositoryIdentity() async throws {
+        let loadedRootPath = "/tmp/issue-860/loaded"
+        let worktreePath = "/tmp/issue-860/advertised"
+        let advertisedIdentity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: "/tmp/repository-a/.git",
+            worktreeID: "worktree-a",
+            worktreeRootPath: worktreePath,
+            mainWorktreeRoot: loadedRootPath
+        )
+        let replacementIdentity = Self.identity(
+            repositoryID: "repo-b",
+            commonGitDir: "/tmp/repository-b/.git",
+            worktreeID: "worktree-b",
+            worktreeRootPath: worktreePath,
+            mainWorktreeRoot: "/tmp/repository-b"
+        )
+        let advertisedWorktree = Self.worktree(from: advertisedIdentity, path: worktreePath)
+        let resolver = Self.resolver(
+            advertisedWorktree: advertisedWorktree,
+            finalDescriptor: Self.repoDescriptor(from: replacementIdentity, path: worktreePath)
+        )
+
+        do {
+            _ = try await resolver.resolveWorktree(
+                selector: "@id:\(advertisedWorktree.worktreeID)",
+                repo: Self.loadedRepo(path: loadedRootPath),
+                allRepos: [Self.loadedRepo(path: loadedRootPath)],
+                authorizedRoots: [Self.root(path: loadedRootPath)]
+            )
+            XCTFail("A same-path resolution with a different repository identity must be rejected")
+        } catch let error as GitRepoTargetResolverError {
+            XCTAssertTrue(error.message.contains("worktree path must be inside a loaded root"))
+        }
+    }
+
+    func testRejectsSamePathWhenFinalExternalResolutionHasNoGitIdentity() async throws {
+        let loadedRootPath = "/tmp/issue-860/loaded"
+        let worktreePath = "/tmp/issue-860/advertised"
+        let identity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: "/tmp/repository-a/.git",
+            worktreeID: "worktree-a",
+            worktreeRootPath: worktreePath,
+            mainWorktreeRoot: loadedRootPath
+        )
+        let advertisedWorktree = Self.worktree(from: identity, path: worktreePath)
+        let finalDescriptor = GitRepoDescriptor(
+            rootURL: URL(fileURLWithPath: worktreePath),
+            rootPath: worktreePath,
+            repoKey: "replacement-repo",
+            displayName: "replacement"
+        )
+        let resolver = Self.resolver(advertisedWorktree: advertisedWorktree, finalDescriptor: finalDescriptor)
+
+        do {
+            _ = try await resolver.resolveWorktree(
+                selector: "@id:\(advertisedWorktree.worktreeID)",
+                repo: Self.loadedRepo(path: loadedRootPath),
+                allRepos: [Self.loadedRepo(path: loadedRootPath)],
+                authorizedRoots: [Self.root(path: loadedRootPath)]
+            )
+            XCTFail("An external resolution without Git identity must be rejected")
+        } catch let error as GitRepoTargetResolverError {
+            XCTAssertTrue(error.message.contains("worktree path must be inside a loaded root"))
+        }
+    }
+
+    func testAllowsSamePathWhenFinalExternalResolutionMatchesRepositoryAndWorktreeIdentity() async throws {
+        let loadedRootPath = "/tmp/issue-860/loaded"
+        let worktreePath = "/tmp/issue-860/advertised"
+        let identity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: "/tmp/repository-a/.git",
+            worktreeID: "worktree-a",
+            worktreeRootPath: worktreePath,
+            mainWorktreeRoot: loadedRootPath
+        )
+        let advertisedWorktree = Self.worktree(from: identity, path: worktreePath)
+        let resolver = Self.resolver(
+            advertisedWorktree: advertisedWorktree,
+            finalDescriptor: Self.repoDescriptor(from: identity, path: worktreePath)
+        )
+
+        let resolved = try await resolver.resolveWorktree(
+            selector: "@id:\(advertisedWorktree.worktreeID)",
+            repo: Self.loadedRepo(path: loadedRootPath),
+            allRepos: [Self.loadedRepo(path: loadedRootPath)],
+            authorizedRoots: [Self.root(path: loadedRootPath)]
+        )
+
+        XCTAssertEqual(resolved, advertisedWorktree)
+    }
+
+    func testPreservesInRootWorktreeWithoutExternalReresolution() async throws {
+        let loadedRootPath = "/tmp/issue-860/loaded"
+        let worktreePath = "/tmp/issue-860/loaded/feature"
+        let identity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: "/tmp/repository-a/.git",
+            worktreeID: "worktree-a",
+            worktreeRootPath: worktreePath,
+            mainWorktreeRoot: loadedRootPath
+        )
+        let advertisedWorktree = Self.worktree(from: identity, path: worktreePath)
+        let resolver = GitRepoTargetResolver(
+            dependencies: .init(
+                resolveRepo: { _ in nil },
+                listWorktrees: { _ in [advertisedWorktree] }
+            )
+        )
+
+        let resolved = try await resolver.resolveWorktree(
+            selector: "@id:\(advertisedWorktree.worktreeID)",
+            repo: Self.loadedRepo(path: loadedRootPath),
+            allRepos: [Self.loadedRepo(path: loadedRootPath)],
+            authorizedRoots: [Self.root(path: loadedRootPath)]
+        )
+
+        XCTAssertEqual(resolved, advertisedWorktree)
+    }
+
+    func testRejectsSamePathReplacementForRepoRootSelectorsAndExplicitPath() async throws {
+        let loadedRootPath = "/tmp/issue-860/loaded"
+        let worktreePath = "/tmp/issue-860/advertised"
+        let identity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: "/tmp/repository-a/.git",
+            worktreeID: "worktree-a",
+            worktreeRootPath: worktreePath,
+            mainWorktreeRoot: loadedRootPath
+        )
+        let advertisedWorktree = Self.worktree(from: identity, path: worktreePath)
+        let replacementIdentity = Self.identity(
+            repositoryID: "repo-b",
+            commonGitDir: "/tmp/repository-b/.git",
+            worktreeID: "worktree-b",
+            worktreeRootPath: worktreePath,
+            mainWorktreeRoot: "/tmp/repository-b"
+        )
+        let tokens = [
+            "@id:\(advertisedWorktree.worktreeID)",
+            "@branch:feature",
+            "feature",
+            worktreePath
+        ]
+
+        for token in tokens {
+            let resolver = Self.resolver(
+                advertisedWorktree: advertisedWorktree,
+                finalDescriptor: Self.repoDescriptor(from: replacementIdentity, path: worktreePath)
+            )
+            do {
+                _ = try await resolver.resolveRepoRoots(
+                    explicitRootTokens: [token],
+                    allRepos: [Self.loadedRepo(path: loadedRootPath)],
+                    visibleRoots: [Self.root(path: loadedRootPath)],
+                    defaultRepo: Self.loadedRepo(path: loadedRootPath)
+                )
+                XCTFail("A replaced external worktree must be rejected for repo_root=\(token)")
+            } catch let error as GitRepoTargetResolverError {
+                XCTAssertTrue(error.message.contains("worktree path must be inside a loaded root"))
+            }
+        }
+    }
+
+    func testAllowsValidExternalLinkedRepoRootSelectorsAndExplicitPath() async throws {
+        let loadedRootPath = "/tmp/issue-860/loaded"
+        let worktreePath = "/tmp/issue-860/advertised"
+        let identity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: "/tmp/repository-a/.git",
+            worktreeID: "worktree-a",
+            worktreeRootPath: worktreePath,
+            mainWorktreeRoot: loadedRootPath
+        )
+        let advertisedWorktree = Self.worktree(from: identity, path: worktreePath)
+        let tokens = [
+            "@id:\(advertisedWorktree.worktreeID)",
+            "@branch:feature",
+            "feature",
+            worktreePath
+        ]
+
+        for token in tokens {
+            let resolver = Self.resolver(
+                advertisedWorktree: advertisedWorktree,
+                finalDescriptor: Self.repoDescriptor(from: identity, path: worktreePath)
+            )
+            let resolved = try await resolver.resolveRepoRoots(
+                explicitRootTokens: [token],
+                allRepos: [Self.loadedRepo(path: loadedRootPath)],
+                visibleRoots: [Self.root(path: loadedRootPath)],
+                defaultRepo: Self.loadedRepo(path: loadedRootPath)
+            )
+            XCTAssertEqual(resolved.count, 1)
+            XCTAssertEqual(resolved.first?.rootPath, worktreePath)
+            XCTAssertEqual(resolved.first?.worktreeIdentity, identity)
+        }
+    }
+
+    func testAllowsValidMainRepoRootSelector() async throws {
+        let mainPath = "/tmp/issue-860/loaded"
+        let linkedPath = "/tmp/issue-860/advertised"
+        let repository = GitWorktreeRepositoryIdentity(
+            repositoryID: "repo-a",
+            repoKey: "repo-key-repo-a",
+            displayName: "repository",
+            commonGitDir: "/tmp/repository-a/.git",
+            mainWorktreeRoot: mainPath
+        )
+        let main = GitWorktreeDescriptor(
+            worktreeID: "worktree-main",
+            repository: repository,
+            path: mainPath,
+            gitDir: nil,
+            name: "loaded",
+            branch: "main",
+            head: "abc123",
+            isMain: true,
+            isCurrent: true,
+            isDetached: false,
+            isLocked: false,
+            lockReason: nil,
+            isPrunable: false,
+            prunableReason: nil
+        )
+        let linked = Self.worktree(
+            from: Self.identity(
+                repositoryID: repository.repositoryID,
+                commonGitDir: repository.commonGitDir,
+                worktreeID: "worktree-linked",
+                worktreeRootPath: linkedPath,
+                mainWorktreeRoot: mainPath
+            ),
+            path: linkedPath
+        )
+        let resolverWithBothWorktrees = GitRepoTargetResolver(
+            dependencies: .init(
+                resolveRepo: { _ in nil },
+                listWorktrees: { _ in [main, linked] }
+            )
+        )
+
+        let resolved = try await resolverWithBothWorktrees.resolveRepoRoots(
+            explicitRootTokens: ["@main"],
+            allRepos: [Self.loadedRepo(path: mainPath)],
+            visibleRoots: [Self.root(path: mainPath)],
+            defaultRepo: Self.loadedRepo(path: mainPath)
+        )
+
+        XCTAssertEqual(resolved.count, 1)
+        XCTAssertEqual(resolved.first?.rootPath, mainPath)
+    }
+
+    func testRejectsSamePathReplacementForMainSelectorAliases() async throws {
+        let fixture = Self.externalMainSelectorFixture()
+        let scenarios: [(selector: String, target: GitWorktreeDescriptor, replacement: GitWorktreeIdentitySnapshot)] = [
+            ("@main", fixture.mainWorktree, fixture.replacementMainIdentity),
+            ("@primary", fixture.mainWorktree, fixture.replacementMainIdentity),
+            ("@main:feature", fixture.branchWorktree, fixture.replacementBranchIdentity),
+            ("@primary:feature", fixture.branchWorktree, fixture.replacementBranchIdentity)
+        ]
+
+        for scenario in scenarios {
+            let resolver = Self.resolver(
+                worktrees: fixture.worktrees,
+                finalDescriptor: Self.repoDescriptor(from: scenario.replacement, path: scenario.target.path)
+            )
+            do {
+                _ = try await resolver.resolveRepoRoots(
+                    explicitRootTokens: [scenario.selector],
+                    allRepos: [fixture.defaultRepo],
+                    visibleRoots: [fixture.visibleRoot],
+                    defaultRepo: fixture.defaultRepo
+                )
+                XCTFail("A replaced external worktree must be rejected for repo_root=\(scenario.selector)")
+            } catch let error as GitRepoTargetResolverError {
+                XCTAssertTrue(error.message.contains("worktree path must be inside a loaded root"), error.message)
+            }
+        }
+    }
+
+    func testAllowsValidExternalMainSelectorAliases() async throws {
+        let fixture = Self.externalMainSelectorFixture()
+        let scenarios: [(selector: String, target: GitWorktreeDescriptor, identity: GitWorktreeIdentitySnapshot)] = [
+            ("@main", fixture.mainWorktree, fixture.mainIdentity),
+            ("@primary", fixture.mainWorktree, fixture.mainIdentity),
+            ("@main:feature", fixture.branchWorktree, fixture.branchIdentity),
+            ("@primary:feature", fixture.branchWorktree, fixture.branchIdentity)
+        ]
+
+        for scenario in scenarios {
+            let resolver = Self.resolver(
+                worktrees: fixture.worktrees,
+                finalDescriptor: Self.repoDescriptor(from: scenario.identity, path: scenario.target.path)
+            )
+            let resolved = try await resolver.resolveRepoRoots(
+                explicitRootTokens: [scenario.selector],
+                allRepos: [fixture.defaultRepo],
+                visibleRoots: [fixture.visibleRoot],
+                defaultRepo: fixture.defaultRepo
+            )
+
+            XCTAssertEqual(resolved.count, 1)
+            XCTAssertEqual(resolved.first?.rootPath, scenario.target.path)
+            XCTAssertEqual(resolved.first?.worktreeIdentity, scenario.identity)
+        }
+    }
+
+    private static func resolver(
+        advertisedWorktree: GitWorktreeDescriptor,
+        finalDescriptor: GitRepoDescriptor?
+    ) -> GitRepoTargetResolver {
+        resolver(worktrees: [advertisedWorktree], finalDescriptor: finalDescriptor)
+    }
+
+    private static func resolver(
+        worktrees: [GitWorktreeDescriptor],
+        finalDescriptor: GitRepoDescriptor?
+    ) -> GitRepoTargetResolver {
+        GitRepoTargetResolver(
+            dependencies: .init(
+                resolveRepo: { _ in finalDescriptor },
+                listWorktrees: { _ in worktrees }
+            )
+        )
+    }
+
+    private struct ExternalMainSelectorFixture {
+        let defaultRepo: GitRepoDescriptor
+        let visibleRoot: WorkspaceRootRef
+        let worktrees: [GitWorktreeDescriptor]
+        let mainWorktree: GitWorktreeDescriptor
+        let branchWorktree: GitWorktreeDescriptor
+        let mainIdentity: GitWorktreeIdentitySnapshot
+        let branchIdentity: GitWorktreeIdentitySnapshot
+        let replacementMainIdentity: GitWorktreeIdentitySnapshot
+        let replacementBranchIdentity: GitWorktreeIdentitySnapshot
+    }
+
+    private static func externalMainSelectorFixture() -> ExternalMainSelectorFixture {
+        let loadedPath = "/tmp/issue-860/loaded-linked"
+        let mainPath = "/tmp/issue-860/external-main"
+        let branchPath = "/tmp/issue-860/external-feature"
+        let mainWorktreeRoot = mainPath
+        let commonGitDir = "/tmp/repository-a/.git"
+        let loadedIdentity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: commonGitDir,
+            worktreeID: "worktree-loaded",
+            worktreeRootPath: loadedPath,
+            mainWorktreeRoot: mainWorktreeRoot
+        )
+        let mainIdentity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: commonGitDir,
+            worktreeID: "worktree-main",
+            worktreeRootPath: mainPath,
+            mainWorktreeRoot: mainWorktreeRoot,
+            isMain: true
+        )
+        let branchIdentity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: commonGitDir,
+            worktreeID: "worktree-feature",
+            worktreeRootPath: branchPath,
+            mainWorktreeRoot: mainWorktreeRoot
+        )
+        let replacementMainIdentity = Self.identity(
+            repositoryID: "repo-b",
+            commonGitDir: "/tmp/repository-b/.git",
+            worktreeID: "replacement-main",
+            worktreeRootPath: mainPath,
+            mainWorktreeRoot: "/tmp/repository-b",
+            isMain: true
+        )
+        let replacementBranchIdentity = Self.identity(
+            repositoryID: "repo-b",
+            commonGitDir: "/tmp/repository-b/.git",
+            worktreeID: "replacement-feature",
+            worktreeRootPath: branchPath,
+            mainWorktreeRoot: "/tmp/repository-b"
+        )
+        let loadedWorktree = Self.worktree(
+            from: loadedIdentity,
+            path: loadedPath,
+            name: "loaded-linked",
+            branch: "loaded"
+        )
+        let mainWorktree = Self.worktree(
+            from: mainIdentity,
+            path: mainPath,
+            name: "external-main",
+            branch: "main"
+        )
+        let branchWorktree = Self.worktree(
+            from: branchIdentity,
+            path: branchPath,
+            name: "external-feature",
+            branch: "feature"
+        )
+
+        return ExternalMainSelectorFixture(
+            defaultRepo: Self.repoDescriptor(from: loadedIdentity, path: loadedPath),
+            visibleRoot: Self.root(path: loadedPath),
+            worktrees: [loadedWorktree, mainWorktree, branchWorktree],
+            mainWorktree: mainWorktree,
+            branchWorktree: branchWorktree,
+            mainIdentity: mainIdentity,
+            branchIdentity: branchIdentity,
+            replacementMainIdentity: replacementMainIdentity,
+            replacementBranchIdentity: replacementBranchIdentity
+        )
+    }
+
+    private static func root(path: String) -> WorkspaceRootRef {
+        WorkspaceRootRef(id: UUID(), name: URL(fileURLWithPath: path).lastPathComponent, fullPath: path)
+    }
+
+    private static func loadedRepo(path: String) -> GitRepoDescriptor {
+        GitRepoDescriptor(
+            rootURL: URL(fileURLWithPath: path),
+            rootPath: path,
+            repoKey: "loaded-repo",
+            displayName: URL(fileURLWithPath: path).lastPathComponent
+        )
+    }
+
+    private static func identity(
+        repositoryID: String,
+        commonGitDir: String,
+        worktreeID: String,
+        worktreeRootPath: String,
+        mainWorktreeRoot: String,
+        isMain: Bool = false
+    ) -> GitWorktreeIdentitySnapshot {
+        GitWorktreeIdentitySnapshot(
+            repository: GitWorktreeRepositoryIdentity(
+                repositoryID: repositoryID,
+                repoKey: "repo-key-\(repositoryID)",
+                displayName: "repository",
+                commonGitDir: commonGitDir,
+                mainWorktreeRoot: mainWorktreeRoot
+            ),
+            worktreeID: worktreeID,
+            worktreeRootPath: worktreeRootPath,
+            isMain: isMain
+        )
+    }
+
+    private static func repoDescriptor(
+        from identity: GitWorktreeIdentitySnapshot,
+        path: String
+    ) -> GitRepoDescriptor {
+        GitRepoDescriptor(
+            rootURL: URL(fileURLWithPath: path),
+            rootPath: path,
+            repoKey: identity.repository.repoKey,
+            displayName: identity.repository.displayName,
+            worktreeIdentity: identity
+        )
+    }
+
+    private static func worktree(
+        from identity: GitWorktreeIdentitySnapshot,
+        path: String,
+        name: String = "feature",
+        branch: String? = "feature"
+    ) -> GitWorktreeDescriptor {
+        GitWorktreeDescriptor(
+            worktreeID: identity.worktreeID,
+            repository: identity.repository,
+            path: path,
+            gitDir: identity.isMain ? nil : "/tmp/git/worktrees/\(identity.worktreeID)",
+            name: name,
+            branch: branch,
+            head: "abc123",
+            isMain: identity.isMain,
+            isCurrent: false,
+            isDetached: false,
+            isLocked: false,
+            lockReason: nil,
+            isPrunable: false,
+            prunableReason: nil
+        )
+    }
+}
+
+final class AgentWorktreeRuntimeWorkspaceResolverIdentityTests: XCTestCase {
+    func testRejectsPersistedBindingWhenFreshIdentityChangesAtTheSamePath() {
+        let path = "/tmp/issue-860/advertised"
+        let binding = Self.binding(
+            path: path,
+            repositoryID: "repo-a",
+            worktreeID: "worktree-a",
+            commonGitDir: "/tmp/repository-a/.git"
+        )
+        let replacement = Self.identity(
+            repositoryID: "repo-b",
+            commonGitDir: "/tmp/repository-b/.git",
+            worktreeID: "worktree-b",
+            worktreeRootPath: path
+        )
+        let dependencies = AgentWorktreeRuntimeWorkspaceResolver.Dependencies(
+            directoryExists: { _ in true },
+            resolveIdentity: { _ in replacement }
+        )
+
+        XCTAssertThrowsError(
+            try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
+                bindings: [binding],
+                fallbackWorkspacePath: "/tmp/issue-860/logical",
+                dependencies: dependencies
+            )
+        )
+    }
+
+    func testRejectsPersistedBindingWhenCommonGitDirectoryChangesAtTheSamePath() {
+        let path = "/tmp/issue-860/advertised"
+        let binding = Self.binding(
+            path: path,
+            repositoryID: "repo-a",
+            worktreeID: "worktree-a",
+            commonGitDir: "/tmp/repository-a/.git"
+        )
+        let replacement = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: "/tmp/repository-b/.git",
+            worktreeID: "worktree-a",
+            worktreeRootPath: path
+        )
+        let dependencies = AgentWorktreeRuntimeWorkspaceResolver.Dependencies(
+            directoryExists: { _ in true },
+            resolveIdentity: { _ in replacement }
+        )
+
+        XCTAssertThrowsError(
+            try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
+                bindings: [binding],
+                fallbackWorkspacePath: "/tmp/issue-860/logical",
+                dependencies: dependencies
+            )
+        )
+    }
+
+    func testRejectsPersistedBindingWhenFreshIdentityIsUnavailable() {
+        let path = "/tmp/issue-860/advertised"
+        let binding = Self.binding(
+            path: path,
+            repositoryID: "repo-a",
+            worktreeID: "worktree-a",
+            commonGitDir: "/tmp/repository-a/.git"
+        )
+        let dependencies = AgentWorktreeRuntimeWorkspaceResolver.Dependencies(
+            directoryExists: { _ in true },
+            resolveIdentity: { _ in nil }
+        )
+
+        XCTAssertThrowsError(
+            try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
+                bindings: [binding],
+                fallbackWorkspacePath: "/tmp/issue-860/logical",
+                dependencies: dependencies
+            )
+        )
+    }
+
+    func testAllowsPersistedBindingWhenFreshIdentityMatchesRepositoryAndWorktree() throws {
+        let path = "/tmp/issue-860/advertised"
+        let identity = Self.identity(
+            repositoryID: "repo-a",
+            commonGitDir: "/tmp/repository-a/.git",
+            worktreeID: "worktree-a",
+            worktreeRootPath: path
+        )
+        let binding = Self.binding(
+            path: path,
+            repositoryID: identity.repository.repositoryID,
+            worktreeID: identity.worktreeID,
+            commonGitDir: identity.repository.commonGitDir
+        )
+        let dependencies = AgentWorktreeRuntimeWorkspaceResolver.Dependencies(
+            directoryExists: { _ in true },
+            resolveIdentity: { _ in identity }
+        )
+
+        let resolved = try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
+            bindings: [binding],
+            fallbackWorkspacePath: "/tmp/issue-860/logical",
+            dependencies: dependencies
+        )
+
+        XCTAssertEqual(resolved, path)
+    }
+
+    private static func binding(
+        path: String,
+        repositoryID: String,
+        worktreeID: String,
+        commonGitDir: String
+    ) -> AgentSessionWorktreeBinding {
+        AgentSessionWorktreeBinding(
+            id: "binding",
+            repositoryID: repositoryID,
+            repoKey: "repo-key-\(repositoryID)",
+            logicalRootPath: "/tmp/issue-860/logical",
+            worktreeID: worktreeID,
+            worktreeRootPath: path,
+            commonGitDir: commonGitDir,
+            isMainWorktree: false,
+            source: "test"
+        )
+    }
+
+    private static func identity(
+        repositoryID: String,
+        commonGitDir: String,
+        worktreeID: String,
+        worktreeRootPath: String
+    ) -> GitWorktreeIdentitySnapshot {
+        GitWorktreeIdentitySnapshot(
+            repository: GitWorktreeRepositoryIdentity(
+                repositoryID: repositoryID,
+                repoKey: "repo-key-\(repositoryID)",
+                displayName: "repository",
+                commonGitDir: commonGitDir,
+                mainWorktreeRoot: "/tmp/issue-860/loaded"
+            ),
+            worktreeID: worktreeID,
+            worktreeRootPath: worktreeRootPath,
+            isMain: false
+        )
+    }
+}


### PR DESCRIPTION
A worktree path can be reused by a different repository after discovery or after an Agent session binding is saved. Re-resolve external worktree targets against the advertised repository and worktree identity before granting access, and validate persisted Agent bindings against fresh identity before starting the agent. Carry optional common-Git-directory and main-worktree metadata in bindings while retaining legacy decoding.

Apply the external-target guard to ID, branch, explicit-path and main/primary selectors, including layout-based resolution. Preserve ordinary in-root authorization and valid linked-worktree access.

Source review is complete. Current-main integration is 524363aa427b872f301e615772622615d6e64dee against 542b111e3074ed7126c0dea8a46572fa569bf51a. 27 focused resolver/binding/persistence tests, both products and lint passed. Actual packaged restart and replacement acceptance remains required. These test fixtures inject identity snapshots; they are not a filesystem race reproduction.

Fixes #860.
