### PR TITLE
Retain physical authority for protected file mutations

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
@@ -15,6 +15,7 @@ private let fileSystemMutationIOQueue = DispatchQueue(
 private struct FileSystemMutationIOExecutor {
     let operation: FileSystemUncancellableMutation
     let physicalMutationGuard: DomainMutationPhysicalCommitGuard?
+    let physicalMutationCapability: DomainMutationPhysicalCapability?
     let willExecute: (@Sendable (FileSystemUncancellableMutation) -> Void)?
 
     func callAsFunction(_ io: @escaping @Sendable () throws -> Void) async throws {
@@ -22,7 +23,9 @@ private struct FileSystemMutationIOExecutor {
             fileSystemMutationIOQueue.async {
                 willExecute?(operation)
                 do {
-                    try physicalMutationGuard?.revalidate()
+                    if physicalMutationCapability == nil {
+                        try physicalMutationGuard?.revalidate()
+                    }
                     try io()
                     continuation.resume()
                 } catch {
@@ -119,11 +122,13 @@ extension FileSystemService {
                 let willBegin: (@Sendable (FileSystemUncancellableMutation) async -> Void)? = nil
                 let willExecute: (@Sendable (FileSystemUncancellableMutation) -> Void)? = nil
             #endif
+            let physicalMutationCapability = try await MCPDomainMutationCommitContext.physicalMutationCapability()
             try await MCPDomainMutationCommitContext.willCommit()
             let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
             let executor = FileSystemMutationIOExecutor(
                 operation: operation,
                 physicalMutationGuard: physicalMutationGuard,
+                physicalMutationCapability: physicalMutationCapability,
                 willExecute: willExecute
             )
             let task = Task.detached(priority: .utility) {
@@ -312,18 +317,27 @@ extension FileSystemService {
             throw FileSystemError.fileAlreadyExists
         }
 
-        let destDir = (newFull as NSString).deletingLastPathComponent
-        let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
-        try physicalMutationGuard?.revalidate()
-        try fm.createDirectory(atPath: destDir, withIntermediateDirectories: true, attributes: nil)
-        _ = try mutationTarget(forRelativePath: newTarget.relativePath)
+        let physicalMutationCapability = try await MCPDomainMutationCommitContext.physicalMutationCapability()
+        if let physicalMutationCapability {
+            try physicalMutationCapability.validateNoReplaceMove(from: oldFull, to: newFull)
+        } else {
+            let destDir = (newFull as NSString).deletingLastPathComponent
+            let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
+            try physicalMutationGuard?.revalidate()
+            try fm.createDirectory(atPath: destDir, withIntermediateDirectories: true, attributes: nil)
+            _ = try mutationTarget(forRelativePath: newTarget.relativePath)
+        }
 
         let mutation = try await startUncancellableMutation(
             .move,
             relativePaths: [oldTarget.relativePath, newTarget.relativePath]
         ) { executor in
             try await executor {
-                try FileManager.default.moveItem(atPath: oldFull, toPath: newFull)
+                if let capability = executor.physicalMutationCapability {
+                    try capability.moveFile(from: oldFull, to: newFull)
+                } else {
+                    try FileManager.default.moveItem(atPath: oldFull, toPath: newFull)
+                }
             }
         }
         Task.detached { [weak self] in
@@ -334,7 +348,8 @@ extension FileSystemService {
                     oldRelativePath: oldTarget.relativePath,
                     newRelativePath: newTarget.relativePath,
                     oldFullPath: oldFull,
-                    newFullPath: newFull
+                    newFullPath: newFull,
+                    physicalMutationCapability: physicalMutationCapability
                 )
             } catch {
                 await self?.completeMutationWaiter(
@@ -351,17 +366,26 @@ extension FileSystemService {
         oldRelativePath: String,
         newRelativePath: String,
         oldFullPath: String,
-        newFullPath: String
+        newFullPath: String,
+        physicalMutationCapability: DomainMutationPhysicalCapability?
     ) async {
         switch await catalogRegularFileEligibility(relativePath: newRelativePath) {
         case .eligible, .ineligible(.ignored):
             break
         case .ineligible:
-            do {
-                try await Self.performBlockingMutationIO {
-                    try FileManager.default.moveItem(atPath: newFullPath, toPath: oldFullPath)
+            if physicalMutationCapability == nil {
+                do {
+                    try await Self.performBlockingMutationIO {
+                        try FileManager.default.moveItem(atPath: newFullPath, toPath: oldFullPath)
+                    }
+                } catch {
+                    forgetTrackedPath(oldRelativePath)
+                    publishFileSystemDeltas(
+                        [.fileRemoved(oldRelativePath), .fileAdded(newRelativePath)],
+                        source: .syntheticMutation
+                    )
                 }
-            } catch {
+            } else {
                 forgetTrackedPath(oldRelativePath)
                 publishFileSystemDeltas(
                     [.fileRemoved(oldRelativePath), .fileAdded(newRelativePath)],
@@ -394,13 +418,23 @@ extension FileSystemService {
         let fullPath = target.url.path
         let fullURL = target.url
 
-        let directoryURL = fullURL.deletingLastPathComponent()
-        let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
-        try physicalMutationGuard?.revalidate()
-        try fm.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
-        _ = try mutationTarget(forRelativePath: target.relativePath)
-        guard !fm.fileExists(atPath: fullPath, isDirectory: nil) else {
-            throw FileSystemError.fileAlreadyExists
+        let physicalMutationCapability = try await MCPDomainMutationCommitContext.physicalMutationCapability()
+        if let physicalMutationCapability {
+            try physicalMutationCapability.validateWriteTarget(
+                at: fullPath,
+                overwrite: false,
+                expectedContentDigest: nil,
+                requireExisting: false
+            )
+        } else {
+            let directoryURL = fullURL.deletingLastPathComponent()
+            let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
+            try physicalMutationGuard?.revalidate()
+            try fm.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
+            _ = try mutationTarget(forRelativePath: target.relativePath)
+            guard !fm.fileExists(atPath: fullPath, isDirectory: nil) else {
+                throw FileSystemError.fileAlreadyExists
+            }
         }
 
         // Materializing a large Swift String as UTF-8 is synchronous and potentially expensive.
@@ -428,7 +462,17 @@ extension FileSystemService {
                 )
             }
             try await executor {
-                try FileSystemService.writeFileRobust(to: fullURL, data: data)
+                if let capability = executor.physicalMutationCapability {
+                    try capability.writeFile(
+                        at: fullPath,
+                        data: data,
+                        overwrite: false,
+                        expectedContentDigest: nil,
+                        requireExisting: false
+                    )
+                } else {
+                    try FileSystemService.writeFileRobust(to: fullURL, data: data)
+                }
             }
         }
         Task.detached { [weak self] in
@@ -437,7 +481,8 @@ extension FileSystemService {
                 await self?.reconcileCreatedFile(
                     mutationID: mutation.id,
                     relativePath: target.relativePath,
-                    url: fullURL
+                    url: fullURL,
+                    physicalMutationCapability: physicalMutationCapability
                 )
             } catch {
                 await self?.completeMutationWaiter(
@@ -452,15 +497,18 @@ extension FileSystemService {
     private func reconcileCreatedFile(
         mutationID: UUID,
         relativePath: String,
-        url: URL
+        url: URL,
+        physicalMutationCapability: DomainMutationPhysicalCapability?
     ) async {
         fileSystemDebugLog("File created at \(url.path)")
         switch await catalogRegularFileEligibility(relativePath: relativePath) {
         case .eligible, .ineligible(.ignored):
             break
         case .ineligible:
-            _ = try? await Self.performBlockingMutationIO {
-                try FileManager.default.removeItem(at: url)
+            if physicalMutationCapability == nil {
+                _ = try? await Self.performBlockingMutationIO {
+                    try FileManager.default.removeItem(at: url)
+                }
             }
             forgetTrackedPath(relativePath)
             completeMutationWaiter(mutationID, error: FileSystemError.invalidRelativePath)
@@ -709,18 +757,40 @@ extension FileSystemService {
                 )
             )
         }
+        let expectedContentDigest = expectedOriginalContent.flatMap { original in
+            original.data(using: encoding).map(DomainContentDigest.sha256)
+        }
+        let physicalMutationCapability = try await MCPDomainMutationCommitContext.physicalMutationCapability()
+        if let physicalMutationCapability {
+            try physicalMutationCapability.validateWriteTarget(
+                at: fullPath,
+                overwrite: true,
+                expectedContentDigest: expectedContentDigest,
+                requireExisting: true
+            )
+        }
         let mutation = try await startUncancellableMutation(
             .edit,
             relativePaths: [target.relativePath]
         ) { executor in
             try await executor {
-                if let expectedOriginalContent {
-                    let currentData = try Data(contentsOf: fullURL)
-                    guard String(data: currentData, encoding: encoding) == expectedOriginalContent else {
-                        throw FileSystemError.fileContentChanged
+                if let capability = executor.physicalMutationCapability {
+                    try capability.writeFile(
+                        at: fullPath,
+                        data: data,
+                        overwrite: true,
+                        expectedContentDigest: expectedContentDigest,
+                        requireExisting: true
+                    )
+                } else {
+                    if let expectedOriginalContent {
+                        let currentData = try Data(contentsOf: fullURL)
+                        guard String(data: currentData, encoding: encoding) == expectedOriginalContent else {
+                            throw FileSystemError.fileContentChanged
+                        }
                     }
+                    try FileSystemService.writeFileRobust(to: fullURL, data: data)
                 }
-                try FileSystemService.writeFileRobust(to: fullURL, data: data)
             }
         }
         Task.detached { [weak self] in
@@ -730,7 +800,8 @@ extension FileSystemService {
                     mutationID: mutation.id,
                     relativePath: target.relativePath,
                     encoding: encoding,
-                    modificationPublicationPolicy: modificationPublicationPolicy
+                    modificationPublicationPolicy: modificationPublicationPolicy,
+                    physicalMutationCapability: physicalMutationCapability
                 )
             } catch FileSystemError.fileContentChanged {
                 await self?.completeMutationWaiter(
@@ -758,7 +829,8 @@ extension FileSystemService {
         mutationID: UUID,
         relativePath: String,
         encoding: String.Encoding,
-        modificationPublicationPolicy: FileSystemEditModificationPublicationPolicy
+        modificationPublicationPolicy: FileSystemEditModificationPublicationPolicy,
+        physicalMutationCapability: DomainMutationPhysicalCapability?
     ) async {
         switch await catalogRegularFileEligibility(relativePath: relativePath) {
         case .eligible, .ineligible(.ignored):
@@ -773,7 +845,9 @@ extension FileSystemService {
         encodingMap[relativePath] = encoding
         visitedPaths.insert(relativePath)
         visitedItems[relativePath] = false
-        let modificationDate = try? await getFileModificationDate(atRelativePath: relativePath)
+        let modificationDate = physicalMutationCapability == nil
+            ? try? await getFileModificationDate(atRelativePath: relativePath)
+            : nil
         let deferredPublication = FileSystemDeferredEditPublication(
             relativePath: relativePath,
             modificationDate: modificationDate

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleExportFileWriter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleExportFileWriter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import RepoPromptDomainRuntime
 
 struct GeneratedOracleExportFileWriter {
     let store: WorkspaceFileContextStore
@@ -36,7 +37,13 @@ struct GeneratedOracleExportFileWriter {
                 userPath: physicalPath,
                 content: content,
                 rootScope: destination.lookupContext.rootScope,
-                pathResolutionPolicy: .literalPreferredIfStronger
+                pathResolutionPolicy: .literalPreferredIfStronger,
+                mutationRootMappings: [
+                    DomainMutationPhysicalRootMapping(
+                        canonicalRoot: physicalRootPath,
+                        physicalRoot: physicalRootPath
+                    )
+                ]
             )
 
             if let reason = writeResult.catalogIneligibility {
@@ -111,6 +118,13 @@ struct GeneratedOracleExportFileWriter {
         root: WorkspaceRootRef,
         rootScope: WorkspaceLookupRootScope
     ) async {
+        let capability: DomainMutationPhysicalCapability?
+        do {
+            capability = try await MCPDomainMutationCommitContext.physicalMutationCapability()
+        } catch {
+            return
+        }
+        if capability != nil { return }
         guard FileManager.default.fileExists(atPath: physicalPath) else { return }
         try? FileManager.default.removeItem(atPath: physicalPath)
         let rootPrefix = root.standardizedFullPath.hasSuffix("/") ? root.standardizedFullPath : root.standardizedFullPath + "/"

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -6647,7 +6647,7 @@ final class MCPServerViewModel: ObservableObject {
         )
     }
 
-    /// Writes prompt export content, allowing absolute paths outside the workspace.
+    /// Writes prompt export content inside an admitted workspace root; external destinations fail closed.
     private func writePromptExportFile(
         path rawPath: String,
         content: String,
@@ -6686,27 +6686,9 @@ final class MCPServerViewModel: ObservableObject {
             return resolvedPath
         }
 
-        let url = URL(fileURLWithPath: resolvedPath)
-        let fm = FileManager.default
-        if fm.fileExists(atPath: url.path) {
-            throw MCPError.invalidParams("path already exists: \(resolvedPath).")
-        }
-        do {
-            try await MCPDomainMutationCommitContext.admitPhysicalTargets(
-                [url.standardizedFileURL.path],
-                rootMappings: mutationRootMappings
-            )
-            try await MCPDomainMutationCommitContext.willCommit()
-            let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
-            try physicalMutationGuard?.revalidate()
-            try fm.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)
-            try physicalMutationGuard?.revalidate()
-            try content.write(to: url, atomically: true, encoding: .utf8)
-        } catch {
-            throw MCPError.invalidParams("File creation failed for '\(resolvedPath)': \(error.localizedDescription)")
-        }
-
-        return resolvedPath
+        throw MCPError.invalidParams(
+            "Protected prompt export outside a loaded workspace root is unsupported."
+        )
     }
 
     private func renameFile(

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -1591,6 +1591,16 @@ actor GitService {
         else { return nil }
         let includeURL = sourceRepoURL.appendingPathComponent(".worktreeinclude", isDirectory: false)
         guard FileManager.default.fileExists(atPath: includeURL.path) else { return nil }
+        let physicalMutationCapability = try await MCPDomainMutationCommitContext.physicalMutationCapability()
+        if MCPDomainMutationCommitContext.controller != nil, physicalMutationCapability == nil {
+            return GitWorktreeIncludeCopyResult(
+                copiedCount: 0,
+                matchedCount: 0,
+                errorSummaries: [
+                    "protected .worktreeinclude copying is unsupported without a descriptor-backed capability"
+                ]
+            )
+        }
         let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
 
         do {

--- a/Sources/RepoPromptDomainRuntime/DomainMutationJournal.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainMutationJournal.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MCP
 
-package enum DomainMutationJournalStatus: String, Codable, Sendable {
+package enum DomainMutationJournalStatus: String, Codable {
     case admitted
     case committing
     case applied
@@ -33,7 +33,7 @@ package enum DomainMutationJournalStatus: String, Codable, Sendable {
     }
 }
 
-package struct DomainMutationJournalRecord: Codable, Sendable {
+package struct DomainMutationJournalRecord: Codable {
     package let key: String
     package let operationID: String
     package let toolName: String
@@ -97,7 +97,7 @@ package struct DomainMutationJournalRecord: Codable, Sendable {
     }
 }
 
-package struct DomainMutationJournalDocument: Codable, Sendable {
+package struct DomainMutationJournalDocument: Codable {
     package static let schemaVersion = 1
 
     var version: Int
@@ -111,18 +111,18 @@ package struct DomainMutationJournalDocument: Codable, Sendable {
     }
 }
 
-package struct DomainMutationJournalTicket: Hashable, Sendable {
+package struct DomainMutationJournalTicket: Hashable {
     package let key: String
     package let fingerprint: String
     package let ownerInvocationID: UUID
 }
 
-package enum DomainMutationJournalBegin: Sendable {
+package enum DomainMutationJournalBegin {
     case execute(DomainMutationJournalTicket)
     case replay(Value)
 }
 
-package enum DomainMutationJournalError: Error, Equatable, LocalizedError, Sendable {
+package enum DomainMutationJournalError: Error, Equatable, LocalizedError {
     case corruptOrFutureJournal
     case operationIDCollision(String)
     case operationInProgress(String)
@@ -421,7 +421,7 @@ package actor DomainMutationCommitState {
     }
 }
 
-package struct DomainMutationPhysicalRootMapping: Hashable, Sendable {
+package struct DomainMutationPhysicalRootMapping: Hashable {
     package let canonicalRoot: String
     package let physicalRoot: String
 
@@ -431,24 +431,28 @@ package struct DomainMutationPhysicalRootMapping: Hashable, Sendable {
     }
 }
 
-package struct DomainMutationCommitController: Sendable {
+package struct DomainMutationCommitController {
     private let admitOperation: @Sendable ([String], [DomainMutationPhysicalRootMapping]) async throws -> Void
     private let physicalGuardOperation: @Sendable () async throws -> DomainMutationPhysicalCommitGuard?
+    private let physicalCapabilityOperation: @Sendable () async throws -> DomainMutationPhysicalCapability?
     private let commitOperation: @Sendable () async throws -> Void
 
     package init(
         admitPhysicalTargets: @Sendable @escaping ([String], [DomainMutationPhysicalRootMapping]) async throws -> Void = { _, _ in },
         physicalMutationGuard: @Sendable @escaping () async throws -> DomainMutationPhysicalCommitGuard? = { nil },
+        physicalMutationCapability: @Sendable @escaping () async throws -> DomainMutationPhysicalCapability? = { nil },
         willCommit: @Sendable @escaping () async throws -> Void
     ) {
         admitOperation = admitPhysicalTargets
         physicalGuardOperation = physicalMutationGuard
+        physicalCapabilityOperation = physicalMutationCapability
         commitOperation = willCommit
     }
 
     package init(operation: @Sendable @escaping () async throws -> Void) {
         admitOperation = { _, _ in }
         physicalGuardOperation = { nil }
+        physicalCapabilityOperation = { nil }
         commitOperation = operation
     }
 
@@ -461,6 +465,10 @@ package struct DomainMutationCommitController: Sendable {
 
     package func physicalMutationGuard() async throws -> DomainMutationPhysicalCommitGuard? {
         try await physicalGuardOperation()
+    }
+
+    package func physicalMutationCapability() async throws -> DomainMutationPhysicalCapability? {
+        try await physicalCapabilityOperation()
     }
 
     package func willCommit() async throws {
@@ -480,6 +488,10 @@ package enum MCPDomainMutationCommitContext {
 
     package static func physicalMutationGuard() async throws -> DomainMutationPhysicalCommitGuard? {
         try await controller?.physicalMutationGuard()
+    }
+
+    package static func physicalMutationCapability() async throws -> DomainMutationPhysicalCapability? {
+        try await controller?.physicalMutationCapability()
     }
 
     package static func willCommit() async throws {

--- a/Sources/RepoPromptDomainRuntime/DomainMutationPathFence.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainMutationPathFence.swift
@@ -1,14 +1,14 @@
 import Darwin
 import Foundation
 
-package struct DomainMutationPathIdentity: Codable, Hashable, Sendable {
+package struct DomainMutationPathIdentity: Codable, Hashable {
     package let originalPath: String
     package let resolvedPath: String
     package let device: UInt64
     package let inode: UInt64
 }
 
-package struct DomainMutationPathFenceEntry: Codable, Hashable, Sendable {
+package struct DomainMutationPathFenceEntry: Codable, Hashable {
     package let requestedPath: String
     package let resolvedPath: String
     /// Identity of the target when it exists, otherwise its nearest existing parent.
@@ -16,7 +16,7 @@ package struct DomainMutationPathFenceEntry: Codable, Hashable, Sendable {
     package let authorizedRoot: DomainMutationPathIdentity
 }
 
-package struct DomainMutationPathFenceSnapshot: Codable, Hashable, Sendable {
+package struct DomainMutationPathFenceSnapshot: Codable, Hashable {
     package let authorizedRoots: [DomainMutationPathIdentity]
     package let entries: [DomainMutationPathFenceEntry]
 
@@ -25,7 +25,7 @@ package struct DomainMutationPathFenceSnapshot: Codable, Hashable, Sendable {
     }
 }
 
-package enum DomainMutationPathFenceError: Error, Equatable, LocalizedError, Sendable {
+package enum DomainMutationPathFenceError: Error, Equatable, LocalizedError {
     case scopeUnavailable
     case relativePath(String)
     case pathOutsideAuthorizedRoots(String)
@@ -51,15 +51,24 @@ package enum DomainMutationPathFenceError: Error, Equatable, LocalizedError, Sen
     }
 }
 
-package struct DomainMutationPhysicalCommitGuard: Sendable {
+package struct DomainMutationPhysicalCommitGuard {
     private let snapshot: DomainMutationPathFenceSnapshot
+    private let capability: DomainMutationPhysicalCapability?
 
-    package init(snapshot: DomainMutationPathFenceSnapshot) {
+    package init(
+        snapshot: DomainMutationPathFenceSnapshot,
+        capability: DomainMutationPhysicalCapability? = nil
+    ) {
         self.snapshot = snapshot
+        self.capability = capability
+    }
+
+    package func physicalMutationCapability() -> DomainMutationPhysicalCapability? {
+        capability
     }
 
     /// Revalidates the admitted path identities synchronously at a path-based mutation boundary.
-    /// This narrows the race window but does not make the later path operation descriptor-bound.
+    /// Protected file I/O uses the retained capability; Git subprocesses retain this path-fence-only guard.
     package func revalidate() throws {
         try DomainMutationPathFence.revalidateBlocking(snapshot)
     }

--- a/Sources/RepoPromptDomainRuntime/DomainMutationPhysicalCapability.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainMutationPhysicalCapability.swift
@@ -283,53 +283,25 @@ package final class DomainMutationPhysicalCapability: @unchecked Sendable {
             )
         }
 
-        do {
-            guard fchmod(temporaryDescriptor.fd, targetMode) == 0 else {
-                throw DomainMutationPhysicalCapabilityError.ioFailure(
-                    operation: "relative-replace-temp-mode",
-                    code: errno
-                )
-            }
-            try write(data, to: temporaryDescriptor.fd, operation: "relative-replace-write")
-            try synchronize(temporaryDescriptor.fd, operation: "relative-replace-file-sync")
-            guard renameat(parent.fd, createdName, parent.fd, name) == 0 else {
-                throw DomainMutationPhysicalCapabilityError.ioFailure(
-                    operation: "relative-atomic-replace",
-                    code: errno
-                )
-            }
-            temporaryName = nil
-            try synchronize(parent.fd, operation: "relative-replace-parent-sync")
-        } catch {
-            if let temporaryName {
-                try? removeIfSame(parent: parent, name: temporaryName, descriptor: temporaryDescriptor)
-            }
-            throw error
+        guard fchmod(temporaryDescriptor.fd, targetMode) == 0 else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-replace-temp-mode",
+                code: errno
+            )
         }
-    }
-
-    private func removeIfSame(
-        parent: DomainMutationPhysicalDescriptor,
-        name: String,
-        descriptor: DomainMutationPhysicalDescriptor
-    ) throws {
-        guard let current = try lookup(parent: parent, name: name, path: name),
-              try current.device == device(of: descriptor),
-              try current.inode == inode(of: descriptor)
-        else {
-            return
+        try write(data, to: temporaryDescriptor.fd, operation: "relative-replace-write")
+        try synchronize(temporaryDescriptor.fd, operation: "relative-replace-file-sync")
+        guard renameat(parent.fd, createdName, parent.fd, name) == 0 else {
+            // Do not attempt pathname cleanup here. The temporary entry is not an
+            // authority for deletion after a failure and may have been replaced.
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-atomic-replace",
+                code: errno
+            )
         }
-        guard unlinkat(parent.fd, name, 0) == 0 else {
-            let code = errno
-            guard code == ENOENT else {
-                throw DomainMutationPhysicalCapabilityError.ioFailure(
-                    operation: "relative-temp-cleanup",
-                    code: code
-                )
-            }
-            return
-        }
-        try synchronize(parent.fd, operation: "relative-temp-cleanup-parent-sync")
+        // A post-rename parent fsync failure is intentionally reported as an
+        // indeterminate/partial outcome to the protected caller.
+        try synchronize(parent.fd, operation: "relative-replace-parent-sync")
     }
 
     private func validateRegularEntry(
@@ -488,17 +460,6 @@ package final class DomainMutationPhysicalCapability: @unchecked Sendable {
         }
         return status.st_dev
     }
-
-    private func inode(of descriptor: DomainMutationPhysicalDescriptor) throws -> ino_t {
-        var status = stat()
-        guard fstat(descriptor.fd, &status) == 0 else {
-            throw DomainMutationPhysicalCapabilityError.ioFailure(
-                operation: "relative-descriptor-stat",
-                code: errno
-            )
-        }
-        return status.st_ino
-    }
 }
 
 private final class DomainMutationPhysicalLease: @unchecked Sendable {
@@ -526,6 +487,9 @@ private final class DomainMutationPhysicalLease: @unchecked Sendable {
     }
 
     func plan(for path: String) throws -> DomainMutationPhysicalTargetPlan {
+        guard !path.contains("\0") else {
+            throw DomainMutationPhysicalCapabilityError.invalidComponent(path)
+        }
         let standardized = URL(fileURLWithPath: path).standardizedFileURL.path
         guard let plan = plans[standardized] else {
             throw DomainMutationPhysicalCapabilityError.pathOutsideAuthorizedRoots(path)
@@ -536,6 +500,9 @@ private final class DomainMutationPhysicalLease: @unchecked Sendable {
     private static func openRoot(
         _ identity: DomainMutationPathIdentity
     ) throws -> DomainMutationPhysicalDescriptor {
+        guard !identity.originalPath.contains("\0") else {
+            throw DomainMutationPhysicalCapabilityError.invalidComponent(identity.originalPath)
+        }
         let descriptor = identity.originalPath.withCString {
             open($0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
         }
@@ -568,6 +535,12 @@ private final class DomainMutationPhysicalLease: @unchecked Sendable {
         root: DomainMutationPathIdentity,
         descriptor rootDescriptor: DomainMutationPhysicalDescriptor
     ) throws -> DomainMutationPhysicalTargetPlan {
+        guard !root.originalPath.contains("\0") else {
+            throw DomainMutationPhysicalCapabilityError.invalidComponent(root.originalPath)
+        }
+        guard !entry.requestedPath.contains("\0") else {
+            throw DomainMutationPhysicalCapabilityError.invalidComponent(entry.requestedPath)
+        }
         let absolutePath = URL(fileURLWithPath: entry.requestedPath).standardizedFileURL.path
         let rootPrefix = root.originalPath == "/" ? "/" : root.originalPath + "/"
         guard absolutePath.hasPrefix(rootPrefix) else {
@@ -712,13 +685,9 @@ private final class DomainMutationPhysicalDescriptor: @unchecked Sendable {
 }
 
 private struct DomainMutationPhysicalFileIdentity {
-    let device: dev_t
-    let inode: ino_t
     let mode: mode_t
 
     init(_ status: stat) {
-        device = status.st_dev
-        inode = status.st_ino
         mode = status.st_mode & mode_t(S_IFMT)
     }
 

--- a/Sources/RepoPromptDomainRuntime/DomainMutationPhysicalCapability.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainMutationPhysicalCapability.swift
@@ -1,0 +1,728 @@
+import Darwin
+import Foundation
+
+package enum DomainMutationPhysicalCapabilityError: Error, Equatable, LocalizedError {
+    case scopeUnavailable
+    case unsupportedOperation(String)
+    case pathOutsideAuthorizedRoots(String)
+    case invalidComponent(String)
+    case symlinkNotAllowed(String)
+    case missingParent(String)
+    case sourceMissing(String)
+    case destinationExists(String)
+    case notRegularFile(String)
+    case expectedContentChanged(String)
+    case crossVolume(String)
+    case ioFailure(operation: String, code: Int32)
+
+    package var errorDescription: String? {
+        switch self {
+        case .scopeUnavailable:
+            "Protected physical mutation denied because no descriptor-backed capability is available."
+        case let .unsupportedOperation(operation):
+            "Protected physical mutation is unsupported for operation: \(operation)."
+        case let .pathOutsideAuthorizedRoots(path):
+            "Protected physical mutation path is outside the admitted descriptor scope: \(path)."
+        case let .invalidComponent(component):
+            "Protected physical mutation rejected an invalid path component: \(component)."
+        case let .symlinkNotAllowed(path):
+            "Protected physical mutation rejected a symbolic link in the physical path: \(path)."
+        case let .missingParent(path):
+            "Protected physical mutation parent directory is unavailable: \(path)."
+        case let .sourceMissing(path):
+            "Protected physical mutation source is missing: \(path)."
+        case let .destinationExists(path):
+            "Protected no-replace mutation destination already exists: \(path)."
+        case let .notRegularFile(path):
+            "Protected physical mutation supports regular files only: \(path)."
+        case let .expectedContentChanged(path):
+            "Protected edit rejected because the admitted file content changed: \(path)."
+        case let .crossVolume(path):
+            "Protected no-replace move cannot cross volumes: \(path)."
+        case let .ioFailure(operation, code):
+            "Protected physical mutation failed during \(operation) with errno \(code)."
+        }
+    }
+}
+
+/// An admitted physical namespace capability. It retains directory descriptors and never
+/// re-resolves the protected target through an absolute pathname during mutation.
+package final class DomainMutationPhysicalCapability: @unchecked Sendable {
+    private let lease: DomainMutationPhysicalLease
+
+    package static func open(
+        snapshot: DomainMutationPathFenceSnapshot
+    ) throws -> DomainMutationPhysicalCapability {
+        try DomainMutationPhysicalCapability(lease: DomainMutationPhysicalLease(snapshot: snapshot))
+    }
+
+    private init(lease: DomainMutationPhysicalLease) {
+        self.lease = lease
+    }
+
+    package func validateNoReplaceMove(
+        from sourcePath: String,
+        to destinationPath: String
+    ) throws {
+        let source = try lease.plan(for: sourcePath)
+        let destination = try lease.plan(for: destinationPath)
+        let sourceParent = try source.existingParent()
+        let existingDestinationParent = try destination.existingParent()
+        guard let sourceParent else {
+            throw DomainMutationPhysicalCapabilityError.missingParent(source.absolutePath)
+        }
+        let destinationParent = existingDestinationParent ?? destination.base
+        try validateRegularEntry(parent: sourceParent, name: source.leaf, path: source.absolutePath)
+        if let existingDestinationParent,
+           try lookup(parent: existingDestinationParent, name: destination.leaf, path: destination.absolutePath) != nil
+        {
+            throw DomainMutationPhysicalCapabilityError.destinationExists(destination.absolutePath)
+        }
+        guard try device(of: sourceParent) == device(of: destinationParent) else {
+            throw DomainMutationPhysicalCapabilityError.crossVolume(destination.absolutePath)
+        }
+    }
+
+    package func moveFile(
+        from sourcePath: String,
+        to destinationPath: String
+    ) throws {
+        let source = try lease.plan(for: sourcePath)
+        let destination = try lease.plan(for: destinationPath)
+        guard let sourceParent = try source.existingParent() else {
+            throw DomainMutationPhysicalCapabilityError.missingParent(source.absolutePath)
+        }
+        let destinationParent = try destination.materializedParent()
+        try validateRegularEntry(parent: sourceParent, name: source.leaf, path: source.absolutePath)
+        guard try device(of: sourceParent) == device(of: destinationParent) else {
+            throw DomainMutationPhysicalCapabilityError.crossVolume(destination.absolutePath)
+        }
+        if try lookup(parent: destinationParent, name: destination.leaf, path: destination.absolutePath) != nil {
+            throw DomainMutationPhysicalCapabilityError.destinationExists(destination.absolutePath)
+        }
+
+        let result = renameatx_np(
+            sourceParent.fd,
+            source.leaf,
+            destinationParent.fd,
+            destination.leaf,
+            UInt32(RENAME_EXCL)
+        )
+        guard result == 0 else {
+            let code = errno
+            switch code {
+            case EEXIST:
+                throw DomainMutationPhysicalCapabilityError.destinationExists(destination.absolutePath)
+            case ENOENT:
+                throw DomainMutationPhysicalCapabilityError.sourceMissing(source.absolutePath)
+            case EXDEV:
+                throw DomainMutationPhysicalCapabilityError.crossVolume(destination.absolutePath)
+            default:
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-no-replace-move",
+                    code: code
+                )
+            }
+        }
+        try synchronize(sourceParent.fd, operation: "move-source-parent-sync")
+        if sourceParent.fd != destinationParent.fd {
+            try synchronize(destinationParent.fd, operation: "move-destination-parent-sync")
+        }
+    }
+
+    package func validateWriteTarget(
+        at path: String,
+        overwrite: Bool,
+        expectedContentDigest: String?,
+        requireExisting: Bool
+    ) throws {
+        let plan = try lease.plan(for: path)
+        guard let parent = try plan.existingParent() else {
+            if requireExisting {
+                throw DomainMutationPhysicalCapabilityError.missingParent(plan.absolutePath)
+            }
+            return
+        }
+        guard let existing = try lookup(parent: parent, name: plan.leaf, path: plan.absolutePath) else {
+            if requireExisting {
+                throw DomainMutationPhysicalCapabilityError.sourceMissing(plan.absolutePath)
+            }
+            return
+        }
+        guard existing.isRegular || overwrite else {
+            throw DomainMutationPhysicalCapabilityError.notRegularFile(plan.absolutePath)
+        }
+        guard overwrite else {
+            throw DomainMutationPhysicalCapabilityError.destinationExists(plan.absolutePath)
+        }
+        let descriptor = try openRegularFile(parent: parent, name: plan.leaf, path: plan.absolutePath)
+        if let expectedContentDigest {
+            let currentDigest = try digest(of: descriptor.fd)
+            guard currentDigest == expectedContentDigest else {
+                throw DomainMutationPhysicalCapabilityError.expectedContentChanged(plan.absolutePath)
+            }
+        }
+    }
+
+    package func writeFile(
+        at path: String,
+        data: Data,
+        overwrite: Bool,
+        expectedContentDigest: String?,
+        requireExisting: Bool
+    ) throws {
+        let plan = try lease.plan(for: path)
+        let parent: DomainMutationPhysicalDescriptor
+        if let existingParent = try plan.existingParent() {
+            parent = existingParent
+        } else {
+            guard !requireExisting else {
+                throw DomainMutationPhysicalCapabilityError.missingParent(plan.absolutePath)
+            }
+            parent = try plan.materializedParent()
+        }
+
+        let existing = try lookup(parent: parent, name: plan.leaf, path: plan.absolutePath)
+        if let existing {
+            guard overwrite else {
+                throw DomainMutationPhysicalCapabilityError.destinationExists(plan.absolutePath)
+            }
+            guard existing.isRegular else {
+                throw DomainMutationPhysicalCapabilityError.notRegularFile(plan.absolutePath)
+            }
+            try replaceExistingFile(
+                parent: parent,
+                name: plan.leaf,
+                path: plan.absolutePath,
+                data: data,
+                expectedContentDigest: expectedContentDigest
+            )
+        } else {
+            guard !requireExisting else {
+                throw DomainMutationPhysicalCapabilityError.sourceMissing(plan.absolutePath)
+            }
+            try createNewFile(parent: parent, name: plan.leaf, path: plan.absolutePath, data: data)
+        }
+    }
+
+    private func createNewFile(
+        parent: DomainMutationPhysicalDescriptor,
+        name: String,
+        path: String,
+        data: Data
+    ) throws {
+        let descriptor = openat(
+            parent.fd,
+            name,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+            mode_t(0o644)
+        )
+        guard descriptor >= 0 else {
+            let code = errno
+            switch code {
+            case EEXIST:
+                throw DomainMutationPhysicalCapabilityError.destinationExists(path)
+            case ELOOP:
+                throw DomainMutationPhysicalCapabilityError.symlinkNotAllowed(path)
+            default:
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-create-open",
+                    code: code
+                )
+            }
+        }
+        let created = DomainMutationPhysicalDescriptor(descriptor)
+        try write(data, to: created.fd, operation: "relative-create-write")
+        try synchronize(created.fd, operation: "relative-create-file-sync")
+        try synchronize(parent.fd, operation: "relative-create-parent-sync")
+    }
+
+    private func replaceExistingFile(
+        parent: DomainMutationPhysicalDescriptor,
+        name: String,
+        path: String,
+        data: Data,
+        expectedContentDigest: String?
+    ) throws {
+        let target = try openRegularFile(parent: parent, name: name, path: path)
+        // Atomic replacement changes the inode; retain the supported POSIX mode contract.
+        let targetMode = try permissionMode(of: target.fd)
+        if let expectedContentDigest {
+            let currentDigest = try digest(of: target.fd)
+            guard currentDigest == expectedContentDigest else {
+                throw DomainMutationPhysicalCapabilityError.expectedContentChanged(path)
+            }
+        }
+
+        var temporaryName: String?
+        var temporaryDescriptor: DomainMutationPhysicalDescriptor?
+        for _ in 0 ..< 8 {
+            let candidate = ".rpce-mutation-\(UUID().uuidString.lowercased())"
+            let descriptor = openat(
+                parent.fd,
+                candidate,
+                O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+                mode_t(0o600)
+            )
+            if descriptor >= 0 {
+                temporaryName = candidate
+                temporaryDescriptor = DomainMutationPhysicalDescriptor(descriptor)
+                break
+            }
+            guard errno == EEXIST else {
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-replace-temp-open",
+                    code: errno
+                )
+            }
+        }
+        guard let createdName = temporaryName, let temporaryDescriptor else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-replace-temp-name",
+                code: EBUSY
+            )
+        }
+
+        do {
+            guard fchmod(temporaryDescriptor.fd, targetMode) == 0 else {
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-replace-temp-mode",
+                    code: errno
+                )
+            }
+            try write(data, to: temporaryDescriptor.fd, operation: "relative-replace-write")
+            try synchronize(temporaryDescriptor.fd, operation: "relative-replace-file-sync")
+            guard renameat(parent.fd, createdName, parent.fd, name) == 0 else {
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-atomic-replace",
+                    code: errno
+                )
+            }
+            temporaryName = nil
+            try synchronize(parent.fd, operation: "relative-replace-parent-sync")
+        } catch {
+            if let temporaryName {
+                try? removeIfSame(parent: parent, name: temporaryName, descriptor: temporaryDescriptor)
+            }
+            throw error
+        }
+    }
+
+    private func removeIfSame(
+        parent: DomainMutationPhysicalDescriptor,
+        name: String,
+        descriptor: DomainMutationPhysicalDescriptor
+    ) throws {
+        guard let current = try lookup(parent: parent, name: name, path: name),
+              try current.device == device(of: descriptor),
+              try current.inode == inode(of: descriptor)
+        else {
+            return
+        }
+        guard unlinkat(parent.fd, name, 0) == 0 else {
+            let code = errno
+            guard code == ENOENT else {
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-temp-cleanup",
+                    code: code
+                )
+            }
+            return
+        }
+        try synchronize(parent.fd, operation: "relative-temp-cleanup-parent-sync")
+    }
+
+    private func validateRegularEntry(
+        parent: DomainMutationPhysicalDescriptor,
+        name: String,
+        path: String
+    ) throws {
+        guard let value = try lookup(parent: parent, name: name, path: path) else {
+            throw DomainMutationPhysicalCapabilityError.sourceMissing(path)
+        }
+        guard value.isRegular else {
+            throw DomainMutationPhysicalCapabilityError.notRegularFile(path)
+        }
+    }
+
+    private func openRegularFile(
+        parent: DomainMutationPhysicalDescriptor,
+        name: String,
+        path: String
+    ) throws -> DomainMutationPhysicalDescriptor {
+        // Avoid blocking if a concurrent replacement turns the entry into a FIFO.
+        let descriptor = openat(parent.fd, name, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            let code = errno
+            switch code {
+            case ENOENT:
+                throw DomainMutationPhysicalCapabilityError.sourceMissing(path)
+            case ELOOP:
+                throw DomainMutationPhysicalCapabilityError.symlinkNotAllowed(path)
+            default:
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-file-open",
+                    code: code
+                )
+            }
+        }
+        let value = DomainMutationPhysicalDescriptor(descriptor)
+        guard try isRegular(value.fd) else {
+            throw DomainMutationPhysicalCapabilityError.notRegularFile(path)
+        }
+        return value
+    }
+
+    private func lookup(
+        parent: DomainMutationPhysicalDescriptor,
+        name: String,
+        path: String
+    ) throws -> DomainMutationPhysicalFileIdentity? {
+        var status = stat()
+        guard fstatat(parent.fd, name, &status, AT_SYMLINK_NOFOLLOW) == 0 else {
+            let code = errno
+            if code == ENOENT { return nil }
+            if code == ELOOP {
+                throw DomainMutationPhysicalCapabilityError.symlinkNotAllowed(path)
+            }
+            throw DomainMutationPhysicalCapabilityError.ioFailure(operation: "relative-entry-stat", code: code)
+        }
+        return DomainMutationPhysicalFileIdentity(status)
+    }
+
+    private func isRegular(_ descriptor: Int32) throws -> Bool {
+        var status = stat()
+        guard fstat(descriptor, &status) == 0 else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-file-descriptor-stat",
+                code: errno
+            )
+        }
+        return status.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG)
+    }
+
+    private func permissionMode(of descriptor: Int32) throws -> mode_t {
+        var status = stat()
+        guard fstat(descriptor, &status) == 0 else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-file-permission-stat",
+                code: errno
+            )
+        }
+        return status.st_mode & mode_t(0o7777)
+    }
+
+    private func digest(of descriptor: Int32) throws -> String {
+        let data = try read(descriptor: descriptor)
+        return DomainContentDigest.sha256(data)
+    }
+
+    private func read(descriptor: Int32) throws -> Data {
+        var status = stat()
+        guard fstat(descriptor, &status) == 0 else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-content-stat",
+                code: errno
+            )
+        }
+        guard status.st_size >= 0, status.st_size <= off_t(Int.max) else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-content-size",
+                code: EFBIG
+            )
+        }
+        var data = Data(count: Int(status.st_size))
+        var offset: off_t = 0
+        while offset < status.st_size {
+            let remaining = Int(status.st_size - offset)
+            let count = data.withUnsafeMutableBytes { buffer -> Int in
+                guard let base = buffer.baseAddress else { return 0 }
+                return pread(descriptor, base.advanced(by: Int(offset)), remaining, offset)
+            }
+            guard count > 0 else {
+                let code = count == 0 ? EIO : errno
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-content-read",
+                    code: code
+                )
+            }
+            offset += off_t(count)
+        }
+        return data
+    }
+
+    private func write(
+        _ data: Data,
+        to descriptor: Int32,
+        operation: String
+    ) throws {
+        var offset = 0
+        while offset < data.count {
+            let count = data.withUnsafeBytes { buffer -> Int in
+                guard let base = buffer.baseAddress else { return 0 }
+                return Darwin.write(descriptor, base.advanced(by: offset), data.count - offset)
+            }
+            guard count > 0 else {
+                let code = count == 0 ? EIO : errno
+                throw DomainMutationPhysicalCapabilityError.ioFailure(operation: operation, code: code)
+            }
+            offset += count
+        }
+    }
+
+    private func synchronize(_ descriptor: Int32, operation: String) throws {
+        while fsync(descriptor) != 0 {
+            guard errno == EINTR else {
+                throw DomainMutationPhysicalCapabilityError.ioFailure(operation: operation, code: errno)
+            }
+        }
+    }
+
+    private func device(of descriptor: DomainMutationPhysicalDescriptor) throws -> dev_t {
+        var status = stat()
+        guard fstat(descriptor.fd, &status) == 0 else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-directory-stat",
+                code: errno
+            )
+        }
+        return status.st_dev
+    }
+
+    private func inode(of descriptor: DomainMutationPhysicalDescriptor) throws -> ino_t {
+        var status = stat()
+        guard fstat(descriptor.fd, &status) == 0 else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "relative-descriptor-stat",
+                code: errno
+            )
+        }
+        return status.st_ino
+    }
+}
+
+private final class DomainMutationPhysicalLease: @unchecked Sendable {
+    private let plans: [String: DomainMutationPhysicalTargetPlan]
+
+    init(snapshot: DomainMutationPathFenceSnapshot) throws {
+        var roots: [DomainMutationPathIdentity: DomainMutationPhysicalDescriptor] = [:]
+        for root in snapshot.authorizedRoots {
+            let descriptor = try Self.openRoot(root)
+            roots[root] = descriptor
+        }
+
+        var builtPlans: [String: DomainMutationPhysicalTargetPlan] = [:]
+        for entry in snapshot.entries {
+            guard let rootDescriptor = roots[entry.authorizedRoot] else {
+                throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+            }
+            let plan = try Self.makePlan(entry: entry, root: entry.authorizedRoot, descriptor: rootDescriptor)
+            builtPlans[plan.absolutePath] = plan
+        }
+        guard !builtPlans.isEmpty else {
+            throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+        }
+        plans = builtPlans
+    }
+
+    func plan(for path: String) throws -> DomainMutationPhysicalTargetPlan {
+        let standardized = URL(fileURLWithPath: path).standardizedFileURL.path
+        guard let plan = plans[standardized] else {
+            throw DomainMutationPhysicalCapabilityError.pathOutsideAuthorizedRoots(path)
+        }
+        return plan
+    }
+
+    private static func openRoot(
+        _ identity: DomainMutationPathIdentity
+    ) throws -> DomainMutationPhysicalDescriptor {
+        let descriptor = identity.originalPath.withCString {
+            open($0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        }
+        guard descriptor >= 0 else {
+            let code = errno
+            if code == ELOOP {
+                throw DomainMutationPhysicalCapabilityError.symlinkNotAllowed(identity.originalPath)
+            }
+            throw DomainMutationPhysicalCapabilityError.ioFailure(operation: "authorized-root-open", code: code)
+        }
+        let value = DomainMutationPhysicalDescriptor(descriptor)
+        var status = stat()
+        guard fstat(value.fd, &status) == 0 else {
+            throw DomainMutationPhysicalCapabilityError.ioFailure(
+                operation: "authorized-root-stat",
+                code: errno
+            )
+        }
+        guard status.st_dev == dev_t(identity.device),
+              status.st_ino == ino_t(identity.inode),
+              status.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR)
+        else {
+            throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+        }
+        return value
+    }
+
+    private static func makePlan(
+        entry: DomainMutationPathFenceEntry,
+        root: DomainMutationPathIdentity,
+        descriptor rootDescriptor: DomainMutationPhysicalDescriptor
+    ) throws -> DomainMutationPhysicalTargetPlan {
+        let absolutePath = URL(fileURLWithPath: entry.requestedPath).standardizedFileURL.path
+        let rootPrefix = root.originalPath == "/" ? "/" : root.originalPath + "/"
+        guard absolutePath.hasPrefix(rootPrefix) else {
+            throw DomainMutationPhysicalCapabilityError.pathOutsideAuthorizedRoots(entry.requestedPath)
+        }
+        let relative = String(absolutePath.dropFirst(rootPrefix.count))
+        let components = relative.split(separator: "/").map(String.init)
+        guard let leaf = components.last else {
+            throw DomainMutationPhysicalCapabilityError.invalidComponent(absolutePath)
+        }
+        for component in components where component.isEmpty || component == "." || component == ".." {
+            throw DomainMutationPhysicalCapabilityError.invalidComponent(component)
+        }
+
+        var current = rootDescriptor
+        var missingComponents: [String] = []
+        var existingAncestorComponents: [String] = []
+        var hasMissingComponent = false
+        for component in components.dropLast() {
+            if hasMissingComponent {
+                missingComponents.append(component)
+                continue
+            }
+            let child = openat(current.fd, component, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+            if child >= 0 {
+                current = DomainMutationPhysicalDescriptor(child)
+                existingAncestorComponents.append(component)
+                continue
+            }
+            let code = errno
+            if code == ENOENT {
+                hasMissingComponent = true
+                missingComponents.append(component)
+                continue
+            }
+            if code == ELOOP {
+                throw DomainMutationPhysicalCapabilityError.symlinkNotAllowed(absolutePath)
+            }
+            throw DomainMutationPhysicalCapabilityError.ioFailure(operation: "authorized-parent-open", code: code)
+        }
+
+        let existingAncestorPath: String = if existingAncestorComponents.isEmpty {
+            root.originalPath
+        } else {
+            URL(fileURLWithPath: root.originalPath)
+                .appendingPathComponent(existingAncestorComponents.joined(separator: "/"))
+                .standardizedFileURL.path
+        }
+
+        if entry.existingAnchor.originalPath != entry.requestedPath {
+            guard entry.existingAnchor.originalPath == existingAncestorPath else {
+                throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+            }
+            var status = stat()
+            guard fstat(current.fd, &status) == 0 else {
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "authorized-anchor-stat",
+                    code: errno
+                )
+            }
+            guard status.st_dev == dev_t(entry.existingAnchor.device),
+                  status.st_ino == ino_t(entry.existingAnchor.inode)
+            else {
+                throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+            }
+        }
+
+        return DomainMutationPhysicalTargetPlan(
+            absolutePath: absolutePath,
+            leaf: leaf,
+            base: current,
+            missingComponents: missingComponents
+        )
+    }
+}
+
+private final class DomainMutationPhysicalTargetPlan: @unchecked Sendable {
+    let absolutePath: String
+    let leaf: String
+    let base: DomainMutationPhysicalDescriptor
+    let missingComponents: [String]
+
+    init(
+        absolutePath: String,
+        leaf: String,
+        base: DomainMutationPhysicalDescriptor,
+        missingComponents: [String]
+    ) {
+        self.absolutePath = absolutePath
+        self.leaf = leaf
+        self.base = base
+        self.missingComponents = missingComponents
+    }
+
+    func existingParent() throws -> DomainMutationPhysicalDescriptor? {
+        missingComponents.isEmpty ? base : nil
+    }
+
+    func materializedParent() throws -> DomainMutationPhysicalDescriptor {
+        var current = base
+        for component in missingComponents {
+            if mkdirat(current.fd, component, mode_t(0o755)) != 0 {
+                let code = errno
+                guard code == EEXIST else {
+                    throw DomainMutationPhysicalCapabilityError.ioFailure(
+                        operation: "relative-parent-materialize",
+                        code: code
+                    )
+                }
+            }
+            let descriptor = openat(
+                current.fd,
+                component,
+                O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC
+            )
+            guard descriptor >= 0 else {
+                let code = errno
+                if code == ELOOP {
+                    throw DomainMutationPhysicalCapabilityError.symlinkNotAllowed(absolutePath)
+                }
+                throw DomainMutationPhysicalCapabilityError.ioFailure(
+                    operation: "relative-parent-open",
+                    code: code
+                )
+            }
+            current = DomainMutationPhysicalDescriptor(descriptor)
+        }
+        return current
+    }
+}
+
+private final class DomainMutationPhysicalDescriptor: @unchecked Sendable {
+    let fd: Int32
+
+    init(_ fd: Int32) {
+        self.fd = fd
+    }
+
+    deinit {
+        Darwin.close(fd)
+    }
+}
+
+private struct DomainMutationPhysicalFileIdentity {
+    let device: dev_t
+    let inode: ino_t
+    let mode: mode_t
+
+    init(_ status: stat) {
+        device = status.st_dev
+        inode = status.st_ino
+        mode = status.st_mode & mode_t(S_IFMT)
+    }
+
+    var isRegular: Bool {
+        mode == mode_t(S_IFREG)
+    }
+}

--- a/Sources/RepoPromptDomainRuntime/MCPDomainCanonicalWorkspaceService.swift
+++ b/Sources/RepoPromptDomainRuntime/MCPDomainCanonicalWorkspaceService.swift
@@ -429,6 +429,12 @@ package struct MCPDomainCanonicalWorkspaceService {
         guard let capability = try await MCPDomainMutationCommitContext.physicalMutationCapability() else {
             throw DomainMutationPhysicalCapabilityError.scopeUnavailable
         }
+        try capability.validateWriteTarget(
+            at: destination.path,
+            overwrite: false,
+            expectedContentDigest: nil,
+            requireExisting: false
+        )
         try await MCPDomainMutationCommitContext.willCommit()
         return capability
     }

--- a/Sources/RepoPromptDomainRuntime/MCPDomainCanonicalWorkspaceService.swift
+++ b/Sources/RepoPromptDomainRuntime/MCPDomainCanonicalWorkspaceService.swift
@@ -20,7 +20,7 @@ package extension DomainPhysicalToolResult {
     }
 }
 
-package struct DomainCanonicalWorkspaceSnapshot: Sendable {
+package struct DomainCanonicalWorkspaceSnapshot {
     package let identity: DomainContextIdentity
     package let roots: [URL]
     package let prompt: String
@@ -39,12 +39,12 @@ package struct DomainCanonicalWorkspaceSnapshot: Sendable {
     }
 }
 
-package enum DomainCanonicalWorkspaceMutation: Sendable {
+package enum DomainCanonicalWorkspaceMutation {
     case setPrompt(String)
     case setSelection([String])
 }
 
-package struct DomainCanonicalWorkspaceAdapter: Sendable {
+package struct DomainCanonicalWorkspaceAdapter {
     package typealias ToolSnapshot = @Sendable (DomainPhysicalToolRequest) async throws -> DomainCanonicalWorkspaceSnapshot
     package typealias ReadSnapshot = @Sendable (DomainPhysicalReadRequest) async throws -> DomainCanonicalWorkspaceSnapshot
     package typealias Mutate = @Sendable (
@@ -79,7 +79,7 @@ package struct DomainCanonicalWorkspaceAdapter: Sendable {
 /// The executable supplies only authoritative snapshot/mutation/path adapters; argument parsing,
 /// selection semantics, file reads, search, tree rendering, codemaps, prompt/context projection,
 /// mutation admission, and response shapes are owned here.
-package struct MCPDomainCanonicalWorkspaceService: Sendable {
+package struct MCPDomainCanonicalWorkspaceService {
     private let adapter: DomainCanonicalWorkspaceAdapter
 
     package init(adapter: DomainCanonicalWorkspaceAdapter) {
@@ -351,9 +351,18 @@ package struct MCPDomainCanonicalWorkspaceService: Sendable {
                 throw MCPError.invalidParams("export requires path")
             }
             let destination = try adapter.resolvePath(path, snapshot.roots, true)
-            try await admitExport(destination, roots: snapshot.roots)
             let content = "Prompt:\n\(snapshot.prompt)\n\nSelection:\n\(snapshot.selection.joined(separator: "\n"))\n"
-            try content.write(to: destination, atomically: true, encoding: .utf8)
+            let capability = try await admitExport(destination, roots: snapshot.roots)
+            guard let data = content.data(using: .utf8) else {
+                throw MCPError.invalidParams("export content is not UTF-8")
+            }
+            try capability.writeFile(
+                at: destination.path,
+                data: data,
+                overwrite: false,
+                expectedContentDigest: nil,
+                requireExisting: false
+            )
             return try .object(["path": .string(destination.path), "exported": .bool(true)])
         case "list_presets":
             return try .object(["presets": .array([])])
@@ -388,8 +397,17 @@ package struct MCPDomainCanonicalWorkspaceService: Sendable {
                 throw MCPError.invalidParams("export requires path")
             }
             let destination = try adapter.resolvePath(path, snapshot.roots, true)
-            try await admitExport(destination, roots: snapshot.roots)
-            try snapshot.prompt.write(to: destination, atomically: true, encoding: .utf8)
+            let capability = try await admitExport(destination, roots: snapshot.roots)
+            guard let data = snapshot.prompt.data(using: .utf8) else {
+                throw MCPError.invalidParams("export content is not UTF-8")
+            }
+            try capability.writeFile(
+                at: destination.path,
+                data: data,
+                overwrite: false,
+                expectedContentDigest: nil,
+                requireExisting: false
+            )
             return try .object(["path": .string(destination.path), "exported": .bool(true)])
         case "list_presets":
             return try .object(["presets": .array([])])
@@ -400,7 +418,7 @@ package struct MCPDomainCanonicalWorkspaceService: Sendable {
         }
     }
 
-    private func admitExport(_ destination: URL, roots: [URL]) async throws {
+    private func admitExport(_ destination: URL, roots: [URL]) async throws -> DomainMutationPhysicalCapability {
         let mappings = roots.map {
             DomainMutationPhysicalRootMapping(canonicalRoot: $0.path, physicalRoot: $0.path)
         }
@@ -408,7 +426,11 @@ package struct MCPDomainCanonicalWorkspaceService: Sendable {
             [destination.path],
             rootMappings: mappings
         )
+        guard let capability = try await MCPDomainMutationCommitContext.physicalMutationCapability() else {
+            throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+        }
         try await MCPDomainMutationCommitContext.willCommit()
+        return capability
     }
 
     private static func codeMapResult(_ url: URL) throws -> Value {

--- a/Sources/RepoPromptDomainRuntime/MCPDomainProtectedMutationToolProvider.swift
+++ b/Sources/RepoPromptDomainRuntime/MCPDomainProtectedMutationToolProvider.swift
@@ -1,12 +1,12 @@
 import Foundation
 import MCP
 
-package struct DomainProtectedMutationOperation: Hashable, Sendable {
+package struct DomainProtectedMutationOperation: Hashable {
     package let toolName: String
     package let action: String
 }
 
-package enum DomainProtectedMutationError: Error, Equatable, LocalizedError, Sendable {
+package enum DomainProtectedMutationError: Error, Equatable, LocalizedError {
     case partialSuccessAfterCommit(operationID: String)
 
     package var errorDescription: String? {
@@ -17,7 +17,7 @@ package enum DomainProtectedMutationError: Error, Equatable, LocalizedError, Sen
     }
 }
 
-package struct MCPDomainProtectedMutationToolProvider: Sendable {
+package struct MCPDomainProtectedMutationToolProvider {
     private let policyStore: DomainMutationPolicyStore
     private let journal: DomainMutationJournal
 
@@ -80,7 +80,7 @@ package struct MCPDomainProtectedMutationToolProvider: Sendable {
     package static func isProtectedFamily(_ toolName: String) -> Bool {
         [
             "manage_selection", "prompt", "workspace_context", "bind_context", "manage_workspaces",
-            "file_actions", "apply_edits", "manage_worktree",
+            "file_actions", "apply_edits", "manage_worktree"
         ].contains(toolName)
     }
 
@@ -117,13 +117,13 @@ package struct MCPDomainProtectedMutationToolProvider: Sendable {
             let action = arguments["action"]?.stringValue ?? "list"
             return [
                 "switch", "create", "hide", "unhide", "delete", "add_folder", "remove_folder",
-                "select_tab", "create_tab", "close_tab",
+                "select_tab", "create_tab", "close_tab"
             ].contains(action) ? .init(toolName: toolName, action: action) : nil
         case "file_actions":
             let action = arguments["action"]?.stringValue ?? ""
             return action.isEmpty ? nil : .init(toolName: toolName, action: action)
         case "apply_edits":
-            let action: String = if arguments["rewrite"] != nil {
+            let action = if arguments["rewrite"] != nil {
                 "rewrite"
             } else if arguments["edits"] != nil {
                 "batch"
@@ -213,6 +213,9 @@ package struct MCPDomainProtectedMutationToolProvider: Sendable {
                 physicalMutationGuard: {
                     guard await commitState.hasBegunCommit() else { return nil }
                     return try await admissionState.physicalMutationGuard()
+                },
+                physicalMutationCapability: {
+                    try await admissionState.physicalMutationCapability()
                 },
                 willCommit: {
                     try await commitState.beginIfNeeded {
@@ -360,6 +363,7 @@ private actor DomainMutationPhysicalAdmissionState {
     private let ticket: DomainMutationJournalTicket
     private var authorization: DomainMutationAuthorizationSnapshot
     private var pathFence: DomainMutationPathFenceSnapshot?
+    private var physicalCapability: DomainMutationPhysicalCapability?
 
     init(
         operation: DomainProtectedMutationOperation,
@@ -385,6 +389,12 @@ private actor DomainMutationPhysicalAdmissionState {
     ) async throws {
         try Task.checkCancellation()
         guard !paths.isEmpty else { throw DomainMutationPathFenceError.scopeUnavailable }
+        guard Self.supportsPhysicalCapability(operation)
+            || Self.supportsPathFenceOnly(operation)
+            || !requiresPhysicalAdmission
+        else {
+            throw DomainMutationPhysicalCapabilityError.unsupportedOperation("\(operation.toolName).\(operation.action)")
+        }
         var mappings = suppliedMappings
         if securityContext.principal.kind == .appProxy,
            securityContext.principal.assurance == .verifiedProcess
@@ -414,9 +424,16 @@ private actor DomainMutationPhysicalAdmissionState {
             requestedPaths: paths.map(Self.standardized),
             authorizedRoots: physicalRoots
         )
-        try await journal.attachPathFence(fence, to: ticket)
+        let combinedFence = Self.combinedPathFence(pathFence, fence)
+        let capability: DomainMutationPhysicalCapability? = if Self.supportsPhysicalCapability(operation) {
+            try DomainMutationPhysicalCapability.open(snapshot: combinedFence)
+        } else {
+            nil
+        }
+        try await journal.attachPathFence(combinedFence, to: ticket)
         self.authorization = authorization
-        pathFence = fence
+        pathFence = combinedFence
+        physicalCapability = capability
     }
 
     func prepareCommit() async throws {
@@ -438,7 +455,52 @@ private actor DomainMutationPhysicalAdmissionState {
             }
             return nil
         }
-        return DomainMutationPhysicalCommitGuard(snapshot: pathFence)
+        guard physicalCapability != nil
+            || !requiresPhysicalAdmission
+            || Self.supportsPathFenceOnly(operation)
+        else {
+            throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+        }
+        return DomainMutationPhysicalCommitGuard(snapshot: pathFence, capability: physicalCapability)
+    }
+
+    func physicalMutationCapability() throws -> DomainMutationPhysicalCapability? {
+        guard let physicalCapability else {
+            if requiresPhysicalAdmission, !Self.supportsPathFenceOnly(operation) {
+                throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+            }
+            return nil
+        }
+        return physicalCapability
+    }
+
+    private static func supportsPathFenceOnly(_ operation: DomainProtectedMutationOperation) -> Bool {
+        operation.toolName == "manage_worktree"
+    }
+
+    private static func supportsPhysicalCapability(_ operation: DomainProtectedMutationOperation) -> Bool {
+        switch operation.toolName {
+        case "file_actions":
+            ["create", "move", "rename"].contains(operation.action)
+        case "apply_edits":
+            true
+        case "prompt", "workspace_context":
+            operation.action == "export"
+        default:
+            false
+        }
+    }
+
+    private static func combinedPathFence(
+        _ existing: DomainMutationPathFenceSnapshot?,
+        _ incoming: DomainMutationPathFenceSnapshot
+    ) -> DomainMutationPathFenceSnapshot {
+        guard let existing else { return incoming }
+        let roots = Array(Set(existing.authorizedRoots + incoming.authorizedRoots))
+            .sorted { $0.originalPath < $1.originalPath }
+        let entries = Array(Set(existing.entries + incoming.entries))
+            .sorted { $0.requestedPath < $1.requestedPath }
+        return DomainMutationPathFenceSnapshot(authorizedRoots: roots, entries: entries)
     }
 
     private static func nearestExistingAncestor(of path: String) -> String? {

--- a/Sources/RepoPromptMCP/DirectHeadlessCapabilityBackends.swift
+++ b/Sources/RepoPromptMCP/DirectHeadlessCapabilityBackends.swift
@@ -18,14 +18,14 @@ actor DirectHeadlessFilesystemBackend: DomainFilesystemMutationBackend {
         else {
             throw MCPError.invalidParams("file_actions requires action and path")
         }
-        guard ["create", "move", "delete"].contains(action) else {
+        guard ["create", "move", "rename", "delete"].contains(action) else {
             throw MCPError.invalidParams("unknown file_actions action: \(action)")
         }
         let allowMissing = action == "create"
         let source = try context.resolvePath(rawPath, roots: snapshot.roots, allowMissingLeaf: allowMissing)
         var targets = [source.path]
         var destination: URL?
-        if action == "move" {
+        if ["move", "rename"].contains(action) {
             guard let rawDestination = args["new_path"]?.stringValue else {
                 throw MCPError.invalidParams("move requires new_path")
             }
@@ -39,7 +39,7 @@ actor DirectHeadlessFilesystemBackend: DomainFilesystemMutationBackend {
             if manager.fileExists(atPath: source.path), args["if_exists"]?.stringValue != "overwrite" {
                 throw MCPError.invalidParams("path already exists: \(source.path)")
             }
-        case "move":
+        case "move", "rename":
             guard let destination else { throw MCPError.invalidParams("move requires new_path") }
             guard manager.fileExists(atPath: source.path) else { throw MCPError.invalidParams("path does not exist") }
             guard !manager.fileExists(atPath: destination.path) else { throw MCPError.invalidParams("destination exists") }
@@ -49,25 +49,36 @@ actor DirectHeadlessFilesystemBackend: DomainFilesystemMutationBackend {
             preconditionFailure("file_actions operation was validated above")
         }
         try await admit(targets, roots: snapshot.roots)
-        try await MCPDomainMutationCommitContext.willCommit()
+        guard let capability = try await MCPDomainMutationCommitContext.physicalMutationCapability() else {
+            throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+        }
+        let overwrites = args["if_exists"]?.stringValue == "overwrite"
         switch action {
         case "create":
-            let exists = manager.fileExists(atPath: source.path)
-            if exists, args["if_exists"]?.stringValue != "overwrite" {
-                throw MCPError.invalidParams("path already exists: \(source.path)")
+            guard let data = (args["content"]?.stringValue ?? "").data(using: .utf8) else {
+                throw MCPError.invalidParams("content must be UTF-8")
             }
-            try manager.createDirectory(at: source.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try (args["content"]?.stringValue ?? "").write(to: source, atomically: true, encoding: .utf8)
-        case "move":
+            try capability.validateWriteTarget(
+                at: source.path,
+                overwrite: overwrites,
+                expectedContentDigest: nil,
+                requireExisting: false
+            )
+            try await MCPDomainMutationCommitContext.willCommit()
+            try capability.writeFile(
+                at: source.path,
+                data: data,
+                overwrite: overwrites,
+                expectedContentDigest: nil,
+                requireExisting: false
+            )
+        case "move", "rename":
             guard let destination else { throw MCPError.invalidParams("move requires new_path") }
-            guard manager.fileExists(atPath: source.path) else { throw MCPError.invalidParams("path does not exist") }
-            guard !manager.fileExists(atPath: destination.path) else { throw MCPError.invalidParams("destination exists") }
-            try manager.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try manager.moveItem(at: source, to: destination)
+            try capability.validateNoReplaceMove(from: source.path, to: destination.path)
+            try await MCPDomainMutationCommitContext.willCommit()
+            try capability.moveFile(from: source.path, to: destination.path)
         case "delete":
-            guard manager.fileExists(atPath: source.path) else { throw MCPError.invalidParams("path does not exist") }
-            var resultingURL: NSURL?
-            try manager.trashItem(at: source, resultingItemURL: &resultingURL)
+            throw DomainMutationPhysicalCapabilityError.unsupportedOperation("file_actions.delete")
         default:
             throw MCPError.invalidParams("unknown file_actions action: \(action)")
         }
@@ -189,28 +200,29 @@ private actor DirectHeadlessFileEditHost: FileEditHost {
             [target.path],
             rootMappings: rootMappings
         )
-        let manager = FileManager.default
-        try validateCurrentRevision(manager: manager, overwrite: overwrite)
-        try await MCPDomainMutationCommitContext.willCommit()
-        // Recheck synchronously after the durable boundary and immediately before atomic replacement.
-        try validateCurrentRevision(manager: manager, overwrite: overwrite)
-        try manager.createDirectory(at: target.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try content.write(to: target, atomically: true, encoding: .utf8)
-    }
-
-    private func validateCurrentRevision(manager: FileManager, overwrite: Bool) throws {
-        if overwrite {
-            guard let expectedDigest,
-                  let current = try? Data(contentsOf: target),
-                  DomainContentDigest.sha256(current) == expectedDigest
-            else {
-                throw MCPError.internalError("apply_edits revision conflict: file changed after preview")
-            }
-        } else {
-            guard expectedMissing, !manager.fileExists(atPath: target.path) else {
-                throw MCPError.internalError("apply_edits revision conflict: file was created concurrently")
-            }
+        guard let capability = try await MCPDomainMutationCommitContext.physicalMutationCapability() else {
+            throw DomainMutationPhysicalCapabilityError.scopeUnavailable
         }
+        if overwrite, expectedDigest == nil {
+            throw MCPError.internalError("apply_edits revision conflict: file was not read before overwrite")
+        }
+        try capability.validateWriteTarget(
+            at: target.path,
+            overwrite: overwrite,
+            expectedContentDigest: expectedDigest,
+            requireExisting: !expectedMissing
+        )
+        guard let data = content.data(using: .utf8) else {
+            throw MCPError.invalidParams("apply_edits requires UTF-8 output")
+        }
+        try await MCPDomainMutationCommitContext.willCommit()
+        try capability.writeFile(
+            at: target.path,
+            data: data,
+            overwrite: overwrite,
+            expectedContentDigest: expectedDigest,
+            requireExisting: !expectedMissing
+        )
     }
 }
 

--- a/Sources/RepoPromptMCP/DirectHeadlessDomainContext.swift
+++ b/Sources/RepoPromptMCP/DirectHeadlessDomainContext.swift
@@ -300,6 +300,9 @@ actor DirectHeadlessDomainContext {
     }
 
     nonisolated static func resolvePath(_ rawPath: String, roots: [URL], allowMissingLeaf: Bool = false) throws -> URL {
+        guard !rawPath.contains("\0") else {
+            throw Error.pathOutsideWorkspace(rawPath)
+        }
         guard !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw MCPError.invalidParams("path must not be empty")
         }

--- a/Tests/RepoPromptDomainRuntimeTests/DomainMutationPhysicalCapabilityTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainMutationPhysicalCapabilityTests.swift
@@ -1,0 +1,182 @@
+import Darwin
+import Foundation
+@testable import RepoPromptDomainRuntime
+import XCTest
+
+final class DomainMutationPhysicalCapabilityTests: XCTestCase {
+    func testDescriptorCapabilityKeepsCreateInsideAdmittedParentAfterPathSwap() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let target = fixture.parent.appendingPathComponent("created.txt")
+        let snapshot = try await DomainMutationPathFence.admit(
+            requestedPaths: [target.path],
+            authorizedRoots: [fixture.root.path]
+        )
+        let capability = try DomainMutationPhysicalCapability.open(snapshot: snapshot)
+
+        try FileManager.default.moveItem(at: fixture.parent, to: fixture.heldParent)
+        try FileManager.default.createSymbolicLink(
+            at: fixture.parent,
+            withDestinationURL: fixture.outside
+        )
+
+        try capability.writeFile(
+            at: target.path,
+            data: Data("inside".utf8),
+            overwrite: false,
+            expectedContentDigest: nil,
+            requireExisting: false
+        )
+
+        XCTAssertEqual(
+            try String(contentsOf: fixture.heldParent.appendingPathComponent("created.txt"), encoding: .utf8),
+            "inside"
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.outside.appendingPathComponent("created.txt").path))
+    }
+
+    func testDescriptorCapabilityProvidesPositiveNoReplaceMove() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let source = fixture.parent.appendingPathComponent("source.txt")
+        let destination = fixture.parent.appendingPathComponent("destination.txt")
+        try Data("source".utf8).write(to: source)
+
+        let snapshot = try await DomainMutationPathFence.admit(
+            requestedPaths: [source.path, destination.path],
+            authorizedRoots: [fixture.root.path]
+        )
+        let capability = try DomainMutationPhysicalCapability.open(snapshot: snapshot)
+
+        try capability.validateNoReplaceMove(from: source.path, to: destination.path)
+        try capability.moveFile(from: source.path, to: destination.path)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: source.path))
+        XCTAssertEqual(
+            try String(contentsOf: destination, encoding: .utf8),
+            "source"
+        )
+    }
+
+    func testDeniedNoReplaceMoveHasNoSideEffect() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let source = fixture.parent.appendingPathComponent("source.txt")
+        let destination = fixture.parent.appendingPathComponent("destination.txt")
+        try Data("source".utf8).write(to: source)
+        try Data("existing".utf8).write(to: destination)
+
+        let snapshot = try await DomainMutationPathFence.admit(
+            requestedPaths: [source.path, destination.path],
+            authorizedRoots: [fixture.root.path]
+        )
+        let capability = try DomainMutationPhysicalCapability.open(snapshot: snapshot)
+
+        XCTAssertThrowsError(
+            try capability.validateNoReplaceMove(from: source.path, to: destination.path)
+        ) { error in
+            XCTAssertEqual(
+                error as? DomainMutationPhysicalCapabilityError,
+                .destinationExists(destination.path)
+            )
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: source.path))
+        XCTAssertEqual(
+            try String(contentsOf: source, encoding: .utf8),
+            "source"
+        )
+        XCTAssertEqual(
+            try String(contentsOf: destination, encoding: .utf8),
+            "existing"
+        )
+    }
+
+    func testDescriptorCapabilityPreservesExecutableModeOnAtomicOverwrite() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let target = fixture.parent.appendingPathComponent("executable.sh")
+        try Data("#!/bin/sh\necho before\n".utf8).write(to: target)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: target.path)
+        let snapshot = try await DomainMutationPathFence.admit(
+            requestedPaths: [target.path],
+            authorizedRoots: [fixture.root.path]
+        )
+        let capability = try DomainMutationPhysicalCapability.open(snapshot: snapshot)
+
+        try capability.validateWriteTarget(
+            at: target.path,
+            overwrite: true,
+            expectedContentDigest: DomainContentDigest.sha256(Data("#!/bin/sh\necho before\n".utf8)),
+            requireExisting: true
+        )
+        try capability.writeFile(
+            at: target.path,
+            data: Data("#!/bin/sh\necho after\n".utf8),
+            overwrite: true,
+            expectedContentDigest: DomainContentDigest.sha256(Data("#!/bin/sh\necho before\n".utf8)),
+            requireExisting: true
+        )
+
+        XCTAssertEqual(try String(contentsOf: target, encoding: .utf8), "#!/bin/sh\necho after\n")
+        let attributes = try FileManager.default.attributesOfItem(atPath: target.path)
+        XCTAssertEqual((attributes[.posixPermissions] as? NSNumber)?.intValue, 0o755)
+        let names = try FileManager.default.contentsOfDirectory(atPath: fixture.parent.path)
+        XCTAssertFalse(names.contains { $0.hasPrefix(".rpce-mutation-") })
+    }
+
+    func testDescriptorCapabilityDeniesFIFOWithoutBlocking() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let target = fixture.parent.appendingPathComponent("named-pipe")
+        XCTAssertEqual(mkfifo(target.path, 0o644), 0)
+        let snapshot = try await DomainMutationPathFence.admit(
+            requestedPaths: [target.path],
+            authorizedRoots: [fixture.root.path]
+        )
+        let capability = try DomainMutationPhysicalCapability.open(snapshot: snapshot)
+
+        XCTAssertThrowsError(
+            try capability.validateWriteTarget(
+                at: target.path,
+                overwrite: true,
+                expectedContentDigest: DomainContentDigest.sha256(Data()),
+                requireExisting: true
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? DomainMutationPhysicalCapabilityError,
+                .notRegularFile(target.path)
+            )
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: target.path))
+    }
+}
+
+private struct Fixture {
+    let container: URL
+    let root: URL
+    let parent: URL
+    let heldParent: URL
+    let outside: URL
+
+    init() throws {
+        let fileManager = FileManager.default
+        container = fileManager.temporaryDirectory
+            .appendingPathComponent("domain-mutation-\(UUID().uuidString)", isDirectory: true)
+        root = container.appendingPathComponent("authorized-root", isDirectory: true)
+        parent = root.appendingPathComponent("parent", isDirectory: true)
+        heldParent = root.appendingPathComponent("held-parent", isDirectory: true)
+        outside = container.appendingPathComponent("outside", isDirectory: true)
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: outside, withIntermediateDirectories: true)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: container)
+    }
+}

--- a/Tests/RepoPromptDomainRuntimeTests/DomainProtectedMutationSecurityTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainProtectedMutationSecurityTests.swift
@@ -3,6 +3,8 @@ import MCP
 @testable import RepoPromptDomainRuntime
 import XCTest
 
+// Async autoclosure assertions require await inside the argument as well as at the call.
+// swiftformat:disable hoistAwait
 final class DomainProtectedMutationSecurityTests: XCTestCase {
     func testFinalRuntimeClassifiesAllProtectedMutationActions() {
         XCTAssertNil(operation("manage_selection", ["op": .string("get")]))
@@ -145,7 +147,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
         )
 
         await XCTAssertThrowsErrorAsync(
-            try MCPDomainInvocationSecurityContext.$current.withValue(context) {
+            try await MCPDomainInvocationSecurityContext.$current.withValue(context) {
                 try await protectedBinding([
                     "action": .string("delete"),
                     "path": .string(target.path)
@@ -169,6 +171,84 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
         XCTAssertEqual(record.status, .failedBeforeCommit)
     }
 
+    func testProtectedCanonicalExportRejectsExistingDestinationBeforeCommit() async throws {
+        let fixture = try RuntimeFixture(mode: .standalone)
+        let fileManager = FileManager.default
+        let container = fileManager.temporaryDirectory
+            .appendingPathComponent("m4-canonical-export-collision-\(UUID().uuidString)", isDirectory: true)
+        let root = container.appendingPathComponent("authorized-root", isDirectory: true)
+        let destination = root.appendingPathComponent("export.md")
+        let existing = Data("existing export bytes\n".utf8)
+        defer { try? fileManager.removeItem(at: container) }
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        try existing.write(to: destination)
+
+        let snapshot = DomainCanonicalWorkspaceSnapshot(
+            identity: DomainContextIdentity(workspaceID: UUID(), contextID: UUID()),
+            roots: [root],
+            prompt: "prompt",
+            selection: []
+        )
+        let snapshotBox = CanonicalWorkspaceSnapshotBox(snapshot)
+        let service = MCPDomainCanonicalWorkspaceService(
+            adapter: DomainCanonicalWorkspaceAdapter(
+                toolSnapshot: { _ in snapshotBox.value },
+                readSnapshot: { _ in snapshotBox.value },
+                mutate: { _, _ in snapshotBox.value },
+                resolvePath: { rawPath, roots, _ in
+                    guard let root = roots.first else {
+                        throw DomainMutationPhysicalCapabilityError.scopeUnavailable
+                    }
+                    return root.appendingPathComponent(rawPath).standardizedFileURL
+                }
+            )
+        )
+        let serviceBox = CanonicalWorkspaceServiceBox(service)
+        let binding = try MCPDomainToolBinding(
+            definition: XCTUnwrap(
+                MCPDomainCanonicalToolDefinitions.definition(named: "workspace_context")
+            ),
+            operation: { arguments in
+                let request = try DomainPhysicalToolRequest(arguments: arguments)
+                let readRequest = DomainPhysicalReadRequest(
+                    request: request,
+                    context: DomainReadInvocationContext(handle: nil, connectionID: nil),
+                    sideEffects: MCPDomainReadSideEffectEmitter(submit: { _, _, _, _, _ in })
+                )
+                _ = try await serviceBox.value.renderWorkspaceContext(readRequest)
+                return .null
+            }
+        )
+        let protectedBinding = fixture.runtime.protectedMutationProvider.protectedBinding(binding)
+        let context = fixture.context(
+            kind: .runScoped,
+            assurance: .hostLaunchToken,
+            authorizedCanonicalRoots: [root.path],
+            ephemeralGrantedToolNames: ["workspace_context"]
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await MCPDomainInvocationSecurityContext.$current.withValue(context) {
+                try await protectedBinding([
+                    "op": .string("export"),
+                    "path": .string("export.md")
+                ])
+            }
+        ) { error in
+            XCTAssertEqual(
+                error as? DomainMutationPhysicalCapabilityError,
+                .destinationExists(destination.path)
+            )
+        }
+
+        XCTAssertEqual(try Data(contentsOf: destination), existing)
+        let journal = try await fixture.runtime.mutationJournal.snapshot()
+        let record = try XCTUnwrap(journal.recordSnapshots.first)
+        XCTAssertEqual(record.toolName, "workspace_context")
+        XCTAssertEqual(record.action, "export")
+        XCTAssertEqual(record.status, .failedBeforeCommit)
+    }
+
     func testExactRunScopedOperationGrantAllowsNamedActionAndDeniesSiblingAction() async throws {
         let fixture = try RuntimeFixture(mode: .standalone)
         let calls = CallCounter()
@@ -184,7 +264,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
             try await binding(["op": .string("set")])
         }
         await XCTAssertThrowsErrorAsync(
-            try MCPDomainInvocationSecurityContext.$current.withValue(exactOperation) {
+            try await MCPDomainInvocationSecurityContext.$current.withValue(exactOperation) {
                 try await binding(["op": .string("append")])
             }
         ) { error in
@@ -294,7 +374,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
             ephemeralGrantedToolNames: []
         )
         await XCTAssertThrowsErrorAsync(
-            try MCPDomainInvocationSecurityContext.$current.withValue(spoofed) {
+            try await MCPDomainInvocationSecurityContext.$current.withValue(spoofed) {
                 try await binding(["op": .string("set")])
             }
         ) { error in
@@ -335,7 +415,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
             try await binding(["action": .string("add_folder"), "folder_path": .string(inside)])
         }
         await XCTAssertThrowsErrorAsync(
-            try MCPDomainInvocationSecurityContext.$current.withValue(allowed) {
+            try await MCPDomainInvocationSecurityContext.$current.withValue(allowed) {
                 try await binding(["action": .string("add_folder"), "folder_path": .string(outside)])
             }
         ) { error in
@@ -350,7 +430,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
             ephemeralGrantedToolNames: ["manage_workspaces"]
         )
         await XCTAssertThrowsErrorAsync(
-            try MCPDomainInvocationSecurityContext.$current.withValue(staleRouting) {
+            try await MCPDomainInvocationSecurityContext.$current.withValue(staleRouting) {
                 try await binding(["action": .string("add_folder"), "folder_path": .string(inside)])
             }
         ) { error in
@@ -396,7 +476,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
         )
 
         await XCTAssertThrowsErrorAsync(
-            try MCPDomainInvocationSecurityContext.$current.withValue(context) {
+            try await MCPDomainInvocationSecurityContext.$current.withValue(context) {
                 try await binding(["op": .string("set")])
             }
         ) { error in
@@ -559,6 +639,22 @@ private func XCTAssertThrowsErrorAsync(
         XCTFail("Expected expression to throw")
     } catch {
         verify(error)
+    }
+}
+
+private final class CanonicalWorkspaceSnapshotBox: @unchecked Sendable {
+    let value: DomainCanonicalWorkspaceSnapshot
+
+    init(_ value: DomainCanonicalWorkspaceSnapshot) {
+        self.value = value
+    }
+}
+
+private final class CanonicalWorkspaceServiceBox: @unchecked Sendable {
+    let value: MCPDomainCanonicalWorkspaceService
+
+    init(_ value: MCPDomainCanonicalWorkspaceService) {
+        self.value = value
     }
 }
 

--- a/Tests/RepoPromptDomainRuntimeTests/DomainProtectedMutationSecurityTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/DomainProtectedMutationSecurityTests.swift
@@ -100,6 +100,75 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
         XCTAssertEqual(runCallCount, 1)
     }
 
+    func testUnsupportedProtectedPhysicalMutationFinishesBeforeCommitWithoutCreatingParent() async throws {
+        let fixture = try RuntimeFixture(mode: .standalone)
+        let fileManager = FileManager.default
+        let container = fileManager.temporaryDirectory
+            .appendingPathComponent("m4-physical-denial-" + UUID().uuidString, isDirectory: true)
+        let root = container.appendingPathComponent("authorized-root", isDirectory: true)
+        let materializationRoot = root.appendingPathComponent("new", isDirectory: true)
+        let parent = materializationRoot.appendingPathComponent("parent", isDirectory: true)
+        let target = parent.appendingPathComponent("file.txt")
+        defer { try? fileManager.removeItem(at: container) }
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let calls = CallCounter()
+        let binding = MCPDomainToolBinding(
+            definition: MCPDomainToolDefinition(
+                name: "file_actions",
+                description: "fixture",
+                inputSchema: .object(["type": .string("object")]),
+                annotations: .init(readOnlyHint: false, destructiveHint: true)
+            ),
+            operation: { _ in
+                try await MCPDomainMutationCommitContext.admitPhysicalTargets(
+                    [target.path],
+                    rootMappings: [
+                        DomainMutationPhysicalRootMapping(
+                            canonicalRoot: root.path,
+                            physicalRoot: root.path
+                        )
+                    ]
+                )
+                try await MCPDomainMutationCommitContext.willCommit()
+                try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+                await calls.increment()
+                return .string("unexpected")
+            }
+        )
+        let protectedBinding = fixture.runtime.protectedMutationProvider.protectedBinding(binding)
+        let context = fixture.context(
+            kind: .runScoped,
+            assurance: .hostLaunchToken,
+            authorizedCanonicalRoots: [root.path],
+            ephemeralGrantedToolNames: ["file_actions"]
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try MCPDomainInvocationSecurityContext.$current.withValue(context) {
+                try await protectedBinding([
+                    "action": .string("delete"),
+                    "path": .string(target.path)
+                ])
+            }
+        ) { error in
+            XCTAssertEqual(
+                error as? DomainMutationPhysicalCapabilityError,
+                .unsupportedOperation("file_actions.delete")
+            )
+        }
+
+        XCTAssertFalse(fileManager.fileExists(atPath: materializationRoot.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: parent.path))
+        let callCount = await calls.value
+        XCTAssertEqual(callCount, 0)
+        let journal = try await fixture.runtime.mutationJournal.snapshot()
+        let record = try XCTUnwrap(journal.recordSnapshots.first)
+        XCTAssertEqual(record.toolName, "file_actions")
+        XCTAssertEqual(record.action, "delete")
+        XCTAssertEqual(record.status, .failedBeforeCommit)
+    }
+
     func testExactRunScopedOperationGrantAllowsNamedActionAndDeniesSiblingAction() async throws {
         let fixture = try RuntimeFixture(mode: .standalone)
         let calls = CallCounter()
@@ -115,7 +184,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
             try await binding(["op": .string("set")])
         }
         await XCTAssertThrowsErrorAsync(
-            try await MCPDomainInvocationSecurityContext.$current.withValue(exactOperation) {
+            try MCPDomainInvocationSecurityContext.$current.withValue(exactOperation) {
                 try await binding(["op": .string("append")])
             }
         ) { error in
@@ -225,7 +294,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
             ephemeralGrantedToolNames: []
         )
         await XCTAssertThrowsErrorAsync(
-            try await MCPDomainInvocationSecurityContext.$current.withValue(spoofed) {
+            try MCPDomainInvocationSecurityContext.$current.withValue(spoofed) {
                 try await binding(["op": .string("set")])
             }
         ) { error in
@@ -266,7 +335,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
             try await binding(["action": .string("add_folder"), "folder_path": .string(inside)])
         }
         await XCTAssertThrowsErrorAsync(
-            try await MCPDomainInvocationSecurityContext.$current.withValue(allowed) {
+            try MCPDomainInvocationSecurityContext.$current.withValue(allowed) {
                 try await binding(["action": .string("add_folder"), "folder_path": .string(outside)])
             }
         ) { error in
@@ -281,7 +350,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
             ephemeralGrantedToolNames: ["manage_workspaces"]
         )
         await XCTAssertThrowsErrorAsync(
-            try await MCPDomainInvocationSecurityContext.$current.withValue(staleRouting) {
+            try MCPDomainInvocationSecurityContext.$current.withValue(staleRouting) {
                 try await binding(["action": .string("add_folder"), "folder_path": .string(inside)])
             }
         ) { error in
@@ -327,7 +396,7 @@ final class DomainProtectedMutationSecurityTests: XCTestCase {
         )
 
         await XCTAssertThrowsErrorAsync(
-            try await MCPDomainInvocationSecurityContext.$current.withValue(context) {
+            try MCPDomainInvocationSecurityContext.$current.withValue(context) {
                 try await binding(["op": .string("set")])
             }
         ) { error in
@@ -481,8 +550,8 @@ private final class RuntimeFixture: @unchecked Sendable {
     }
 }
 
-private func XCTAssertThrowsErrorAsync<T>(
-    _ expression: @autoclosure () async throws -> T,
+private func XCTAssertThrowsErrorAsync(
+    _ expression: @autoclosure () async throws -> some Any,
     _ verify: (Error) -> Void = { _ in }
 ) async {
     do {

--- a/Tests/RepoPromptTests/MCP/DirectHeadlessCompositionTests.swift
+++ b/Tests/RepoPromptTests/MCP/DirectHeadlessCompositionTests.swift
@@ -87,6 +87,50 @@ final class DirectHeadlessCompositionTests: XCTestCase {
         }
     }
 
+    func testHeadlessResolverRejectsEscapedJSONNULWithoutWritingPrefix() throws {
+        let fileManager = FileManager.default
+        let container = fileManager.temporaryDirectory
+            .appendingPathComponent("rp-headless-nul-\(UUID().uuidString)", isDirectory: true)
+        let root = container.appendingPathComponent("authorized-root", isDirectory: true)
+        let outside = container.appendingPathComponent("outside", isDirectory: true)
+        let prefix = root.appendingPathComponent("prefix")
+        let original = Data("original bytes\n".utf8)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: outside, withIntermediateDirectories: true)
+        try original.write(to: prefix)
+        defer { try? fileManager.removeItem(at: container) }
+
+        let rawPath = "prefix\0/created.txt"
+        let encoded = try JSONEncoder().encode([
+            "action": Value.string("create"),
+            "path": Value.string(rawPath),
+            "content": Value.string("must not be written")
+        ])
+        let decoded = try JSONDecoder().decode([String: Value].self, from: encoded)
+        let decodedPath = try XCTUnwrap(decoded["path"]?.stringValue)
+        XCTAssertTrue(String(data: encoded, encoding: .utf8)?.contains("\\u0000") == true)
+        XCTAssertEqual(
+            try DirectHeadlessDomainContext.resolvePath("prefix", roots: [root]).path,
+            prefix.path
+        )
+
+        do {
+            let resolved = try DirectHeadlessDomainContext.resolvePath(
+                decodedPath,
+                roots: [root],
+                allowMissingLeaf: true
+            )
+            try Data("must not be written".utf8).write(to: resolved)
+            XCTFail("embedded NUL path must be rejected before any write")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("outside the bound workspace roots"), String(describing: error))
+        }
+
+        XCTAssertEqual(try Data(contentsOf: prefix), original)
+        XCTAssertFalse(fileManager.fileExists(atPath: root.appendingPathComponent("created.txt").path))
+        XCTAssertFalse(fileManager.fileExists(atPath: outside.appendingPathComponent("created.txt").path))
+    }
+
     func testHeadlessMergeMutationRejectsPreviewEndpointMovedOutsideViaSymlink() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("rp-headless-merge-fence-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
Protected create, edit, same-volume move and in-root export now retain directory descriptors and reject symlink traversal through the physical mutation boundary. App and direct-headless callers use the same capability; exclusive creation preserves competing files, and failed overwrite cleanup cannot unlink another writer’s entry. Embedded NUL paths and existing no-replace export destinations fail before commit.

Protected Trash/delete, cross-volume moves and external exports fail closed. Git operations retain their existing path fences; this does not claim to resolve their broader namespace authority problem. Failed overwrite attempts can leave a private temporary file.

Validation: 59 focused tests, both app and MCP products, lint, and two independent final reviews passed. The feature diff is byte-identical after integrating main 7f2d347c. Hosted checks remain pending.

Refs #858.
