### PR TITLE
Prevent load-time repair from resurrecting deleted sessions

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
@@ -183,6 +183,8 @@ actor AgentSessionDataService {
     #if DEBUG
         private var deletionTombstoneWaitersByURL: [URL: [CheckedContinuation<Void, Never>]] = [:]
         private var workspaceRootOverrideForTesting: URL?
+        private var testWorktreeMergeReconciliationHooks: AgentSessionWorktreeMergeReconciliationHooks?
+        private var testBeforeLoadRepairWriteHook: (@Sendable (URL) async -> Void)?
     #endif
     private var metadataIndexReconciliationTasksByFolder: [URL: MetadataIndexReconciliationTaskState] = [:]
     private var metadataIndexReconciledThisProcess: Set<URL> = []
@@ -489,7 +491,67 @@ actor AgentSessionDataService {
     }
 
     private func writeDataAtomically(_ data: Data, to fileURL: URL) async throws {
-        try await diskWriter.enqueueAndWait(data: data, url: fileURL)
+        try await diskWriter.enqueueAndWait(data: data, url: fileURL.standardizedFileURL)
+    }
+
+    private func reconcileLoadedWorktreeMergeOperations(
+        _ operations: [AgentSessionWorktreeMergeOperation]
+    ) async -> [AgentSessionWorktreeMergeOperation] {
+        #if DEBUG
+            let hooks = testWorktreeMergeReconciliationHooks ?? .live()
+        #else
+            let hooks = AgentSessionWorktreeMergeReconciliationHooks.live()
+        #endif
+        return await AgentSessionWorktreeMergeReconciler.reconcile(operations, hooks: hooks)
+    }
+
+    private func ensureSessionWriteAllowed(_ sessionID: UUID, fileURL: URL) throws {
+        let fileURL = fileURL.standardizedFileURL
+        guard !deletedSessionFileURLs.contains(fileURL) else {
+            throw AgentSessionDataError.sessionDeleted(sessionID)
+        }
+    }
+
+    /// The ordinary save and load/recovery writebacks share this session-file/metadata fence.
+    /// The preflight is repeated after the DEBUG gate because deletion can complete while a
+    /// suspended load is waiting to resume; the post-write checks withdraw any write that crossed
+    /// the deletion boundary and remove its derived metadata.
+    private func persistSessionAndMetadata(
+        _ session: AgentSession,
+        encodedData: Data,
+        fileURL: URL,
+        folder: URL,
+        isLoadRepair: Bool
+    ) async throws {
+        let fileURL = fileURL.standardizedFileURL
+        try ensureSessionWriteAllowed(session.id, fileURL: fileURL)
+        #if DEBUG
+            if isLoadRepair, let testBeforeLoadRepairWriteHook {
+                await testBeforeLoadRepairWriteHook(fileURL)
+            }
+        #endif
+        try ensureSessionWriteAllowed(session.id, fileURL: fileURL)
+        try await writeDataAtomically(encodedData, to: fileURL)
+        try await discardSaveIfSessionWasDeleted(session.id, fileURL: fileURL, folder: folder)
+        await upsertMetadataRecord(metadataRecord(from: session, fileURL: fileURL), folder: folder)
+        try await discardSaveIfSessionWasDeleted(session.id, fileURL: fileURL, folder: folder)
+    }
+
+    private func persistLoadedMetadataIfIndexPresent(
+        _ session: AgentSession,
+        fileURL: URL
+    ) async throws {
+        let fileURL = fileURL.standardizedFileURL
+        let folder = fileURL.deletingLastPathComponent()
+        try ensureSessionWriteAllowed(session.id, fileURL: fileURL)
+        #if DEBUG
+            if let testBeforeLoadRepairWriteHook {
+                await testBeforeLoadRepairWriteHook(fileURL)
+            }
+        #endif
+        try ensureSessionWriteAllowed(session.id, fileURL: fileURL)
+        await upsertMetadataRecordIfIndexPresent(session, fileURL: fileURL)
+        try await discardSaveIfSessionWasDeleted(session.id, fileURL: fileURL, folder: folder)
     }
 
     // MARK: - Metadata Index Helpers
@@ -1128,10 +1190,13 @@ actor AgentSessionDataService {
         )
         let freshEncoder = JSONEncoder()
         let data = try freshEncoder.encode(sessionToSave)
-        try await diskWriter.enqueueAndWait(data: data, url: fileURL)
-        try await discardSaveIfSessionWasDeleted(session.id, fileURL: fileURL, folder: agentSessionsFolder)
-        await upsertMetadataRecord(metadataRecord(from: sessionToSave, fileURL: fileURL), folder: agentSessionsFolder)
-        try await discardSaveIfSessionWasDeleted(session.id, fileURL: fileURL, folder: agentSessionsFolder)
+        try await persistSessionAndMetadata(
+            sessionToSave,
+            encodedData: data,
+            fileURL: fileURL,
+            folder: agentSessionsFolder,
+            isLoadRepair: false
+        )
         return fileURL
     }
 
@@ -1161,7 +1226,9 @@ actor AgentSessionDataService {
             let normalized = normalizeLoadedSession(session, fileURL: fileURL)
             var runtimeSession = normalized.runtimeSession
             var persistedSessionToRewrite = normalized.persistedSessionToRewrite
-            let reconciledMergeOperations = await AgentSessionWorktreeMergeReconciler.reconcile(runtimeSession.worktreeMergeOperations)
+            let reconciledMergeOperations = await reconcileLoadedWorktreeMergeOperations(
+                runtimeSession.worktreeMergeOperations
+            )
             if reconciledMergeOperations != runtimeSession.worktreeMergeOperations {
                 runtimeSession.worktreeMergeOperations = reconciledMergeOperations
                 persistedSessionToRewrite = sessionPreparedForStorage(
@@ -1174,13 +1241,15 @@ actor AgentSessionDataService {
             }
             if let persistedSession = persistedSessionToRewrite {
                 let encoded = try encoder.encode(persistedSession)
-                try await writeDataAtomically(encoded, to: fileURL)
-                await upsertMetadataRecord(
-                    metadataRecord(from: persistedSession, fileURL: fileURL),
-                    folder: fileURL.deletingLastPathComponent()
+                try await persistSessionAndMetadata(
+                    persistedSession,
+                    encodedData: encoded,
+                    fileURL: fileURL,
+                    folder: fileURL.deletingLastPathComponent(),
+                    isLoadRepair: true
                 )
             } else {
-                await upsertMetadataRecordIfIndexPresent(runtimeSession, fileURL: fileURL)
+                try await persistLoadedMetadataIfIndexPresent(runtimeSession, fileURL: fileURL)
             }
             return runtimeSession
         } catch {
@@ -1234,10 +1303,12 @@ actor AgentSessionDataService {
                 {
                     do {
                         let encoded = try encoder.encode(persistedSession)
-                        try await writeDataAtomically(encoded, to: fileURL)
-                        await upsertMetadataRecord(
-                            metadataRecord(from: persistedSession, fileURL: fileURL),
-                            folder: fileURL.deletingLastPathComponent()
+                        try await persistSessionAndMetadata(
+                            persistedSession,
+                            encodedData: encoded,
+                            fileURL: fileURL,
+                            folder: fileURL.deletingLastPathComponent(),
+                            isLoadRepair: true
                         )
                     } catch {
                         // Best-effort migration only; continue serving recovered values in-memory.
@@ -1615,6 +1686,16 @@ actor AgentSessionDataService {
 
         func test_setBeforeSessionWriteHook(_ hook: (@Sendable (URL) async -> Void)?) async {
             await diskWriter.test_setBeforeWriteHook(hook)
+        }
+
+        func test_setWorktreeMergeReconciliationHooks(
+            _ hooks: AgentSessionWorktreeMergeReconciliationHooks?
+        ) {
+            testWorktreeMergeReconciliationHooks = hooks
+        }
+
+        func test_setBeforeLoadRepairWriteHook(_ hook: (@Sendable (URL) async -> Void)?) {
+            testBeforeLoadRepairWriteHook = hook
         }
 
         func test_waitUntilDeletionTombstone(for fileURL: URL) async {

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionDataServiceLoadRepairDeletionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionDataServiceLoadRepairDeletionTests.swift
@@ -1,0 +1,519 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+private let issue863GateWatchdogNanoseconds: UInt64 = 5_000_000_000
+
+final class AgentSessionDataServiceLoadRepairDeletionTests: XCTestCase {
+    func testLoadReconciliationDoesNotResurrectAfterDeletion() async throws {
+        let service = AgentSessionDataService()
+        let workspace = makeTemporaryWorkspace()
+        let storageURL = try XCTUnwrap(workspace.customStoragePath)
+        let reconciliationGate = Issue863TestAsyncGate()
+        let cleanup = Issue863TestRepairCleanup(service: service, gate: reconciliationGate)
+        addTeardownBlock {
+            await cleanup.finish()
+            try? FileManager.default.removeItem(at: storageURL)
+        }
+
+        let sessionID = UUID()
+        let session = AgentSession(
+            id: sessionID,
+            workspaceID: workspace.id,
+            name: "Reconciliation Delete Race",
+            savedAt: Date(timeIntervalSinceReferenceDate: 10),
+            itemCount: 0,
+            autoEditEnabled: true,
+            worktreeMergeOperations: [makeActiveMergeOperation()]
+        )
+        let fileURL = try await service.saveAgentSession(
+            session,
+            for: workspace,
+            preparation: .alreadyCanonicalTranscript,
+            trustedCanonicalItemCount: 0
+        )
+        await service.test_setWorktreeMergeReconciliationHooks(
+            AgentSessionWorktreeMergeReconciliationHooks { _ in
+                await reconciliationGate.wait()
+                return AgentSessionWorktreeMergeReconciliationInspection(
+                    targetMergeInProgress: true,
+                    targetHead: nil
+                )
+            }
+        )
+
+        let loadTask = Task {
+            try await service.loadAgentSession(from: fileURL)
+        }
+        await cleanup.registerLoadTask(loadTask)
+        await cleanup.registerWatchdog(makeGateWatchdog(for: reconciliationGate))
+        guard await reconciliationGate.waitUntilEntered() else {
+            XCTFail("Load reconciliation did not reach its deterministic gate")
+            return
+        }
+
+        let deleteTask = Task {
+            try await service.deleteAgentSession(id: sessionID, for: workspace)
+        }
+        await cleanup.registerDeleteTask(deleteTask)
+        try await deleteTask.value
+        await reconciliationGate.open()
+
+        do {
+            _ = try await loadTask.value
+            XCTFail("A load repair resumed after deletion and unexpectedly succeeded")
+        } catch {
+            assertLoadFailedWithSessionDeleted(error, sessionID: sessionID)
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        XCTAssertNil(try metadataRecord(sessionID, nextTo: fileURL))
+    }
+
+    func testStubRecoveryDoesNotResurrectAfterDeletion() async throws {
+        let service = AgentSessionDataService()
+        let workspace = makeTemporaryWorkspace()
+        let storageURL = try XCTUnwrap(workspace.customStoragePath)
+        let recoveryGate = Issue863TestAsyncGate()
+        let cleanup = Issue863TestRepairCleanup(service: service, gate: recoveryGate)
+        addTeardownBlock {
+            await cleanup.finish()
+            try? FileManager.default.removeItem(at: storageURL)
+        }
+
+        let sessionID = UUID()
+        let fileURL = try await seedLegacySession(
+            service: service,
+            workspace: workspace,
+            sessionID: sessionID
+        )
+        await service.test_setBeforeLoadRepairWriteHook { url in
+            guard url == fileURL.standardizedFileURL else { return }
+            await recoveryGate.wait()
+        }
+
+        let recoveryTask = Task {
+            try await service.loadAgentSessionStub(
+                from: fileURL,
+                recoverMissingMetadata: true,
+                persistRecoveredMetadata: true
+            )
+        }
+        await cleanup.registerLoadTask(recoveryTask)
+        await cleanup.registerWatchdog(makeGateWatchdog(for: recoveryGate))
+        guard await recoveryGate.waitUntilEntered() else {
+            XCTFail("Stub recovery did not reach its deterministic gate")
+            return
+        }
+
+        let deleteTask = Task {
+            try await service.deleteAgentSession(id: sessionID, for: workspace)
+        }
+        await cleanup.registerDeleteTask(deleteTask)
+        try await deleteTask.value
+        await recoveryGate.open()
+
+        let recovered = try await recoveryTask.value
+        XCTAssertEqual(recovered.id, sessionID)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        XCTAssertNil(try metadataRecord(sessionID, nextTo: fileURL))
+    }
+
+    func testStubRecoveryPersistsForNondeletedSession() async throws {
+        let service = AgentSessionDataService()
+        let workspace = makeTemporaryWorkspace()
+        let storageURL = try XCTUnwrap(workspace.customStoragePath)
+        let recoveryGate = Issue863TestAsyncGate()
+        let cleanup = Issue863TestRepairCleanup(service: service, gate: recoveryGate)
+        addTeardownBlock {
+            await cleanup.finish()
+            try? FileManager.default.removeItem(at: storageURL)
+        }
+
+        let sessionID = UUID()
+        let fileURL = try await seedLegacySession(
+            service: service,
+            workspace: workspace,
+            sessionID: sessionID
+        )
+        try await removeMetadataIndex(for: service, nextTo: fileURL)
+        XCTAssertNil(try metadataRecord(sessionID, nextTo: fileURL))
+
+        await service.test_setBeforeLoadRepairWriteHook { url in
+            guard url == fileURL.standardizedFileURL else { return }
+            await recoveryGate.wait()
+        }
+
+        let recoveryTask = Task {
+            try await service.loadAgentSessionStub(
+                from: fileURL,
+                recoverMissingMetadata: true,
+                persistRecoveredMetadata: true
+            )
+        }
+        await cleanup.registerLoadTask(recoveryTask)
+        await cleanup.registerWatchdog(makeGateWatchdog(for: recoveryGate))
+        guard await recoveryGate.waitUntilEntered() else {
+            XCTFail("Stub recovery did not reach its deterministic gate")
+            return
+        }
+
+        await recoveryGate.open()
+        _ = try await recoveryTask.value
+
+        let repaired = try JSONDecoder().decode(
+            AgentSession.self,
+            from: Data(contentsOf: fileURL)
+        )
+        XCTAssertEqual(repaired.serializationVersion, AgentSession.currentSerializationVersion)
+
+        let record = try XCTUnwrap(try metadataRecord(sessionID, nextTo: fileURL))
+        XCTAssertEqual(record.id, sessionID)
+        XCTAssertEqual(record.filename, fileURL.lastPathComponent)
+        XCTAssertEqual(record.serializationVersion, AgentSession.currentSerializationVersion)
+        XCTAssertEqual(record.itemCount, repaired.effectiveItemCount)
+    }
+
+    func testLoadReconciliationPersistsForNondeletedSession() async throws {
+        let service = AgentSessionDataService()
+        let workspace = makeTemporaryWorkspace()
+        let storageURL = try XCTUnwrap(workspace.customStoragePath)
+        let repairGate = Issue863TestAsyncGate()
+        let cleanup = Issue863TestRepairCleanup(service: service, gate: repairGate)
+        addTeardownBlock {
+            await cleanup.finish()
+            try? FileManager.default.removeItem(at: storageURL)
+        }
+
+        let sessionID = UUID()
+        let fileURL = try await service.saveAgentSession(
+            AgentSession(
+                id: sessionID,
+                workspaceID: workspace.id,
+                name: "Full Load Repair Control",
+                savedAt: Date(timeIntervalSinceReferenceDate: 30),
+                itemCount: 0,
+                autoEditEnabled: true,
+                worktreeMergeOperations: [makeActiveMergeOperation()]
+            ),
+            for: workspace,
+            preparation: .alreadyCanonicalTranscript,
+            trustedCanonicalItemCount: 0
+        )
+        try await removeMetadataIndex(for: service, nextTo: fileURL)
+        XCTAssertNil(try metadataRecord(sessionID, nextTo: fileURL))
+
+        await service.test_setWorktreeMergeReconciliationHooks(
+            AgentSessionWorktreeMergeReconciliationHooks { _ in
+                AgentSessionWorktreeMergeReconciliationInspection(
+                    targetMergeInProgress: true,
+                    targetHead: nil
+                )
+            }
+        )
+        await service.test_setBeforeLoadRepairWriteHook { url in
+            guard url == fileURL.standardizedFileURL else { return }
+            await repairGate.wait()
+        }
+
+        let loadTask = Task {
+            try await service.loadAgentSession(from: fileURL)
+        }
+        await cleanup.registerLoadTask(loadTask)
+        await cleanup.registerWatchdog(makeGateWatchdog(for: repairGate))
+        guard await repairGate.waitUntilEntered() else {
+            XCTFail("Full load repair did not reach its deterministic write gate")
+            return
+        }
+
+        await repairGate.open()
+        let loaded = try await loadTask.value
+        XCTAssertEqual(loaded.worktreeMergeOperations.first?.status, .awaitingCommit)
+
+        let repaired = try JSONDecoder().decode(
+            AgentSession.self,
+            from: Data(contentsOf: fileURL)
+        )
+        XCTAssertEqual(repaired.worktreeMergeOperations.first?.status, .awaitingCommit)
+
+        let record = try XCTUnwrap(try metadataRecord(sessionID, nextTo: fileURL))
+        XCTAssertEqual(record.id, sessionID)
+        XCTAssertEqual(record.filename, fileURL.lastPathComponent)
+        XCTAssertEqual(record.serializationVersion, AgentSession.currentSerializationVersion)
+        XCTAssertEqual(record.activeWorktreeMergeSummaries.map(\.status), [.awaitingCommit])
+    }
+
+    private func seedLegacySession(
+        service: AgentSessionDataService,
+        workspace: WorkspaceModel,
+        sessionID: UUID
+    ) async throws -> URL {
+        let seeded = AgentSession(
+            id: sessionID,
+            workspaceID: workspace.id,
+            name: "Legacy Stub Recovery",
+            savedAt: Date(timeIntervalSinceReferenceDate: 20),
+            itemCount: 0,
+            autoEditEnabled: true
+        )
+        let fileURL = try await service.saveAgentSession(
+            seeded,
+            for: workspace,
+            preparation: .alreadyCanonicalTranscript,
+            trustedCanonicalItemCount: 0
+        )
+        var legacy = seeded
+        legacy.serializationVersion = AgentSession.currentSerializationVersion - 1
+        legacy.itemCount = nil
+        legacy.transcriptProjectionCounts = nil
+        legacy.lastUserMessageAt = nil
+        let data = try JSONEncoder().encode(legacy)
+        try data.write(to: fileURL, options: .atomic)
+        return fileURL
+    }
+
+    private func removeMetadataIndex(
+        for service: AgentSessionDataService,
+        nextTo fileURL: URL
+    ) async throws {
+        let folder = fileURL.deletingLastPathComponent()
+        let indexURL = folder.appendingPathComponent("AgentSessionIndex.json")
+        try FileManager.default.removeItem(at: indexURL)
+        await service.test_clearMetadataIndexCache(forAgentSessionsFolder: folder)
+    }
+
+    private func metadataRecord(
+        _ sessionID: UUID,
+        nextTo fileURL: URL
+    ) throws -> AgentSessionMetadataRecord? {
+        let indexURL = fileURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("AgentSessionIndex.json")
+        guard FileManager.default.fileExists(atPath: indexURL.path) else { return nil }
+        let data = try Data(contentsOf: indexURL)
+        let index = try JSONDecoder().decode(AgentSessionMetadataIndex.self, from: data)
+        return index.entries.first { $0.id == sessionID }
+    }
+
+    private func assertLoadFailedWithSessionDeleted(
+        _ error: Error,
+        sessionID: UUID,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let loadError = error as? AgentSessionDataError else {
+            XCTFail("Expected AgentSessionDataError.loadFailed(sessionDeleted), got \(error)", file: file, line: line)
+            return
+        }
+        guard case let .loadFailed(underlying) = loadError else {
+            XCTFail("Expected AgentSessionDataError.loadFailed(sessionDeleted), got \(error)", file: file, line: line)
+            return
+        }
+        guard let deletionError = underlying as? AgentSessionDataError else {
+            XCTFail("Expected loadFailed to wrap sessionDeleted, got \(underlying)", file: file, line: line)
+            return
+        }
+        guard case let .sessionDeleted(deletedSessionID) = deletionError else {
+            XCTFail("Expected loadFailed to wrap sessionDeleted, got \(underlying)", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(deletedSessionID, sessionID, file: file, line: line)
+    }
+
+    private func makeGateWatchdog(for gate: Issue863TestAsyncGate) -> Task<Void, Never> {
+        Task {
+            do {
+                try await Task.sleep(nanoseconds: issue863GateWatchdogNanoseconds)
+            } catch {
+                return
+            }
+            await gate.expireEntryWaitIfNeeded()
+        }
+    }
+
+    private func makeActiveMergeOperation() -> AgentSessionWorktreeMergeOperation {
+        let source = GitWorktreeMergeEndpoint(
+            worktreeID: "issue863-source",
+            repositoryID: "issue863-repository",
+            repoKey: "issue863",
+            path: "/tmp/issue863-source",
+            name: "source",
+            branch: "feature/issue863",
+            head: "source-head",
+            isMain: false
+        )
+        let target = GitWorktreeMergeEndpoint(
+            worktreeID: "issue863-target",
+            repositoryID: "issue863-repository",
+            repoKey: "issue863",
+            path: "/tmp/issue863-target",
+            name: "main",
+            branch: "main",
+            head: "target-head",
+            isMain: true
+        )
+        return AgentSessionWorktreeMergeOperation(
+            id: "issue863-merge",
+            source: source,
+            target: target,
+            mergeBase: "merge-base",
+            sourceHead: source.head,
+            targetHeadBefore: target.head,
+            status: .applying
+        )
+    }
+
+    private func makeTemporaryWorkspace() -> WorkspaceModel {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentSessionDataServiceLoadRepairDeletionTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        return WorkspaceModel(
+            name: "Agent Session Load Repair",
+            repoPaths: ["/tmp/repo"],
+            customStoragePath: directory
+        )
+    }
+}
+
+private actor Issue863TestRepairCleanup {
+    private let service: AgentSessionDataService
+    private let gate: Issue863TestAsyncGate
+    private var loadTask: Task<AgentSession, Error>?
+    private var deleteTask: Task<Void, Error>?
+    private var watchdogTask: Task<Void, Never>?
+    private var hasFinished = false
+
+    init(service: AgentSessionDataService, gate: Issue863TestAsyncGate) {
+        self.service = service
+        self.gate = gate
+    }
+
+    func registerLoadTask(_ task: Task<AgentSession, Error>) {
+        loadTask = task
+    }
+
+    func registerDeleteTask(_ task: Task<Void, Error>) {
+        deleteTask = task
+    }
+
+    func registerWatchdog(_ task: Task<Void, Never>) {
+        watchdogTask = task
+    }
+
+    func finish() async {
+        guard !hasFinished else { return }
+        hasFinished = true
+
+        await gate.open()
+
+        watchdogTask?.cancel()
+        if let watchdogTask {
+            await watchdogTask.value
+        }
+
+        loadTask?.cancel()
+        if let loadTask {
+            _ = await loadTask.result
+        }
+
+        deleteTask?.cancel()
+        if let deleteTask {
+            _ = await deleteTask.result
+        }
+
+        await service.test_setWorktreeMergeReconciliationHooks(nil)
+        await service.test_setBeforeLoadRepairWriteHook(nil)
+    }
+}
+
+private actor Issue863TestAsyncGate {
+    private var enteredContinuation: CheckedContinuation<Bool, Never>?
+    private var enteredWaiterID: UUID?
+    private var openContinuation: CheckedContinuation<Void, Never>?
+    private var openWaiterID: UUID?
+    private var hasEntered = false
+    private var isOpen = false
+
+    func wait() async {
+        if !hasEntered {
+            hasEntered = true
+            let continuation = enteredContinuation
+            enteredContinuation = nil
+            enteredWaiterID = nil
+            continuation?.resume(returning: true)
+        }
+        guard !isOpen, !Task.isCancelled else { return }
+
+        let waiterID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                if isOpen || Task.isCancelled {
+                    continuation.resume()
+                } else {
+                    openWaiterID = waiterID
+                    openContinuation = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelOpenWaiter(id: waiterID) }
+        }
+    }
+
+    func waitUntilEntered() async -> Bool {
+        guard !hasEntered, !isOpen, !Task.isCancelled else {
+            return hasEntered
+        }
+
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                if hasEntered {
+                    continuation.resume(returning: true)
+                } else if isOpen || Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else {
+                    enteredWaiterID = waiterID
+                    enteredContinuation = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelEnteredWaiter(id: waiterID) }
+        }
+    }
+
+    func expireEntryWaitIfNeeded() {
+        guard !hasEntered else { return }
+        open()
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+
+        let entered = enteredContinuation
+        enteredContinuation = nil
+        enteredWaiterID = nil
+        entered?.resume(returning: hasEntered)
+
+        let open = openContinuation
+        openContinuation = nil
+        openWaiterID = nil
+        open?.resume()
+    }
+
+    private func cancelEnteredWaiter(id: UUID) {
+        guard enteredWaiterID == id else { return }
+        let continuation = enteredContinuation
+        enteredContinuation = nil
+        enteredWaiterID = nil
+        continuation?.resume(returning: false)
+    }
+
+    private func cancelOpenWaiter(id: UUID) {
+        guard openWaiterID == id else { return }
+        let continuation = openContinuation
+        openContinuation = nil
+        openWaiterID = nil
+        continuation?.resume()
+    }
+}


### PR DESCRIPTION
A load-time session repair could rewrite its file after deletion completed, resurrecting a deleted conversation. Route full-load repair, stub recovery and metadata repair through the same per-file disk writer and deletion tombstone used by ordinary saves, and reject a repair once deletion owns that session path.

Four focused deletion/repair regressions, the app build and strict lint passed on the reviewed feature. Current-main integration preserves the feature patch and includes #959: index-independent batch deletion also calls the same durable deletion coordinator. Tests cover deletion racing full-load repair, stub recovery and metadata persistence, with nondeleted-session controls.

Fresh hosted checks and packaged acceptance remain required.

Fixes #863.
