### PR TITLE
Retain process ownership until child termination settles

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -1266,12 +1266,16 @@ actor ACPAgentSessionController {
     private func startProcessWaitTask(for process: SpawnedProcess) {
         processWaitTask = Task { [weak self] in
             guard let self else { return }
-            let result = try? await ProcessTermination.waitForTermination(
-                pid: process.pid,
-                processGroupID: process.processGroupID,
-                timeout: nil
-            )
-            await handleProcessExit(result?.exitCode ?? 0, timedOut: result?.timedOut ?? false)
+            do {
+                let result = try await ProcessTermination.waitForTermination(
+                    pid: process.pid,
+                    processGroupID: process.processGroupID,
+                    timeout: nil
+                )
+                await handleProcessExit(result.exitCode, timedOut: result.timedOut)
+            } catch {
+                await handleProcessWaitFailure(error)
+            }
         }
     }
 
@@ -1564,6 +1568,26 @@ actor ACPAgentSessionController {
             let message = timedOut
                 ? "ACP process timed out."
                 : "ACP process exited unexpectedly with code \(exitCode)."
+            emit(.stream(AIStreamResult(type: "error", text: message)))
+            emitTerminal(state: .failed, errorText: message)
+        }
+
+        failAllPromptSettlementWaiters(with: ControllerError.transportClosed)
+        failPendingRequests(with: ControllerError.transportClosed)
+        state = .failed
+        await clearExpectedAgentPIDIfNeeded()
+        await cleanupLaunchArtifacts()
+        finishEventsIfNeeded()
+    }
+
+    private func handleProcessWaitFailure(_ error: Error) async {
+        guard state != .closing, state != .closed else {
+            finishEventsIfNeeded()
+            return
+        }
+
+        let message = "ACP process termination observation failed: \(error.localizedDescription)"
+        if state == .promptRunning || !didEmitTerminal {
             emit(.stream(AIStreamResult(type: "error", text: message)))
             emitTerminal(state: .failed, errorText: message)
         }

--- a/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
@@ -88,8 +88,8 @@ private final class ProcessDescriptorCleanup: @unchecked Sendable {
     private func markClosed(_ keyPath: ReferenceWritableKeyPath<ProcessDescriptorCleanup, Bool>) -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        guard !self[keyPath] else { return false }
-        self[keyPath] = true
+        guard !self[keyPath: keyPath] else { return false }
+        self[keyPath: keyPath] = true
         return true
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
@@ -22,6 +22,78 @@ private actor GateReleaseCoordinator {
     }
 }
 
+/// Serializes bounded termination requests without owning the child's destructive reap.
+/// The `ChildProcessExitObserver` remains the only waitpid owner; timeout and stream
+/// cancellation share this actor so they cannot duplicate process-group escalation or
+/// descendant cleanup.
+private actor OwnedProcessTerminationCoordinator {
+    private let observer: ChildProcessExitObserver
+    private let processGroupID: pid_t?
+    private var terminationTask: Task<Void, Never>?
+
+    init(observer: ChildProcessExitObserver, processGroupID: pid_t?) {
+        self.observer = observer
+        self.processGroupID = processGroupID
+    }
+
+    func terminate(logger: @escaping @Sendable (String) -> Void) async {
+        if let terminationTask {
+            await terminationTask.value
+            return
+        }
+
+        let task = Task.detached { [observer, processGroupID] in
+            await ProcessTermination.terminateObservedProcessFamily(
+                observer: observer,
+                processGroupID: processGroupID,
+                logger: logger
+            )
+        }
+        terminationTask = task
+        await task.value
+    }
+}
+
+/// Idempotently closes the three parent-side descriptors for one spawned child.
+/// The lock deduplicates close requests; it does not synchronize read/write
+/// operations. The reaper/gate owner remains separate.
+private final class ProcessDescriptorCleanup: @unchecked Sendable {
+    private let process: SpawnedProcess
+    private let lock = NSLock()
+    private var stdinClosed = false
+    private var stdoutClosed = false
+    private var stderrClosed = false
+
+    init(process: SpawnedProcess) {
+        self.process = process
+    }
+
+    func closeInput() {
+        guard markClosed(\.stdinClosed) else { return }
+        process.stdin?.closeFile()
+    }
+
+    func closeOutput() {
+        let shouldCloseStdout = markClosed(\.stdoutClosed)
+        let shouldCloseStderr = markClosed(\.stderrClosed)
+        if shouldCloseStdout { process.stdout.closeFile() }
+        if shouldCloseStderr { process.stderr.closeFile() }
+    }
+
+    func closeAll() {
+        closeInput()
+        closeOutput()
+    }
+
+    private func markClosed(_ keyPath: ReferenceWritableKeyPath<ProcessDescriptorCleanup, Bool>) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !self[keyPath] else { return false }
+        self[keyPath] = true
+        return true
+    }
+}
+
 /// Global cache: remember the absolute path to a command once we've
 /// successfully launched it at least once. This avoids repeating
 /// interactive-shell lookups (which are relatively expensive).
@@ -97,10 +169,18 @@ final class CLIProcessRunner {
     let config: CLIProcessConfiguration
     private let registry = ProcessRegistry()
     private let gate: TaskSemaphore
+    private let processExitObserverFactory: @Sendable (pid_t) -> ChildProcessExitObserver
 
-    init(config: CLIProcessConfiguration, concurrencyLimit: Int = 1) {
+    init(
+        config: CLIProcessConfiguration,
+        concurrencyLimit: Int = 1,
+        processExitObserverFactory: @escaping @Sendable (pid_t) -> ChildProcessExitObserver = { pid in
+            ChildProcessExitObserver(pid: pid)
+        }
+    ) {
         self.config = config
         gate = TaskSemaphore(max(concurrencyLimit, 1))
+        self.processExitObserverFactory = processExitObserverFactory
     }
 
     @inline(__always)
@@ -482,6 +562,11 @@ final class CLIProcessRunner {
         }
 
         await registry.add(spawned)
+        let exitObserver = processExitObserverFactory(spawned.pid)
+        let terminationCoordinator = OwnedProcessTerminationCoordinator(
+            observer: exitObserver,
+            processGroupID: spawned.processGroupID
+        )
         await onProcessStarted?(spawned.pid)
 
         let collector = config.logCollector
@@ -497,6 +582,7 @@ final class CLIProcessRunner {
             var stderrTail = Data()
 
             let gateCoordinator = GateReleaseCoordinator()
+            let descriptorCleanup = ProcessDescriptorCleanup(process: spawned)
 
             group.enter()
             DispatchQueue.global(qos: .userInitiated).async {
@@ -538,7 +624,7 @@ final class CLIProcessRunner {
                 group.enter()
                 DispatchQueue.global(qos: .userInitiated).async {
                     defer {
-                        stdinHandle.closeFile()
+                        descriptorCleanup.closeInput()
                         group.leave()
                     }
                     let chunkSize = 64 * 1024
@@ -552,76 +638,76 @@ final class CLIProcessRunner {
                     }
                 }
             } else {
-                spawned.stdin?.closeFile()
+                descriptorCleanup.closeInput()
             }
 
-            let waitTask = Task.detached { () throws -> (Int32, Bool) in
-                // Use async, cooperative waiting to avoid blocking the pool
-                try await Self.waitForTerminationAsync(
-                    pid: spawned.pid,
+            // This task owns only the stream's bounded terminal result. It never
+            // performs registry, descriptor, callback, or gate cleanup.
+            let resultTask = Task.detached { () throws -> (Int32, Bool) in
+                let outcome: ChildProcessExitObserver.Outcome
+                let timedOut: Bool
+                if let timeout {
+                    if let observedOutcome = await exitObserver.wait(timeout: timeout) {
+                        outcome = observedOutcome
+                        timedOut = false
+                    } else {
+                        timedOut = true
+                        ProcessDiagnostics.log("Process timed out after \(timeout) seconds; terminating")
+                        await terminationCoordinator.terminate { message in
+                            ProcessDiagnostics.log(message)
+                        }
+                        guard let settledOutcome = await exitObserver.wait(timeout: 0) else {
+                            throw Self.unresolvedOwnedProcessError(pid: spawned.pid)
+                        }
+                        outcome = settledOutcome
+                    }
+                } else {
+                    guard let observedOutcome = await exitObserver.wait() else {
+                        throw Self.unresolvedOwnedProcessError(pid: spawned.pid)
+                    }
+                    outcome = observedOutcome
+                    timedOut = false
+                }
+                return try Self.streamTerminationResult(from: outcome, timedOut: timedOut)
+            }
+
+            // This is the sole physical finalizer. It may remain pending after a
+            // bounded stream failure, retaining observer/registry/gate ownership
+            // until the existing observer reports a terminal outcome.
+            let finalizationTask = Task.detached { [self, gateCoordinator] in
+                guard let outcome = await exitObserver.wait() else {
+                    ProcessDiagnostics.log(Self.unresolvedOwnedProcessError(pid: spawned.pid).localizedDescription)
+                    return
+                }
+
+                if case let .failed(error) = outcome {
+                    ProcessDiagnostics.log("❌ [REAPER] Observation failed for pid=\(spawned.pid): \(error)")
+                }
+                await ProcessTermination.terminateProcessGroupAfterRootReap(
                     processGroupID: spawned.processGroupID,
-                    timeout: timeout
-                ) { warning in
-                    ProcessDiagnostics.log(warning)
+                    logger: { message in
+                        ProcessDiagnostics.log(message)
+                    }
+                )
+                ProcessDiagnostics.log("🔒 [FD] Closing FDs for pid=\(spawned.pid)")
+                descriptorCleanup.closeAll()
+
+                let groupFinished = await Self.waitForGroup(group, timeout: 5.0, pid: spawned.pid) { msg in
+                    ProcessDiagnostics.log(msg)
                 }
-            }
-
-            // Detached so its lifetime outlives this closure and it always releases the permit
-            let _ = Task.detached { [self, gateCoordinator] in
-                do {
-                    let (status, timedOut) = try await waitTask.value
-
-                    // IMPORTANT: The child has terminated. Close FDs to unblock reads
-                    // and wait for readers to finish.
-                    ProcessDiagnostics.log("🔒 [FD] Closing FDs for pid=\(spawned.pid)")
-                    spawned.stdout.closeFile()
-                    spawned.stderr.closeFile()
-
-                    let groupFinished = await Self.waitForGroup(group, timeout: 5.0, pid: spawned.pid) { msg in
-                        ProcessDiagnostics.log(msg)
-                    }
-                    if !groupFinished {
-                        ProcessDiagnostics.log("⚠️ [GROUP] Reader threads timed out for pid=\(spawned.pid)")
-                    }
-
-                    // Collect whatever has been read so far.
-                    if !stdoutTail.isEmpty {
-                        collector?.appendDataSection(title: "STDOUT", data: stdoutTail)
-                    }
-                    if !stderrTail.isEmpty {
-                        collector?.appendDataSection(title: "STDERR", data: stderrTail)
-                    }
-                    // On success, memorize the absolute path for next time.
-                    if status == 0, !timedOut, resolvedCommand.contains("/"),
-                       Self.isRunnableExecutable(resolvedCommand)
-                    {
-                        await ResolvedCommandCache.shared.put(resolvedCommand, for: config.command)
-                    }
-                    continuation.yield(.terminated(status: status, timedOut: timedOut))
-                    continuation.finish()
-                    ProcessDiagnostics.log("✅ [STREAM] Finished normally for pid=\(spawned.pid)")
-                } catch {
-                    ProcessDiagnostics.log("❌ [ERROR] Wait failed for pid=\(spawned.pid): \(error)")
-                    spawned.stdout.closeFile()
-                    spawned.stderr.closeFile()
-
-                    let groupFinished = await Self.waitForGroup(group, timeout: 5.0, pid: spawned.pid) { msg in
-                        ProcessDiagnostics.log(msg)
-                    }
-                    if !groupFinished {
-                        ProcessDiagnostics.log("⚠️ [GROUP] Reader timeout (error path) pid=\(spawned.pid)")
-                    }
-
-                    if !stdoutTail.isEmpty {
-                        collector?.appendDataSection(title: "STDOUT", data: stdoutTail)
-                    }
-                    if !stderrTail.isEmpty {
-                        collector?.appendDataSection(title: "STDERR", data: stderrTail)
-                    }
-                    continuation.finish(throwing: error)
+                if !groupFinished {
+                    ProcessDiagnostics.log("⚠️ [GROUP] Reader threads timed out for pid=\(spawned.pid)")
                 }
+
+                if !stdoutTail.isEmpty {
+                    collector?.appendDataSection(title: "STDOUT", data: stdoutTail)
+                }
+                if !stderrTail.isEmpty {
+                    collector?.appendDataSection(title: "STDERR", data: stderrTail)
+                }
+
                 ProcessDiagnostics.log("🧹 [CLEANUP] Cleaning up pid=\(spawned.pid)")
-                if await cleanupProcess(pid: spawned.pid) {
+                if await cleanupProcess(pid: spawned.pid, descriptorCleanup: descriptorCleanup) {
                     await onProcessTerminated?(spawned.pid)
                 }
                 ProcessDiagnostics.log("🔴 [GATE] Releasing gate for pid=\(spawned.pid)")
@@ -633,55 +719,60 @@ final class CLIProcessRunner {
                 }
             }
 
-            continuation.onTermination = { [self, gateCoordinator, spawned, group] reason in
-                if case .cancelled = reason {
-                    ProcessDiagnostics.log("🛑 [CANCEL] Cancelled pid=\(spawned.pid)")
-                    // Ask child to exit and proactively complete cleanup ourselves.
-                    terminateChild(spawned, sendSigterm: true)
-
-                    // Fast-path cleanup: wait up to ~3s, escalate to SIGKILL if needed,
-                    // then close FDs, drain readers briefly, and release the gate.
-                    Task.detached { [self, gateCoordinator] in
-                        let timeout = ProcessTermination.cooperativeCancellationWaitTimeout()
-                        _ = try? await Self.waitForTerminationAsync(
-                            pid: spawned.pid,
-                            processGroupID: spawned.processGroupID,
-                            timeout: timeout
-                        ) { msg in
-                            ProcessDiagnostics.log(msg)
-                        }
-                        // Ensure reader threads unblock even if the monitor path stalls.
-                        ProcessDiagnostics.log("🔒 [FD] Closing FDs (onTermination) for pid=\(spawned.pid)")
-                        spawned.stdout.closeFile()
-                        spawned.stderr.closeFile()
-
-                        let _ = await Self.waitForGroup(group, timeout: 2.0, pid: spawned.pid) { msg in
-                            ProcessDiagnostics.log(msg)
-                        }
-                        if await cleanupProcess(pid: spawned.pid) {
-                            await onProcessTerminated?(spawned.pid)
-                        }
-
-                        if await gateCoordinator.markReleased() {
-                            ProcessDiagnostics.log("🟠 [CANCEL] Releasing gate (onTermination) pid=\(spawned.pid)")
-                            await gate.release()
-                        } else {
-                            ProcessDiagnostics.log("⚠️ [GATE] Double-release prevented (onTermination) pid=\(spawned.pid)")
-                        }
+            // Stream publication is separate from physical finalization so a
+            // bounded timeout/failure is observable without returning admission
+            // capacity while the observer still owns the child.
+            Task.detached { [self] in
+                do {
+                    let (status, timedOut) = try await resultTask.value
+                    // A successful terminal result is published only after the sole
+                    // finalizer has closed descriptors and drained the reader group.
+                    // If resultTask throws an unresolved-owner failure, this await is
+                    // skipped so the bounded failure remains observable immediately.
+                    await finalizationTask.value
+                    if status == 0, !timedOut, resolvedCommand.contains("/"),
+                       Self.isRunnableExecutable(resolvedCommand)
+                    {
+                        await ResolvedCommandCache.shared.put(resolvedCommand, for: config.command)
                     }
-                } else {
-                    // Normal finish: let the waitpid-driven cleanup close streams and release the gate.
-                }
-
-                // Safety net: if gate hasn't been released within 15 seconds, force release.
-                Task { [self, gateCoordinator] in
-                    try? await Task.sleep(nanoseconds: 15_000_000_000)
-                    if await gateCoordinator.markReleased() {
-                        ProcessDiagnostics.log("🚨 [WATCHDOG] DEADLOCK! Force releasing gate for pid=\(spawned.pid)")
-                        await gate.release()
-                    }
+                    continuation.yield(.terminated(status: status, timedOut: timedOut))
+                    continuation.finish()
+                    ProcessDiagnostics.log("✅ [STREAM] Finished normally for pid=\(spawned.pid)")
+                } catch {
+                    ProcessDiagnostics.log("❌ [ERROR] Wait failed for pid=\(spawned.pid): \(error)")
+                    continuation.finish(throwing: error)
                 }
             }
+
+            continuation.onTermination = { [spawned, exitObserver, terminationCoordinator, finalizationTask] reason in
+                guard case .cancelled = reason else {
+                    // Normal finish: the observer-driven finalizer owns descriptor,
+                    // registry, callback, and gate cleanup.
+                    return
+                }
+
+                ProcessDiagnostics.log("🛑 [CANCEL] Cancelled pid=\(spawned.pid)")
+                // Cancellation requests bounded TERM→KILL cleanup through the same
+                // observer owner. The finalizer remains responsible for eventual
+                // descriptor, registry, lifecycle-callback, and gate cleanup.
+                Task.detached {
+                    await terminationCoordinator.terminate { message in
+                        ProcessDiagnostics.log(message)
+                    }
+                    guard await exitObserver.wait(timeout: 0) == nil else {
+                        await finalizationTask.value
+                        return
+                    }
+                    let error = Self.unresolvedOwnedProcessError(pid: spawned.pid)
+                    ProcessDiagnostics.log("⚠️ [REAPER] \(error.localizedDescription)")
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            // Keep the finalizer alive independently of stream consumption. Its
+            // task handle is intentionally captured by the stream closure so the
+            // owner remains associated with this child until physical settlement.
+            _ = finalizationTask
         }
     }
 
@@ -689,8 +780,7 @@ final class CLIProcessRunner {
         // Do not steal cleanup ownership from runStreaming; just request termination.
         let processes = await registry.current()
         for process in processes {
-            // Stop further input and ask the child to exit. The waitpid cleanup will close stdout/stderr.
-            process.stdin?.closeFile()
+            // The sole cleanup owner closes all descriptors after observing the child.
             ProcessTermination.signalProcessGroupOrPID(
                 pid: process.pid,
                 processGroupID: process.processGroupID,
@@ -699,7 +789,7 @@ final class CLIProcessRunner {
             )
         }
         for process in processes {
-            // The streaming wait task remains the sole waitpid owner. Escalate only through the
+            // The exit observer remains the sole waitpid owner. Escalate only through the
             // process group so a promptly-exited root cannot leave TERM-ignoring descendants
             // alive or race a second destructive reap.
             guard let processGroupID = process.processGroupID else {
@@ -741,11 +831,18 @@ final class CLIProcessRunner {
     }
 
     @discardableResult
-    private func cleanupProcess(pid: pid_t) async -> Bool {
+    private func cleanupProcess(
+        pid: pid_t,
+        descriptorCleanup: ProcessDescriptorCleanup? = nil
+    ) async -> Bool {
         guard let process = await registry.remove(pid: pid) else { return false }
-        process.stdin?.closeFile()
-        process.stdout.closeFile()
-        process.stderr.closeFile()
+        if let descriptorCleanup {
+            descriptorCleanup.closeAll()
+        } else {
+            process.stdin?.closeFile()
+            process.stdout.closeFile()
+            process.stderr.closeFile()
+        }
         return true
     }
 
@@ -831,6 +928,34 @@ final class CLIProcessRunner {
 
     // MARK: - Cooperative process termination (no blocking sleeps)
 
+    private static func unresolvedOwnedProcessError(pid: pid_t) -> CLIProcessRunnerError {
+        .waitFailed(
+            "Owned process \(pid) did not settle after bounded termination; "
+                + "the exit observer remains responsible for cleanup"
+        )
+    }
+
+    private static func streamTerminationResult(
+        from outcome: ChildProcessExitObserver.Outcome,
+        timedOut: Bool
+    ) throws -> (Int32, Bool) {
+        switch outcome {
+        case let .exited(status):
+            return (status.normalizedExitCode, timedOut)
+        case let .failed(error):
+            throw mapTerminationError(error)
+        }
+    }
+
+    private static func mapTerminationError(_ error: ProcessTerminationError) -> CLIProcessRunnerError {
+        switch error {
+        case let .childOwnershipLost(pid):
+            .waitFailed("waitpid reported ECHILD for sole-reaper child \(pid)")
+        case let .waitFailed(message):
+            .waitFailed(message)
+        }
+    }
+
     private static func waitForTerminationAsync(
         pid: pid_t,
         processGroupID: pid_t?,
@@ -846,14 +971,7 @@ final class CLIProcessRunner {
             )
             return (exitCode, timedOut)
         } catch let terminationError as ProcessTerminationError {
-            switch terminationError {
-            case let .childOwnershipLost(pid):
-                throw CLIProcessRunnerError.waitFailed(
-                    "waitpid reported ECHILD for sole-reaper child \(pid)"
-                )
-            case let .waitFailed(message):
-                throw CLIProcessRunnerError.waitFailed(message)
-            }
+            throw mapTerminationError(terminationError)
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Process/ProcessTermination.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ProcessTermination.swift
@@ -700,7 +700,8 @@ enum ProcessTermination {
 
     /// Detailed variant of `waitForTermination` that preserves exited-vs-signaled
     /// semantics. Identical waiting, cancellation, timeout, and escalation
-    /// behavior; only the result representation differs.
+    /// behavior; only the result representation differs. ECHILD without a status
+    /// reaped by this owner is reported as ownership loss rather than decoded.
     static func waitForTerminationStatus(
         pid: pid_t,
         processGroupID: pid_t?,
@@ -755,7 +756,9 @@ enum ProcessTermination {
                     continue
                 }
                 if r == -1, errno == EINTR { continue }
-                if r == -1, errno == ECHILD { return (decodeWaitStatus(status), false) }
+                if r == -1, errno == ECHILD {
+                    throw ProcessTerminationError.childOwnershipLost(pid: pid)
+                }
                 if r == -1 {
                     let message = String(cString: strerror(errno))
                     throw ProcessTerminationError.waitFailed(message)
@@ -785,7 +788,9 @@ enum ProcessTermination {
                 continue
             }
             if r == -1, errno == EINTR { continue }
-            if r == -1, errno == ECHILD { return (decodeWaitStatus(status), false) }
+            if r == -1, errno == ECHILD {
+                throw ProcessTerminationError.childOwnershipLost(pid: pid)
+            }
             if r == -1 {
                 let message = String(cString: strerror(errno))
                 throw ProcessTerminationError.waitFailed(message)

--- a/Tests/RepoPromptTests/AI/CLIProcessRunnerCancellationTests.swift
+++ b/Tests/RepoPromptTests/AI/CLIProcessRunnerCancellationTests.swift
@@ -8,21 +8,26 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
         let reaper = RecordingChildStatusObserver()
         let lifecycle = ProcessLifecycleProbe()
         let started = expectation(description: "streaming process started")
-        let ready = expectation(description: "streaming process produced readiness output")
+        let consumerStarted = expectation(description: "stream consumer entered")
         let terminated = expectation(description: "streaming process terminated")
         let secondStarted = expectation(description: "second process started after gate release")
         let secondTerminated = expectation(description: "second process terminated")
 
+        let taskBag = TestTaskCancellationBag()
         let runner = makeRunner(statusObserver: { pid, beforeReap, completion in
             reaper.observe(pid: pid, beforeReap: beforeReap, completion: completion)
         })
         addTeardownBlock {
+            taskBag.cancelAll()
             await runner.cancelAll()
-            await self.fulfillment(of: [terminated, secondTerminated], timeout: 5)
+            let processesTerminated = await lifecycle.waitForAllProcessesToTerminate()
+            if !processesTerminated {
+                XCTFail("owned streaming processes did not terminate during bounded teardown")
+            }
         }
 
         let stream = try await runner.runStreaming(
-            args: ["-c", "printf 'ready\\n'; exec /bin/sleep 60"],
+            args: ["-c", "exec /bin/sleep 60"],
             stdin: nil,
             outputMode: .none,
             timeout: 10,
@@ -41,13 +46,9 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
         let consumer = Task {
             defer { consumerFinished.fulfill() }
             do {
-                for try await event in stream {
-                    if case let .stdout(data) = event,
-                       data.range(of: Data("ready\n".utf8)) != nil
-                    {
-                        ready.fulfill()
-                    }
-                }
+                var iterator = stream.makeAsyncIterator()
+                consumerStarted.fulfill()
+                while let _ = try await iterator.next() {}
                 await consumerOutcome.recordSuccess()
             } catch {
                 if error is CancellationError {
@@ -62,8 +63,9 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
                 }
             }
         }
+        taskBag.add(consumer)
 
-        await fulfillment(of: [started, ready], timeout: 2)
+        await fulfillment(of: [started, consumerStarted], timeout: 2)
         consumer.cancel()
         await fulfillment(of: [consumerFinished], timeout: 5)
         guard let consumerResult = await consumerOutcome.value else {
@@ -108,6 +110,7 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
                 }
             )
         }
+        taskBag.add(secondTask)
         await fulfillment(of: [secondStarted], timeout: 2)
         guard await lifecycle.startedCount == 2 else {
             secondTask.cancel()
@@ -139,6 +142,7 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
                 }
             }
         }
+        taskBag.add(secondConsumer)
         await fulfillment(of: [secondConsumerFinished, secondTerminated], timeout: 5)
         guard let secondResult = await secondOutcome.value else {
             secondConsumer.cancel()
@@ -163,13 +167,15 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
     func testStreamingNormalCompletionDrainsOutputBeforeTerminalEvent() async throws {
         let reaper = RecordingChildStatusObserver()
         let lifecycle = ProcessLifecycleProbe()
-        let processTerminated = expectation(description: "normal stream process terminated")
         let runner = makeRunner(statusObserver: { pid, beforeReap, completion in
             reaper.observe(pid: pid, beforeReap: beforeReap, completion: completion)
         })
         addTeardownBlock {
             await runner.cancelAll()
-            await self.fulfillment(of: [processTerminated], timeout: 5)
+            let processTerminated = await lifecycle.waitForAllProcessesToTerminate()
+            if !processTerminated {
+                XCTFail("owned streaming process did not terminate during bounded teardown")
+            }
         }
 
         let stream = try await runner.runStreaming(
@@ -180,9 +186,11 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
             stdin: nil,
             outputMode: .none,
             timeout: 2,
+            onProcessStarted: { pid in
+                await lifecycle.recordStarted(pid)
+            },
             onProcessTerminated: { pid in
                 await lifecycle.recordTerminated(pid)
-                processTerminated.fulfill()
             }
         )
 
@@ -225,13 +233,18 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
         let secondStarted = expectation(description: "gate-reuse control started")
         let secondTerminated = expectation(description: "gate reuse process terminated")
 
+        let taskBag = TestTaskCancellationBag()
         let runner = makeRunner(statusObserver: { pid, beforeReap, completion in
             delayedObserver.observe(pid: pid, beforeReap: beforeReap, completion: completion)
         })
         addTeardownBlock {
+            taskBag.cancelAll()
             delayedObserver.releaseObservation()
             await runner.cancelAll()
-            await self.fulfillment(of: [terminated, secondTerminated], timeout: 5)
+            let processesTerminated = await lifecycle.waitForAllProcessesToTerminate()
+            if !processesTerminated {
+                XCTFail("owned streaming processes did not terminate during bounded teardown")
+            }
         }
 
         let stream = try await runner.runStreaming(
@@ -270,6 +283,7 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
                 }
             }
         }
+        taskBag.add(consumer)
         await fulfillment(of: [consumerFinished], timeout: 5)
         guard let consumerResult = await consumerOutcome.value else {
             consumer.cancel()
@@ -317,6 +331,7 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
                 }
             )
         }
+        taskBag.add(secondTask)
         delayedObserver.releaseObservation()
         await fulfillment(of: [terminated, secondStarted], timeout: 5)
         let firstPIDValue = await lifecycle.firstStartedPID()
@@ -355,6 +370,7 @@ final class CLIProcessRunnerCancellationTests: XCTestCase {
                 }
             }
         }
+        taskBag.add(secondConsumer)
         await fulfillment(of: [secondConsumerFinished, secondTerminated], timeout: 5)
         guard let secondResult = await secondOutcome.value else {
             secondConsumer.cancel()
@@ -624,6 +640,32 @@ private actor ConsumerOutcomeProbe {
     }
 }
 
+private final class TestTaskCancellationBag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelActions: [@Sendable () -> Void] = []
+    private var cancellationRequested = false
+
+    func add(_ task: Task<some Any, some Error>) {
+        lock.lock()
+        guard !cancellationRequested else {
+            lock.unlock()
+            task.cancel()
+            return
+        }
+        cancelActions.append { task.cancel() }
+        lock.unlock()
+    }
+
+    func cancelAll() {
+        lock.lock()
+        cancellationRequested = true
+        let actions = cancelActions
+        cancelActions.removeAll()
+        lock.unlock()
+        actions.forEach { $0() }
+    }
+}
+
 private actor ProcessLifecycleProbe {
     private var startedPIDs: [pid_t] = []
     private var terminatedPIDs: [pid_t] = []
@@ -650,6 +692,15 @@ private actor ProcessLifecycleProbe {
 
     func terminationCount(for pid: pid_t) -> Int {
         terminatedPIDs.count(where: { $0 == pid })
+    }
+
+    func waitForAllProcessesToTerminate() async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while terminatedPIDs.count < startedPIDs.count {
+            guard ContinuousClock.now < deadline else { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return true
     }
 }
 

--- a/Tests/RepoPromptTests/AI/CLIProcessRunnerCancellationTests.swift
+++ b/Tests/RepoPromptTests/AI/CLIProcessRunnerCancellationTests.swift
@@ -1,0 +1,707 @@
+import Darwin
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class CLIProcessRunnerCancellationTests: XCTestCase {
+    func testStreamingCancellationInvokesOneLifecycleCallbackAndReusesGate() async throws {
+        let reaper = RecordingChildStatusObserver()
+        let lifecycle = ProcessLifecycleProbe()
+        let started = expectation(description: "streaming process started")
+        let ready = expectation(description: "streaming process produced readiness output")
+        let terminated = expectation(description: "streaming process terminated")
+        let secondStarted = expectation(description: "second process started after gate release")
+        let secondTerminated = expectation(description: "second process terminated")
+
+        let runner = makeRunner(statusObserver: { pid, beforeReap, completion in
+            reaper.observe(pid: pid, beforeReap: beforeReap, completion: completion)
+        })
+        addTeardownBlock {
+            await runner.cancelAll()
+            await self.fulfillment(of: [terminated, secondTerminated], timeout: 5)
+        }
+
+        let stream = try await runner.runStreaming(
+            args: ["-c", "printf 'ready\\n'; exec /bin/sleep 60"],
+            stdin: nil,
+            outputMode: .none,
+            timeout: 10,
+            onProcessStarted: { pid in
+                await lifecycle.recordStarted(pid)
+                started.fulfill()
+            },
+            onProcessTerminated: { pid in
+                await lifecycle.recordTerminated(pid)
+                terminated.fulfill()
+            }
+        )
+
+        let consumerOutcome = ConsumerOutcomeProbe()
+        let consumerFinished = expectation(description: "stream consumer finished")
+        let consumer = Task {
+            defer { consumerFinished.fulfill() }
+            do {
+                for try await event in stream {
+                    if case let .stdout(data) = event,
+                       data.range(of: Data("ready\n".utf8)) != nil
+                    {
+                        ready.fulfill()
+                    }
+                }
+                await consumerOutcome.recordSuccess()
+            } catch {
+                if error is CancellationError {
+                    await consumerOutcome.recordCancelled()
+                } else {
+                    var failure: ConsumerOutcomeProbe.Failure = if let runnerError = error as? CLIProcessRunnerError {
+                        .cliProcessRunner(runnerError)
+                    } else {
+                        .unexpected(String(describing: error))
+                    }
+                    await consumerOutcome.record(failure: failure)
+                }
+            }
+        }
+
+        await fulfillment(of: [started, ready], timeout: 2)
+        consumer.cancel()
+        await fulfillment(of: [consumerFinished], timeout: 5)
+        guard let consumerResult = await consumerOutcome.value else {
+            consumer.cancel()
+            return
+        }
+        switch consumerResult {
+        case .success, .cancelled:
+            break
+        case let .failure(failure):
+            XCTFail("unexpected cancellation stream error: \(failure.diagnostic)")
+        }
+        await fulfillment(of: [terminated], timeout: 5)
+
+        let firstPIDValue = await lifecycle.firstStartedPID()
+        let firstPID = try XCTUnwrap(firstPIDValue)
+        let firstTerminationCount = await lifecycle.terminationCount(for: firstPID)
+        XCTAssertEqual(firstTerminationCount, 1)
+        XCTAssertEqual(reaper.registrationCount, 1)
+        XCTAssertEqual(reaper.reapBoundaryCount(for: firstPID), 1)
+
+        do {
+            _ = try await ProcessTermination.reapChildStatus(pid: firstPID)
+            XCTFail("stream cancellation must not leave an unconsumed root status")
+        } catch let error as ProcessTerminationError {
+            XCTAssertEqual(error, .childOwnershipLost(pid: firstPID))
+        }
+
+        let secondTask = Task {
+            try await runner.runStreaming(
+                args: ["-c", "exit 0"],
+                stdin: nil,
+                outputMode: .none,
+                timeout: 2,
+                onProcessStarted: { pid in
+                    await lifecycle.recordStarted(pid)
+                    secondStarted.fulfill()
+                },
+                onProcessTerminated: { pid in
+                    await lifecycle.recordTerminated(pid)
+                    secondTerminated.fulfill()
+                }
+            )
+        }
+        await fulfillment(of: [secondStarted], timeout: 2)
+        guard await lifecycle.startedCount == 2 else {
+            secondTask.cancel()
+            return
+        }
+        let secondStream = try await secondTask.value
+        let secondStatusProbe = StreamStatusProbe()
+        let secondOutcome = ConsumerOutcomeProbe()
+        let secondConsumerFinished = expectation(description: "normal-completion consumer finished")
+        let secondConsumer = Task {
+            defer { secondConsumerFinished.fulfill() }
+            do {
+                for try await event in secondStream {
+                    if case let .terminated(status, timedOut) = event {
+                        await secondStatusProbe.record(status: status, timedOut: timedOut)
+                    }
+                }
+                await secondOutcome.recordSuccess()
+            } catch {
+                if error is CancellationError {
+                    await secondOutcome.recordCancelled()
+                } else {
+                    var failure: ConsumerOutcomeProbe.Failure = if let runnerError = error as? CLIProcessRunnerError {
+                        .cliProcessRunner(runnerError)
+                    } else {
+                        .unexpected(String(describing: error))
+                    }
+                    await secondOutcome.record(failure: failure)
+                }
+            }
+        }
+        await fulfillment(of: [secondConsumerFinished, secondTerminated], timeout: 5)
+        guard let secondResult = await secondOutcome.value else {
+            secondConsumer.cancel()
+            return
+        }
+        switch secondResult {
+        case .success:
+            break
+        case .cancelled:
+            XCTFail("normal-completion control was cancelled")
+        case let .failure(failure):
+            XCTFail("normal-completion control failed: \(failure.diagnostic)")
+        }
+        let secondStatus = await secondStatusProbe.value
+        XCTAssertEqual(secondStatus, 0)
+        let finalTerminationCount = await lifecycle.terminationCount
+        XCTAssertEqual(finalTerminationCount, 2)
+        XCTAssertEqual(reaper.registrationCount, 2)
+        XCTAssertEqual(reaper.reapBoundaryCount, 2)
+    }
+
+    func testStreamingNormalCompletionDrainsOutputBeforeTerminalEvent() async throws {
+        let reaper = RecordingChildStatusObserver()
+        let lifecycle = ProcessLifecycleProbe()
+        let processTerminated = expectation(description: "normal stream process terminated")
+        let runner = makeRunner(statusObserver: { pid, beforeReap, completion in
+            reaper.observe(pid: pid, beforeReap: beforeReap, completion: completion)
+        })
+        addTeardownBlock {
+            await runner.cancelAll()
+            await self.fulfillment(of: [processTerminated], timeout: 5)
+        }
+
+        let stream = try await runner.runStreaming(
+            args: [
+                "-c",
+                "printf 'stdout-before-exit\\n'; printf 'stderr-before-exit\\n' >&2"
+            ],
+            stdin: nil,
+            outputMode: .none,
+            timeout: 2,
+            onProcessTerminated: { pid in
+                await lifecycle.recordTerminated(pid)
+                processTerminated.fulfill()
+            }
+        )
+
+        var stdout = Data()
+        var stderr = Data()
+        var terminalCount = 0
+        var terminalStatus: Int32?
+        var terminalTimedOut: Bool?
+        var sawOutputAfterTerminal = false
+        for try await event in stream {
+            switch event {
+            case let .stdout(chunk):
+                if terminalCount > 0 { sawOutputAfterTerminal = true }
+                stdout.append(chunk)
+            case let .stderr(chunk):
+                if terminalCount > 0 { sawOutputAfterTerminal = true }
+                stderr.append(chunk)
+            case let .terminated(status, timedOut):
+                terminalCount += 1
+                terminalStatus = status
+                terminalTimedOut = timedOut
+            }
+        }
+
+        XCTAssertEqual(stdout, Data("stdout-before-exit\n".utf8))
+        XCTAssertEqual(stderr, Data("stderr-before-exit\n".utf8))
+        XCTAssertEqual(terminalCount, 1)
+        XCTAssertEqual(terminalStatus, 0)
+        XCTAssertEqual(terminalTimedOut, false)
+        XCTAssertFalse(sawOutputAfterTerminal)
+        let terminationCount = await lifecycle.terminationCount
+        XCTAssertEqual(terminationCount, 1)
+    }
+
+    func testStreamingTimeoutReportsUnresolvedBeforeLateObservationAndCleansOnce() async throws {
+        let delayedObserver = DelayedChildStatusObserver()
+        let lifecycle = ProcessLifecycleProbe()
+        let started = expectation(description: "timeout process started")
+        let terminated = expectation(description: "timeout process eventually terminated")
+        let secondStarted = expectation(description: "gate-reuse control started")
+        let secondTerminated = expectation(description: "gate reuse process terminated")
+
+        let runner = makeRunner(statusObserver: { pid, beforeReap, completion in
+            delayedObserver.observe(pid: pid, beforeReap: beforeReap, completion: completion)
+        })
+        addTeardownBlock {
+            delayedObserver.releaseObservation()
+            await runner.cancelAll()
+            await self.fulfillment(of: [terminated, secondTerminated], timeout: 5)
+        }
+
+        let stream = try await runner.runStreaming(
+            args: ["-c", "exec /bin/sleep 60"],
+            stdin: nil,
+            outputMode: .none,
+            timeout: 0.01,
+            onProcessStarted: { pid in
+                await lifecycle.recordStarted(pid)
+                started.fulfill()
+            },
+            onProcessTerminated: { pid in
+                await lifecycle.recordTerminated(pid)
+                terminated.fulfill()
+            }
+        )
+        await fulfillment(of: [started], timeout: 2)
+
+        let consumerOutcome = ConsumerOutcomeProbe()
+        let consumerFinished = expectation(description: "timeout stream consumer finished")
+        let consumer = Task {
+            defer { consumerFinished.fulfill() }
+            do {
+                for try await _ in stream {}
+                await consumerOutcome.recordSuccess()
+            } catch {
+                if error is CancellationError {
+                    await consumerOutcome.recordCancelled()
+                } else {
+                    var failure: ConsumerOutcomeProbe.Failure = if let runnerError = error as? CLIProcessRunnerError {
+                        .cliProcessRunner(runnerError)
+                    } else {
+                        .unexpected(String(describing: error))
+                    }
+                    await consumerOutcome.record(failure: failure)
+                }
+            }
+        }
+        await fulfillment(of: [consumerFinished], timeout: 5)
+        guard let consumerResult = await consumerOutcome.value else {
+            consumer.cancel()
+            return
+        }
+        switch consumerResult {
+        case .success, .cancelled:
+            XCTFail("unresolved owned process must finish the stream with a failure")
+        case let .failure(failure):
+            switch failure {
+            case let .cliProcessRunner(error):
+                guard case let .waitFailed(message) = error else {
+                    XCTFail("expected CLIProcessRunnerError.waitFailed, got \(error.localizedDescription)")
+                    break
+                }
+                XCTAssertTrue(
+                    message.contains("did not settle after bounded termination"),
+                    "missing unresolved-owner diagnostic: \(message)"
+                )
+                XCTAssertTrue(
+                    message.contains("exit observer remains responsible for cleanup"),
+                    "missing observer-ownership diagnostic: \(message)"
+                )
+            case let .unexpected(message):
+                XCTFail("expected CLIProcessRunnerError.waitFailed, got \(message)")
+            }
+        }
+
+        // Start a normal-completion control before releasing the delayed
+        // observation. No scheduler timing is used as a permit-retention oracle;
+        // source review covers finalizer-owned release.
+        let secondTask = Task {
+            try await runner.runStreaming(
+                args: ["-c", "exit 0"],
+                stdin: nil,
+                outputMode: .none,
+                timeout: 2,
+                onProcessStarted: { pid in
+                    await lifecycle.recordStarted(pid)
+                    secondStarted.fulfill()
+                },
+                onProcessTerminated: { pid in
+                    await lifecycle.recordTerminated(pid)
+                    secondTerminated.fulfill()
+                }
+            )
+        }
+        delayedObserver.releaseObservation()
+        await fulfillment(of: [terminated, secondStarted], timeout: 5)
+        let firstPIDValue = await lifecycle.firstStartedPID()
+        let firstPID = try XCTUnwrap(firstPIDValue)
+        let firstTerminationCount = await lifecycle.terminationCount(for: firstPID)
+        XCTAssertEqual(firstTerminationCount, 1)
+        XCTAssertEqual(delayedObserver.reapBoundaryCount(for: firstPID), 1)
+
+        guard await lifecycle.startedCount == 2 else {
+            secondTask.cancel()
+            return
+        }
+        let secondStream = try await secondTask.value
+        let secondStatusProbe = StreamStatusProbe()
+        let secondOutcome = ConsumerOutcomeProbe()
+        let secondConsumerFinished = expectation(description: "late-observation control consumer finished")
+        let secondConsumer = Task {
+            defer { secondConsumerFinished.fulfill() }
+            do {
+                for try await event in secondStream {
+                    if case let .terminated(status, timedOut) = event {
+                        await secondStatusProbe.record(status: status, timedOut: timedOut)
+                    }
+                }
+                await secondOutcome.recordSuccess()
+            } catch {
+                if error is CancellationError {
+                    await secondOutcome.recordCancelled()
+                } else {
+                    var failure: ConsumerOutcomeProbe.Failure = if let runnerError = error as? CLIProcessRunnerError {
+                        .cliProcessRunner(runnerError)
+                    } else {
+                        .unexpected(String(describing: error))
+                    }
+                    await secondOutcome.record(failure: failure)
+                }
+            }
+        }
+        await fulfillment(of: [secondConsumerFinished, secondTerminated], timeout: 5)
+        guard let secondResult = await secondOutcome.value else {
+            secondConsumer.cancel()
+            return
+        }
+        switch secondResult {
+        case .success:
+            break
+        case .cancelled:
+            XCTFail("late-observation gate-reuse control was cancelled")
+        case let .failure(failure):
+            XCTFail("late-observation gate-reuse control failed: \(failure.diagnostic)")
+        }
+        let secondStatus = await secondStatusProbe.value
+        XCTAssertEqual(secondStatus, 0)
+        let finalTerminationCount = await lifecycle.terminationCount
+        XCTAssertEqual(finalTerminationCount, 2)
+        XCTAssertEqual(delayedObserver.reapBoundaryCount, 2)
+    }
+
+    func testWaitForTerminationStatusReportsOwnershipLossInsteadOfExitZero() async throws {
+        let timeouts: [TimeInterval?] = [nil, 1]
+        for timeout in timeouts {
+            let spawned = try ProcessLauncher.spawn(
+                command: "/bin/sh",
+                arguments: ["-c", "exit 0"],
+                environment: [:],
+                workingDirectory: nil
+            )
+            let fixture = OwnedFixtureCleanup(spawned)
+            addTeardownBlock { await fixture.cleanup() }
+            defer { fixture.closeHandles() }
+
+            let firstStatus = try await ProcessTermination.reapChildStatus(pid: spawned.pid)
+            fixture.markSettled()
+            XCTAssertEqual(firstStatus, .exited(code: 0))
+
+            do {
+                _ = try await ProcessTermination.waitForTerminationStatus(
+                    pid: spawned.pid,
+                    processGroupID: spawned.processGroupID,
+                    timeout: timeout
+                )
+                XCTFail("ECHILD without a reaped status must not become exit 0")
+            } catch let error as ProcessTerminationError {
+                XCTAssertEqual(error, .childOwnershipLost(pid: spawned.pid))
+            }
+        }
+    }
+
+    func testWaitForTerminationStatusPreservesRealTerminalResult() async throws {
+        let spawned = try ProcessLauncher.spawn(
+            command: "/bin/sh",
+            arguments: ["-c", "exit 7"],
+            environment: [:],
+            workingDirectory: nil
+        )
+        let fixture = OwnedFixtureCleanup(spawned)
+        addTeardownBlock { await fixture.cleanup() }
+        defer { fixture.closeHandles() }
+
+        let result = try await ProcessTermination.waitForTerminationStatus(
+            pid: spawned.pid,
+            processGroupID: spawned.processGroupID,
+            timeout: 2
+        )
+        fixture.markSettled()
+        XCTAssertFalse(result.timedOut)
+        XCTAssertEqual(result.status, .exited(code: 7))
+    }
+
+    private func makeRunner(
+        statusObserver: @escaping ChildProcessExitObserver.StatusObserver
+    ) -> CLIProcessRunner {
+        CLIProcessRunner(
+            config: CLIProcessConfiguration(command: "/bin/sh", enableDebugLogging: false),
+            processExitObserverFactory: { pid in
+                ChildProcessExitObserver(pid: pid, statusObserver: statusObserver)
+            }
+        )
+    }
+}
+
+private final class RecordingChildStatusObserver: @unchecked Sendable {
+    private let lock = NSLock()
+    private var registrations = 0
+    private var reapBoundaries: [pid_t: Int] = [:]
+
+    var registrationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return registrations
+    }
+
+    var reapBoundaryCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return reapBoundaries.values.reduce(0, +)
+    }
+
+    func reapBoundaryCount(for pid: pid_t) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return reapBoundaries[pid, default: 0]
+    }
+
+    func observe(
+        pid: pid_t,
+        beforeReap: @escaping @Sendable () -> Void,
+        completion: @escaping @Sendable (Result<ProcessExitStatus, ProcessTerminationError>) -> Void
+    ) {
+        lock.lock()
+        registrations += 1
+        lock.unlock()
+        ProcessTermination.observeChildStatus(
+            pid: pid,
+            beforeReap: { [self] in
+                lock.lock()
+                reapBoundaries[pid, default: 0] += 1
+                lock.unlock()
+                beforeReap()
+            },
+            completion: completion
+        )
+    }
+}
+
+private final class DelayedChildStatusObserver: @unchecked Sendable {
+    private struct PendingObservation: @unchecked Sendable {
+        let pid: pid_t
+        let beforeReap: @Sendable () -> Void
+        let completion: @Sendable (Result<ProcessExitStatus, ProcessTerminationError>) -> Void
+    }
+
+    private let lock = NSLock()
+    private var pendingObservations: [PendingObservation] = []
+    private var releaseRequested = false
+    private var forwarding = false
+    private var registrations = 0
+    private var reapBoundaries: [pid_t: Int] = [:]
+
+    var registrationCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return registrations
+    }
+
+    var reapBoundaryCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return reapBoundaries.values.reduce(0, +)
+    }
+
+    func reapBoundaryCount(for pid: pid_t) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return reapBoundaries[pid, default: 0]
+    }
+
+    func observe(
+        pid: pid_t,
+        beforeReap: @escaping @Sendable () -> Void,
+        completion: @escaping @Sendable (Result<ProcessExitStatus, ProcessTerminationError>) -> Void
+    ) {
+        lock.lock()
+        registrations += 1
+        pendingObservations.append(
+            PendingObservation(pid: pid, beforeReap: beforeReap, completion: completion)
+        )
+        let shouldForward = releaseRequested && !forwarding
+        if shouldForward {
+            forwarding = true
+        }
+        lock.unlock()
+        if shouldForward {
+            forwardPendingObservations()
+        }
+    }
+
+    func releaseObservation() {
+        lock.lock()
+        releaseRequested = true
+        let shouldForward = !forwarding
+        if shouldForward {
+            forwarding = true
+        }
+        lock.unlock()
+        if shouldForward {
+            forwardPendingObservations()
+        }
+    }
+
+    private func forwardPendingObservations() {
+        while true {
+            lock.lock()
+            guard releaseRequested, !pendingObservations.isEmpty else {
+                forwarding = false
+                lock.unlock()
+                return
+            }
+            let observation = pendingObservations.removeFirst()
+            lock.unlock()
+
+            ProcessTermination.observeChildStatus(
+                pid: observation.pid,
+                beforeReap: { [self] in
+                    lock.lock()
+                    reapBoundaries[observation.pid, default: 0] += 1
+                    lock.unlock()
+                    observation.beforeReap()
+                },
+                completion: observation.completion
+            )
+        }
+    }
+}
+
+private actor StreamStatusProbe {
+    private var terminalStatus: Int32?
+
+    var value: Int32? {
+        terminalStatus
+    }
+
+    func record(status: Int32, timedOut: Bool) {
+        terminalStatus = timedOut ? nil : status
+    }
+}
+
+private actor ConsumerOutcomeProbe {
+    enum Failure: @unchecked Sendable {
+        case cliProcessRunner(CLIProcessRunnerError)
+        case unexpected(String)
+
+        var diagnostic: String {
+            switch self {
+            case let .cliProcessRunner(error):
+                error.localizedDescription
+            case let .unexpected(message):
+                message
+            }
+        }
+    }
+
+    enum Outcome: @unchecked Sendable {
+        case success
+        case cancelled
+        case failure(Failure)
+    }
+
+    private var storedOutcome: Outcome?
+
+    var value: Outcome? {
+        storedOutcome
+    }
+
+    func recordSuccess() {
+        storedOutcome = .success
+    }
+
+    func recordCancelled() {
+        storedOutcome = .cancelled
+    }
+
+    func record(failure: Failure) {
+        storedOutcome = .failure(failure)
+    }
+}
+
+private actor ProcessLifecycleProbe {
+    private var startedPIDs: [pid_t] = []
+    private var terminatedPIDs: [pid_t] = []
+
+    func recordStarted(_ pid: pid_t) {
+        startedPIDs.append(pid)
+    }
+
+    func recordTerminated(_ pid: pid_t) {
+        terminatedPIDs.append(pid)
+    }
+
+    func firstStartedPID() -> pid_t? {
+        startedPIDs.first
+    }
+
+    var startedCount: Int {
+        startedPIDs.count
+    }
+
+    var terminationCount: Int {
+        terminatedPIDs.count
+    }
+
+    func terminationCount(for pid: pid_t) -> Int {
+        terminatedPIDs.count(where: { $0 == pid })
+    }
+}
+
+private final class OwnedFixtureCleanup: @unchecked Sendable {
+    private let spawned: SpawnedProcess
+    private let lock = NSLock()
+    private var settled = false
+    private var cleanupStarted = false
+    private var handlesClosed = false
+
+    init(_ spawned: SpawnedProcess) {
+        self.spawned = spawned
+    }
+
+    func markSettled() {
+        lock.lock()
+        settled = true
+        lock.unlock()
+    }
+
+    func closeHandles() {
+        lock.lock()
+        guard !handlesClosed else {
+            lock.unlock()
+            return
+        }
+        handlesClosed = true
+        lock.unlock()
+        spawned.stdin?.closeFile()
+        spawned.stdout.closeFile()
+        spawned.stderr.closeFile()
+    }
+
+    func cleanup() async {
+        lock.lock()
+        guard !cleanupStarted else {
+            lock.unlock()
+            return
+        }
+        cleanupStarted = true
+        let needsReap = !settled
+        lock.unlock()
+
+        if needsReap {
+            _ = await ProcessTermination.terminateAndReap(
+                pid: spawned.pid,
+                processGroupID: spawned.processGroupID,
+                sigtermGrace: 0.25,
+                sigkillGrace: 0.25
+            )
+            markSettled()
+        }
+        closeHandles()
+    }
+}


### PR DESCRIPTION
Keep one observer responsible for consuming a child process exit status through cancellation and timeout. A bounded timeout may report unresolved ownership while the retained finalizer continues to own descriptor cleanup, registry removal, lifecycle notification and gate release. Report lost child ownership as an error instead of synthesizing success. Successful streaming completion waits for output readers to drain before publishing its terminal event.

Five focused process tests, the app build and lint passed on the reviewed feature. Current-main integration preserves the feature patch byte for byte. Tests cover cancellation and one reap owner, delayed observation and gate reuse, ownership loss, a real nonzero exit, and stdout/stderr completion with bounded owned-resource cleanup.

This does not establish a package-wide single-waiter guarantee for legacy ACP shutdown. Fresh hosted checks and packaged provider cancellation/quit acceptance remain required.

Fixes #865.
