### PR TITLE
Preserve settings across schema migration and recovery retries

### DIFF
--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
@@ -5,16 +5,21 @@ import Foundation
 ///
 /// Schema v1 contains copy settings, chat settings, and cross-workspace global
 /// defaults. Schema v2 adds optional scalar preference groups. Schema v4 adds
-/// workspace-scoped Agent Models profiles. Scalar fields stay optional so missing
-/// JSON fields fall back through the typed GlobalSettingsStore accessors without
-/// losing current default behavior.
+/// workspace-scoped Agent Models profiles. Schema v5 fences the Context Builder
+/// behavior group from pre-Context-Builder typed writers. Scalar fields stay optional
+/// so missing JSON fields fall back through the typed GlobalSettingsStore accessors
+/// without losing current default behavior.
 struct GlobalSettingsDocument: Codable {
     /// Fixed feature-version constants are permanent compatibility boundaries. Add a new
     /// constant for each schema-requiring feature; never infer an existing feature's minimum
     /// version from `currentSchemaVersion`.
     static let baselineSchemaVersion = 2
     static let workspaceAgentModelsSchemaVersion = 4
-    static let currentSchemaVersion = 4
+    /// Context Builder behavior was introduced after the released v1.3 typed codec.
+    /// Keep it above that codec's supported v4 so older writers reject the document
+    /// before their typed save can silently drop the group.
+    static let contextBuilderSchemaVersion = 5
+    static let currentSchemaVersion = contextBuilderSchemaVersion
     /// Lineage marker for settings files written by this open-source CE schema family.
     ///
     /// CE inherited numeric schema versions from classic/internal builds, so version numbers
@@ -77,6 +82,9 @@ struct GlobalSettingsDocument: Codable {
         var requiredVersion = Self.baselineSchemaVersion
         if let agentModelsSettingsByWorkspaceID, !agentModelsSettingsByWorkspaceID.isEmpty {
             requiredVersion = max(requiredVersion, Self.workspaceAgentModelsSchemaVersion)
+        }
+        if scalarPreferences?.contextBuilder != nil {
+            requiredVersion = max(requiredVersion, Self.contextBuilderSchemaVersion)
         }
         return requiredVersion
     }

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsFileStore.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsFileStore.swift
@@ -12,6 +12,12 @@ protocol GlobalSettingsFileStoring {
         _ document: GlobalSettingsDocument,
         includeModelSelectionRepair: Bool
     ) throws
+    /// True after a raw-preserving startup migration write failed and must be retried
+    /// through the same preservation transaction.
+    var hasPendingStartupMigration: Bool { get }
+    /// Retries a failed raw-preserving startup migration. Ordinary typed saves must not
+    /// be used to clear this state.
+    func retryStartupMigrationPreservingUnknownFields(_ document: GlobalSettingsDocument) throws
     /// User-initiated recovery: backs up the offending file, writes a current-schema replacement, clears the block.
     @discardableResult
     func performUserInitiatedRecovery(replacementDocument: GlobalSettingsDocument) -> Bool
@@ -54,9 +60,23 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
     private let now: () -> Date
     private let normalizationBackupWriter: (Data, URL) throws -> Void
     private let normalizationAtomicWriter: (Data, URL) throws -> Void
+    private let startupMigrationAtomicWriter: (Data, URL) throws -> Void
     private var preservingUnsupportedFutureDocument = false
     private var preservingUnbackedCorruptDocument = false
     private var preservingFailedAutomaticNormalization = false
+
+    private struct PendingStartupMigration {
+        /// The typed document used for the failed attempt. Retry compares against this
+        /// snapshot so only known values changed while persistence was blocked are overlaid.
+        let initialDocument: GlobalSettingsDocument
+        let includeModelSelectionRepair: Bool
+    }
+
+    private var pendingStartupMigration: PendingStartupMigration?
+
+    var hasPendingStartupMigration: Bool {
+        pendingStartupMigration != nil
+    }
 
     /// Non-nil when the on-disk file cannot be safely read or overwritten, so the store falls
     /// back to in-memory defaults and refuses saves. Surfaced to the user (never auto-recovered).
@@ -72,6 +92,9 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
         },
         normalizationAtomicWriter: @escaping (Data, URL) throws -> Void = { data, url in
             try data.write(to: url, options: .atomic)
+        },
+        startupMigrationAtomicWriter: @escaping (Data, URL) throws -> Void = { data, url in
+            try data.write(to: url, options: .atomic)
         }
     ) {
         self.fileURL = fileURL
@@ -79,6 +102,7 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
         self.now = now
         self.normalizationBackupWriter = normalizationBackupWriter
         self.normalizationAtomicWriter = normalizationAtomicWriter
+        self.startupMigrationAtomicWriter = startupMigrationAtomicWriter
     }
 
     static func defaultFileURL(fileManager: FileManager = .default) -> URL {
@@ -146,7 +170,7 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
                 preservingFailedAutomaticNormalization = false
                 preservingUnsupportedFutureDocument = false
                 preservingUnbackedCorruptDocument = false
-                blockReason = nil
+                blockReason = pendingStartupMigration == nil ? nil : .saveFailed
                 return normalizedDocument
             } catch {
                 preservingFailedAutomaticNormalization = true
@@ -158,7 +182,7 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
         preservingFailedAutomaticNormalization = false
         preservingUnsupportedFutureDocument = false
         preservingUnbackedCorruptDocument = false
-        blockReason = nil
+        blockReason = pendingStartupMigration == nil ? nil : .saveFailed
         return document
     }
 
@@ -230,6 +254,7 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
         preservingFailedAutomaticNormalization = false
         preservingUnsupportedFutureDocument = false
         preservingUnbackedCorruptDocument = false
+        pendingStartupMigration = nil
         let documentToWrite = GlobalSettingsDocument(
             updatedAt: importedDocument.updatedAt,
             copySettings: importedDocument.copySettings,
@@ -268,6 +293,7 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
         preservingUnsupportedFutureDocument = false
         preservingUnbackedCorruptDocument = false
         preservingFailedAutomaticNormalization = false
+        pendingStartupMigration = nil
         do {
             var documentToWrite = replacementDocument
             documentToWrite.schemaLineage = GlobalSettingsDocument.schemaLineage
@@ -302,8 +328,38 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
         _ document: GlobalSettingsDocument,
         includeModelSelectionRepair: Bool
     ) throws {
-        try validateSavePermission()
+        try writeStartupMigrationPreservingUnknownFields(
+            document,
+            retryBaselineDocument: nil,
+            includeModelSelectionRepair: includeModelSelectionRepair,
+            allowRetryOfFailedMigration: false
+        )
+    }
+
+    func retryStartupMigrationPreservingUnknownFields(_ document: GlobalSettingsDocument) throws {
+        guard let pendingStartupMigration else {
+            throw GlobalSettingsFileStoreError.startupMigrationRetryUnavailable
+        }
+        try writeStartupMigrationPreservingUnknownFields(
+            document,
+            retryBaselineDocument: pendingStartupMigration.initialDocument,
+            includeModelSelectionRepair: pendingStartupMigration.includeModelSelectionRepair,
+            allowRetryOfFailedMigration: true
+        )
+    }
+
+    private func writeStartupMigrationPreservingUnknownFields(
+        _ document: GlobalSettingsDocument,
+        retryBaselineDocument: GlobalSettingsDocument?,
+        includeModelSelectionRepair: Bool,
+        allowRetryOfFailedMigration: Bool
+    ) throws {
+        try validateSavePermission(allowRetryOfFailedMigration: allowRetryOfFailedMigration)
         guard fileManager.fileExists(atPath: fileURL.path) else {
+            guard !allowRetryOfFailedMigration else {
+                blockReason = .saveFailed
+                throw GlobalSettingsFileStoreError.startupMigrationRetryRequired
+            }
             try save(document)
             return
         }
@@ -322,6 +378,21 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
               let knownGlobalDefaults = knownRoot["globalDefaults"] as? [String: Any]
         else {
             throw GlobalSettingsFileStoreError.contextBuilderMigrationEncodingFailed
+        }
+
+        let retryBaselineRoot: [String: Any]?
+        if let retryBaselineDocument {
+            var baselineDocumentToEncode = retryBaselineDocument
+            baselineDocumentToEncode.schemaVersion = baselineDocumentToEncode.requiredSchemaVersion
+            baselineDocumentToEncode.schemaLineage = GlobalSettingsDocument.schemaLineage
+            baselineDocumentToEncode.updatedAt = now()
+            let baselineData = try Self.encoder.encode(baselineDocumentToEncode)
+            guard let encodedBaselineRoot = try JSONSerialization.jsonObject(with: baselineData) as? [String: Any] else {
+                throw GlobalSettingsFileStoreError.contextBuilderMigrationEncodingFailed
+            }
+            retryBaselineRoot = encodedBaselineRoot
+        } else {
+            retryBaselineRoot = nil
         }
 
         var rawScalarPreferences = rawRoot["scalarPreferences"] as? [String: Any] ?? [:]
@@ -428,6 +499,14 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
             rawRoot["chatSettingsByWorkspaceID"] = rawChatSettings
         }
 
+        if let retryBaselineRoot {
+            Self.overlayKnownRetryChanges(
+                from: retryBaselineRoot,
+                to: knownRoot,
+                onto: &rawRoot
+            )
+        }
+
         rawRoot["schemaVersion"] = knownRoot["schemaVersion"]
         rawRoot["schemaLineage"] = knownRoot["schemaLineage"]
         rawRoot["updatedAt"] = knownRoot["updatedAt"]
@@ -435,17 +514,151 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
             withJSONObject: rawRoot,
             options: [.prettyPrinted, .sortedKeys]
         )
-        try ensureSettingsDirectoryExists()
         do {
-            try migratedData.write(to: fileURL, options: .atomic)
+            try ensureSettingsDirectoryExists()
+            try startupMigrationAtomicWriter(migratedData, fileURL)
+            pendingStartupMigration = nil
             blockReason = nil
         } catch {
+            // Keep the first failed attempt as the retry baseline. A later failed retry
+            // must not make earlier accepted in-memory edits look like the new baseline.
+            if pendingStartupMigration == nil {
+                pendingStartupMigration = PendingStartupMigration(
+                    initialDocument: document,
+                    includeModelSelectionRepair: includeModelSelectionRepair
+                )
+            }
             blockReason = .saveFailed
             throw error
         }
     }
 
-    private func validateSavePermission() throws {
+    /// Overlays only typed values changed after the failed migration attempt. The explicit
+    /// root-key list is the ownership boundary for this retry transaction; recursive merging
+    /// retains unknown raw members and removes changed known optional values without replacing
+    /// their containing raw objects wholesale.
+    private static let retryOwnedRootKeys = [
+        "copySettingsByWorkspaceID",
+        "chatSettingsByWorkspaceID",
+        "agentModelsSettingsByWorkspaceID",
+        "globalDefaults",
+        "scalarPreferences"
+    ]
+
+    private static func overlayKnownRetryChanges(
+        from initialRoot: [String: Any],
+        to currentRoot: [String: Any],
+        onto rawRoot: inout [String: Any]
+    ) {
+        for key in retryOwnedRootKeys {
+            let initialValue = initialRoot[key]
+            let currentValue = currentRoot[key]
+            guard !jsonValuesEqual(initialValue, currentValue) else { continue }
+            if let mergedValue = mergedKnownRetryValue(
+                initialValue: initialValue,
+                currentValue: currentValue,
+                rawValue: rawRoot[key]
+            ) {
+                rawRoot[key] = mergedValue
+            } else {
+                rawRoot.removeValue(forKey: key)
+            }
+        }
+    }
+
+    private static func mergedKnownRetryValue(
+        initialValue: Any?,
+        currentValue: Any?,
+        rawValue: Any?
+    ) -> Any? {
+        if let currentObject = currentValue as? [String: Any] {
+            let initialObject = initialValue as? [String: Any] ?? [:]
+            var mergedObject = rawValue as? [String: Any] ?? [:]
+            let keys = Set(initialObject.keys).union(currentObject.keys).sorted()
+            for key in keys {
+                let initialMember = initialObject[key]
+                let currentMember = currentObject[key]
+                guard !jsonValuesEqual(initialMember, currentMember) else { continue }
+
+                if let currentMember {
+                    if let mergedMember = mergedKnownRetryValue(
+                        initialValue: initialMember,
+                        currentValue: currentMember,
+                        rawValue: mergedObject[key]
+                    ) {
+                        mergedObject[key] = mergedMember
+                    } else {
+                        mergedObject.removeValue(forKey: key)
+                    }
+                } else if let initialObject = initialMember as? [String: Any],
+                          var rawObject = mergedObject[key] as? [String: Any]
+                {
+                    // A removed optional group/member may still contain unknown raw
+                    // members. Remove only the known typed members from that object.
+                    for knownKey in initialObject.keys {
+                        rawObject.removeValue(forKey: knownKey)
+                    }
+                    if rawObject.isEmpty {
+                        mergedObject.removeValue(forKey: key)
+                    } else {
+                        mergedObject[key] = rawObject
+                    }
+                } else {
+                    mergedObject.removeValue(forKey: key)
+                }
+            }
+            return mergedObject
+        }
+
+        guard currentValue != nil else {
+            if let initialObject = initialValue as? [String: Any],
+               var rawObject = rawValue as? [String: Any]
+            {
+                // Preserve unknown nested fields when an entire known optional object
+                // is removed from the typed retry document.
+                for knownKey in initialObject.keys {
+                    rawObject.removeValue(forKey: knownKey)
+                }
+                return rawObject.isEmpty ? nil : rawObject
+            }
+            return nil
+        }
+
+        return currentValue
+    }
+
+    private static func jsonValuesEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case let (lhs as NSNull, rhs as NSNull):
+            return lhs.isEqual(rhs)
+        case let (lhs as [String: Any], rhs as [String: Any]):
+            guard lhs.keys.count == rhs.keys.count else { return false }
+            return lhs.allSatisfy { element in
+                jsonValuesEqual(element.value, rhs[element.key])
+            }
+        case let (lhs as [Any], rhs as [Any]):
+            guard lhs.count == rhs.count else { return false }
+            return zip(lhs, rhs).allSatisfy { jsonValuesEqual($0.0, $0.1) }
+        case (nil, _), (_, nil):
+            return false
+        default:
+            guard let lhsObject = lhs as? NSObject,
+                  let rhsObject = rhs as? NSObject
+            else {
+                return false
+            }
+            return lhsObject.isEqual(rhsObject)
+        }
+    }
+
+    private func validateSavePermission(allowRetryOfFailedMigration: Bool = false) throws {
+        guard allowRetryOfFailedMigration || pendingStartupMigration == nil else {
+            blockReason = .saveFailed
+            throw GlobalSettingsFileStoreError.startupMigrationRetryRequired
+        }
+
         guard !preservingFailedAutomaticNormalization else {
             blockReason = .automaticSchemaNormalizationFailed
             throw GlobalSettingsFileStoreError.automaticSchemaNormalizationPreserved
@@ -724,6 +937,8 @@ final class GlobalSettingsFileStore: GlobalSettingsFileStoring {
         case corruptDocumentPreserved
         case automaticSchemaNormalizationFailed
         case automaticSchemaNormalizationPreserved
+        case startupMigrationRetryRequired
+        case startupMigrationRetryUnavailable
         case contextBuilderMigrationEncodingFailed
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -345,6 +345,12 @@ class GlobalSettingsStore: ObservableObject, CodexHookApprovalSettingsProviding 
         didSet { reconcilePersistenceBlockDismissal() }
     }
 
+    /// True when a failed startup migration must be retried through the raw-preserving
+    /// transaction instead of the ordinary typed save path.
+    var isPendingPreservingMigrationRetry: Bool {
+        fileStore.hasPendingStartupMigration
+    }
+
     @Published private(set) var sessionDismissedPersistenceBlockReason: GlobalSettingsPersistenceBlockReason?
 
     private var globalDefaults = GlobalDefaults(discoverAgentRaw: nil, discoverModelsByAgent: nil)
@@ -2342,6 +2348,7 @@ class GlobalSettingsStore: ObservableObject, CodexHookApprovalSettingsProviding 
             }
         }
         let document = loadedExistingDocument ?? fileStore.loadOrCreateDefault()
+        let needsSchemaVersionUpgrade = document.requiredSchemaVersion > document.schemaVersion
         copySettings = document.copySettings
         let migratedContextBuilderState = Self.migratingLegacyContextBuilderState(
             chatSettings: document.chatSettings,
@@ -2360,7 +2367,10 @@ class GlobalSettingsStore: ObservableObject, CodexHookApprovalSettingsProviding 
         codeMapsGloballyDisabled = globalDefaults.codeMapsGloballyDisabled ?? false
         persistenceBlockReason = fileStore.blockReason
         if persistenceBlockReason == nil,
-           migratedContextBuilderState.didChange || seededFileSystemDefaults || disabledInvalidSync
+           migratedContextBuilderState.didChange
+           || seededFileSystemDefaults
+           || disabledInvalidSync
+           || needsSchemaVersionUpgrade
         {
             saveStartupMigration(includeModelSelectionRepair: disabledInvalidSync)
         }
@@ -2409,7 +2419,12 @@ class GlobalSettingsStore: ObservableObject, CodexHookApprovalSettingsProviding 
     /// backing up or resetting the user's settings. Returns true when persistence is unblocked.
     @discardableResult
     func retryBlockedPersistenceSave() -> Bool {
-        save()
+        if fileStore.hasPendingStartupMigration {
+            return persist {
+                try fileStore.retryStartupMigrationPreservingUnknownFields(makeDocument())
+            }
+        }
+        return save()
     }
 
     @discardableResult
@@ -2418,6 +2433,7 @@ class GlobalSettingsStore: ObservableObject, CodexHookApprovalSettingsProviding 
             let oldGlobalProfile = globalAgentModelsProfile()
             let oldWorkspaceSettings = agentModelsSettingsByWorkspaceID
             let document = try fileStore.load()
+            let needsSchemaVersionUpgrade = document.requiredSchemaVersion > document.schemaVersion
             objectWillChange.send()
             copySettings = document.copySettings
             let migratedContextBuilderState = Self.migratingLegacyContextBuilderState(
@@ -2435,7 +2451,10 @@ class GlobalSettingsStore: ObservableObject, CodexHookApprovalSettingsProviding 
             codeMapsGloballyDisabled = globalDefaults.codeMapsGloballyDisabled ?? false
             persistenceBlockReason = fileStore.blockReason
             if persistenceBlockReason == nil,
-               migratedContextBuilderState.didChange || seededFileSystemDefaults || disabledInvalidSync
+               migratedContextBuilderState.didChange
+               || seededFileSystemDefaults
+               || disabledInvalidSync
+               || needsSchemaVersionUpgrade
             {
                 saveStartupMigration(includeModelSelectionRepair: disabledInvalidSync)
             }

--- a/Sources/RepoPrompt/Features/Settings/Views/GlobalSettingsPersistenceBlockBanner.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/GlobalSettingsPersistenceBlockBanner.swift
@@ -52,7 +52,11 @@ struct GlobalSettingsPersistenceBlockBanner: View {
                 HStack {
                     switch reason {
                     case .saveFailed:
-                        Button("Try again") {
+                        Button(
+                            store.isPendingPreservingMigrationRetry
+                                ? "Retry settings update"
+                                : "Try again"
+                        ) {
                             recoveryActionError = store.retryBlockedPersistenceSave()
                                 ? nil
                                 : "Save still failed. Check file permissions or available disk space, then try again."
@@ -134,7 +138,11 @@ struct GlobalSettingsPersistenceBlockBanner: View {
     private func resetConfirmationMessage(for reason: GlobalSettingsPersistenceBlockReason) -> String {
         switch reason {
         case .saveFailed:
-            "If retrying after fixing permissions or disk space does not work, RepoPrompt can move the current globalSettings.json to the Backups folder and write your current in-memory settings to a fresh current-schema file. This cannot be undone."
+            if store.isPendingPreservingMigrationRetry {
+                "If retrying does not work, RepoPrompt can move the original settings file to the Backups folder and save your current settings in a new file. This cannot be undone."
+            } else {
+                "If retrying after fixing permissions or disk space does not work, RepoPrompt can move the current globalSettings.json to the Backups folder and write your current in-memory settings to a fresh current-schema file. This cannot be undone."
+            }
         case .unsupportedFutureSchema, .incompatibleSchema, .corruptUnrecoverable,
              .automaticSchemaNormalizationFailed:
             "The current globalSettings.json will be moved to the Backups folder and your current in-memory settings will be written to a fresh current-schema file. Your settings will then save normally. This cannot be undone."
@@ -150,7 +158,11 @@ struct GlobalSettingsPersistenceBlockBanner: View {
         case .corruptUnrecoverable:
             "Global settings can't be saved: the settings file is unreadable and couldn't be backed up. Changes won't persist until you recover."
         case .saveFailed:
-            "Global settings can't be saved: RepoPrompt couldn't write globalSettings.json. Check file permissions or available disk space, then try again."
+            if store.isPendingPreservingMigrationRetry {
+                "RepoPrompt could not finish updating your settings. Your original settings file is preserved. Check file permissions or available disk space, then try again."
+            } else {
+                "Global settings can't be saved: RepoPrompt couldn't write globalSettings.json. Check file permissions or available disk space, then try again."
+            }
         case .automaticSchemaNormalizationFailed:
             "Global settings can't be saved: RepoPrompt identified a same-lineage schema v4 file that may only require schema v2, but couldn't safely verify, back up, and atomically normalize it. The original file is preserved. You can show the file or explicitly reset after a backup."
         }

--- a/Tests/RepoPromptTests/Fixtures/FrozenV130GlobalSettingsCompatibility.swift
+++ b/Tests/RepoPromptTests/Fixtures/FrozenV130GlobalSettingsCompatibility.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+/// Test-only compatibility codec frozen from the released RepoPrompt CE v1.3.0
+/// source at `b8042678fac558842ef4bc37027d0cd26246fdd6`, before commit
+/// `0b4d738a276c6489dc998f04d83082b01b49c8af` introduced the global
+/// `scalarPreferences.contextBuilder` group.
+///
+/// The scalar preference shape below is the released typed Codable shape. It intentionally
+/// has no `contextBuilder` member: decoding a document with that key and saving it again is
+/// the exact old-writer compatibility boundary under test. Opaque JSON values are used only
+/// for unrelated root maps so this fixture stays focused on the old scalar codec.
+struct FrozenV130GlobalSettingsDocument: Codable {
+    static let supportedSchemaVersion = 4
+    static let schemaLineage = "repoprompt-ce.global-settings"
+
+    var schemaVersion: Int
+    var schemaLineage: String?
+    var updatedAt: Date
+    var copySettingsByWorkspaceID: [String: FrozenV130JSONValue]
+    var chatSettingsByWorkspaceID: [String: FrozenV130JSONValue]
+    var agentModelsSettingsByWorkspaceID: [String: FrozenV130JSONValue]?
+    var globalDefaults: FrozenV130JSONValue
+    var scalarPreferences: FrozenV130GlobalScalarPreferences?
+
+    static func load(from url: URL) throws -> Self {
+        let document = try decoder.decode(Self.self, from: Data(contentsOf: url))
+        if document.schemaLineage == Self.schemaLineage,
+           document.schemaVersion > Self.supportedSchemaVersion
+        {
+            throw CompatibilityError.unsupportedFutureSchema(document.schemaVersion)
+        }
+        return document
+    }
+
+    var requiredSchemaVersion: Int {
+        guard let agentModelsSettingsByWorkspaceID,
+              !agentModelsSettingsByWorkspaceID.isEmpty
+        else {
+            return 2
+        }
+        return 4
+    }
+
+    mutating func save(to url: URL, now: Date) throws {
+        schemaVersion = requiredSchemaVersion
+        schemaLineage = Self.schemaLineage
+        updatedAt = now
+        try Self.encoder.encode(self).write(to: url, options: .atomic)
+    }
+
+    enum CompatibilityError: Error, Equatable {
+        case unsupportedFutureSchema(Int)
+    }
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+}
+
+struct FrozenV130GlobalScalarPreferences: Codable {
+    var ui: UISettings?
+    var promptPackaging: PromptPackagingSettings?
+    var modelSelection: ModelSelectionSettings?
+    var mcp: MCPSettings?
+    var fileSystem: FileSystemSettings?
+    var agentMode: AgentModeSettings?
+    var telemetry: TelemetrySettings?
+    var modelOverrides: ModelOverrideSettingsData?
+
+    struct UISettings: Codable {
+        var appearanceMode: String?
+        var useTransparency: Bool?
+        var collapseLatestFileChanges: Bool?
+        var showTooltips: Bool?
+        var experimentalAttributedTextEditor: Bool?
+        var fileMentionPickerStyle: String?
+        var enableKeyboardShortcuts: Bool?
+        var fontScaleBodySize: Double?
+        var showDatesInMessageTimestamps: Bool?
+    }
+
+    struct PromptPackagingSettings: Codable {
+        var promptSectionsOrder: String?
+        var duplicateUserInstructionsAtTop: Bool?
+        var filePathDisplayOption: String?
+        var selectedFilesSortMethod: String?
+        var fileEditFormat: String?
+        var includeDatetimeInUserInstructions: Bool?
+        var customPlanningPrompt: String?
+        var modelTemperature: Double?
+        var setModelTemperature: Bool?
+        var complexEditStrategy: String?
+    }
+
+    struct ModelSelectionSettings: Codable {
+        var preferredComposeModel: String?
+        var planningModel: String?
+        var syncChatModelWithOracle: Bool?
+    }
+
+    struct MCPSettings: Codable {
+        var autoStart: Bool?
+        var showModelPresets: Bool?
+        var temporarilyDisablePresets: Bool?
+    }
+
+    struct FileSystemSettings: Codable {
+        var respectRepoIgnore: Bool?
+        var respectCursorignore: Bool?
+        var globalIgnoreDefaults: String?
+        var enableHierarchicalIgnores: Bool?
+        var skipSymlinks: Bool?
+        var showEmptyFolders: Bool?
+    }
+
+    struct TelemetrySettings: Codable {
+        var enabled: Bool?
+        var appHangReportsEnabled: Bool?
+        var performanceTracingEnabled: Bool?
+    }
+
+    struct ModelOverrideSettingsData: Codable {
+        var diffOverrides: [String: Bool]?
+        var streamOverrides: [String: Bool]?
+        var temperatureOverrides: [String: Double]?
+        var responsesOverrides: [String: Bool]?
+    }
+
+    struct AgentModeSettings: Codable {
+        var proEditAgentMode: Bool?
+        var proEditAgentKind: String?
+        var proEditAgentModel: String?
+        var proEditAgentModeMigrated: Bool?
+        var agentAutoExpandToolCards: Bool?
+        var maxBackgroundAgentComposeTabs: Int?
+        var showBuiltInWorkflowCleanupGuidance: Bool?
+        var codexGoalSupportEnabled: Bool?
+        var codexReasoningSummariesEnabled: Bool?
+        var codexMemoriesEnabled: Bool?
+        var providerConversationCleanupAction: String?
+        var restrictMCPAgentDiscoveryToRoleLabels: Bool?
+        var agentSessionHandoffInstructions: String?
+    }
+}
+
+indirect enum FrozenV130JSONValue: Codable {
+    case object([String: Self])
+    case array([Self])
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+
+    var objectValue: [String: Self]? {
+        guard case let .object(value) = self else { return nil }
+        return value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode([String: Self].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([Self].self) {
+            self = .array(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        } else {
+            self = try .string(container.decode(String.self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case let .object(value): try container.encode(value)
+        case let .array(value): try container.encode(value)
+        case let .string(value): try container.encode(value)
+        case let .number(value): try container.encode(value)
+        case let .bool(value): try container.encode(value)
+        case .null: try container.encodeNil()
+        }
+    }
+}

--- a/Tests/RepoPromptTests/Settings/GlobalSettingsPersistenceSafetyTests.swift
+++ b/Tests/RepoPromptTests/Settings/GlobalSettingsPersistenceSafetyTests.swift
@@ -1,0 +1,336 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class GlobalSettingsPersistenceSafetyTests: XCTestCase {
+    func testContextBuilderContentGetsV5FenceAndV130CodecRejectsIt() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("Settings/globalSettings.json")
+        let document = makeDocument(
+            contextBuilder: makeContextBuilderSettings(),
+            fileSystemGlobalIgnoreDefaults: "keep"
+        )
+        let store = GlobalSettingsFileStore(fileURL: fileURL)
+
+        try store.save(document)
+
+        let savedRoot = try readJSONObject(at: fileURL)
+        XCTAssertEqual(
+            savedRoot["schemaVersion"] as? Int,
+            GlobalSettingsDocument.contextBuilderSchemaVersion
+        )
+        XCTAssertNotNil((savedRoot["scalarPreferences"] as? [String: Any])?["contextBuilder"])
+        XCTAssertThrowsError(try FrozenV130GlobalSettingsDocument.load(from: fileURL)) { error in
+            XCTAssertEqual(
+                error as? FrozenV130GlobalSettingsDocument.CompatibilityError,
+                .unsupportedFutureSchema(GlobalSettingsDocument.contextBuilderSchemaVersion)
+            )
+        }
+    }
+
+    func testPreContextBuilderV130TypedCodecWouldDropTheGroupWithoutTheFence() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("Settings/globalSettings.json")
+        let document = makeDocument(
+            contextBuilder: makeContextBuilderSettings(),
+            fileSystemGlobalIgnoreDefaults: "keep"
+        )
+        let store = GlobalSettingsFileStore(fileURL: fileURL)
+        try store.save(document)
+
+        var preFenceRoot = try readJSONObject(at: fileURL)
+        preFenceRoot["schemaVersion"] = FrozenV130GlobalSettingsDocument.supportedSchemaVersion
+        try writeJSONObject(preFenceRoot, to: fileURL)
+
+        var oldDocument = try FrozenV130GlobalSettingsDocument.load(from: fileURL)
+        oldDocument.scalarPreferences?.ui?.appearanceMode = "Dark"
+        try oldDocument.save(to: fileURL, now: Date(timeIntervalSince1970: 1000))
+
+        let oldWriterRoot = try readJSONObject(at: fileURL)
+        let oldWriterScalar = oldWriterRoot["scalarPreferences"] as? [String: Any]
+        XCTAssertNil(oldWriterScalar?["contextBuilder"])
+        XCTAssertEqual(
+            (oldWriterScalar?["ui"] as? [String: Any])?["appearanceMode"] as? String,
+            "Dark"
+        )
+    }
+
+    func testExistingV4DocumentWithContextBuilderIsUpgradedOnSequentialCurrentProcessPath() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("Settings/globalSettings.json")
+        let document = makeDocument(
+            contextBuilder: makeContextBuilderSettings(),
+            fileSystemGlobalIgnoreDefaults: "already-seeded"
+        )
+        let initialStore = GlobalSettingsFileStore(fileURL: fileURL)
+        try initialStore.save(document)
+
+        var v4Root = try readJSONObject(at: fileURL)
+        v4Root["schemaVersion"] = FrozenV130GlobalSettingsDocument.supportedSchemaVersion
+        try writeJSONObject(v4Root, to: fileURL)
+
+        let suiteName = "GlobalSettingsPersistenceSafetyTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        _ = GlobalSettingsStore(
+            defaults: defaults,
+            fileStore: GlobalSettingsFileStore(fileURL: fileURL)
+        )
+
+        let upgradedRoot = try readJSONObject(at: fileURL)
+        XCTAssertEqual(
+            upgradedRoot["schemaVersion"] as? Int,
+            GlobalSettingsDocument.contextBuilderSchemaVersion
+        )
+        let upgradedContextBuilder = try XCTUnwrap(
+            (upgradedRoot["scalarPreferences"] as? [String: Any])?["contextBuilder"] as? [String: Any]
+        )
+        let originalContextBuilder = try XCTUnwrap(
+            (v4Root["scalarPreferences"] as? [String: Any])?["contextBuilder"] as? [String: Any]
+        )
+        XCTAssertEqual(
+            try JSONSerialization.data(withJSONObject: upgradedContextBuilder, options: [.sortedKeys]),
+            try JSONSerialization.data(withJSONObject: originalContextBuilder, options: [.sortedKeys])
+        )
+    }
+
+    func testFailedMigrationRetryMergesKnownEditsAndPreservesUnknownFields() throws {
+        let root = try makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("Settings/globalSettings.json")
+        let workspaceID = UUID()
+        let document = makeDocument(
+            workspaceID: workspaceID,
+            includeLegacyChatSettings: true,
+            includeAgentModelsProfile: true,
+            contextBuilder: makeContextBuilderSettings(),
+            fileSystemGlobalIgnoreDefaults: "keep"
+        )
+        let initialStore = GlobalSettingsFileStore(fileURL: fileURL)
+        try initialStore.save(document)
+        try addUnknownFields(to: fileURL, workspaceID: workspaceID)
+        var v4Root = try readJSONObject(at: fileURL)
+        v4Root["schemaVersion"] = FrozenV130GlobalSettingsDocument.supportedSchemaVersion
+        try writeJSONObject(v4Root, to: fileURL)
+        let originalBytes = try Data(contentsOf: fileURL)
+
+        var writeAttempts = 0
+        let fileStore = GlobalSettingsFileStore(
+            fileURL: fileURL,
+            startupMigrationAtomicWriter: { data, url in
+                writeAttempts += 1
+                if writeAttempts <= 2 {
+                    throw CocoaError(.fileWriteNoPermission)
+                }
+                try data.write(to: url, options: .atomic)
+            }
+        )
+        let suiteName = "GlobalSettingsPersistenceSafetyTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = GlobalSettingsStore(defaults: defaults, fileStore: fileStore)
+
+        XCTAssertEqual(writeAttempts, 1)
+        XCTAssertEqual(settings.persistenceBlockReason, .saveFailed)
+        XCTAssertTrue(settings.isPendingPreservingMigrationRetry)
+        XCTAssertEqual(try Data(contentsOf: fileURL), originalBytes)
+
+        settings.setAppearanceModeRaw("Dark")
+        settings.setPlanningModelRaw("retry-planning-model")
+        var changedBehavior = settings.contextBuilderBehaviorSettings()
+        changedBehavior.analysisTokenBudget += 1
+        settings.setContextBuilderBehaviorSettings(changedBehavior)
+        XCTAssertEqual(settings.appearanceModeRaw(), "Dark")
+        XCTAssertEqual(settings.planningModelRaw(), "retry-planning-model")
+        XCTAssertEqual(
+            settings.contextBuilderBehaviorSettings().analysisTokenBudget,
+            changedBehavior.analysisTokenBudget
+        )
+        XCTAssertEqual(settings.persistenceBlockReason, .saveFailed)
+        XCTAssertThrowsError(try fileStore.save(document)) { error in
+            XCTAssertEqual(
+                error as? GlobalSettingsFileStore.GlobalSettingsFileStoreError,
+                .startupMigrationRetryRequired
+            )
+        }
+        XCTAssertEqual(try Data(contentsOf: fileURL), originalBytes)
+
+        XCTAssertFalse(settings.retryBlockedPersistenceSave())
+        XCTAssertEqual(writeAttempts, 2)
+        XCTAssertEqual(settings.persistenceBlockReason, .saveFailed)
+        XCTAssertTrue(settings.isPendingPreservingMigrationRetry)
+        XCTAssertEqual(try Data(contentsOf: fileURL), originalBytes)
+
+        XCTAssertTrue(settings.retryBlockedPersistenceSave())
+        XCTAssertEqual(writeAttempts, 3)
+        XCTAssertNil(settings.persistenceBlockReason)
+        XCTAssertFalse(settings.isPendingPreservingMigrationRetry)
+
+        let freshStore = GlobalSettingsFileStore(fileURL: fileURL)
+        let freshDocument = try freshStore.load()
+        XCTAssertEqual(
+            freshDocument.scalarPreferences?.ui?.appearanceMode,
+            "Dark"
+        )
+        XCTAssertEqual(
+            freshDocument.scalarPreferences?.modelSelection?.planningModel,
+            "retry-planning-model"
+        )
+        XCTAssertEqual(
+            freshDocument.scalarPreferences?.contextBuilder?.analysisTokenBudget,
+            changedBehavior.analysisTokenBudget
+        )
+
+        let migratedRoot = try readJSONObject(at: fileURL)
+        XCTAssertEqual(
+            migratedRoot["schemaVersion"] as? Int,
+            GlobalSettingsDocument.contextBuilderSchemaVersion
+        )
+        XCTAssertEqual(
+            (migratedRoot["futureRoot"] as? [String: Any])?["value"] as? String,
+            "root-preserved"
+        )
+        let migratedScalar = try XCTUnwrap(migratedRoot["scalarPreferences"] as? [String: Any])
+        XCTAssertEqual(
+            (migratedScalar["futureScalar"] as? [String: Any])?["value"] as? String,
+            "scalar-preserved"
+        )
+        XCTAssertEqual(
+            ((migratedScalar["contextBuilder"] as? [String: Any])?["futureContextBuilder"] as? [String: Any])?["value"] as? String,
+            "context-builder-preserved"
+        )
+        XCTAssertEqual(
+            ((migratedRoot["globalDefaults"] as? [String: Any])?["futureGlobalDefaults"] as? [String: Any])?["value"] as? String,
+            "global-defaults-preserved"
+        )
+        let migratedWorkspace = try XCTUnwrap(
+            (migratedRoot["chatSettingsByWorkspaceID"] as? [String: Any])?[workspaceID.uuidString] as? [String: Any]
+        )
+        XCTAssertEqual(
+            (migratedWorkspace["futureWorkspace"] as? [String: Any])?["value"] as? String,
+            "workspace-preserved"
+        )
+        let migratedProfile = try XCTUnwrap(
+            (((migratedRoot["agentModelsSettingsByWorkspaceID"] as? [String: Any])?[workspaceID.uuidString] as? [String: Any])?["profile"] as? [String: Any])
+        )
+        XCTAssertEqual(
+            (migratedProfile["futureProfile"] as? [String: Any])?["value"] as? String,
+            "profile-preserved"
+        )
+    }
+
+    private func makeTemporaryRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlobalSettingsPersistenceSafetyTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func makeDocument(
+        workspaceID: UUID = UUID(),
+        includeLegacyChatSettings: Bool = false,
+        includeAgentModelsProfile: Bool = false,
+        contextBuilder: GlobalScalarPreferences.ContextBuilderSettings? = nil,
+        fileSystemGlobalIgnoreDefaults: String? = nil
+    ) -> GlobalSettingsDocument {
+        var chatSettings: [UUID: ChatGlobalSettings] = [:]
+        if includeLegacyChatSettings {
+            var legacy = ChatGlobalSettings(
+                workspaceID: workspaceID,
+                discoveryTokenBudget: 12345,
+                discoveryEnhancementMode: "balanced",
+                discoveryAutoGeneratePlan: true
+            )
+            legacy.discoveryAllowClarifyingQuestions = true
+            legacy.discoveryAllowClarifyingQuestionsForMCP = false
+            legacy.discoveryQuestionTimeoutSeconds = 91
+            legacy.discoveryPlanTokenBudget = 6789
+            chatSettings[workspaceID] = legacy
+        }
+
+        var agentModelsSettings: [UUID: WorkspaceAgentModelsSettings] = [:]
+        if includeAgentModelsProfile {
+            agentModelsSettings[workspaceID] = WorkspaceAgentModelsSettings(
+                inheritanceMode: .useWorkspaceOverrides,
+                profile: AgentModelsSettingsProfile(
+                    planningModelRaw: "planning-model",
+                    preferredComposeModelRaw: "compose-model",
+                    syncChatModelWithOracle: false,
+                    contextBuilderAgentRaw: "codexExec",
+                    contextBuilderModelsByAgent: ["codexExec": "context-model"],
+                    mcpAgentRoleOverrides: ["explore": "context-model"],
+                    restrictMCPAgentDiscoveryToRoleLabels: false
+                )
+            )
+        }
+
+        return GlobalSettingsDocument(
+            chatSettings: chatSettings,
+            agentModelsSettings: agentModelsSettings,
+            scalarPreferences: GlobalScalarPreferences(
+                ui: .init(appearanceMode: "System"),
+                contextBuilder: contextBuilder,
+                fileSystem: .init(globalIgnoreDefaults: fileSystemGlobalIgnoreDefaults)
+            )
+        )
+    }
+
+    private func makeContextBuilderSettings() -> GlobalScalarPreferences.ContextBuilderSettings {
+        GlobalScalarPreferences.ContextBuilderSettings(
+            contextTokenBudget: 1234,
+            analysisTokenBudget: 5678,
+            enhancementMode: "balanced",
+            questionTimeoutSeconds: 91,
+            allowUIClarifyingQuestions: true,
+            allowMCPClarifyingQuestions: false,
+            followUpAnalysisEnabled: true
+        )
+    }
+
+    private func readJSONObject(at url: URL) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        return try XCTUnwrap(object as? [String: Any])
+    }
+
+    private func writeJSONObject(_ object: [String: Any], to url: URL) throws {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: url, options: .atomic)
+    }
+
+    private func addUnknownFields(to url: URL, workspaceID: UUID) throws {
+        var root = try readJSONObject(at: url)
+        root["futureRoot"] = ["value": "root-preserved"]
+
+        var scalarPreferences = try XCTUnwrap(root["scalarPreferences"] as? [String: Any])
+        scalarPreferences["futureScalar"] = ["value": "scalar-preserved"]
+        var contextBuilder = try XCTUnwrap(scalarPreferences["contextBuilder"] as? [String: Any])
+        contextBuilder["futureContextBuilder"] = ["value": "context-builder-preserved"]
+        scalarPreferences["contextBuilder"] = contextBuilder
+        root["scalarPreferences"] = scalarPreferences
+
+        var globalDefaults = try XCTUnwrap(root["globalDefaults"] as? [String: Any])
+        globalDefaults["futureGlobalDefaults"] = ["value": "global-defaults-preserved"]
+        root["globalDefaults"] = globalDefaults
+
+        var chatSettings = try XCTUnwrap(root["chatSettingsByWorkspaceID"] as? [String: Any])
+        var workspaceSettings = try XCTUnwrap(chatSettings[workspaceID.uuidString] as? [String: Any])
+        workspaceSettings["futureWorkspace"] = ["value": "workspace-preserved"]
+        chatSettings[workspaceID.uuidString] = workspaceSettings
+        root["chatSettingsByWorkspaceID"] = chatSettings
+
+        var agentModelsSettings = try XCTUnwrap(root["agentModelsSettingsByWorkspaceID"] as? [String: Any])
+        var workspaceAgentModels = try XCTUnwrap(agentModelsSettings[workspaceID.uuidString] as? [String: Any])
+        var profile = try XCTUnwrap(workspaceAgentModels["profile"] as? [String: Any])
+        profile["futureProfile"] = ["value": "profile-preserved"]
+        workspaceAgentModels["profile"] = profile
+        agentModelsSettings[workspaceID.uuidString] = workspaceAgentModels
+        root["agentModelsSettingsByWorkspaceID"] = agentModelsSettings
+
+        try writeJSONObject(root, to: url)
+    }
+}

--- a/Tests/RepoPromptTests/Settings/GlobalSettingsRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Settings/GlobalSettingsRecoveryTests.swift
@@ -157,6 +157,14 @@ private final class FailingRecoveryGlobalSettingsFileStore: GlobalSettingsFileSt
         includeModelSelectionRepair: Bool
     ) throws {}
 
+    var hasPendingStartupMigration: Bool {
+        false
+    }
+
+    func retryStartupMigrationPreservingUnknownFields(_: GlobalSettingsDocument) throws {
+        throw GlobalSettingsFileStore.GlobalSettingsFileStoreError.startupMigrationRetryUnavailable
+    }
+
     func performUserInitiatedRecovery(replacementDocument: GlobalSettingsDocument) -> Bool {
         recoveryDocuments.append(replacementDocument)
         let backupDirectory = fileURL

--- a/docs/architecture/settings-persistence.md
+++ b/docs/architecture/settings-persistence.md
@@ -1,6 +1,6 @@
 # Settings Persistence
 
-Current as of 2026-08-11. This document is contributor-facing: use it when changing durable settings, workspace overrides, Agent Models settings, or MCP settings surfaces.
+Current as of 2026-09-05. This document is contributor-facing: use it when changing durable settings, workspace overrides, Agent Models settings, or MCP settings surfaces.
 
 ## Durable settings file
 
@@ -40,14 +40,17 @@ representing its content. Schema-requiring features have fixed introduction cons
 
 - `baselineSchemaVersion = 2`
 - `workspaceAgentModelsSchemaVersion = 4`
+- `contextBuilderSchemaVersion = 5`
 
 `requiredSchemaVersion` returns the maximum fixed feature version required by the
-document. It must never use `currentSchemaVersion` as the version of an existing feature:
-when another feature introduces v5, add a fixed constant for that feature and include it
-in the maximum. Baseline CE content is stamped v2. A document is stamped v4 only when
-`agentModelsSettingsByWorkspaceID` is nonempty. Save, compatible import, recovery, and
-default creation all use this content-derived minimum. Lineage is still stamped on every
-CE write, and future-schema and unlineaged preservation guards remain unchanged.
+document. It must never use `currentSchemaVersion` as the version of an existing feature.
+Baseline CE content is stamped v2; a document is stamped v4 only when
+`agentModelsSettingsByWorkspaceID` is nonempty; and a document containing the
+`scalarPreferences.contextBuilder` group is stamped v5. An existing same-lineage v4 file
+that already contains that group is upgraded through the raw-preserving startup
+transaction before an ordinary typed save can occur. Save, compatible import, recovery,
+and default creation all use this content-derived minimum. Lineage is still stamped on
+every CE write, and future-schema and unlineaged preservation guards remain unchanged.
 
 ## False-v4 normalization
 
@@ -69,12 +72,19 @@ preserved and persistence is latched closed. If verification, backup, or atomic
 replacement fails, the same fail-closed rule applies. Startup default seeding and
 ordinary mutations cannot bypass that latch; explicit backup/reset remains available.
 
-The rollback boundary uses a test-only codec frozen from annotated tag `v1.0.28`
+The rollback boundary uses two test-only codecs. `FrozenV1028GlobalSettingsCompatibility`
+is frozen from annotated tag `v1.0.28`
 (`65d473858d7a140dc82364f4b359482d6dc5ce80`), peeled commit
-`1b185f74e72af3000550796b3d1d7476d244e546`. That source defines the seven-field v2
-root contract. Tests exercise baseline and normalized files across patched → v1.0.28 →
-patched round trips. Genuine same-lineage v4 workspace-profile documents are outside
-that rollback compatibility guarantee.
+`1b185f74e72af3000550796b3d1d7476d244e546`; it covers the seven-field v2 root contract
+and baseline/false-v4 normalization round trips. `FrozenV130GlobalSettingsCompatibility`
+is frozen from released v1.3.0 commit `b8042678fac558842ef4bc37027d0cd26246fdd6`.
+That typed scalar shape supports through v4 and has no Context Builder group, so it
+rejects a v5 file rather than silently dropping that group. Existing same-lineage v4
+files containing Context Builder content are upgraded raw-preservingly before a subsequent
+old write on the non-interleaved, single-writer path. This does not claim cross-process ordering;
+#806 remains unresolved. Do not treat this as a lossless v1.3 round-trip guarantee for
+v4 files; genuine v4 workspace-profile compatibility remains outside the v1.0.28
+rollback guarantee.
 
 ## Frozen legacy ceiling
 
@@ -102,7 +112,12 @@ the preserved file until the user chooses an action:
 - **Incompatible/foreign JSON**: offer compatible import. Import backs up the original
   byte-for-byte, decodes CE-known fields, writes a current-schema CE file, and leaves
   unknown fields only in the backup.
-- **Save failure**: offer retry before reset.
+- **Save failure**: offer retry before reset. If a raw-preserving startup migration
+  failed, retry repeats that same raw-preserving transaction; it records the typed document
+  from the failed attempt and overlays only changed, explicitly owned known fields onto the
+  latest raw JSON, including known optional removals. Unknown root and nested fields remain,
+  and ordinary typed saves remain blocked until the preserving retry succeeds or the user
+  explicitly chooses backup/reset.
 
 Telemetry enablement has a `UserDefaults` mirror so startup can make a safe decision before
 the canonical JSON document is available. A successful settings load synchronizes that
@@ -114,7 +129,11 @@ resynchronizes the mirror from the replacement current-schema document. None of 
 mirror decisions bypass the blocked file's byte-preservation and save latch.
 
 Every save re-checks the on-disk header before writing. This matters because CE dev builds
-can share the live app support folder; a future/foreign file may appear after launch.
+can share the live app support folder; a future/foreign file may appear after launch. This
+is a fail-closed header preflight, not a compare-and-swap transaction: it does not protect
+the read/merge/write interval from a non-cooperating older writer. The supported-writer
+ownership and atomic-CAS design for that interval remains unresolved in #806 and must not
+be represented as closed by this preflight.
 
 Blocked-persistence warnings may be dismissed in workspace windows for the current app
 session. The store owns dismissal across workspace windows and clears it when the reason
@@ -180,7 +199,12 @@ scalarPreferences.contextBuilder.followUpAnalysisEnabled
 
 `GlobalSettingsStore.contextBuilderBehaviorSettings()` resolves a complete non-optional `ContextBuilderBehaviorSettings` value through `ContextBuilderDefaults`; the whole-snapshot setter preserves sibling scalar groups and publishes through the store. Every window reads this same authority. Workspace and tab changes do not change these values, and Context Builder behavior does not use Agent Models workspace inheritance.
 
-The optional scalar group is baseline schema-v2 content. It does not add a feature-version constant or change `requiredSchemaVersion`: documents without workspace Agent Models profiles remain v2, documents with profiles remain v4, and all future/foreign preservation and false-v4 rules continue to apply.
+The optional scalar group is a schema-v5 fenced feature because released v1.3 typed
+writers do not decode or preserve it. A document without workspace Agent Models profiles
+remains v2 when the group is absent; documents with profiles remain v4 when the group is
+absent; and any document containing the group requires v5. Existing v4 documents with
+that group are upgraded through the raw-preserving startup transaction before ordinary
+saves. All future/foreign preservation and false-v4 rules continue to apply.
 
 When the scalar group is absent, load and reload migrate legacy workspace fields deterministically. Workspace entries are sorted by UUID string, then each field independently takes the first applicable value; invalid enhancement modes are skipped and missing values use `ContextBuilderDefaults`. The complete scalar group is materialized and legacy `ChatGlobalSettings` Context Builder fields are stripped. Startup normalization writes these changes, an absent `scalarPreferences.fileSystem.globalIgnoreDefaults` value, and repairs to invalid Oracle ↔ Built-in Chat synchronized-model state through one raw-preserving transaction. The transaction patches only its owned JSON paths, canonicalizes workspace Agent Models UUID keys with the same deterministic winner used during typed decoding, and preserves unknown root, scalar, global-default, workspace, and UUID-backed profile fields, including when false-v4 normalization runs first. Compatible import reconstructs UUID-keyed maps from decoded projections before content-derived schema stamping while retaining the original bytes in the import backup. If persistence is blocked or the save fails, repaired values remain active in memory while the original disk bytes remain under the existing recovery contract. Those optional workspace properties remain decode-compatible legacy migration inputs only. Dormant `GlobalDefaults.discoveryTokenBudget` and `discoveryEnhancementMode` never participate in migration or runtime resolution.
 


### PR DESCRIPTION
Preserve Context Builder settings when older app versions encounter the shared settings file, and preserve unknown fields when retrying a failed startup migration. Settings documents containing Context Builder preferences now use schema v5, which the frozen v1.3.0 codec rejects. A failed preserving migration blocks ordinary typed saves; retry merges the known edits made since failure into freshly read raw content while retaining unknown fields.

The migration banner offers the preserving retry action. This addresses sequential old-version compatibility and failed migration retries. Concurrent old processes that already loaded settings remain the separate #806 ownership decision.

Source review and formatting passed. Current-main integration is 497c2b69b7ab668e6faa6a7780a839b96734aba9 against 542b111e3074ed7126c0dea8a46572fa569bf51a. 11 focused settings and MCP settings tests, app build and lint passed. Packaged upgrade/restart acceptance remains required.

Fixes #805. Fixes #807.
