### PR TITLE
Preserve file authority across context binding

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
@@ -45,6 +45,11 @@ struct AgentWorkspaceLookupContextSource: Equatable {
         )
     }
 
+    /// Canonical routed contexts have authority without an Agent binding identity.
+    var authorityIdentity: AgentWorkspaceLookupContextIdentity? {
+        activeAgentSessionID == nil ? nil : identity
+    }
+
     static func worktreeBindingFingerprint(_ bindings: [AgentSessionWorktreeBinding]) -> String {
         worktreeBindingFingerprint(.hydrated(bindings))
     }
@@ -136,17 +141,54 @@ enum AgentWorkspaceLookupContextResolver {
         source: AgentWorkspaceLookupContextSource,
         store: WorkspaceFileContextStore
     ) async throws -> WorkspaceLookupContext {
+        let visibleRoots = await store.rootRefs(scope: .visibleWorkspace)
+        return try await requiredLookupContext(
+            source: source,
+            visibleRoots: visibleRoots,
+            store: store
+        )
+    }
+
+    static func requiredLookupContext(
+        source: AgentWorkspaceLookupContextSource,
+        visibleRoots: [WorkspaceRootRef],
+        store: WorkspaceFileContextStore
+    ) async throws -> WorkspaceLookupContext {
+        let capturedCanonicalRoots = Set(visibleRoots)
+        guard await Set(store.rootRefs(scope: .visibleWorkspace)) == capturedCanonicalRoots else {
+            throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+        }
         guard let sessionID = source.activeAgentSessionID else {
-            return .visibleWorkspace
+            return WorkspaceLookupContext(
+                rootScope: .validatedSessionBoundWorkspace(
+                    canonicalRoots: capturedCanonicalRoots,
+                    physicalRoots: []
+                ),
+                bindingProjection: nil
+            )
         }
         guard case let .hydrated(bindings) = source.worktreeBindingState else {
             throw AgentWorkspaceLookupContextResolutionError.unknownBindingState
         }
         guard !bindings.isEmpty else {
-            return .visibleWorkspace
+            return WorkspaceLookupContext(
+                rootScope: .validatedSessionBoundWorkspace(
+                    canonicalRoots: capturedCanonicalRoots,
+                    physicalRoots: []
+                ),
+                bindingProjection: nil
+            )
         }
 
-        let visibleRootPaths = await Set(store.rootRefs(scope: .visibleWorkspace).map(\.standardizedFullPath))
+        for root in visibleRoots {
+            guard let currentRoot = await store.exactRootRef(
+                path: root.standardizedFullPath,
+                kind: .primaryWorkspace
+            ), currentRoot == root else {
+                throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+            }
+        }
+        let visibleRootPaths = Set(visibleRoots.map(\.standardizedFullPath))
         let logicalRootPaths = Set(bindings.compactMap {
             AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath($0.logicalRootPath)
         })
@@ -172,7 +214,12 @@ enum AgentWorkspaceLookupContextResolver {
         }
         let cacheKey = CacheKey(storeID: ObjectIdentifier(store), identity: source.identity)
         if let cached = projectionCache.context(for: cacheKey) {
-            if await canReuseAuthoritativeLookupContext(cached, source: source, store: store) {
+            if await canReuseAuthoritativeLookupContext(
+                cached,
+                source: source,
+                visibleRoots: visibleRoots,
+                store: store
+            ) {
                 return cached
             }
             projectionCache.removeValue(for: cacheKey)
@@ -180,7 +227,8 @@ enum AgentWorkspaceLookupContextResolver {
 
         guard let projection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
             sessionID: sessionID,
-            bindings: bindings
+            bindings: bindings,
+            visibleRoots: visibleRoots
         ),
             !projection.isEmpty,
             projection.isFullyMaterialized
@@ -202,6 +250,7 @@ enum AgentWorkspaceLookupContextResolver {
     static func canReuseAuthoritativeLookupContext(
         _ lookupContext: WorkspaceLookupContext,
         source: AgentWorkspaceLookupContextSource,
+        visibleRoots suppliedVisibleRoots: [WorkspaceRootRef]? = nil,
         store: WorkspaceFileContextStore
     ) async -> Bool {
         guard !Task.isCancelled,
@@ -224,12 +273,19 @@ enum AgentWorkspaceLookupContextResolver {
             return false
         }
 
-        let visibleRoots = await store.rootRefs(scope: .visibleWorkspace)
+        let visibleRoots = if let suppliedVisibleRoots {
+            suppliedVisibleRoots
+        } else {
+            await store.rootRefs(scope: .visibleWorkspace)
+        }
         guard !Task.isCancelled else { return false }
         let visibleRootIDsByPath = Dictionary(
             visibleRoots.map { ($0.standardizedFullPath, $0.id) },
             uniquingKeysWith: { first, _ in first }
         )
+        guard Set(projection.visibleLogicalRootRefs) == Set(visibleRoots) else {
+            return false
+        }
         guard projection.logicalRootRefs.allSatisfy({ visibleRootIDsByPath[$0.standardizedFullPath] == $0.id }) else {
             return false
         }

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -993,6 +993,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     private struct WorkspaceSearchReadinessWaiter {
         let ticket: WorkspaceSearchReadinessTicket
+        let admission: WorkspaceReadinessAdmission
         let continuation: CheckedContinuation<WorkspaceSearchReadinessTicket, any Error>
         let timeoutTask: Task<Void, Never>
     }
@@ -1005,6 +1006,8 @@ class WorkspaceManagerViewModel: ObservableObject {
         private var workspaceSwitchRecoveryWillBeginHandlerForTesting: (@MainActor () async -> Void)?
         private var workspaceSwitchReadinessDidInvalidateHandlerForTesting: (@MainActor () async -> Void)?
         private var workspaceHydrationGenerationDidAdvanceHandlerForTesting: (@MainActor () -> Void)?
+        private var workspaceRootHydrationWillSpawnHandlerForTesting: (@MainActor (UUID) async -> Void)?
+        private var workspaceRootCatalogDidCaptureRootsHandlerForTesting: (@MainActor () async -> Void)?
     #endif
 
     private struct WorkspaceDidSwitchListener {
@@ -3297,17 +3300,47 @@ class WorkspaceManagerViewModel: ObservableObject {
         ) {
             workspaceHydrationGenerationDidAdvanceHandlerForTesting = handler
         }
+
+        /// Fires after `activeWorkspaceID` is published and before root hydration is spawned,
+        /// which is the only point where the workspace is "current" while its root catalog is
+        /// still empty. Awaitable so a test can hold that window open.
+        func setWorkspaceRootHydrationWillSpawnHandlerForTesting(
+            _ handler: (@MainActor (UUID) async -> Void)?
+        ) {
+            workspaceRootHydrationWillSpawnHandlerForTesting = handler
+        }
+
+        func setWorkspaceRootCatalogDidCaptureRootsHandlerForTesting(
+            _ handler: (@MainActor () async -> Void)?
+        ) {
+            workspaceRootCatalogDidCaptureRootsHandlerForTesting = handler
+        }
+
+        func republishReadyRootCatalogWithNextGenerationForTesting() {
+            guard case let .ready(workspaceID, _, catalogGeneration, indexedGeneration, diagnostics) = workspaceSearchReadinessState else {
+                preconditionFailure("Expected ready workspace state before advancing its test generation")
+            }
+            let generation = advanceWorkspaceHydrationGeneration()
+            workspaceSearchReadinessState = .ready(
+                workspaceID: workspaceID,
+                generation: generation,
+                catalogGeneration: catalogGeneration,
+                indexedGeneration: indexedGeneration,
+                diagnostics: diagnostics
+            )
+        }
     #endif
 
     func awaitWorkspaceSearchReadiness(
-        timeout: Duration
+        timeout: Duration,
+        admission: WorkspaceReadinessAdmission = .searchIndex
     ) async throws -> WorkspaceSearchReadinessTicket {
         try Task.checkCancellation()
         guard let ticket = workspaceSearchReadinessState.ticket else {
             throw WorkspaceSearchReadinessWaitError.unavailable
         }
-        if workspaceSearchReadinessState.isSearchAdmissible {
-            try validateWorkspaceSearchReadiness(ticket)
+        if admission.admits(workspaceSearchReadinessState) {
+            try validateWorkspaceSearchReadiness(ticket, admission: admission)
             return ticket
         }
 
@@ -3323,9 +3356,9 @@ class WorkspaceManagerViewModel: ObservableObject {
                     continuation.resume(throwing: WorkspaceSearchReadinessWaitError.superseded)
                     return
                 }
-                if workspaceSearchReadinessState.isSearchAdmissible {
+                if admission.admits(workspaceSearchReadinessState) {
                     do {
-                        try validateWorkspaceSearchReadiness(ticket)
+                        try validateWorkspaceSearchReadiness(ticket, admission: admission)
                         continuation.resume(returning: ticket)
                     } catch {
                         continuation.resume(throwing: error)
@@ -3347,6 +3380,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 }
                 workspaceSearchReadinessWaiters[waiterID] = WorkspaceSearchReadinessWaiter(
                     ticket: ticket,
+                    admission: admission,
                     continuation: continuation,
                     timeoutTask: timeoutTask
                 )
@@ -3361,6 +3395,108 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
     }
 
+    func awaitWorkspaceRootCatalogSnapshot(
+        workspaceID: UUID,
+        timeout: Duration
+    ) async throws -> WorkspaceRootCatalogSnapshot {
+        try Task.checkCancellation()
+        guard activeWorkspaceID == workspaceID,
+              activeWorkspace?.id == workspaceID
+        else {
+            throw WorkspaceRootCatalogSnapshotError.workspaceNotActive
+        }
+
+        let ticket: WorkspaceSearchReadinessTicket
+        do {
+            ticket = try await awaitWorkspaceSearchReadiness(
+                timeout: timeout,
+                admission: .rootCatalog
+            )
+        } catch let error as WorkspaceSearchReadinessWaitError {
+            switch error {
+            case .unavailable:
+                throw WorkspaceRootCatalogSnapshotError.readinessUnavailable
+            case .timedOut:
+                throw WorkspaceRootCatalogSnapshotError.readinessTimedOut
+            case .superseded:
+                throw WorkspaceRootCatalogSnapshotError.readinessSuperseded
+            }
+        }
+        try Task.checkCancellation()
+
+        guard ticket.workspaceID == workspaceID else {
+            throw WorkspaceRootCatalogSnapshotError.missingWorkspaceIdentity
+        }
+        try validateWorkspaceRootCatalogReadiness(ticket)
+        guard let workspace = activeWorkspace,
+              workspace.id == workspaceID
+        else {
+            throw WorkspaceRootCatalogSnapshotError.workspaceNotActive
+        }
+        let configuredRootPaths = uniqueWorkspaceRootLoadRequests(
+            for: Self.loadableRepoPaths(for: workspace)
+        ).map(\.canonicalPath)
+        let primaryRootRecords = await fileManager.workspaceFileContextStore.roots()
+            .filter { $0.kind == .primaryWorkspace }
+        try Task.checkCancellation()
+        #if DEBUG
+            await workspaceRootCatalogDidCaptureRootsHandlerForTesting?()
+        #endif
+        try Task.checkCancellation()
+
+        try validateWorkspaceRootCatalogReadiness(ticket)
+        guard activeWorkspaceID == workspaceID,
+              let currentWorkspace = activeWorkspace,
+              currentWorkspace.id == workspaceID
+        else {
+            throw WorkspaceRootCatalogSnapshotError.workspaceNotActive
+        }
+        let currentConfiguredRootPaths = uniqueWorkspaceRootLoadRequests(
+            for: Self.loadableRepoPaths(for: currentWorkspace)
+        ).map(\.canonicalPath)
+        guard currentConfiguredRootPaths == configuredRootPaths else {
+            throw WorkspaceRootCatalogSnapshotError.inconsistentRootProjection
+        }
+
+        var rootsByPath: [String: WorkspaceRootRecord] = [:]
+        for root in primaryRootRecords {
+            guard rootsByPath.updateValue(root, forKey: root.standardizedFullPath) == nil else {
+                throw WorkspaceRootCatalogSnapshotError.inconsistentRootProjection
+            }
+        }
+        guard rootsByPath.count == configuredRootPaths.count,
+              Set(rootsByPath.keys) == Set(configuredRootPaths)
+        else {
+            throw WorkspaceRootCatalogSnapshotError.inconsistentRootProjection
+        }
+
+        let orderedRoots = configuredRootPaths.compactMap { path -> WorkspaceRootRef? in
+            guard let root = rootsByPath[path] else { return nil }
+            return WorkspaceRootRef(id: root.id, name: root.name, fullPath: root.standardizedFullPath)
+        }
+        guard orderedRoots.count == configuredRootPaths.count else {
+            throw WorkspaceRootCatalogSnapshotError.inconsistentRootProjection
+        }
+        try Task.checkCancellation()
+
+        return WorkspaceRootCatalogSnapshot(
+            ticket: ticket,
+            workspaceID: workspaceID,
+            configuredRootPaths: configuredRootPaths,
+            primaryRoots: orderedRoots
+        )
+    }
+
+    private func validateWorkspaceRootCatalogReadiness(
+        _ ticket: WorkspaceSearchReadinessTicket
+    ) throws {
+        do {
+            try validateWorkspaceSearchReadiness(ticket, admission: .rootCatalog)
+        } catch is WorkspaceSearchReadinessWaitError {
+            throw WorkspaceRootCatalogSnapshotError.readinessSuperseded
+        }
+    }
+
     nonisolated func validateWorkspaceSearchReadinessSnapshot(
         _ ticket: WorkspaceSearchReadinessTicket
     ) throws {
@@ -3370,9 +3506,10 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     func validateWorkspaceSearchReadiness(
-        _ ticket: WorkspaceSearchReadinessTicket
+        _ ticket: WorkspaceSearchReadinessTicket,
+        admission: WorkspaceReadinessAdmission = .searchIndex
     ) throws {
-        guard workspaceSearchReadinessState.isSearchAdmissible,
+        guard admission.admits(workspaceSearchReadinessState),
               workspaceSearchReadinessState.ticket == ticket,
               workspaceHydrationGeneration == ticket.generation,
               activeWorkspaceID == ticket.workspaceID
@@ -3391,9 +3528,9 @@ class WorkspaceManagerViewModel: ObservableObject {
                 )
                 continue
             }
-            guard workspaceSearchReadinessState.isSearchAdmissible else { continue }
+            guard waiter.admission.admits(workspaceSearchReadinessState) else { continue }
             do {
-                try validateWorkspaceSearchReadiness(waiter.ticket)
+                try validateWorkspaceSearchReadiness(waiter.ticket, admission: waiter.admission)
                 succeedWorkspaceSearchReadinessWaiter(waiterID, ticket: waiter.ticket)
             } catch {
                 failWorkspaceSearchReadinessWaiter(waiterID, throwing: error)
@@ -3798,6 +3935,9 @@ class WorkspaceManagerViewModel: ObservableObject {
         if shouldOverlapRootHydration {
             folderLoadStart = Date()
             logWorkspaceSwitch("catalog hydration BEGIN workspace=\"\(activeWS.name)\" roots=\(activeWS.repoPaths.count)")
+            #if DEBUG
+                await workspaceRootHydrationWillSpawnHandlerForTesting?(activeWS.id)
+            #endif
             folderLoadTask = Task { @MainActor in
                 await loadTargetWorkspaceFolders()
             }

--- a/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
@@ -183,6 +183,10 @@ struct StoredSelection: Codable, Equatable, Hashable {
         self.codemapAutoEnabled = codemapAutoEnabled
     }
 
+    var isEmptyForSelectedFileTree: Bool {
+        selectedPaths.isEmpty && manualCodemapPaths.isEmpty && slices.isEmpty
+    }
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         try self.init(

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -560,8 +560,13 @@ struct MCPOracleToolService {
     }
 
     private func oraclePackagingLookupContext(for context: TabContextSnapshot) async throws -> WorkspaceLookupContext {
-        if let frozenLookupContext = context.frozenLookupContext {
-            return frozenLookupContext
+        if let authority = context.frozenFileToolAuthority {
+            let targetWindow = try requireTargetWindow()
+            try await authority.validate(
+                workspaceManager: targetWindow.workspaceManager,
+                store: targetWindow.promptManager.workspaceFileContextStore
+            )
+            return authority.lookupContext
         }
         return try await requiredOracleLookupContext(
             source: AgentWorkspaceLookupContextSource(

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
@@ -255,6 +255,10 @@ enum ToolResultDTOs {
         let note: String?
         let wasTruncated: Bool?
         let worktreeScope: WorktreeScopeDTO?
+        let errorMessage: String?
+        let errorCode: String?
+        let retryable: Bool?
+        let retryAfterMilliseconds: Int?
 
         init(
             rootsCount: Int,
@@ -262,7 +266,11 @@ enum ToolResultDTOs {
             tree: String,
             note: String? = nil,
             wasTruncated: Bool? = nil,
-            worktreeScope: WorktreeScopeDTO? = nil
+            worktreeScope: WorktreeScopeDTO? = nil,
+            errorMessage: String? = nil,
+            errorCode: String? = nil,
+            retryable: Bool? = nil,
+            retryAfterMilliseconds: Int? = nil
         ) {
             self.rootsCount = rootsCount
             self.usesLegend = usesLegend
@@ -270,6 +278,10 @@ enum ToolResultDTOs {
             self.note = note
             self.wasTruncated = wasTruncated
             self.worktreeScope = worktreeScope
+            self.errorMessage = errorMessage
+            self.errorCode = errorCode
+            self.retryable = retryable
+            self.retryAfterMilliseconds = retryAfterMilliseconds
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -279,6 +291,10 @@ enum ToolResultDTOs {
             case note
             case wasTruncated = "was_truncated"
             case worktreeScope = "worktree_scope"
+            case errorMessage = "error"
+            case errorCode = "error_code"
+            case retryable
+            case retryAfterMilliseconds = "retry_after_ms"
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift
@@ -269,7 +269,8 @@ final class MCPReadFileAutoSelectionCoordinator {
         case authoritativeFallback(ReadFileAutoSelectionCoverageCertificateMissReason)
     }
 
-    struct CanonicalBatch: Equatable {
+    struct CanonicalBatch {
+        let authority: MCPServerViewModel.FrozenFileToolAuthority
         private(set) var fullPaths: [String] = []
         private(set) var sliceEntries: [WorkspaceSelectionSliceInput] = []
         private(set) var coverageIdentity: CoverageIdentity?
@@ -281,7 +282,12 @@ final class MCPReadFileAutoSelectionCoordinator {
         private var originalSlicePathByKey: [String: String] = [:]
         private var coveragePermitted: Bool
 
-        init(intent: Intent, coverageIdentity: CoverageIdentity? = nil) {
+        init(
+            intent: Intent,
+            authority: MCPServerViewModel.FrozenFileToolAuthority,
+            coverageIdentity: CoverageIdentity? = nil
+        ) {
+            self.authority = authority
             self.coverageIdentity = nil
             coveragePermitted = coverageIdentity != nil
             merge(intent, coverageIdentity: coverageIdentity)
@@ -532,6 +538,7 @@ final class MCPReadFileAutoSelectionCoordinator {
     @discardableResult
     func enqueue(
         intent: Intent,
+        authority: MCPServerViewModel.FrozenFileToolAuthority,
         coverageIdentity: CoverageIdentity? = nil,
         for key: ContextKey,
         lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation? = EditFlowPerf.currentLifecycleCorrelation
@@ -554,9 +561,15 @@ final class MCPReadFileAutoSelectionCoordinator {
             return false
         }
 
+        var lane = canonicalLanes[key] ?? CanonicalLane()
+        if let pending = lane.pending,
+           !pending.batch.authority.hasSameRoutingAuthority(as: authority)
+        {
+            outcome = "invalidated"
+            return false
+        }
         nextSequence &+= 1
         let sequence = nextSequence
-        var lane = canonicalLanes[key] ?? CanonicalLane()
         let previousAcceptedSequence = lane.acceptedSequence
         lane.acceptedSequence = sequence
         if var pending = lane.pending {
@@ -573,7 +586,11 @@ final class MCPReadFileAutoSelectionCoordinator {
             )
         } else {
             lane.pending = QueuedCanonicalBatch(
-                batch: CanonicalBatch(intent: intent, coverageIdentity: coverageIdentity),
+                batch: CanonicalBatch(
+                    intent: intent,
+                    authority: authority,
+                    coverageIdentity: coverageIdentity
+                ),
                 lowestSequence: sequence,
                 highestSequence: sequence,
                 acceptedIntentCount: 1,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+DomainRouting.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+DomainRouting.swift
@@ -7,7 +7,14 @@ extension MCPServerViewModel {
         let metadata: RequestMetadata
         let resolvedTabContext: ResolvedTabContextSnapshot
         let lookupContext: WorkspaceLookupContext
+        let frozenFileToolAuthority: FrozenFileToolAuthority?
         let targetWindowID: Int
+        let fileToolDependencies: MCPFileToolProvider.Dependencies
+    }
+
+    private func requiresFrozenFileAuthority(toolName: String) -> Bool {
+        MCPAppToolGroup.files.orderedToolNames.contains(toolName)
+            && toolName != MCPWindowToolName.fileActions
     }
 
     @MainActor
@@ -302,6 +309,14 @@ extension MCPServerViewModel {
             )
         }
 
+        // File authority must be complete before coordinator registration or rebinding so a
+        // retryable hydration failure cannot replace the connection's last usable domain route.
+        let prevalidatedFileAuthority: FrozenFileToolAuthority? = if requiresFrozenFileAuthority(toolName: toolName) {
+            try await targetServer.requiredFileToolLookupContext(from: metadata)
+        } else {
+            nil
+        }
+
         do {
             // The shared provider may be owned by a different window than the routed tab. Register
             // against the resolved target window so awaited reads also cover ephemeral workspaces.
@@ -419,14 +434,45 @@ extension MCPServerViewModel {
                     diagnostic: "bound run identity changed before execution"
                 )
             }
-            let invocation = DomainReadInvocationContext(handle: handle, connectionID: connectionID)
+            let lookupContext: WorkspaceLookupContext = if let prevalidatedFileAuthority {
+                prevalidatedFileAuthority.lookupContext
+            } else {
+                await targetServer.lookupContext(for: context)
+            }
+            let executionHandle: DomainReadContextHandle
+            if requiresFrozenFileAuthority(toolName: toolName) {
+                let currentHandle = try await coordinator.resolveReadContext(connection: registration)
+                guard currentHandle.context == targetContext,
+                      Self.domainReadBindingSatisfiesRequestedRun(
+                          requestedRunID: context.runID,
+                          resolvedBindingKind: currentHandle.bindingKind
+                      )
+                else {
+                    return try domainReadUnavailable(
+                        toolName: toolName,
+                        requirement: requirement,
+                        connectionID: connectionID,
+                        diagnostic: "bound context changed while file authority was resolving"
+                    )
+                }
+                executionHandle = currentHandle
+            } else {
+                executionHandle = handle
+            }
+            let invocation = DomainReadInvocationContext(handle: executionHandle, connectionID: connectionID)
             domainReadAppExecutionContexts[invocation.invocationID] = await DomainReadAppExecutionContext(
                 metadata: metadata,
                 resolvedTabContext: resolved,
-                lookupContext: targetServer.lookupContext(for: context),
-                targetWindowID: context.windowID
+                lookupContext: lookupContext,
+                frozenFileToolAuthority: prevalidatedFileAuthority,
+                targetWindowID: context.windowID,
+                fileToolDependencies: targetServer.domainReadFileToolDependencies()
             )
             return invocation
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as MCPError {
+            throw error
         } catch {
             return try domainReadUnavailable(
                 toolName: toolName,
@@ -481,11 +527,37 @@ extension MCPServerViewModel {
             refreshesDomainRouting: false
         )
         let targetServer = WindowStatesManager.shared.window(withID: context.windowID)?.mcpServer ?? self
+        let frozenFileToolAuthority: FrozenFileToolAuthority? = if requiresFrozenFileAuthority(toolName: toolName) {
+            try await targetServer.requiredFileToolLookupContext(from: metadata)
+        } else {
+            nil
+        }
+        let lookupContext = if let frozenFileToolAuthority {
+            frozenFileToolAuthority.lookupContext
+        } else {
+            await targetServer.lookupContext(for: context)
+        }
+        if requiresFrozenFileAuthority(toolName: toolName) {
+            let currentResolved = try targetServer.resolveTabContextSnapshot(
+                from: metadata,
+                toolName: toolName
+            )
+            guard targetServer.fileToolLookupSnapshotMatches(context, currentResolved.snapshot) else {
+                return try domainReadUnavailable(
+                    toolName: toolName,
+                    requirement: requirement,
+                    connectionID: metadata.connectionID,
+                    diagnostic: "fallback context changed while file authority was resolving"
+                )
+            }
+        }
         domainReadAppExecutionContexts[invocation.invocationID] = await DomainReadAppExecutionContext(
             metadata: metadata,
             resolvedTabContext: resolved,
-            lookupContext: targetServer.lookupContext(for: context),
-            targetWindowID: context.windowID
+            lookupContext: lookupContext,
+            frozenFileToolAuthority: frozenFileToolAuthority,
+            targetWindowID: context.windowID,
+            fileToolDependencies: targetServer.domainReadFileToolDependencies()
         )
         return invocation
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
@@ -107,8 +107,18 @@ extension MCPServerViewModel {
 
     @MainActor
     func lookupContext(for context: TabContextSnapshot) async -> WorkspaceLookupContext {
-        if let frozenLookupContext = context.frozenLookupContext {
-            return frozenLookupContext
+        if let authority = context.frozenFileToolAuthority,
+           let workspaceManager
+        {
+            do {
+                try await authority.validate(
+                    workspaceManager: workspaceManager,
+                    store: promptVM.workspaceFileContextStore
+                )
+                return authority.lookupContext
+            } catch {
+                return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+            }
         }
         return await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
             source: AgentWorkspaceLookupContextSource(

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import MCP
+import RepoPromptShared
 
 #if DEBUG
     private func tabContextLog(_ message: @autoclosure () -> String) {
@@ -236,8 +237,26 @@ extension MCPServerViewModel {
             set { worktreeBindingState = .hydrated(newValue) }
         }
 
-        /// Frozen lookup context inherited by nested run-scoped tools.
-        var frozenLookupContext: WorkspaceLookupContext?
+        var fileToolAuthoritySourceIdentity: AgentWorkspaceLookupContextIdentity? {
+            AgentWorkspaceLookupContextSource(
+                activeAgentSessionID: activeAgentSessionID,
+                worktreeBindingState: worktreeBindingState
+            ).authorityIdentity
+        }
+
+        /// Process-lifetime catalog, lookup, and worktree-lifetime authority inherited by nested tools.
+        var frozenFileToolAuthority: FrozenFileToolAuthority?
+        private var fallbackFrozenLookupContext: WorkspaceLookupContext?
+        var frozenLookupContext: WorkspaceLookupContext? {
+            get { frozenFileToolAuthority?.lookupContext ?? fallbackFrozenLookupContext }
+            set {
+                fallbackFrozenLookupContext = newValue
+                if frozenFileToolAuthority?.lookupContext != newValue {
+                    frozenFileToolAuthority = nil
+                }
+            }
+        }
+
         /// Ephemeral Context Builder review repository authority for one exact nested run.
         var contextBuilderReviewTargetResolution: ContextBuilderReviewTargetResolution?
         /// True if this snapshot was created via explicit `bind_context` / `_tabID` binding.
@@ -263,6 +282,7 @@ extension MCPServerViewModel {
             worktreeBindings: [AgentSessionWorktreeBinding] = [],
             worktreeBindingState: AgentSessionWorktreeBindingState? = nil,
             frozenLookupContext: WorkspaceLookupContext? = nil,
+            frozenFileToolAuthority: FrozenFileToolAuthority? = nil,
             contextBuilderReviewTargetResolution: ContextBuilderReviewTargetResolution? = nil,
             explicitlyBound: Bool,
             readFileAutoSelectionGeneration: UInt64 = 0
@@ -281,7 +301,8 @@ extension MCPServerViewModel {
             self.activeAgentSessionID = activeAgentSessionID
             self.worktreeBindingState = worktreeBindingState
                 ?? (activeAgentSessionID == nil ? .notApplicable : .hydrated(worktreeBindings))
-            self.frozenLookupContext = frozenLookupContext
+            fallbackFrozenLookupContext = frozenLookupContext
+            self.frozenFileToolAuthority = frozenFileToolAuthority
             self.contextBuilderReviewTargetResolution = contextBuilderReviewTargetResolution
             self.explicitlyBound = explicitlyBound
             self.readFileAutoSelectionGeneration = readFileAutoSelectionGeneration
@@ -744,9 +765,18 @@ extension MCPServerViewModel {
                     let promptChanged = bound.promptText != snapshot.promptText
                     let metaChanged = bound.selectedMetaPromptIDs != snapshot.selectedMetaPromptIDs
                     let nameChanged = bound.tabName != snapshot.name
-                    let sessionChanged = bound.runID == nil
-                        && bound.activeAgentSessionID != snapshot.activeAgentSessionID
-                    if selectionChanged || promptChanged || metaChanged || nameChanged || sessionChanged {
+                    let incomingBindingState = snapshot.activeAgentSessionID.map {
+                        self.agentWorktreeBindingStateProvider?($0, snapshot.id) ?? .unhydrated
+                    } ?? .notApplicable
+                    let sourceChanged = bound.runID == nil
+                        && AgentWorkspaceLookupContextSource(
+                            activeAgentSessionID: bound.activeAgentSessionID,
+                            worktreeBindingState: bound.worktreeBindingState
+                        ).identity != AgentWorkspaceLookupContextSource(
+                            activeAgentSessionID: snapshot.activeAgentSessionID,
+                            worktreeBindingState: incomingBindingState
+                        ).identity
+                    if selectionChanged || promptChanged || metaChanged || nameChanged || sourceChanged {
                         bound.selection = incomingSelection
                         if let workspaceID = bound.workspaceID {
                             bound.selectionRevision = manager.selectionRevisionForMCP(
@@ -757,13 +787,13 @@ extension MCPServerViewModel {
                         bound.promptText = snapshot.promptText
                         bound.selectedMetaPromptIDs = snapshot.selectedMetaPromptIDs
                         bound.tabName = snapshot.name
-                        if sessionChanged {
-                            bound.activeAgentSessionID = snapshot.activeAgentSessionID
-                            bound.worktreeBindingState = snapshot.activeAgentSessionID.map {
-                                self.agentWorktreeBindingStateProvider?($0, snapshot.id) ?? .unhydrated
-                            } ?? .notApplicable
-                            self.fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
-                            self.pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)?.task.cancel()
+                        if sourceChanged {
+                            self.replaceFileToolBindingSource(
+                                connectionID: connectionID,
+                                context: &bound,
+                                activeAgentSessionID: snapshot.activeAgentSessionID,
+                                worktreeBindingState: incomingBindingState
+                            )
                         }
                         self.tabContextByConnectionID[connectionID] = bound
                         tabContextLog("applied snapshot connectionID=\(connectionID) tab=\(context.tabID) selCount=\(incomingSelection.selectedPaths.count) promptChars=\(snapshot.promptText.count)")
@@ -1121,6 +1151,7 @@ extension MCPServerViewModel {
         workspaceID: UUID,
         windowID: Int,
         runID: UUID? = nil,
+        frozenFileToolAuthority: FrozenFileToolAuthority? = nil,
         explicitlyBound: Bool = true
     ) throws {
         guard let manager = workspaceManager else {
@@ -1147,6 +1178,7 @@ extension MCPServerViewModel {
             captureActiveUIState: false,
             flushActiveSelection: false
         )
+        context.frozenFileToolAuthority = frozenFileToolAuthority
 
         if tabContextByConnectionID[connectionID] != nil {
             releaseBinding(connectionID: connectionID)
@@ -1505,6 +1537,22 @@ extension MCPServerViewModel {
     }
 
     @MainActor
+    func updateBoundFileToolAuthority(
+        connectionID: UUID,
+        tabID: UUID,
+        workspaceID: UUID,
+        authority: FrozenFileToolAuthority
+    ) {
+        guard var context = tabContextByConnectionID[connectionID],
+              context.tabID == tabID,
+              context.workspaceID == workspaceID
+        else { return }
+        context.frozenFileToolAuthority = authority
+        tabContextByConnectionID[connectionID] = context
+        publishDomainRoutingBinding(connectionID: connectionID, context: context)
+    }
+
+    @MainActor
     func captureRequestMetadata() async -> RequestMetadata {
         #if DEBUG
             if let requestMetadataOverrideForTesting {
@@ -1597,7 +1645,7 @@ extension MCPServerViewModel {
         merged.selectedContextBuilderPromptIDs = context.selectedContextBuilderPromptIDs
         merged.activeAgentSessionID = context.activeAgentSessionID
         merged.worktreeBindingState = context.worktreeBindingState
-        merged.frozenLookupContext = context.frozenLookupContext
+        merged.frozenFileToolAuthority = context.frozenFileToolAuthority
         merged.contextBuilderReviewTargetResolution = context.contextBuilderReviewTargetResolution
         merged.readFileAutoSelectionGeneration = context.readFileAutoSelectionGeneration
         return merged
@@ -2023,105 +2071,34 @@ extension MCPServerViewModel {
         tabID: UUID,
         workspaceID: UUID?
     ) async throws -> WorkspaceLookupContext {
-        try await resolveProspectiveFileToolLookupContext(
+        try await resolveFileToolAuthority(
             tabID: tabID,
             workspaceID: workspaceID
         ).lookupContext
     }
 
-    struct ProspectiveFileToolLookupResolution {
-        let lookupContext: WorkspaceLookupContext
-        let sourceIdentity: AgentWorkspaceLookupContextIdentity
-        fileprivate let visibleRootFingerprint: String
-        fileprivate let sessionRootLifetimeSnapshot: WorkspaceSessionRootLifetimeSnapshot?
-    }
-
     @MainActor
-    func resolveProspectiveFileToolLookupContext(
+    func resolveFileToolAuthority(
         tabID: UUID,
         workspaceID: UUID?
-    ) async throws -> ProspectiveFileToolLookupResolution {
-        let visibleRootFingerprint = await fileToolVisibleRootFingerprint()
-        var snapshot = try makeTabContextSnapshot(
-            tabID: tabID,
-            workspaceID: workspaceID,
+    ) async throws -> FrozenFileToolAuthority {
+        try await requiredFileToolLookupContext(from: RequestMetadata(
+            connectionID: nil,
+            clientName: nil,
             windowID: windowID,
-            runID: nil,
-            explicitlyBound: false,
-            captureActiveUIState: false,
-            flushActiveSelection: false
-        )
-        guard await hydrateFileToolLookupSnapshotIfNeeded(&snapshot, connectionID: nil) else {
-            let source = AgentWorkspaceLookupContextSource(
-                activeAgentSessionID: snapshot.activeAgentSessionID,
-                worktreeBindingState: snapshot.worktreeBindingState
+            tabContextHint: TabContextHint(
+                tabID: tabID,
+                workspaceID: workspaceID,
+                windowID: windowID
             )
-            return ProspectiveFileToolLookupResolution(
-                lookupContext: AgentWorkspaceLookupContextResolver.failClosedLookupContext,
-                sourceIdentity: source.identity,
-                visibleRootFingerprint: visibleRootFingerprint,
-                sessionRootLifetimeSnapshot: nil
-            )
-        }
-
-        let source = AgentWorkspaceLookupContextSource(
-            activeAgentSessionID: snapshot.activeAgentSessionID,
-            worktreeBindingState: snapshot.worktreeBindingState
-        )
-        let lookupContext = await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
-            source: source,
-            store: promptVM.workspaceFileContextStore
-        )
-        let sessionRootLifetimeSnapshot: WorkspaceSessionRootLifetimeSnapshot? = if let bindingProjection = lookupContext.bindingProjection {
-            await promptVM.workspaceFileContextStore.sessionBoundRootScopeValidationSnapshot(
-                lookupContext.rootScope,
-                expectedPhysicalRoots: bindingProjection.physicalRootRefs
-            )
-        } else {
-            nil
-        }
-        let currentVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
-        guard currentVisibleRootFingerprint == visibleRootFingerprint,
-              lookupContext.bindingProjection == nil || sessionRootLifetimeSnapshot != nil,
-              fileToolLookupSnapshotIsCurrent(snapshot, connectionID: nil),
-              fileToolBindingSourceIsCurrent(source, for: snapshot)
-        else {
-            #if DEBUG
-                fileToolLookupContextStaleCompletionCount += 1
-            #endif
-            return ProspectiveFileToolLookupResolution(
-                lookupContext: AgentWorkspaceLookupContextResolver.failClosedLookupContext,
-                sourceIdentity: source.identity,
-                visibleRootFingerprint: visibleRootFingerprint,
-                sessionRootLifetimeSnapshot: nil
-            )
-        }
-        if let sessionRootLifetimeSnapshot {
-            guard await sessionRootLifetimeSnapshot.isCurrent() else {
-                #if DEBUG
-                    fileToolLookupContextStaleCompletionCount += 1
-                #endif
-                return ProspectiveFileToolLookupResolution(
-                    lookupContext: AgentWorkspaceLookupContextResolver.failClosedLookupContext,
-                    sourceIdentity: source.identity,
-                    visibleRootFingerprint: visibleRootFingerprint,
-                    sessionRootLifetimeSnapshot: nil
-                )
-            }
-        }
-        return ProspectiveFileToolLookupResolution(
-            lookupContext: lookupContext,
-            sourceIdentity: source.identity,
-            visibleRootFingerprint: visibleRootFingerprint,
-            sessionRootLifetimeSnapshot: sessionRootLifetimeSnapshot
-        )
+        ))
     }
 
     @MainActor
     func prospectiveFileToolLookupSourceIsCurrent(
         tabID: UUID,
         workspaceID: UUID,
-        expectedSourceIdentity: AgentWorkspaceLookupContextIdentity
+        expectedSourceIdentity: AgentWorkspaceLookupContextIdentity?
     ) -> Bool {
         guard var snapshot = try? makeTabContextSnapshot(
             tabID: tabID,
@@ -2143,12 +2120,12 @@ extension MCPServerViewModel {
             worktreeBindingState: snapshot.worktreeBindingState
         )
         return fileToolLookupSnapshotIsCurrent(snapshot, connectionID: nil)
-            && source.identity == expectedSourceIdentity
+            && source.authorityIdentity == expectedSourceIdentity
     }
 
     @MainActor
-    func performIfProspectiveFileToolLookupResolutionIsCurrent(
-        _ resolution: ProspectiveFileToolLookupResolution,
+    func performIfFileToolAuthorityIsCurrent(
+        _ authority: FrozenFileToolAuthority,
         tabID: UUID,
         workspaceID: UUID,
         operation: @MainActor () throws -> Void
@@ -2156,14 +2133,8 @@ extension MCPServerViewModel {
         guard prospectiveFileToolLookupSourceIsCurrent(
             tabID: tabID,
             workspaceID: workspaceID,
-            expectedSourceIdentity: resolution.sourceIdentity
+            expectedSourceIdentity: authority.sourceIdentity
         ) else { return false }
-
-        let currentVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
-        guard currentVisibleRootFingerprint == resolution.visibleRootFingerprint else { return false }
-        if let sessionRootLifetimeSnapshot = resolution.sessionRootLifetimeSnapshot {
-            guard await sessionRootLifetimeSnapshot.isCurrent() else { return false }
-        }
 
         #if DEBUG
             if let debugAfterFileToolLookupContextRootValidationForTesting {
@@ -2171,45 +2142,206 @@ extension MCPServerViewModel {
             }
         #endif
 
-        let finalVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
-        guard finalVisibleRootFingerprint == resolution.visibleRootFingerprint,
-              prospectiveFileToolLookupSourceIsCurrent(
-                  tabID: tabID,
-                  workspaceID: workspaceID,
-                  expectedSourceIdentity: resolution.sourceIdentity
-              )
-        else { return false }
-
-        if let sessionRootLifetimeSnapshot = resolution.sessionRootLifetimeSnapshot {
-            var operationError: Error?
-            let didPerform = sessionRootLifetimeSnapshot.performIfGenerationCurrent {
-                do {
-                    try operation()
-                } catch {
-                    operationError = error
-                }
-            }
-            if let operationError {
-                throw operationError
-            }
-            return didPerform
+        guard prospectiveFileToolLookupSourceIsCurrent(
+            tabID: tabID,
+            workspaceID: workspaceID,
+            expectedSourceIdentity: authority.sourceIdentity
+        ) else { return false }
+        guard let workspaceManager else { return false }
+        do {
+            try await authority.validate(
+                workspaceManager: workspaceManager,
+                store: promptVM.workspaceFileContextStore
+            )
+        } catch is FileToolAuthorityFailure {
+            return false
         }
-
-        try operation()
-        return true
+        return try authority.performIfCurrent(
+            workspaceManager: workspaceManager,
+            operation: operation
+        )
     }
 
     @MainActor
     func resolveFileToolLookupContext(
         from metadata: RequestMetadata
     ) async -> WorkspaceLookupContext {
-        let purpose = metadata.runPurpose ?? .unknown
-        var resolved = try? resolveTabContextSnapshot(
+        await (try? resolveFileToolLookupContext(from: metadata, rootCatalogSnapshot: nil))
+            ?? AgentWorkspaceLookupContextResolver.failClosedLookupContext
+    }
+
+    @MainActor
+    func requiredFileToolLookupContext(
+        from metadata: RequestMetadata,
+        readinessTimeout: Duration = MCPTimeoutPolicy.fileToolAuthorityReadinessWaitTimeout
+    ) async throws -> FrozenFileToolAuthority {
+        let routed = try resolveTabContextSnapshot(
             from: metadata,
             toolName: "file_tool_lookup_scope"
         )
+        if let frozenAuthority = routed.snapshot.frozenFileToolAuthority {
+            guard let workspaceManager else { throw FileToolAuthorityFailure.unavailable }
+            var liveSourceSnapshot = routed.snapshot
+            if routed.snapshot.runID == nil,
+               let workspaceID = routed.snapshot.workspaceID,
+               let current = try? makeTabContextSnapshot(
+                   tabID: routed.snapshot.tabID,
+                   workspaceID: workspaceID,
+                   windowID: routed.snapshot.windowID,
+                   runID: nil,
+                   explicitlyBound: routed.snapshot.explicitlyBound,
+                   captureActiveUIState: false,
+                   flushActiveSelection: false
+               )
+            {
+                liveSourceSnapshot.activeAgentSessionID = current.activeAgentSessionID
+                liveSourceSnapshot.worktreeBindingState = current.activeAgentSessionID.map {
+                    agentWorktreeBindingStateProvider?($0, current.tabID) ?? .unhydrated
+                } ?? .notApplicable
+            }
+            if frozenAuthority.sourceIdentity != liveSourceSnapshot.fileToolAuthoritySourceIdentity {
+                if let connectionID = metadata.connectionID,
+                   var bound = tabContextByConnectionID[connectionID],
+                   fileToolLookupRouteMatches(bound, routed.snapshot)
+                {
+                    replaceFileToolBindingSource(
+                        connectionID: connectionID,
+                        context: &bound,
+                        activeAgentSessionID: liveSourceSnapshot.activeAgentSessionID,
+                        worktreeBindingState: liveSourceSnapshot.worktreeBindingState
+                    )
+                    tabContextByConnectionID[connectionID] = bound
+                }
+                throw FileToolAuthorityFailure.superseded
+            }
+            try await frozenAuthority.validate(
+                workspaceManager: workspaceManager,
+                store: promptVM.workspaceFileContextStore
+            )
+            return frozenAuthority
+        }
+        var authoritySnapshot = routed.snapshot
+        guard await hydrateFileToolLookupSnapshotIfNeeded(
+            &authoritySnapshot,
+            connectionID: metadata.connectionID
+        ) else {
+            throw FileToolAuthorityFailure.superseded
+        }
+        guard let workspaceID = authoritySnapshot.workspaceID,
+              let workspaceManager
+        else {
+            throw FileToolAuthorityFailure.unavailable
+        }
+        let authoritySource = AgentWorkspaceLookupContextSource(
+            activeAgentSessionID: authoritySnapshot.activeAgentSessionID,
+            worktreeBindingState: authoritySnapshot.worktreeBindingState
+        )
+        let capturedRoute = ResolvedTabContextSnapshot(
+            snapshot: authoritySnapshot,
+            source: routed.source
+        )
+
+        let rootCatalogSnapshot: WorkspaceRootCatalogSnapshot
+        do {
+            rootCatalogSnapshot = try await workspaceManager.awaitWorkspaceRootCatalogSnapshot(
+                workspaceID: workspaceID,
+                timeout: readinessTimeout
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as WorkspaceRootCatalogSnapshotError {
+            throw Self.fileToolAuthorityFailure(for: error)
+        }
+
+        guard fileToolLookupSnapshotIsCurrent(
+            authoritySnapshot,
+            connectionID: metadata.connectionID
+        ), fileToolBindingSourceIsCurrent(authoritySource, for: authoritySnapshot)
+        else {
+            throw FileToolAuthorityFailure.superseded
+        }
+
+        do {
+            let lookupContext = try await resolveFileToolLookupContext(
+                from: metadata,
+                rootCatalogSnapshot: rootCatalogSnapshot,
+                capturedRoute: capturedRoute
+            )
+            guard lookupContext != AgentWorkspaceLookupContextResolver.failClosedLookupContext,
+                  fileToolRootCatalogSnapshotIsCurrent(rootCatalogSnapshot)
+            else {
+                throw FileToolAuthorityFailure.superseded
+            }
+            let frozenAuthority = try await FrozenFileToolAuthority.capture(
+                lookupContext: lookupContext,
+                rootCatalogSnapshot: rootCatalogSnapshot,
+                store: promptVM.workspaceFileContextStore,
+                sourceIdentity: authoritySource.authorityIdentity
+            )
+            guard fileToolLookupSnapshotIsCurrent(
+                authoritySnapshot,
+                connectionID: metadata.connectionID
+            ), fileToolBindingSourceIsCurrent(authoritySource, for: authoritySnapshot),
+            fileToolRootCatalogSnapshotIsCurrent(rootCatalogSnapshot)
+            else {
+                throw FileToolAuthorityFailure.superseded
+            }
+            try await frozenAuthority.validate(
+                workspaceManager: workspaceManager,
+                store: promptVM.workspaceFileContextStore
+            )
+            return frozenAuthority
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as FileToolAuthorityFailure {
+            if error == .unavailable,
+               !fileToolLookupSnapshotIsCurrent(
+                   authoritySnapshot,
+                   connectionID: metadata.connectionID
+               ) || !fileToolBindingSourceIsCurrent(authoritySource, for: authoritySnapshot)
+            {
+                throw FileToolAuthorityFailure.superseded
+            }
+            throw error
+        } catch {
+            throw FileToolAuthorityFailure.unavailable
+        }
+    }
+
+    static func fileToolAuthorityFailure(
+        for error: WorkspaceRootCatalogSnapshotError
+    ) -> FileToolAuthorityFailure {
+        switch error {
+        case .readinessTimedOut: .timedOut
+        case .readinessSuperseded, .workspaceNotActive: .superseded
+        case .inconsistentRootProjection: .mismatchedProjection
+        case .missingWorkspaceIdentity, .readinessUnavailable: .unavailable
+        }
+    }
+
+    private func unavailableFileToolLookupContext(
+        rootCatalogSnapshot: WorkspaceRootCatalogSnapshot?
+    ) throws -> WorkspaceLookupContext {
+        guard rootCatalogSnapshot == nil else {
+            throw FileToolAuthorityFailure.unavailable
+        }
+        return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+    }
+
+    @MainActor
+    private func resolveFileToolLookupContext(
+        from metadata: RequestMetadata,
+        rootCatalogSnapshot: WorkspaceRootCatalogSnapshot?,
+        capturedRoute: ResolvedTabContextSnapshot? = nil
+    ) async throws -> WorkspaceLookupContext {
+        let purpose = metadata.runPurpose ?? .unknown
+        var resolved = capturedRoute ?? (try? resolveTabContextSnapshot(
+            from: metadata,
+            toolName: "file_tool_lookup_scope"
+        ))
         if var snapshot = resolved?.snapshot {
-            if snapshot.runID == nil,
+            if capturedRoute == nil,
+               snapshot.runID == nil,
                let workspaceID = snapshot.workspaceID,
                let liveTab = workspaceManager?.composeTab(
                    for: WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: snapshot.tabID)
@@ -2224,11 +2356,13 @@ extension MCPServerViewModel {
                    var bound = tabContextByConnectionID[connectionID],
                    fileToolLookupRouteMatches(bound, snapshot)
                 {
-                    bound.activeAgentSessionID = snapshot.activeAgentSessionID
-                    bound.worktreeBindingState = snapshot.worktreeBindingState
+                    replaceFileToolBindingSource(
+                        connectionID: connectionID,
+                        context: &bound,
+                        activeAgentSessionID: snapshot.activeAgentSessionID,
+                        worktreeBindingState: snapshot.worktreeBindingState
+                    )
                     tabContextByConnectionID[connectionID] = bound
-                    fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
-                    pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)?.task.cancel()
                 }
             }
 
@@ -2236,7 +2370,7 @@ extension MCPServerViewModel {
                 &snapshot,
                 connectionID: metadata.connectionID
             ) else {
-                return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+                return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
             }
 
             resolved?.snapshot = snapshot
@@ -2247,11 +2381,13 @@ extension MCPServerViewModel {
                 if bound.activeAgentSessionID != snapshot.activeAgentSessionID
                     || bound.worktreeBindingState != snapshot.worktreeBindingState
                 {
-                    fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
-                    pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)?.task.cancel()
+                    replaceFileToolBindingSource(
+                        connectionID: connectionID,
+                        context: &bound,
+                        activeAgentSessionID: snapshot.activeAgentSessionID,
+                        worktreeBindingState: snapshot.worktreeBindingState
+                    )
                 }
-                bound.activeAgentSessionID = snapshot.activeAgentSessionID
-                bound.worktreeBindingState = snapshot.worktreeBindingState
                 tabContextByConnectionID[connectionID] = bound
             }
         }
@@ -2259,12 +2395,12 @@ extension MCPServerViewModel {
         let baseScope = Self.resolveFileToolLookupRootScope(purpose: purpose, resolvedContext: resolved)
         guard let resolved else {
             if purpose == .agentModeRun {
-                return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+                return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
             }
             return WorkspaceLookupContext(rootScope: baseScope, bindingProjection: nil)
         }
-        if let frozenLookupContext = resolved.snapshot.frozenLookupContext {
-            return frozenLookupContext
+        if let frozenAuthority = resolved.snapshot.frozenFileToolAuthority {
+            return frozenAuthority.lookupContext
         }
 
         let source = AgentWorkspaceLookupContextSource(
@@ -2277,21 +2413,23 @@ extension MCPServerViewModel {
               source.activeAgentSessionID != nil,
               !source.worktreeBindings.isEmpty
         else {
-            let lookupContext = await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
+            let lookupContext = try await authoritativeFileToolLookupContext(
                 source: source,
-                store: promptVM.workspaceFileContextStore
+                rootCatalogSnapshot: rootCatalogSnapshot
             )
             return Self.fileToolLookupContext(lookupContext, applying: baseScope)
         }
 
-        let visibleRootFingerprint = await fileToolVisibleRootFingerprint()
+        let visibleRootFingerprint = await fileToolVisibleRootFingerprint(
+            rootCatalogSnapshot: rootCatalogSnapshot
+        )
         guard fileToolLookupSnapshotIsCurrent(resolved.snapshot, connectionID: connectionID),
               fileToolBindingSourceIsCurrent(source, for: resolved.snapshot)
         else {
             #if DEBUG
                 fileToolLookupContextStaleCompletionCount += 1
             #endif
-            return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+            return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
         }
         let cacheKey = FileToolLookupContextCacheKey(
             connectionID: connectionID,
@@ -2302,7 +2440,8 @@ extension MCPServerViewModel {
             bindingGeneration: resolved.snapshot.readFileAutoSelectionGeneration,
             baseScope: baseScope,
             sourceIdentity: source.identity,
-            visibleRootFingerprint: visibleRootFingerprint
+            visibleRootFingerprint: visibleRootFingerprint,
+            readinessTicket: rootCatalogSnapshot?.ticket
         )
         if let cached = fileToolLookupContextCacheByConnectionID[connectionID],
            cached.key == cacheKey,
@@ -2311,6 +2450,7 @@ extension MCPServerViewModel {
             let canReuse = await AgentWorkspaceLookupContextResolver.canReuseAuthoritativeLookupContext(
                 cached.context,
                 source: source,
+                visibleRoots: rootCatalogSnapshot?.primaryRoots,
                 store: promptVM.workspaceFileContextStore
             )
             if canReuse {
@@ -2319,8 +2459,13 @@ extension MCPServerViewModel {
                         await debugAfterFileToolLookupContextRootValidationForTesting()
                     }
                 #endif
-                let currentVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
+                try Task.checkCancellation()
+                let currentVisibleRootFingerprint = await fileToolVisibleRootFingerprint(
+                    rootCatalogSnapshot: rootCatalogSnapshot
+                )
+                try Task.checkCancellation()
                 guard currentVisibleRootFingerprint == visibleRootFingerprint,
+                      fileToolRootCatalogSnapshotIsCurrent(rootCatalogSnapshot),
                       fileToolLookupSnapshotIsCurrent(resolved.snapshot, connectionID: connectionID),
                       fileToolBindingSourceIsCurrent(source, for: resolved.snapshot)
                 else {
@@ -2328,10 +2473,12 @@ extension MCPServerViewModel {
                     #if DEBUG
                         fileToolLookupContextStaleCompletionCount += 1
                     #endif
-                    return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+                    return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
                 }
                 var currentCachedContext: WorkspaceLookupContext?
-                guard await cached.sessionRootLifetimeSnapshot.isCurrent(),
+                let cachedLifetimeIsCurrent = await cached.sessionRootLifetimeSnapshot.isCurrent()
+                try Task.checkCancellation()
+                guard cachedLifetimeIsCurrent,
                       cached.sessionRootLifetimeSnapshot.performIfGenerationCurrent({
                           currentCachedContext = cached.context
                       }), let currentCachedContext
@@ -2340,11 +2487,12 @@ extension MCPServerViewModel {
                     #if DEBUG
                         fileToolLookupContextStaleCompletionCount += 1
                     #endif
-                    return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+                    return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
                 }
                 #if DEBUG
                     fileToolLookupContextCacheHitCount += 1
                 #endif
+                try Task.checkCancellation()
                 return currentCachedContext
             }
             fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
@@ -2352,9 +2500,11 @@ extension MCPServerViewModel {
         fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
 
         let pendingResolution: PendingFileToolLookupContextResolution
-        if let pending = pendingFileToolLookupContextResolutionByConnectionID[connectionID],
+        if var pending = pendingFileToolLookupContextResolutionByConnectionID[connectionID],
            pending.key == cacheKey
         {
+            pending.waiterCount += 1
+            pendingFileToolLookupContextResolutionByConnectionID[connectionID] = pending
             #if DEBUG
                 fileToolLookupContextCoalescedWaitCount += 1
                 if let debugFileToolLookupContextDidCoalesceForTesting {
@@ -2363,38 +2513,84 @@ extension MCPServerViewModel {
             #endif
             pendingResolution = pending
         } else {
-            pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)?.task.cancel()
+            supersedePendingFileToolLookupContextResolution(connectionID: connectionID)
             #if DEBUG
                 fileToolLookupContextCacheMissCount += 1
                 let beforeResolution = debugBeforeFileToolLookupContextResolutionForTesting
             #endif
             let resolutionID = UUID()
-            let resolutionTask = Task { @MainActor in
-                #if DEBUG
-                    if let beforeResolution {
-                        await beforeResolution()
-                    }
-                #endif
-                return await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
-                    source: source,
-                    store: promptVM.workspaceFileContextStore
-                )
+            let resolutionTask: Task<FileToolLookupResolution, Never> = Task { @MainActor in
+                do {
+                    #if DEBUG
+                        if let beforeResolution {
+                            await beforeResolution()
+                        }
+                    #endif
+                    return try await .success(authoritativeFileToolLookupContext(
+                        source: source,
+                        rootCatalogSnapshot: rootCatalogSnapshot
+                    ))
+                } catch is CancellationError {
+                    return .failure(.cancelled)
+                } catch {
+                    return .failure(.authority((error as? FileToolAuthorityFailure) ?? .unavailable))
+                }
             }
             pendingResolution = PendingFileToolLookupContextResolution(
                 id: resolutionID,
                 key: cacheKey,
-                task: resolutionTask
+                task: resolutionTask,
+                supersession: FileToolLookupResolutionSupersession(),
+                waiterCount: 1
             )
             pendingFileToolLookupContextResolutionByConnectionID[connectionID] = pendingResolution
         }
 
-        let lookupContext = await pendingResolution.task.value
-        let currentVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
+        let resolution: FileToolLookupResolution
+        do {
+            resolution = try await FileToolLookupResolutionWaiter().value(from: pendingResolution.task)
+        } catch is CancellationError {
+            releaseCancelledFileToolLookupResolutionWaiter(
+                connectionID: connectionID,
+                pendingResolution: pendingResolution
+            )
+            throw CancellationError()
+        }
+        guard !pendingResolution.supersession.isSuperseded else {
+            throw FileToolAuthorityFailure.superseded
+        }
+        let lookupContext: WorkspaceLookupContext
+        switch resolution {
+        case let .success(context):
+            lookupContext = context
+        case .failure(.cancelled):
+            if pendingFileToolLookupContextResolutionByConnectionID[connectionID]?.id == pendingResolution.id {
+                pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
+            }
+            throw CancellationError()
+        case let .failure(.authority(failure)):
+            if pendingFileToolLookupContextResolutionByConnectionID[connectionID]?.id == pendingResolution.id {
+                pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
+            }
+            throw failure
+        }
+        try checkFileToolLookupCallerCancellation(
+            connectionID: connectionID,
+            pendingResolution: pendingResolution
+        )
+        let currentVisibleRootFingerprint = await fileToolVisibleRootFingerprint(
+            rootCatalogSnapshot: rootCatalogSnapshot
+        )
+        try checkFileToolLookupCallerCancellation(
+            connectionID: connectionID,
+            pendingResolution: pendingResolution
+        )
         let ownsPendingResolution = pendingFileToolLookupContextResolutionByConnectionID[connectionID]?.id
             == pendingResolution.id
         let publishedEntry = fileToolLookupContextCacheByConnectionID[connectionID]
             .flatMap { $0.key == cacheKey ? $0 : nil }
         guard currentVisibleRootFingerprint == visibleRootFingerprint,
+              fileToolRootCatalogSnapshotIsCurrent(rootCatalogSnapshot),
               ownsPendingResolution || publishedEntry != nil,
               fileToolLookupSnapshotIsCurrent(resolved.snapshot, connectionID: connectionID),
               fileToolBindingSourceIsCurrent(source, for: resolved.snapshot)
@@ -2405,7 +2601,7 @@ extension MCPServerViewModel {
             #if DEBUG
                 fileToolLookupContextStaleCompletionCount += 1
             #endif
-            return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+            return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
         }
         let adjustedLookupContext = publishedEntry?.context
             ?? Self.fileToolLookupContext(lookupContext, applying: baseScope)
@@ -2416,7 +2612,7 @@ extension MCPServerViewModel {
             return adjustedLookupContext
         }
 
-        let sessionRootLifetimeSnapshot: WorkspaceSessionRootLifetimeSnapshot? = if let publishedEntry {
+        let lifetime = if let publishedEntry {
             publishedEntry.sessionRootLifetimeSnapshot
         } else {
             await promptVM.workspaceFileContextStore.sessionBoundRootScopeValidationSnapshot(
@@ -2424,70 +2620,122 @@ extension MCPServerViewModel {
                 expectedPhysicalRoots: bindingProjection.physicalRootRefs
             )
         }
-        #if DEBUG
-            if let debugAfterFileToolLookupContextRootValidationForTesting {
-                await debugAfterFileToolLookupContextRootValidationForTesting()
-            }
-        #endif
-        let finalVisibleRootFingerprint = await fileToolVisibleRootFingerprint()
-        let stillOwnsResolution = pendingFileToolLookupContextResolutionByConnectionID[connectionID]?.id
-            == pendingResolution.id
-        let matchingPublishedEntryExists = fileToolLookupContextCacheByConnectionID[connectionID]?.key == cacheKey
-        guard let sessionRootLifetimeSnapshot,
-              finalVisibleRootFingerprint == visibleRootFingerprint,
-              stillOwnsResolution || matchingPublishedEntryExists,
-              fileToolLookupSnapshotIsCurrent(resolved.snapshot, connectionID: connectionID),
-              fileToolBindingSourceIsCurrent(source, for: resolved.snapshot)
-        else {
-            if stillOwnsResolution {
+        try checkFileToolLookupCallerCancellation(
+            connectionID: connectionID,
+            pendingResolution: pendingResolution
+        )
+        guard let lifetime, await lifetime.isCurrent() else {
+            if ownsPendingResolution {
                 pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
-            }
-            if matchingPublishedEntryExists {
-                fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
             }
             #if DEBUG
                 fileToolLookupContextStaleCompletionCount += 1
             #endif
-            return AgentWorkspaceLookupContextResolver.failClosedLookupContext
-        }
-        if let publishedEntry {
-            var currentPublishedContext: WorkspaceLookupContext?
-            guard await sessionRootLifetimeSnapshot.isCurrent(),
-                  sessionRootLifetimeSnapshot.performIfGenerationCurrent({
-                      currentPublishedContext = publishedEntry.context
-                  }), let currentPublishedContext
-            else {
-                fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
-                #if DEBUG
-                    fileToolLookupContextStaleCompletionCount += 1
-                #endif
-                return AgentWorkspaceLookupContextResolver.failClosedLookupContext
-            }
-            return currentPublishedContext
+            return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
         }
 
-        let cacheEntry = FileToolLookupContextCacheEntry(
+        if let publishedEntry {
+            var currentContext: WorkspaceLookupContext?
+            guard fileToolLookupContextCacheByConnectionID[connectionID]?.key == cacheKey,
+                  lifetime.performIfGenerationCurrent({ currentContext = publishedEntry.context }),
+                  let currentContext
+            else {
+                fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
+                return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
+            }
+            return currentContext
+        }
+
+        let entry = FileToolLookupContextCacheEntry(
             key: cacheKey,
             context: adjustedLookupContext,
-            sessionRootLifetimeSnapshot: sessionRootLifetimeSnapshot
+            sessionRootLifetimeSnapshot: lifetime
         )
-        guard await sessionRootLifetimeSnapshot.isCurrent(),
-              sessionRootLifetimeSnapshot.performIfGenerationCurrent({
-                  fileToolLookupContextCacheByConnectionID[connectionID] = cacheEntry
+        guard pendingFileToolLookupContextResolutionByConnectionID[connectionID]?.id == pendingResolution.id,
+              fileToolLookupContextCacheByConnectionID[connectionID] == nil,
+              lifetime.performIfGenerationCurrent({
+                  fileToolLookupContextCacheByConnectionID[connectionID] = entry
               })
         else {
-            if stillOwnsResolution {
-                pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
-            }
-            #if DEBUG
-                fileToolLookupContextStaleCompletionCount += 1
-            #endif
-            return AgentWorkspaceLookupContextResolver.failClosedLookupContext
+            pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
+            return try unavailableFileToolLookupContext(rootCatalogSnapshot: rootCatalogSnapshot)
         }
-        if stillOwnsResolution {
+        pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
+        return adjustedLookupContext
+    }
+
+    @MainActor
+    private func checkFileToolLookupCallerCancellation(
+        connectionID: UUID,
+        pendingResolution: PendingFileToolLookupContextResolution
+    ) throws {
+        do {
+            try Task.checkCancellation()
+        } catch {
+            releaseCancelledFileToolLookupResolutionWaiter(
+                connectionID: connectionID,
+                pendingResolution: pendingResolution
+            )
+            throw error
+        }
+    }
+
+    @MainActor
+    private func releaseCancelledFileToolLookupResolutionWaiter(
+        connectionID: UUID,
+        pendingResolution: PendingFileToolLookupContextResolution
+    ) {
+        guard var pending = pendingFileToolLookupContextResolutionByConnectionID[connectionID],
+              pending.id == pendingResolution.id
+        else { return }
+        pending.waiterCount = max(0, pending.waiterCount - 1)
+        pendingFileToolLookupContextResolutionByConnectionID[connectionID] = pending
+        guard pending.waiterCount == 0 else { return }
+
+        Task { @MainActor [weak self, task = pending.task, resolutionID = pending.id] in
+            _ = await task.value
+            guard let self,
+                  let completed = pendingFileToolLookupContextResolutionByConnectionID[connectionID],
+                  completed.id == resolutionID,
+                  completed.waiterCount == 0
+            else { return }
             pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
         }
-        return adjustedLookupContext
+    }
+
+    /// Routing replacement is not caller cancellation. Mark the flight before stopping its work so
+    /// every existing waiter receives a retryable superseded result, including across ABA changes.
+    @MainActor
+    private func supersedePendingFileToolLookupContextResolution(connectionID: UUID) {
+        let pending = pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: connectionID)
+        pending?.supersession.markSuperseded()
+        pending?.task.cancel()
+    }
+
+    @MainActor
+    private func replaceFileToolBindingSource(
+        connectionID: UUID,
+        context: inout TabContextSnapshot,
+        activeAgentSessionID: UUID?,
+        worktreeBindingState: AgentSessionWorktreeBindingState
+    ) {
+        let currentIdentity = AgentWorkspaceLookupContextSource(
+            activeAgentSessionID: context.activeAgentSessionID,
+            worktreeBindingState: context.worktreeBindingState
+        ).identity
+        let replacementIdentity = AgentWorkspaceLookupContextSource(
+            activeAgentSessionID: activeAgentSessionID,
+            worktreeBindingState: worktreeBindingState
+        ).identity
+        guard currentIdentity != replacementIdentity else { return }
+
+        invalidateReadFileAutoSelection(connectionID: connectionID, context: context)
+        context.frozenFileToolAuthority = nil
+        context.activeAgentSessionID = activeAgentSessionID
+        context.worktreeBindingState = worktreeBindingState
+        activateReadFileAutoSelection(&context)
+        fileToolLookupContextCacheByConnectionID.removeValue(forKey: connectionID)
+        supersedePendingFileToolLookupContextResolution(connectionID: connectionID)
     }
 
     @MainActor
@@ -2556,11 +2804,59 @@ extension MCPServerViewModel {
     }
 
     @MainActor
-    private func fileToolVisibleRootFingerprint() async -> String {
-        await promptVM.workspaceFileContextStore.rootRefs(scope: .visibleWorkspace)
+    private func fileToolVisibleRootFingerprint(
+        rootCatalogSnapshot: WorkspaceRootCatalogSnapshot? = nil
+    ) async -> String {
+        let roots = if let rootCatalogSnapshot {
+            rootCatalogSnapshot.primaryRoots
+        } else {
+            await promptVM.workspaceFileContextStore.rootRefs(scope: .visibleWorkspace)
+        }
+        return roots
             .map { "\($0.id.uuidString)\u{1F}\($0.standardizedFullPath)" }
             .sorted()
             .joined(separator: "\u{1E}")
+    }
+
+    @MainActor
+    private func authoritativeFileToolLookupContext(
+        source: AgentWorkspaceLookupContextSource,
+        rootCatalogSnapshot: WorkspaceRootCatalogSnapshot?
+    ) async throws -> WorkspaceLookupContext {
+        guard let rootCatalogSnapshot else {
+            return await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
+                source: source,
+                store: promptVM.workspaceFileContextStore
+            )
+        }
+        return try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+            source: source,
+            visibleRoots: rootCatalogSnapshot.primaryRoots,
+            store: promptVM.workspaceFileContextStore
+        )
+    }
+
+    @MainActor
+    private func fileToolRootCatalogSnapshotIsCurrent(
+        _ snapshot: WorkspaceRootCatalogSnapshot?
+    ) -> Bool {
+        guard let snapshot else { return true }
+        return fileToolRootCatalogTicketIsCurrent(snapshot.ticket)
+    }
+
+    @MainActor
+    private func fileToolRootCatalogTicketIsCurrent(
+        _ ticket: WorkspaceSearchReadinessTicket
+    ) -> Bool {
+        do {
+            try workspaceManager?.validateWorkspaceSearchReadiness(
+                ticket,
+                admission: .rootCatalog
+            )
+            return workspaceManager != nil
+        } catch {
+            return false
+        }
     }
 
     @MainActor
@@ -2598,7 +2894,7 @@ extension MCPServerViewModel {
     }
 
     @MainActor
-    private func fileToolLookupSnapshotMatches(
+    func fileToolLookupSnapshotMatches(
         _ lhs: TabContextSnapshot,
         _ rhs: TabContextSnapshot
     ) -> Bool {
@@ -3036,7 +3332,7 @@ extension MCPServerViewModel {
         readFileAutoSelectionHandoverLineageByConnectionID.removeValue(forKey: previousConnection)
         readFileAutoSelectionHandoverLineageByConnectionID.removeValue(forKey: connectionID)
         fileToolLookupContextCacheByConnectionID.removeValue(forKey: previousConnection)
-        pendingFileToolLookupContextResolutionByConnectionID.removeValue(forKey: previousConnection)?.task.cancel()
+        supersedePendingFileToolLookupContextResolution(connectionID: previousConnection)
         tabContextByConnectionID.removeValue(forKey: previousConnection)
         invalidateReadFileAutoSelection(connectionID: previousConnection, context: existing)
         endMirroringForConnection(previousConnection)

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -165,6 +165,7 @@ final class MCPServerViewModel: ObservableObject {
         let baseScope: WorkspaceLookupRootScope
         let sourceIdentity: AgentWorkspaceLookupContextIdentity
         let visibleRootFingerprint: String
+        let readinessTicket: WorkspaceSearchReadinessTicket?
     }
 
     struct FileToolLookupContextCacheEntry {
@@ -173,10 +174,277 @@ final class MCPServerViewModel: ObservableObject {
         let sessionRootLifetimeSnapshot: WorkspaceSessionRootLifetimeSnapshot
     }
 
+    struct FrozenFileToolAuthority {
+        let lookupContext: WorkspaceLookupContext
+        let rootCatalogSnapshot: WorkspaceRootCatalogSnapshot
+        var canonicalRoots: Set<WorkspaceRootRef> {
+            Set(rootCatalogSnapshot.primaryRoots)
+        }
+
+        let sessionRootLifetimeSnapshot: WorkspaceSessionRootLifetimeSnapshot?
+        let sourceIdentity: AgentWorkspaceLookupContextIdentity?
+
+        @MainActor
+        static func capture(
+            lookupContext: WorkspaceLookupContext,
+            rootCatalogSnapshot: WorkspaceRootCatalogSnapshot,
+            store: WorkspaceFileContextStore,
+            sourceIdentity: AgentWorkspaceLookupContextIdentity? = nil
+        ) async throws -> FrozenFileToolAuthority {
+            try Task.checkCancellation()
+            let lifetime: WorkspaceSessionRootLifetimeSnapshot?
+            if let projection = lookupContext.bindingProjection {
+                guard Set(projection.visibleLogicalRootRefs) == Set(rootCatalogSnapshot.primaryRoots) else {
+                    throw FileToolAuthorityFailure.mismatchedProjection
+                }
+                lifetime = await store.sessionBoundRootScopeValidationSnapshot(
+                    lookupContext.rootScope,
+                    expectedPhysicalRoots: projection.physicalRootRefs
+                )
+            } else {
+                lifetime = nil
+            }
+            let canonicalRoots = Set(rootCatalogSnapshot.primaryRoots)
+            guard await Set(store.rootRefs(scope: .visibleWorkspace)) == canonicalRoots else {
+                throw FileToolAuthorityFailure.mismatchedProjection
+            }
+            try Task.checkCancellation()
+            if lookupContext.bindingProjection != nil, lifetime == nil {
+                throw FileToolAuthorityFailure.worktreeScopeUnavailable
+            }
+            if let lifetime, await !(lifetime.isCurrent()) {
+                throw FileToolAuthorityFailure.worktreeScopeUnavailable
+            }
+            return FrozenFileToolAuthority(
+                lookupContext: lookupContext,
+                rootCatalogSnapshot: rootCatalogSnapshot,
+                sessionRootLifetimeSnapshot: lifetime,
+                sourceIdentity: sourceIdentity
+            )
+        }
+
+        @MainActor
+        func validate(
+            workspaceManager: WorkspaceManagerViewModel,
+            store: WorkspaceFileContextStore
+        ) async throws {
+            guard rootCatalogSnapshot.workspaceID == rootCatalogSnapshot.ticket.workspaceID else {
+                throw FileToolAuthorityFailure.superseded
+            }
+            do {
+                try workspaceManager.validateWorkspaceSearchReadiness(
+                    rootCatalogSnapshot.ticket,
+                    admission: .rootCatalog
+                )
+            } catch {
+                throw FileToolAuthorityFailure.superseded
+            }
+            guard await Set(store.rootRefs(scope: .visibleWorkspace)) == canonicalRoots else {
+                throw FileToolAuthorityFailure.mismatchedProjection
+            }
+            if lookupContext.bindingProjection != nil {
+                guard let sessionRootLifetimeSnapshot else {
+                    throw FileToolAuthorityFailure.worktreeScopeUnavailable
+                }
+                guard await sessionRootLifetimeSnapshot.isCurrent() else {
+                    throw FileToolAuthorityFailure.worktreeScopeUnavailable
+                }
+            }
+        }
+
+        @MainActor
+        func performIfCurrent(
+            workspaceManager: WorkspaceManagerViewModel,
+            operation: @MainActor () throws -> Void
+        ) throws -> Bool {
+            if let projection = lookupContext.bindingProjection {
+                guard Set(projection.visibleLogicalRootRefs) == Set(rootCatalogSnapshot.primaryRoots) else {
+                    throw FileToolAuthorityFailure.mismatchedProjection
+                }
+            }
+
+            var operationError: Error?
+            do {
+                try workspaceManager.validateWorkspaceSearchReadiness(
+                    rootCatalogSnapshot.ticket,
+                    admission: .rootCatalog
+                )
+            } catch {
+                return false
+            }
+            if lookupContext.bindingProjection != nil {
+                guard let sessionRootLifetimeSnapshot else { return false }
+                let performed = sessionRootLifetimeSnapshot.performIfGenerationCurrent {
+                    do {
+                        try operation()
+                    } catch {
+                        operationError = error
+                    }
+                }
+                if let operationError { throw operationError }
+                return performed
+            } else {
+                try operation()
+                return true
+            }
+        }
+
+        func hasSameRoutingAuthority(as other: FrozenFileToolAuthority) -> Bool {
+            guard sourceIdentity == other.sourceIdentity,
+                  lookupContext == other.lookupContext,
+                  rootCatalogSnapshot == other.rootCatalogSnapshot,
+                  canonicalRoots == other.canonicalRoots
+            else {
+                return false
+            }
+            switch (sessionRootLifetimeSnapshot, other.sessionRootLifetimeSnapshot) {
+            case (nil, nil):
+                return true
+            case let (lhs?, _?):
+                return lhs.isGenerationCurrent()
+            default:
+                return false
+            }
+        }
+    }
+
+    enum FileToolAuthorityFailure: LocalizedError, Equatable {
+        case unavailable
+        case timedOut
+        case superseded
+        case mismatchedProjection
+        case worktreeScopeUnavailable
+
+        static let retryAfterMilliseconds = 1000
+
+        var errorCode: String {
+            switch self {
+            case .unavailable: "workspace_authority_unavailable"
+            case .timedOut: "workspace_authority_timeout"
+            case .superseded: "workspace_authority_superseded"
+            case .mismatchedProjection: "workspace_authority_mismatch"
+            case .worktreeScopeUnavailable: "worktree_scope_unavailable"
+            }
+        }
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable:
+                "The resolved workspace file authority is unavailable. No canonical checkout was used."
+            case .timedOut:
+                "The workspace root catalog did not become ready in time. No canonical checkout was used."
+            case .superseded:
+                "Workspace authority changed while the file request was resolving. No canonical checkout was used."
+            case .mismatchedProjection:
+                "The workspace root catalog no longer matches the loaded roots. No canonical checkout was used."
+            case .worktreeScopeUnavailable:
+                "The bound worktree scope is unavailable. No canonical checkout was used."
+            }
+        }
+
+        var retryable: Bool {
+            true
+        }
+    }
+
+    enum FileToolLookupResolutionFailure: Error, Equatable {
+        case authority(FileToolAuthorityFailure)
+        case cancelled
+    }
+
+    typealias FileToolLookupResolution = Result<WorkspaceLookupContext, FileToolLookupResolutionFailure>
+
+    @MainActor
+    final class FileToolLookupResolutionSupersession {
+        private(set) var isSuperseded = false
+
+        func markSuperseded() {
+            isSuperseded = true
+        }
+    }
+
     struct PendingFileToolLookupContextResolution {
         let id: UUID
         let key: FileToolLookupContextCacheKey
-        let task: Task<WorkspaceLookupContext, Never>
+        let task: Task<FileToolLookupResolution, Never>
+        let supersession: FileToolLookupResolutionSupersession
+        var waiterCount: Int
+    }
+
+    /// Bridges a shared resolution task to one caller without transferring cancellation
+    /// ownership. The first terminal event wins, so cancelling one request resumes only that
+    /// request while the shared flight remains available to other waiters.
+    final class FileToolLookupResolutionWaiter: @unchecked Sendable {
+        private enum Terminal {
+            case resolution(FileToolLookupResolution)
+            case cancelled
+        }
+
+        private let lock = NSLock()
+        private var terminal: Terminal?
+        private var continuation: CheckedContinuation<FileToolLookupResolution, any Error>?
+
+        func value(
+            from task: Task<FileToolLookupResolution, Never>
+        ) async throws -> FileToolLookupResolution {
+            try Task.checkCancellation()
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    install(continuation)
+                    Task { @MainActor [weak self] in
+                        let resolution = await task.value
+                        self?.finish(.resolution(resolution))
+                    }
+                }
+            } onCancel: {
+                finish(.cancelled)
+            }
+        }
+
+        private func install(
+            _ continuation: CheckedContinuation<FileToolLookupResolution, any Error>
+        ) {
+            let terminal: Terminal?
+            lock.lock()
+            if self.continuation == nil, self.terminal == nil {
+                self.continuation = continuation
+                terminal = nil
+            } else {
+                terminal = self.terminal
+            }
+            lock.unlock()
+            if let terminal {
+                resume(continuation, with: terminal)
+            }
+        }
+
+        private func finish(_ terminal: Terminal) {
+            let continuation: CheckedContinuation<FileToolLookupResolution, any Error>?
+            lock.lock()
+            guard self.terminal == nil else {
+                lock.unlock()
+                return
+            }
+            self.terminal = terminal
+            continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+            if let continuation {
+                resume(continuation, with: terminal)
+            }
+        }
+
+        private func resume(
+            _ continuation: CheckedContinuation<FileToolLookupResolution, any Error>,
+            with terminal: Terminal
+        ) {
+            switch terminal {
+            case let .resolution(resolution):
+                continuation.resume(returning: resolution)
+            case .cancelled:
+                continuation.resume(throwing: CancellationError())
+            }
+        }
     }
 
     #if DEBUG
@@ -1370,6 +1638,12 @@ final class MCPServerViewModel: ObservableObject {
             guard let self else { return .visibleWorkspace }
             return await resolveFileToolLookupContext(from: metadata)
         },
+        requiredFileToolLookupContext: { [weak self] metadata in
+            guard let self else {
+                throw MCPError.internalError("Window deallocated while resolving file-tool authority")
+            }
+            return try await requiredFileToolLookupContext(from: metadata)
+        },
         resolveMutationFileToolContext: { [weak self] metadata, toolName in
             guard let self else {
                 throw MCPError.internalError("Window deallocated while resolving mutation worktree scope")
@@ -1567,27 +1841,29 @@ final class MCPServerViewModel: ObservableObject {
                 lookupContext: lookupContext
             )
         },
-        enqueueReadFileAutoSelection: { [weak self] reply, requestedPath, absolutePhysicalPath, metadata in
+        enqueueReadFileAutoSelection: { [weak self] reply, requestedPath, absolutePhysicalPath, metadata, authority in
             guard let self else { throw MCPError.internalError("Window deallocated while enqueuing read_file auto-selection") }
-            try await enqueueReadFileAutoSelection(
+            return try await enqueueReadFileAutoSelection(
                 reply: reply,
                 requestedPath: requestedPath,
                 absolutePhysicalPath: absolutePhysicalPath,
-                metadata: metadata
+                metadata: metadata,
+                authority: authority
             )
         },
         drainReadFileAutoSelection: { [weak self] metadata, requirement in
             guard let self else { throw MCPError.internalError("Window deallocated while draining read_file auto-selection") }
             return try await drainReadFileAutoSelection(metadata: metadata, requirement: requirement)
         },
-        enqueueFileSearchAutoSelection: { [weak self] mode, contextLines, reply, resolvedPhysicalPaths, metadata in
+        enqueueFileSearchAutoSelection: { [weak self] mode, contextLines, reply, resolvedPhysicalPaths, metadata, authority in
             guard let self else { throw MCPError.internalError("Window deallocated while enqueuing file_search auto-selection") }
-            try await enqueueFileSearchAutoSelection(
+            return try await enqueueFileSearchAutoSelection(
                 mode: mode,
                 contextLines: contextLines,
                 reply: reply,
                 resolvedPhysicalPaths: resolvedPhysicalPaths,
-                metadata: metadata
+                metadata: metadata,
+                authority: authority
             )
         },
         workspaceContextMessage: { [weak self] operation, path in
@@ -1667,6 +1943,16 @@ final class MCPServerViewModel: ObservableObject {
         selection: windowToolSelectionCapabilities,
         files: windowToolFileCapabilities
     )
+
+    @MainActor
+    func domainReadFileToolDependencies() -> MCPFileToolProvider.Dependencies {
+        (
+            context: windowToolContextCapabilities,
+            selection: windowToolSelectionCapabilities,
+            files: windowToolFileCapabilities
+        )
+    }
+
     @MainActor
     private lazy var promptContextToolProvider = MCPPromptContextToolProvider(
         runtime: windowToolRuntime,
@@ -1706,6 +1992,15 @@ final class MCPServerViewModel: ObservableObject {
         },
         releaseContext: { [weak self] context in
             await self?.releaseDomainReadAppExecutionContext(for: context)
+        },
+        resolveFailure: { toolName, arguments, error in
+            guard let failure = error as? FileToolAuthorityFailure
+            else { return nil }
+            return try MCPFileToolProvider.authorityFailureValue(
+                toolName: toolName,
+                args: arguments,
+                failure: failure
+            )
         },
         backend: MCPDomainReadToolBackend { [weak self] toolName, context, args, sideEffects in
             guard let self else {
@@ -4305,8 +4600,9 @@ final class MCPServerViewModel: ObservableObject {
         reply: ToolResultDTOs.ReadFileReply,
         requestedPath: String,
         absolutePhysicalPath: String,
-        metadata: RequestMetadata
-    ) async throws {
+        metadata: RequestMetadata,
+        authority: FrozenFileToolAuthority
+    ) async throws -> Bool {
         #if DEBUG || EDIT_FLOW_PERF
             let autoSelectTotal = EditFlowPerf.begin(EditFlowPerf.Stage.ReadFile.AutoSelect.total)
             defer { EditFlowPerf.end(EditFlowPerf.Stage.ReadFile.AutoSelect.total, autoSelectTotal) }
@@ -4325,9 +4621,8 @@ final class MCPServerViewModel: ObservableObject {
         } else {
             await ServerNetworkManager.shared.runPurpose(for: connectionID)
         }
-        let resolvedContext: ResolvedTabContextSnapshot
         do {
-            resolvedContext = try resolveTabContextSnapshot(
+            _ = try resolveTabContextSnapshot(
                 from: metadata,
                 toolName: "enqueueReadFileAutoSelection"
             )
@@ -4349,7 +4644,7 @@ final class MCPServerViewModel: ObservableObject {
             eligibilityResolution,
             EditFlowPerf.Dimensions(outcome: shouldApply ? "eligible" : "ineligible")
         )
-        guard shouldApply else { return }
+        guard shouldApply else { return false }
 
         let selectionProjection = EditFlowPerf.begin(EditFlowPerf.Stage.ReadFile.AutoSelect.selectionProjection)
         guard let selection = AutoSliceSelection.readFileSelection(from: reply, fallbackPath: requestedPath) else {
@@ -4358,7 +4653,7 @@ final class MCPServerViewModel: ObservableObject {
                 selectionProjection,
                 EditFlowPerf.Dimensions(outcome: "missing")
             )
-            return
+            return false
         }
         let intent: MCPReadFileAutoSelectionCoordinator.Intent = switch selection {
         case .full:
@@ -4386,18 +4681,26 @@ final class MCPServerViewModel: ObservableObject {
             intent: intent,
             resolvedPaths: [absolutePhysicalPath]
         )
-        let key = try readFileAutoSelectionContextKey(resolvedContext: resolvedContext, metadata: metadata)
-        let accepted = readFileAutoSelectionCoordinator.enqueue(
+        let currentResolvedContext = try resolveTabContextSnapshot(
+            from: metadata,
+            toolName: "enqueueReadFileAutoSelection"
+        )
+        let key = try readFileAutoSelectionContextKey(resolvedContext: currentResolvedContext, metadata: metadata)
+        guard readFileAutoSelectionCoordinator.enqueue(
             intent: intent,
+            authority: authority,
             coverageIdentity: coverageIdentity,
             for: key
-        )
-        if accepted, purpose == .unknown {
+        ) else {
+            throw FileToolAuthorityFailure.superseded
+        }
+        if purpose == .unknown {
             // Interactive CLI requests have no run policy and commonly disconnect after one call.
             // Make the successful read response their selection durability boundary while preserving
             // Agent Mode's asynchronous response path.
             _ = await readFileAutoSelectionCoordinator.drain(.mirroredSelectionAndMetrics, for: key)
         }
+        return true
     }
 
     @MainActor
@@ -5173,8 +5476,9 @@ final class MCPServerViewModel: ObservableObject {
         contextLines: Int,
         reply: ToolResultDTOs.SearchResultDTO,
         resolvedPhysicalPaths: [String],
-        metadata: RequestMetadata
-    ) async throws {
+        metadata: RequestMetadata,
+        authority: FrozenFileToolAuthority
+    ) async throws -> Bool {
         let shapeEligibility = EditFlowPerf.begin(
             EditFlowPerf.Stage.Search.AutoSelect.shapeEligibility,
             EditFlowPerf.Dimensions(searchMode: mode.rawValue, contextLines: contextLines)
@@ -5185,7 +5489,7 @@ final class MCPServerViewModel: ObservableObject {
                 shapeEligibility,
                 EditFlowPerf.Dimensions(outcome: "skippedShape", searchMode: mode.rawValue, contextLines: contextLines)
             )
-            return
+            return false
         }
         guard !reply.contentMatchGroups.isEmpty else {
             EditFlowPerf.end(
@@ -5193,7 +5497,7 @@ final class MCPServerViewModel: ObservableObject {
                 shapeEligibility,
                 EditFlowPerf.Dimensions(outcome: "skippedEmpty", searchMode: mode.rawValue, contextLines: contextLines)
             )
-            return
+            return false
         }
         EditFlowPerf.end(
             EditFlowPerf.Stage.Search.AutoSelect.shapeEligibility,
@@ -5238,7 +5542,7 @@ final class MCPServerViewModel: ObservableObject {
             agentEligibility,
             EditFlowPerf.Dimensions(outcome: shouldApply ? "eligible" : "ineligible")
         )
-        guard shouldApply else { return }
+        guard shouldApply else { return false }
 
         let mutation = EditFlowPerf.begin(EditFlowPerf.Stage.Search.AutoSelect.mutation)
         let entries = AutoSliceSelection.searchEntries(from: reply.contentMatchGroups).map { entry in
@@ -5250,7 +5554,7 @@ final class MCPServerViewModel: ObservableObject {
                 mutation,
                 EditFlowPerf.Dimensions(outcome: "skippedEmpty")
             )
-            return
+            return false
         }
         let intent = MCPReadFileAutoSelectionCoordinator.Intent.slices(
             entries: entries,
@@ -5263,6 +5567,7 @@ final class MCPServerViewModel: ObservableObject {
         let key = try readFileAutoSelectionContextKey(resolvedContext: resolvedContext, metadata: metadata)
         let accepted = readFileAutoSelectionCoordinator.enqueue(
             intent: intent,
+            authority: authority,
             coverageIdentity: coverageIdentity,
             for: key
         )
@@ -5280,6 +5585,7 @@ final class MCPServerViewModel: ObservableObject {
             mutation,
             EditFlowPerf.Dimensions(outcome: accepted ? "enqueued" : "invalidated")
         )
+        return accepted
     }
 
     private func applySelectionSlices(
@@ -6797,7 +7103,7 @@ final class MCPServerViewModel: ObservableObject {
         maxDepth: Int?,
         startPath: String?,
         lookupContext: WorkspaceLookupContext = .visibleWorkspace
-    ) async throws -> (result: FileTreeResult, rootCount: Int) {
+    ) async throws -> (result: FileTreeResult, rootCount: Int, emptyReason: MCPStoreBackedFileTreeEmptyReason?) {
         let presentationMode: WorkspaceFileTreePresentationMode
         switch mode.lowercased() {
         case "selected": presentationMode = .selected
@@ -6810,13 +7116,24 @@ final class MCPServerViewModel: ObservableObject {
         let filePathDisplay = await MainActor.run { promptVM.filePathDisplayOption }
         let showCodeMapMarkers = await MainActor.run { !promptVM.codeMapsGloballyDisabled }
         let selection = try await lookupContext.physicalizeSelection(storedSelectionForCurrentTabContext(includeCodemapPathsWhenSelectedUsage: true))
+        if presentationMode == .selected,
+           selection.isEmptyForSelectedFileTree
+        {
+            return (FileTreeResult(
+                tree: "No files are selected.",
+                usedSelectedMarker: false,
+                usedCodeMapMarker: false,
+                wasTruncated: false,
+                note: "Selection is empty"
+            ), 0, .selectionEmpty)
+        }
         let store = promptVM.workspaceFileContextStore
         let fileTree = await store.makeCurrentSnapshotFileTreePresentation(
             selection: selection,
             request: WorkspaceFileTreePresentationRequest(
                 mode: presentationMode,
                 filePathDisplay: filePathDisplay,
-                onlyIncludeRootsWithSelectedFiles: false,
+                onlyIncludeRootsWithSelectedFiles: presentationMode == .selected,
                 includeLegend: false,
                 showCodeMapMarkers: showCodeMapMarkers,
                 rootScope: lookupContext.rootScope,
@@ -6826,16 +7143,40 @@ final class MCPServerViewModel: ObservableObject {
             lookupContext: lookupContext,
             profile: .mcpRead
         )
-        if fileTree.rootCount == 0 {
+        let selectedProjectionIsEmpty = presentationMode == .selected
+            && selection.manualCodemapPaths.isEmpty
+            && fileTree.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if fileTree.rootCount == 0 || selectedProjectionIsEmpty {
             let hasStartPath = startPath?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-            let msg = await workspaceContextMessage(forOperation: MCPWindowToolName.getFileTree, path: hasStartPath ? startPath : nil)
+            let selectedPathsUnavailable = presentationMode == .selected && !hasStartPath
+            let msg = if selectedPathsUnavailable {
+                "No selected files could be resolved in the loaded workspace."
+            } else if hasStartPath {
+                await workspaceContextMessage(forOperation: MCPWindowToolName.getFileTree, path: startPath)
+            } else {
+                "The resolved workspace has no configured roots."
+            }
+            let emptyReason: MCPStoreBackedFileTreeEmptyReason = if hasStartPath {
+                .requestedPathOutsideLoadedRoots
+            } else if presentationMode == .selected {
+                .selectionEmpty
+            } else {
+                .rootProjectionEmpty
+            }
+            let note = if selectedPathsUnavailable {
+                "Selected files are unavailable"
+            } else if hasStartPath {
+                "Requested path is outside the loaded roots"
+            } else {
+                "No roots configured"
+            }
             return (FileTreeResult(
                 tree: msg,
                 usedSelectedMarker: false,
                 usedCodeMapMarker: false,
                 wasTruncated: false,
-                note: hasStartPath ? "Requested path is outside the loaded roots" : "No workspace loaded"
-            ), 0)
+                note: note
+            ), 0, emptyReason)
         }
 
         return (FileTreeResult(
@@ -6844,7 +7185,7 @@ final class MCPServerViewModel: ObservableObject {
             usedCodeMapMarker: showCodeMapMarkers && fileTree.content.contains(" +"),
             wasTruncated: false,
             note: nil
-        ), fileTree.rootCount)
+        ), fileTree.rootCount, nil)
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowRoutingService.swift
@@ -206,6 +206,10 @@ public struct BindContextResponse: Codable, Sendable {
     public let createdWorkspace: Bool?
     public let normalizedWorkingDirs: [String]?
     public let note: String?
+    public let error: String?
+    public let errorCode: String?
+    public let retryable: Bool?
+    public let retryAfterMilliseconds: Int?
 
     private enum CodingKeys: String, CodingKey {
         case windows
@@ -217,6 +221,10 @@ public struct BindContextResponse: Codable, Sendable {
         case createdWorkspace = "created_workspace"
         case normalizedWorkingDirs = "normalized_working_dirs"
         case note
+        case error
+        case errorCode = "error_code"
+        case retryable
+        case retryAfterMilliseconds = "retry_after_ms"
     }
 
     public init(
@@ -228,7 +236,11 @@ public struct BindContextResponse: Codable, Sendable {
         createdTab: Bool? = nil,
         createdWorkspace: Bool? = nil,
         normalizedWorkingDirs: [String]? = nil,
-        note: String? = nil
+        note: String? = nil,
+        error: String? = nil,
+        errorCode: String? = nil,
+        retryable: Bool? = nil,
+        retryAfterMilliseconds: Int? = nil
     ) {
         self.windows = windows
         self.binding = binding
@@ -239,6 +251,10 @@ public struct BindContextResponse: Codable, Sendable {
         self.createdWorkspace = createdWorkspace
         self.normalizedWorkingDirs = normalizedWorkingDirs
         self.note = note
+        self.error = error
+        self.errorCode = errorCode
+        self.retryable = retryable
+        self.retryAfterMilliseconds = retryAfterMilliseconds
     }
 }
 
@@ -325,6 +341,7 @@ final class WindowRoutingService: Service {
     // ---------------------------------------------------------------------
     private let windowStates: WindowStatesManager
     private let networkMgr: ServerNetworkManager
+    private let setActiveWindowForCurrentConnection: @Sendable (Int) async throws -> Void
 
     /// Thread-safe tools storage. Routing definitions are static in M1; disabled-tool
     /// filtering and window selection are applied from live state outside this cache.
@@ -337,10 +354,14 @@ final class WindowRoutingService: Service {
     /// ---------------------------------------------------------------------
     init(
         windowStates: WindowStatesManager,
-        networkMgr: ServerNetworkManager
+        networkMgr: ServerNetworkManager,
+        setActiveWindowForCurrentConnection: (@Sendable (Int) async throws -> Void)? = nil
     ) {
         self.windowStates = windowStates
         self.networkMgr = networkMgr
+        self.setActiveWindowForCurrentConnection = setActiveWindowForCurrentConnection ?? { windowID in
+            try await networkMgr.setActiveWindowForCurrentConnection(windowID)
+        }
     }
 
     /// Materializes the static M1 routing definitions without publishing them.
@@ -720,6 +741,11 @@ final class WindowRoutingService: Service {
         let matchedBy: String
         let createdTab: Bool
         let normalizedWorkingDirs: [String]?
+    }
+
+    private enum BindTargetCurrentness {
+        case exactContext
+        case activeTab
     }
 
     private struct WorkingDirsBindResolution {
@@ -1868,53 +1894,62 @@ final class WindowRoutingService: Service {
         _ target: ResolvedBindTarget,
         connectionID: UUID,
         clientName: String?,
-        expectedWorkingDirsResolution: MCPServerViewModel.ProspectiveFileToolLookupResolution? = nil,
-        bindingAlreadyMatches: Bool = false
-    ) async throws {
+        expectedFileAuthority: MCPServerViewModel.FrozenFileToolAuthority? = nil,
+        currentness: BindTargetCurrentness = .activeTab
+    ) async throws -> Bool {
         guard let targetWindow = windowStates.allWindows.first(where: { $0.windowID == target.windowID }) else {
             throw MCPError.invalidParams("Window \(target.windowID) not found")
         }
-        if let expectedWorkingDirsResolution {
-            let currentTarget = try? resolveActiveTabBindTarget(
-                windowID: target.windowID,
-                expectedWorkspaceID: target.workspaceID,
-                matchedBy: target.matchedBy,
-                normalizedWorkingDirs: target.normalizedWorkingDirs
-            )
-            guard currentTarget?.tabID == target.tabID else {
-                throw staleWorkingDirsTargetError()
+        try await setActiveWindowForCurrentConnection(target.windowID)
+        var bindingChanged = false
+        if let expectedFileAuthority {
+            guard bindTargetIsCurrent(target, currentness: currentness) else {
+                throw staleBindTargetError()
             }
-            let didBind = try await targetWindow.mcpServer.performIfProspectiveFileToolLookupResolutionIsCurrent(
-                expectedWorkingDirsResolution,
+            let didBind = try await targetWindow.mcpServer.performIfFileToolAuthorityIsCurrent(
+                expectedFileAuthority,
                 tabID: target.tabID,
                 workspaceID: target.workspaceID
             ) {
-                let commitTarget = try? resolveActiveTabBindTarget(
-                    windowID: target.windowID,
-                    expectedWorkspaceID: target.workspaceID,
-                    matchedBy: target.matchedBy,
-                    normalizedWorkingDirs: target.normalizedWorkingDirs
-                )
-                guard commitTarget?.tabID == target.tabID else {
-                    throw staleWorkingDirsTargetError()
+                guard bindTargetIsCurrent(target, currentness: currentness) else {
+                    throw staleBindTargetError()
                 }
-                guard !bindingAlreadyMatches else { return }
+                let existingBinding = targetWindow.mcpServer.connectionBindingSnapshot(
+                    forConnection: connectionID
+                )
+                guard !connectionBindingMatchesTarget(existingBinding, target: target) else {
+                    targetWindow.mcpServer.updateBoundFileToolAuthority(
+                        connectionID: connectionID,
+                        tabID: target.tabID,
+                        workspaceID: target.workspaceID,
+                        authority: expectedFileAuthority
+                    )
+                    return
+                }
                 try targetWindow.mcpServer.bindTabForConnection(
                     connectionID: connectionID,
                     clientName: clientName,
                     tabID: target.tabID,
                     workspaceID: target.workspaceID,
-                    windowID: target.windowID
+                    windowID: target.windowID,
+                    frozenFileToolAuthority: expectedFileAuthority
                 )
                 clearNonRunScopedBindingsAcrossWindows(
                     for: connectionID,
                     excludingWindowID: target.windowID
                 )
+                bindingChanged = true
             }
             guard didBind else {
-                throw staleWorkingDirsTargetError()
+                throw staleBindTargetError()
             }
-        } else if !bindingAlreadyMatches {
+        } else {
+            let existingBinding = targetWindow.mcpServer.connectionBindingSnapshot(
+                forConnection: connectionID
+            )
+            guard !connectionBindingMatchesTarget(existingBinding, target: target) else {
+                return false
+            }
             try targetWindow.mcpServer.bindTabForConnection(
                 connectionID: connectionID,
                 clientName: clientName,
@@ -1926,14 +1961,91 @@ final class WindowRoutingService: Service {
                 for: connectionID,
                 excludingWindowID: target.windowID
             )
+            bindingChanged = true
         }
-        try await networkMgr.setActiveWindowForCurrentConnection(target.windowID)
+        return bindingChanged
     }
 
-    private func staleWorkingDirsTargetError() -> MCPError {
+    private func bindAuthorityFailureResponse(
+        _ failure: MCPServerViewModel.FileToolAuthorityFailure,
+        connectionID: UUID
+    ) async -> BindContextResponse {
+        await BindContextResponse(
+            binding: currentBindingSummary(for: connectionID),
+            changed: false,
+            error: failure.localizedDescription,
+            errorCode: failure.errorCode,
+            retryable: failure.retryable,
+            retryAfterMilliseconds: MCPServerViewModel.FileToolAuthorityFailure.retryAfterMilliseconds
+        )
+    }
+
+    private func connectionBindingMatchesTarget(
+        _ binding: MCPServerViewModel.ConnectionBindingSnapshot,
+        target: ResolvedBindTarget
+    ) -> Bool {
+        binding.windowID == target.windowID
+            && binding.workspaceID == target.workspaceID
+            && binding.tabID == target.tabID
+            && binding.explicitlyBound
+            && binding.runID == nil
+    }
+
+    private func bindTargetIsCurrent(
+        _ target: ResolvedBindTarget,
+        currentness: BindTargetCurrentness
+    ) -> Bool {
+        switch currentness {
+        case .exactContext:
+            guard let window = windowStates.allWindows.first(where: { $0.windowID == target.windowID }),
+                  let candidate = window.workspaceManager.storedBindingCandidate(forContextID: target.tabID),
+                  candidate.workspaceID == target.workspaceID
+            else { return false }
+            return WorkspaceRootSetKey(paths: candidate.repoPaths) == WorkspaceRootSetKey(paths: target.repoPaths)
+        case .activeTab:
+            let currentTarget = try? resolveActiveTabBindTarget(
+                windowID: target.windowID,
+                expectedWorkspaceID: target.workspaceID,
+                matchedBy: target.matchedBy,
+                normalizedWorkingDirs: target.normalizedWorkingDirs
+            )
+            return currentTarget?.tabID == target.tabID
+        }
+    }
+
+    #if DEBUG
+        func test_bindTarget(
+            windowID: Int,
+            workspaceID: UUID,
+            tabID: UUID,
+            repoPaths: [String],
+            connectionID: UUID,
+            authority: MCPServerViewModel.FrozenFileToolAuthority
+        ) async throws -> Bool {
+            try await bindTarget(
+                ResolvedBindTarget(
+                    windowID: windowID,
+                    workspaceID: workspaceID,
+                    workspaceName: "Test Workspace",
+                    tabID: tabID,
+                    tabName: "Test Context",
+                    repoPaths: repoPaths,
+                    matchedBy: "context_id",
+                    createdTab: false,
+                    normalizedWorkingDirs: nil
+                ),
+                connectionID: connectionID,
+                clientName: "BindContextFileAuthorityTests",
+                expectedFileAuthority: authority,
+                currentness: .exactContext
+            )
+        }
+    #endif
+
+    private func staleBindTargetError() -> MCPError {
         MCPError.invalidRequest(
-            "The working_dirs target changed while its root projection was being resolved. " +
-                "The existing MCP binding was not changed. Bind again with the same working_dirs."
+            "The requested bind target changed while its root authority was being resolved. " +
+                "The existing MCP binding was not changed. Bind the intended context again."
         )
     }
 
@@ -1978,9 +2090,9 @@ final class WindowRoutingService: Service {
     private func ensureWorkingDirsRootProjectionIsLoaded(
         _ target: ResolvedBindTarget,
         requestedRoots: [String]
-    ) async throws -> MCPServerViewModel.ProspectiveFileToolLookupResolution {
+    ) async throws -> MCPServerViewModel.FrozenFileToolAuthority {
         let window = try resolveWindowForBinding(windowID: target.windowID)
-        let resolution = try await window.mcpServer.resolveProspectiveFileToolLookupContext(
+        let resolution = try await window.mcpServer.resolveFileToolAuthority(
             tabID: target.tabID,
             workspaceID: target.workspaceID
         )
@@ -2001,6 +2113,16 @@ final class WindowRoutingService: Service {
             )
         }
         return resolution
+    }
+
+    private func ensureBindTargetFileAuthority(
+        _ target: ResolvedBindTarget
+    ) async throws -> MCPServerViewModel.FrozenFileToolAuthority {
+        let window = try resolveWindowForBinding(windowID: target.windowID)
+        return try await window.mcpServer.resolveFileToolAuthority(
+            tabID: target.tabID,
+            workspaceID: target.workspaceID
+        )
     }
 
     private func listBindContextWindows(
@@ -2134,112 +2256,102 @@ final class WindowRoutingService: Service {
                     guard let connectionID else {
                         throw MCPError.internalError("No active connection context")
                     }
-                    let previousBinding = await currentBindingSummary(for: connectionID)
                     let clientName = await networkMgr.currentClientIdentifier()
-                    switch request.matchKind {
-                    case .contextID:
-                        let connectionPreferredWindow = await networkMgr.selectedWindow(for: connectionID)
-                        let target = try await MainActor.run {
-                            try self.resolveContextIDBindTarget(contextID: request.contextID!, windowID: request.windowID, connectionPreferredWindowID: connectionPreferredWindow)
-                        }
-                        let unchanged = previousBinding.bindingKind == "tab_context"
-                            && previousBinding.windowID == target.windowID
-                            && previousBinding.contextID == target.tabID
-                            && previousBinding.explicit
-                            && !previousBinding.runScoped
+                    do {
+                        switch request.matchKind {
+                        case .contextID:
+                            let connectionPreferredWindow = await networkMgr.selectedWindow(for: connectionID)
+                            let target = try await MainActor.run {
+                                try self.resolveContextIDBindTarget(contextID: request.contextID!, windowID: request.windowID, connectionPreferredWindowID: connectionPreferredWindow)
+                            }
+                            let authority = try await ensureBindTargetFileAuthority(target)
+                            let changed = try await bindTarget(
+                                target,
+                                connectionID: connectionID,
+                                clientName: clientName,
+                                expectedFileAuthority: authority,
+                                currentness: .exactContext
+                            )
 
-                        if !unchanged {
-                            try await bindTarget(target, connectionID: connectionID, clientName: clientName)
-                        } else {
-                            try await networkMgr.setActiveWindowForCurrentConnection(target.windowID)
-                        }
-
-                        let binding = await currentBindingSummary(for: connectionID)
-                        let note = await MainActor.run { self.bindContextWindowNote(windowID: binding.windowID) }
-                        return BindContextResponse(
-                            binding: binding,
-                            changed: !unchanged,
-                            matchedBy: target.matchedBy,
-                            createdTab: target.createdTab,
-                            normalizedWorkingDirs: target.normalizedWorkingDirs,
-                            note: note
-                        )
-                    case .workingDirs:
-                        let target = try await resolveWorkingDirsBindTarget(
-                            workingDirs: request.workingDirs,
-                            windowID: request.windowID,
-                            createIfMissing: request.createIfMissing,
-                            tabName: request.tabName,
-                            connectionID: connectionID
-                        )
-
-                        let tabTarget = try await MainActor.run {
-                            try self.resolveActiveTabBindTarget(
-                                windowID: target.windowID,
-                                expectedWorkspaceID: target.workspaceID,
+                            let binding = await currentBindingSummary(for: connectionID)
+                            let note = await MainActor.run { self.bindContextWindowNote(windowID: binding.windowID) }
+                            return BindContextResponse(
+                                binding: binding,
+                                changed: changed,
                                 matchedBy: target.matchedBy,
-                                normalizedWorkingDirs: target.normalizedWorkingDirs
+                                createdTab: target.createdTab,
+                                normalizedWorkingDirs: target.normalizedWorkingDirs,
+                                note: note
                             )
-                        }
-                        let prospectiveLookupResolution = try await ensureWorkingDirsRootProjectionIsLoaded(
-                            tabTarget,
-                            requestedRoots: target.normalizedWorkingDirs
-                        )
-                        let unchanged = previousBinding.bindingKind == "tab_context"
-                            && previousBinding.windowID == tabTarget.windowID
-                            && previousBinding.contextID == tabTarget.tabID
-                            && previousBinding.explicit
-                            && !previousBinding.runScoped
-                        try await bindTarget(
-                            tabTarget,
-                            connectionID: connectionID,
-                            clientName: clientName,
-                            expectedWorkingDirsResolution: prospectiveLookupResolution,
-                            bindingAlreadyMatches: unchanged
-                        )
-
-                        let binding = await currentBindingSummary(for: connectionID)
-                        let note = await MainActor.run { self.bindContextWindowNote(windowID: binding.windowID) }
-                        return BindContextResponse(
-                            binding: binding,
-                            changed: binding != previousBinding,
-                            matchedBy: target.matchedBy,
-                            createdTab: false,
-                            createdWorkspace: target.createdWorkspace,
-                            normalizedWorkingDirs: target.normalizedWorkingDirs,
-                            note: note
-                        )
-                    case .windowID:
-                        let windowID = request.windowID!
-                        let target = try await MainActor.run {
-                            try self.resolveActiveTabBindTarget(
-                                windowID: windowID,
-                                matchedBy: BindContextRequest.MatchKind.windowID.rawValue
+                        case .workingDirs:
+                            let target = try await resolveWorkingDirsBindTarget(
+                                workingDirs: request.workingDirs,
+                                windowID: request.windowID,
+                                createIfMissing: request.createIfMissing,
+                                tabName: request.tabName,
+                                connectionID: connectionID
                             )
-                        }
-                        let unchanged = previousBinding.bindingKind == "tab_context"
-                            && previousBinding.windowID == target.windowID
-                            && previousBinding.contextID == target.tabID
-                            && previousBinding.explicit
-                            && !previousBinding.runScoped
 
-                        if !unchanged {
-                            try await bindTarget(target, connectionID: connectionID, clientName: clientName)
-                        } else {
-                            try await networkMgr.setActiveWindowForCurrentConnection(windowID)
-                        }
+                            let tabTarget = try await MainActor.run {
+                                try self.resolveActiveTabBindTarget(
+                                    windowID: target.windowID,
+                                    expectedWorkspaceID: target.workspaceID,
+                                    matchedBy: target.matchedBy,
+                                    normalizedWorkingDirs: target.normalizedWorkingDirs
+                                )
+                            }
+                            let prospectiveLookupResolution = try await ensureWorkingDirsRootProjectionIsLoaded(
+                                tabTarget,
+                                requestedRoots: target.normalizedWorkingDirs
+                            )
+                            let changed = try await bindTarget(
+                                tabTarget,
+                                connectionID: connectionID,
+                                clientName: clientName,
+                                expectedFileAuthority: prospectiveLookupResolution
+                            )
 
-                        let binding = await currentBindingSummary(for: connectionID)
-                        let note = await MainActor.run { self.bindContextWindowNote(windowID: binding.windowID) }
-                        return BindContextResponse(
-                            binding: binding,
-                            changed: !unchanged,
-                            matchedBy: BindContextRequest.MatchKind.windowID.rawValue,
-                            createdTab: false,
-                            note: note
-                        )
-                    case .none:
-                        throw MCPError.invalidParams("bind_context op='bind' requires context_id, working_dirs, or window_id.")
+                            let binding = await currentBindingSummary(for: connectionID)
+                            let note = await MainActor.run { self.bindContextWindowNote(windowID: binding.windowID) }
+                            return BindContextResponse(
+                                binding: binding,
+                                changed: changed,
+                                matchedBy: target.matchedBy,
+                                createdTab: false,
+                                createdWorkspace: target.createdWorkspace,
+                                normalizedWorkingDirs: target.normalizedWorkingDirs,
+                                note: note
+                            )
+                        case .windowID:
+                            let windowID = request.windowID!
+                            let target = try await MainActor.run {
+                                try self.resolveActiveTabBindTarget(
+                                    windowID: windowID,
+                                    matchedBy: BindContextRequest.MatchKind.windowID.rawValue
+                                )
+                            }
+                            let authority = try await ensureBindTargetFileAuthority(target)
+                            let changed = try await bindTarget(
+                                target,
+                                connectionID: connectionID,
+                                clientName: clientName,
+                                expectedFileAuthority: authority
+                            )
+
+                            let binding = await currentBindingSummary(for: connectionID)
+                            let note = await MainActor.run { self.bindContextWindowNote(windowID: binding.windowID) }
+                            return BindContextResponse(
+                                binding: binding,
+                                changed: changed,
+                                matchedBy: BindContextRequest.MatchKind.windowID.rawValue,
+                                createdTab: false,
+                                note: note
+                            )
+                        case .none:
+                            throw MCPError.invalidParams("bind_context op='bind' requires context_id, working_dirs, or window_id.")
+                        }
+                    } catch let failure as MCPServerViewModel.FileToolAuthorityFailure {
+                        return await bindAuthorityFailureResponse(failure, connectionID: connectionID)
                     }
                 }
             }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAppPhysicalCapabilityAdapters.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAppPhysicalCapabilityAdapters.swift
@@ -20,6 +20,12 @@ enum MCPAppFileReadResult {
     case nonSelecting(reply: ToolResultDTOs.ReadFileReply)
 }
 
+enum MCPStoreBackedFileTreeEmptyReason: Equatable {
+    case requestedPathOutsideLoadedRoots
+    case selectionEmpty
+    case rootProjectionEmpty
+}
+
 /// Namespace for independently injected app-process capability families.
 /// No provider receives an unrestricted aggregate of every app capability.
 enum MCPAppPhysicalCapabilityAdapters {
@@ -176,6 +182,7 @@ enum MCPAppPhysicalCapabilityAdapters {
     ) async -> FrozenPromptGitReviewContext
     typealias ParseManageSelectionInputs = @Sendable (_ rawPaths: [String], _ slicesValue: Value?) -> MCPServerViewModel.ManageSelectionInputs
     typealias ResolveFileToolLookupContext = @MainActor @Sendable (_ metadata: MCPServerViewModel.RequestMetadata) async -> WorkspaceLookupContext
+    typealias RequiredFileToolLookupContext = @MainActor @Sendable (_ metadata: MCPServerViewModel.RequestMetadata) async throws -> MCPServerViewModel.FrozenFileToolAuthority
     typealias ResolveMutationFileToolContext = @MainActor @Sendable (
         _ metadata: MCPServerViewModel.RequestMetadata,
         _ toolName: String
@@ -283,7 +290,7 @@ enum MCPAppPhysicalCapabilityAdapters {
     typealias PerformFileAction = @MainActor @Sendable (_ action: String, _ path: String, _ content: String?, _ newPath: String?, _ ifExists: String?, _ operationID: String) async throws -> MCPFileActionMutationAcknowledgement
     typealias BuildCodeStructureDTO = @MainActor @Sendable (_ files: [WorkspaceFileRecord], _ request: MCPServerViewModel.CodeStructureRequest, _ includePathNotFoundIssue: Bool, _ requestedPaths: [String], _ lookupContext: WorkspaceLookupContext) async throws -> ToolResultDTOs.CodeStructureReplyDTO
     typealias ResolveFilesForCodeStructure = @MainActor @Sendable (_ paths: [String], _ lookupRootScope: WorkspaceLookupRootScope, _ maximumSeedCount: Int) async throws -> [WorkspaceFileRecord]
-    typealias BuildStoreBackedFileTreeResult = @MainActor @Sendable (_ mode: String, _ maxDepth: Int?, _ startPath: String?, _ lookupContext: WorkspaceLookupContext) async throws -> (result: FileTreeResult, rootCount: Int)
+    typealias BuildStoreBackedFileTreeResult = @MainActor @Sendable (_ mode: String, _ maxDepth: Int?, _ startPath: String?, _ lookupContext: WorkspaceLookupContext) async throws -> (result: FileTreeResult, rootCount: Int, emptyReason: MCPStoreBackedFileTreeEmptyReason?)
     typealias ReadFile = @MainActor @Sendable (
         _ input: WorkspaceExactFileInput,
         _ startLine1Based: Int?,
@@ -302,16 +309,18 @@ enum MCPAppPhysicalCapabilityAdapters {
         _ reply: ToolResultDTOs.ReadFileReply,
         _ requestedPath: String,
         _ absolutePhysicalPath: String,
-        _ metadata: MCPServerViewModel.RequestMetadata
-    ) async throws -> Void
+        _ metadata: MCPServerViewModel.RequestMetadata,
+        _ authority: MCPServerViewModel.FrozenFileToolAuthority
+    ) async throws -> Bool
     typealias DrainReadFileAutoSelection = @MainActor @Sendable (_ metadata: MCPServerViewModel.RequestMetadata, _ requirement: MCPReadFileAutoSelectionCoordinator.DrainRequirement) async throws -> MCPReadFileAutoSelectionCoordinator.DrainResult
     typealias EnqueueFileSearchAutoSelection = @MainActor @Sendable (
         _ mode: SearchMode,
         _ contextLines: Int,
         _ reply: ToolResultDTOs.SearchResultDTO,
         _ resolvedPhysicalPaths: [String],
-        _ metadata: MCPServerViewModel.RequestMetadata
-    ) async throws -> Void
+        _ metadata: MCPServerViewModel.RequestMetadata,
+        _ authority: MCPServerViewModel.FrozenFileToolAuthority
+    ) async throws -> Bool
     typealias WorkspaceContextMessage = @MainActor @Sendable (_ operation: String?, _ path: String?) async -> String
     typealias ParseCopyPresetSelector = @Sendable (_ value: Value?) -> MCPServerViewModel.CopyPresetSelector?
     typealias ResolveCopyPreset = @MainActor @Sendable (_ selector: MCPServerViewModel.CopyPresetSelector) -> CopyPreset?
@@ -386,6 +395,7 @@ enum MCPAppPhysicalCapabilityAdapters {
         let workspaceSearch: WorkspaceSearch
         let parseManageSelectionInputs: ParseManageSelectionInputs
         let resolveFileToolLookupContext: ResolveFileToolLookupContext
+        let requiredFileToolLookupContext: RequiredFileToolLookupContext
         let resolveMutationFileToolContext: ResolveMutationFileToolContext
         let stabilizedVirtualSelection: StabilizedVirtualSelection
         let freezePromptGitReviewContext: FreezePromptGitReviewContext

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -3,19 +3,30 @@ import JSONSchema
 import MCP
 import Ontology
 import RepoPromptDomainRuntime
+import RepoPromptShared
 
 @MainActor
 final class MCPFileToolProvider: MCPAppToolProviding {
     let group: MCPAppToolGroup = .files
 
     private let runtime: MCPAppToolBinder
-    private typealias Dependencies = (
+    typealias Dependencies = (
         context: MCPAppPhysicalCapabilityAdapters.Context,
         selection: MCPAppPhysicalCapabilityAdapters.Selection,
         files: MCPAppPhysicalCapabilityAdapters.Files
     )
 
     private let dependencies: Dependencies
+
+    private struct ReadAuthority {
+        let metadata: MCPServerViewModel.RequestMetadata
+        let frozen: MCPServerViewModel.FrozenFileToolAuthority
+        let dependencies: Dependencies
+
+        var lookupContext: WorkspaceLookupContext {
+            frozen.lookupContext
+        }
+    }
 
     init(runtime: MCPAppToolBinder, context: MCPAppPhysicalCapabilityAdapters.Context, selection: MCPAppPhysicalCapabilityAdapters.Selection, files: MCPAppPhysicalCapabilityAdapters.Files) {
         self.runtime = runtime
@@ -33,40 +44,139 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         args: [String: Value],
         sideEffects: MCPDomainReadSideEffectEmitter
     ) async throws -> Value {
-        switch toolName {
-        case MCPWindowToolName.getCodeStructure:
-            try await executeGetCodeStructure(args: args, appContext: appContext)
-        case MCPWindowToolName.getFileTree:
-            try await executeGetFileTree(args: args, appContext: appContext)
-        case MCPWindowToolName.readFile:
-            try await executeReadFile(args: args, appContext: appContext, sideEffects: sideEffects)
-        case MCPWindowToolName.search:
-            try await executeFileSearchToolValue(args: args, appContext: appContext, sideEffects: sideEffects)
-        default:
-            throw MCPError.invalidParams("Unsupported file read tool: \(toolName)")
+        do {
+            let authority = try await readAuthority(appContext)
+            return switch toolName {
+            case MCPWindowToolName.getCodeStructure:
+                try await executeGetCodeStructure(args: args, authority: authority)
+            case MCPWindowToolName.getFileTree:
+                try await executeGetFileTree(args: args, authority: authority)
+            case MCPWindowToolName.readFile:
+                try await executeReadFile(args: args, authority: authority, sideEffects: sideEffects)
+            case MCPWindowToolName.search:
+                try await executeFileSearchToolValue(args: args, authority: authority, sideEffects: sideEffects)
+            default:
+                throw MCPError.invalidParams("Unsupported file read tool: \(toolName)")
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let failure as MCPServerViewModel.FileToolAuthorityFailure {
+            return try Self.authorityFailureValue(toolName: toolName, args: args, failure: failure)
         }
     }
 
     private func readAuthority(
         _ appContext: MCPServerViewModel.DomainReadAppExecutionContext?
-    ) async -> (
-        metadata: MCPServerViewModel.RequestMetadata,
-        lookupContext: WorkspaceLookupContext
-    ) {
+    ) async throws -> ReadAuthority {
         if let appContext {
-            return (appContext.metadata, appContext.lookupContext)
+            guard let frozen = appContext.frozenFileToolAuthority else {
+                throw MCPServerViewModel.FileToolAuthorityFailure.unavailable
+            }
+            let authority = ReadAuthority(
+                metadata: appContext.metadata,
+                frozen: frozen,
+                dependencies: appContext.fileToolDependencies
+            )
+            try await validate(authority)
+            return authority
         }
         let metadata = await dependencies.context.captureRequestMetadata()
-        return await (metadata, dependencies.selection.resolveFileToolLookupContext(metadata))
+        let frozen = try await dependencies.selection.requiredFileToolLookupContext(metadata)
+        return ReadAuthority(metadata: metadata, frozen: frozen, dependencies: dependencies)
+    }
+
+    private func validate(_ authority: ReadAuthority) async throws {
+        guard let workspaceManager = authority.dependencies.context.workspaceManager else {
+            throw MCPServerViewModel.FileToolAuthorityFailure.unavailable
+        }
+        try await authority.frozen.validate(
+            workspaceManager: workspaceManager,
+            store: authority.dependencies.context.promptVM.workspaceFileContextStore
+        )
+    }
+
+    nonisolated static func authorityFailureValue(
+        toolName: String,
+        args: [String: Value],
+        failure: MCPServerViewModel.FileToolAuthorityFailure
+    ) throws -> Value {
+        let message = failure.localizedDescription
+        let retryAfter = MCPServerViewModel.FileToolAuthorityFailure.retryAfterMilliseconds
+        switch toolName {
+        case MCPWindowToolName.search:
+            return try Value(ToolResultDTOs.SearchResultDTO(
+                totalMatches: 0,
+                totalFiles: 0,
+                contentMatches: 0,
+                pathMatches: 0,
+                limitHit: false,
+                perFileCounts: [],
+                pathMatchLines: [],
+                contentMatchGroups: [],
+                errorMessage: message,
+                errorCode: failure.errorCode,
+                retryable: failure.retryable,
+                retryAfterMilliseconds: retryAfter,
+                suggestion: "Retry after workspace restoration settles or bind the intended context again."
+            ))
+        case MCPWindowToolName.readFile:
+            let path = args["path"]?.stringValue ?? ""
+            return try Value(ToolResultDTOs.ReadFileReply(
+                content: "",
+                totalLines: 0,
+                firstLine: 0,
+                lastLine: 0,
+                message: message,
+                displayPath: path,
+                errorMessage: message,
+                errorCode: failure.errorCode,
+                retryable: failure.retryable,
+                retryAfterMilliseconds: retryAfter
+            ))
+        case MCPWindowToolName.getFileTree:
+            return try Value(ToolResultDTOs.FileTreeDTO(
+                rootsCount: 0,
+                usesLegend: false,
+                tree: message,
+                note: "Workspace authority unavailable",
+                wasTruncated: false,
+                errorMessage: message,
+                errorCode: failure.errorCode,
+                retryable: failure.retryable,
+                retryAfterMilliseconds: retryAfter
+            ))
+        case MCPWindowToolName.getCodeStructure:
+            let size = args["size"]?.stringValue.flatMap(WorkspaceCodemapGraphOutputSize.init(rawValue:)) ?? .medium
+            let issue = ToolResultDTOs.CodeStructureReplyDTO.IssueDTO(
+                code: failure.errorCode,
+                phase: "workspace_authority",
+                path: nil,
+                retryable: failure.retryable,
+                retryAfterMilliseconds: retryAfter,
+                attempted: nil,
+                limit: nil,
+                message: message
+            )
+            return try Value(ToolResultDTOs.CodeStructureReplyDTO(
+                status: .unavailable,
+                size: size,
+                roots: [],
+                files: [],
+                summary: .init(seeds: 0, nodes: 0, edges: 0, files: 0, tokens: 0),
+                issues: [issue],
+                retry: .init(retryable: failure.retryable, retryAfterMilliseconds: retryAfter),
+                worktreeScope: nil
+            ))
+        default:
+            throw failure
+        }
     }
 
     private func withActiveWorktreeStartupBenchmarkTag<T>(
-        appContext: MCPServerViewModel.DomainReadAppExecutionContext?,
+        lookupContext: WorkspaceLookupContext,
         _ operation: () async throws -> T
     ) async rethrows -> T {
         #if DEBUG
-            let authority = await readAuthority(appContext)
-            let lookupContext = authority.lookupContext
             let tag = lookupContext.bindingProjection.map(\.sessionID).flatMap {
                 WorktreeStartupBenchmarkDiagnostics.shared.activeBenchmarkMetricTag(
                     agentSessionID: $0
@@ -162,9 +272,10 @@ final class MCPFileToolProvider: MCPAppToolProviding {
 
     private func executeGetCodeStructure(
         args: [String: Value],
-        appContext: MCPServerViewModel.DomainReadAppExecutionContext?
+        authority: ReadAuthority
     ) async throws -> Value {
-        try await withActiveWorktreeStartupBenchmarkTag(appContext: appContext) {
+        let dependencies = authority.dependencies
+        return try await withActiveWorktreeStartupBenchmarkTag(lookupContext: authority.lookupContext) {
             try await MCPToolWorkCountDiagnostics.withGitInvocation(
                 operation: MCPWindowToolName.getCodeStructure
             ) {
@@ -236,7 +347,6 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                 )
 
                 await MCPToolExecutionHandlerPhaseContext.report(.getCodeStructureSeedResolution)
-                let authority = await readAuthority(appContext)
                 let metadata = authority.metadata
                 try Task.checkCancellation()
                 let lookupContext = authority.lookupContext
@@ -297,6 +407,7 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                     lookupContext
                 )
                 try Task.checkCancellation()
+                try await validate(authority)
                 return try Value(reply)
             }
         }
@@ -304,15 +415,16 @@ final class MCPFileToolProvider: MCPAppToolProviding {
 
     private func executeGetFileTree(
         args: [String: Value],
-        appContext: MCPServerViewModel.DomainReadAppExecutionContext?
+        authority: ReadAuthority
     ) async throws -> Value {
+        let dependencies = authority.dependencies
         await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeRequestResolution)
-        return try await withActiveWorktreeStartupBenchmarkTag(appContext: appContext) {
+        return try await withActiveWorktreeStartupBenchmarkTag(lookupContext: authority.lookupContext) {
             let type = args["type"]?.stringValue ?? "files"
             switch type {
             case "roots":
                 let filePathDisplay = await MainActor.run { dependencies.context.promptVM.filePathDisplayOption }
-                let lookupContext = await readAuthority(appContext).lookupContext
+                let lookupContext = authority.lookupContext
                 await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeRequestResolution, transition: .completed)
                 await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeIngressWait)
                 _ = await dependencies.context.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
@@ -325,15 +437,26 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                     request: WorkspaceFileTreeSnapshotRequest(mode: .full, filePathDisplay: filePathDisplay, onlyIncludeRootsWithSelectedFiles: false, includeLegend: false, showCodeMapMarkers: false, rootScope: lookupContext.rootScope),
                     profile: .mcpRead
                 )
+                try await validate(authority)
                 if snapshot.roots.isEmpty {
-                    let msg = await dependencies.files.workspaceContextMessage(MCPWindowToolName.getFileTree, nil)
+                    guard authority.frozen.rootCatalogSnapshot.isGenuinelyRootless else {
+                        throw MCPServerViewModel.FileToolAuthorityFailure.mismatchedProjection
+                    }
                     await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeConstruction, transition: .completed)
-                    return try Value(ToolResultDTOs.FileTreeDTO(rootsCount: 0, usesLegend: false, tree: msg, note: "No workspace loaded", wasTruncated: false, worktreeScope: worktreeScope))
+                    return try Value(ToolResultDTOs.FileTreeDTO(
+                        rootsCount: 0,
+                        usesLegend: false,
+                        tree: "The resolved workspace has no configured roots.",
+                        note: "No roots configured",
+                        wasTruncated: false,
+                        worktreeScope: worktreeScope
+                    ))
                 }
                 let rootLines = snapshot.roots.map { root in
                     lookupContext.bindingProjection?.projectedLogicalDisplayPath(forPhysicalPath: root.fullPath, display: .full) ?? root.fullPath
                 }
                 await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeConstruction, transition: .completed)
+                try await validate(authority)
                 return try Value(ToolResultDTOs.FileTreeDTO(rootsCount: snapshot.roots.count, usesLegend: false, tree: rootLines.joined(separator: "\n"), note: nil, wasTruncated: false, worktreeScope: worktreeScope))
             case "files":
                 let mode = args["mode"]?.stringValue ?? "auto"
@@ -344,7 +467,6 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                 } else {
                     maxDepth = nil
                 }
-                let authority = await readAuthority(appContext)
                 let metadata = authority.metadata
                 let lookupContext = authority.lookupContext
                 await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeRequestResolution, transition: .completed)
@@ -361,6 +483,12 @@ final class MCPFileToolProvider: MCPAppToolProviding {
                 let worktreeScope = ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: lookupContext.bindingProjection)
                 let resultAndRootCount = try await dependencies.files.buildStoreBackedFileTreeResult(mode, maxDepth, args["path"]?.stringValue, lookupContext)
                 await MCPToolExecutionHandlerPhaseContext.report(.getFileTreeConstruction, transition: .completed)
+                try await validate(authority)
+                if resultAndRootCount.emptyReason == .rootProjectionEmpty,
+                   !authority.frozen.rootCatalogSnapshot.isGenuinelyRootless
+                {
+                    throw MCPServerViewModel.FileToolAuthorityFailure.mismatchedProjection
+                }
                 return try Value(ToolResultDTOs.FileTreeDTO(
                     rootsCount: resultAndRootCount.rootCount,
                     usesLegend: resultAndRootCount.result.usesLegend,
@@ -377,17 +505,18 @@ final class MCPFileToolProvider: MCPAppToolProviding {
 
     private func executeReadFile(
         args: [String: Value],
-        appContext: MCPServerViewModel.DomainReadAppExecutionContext?,
+        authority: ReadAuthority,
         sideEffects: MCPDomainReadSideEffectEmitter
     ) async throws -> Value {
-        try await executeReadFileBody(args: args, appContext: appContext, sideEffects: sideEffects)
+        try await executeReadFileBody(args: args, authority: authority, sideEffects: sideEffects)
     }
 
     private func executeReadFileBody(
         args: [String: Value],
-        appContext: MCPServerViewModel.DomainReadAppExecutionContext?,
+        authority: ReadAuthority,
         sideEffects: MCPDomainReadSideEffectEmitter
     ) async throws -> Value {
+        let dependencies = authority.dependencies
         try Task.checkCancellation()
         await MCPToolExecutionHandlerPhaseContext.report(.readFileRequestResolution)
         EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.ReadFile.providerEntered)
@@ -403,9 +532,6 @@ final class MCPFileToolProvider: MCPAppToolProviding {
             let startLine1Based = startLineFromInteger ?? offsetFromInteger ?? startLineFromString ?? offsetFromString
             let limit = args["limit"]?.intValue ?? args["limit"]?.stringValue.flatMap(Int.init)
             return (path, startLine1Based, limit)
-        }
-        let authority = await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerRequestMetadata) {
-            await readAuthority(appContext)
         }
         let metadata = authority.metadata
         try Task.checkCancellation()
@@ -478,6 +604,7 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         case .workspace: "attempted"
         case .nonSelecting: "skipped"
         }
+        try await validate(authority)
         await MCPToolExecutionHandlerPhaseContext.report(.readFileAutoSelection)
         try await EditFlowPerf.measure(
             EditFlowPerf.Stage.ReadFile.providerAutoSelect,
@@ -486,11 +613,13 @@ final class MCPFileToolProvider: MCPAppToolProviding {
             if case let .workspace(reply, absolutePhysicalPath) = readResult {
                 try await sideEffects.submitAndWait(fingerprint: "read_file_auto_selection") { [weak self] in
                     guard let self else { throw CancellationError() }
-                    try await applyReadFileSideEffect(
+                    _ = try await applyReadFileSideEffect(
                         reply: reply,
                         requestedPath: path,
                         absolutePhysicalPath: absolutePhysicalPath,
-                        metadata: metadata
+                        metadata: metadata,
+                        authority: authority.frozen,
+                        files: dependencies.files
                     )
                 }
             }
@@ -500,6 +629,7 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         let projectedReply = switch readResult {
         case let .workspace(reply, _), let .nonSelecting(reply): reply
         }
+        try await validate(authority)
         let value = try await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.providerValueEncoding) {
             try await MCPProviderProjectionWorker.encode(
                 projectedReply,
@@ -531,7 +661,7 @@ final class MCPFileToolProvider: MCPAppToolProviding {
 
     private func executeFileSearchToolValue(
         args: [String: Value],
-        appContext: MCPServerViewModel.DomainReadAppExecutionContext?,
+        authority: ReadAuthority,
         sideEffects: MCPDomainReadSideEffectEmitter
     ) async throws -> Value {
         EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.Search.providerEntered)
@@ -539,11 +669,12 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         defer { EditFlowPerf.end(EditFlowPerf.Stage.Search.providerTotal, providerTotal) }
         let reply = try await executeFileSearch(
             args: args,
-            appContext: appContext,
+            authority: authority,
             sideEffects: sideEffects
         )
 
         try Task.checkCancellation()
+        try await validate(authority)
         let value = try EditFlowPerf.measure(EditFlowPerf.Stage.Search.providerValueEncoding) {
             try Value(reply)
         }
@@ -553,9 +684,10 @@ final class MCPFileToolProvider: MCPAppToolProviding {
 
     private func executeFileSearch(
         args: [String: Value],
-        appContext: MCPServerViewModel.DomainReadAppExecutionContext?,
+        authority: ReadAuthority,
         sideEffects: MCPDomainReadSideEffectEmitter
     ) async throws -> ToolResultDTOs.SearchResultDTO {
+        let dependencies = authority.dependencies
         try Task.checkCancellation()
         let rawPattern = args["pattern"]?.stringValue ?? ""
         let pattern = rawPattern.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -585,9 +717,6 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         }
 
         let mode = SearchMode(rawValue: modeRaw) ?? .auto
-        let authority = await EditFlowPerf.measure(EditFlowPerf.Stage.Search.providerRequestMetadata) {
-            await readAuthority(appContext)
-        }
         let metadata = authority.metadata
         try Task.checkCancellation()
         let lookupContext = EditFlowPerf.measure(
@@ -901,18 +1030,21 @@ final class MCPFileToolProvider: MCPAppToolProviding {
             )
         )
         try Task.checkCancellation()
+        try await validate(authority)
         try await EditFlowPerf.measure(
             EditFlowPerf.Stage.Search.providerAutoSelection,
             EditFlowPerf.Dimensions(searchMode: mode.rawValue, contextLines: contextLines)
         ) {
             try await sideEffects.submitAndWait(fingerprint: "file_search_auto_selection") { [weak self] in
                 guard let self else { throw CancellationError() }
-                try await applyFileSearchSideEffect(
+                _ = try await applyFileSearchSideEffect(
                     mode: mode,
                     contextLines: contextLines,
                     reply: reply,
                     resolvedPhysicalPaths: autoSelectionResolvedPhysicalPaths,
-                    metadata: metadata
+                    metadata: metadata,
+                    authority: authority.frozen,
+                    files: dependencies.files
                 )
             }
         }
@@ -924,17 +1056,17 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         reply: ToolResultDTOs.ReadFileReply,
         requestedPath: String,
         absolutePhysicalPath: String,
-        metadata: MCPServerViewModel.RequestMetadata
-    ) async throws {
-        try await dependencies.files.enqueueReadFileAutoSelection(
+        metadata: MCPServerViewModel.RequestMetadata,
+        authority: MCPServerViewModel.FrozenFileToolAuthority,
+        files: MCPAppPhysicalCapabilityAdapters.Files
+    ) async throws -> Bool {
+        try await files.enqueueReadFileAutoSelection(
             reply,
             requestedPath,
             absolutePhysicalPath,
-            metadata
+            metadata,
+            authority
         )
-        // Historical read_file completion guaranteed queue admission, not completion of the
-        // deferred presentation mirror. Legacy consumers can now drain immediately after reply.
-        try Task.checkCancellation()
     }
 
     private func applyFileSearchSideEffect(
@@ -942,18 +1074,18 @@ final class MCPFileToolProvider: MCPAppToolProviding {
         contextLines: Int,
         reply: ToolResultDTOs.SearchResultDTO,
         resolvedPhysicalPaths: [String],
-        metadata: MCPServerViewModel.RequestMetadata
-    ) async throws {
-        try await dependencies.files.enqueueFileSearchAutoSelection(
+        metadata: MCPServerViewModel.RequestMetadata,
+        authority: MCPServerViewModel.FrozenFileToolAuthority,
+        files: MCPAppPhysicalCapabilityAdapters.Files
+    ) async throws -> Bool {
+        try await files.enqueueFileSearchAutoSelection(
             mode,
             contextLines,
             reply,
             resolvedPhysicalPaths,
-            metadata
+            metadata,
+            authority
         )
-        // Match read_file: publish admission before reply without serializing the response on UI
-        // mirroring/metrics work.
-        try Task.checkCancellation()
     }
 
     static func searchRetryableFailureDTO(

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
@@ -161,6 +161,88 @@ enum WorkspaceSearchReadinessState: Equatable {
             false
         }
     }
+
+    /// Root-catalog completion, which happens one state earlier than search readiness:
+    /// `.buildingIndexes` already carries the catalog generation and the load failures, so
+    /// every configured root is either registered or recorded as failed by then. A consumer
+    /// that only needs root identities must not wait for search-index construction it never
+    /// reads.
+    var isRootCatalogAdmissible: Bool {
+        switch self {
+        case .buildingIndexes, .ready:
+            true
+        case let .degraded(_, _, catalogGeneration, _, _, _):
+            catalogGeneration != nil
+        case .idle, .activating, .loadingCatalog:
+            false
+        }
+    }
+}
+
+/// Which completion a readiness waiter is gated on. Two consumers wait on the same state
+/// machine for different things, so the admission rule travels with the waiter rather than
+/// being baked into the state.
+enum WorkspaceReadinessAdmission: Equatable {
+    case searchIndex
+    case rootCatalog
+
+    func admits(_ state: WorkspaceSearchReadinessState) -> Bool {
+        switch self {
+        case .searchIndex:
+            state.isSearchAdmissible
+        case .rootCatalog:
+            state.isRootCatalogAdmissible
+        }
+    }
+}
+
+/// Evidence that one workspace's configured roots are all loaded under one hydration
+/// generation.
+///
+/// Deliberately carries no `Codable`/serialization conformance: the ticket and the root
+/// identities are process-lifetime values, so a persisted copy would outlive the generation
+/// that makes it true and would reassert loaded roots that no longer exist.
+struct WorkspaceRootCatalogSnapshot: Equatable {
+    let ticket: WorkspaceSearchReadinessTicket
+    let workspaceID: UUID
+    /// Canonical, de-duplicated, workspace-declaration order.
+    let configuredRootPaths: [String]
+    /// Loaded primary roots, ordered to match `configuredRootPaths`.
+    let primaryRoots: [WorkspaceRootRef]
+
+    /// A workspace that declares no roots at all. Distinct from a workspace whose roots
+    /// have not been hydrated yet, which never produces a snapshot.
+    var isGenuinelyRootless: Bool {
+        configuredRootPaths.isEmpty && primaryRoots.isEmpty
+    }
+}
+
+/// Messages stay free of absolute root paths so a failure can be surfaced to an MCP client
+/// without leaking filesystem layout.
+enum WorkspaceRootCatalogSnapshotError: LocalizedError, Equatable {
+    case missingWorkspaceIdentity
+    case workspaceNotActive
+    case readinessUnavailable
+    case readinessTimedOut
+    case readinessSuperseded
+    case inconsistentRootProjection
+
+    var errorDescription: String? {
+        switch self {
+        case .missingWorkspaceIdentity:
+            "Workspace readiness did not identify a workspace."
+        case .workspaceNotActive:
+            "The requested workspace is not the active workspace."
+        case .readinessUnavailable:
+            "Workspace readiness is not being tracked."
+        case .readinessTimedOut:
+            "The workspace root catalog did not finish loading in time."
+        case .readinessSuperseded:
+            "Workspace hydration advanced before the root catalog could be read."
+        case .inconsistentRootProjection:
+            "The workspace's configured roots and loaded roots do not agree."
+        }
+    }
 }
 
 struct WorkspaceCatalogDiagnostics: Equatable {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootBindingProjection.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootBindingProjection.swift
@@ -349,6 +349,7 @@ struct WorkspaceRootBindingProjectionPreparation {
     let sessionID: UUID
     let bindings: [AgentSessionWorktreeBinding]
     let visibleRoots: [WorkspaceRootRef]
+    let logicalRootsByPath: [String: WorkspaceRootRef]
     let ownership: WorkspaceSessionWorktreeOwnershipPreparation
     let startupContext: WorktreeStartupContext?
 }
@@ -391,13 +392,32 @@ struct WorkspaceRootBindingProjectionMaterializer {
         return preparation
     }
 
-    private func prepare(
+    func prepare(
         sessionID: UUID,
         bindings: [AgentSessionWorktreeBinding],
         visibleRoots: [WorkspaceRootRef],
         startupContext: WorktreeStartupContext?,
         initializationHintsByBindingID: [String: WorkspaceRootMaterializationHint]
     ) async throws -> WorkspaceRootBindingProjectionPreparation {
+        var visibleRootsByPath: [String: WorkspaceRootRef] = [:]
+        for root in visibleRoots {
+            guard visibleRootsByPath.updateValue(root, forKey: root.standardizedFullPath) == nil else {
+                throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+            }
+        }
+        var logicalRootsByPath: [String: WorkspaceRootRef] = [:]
+        for binding in bindings {
+            let logicalPath = StandardizedPath.absolute(
+                (binding.logicalRootPath as NSString).expandingTildeInPath
+            )
+            guard logicalRootsByPath[logicalPath] == nil,
+                  let logicalRoot = visibleRootsByPath[logicalPath]
+            else {
+                throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+            }
+            logicalRootsByPath[logicalPath] = logicalRoot
+        }
+
         let ownershipStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
         var initializationHintsByPhysicalRootPath: [String: WorkspaceRootMaterializationHint] = [:]
         #if DEBUG
@@ -449,6 +469,7 @@ struct WorkspaceRootBindingProjectionMaterializer {
             sessionID: sessionID,
             bindings: bindings,
             visibleRoots: visibleRoots,
+            logicalRootsByPath: logicalRootsByPath,
             ownership: ownership,
             startupContext: startupContext
         )
@@ -482,67 +503,76 @@ struct WorkspaceRootBindingProjectionMaterializer {
         }
         guard !preparation.bindings.isEmpty else { return nil }
 
-        var recordsByPath: [String: WorkspaceSessionWorktreeOwnedRoot] = [:]
-        for record in records {
-            if let existing = recordsByPath[record.standardizedPhysicalPath], existing != record {
-                await store.releaseSessionWorktreeOwnership(ownerID: preparation.sessionID)
-                throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(record.standardizedPhysicalPath)
+        do {
+            var recordsByPath: [String: WorkspaceSessionWorktreeOwnedRoot] = [:]
+            for record in records {
+                if let existing = recordsByPath[record.standardizedPhysicalPath], existing != record {
+                    throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(record.standardizedPhysicalPath)
+                }
+                recordsByPath[record.standardizedPhysicalPath] = record
             }
-            recordsByPath[record.standardizedPhysicalPath] = record
-        }
 
-        var physicalRootsByID: [UUID: WorkspaceRootRef] = [:]
-        var boundRoots: [WorkspaceRootBindingProjection.BoundRoot] = []
-        for binding in preparation.bindings {
-            let logicalRoot = logicalRoot(for: binding, visibleRoots: preparation.visibleRoots)
-            let physicalPath = StandardizedPath.absolute((binding.worktreeRootPath as NSString).expandingTildeInPath)
-            guard let physicalRecord = recordsByPath[physicalPath] else {
-                await store.releaseSessionWorktreeOwnership(ownerID: preparation.sessionID)
-                throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(physicalPath)
-            }
-            let physicalRoot: WorkspaceRootRef
-            if let existing = physicalRootsByID[physicalRecord.rootID] {
-                guard existing.standardizedFullPath == physicalRecord.standardizedPhysicalPath else {
-                    await store.releaseSessionWorktreeOwnership(ownerID: preparation.sessionID)
+            var physicalRootsByID: [UUID: WorkspaceRootRef] = [:]
+            var boundRoots: [WorkspaceRootBindingProjection.BoundRoot] = []
+            for binding in preparation.bindings {
+                let logicalPath = StandardizedPath.absolute(
+                    (binding.logicalRootPath as NSString).expandingTildeInPath
+                )
+                guard let logicalRoot = preparation.logicalRootsByPath[logicalPath] else {
+                    throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+                }
+                let physicalPath = StandardizedPath.absolute(
+                    (binding.worktreeRootPath as NSString).expandingTildeInPath
+                )
+                guard let physicalRecord = recordsByPath[physicalPath] else {
                     throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(physicalPath)
                 }
-                physicalRoot = existing
-            } else {
-                physicalRoot = WorkspaceRootRef(
-                    id: physicalRecord.rootID,
-                    name: URL(fileURLWithPath: physicalRecord.standardizedPhysicalPath).lastPathComponent,
-                    fullPath: physicalRecord.standardizedPhysicalPath
-                )
-                physicalRootsByID[physicalRecord.rootID] = physicalRoot
+                let physicalRoot: WorkspaceRootRef
+                if let existing = physicalRootsByID[physicalRecord.rootID] {
+                    guard existing.standardizedFullPath == physicalRecord.standardizedPhysicalPath else {
+                        throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(physicalPath)
+                    }
+                    physicalRoot = existing
+                } else {
+                    physicalRoot = WorkspaceRootRef(
+                        id: physicalRecord.rootID,
+                        name: URL(fileURLWithPath: physicalRecord.standardizedPhysicalPath).lastPathComponent,
+                        fullPath: physicalRecord.standardizedPhysicalPath
+                    )
+                    physicalRootsByID[physicalRecord.rootID] = physicalRoot
+                }
+                boundRoots.append(.init(
+                    logicalRoot: logicalRoot,
+                    physicalRoot: physicalRoot,
+                    binding: binding,
+                    sessionRootAuthorization: WorkspaceSessionRootAuthorization(
+                        sessionID: preparation.sessionID,
+                        ownershipGeneration: preparation.ownership.token.generation,
+                        root: physicalRoot,
+                        lifetimeID: physicalRecord.lifetimeID
+                    )
+                ))
             }
-            boundRoots.append(.init(
-                logicalRoot: logicalRoot,
-                physicalRoot: physicalRoot,
-                binding: binding,
-                sessionRootAuthorization: WorkspaceSessionRootAuthorization(
-                    sessionID: preparation.sessionID,
-                    ownershipGeneration: preparation.ownership.token.generation,
-                    root: physicalRoot,
-                    lifetimeID: physicalRecord.lifetimeID
-                )
-            ))
+            let projection = WorkspaceRootBindingProjection(
+                sessionID: preparation.sessionID,
+                boundRoots: boundRoots,
+                visibleLogicalRoots: preparation.visibleRoots
+            )
+            AgentSelectedFilesDiagnostics.durationEvent(
+                "projection.commit",
+                startMS: startMS,
+                fields: [
+                    "sessionID": AgentSelectedFilesDiagnostics.shortID(preparation.sessionID),
+                    "boundRootCount": String(boundRoots.count),
+                    "visibleRootCount": String(preparation.visibleRoots.count),
+                    "fullyMaterialized": String(projection.isFullyMaterialized)
+                ]
+            )
+            return projection
+        } catch {
+            await store.releaseSessionWorktreeOwnership(ownerID: preparation.sessionID)
+            throw error
         }
-        let projection = WorkspaceRootBindingProjection(
-            sessionID: preparation.sessionID,
-            boundRoots: boundRoots,
-            visibleLogicalRoots: preparation.visibleRoots
-        )
-        AgentSelectedFilesDiagnostics.durationEvent(
-            "projection.commit",
-            startMS: startMS,
-            fields: [
-                "sessionID": AgentSelectedFilesDiagnostics.shortID(preparation.sessionID),
-                "boundRootCount": String(boundRoots.count),
-                "visibleRootCount": String(preparation.visibleRoots.count),
-                "fullyMaterialized": String(projection.isFullyMaterialized)
-            ]
-        )
-        return projection
     }
 
     func abort(_ preparation: WorkspaceRootBindingProjectionPreparation) async {
@@ -560,14 +590,30 @@ struct WorkspaceRootBindingProjectionMaterializer {
         await FileSystemService.withContentReadForegroundActivity(kind: .materialization) {
             await materializeWithinForegroundActivity(
                 sessionID: sessionID,
-                bindings: bindings
+                bindings: bindings,
+                visibleRoots: nil
+            )
+        }
+    }
+
+    func materialize(
+        sessionID: UUID,
+        bindings: [AgentSessionWorktreeBinding],
+        visibleRoots: [WorkspaceRootRef]
+    ) async -> WorkspaceRootBindingProjection? {
+        await FileSystemService.withContentReadForegroundActivity(kind: .materialization) {
+            await materializeWithinForegroundActivity(
+                sessionID: sessionID,
+                bindings: bindings,
+                visibleRoots: visibleRoots
             )
         }
     }
 
     private func materializeWithinForegroundActivity(
         sessionID: UUID,
-        bindings: [AgentSessionWorktreeBinding]
+        bindings: [AgentSessionWorktreeBinding],
+        visibleRoots suppliedVisibleRoots: [WorkspaceRootRef]?
     ) async -> WorkspaceRootBindingProjection? {
         let startMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
         AgentSelectedFilesDiagnostics.event(
@@ -585,7 +631,11 @@ struct WorkspaceRootBindingProjectionMaterializer {
             var commitNanoseconds: UInt64 = 0
         #endif
         let visibleRootsStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
-        let visibleRoots = await store.rootRefs(scope: .visibleWorkspace)
+        let visibleRoots = if let suppliedVisibleRoots {
+            suppliedVisibleRoots
+        } else {
+            await store.rootRefs(scope: .visibleWorkspace)
+        }
         AgentSelectedFilesDiagnostics.durationEvent(
             "projection.materialize.visibleRoots",
             startMS: visibleRootsStartMS,
@@ -659,11 +709,7 @@ struct WorkspaceRootBindingProjectionMaterializer {
                         "error": String(describing: error)
                     ]
                 )
-                return failClosedProjection(
-                    sessionID: sessionID,
-                    bindings: bindings,
-                    visibleRoots: visibleRoots
-                )
+                return nil
             }
         } catch {
             #if DEBUG
@@ -685,57 +731,8 @@ struct WorkspaceRootBindingProjectionMaterializer {
                     "error": String(describing: error)
                 ]
             )
-            return failClosedProjection(
-                sessionID: sessionID,
-                bindings: bindings,
-                visibleRoots: visibleRoots
-            )
+            return nil
         }
-    }
-
-    private func failClosedProjection(
-        sessionID: UUID,
-        bindings: [AgentSessionWorktreeBinding],
-        visibleRoots: [WorkspaceRootRef]
-    ) -> WorkspaceRootBindingProjection? {
-        guard !bindings.isEmpty else { return nil }
-        let boundRoots = bindings.map { binding in
-            let logicalRoot = logicalRoot(for: binding, visibleRoots: visibleRoots)
-            let physicalPath = StandardizedPath.absolute(
-                (binding.worktreeRootPath as NSString).expandingTildeInPath
-            )
-            return WorkspaceRootBindingProjection.BoundRoot(
-                logicalRoot: logicalRoot,
-                physicalRoot: WorkspaceRootRef(
-                    id: UUID(),
-                    name: logicalRoot.name,
-                    fullPath: physicalPath
-                ),
-                binding: binding,
-                sessionRootAuthorization: nil
-            )
-        }
-        return WorkspaceRootBindingProjection(
-            sessionID: sessionID,
-            boundRoots: boundRoots,
-            visibleLogicalRoots: visibleRoots,
-            lookupPhysicalRootPaths: []
-        )
-    }
-
-    private func logicalRoot(
-        for binding: AgentSessionWorktreeBinding,
-        visibleRoots: [WorkspaceRootRef]
-    ) -> WorkspaceRootRef {
-        let logicalPath = StandardizedPath.absolute(
-            (binding.logicalRootPath as NSString).expandingTildeInPath
-        )
-        return visibleRoots.first { $0.standardizedFullPath == logicalPath }
-            ?? WorkspaceRootRef(
-                id: UUID(),
-                name: binding.logicalRootName ?? URL(fileURLWithPath: logicalPath).lastPathComponent,
-                fullPath: logicalPath
-            )
     }
 }
 

--- a/Sources/RepoPromptDomainRuntime/MCPDomainReadToolProvider.swift
+++ b/Sources/RepoPromptDomainRuntime/MCPDomainReadToolProvider.swift
@@ -99,10 +99,16 @@ package struct MCPDomainReadToolProvider {
     package typealias ReleaseContext = @Sendable (
         _ context: DomainReadInvocationContext
     ) async -> Void
+    package typealias ResolveFailure = @Sendable (
+        _ toolName: String,
+        _ arguments: [String: Value],
+        _ error: Error
+    ) throws -> Value?
 
     private let resolveContext: ResolveContext
     private let refreshContext: RefreshContext
     private let releaseContext: ReleaseContext
+    private let resolveFailure: ResolveFailure
     private let backend: MCPDomainReadToolBackend
     private let sideEffects: DomainReadSideEffectCoordinator
 
@@ -110,12 +116,14 @@ package struct MCPDomainReadToolProvider {
         resolveContext: @escaping ResolveContext,
         refreshContext: @escaping RefreshContext = { $0 },
         releaseContext: @escaping ReleaseContext = { _ in },
+        resolveFailure: @escaping ResolveFailure = { _, _, _ in nil },
         backend: MCPDomainReadToolBackend,
         sideEffects: DomainReadSideEffectCoordinator
     ) {
         self.resolveContext = resolveContext
         self.refreshContext = refreshContext
         self.releaseContext = releaseContext
+        self.resolveFailure = resolveFailure
         self.backend = backend
         self.sideEffects = sideEffects
     }
@@ -143,7 +151,17 @@ package struct MCPDomainReadToolProvider {
         // Historical parameter failures must win over unrelated routing/workspace failures.
         try validateTopLevelArguments(toolName: toolName, arguments: arguments)
         let requirement = contextRequirement(toolName)
-        let context = try await resolveContext(toolName, requirement)
+        let context: DomainReadInvocationContext
+        do {
+            context = try await resolveContext(toolName, requirement)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if let value = try resolveFailure(toolName, arguments, error) {
+                return value
+            }
+            throw error
+        }
         do {
             try Task.checkCancellation()
             if requirement == .workspaceRequired, context.handle == nil {

--- a/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
+++ b/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
@@ -27,6 +27,23 @@ public enum MCPTimeoutPolicy {
     public static let workspaceReadinessWaitTimeoutSeconds = 30
     public static let workspaceReadinessWaitTimeout: Duration = .seconds(workspaceReadinessWaitTimeoutSeconds)
 
+    /// Root-catalog authority fence for a single MCP file-tool call. Shorter than
+    /// `workspaceReadinessWaitTimeout` because catalog admissibility excludes search-index
+    /// construction: this window covers only the filesystem crawl. It stays well inside
+    /// `boundedToolExecutionDeadline` so a crawl that overruns surfaces as an explicit
+    /// retryable readiness error rather than racing the tool watchdog.
+    public static let fileToolAuthorityReadinessWaitTimeoutSeconds = 5
+    public static let fileToolAuthorityReadinessWaitTimeout: Duration = .seconds(
+        fileToolAuthorityReadinessWaitTimeoutSeconds
+    )
+
+    /// Context Builder freezes roots once for an entire discovery run, so paying a longer
+    /// wait once is cheaper than failing a run that would have resolved.
+    public static let contextBuilderAuthorityReadinessWaitTimeoutSeconds = 10
+    public static let contextBuilderAuthorityReadinessWaitTimeout: Duration = .seconds(
+        contextBuilderAuthorityReadinessWaitTimeoutSeconds
+    )
+
     public static let workspaceSwitchToolExecutionDeadlineSeconds = 120
     public static let workspaceSwitchToolExecutionDeadline: Duration = .seconds(
         workspaceSwitchToolExecutionDeadlineSeconds

--- a/Tests/RepoPromptDomainRuntimeTests/MCPDomainReadToolProviderTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/MCPDomainReadToolProviderTests.swift
@@ -143,6 +143,44 @@ final class MCPDomainReadToolProviderTests: XCTestCase {
         XCTAssertEqual(resolutionCount, 0, "argument validation must precede unrelated routing")
     }
 
+    func testResolveFailureReturnsTypedValueWithoutExecutingBackend() async throws {
+        enum ResolutionFailure: Error {
+            case unavailable
+        }
+
+        let identity = makeIdentity()
+        let backendInvocations = InvocationRecorder()
+        let provider = MCPDomainReadToolProvider(
+            resolveContext: { _, _ in
+                throw ResolutionFailure.unavailable
+            },
+            resolveFailure: { toolName, arguments, error in
+                guard toolName == "read_file",
+                      arguments["path"]?.stringValue == "file.swift",
+                      error is ResolutionFailure
+                else { return nil }
+                return .object([
+                    "error_code": .string("workspace_authority_unavailable"),
+                    "retryable": .bool(true)
+                ])
+            },
+            backend: MCPDomainReadToolBackend { name, context, arguments, _ in
+                await backendInvocations.record(name: name, context: context, arguments: arguments)
+                return .string("unexpected")
+            },
+            sideEffects: DomainReadSideEffectCoordinator(identity: identity)
+        )
+
+        let value = try await XCTUnwrap(provider.binding(named: "read_file"))([
+            "path": .string("file.swift")
+        ])
+
+        XCTAssertEqual(value.objectValue?["error_code"]?.stringValue, "workspace_authority_unavailable")
+        XCTAssertEqual(value.objectValue?["retryable"]?.boolValue, true)
+        let invocations = await backendInvocations.snapshot()
+        XCTAssertTrue(invocations.isEmpty)
+    }
+
     private func makeIdentity() -> DomainRuntimeIdentity {
         DomainRuntimeIdentity(
             runtimeID: UUID(),

--- a/Tests/RepoPromptTests/MCP/Control/BindContextFileAuthorityTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/BindContextFileAuthorityTests.swift
@@ -1,0 +1,507 @@
+import Darwin
+import Foundation
+import MCP
+@testable import RepoPromptApp
+import XCTest
+
+#if DEBUG
+    final class BindContextFileAuthorityTests: XCTestCase {
+        @MainActor
+        func testBindStoresAuthorityConsumedByNextFileOperation() async throws {
+            let fixture = try await makeFixture(rootPaths: [makeTemporaryRoot().path])
+            let authority = try await fixture.window.mcpServer.resolveFileToolAuthority(
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id
+            )
+
+            try fixture.window.mcpServer.bindTabForConnection(
+                connectionID: fixture.connectionID,
+                clientName: "BindContextFileAuthorityTests",
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id,
+                windowID: fixture.window.windowID,
+                frozenFileToolAuthority: authority
+            )
+            let consumed = try await fixture.window.mcpServer.requiredFileToolLookupContext(
+                from: metadata(for: fixture)
+            )
+
+            XCTAssertTrue(authority.hasSameRoutingAuthority(as: consumed))
+            XCTAssertEqual(consumed.lookupContext, authority.lookupContext)
+        }
+
+        @MainActor
+        func testRepeatedBindRefreshesStoredAuthorityWithoutChangingRoute() async throws {
+            let fixture = try await makeFixture(rootPaths: [makeTemporaryRoot().path])
+            let first = try await fixture.window.mcpServer.resolveFileToolAuthority(
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id
+            )
+            try fixture.window.mcpServer.bindTabForConnection(
+                connectionID: fixture.connectionID,
+                clientName: nil,
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id,
+                windowID: fixture.window.windowID,
+                frozenFileToolAuthority: first
+            )
+            fixture.window.workspaceManager.republishReadyRootCatalogWithNextGenerationForTesting()
+            let refreshed = try await fixture.window.mcpServer.resolveFileToolAuthority(
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id
+            )
+
+            fixture.window.mcpServer.updateBoundFileToolAuthority(
+                connectionID: fixture.connectionID,
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id,
+                authority: refreshed
+            )
+            let consumed = try await fixture.window.mcpServer.requiredFileToolLookupContext(
+                from: metadata(for: fixture)
+            )
+
+            XCTAssertTrue(refreshed.hasSameRoutingAuthority(as: consumed))
+            XCTAssertFalse(first.hasSameRoutingAuthority(as: consumed))
+        }
+
+        @MainActor
+        func testFailedReplacementPreservesPriorBinding() async throws {
+            let fixture = try await makeFixture(rootPaths: [makeTemporaryRoot().path])
+            let authority = try await fixture.window.mcpServer.resolveFileToolAuthority(
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id
+            )
+            try fixture.window.mcpServer.bindTabForConnection(
+                connectionID: fixture.connectionID,
+                clientName: nil,
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id,
+                windowID: fixture.window.windowID,
+                frozenFileToolAuthority: authority
+            )
+            let prior = fixture.window.mcpServer.connectionBindingSnapshot(
+                forConnection: fixture.connectionID
+            )
+
+            XCTAssertThrowsError(try fixture.window.mcpServer.bindTabForConnection(
+                connectionID: fixture.connectionID,
+                clientName: nil,
+                tabID: UUID(),
+                workspaceID: UUID(),
+                windowID: fixture.window.windowID,
+                frozenFileToolAuthority: authority
+            ))
+
+            let retained = fixture.window.mcpServer.connectionBindingSnapshot(
+                forConnection: fixture.connectionID
+            )
+            XCTAssertEqual(retained.windowID, prior.windowID)
+            XCTAssertEqual(retained.workspaceID, prior.workspaceID)
+            XCTAssertEqual(retained.tabID, prior.tabID)
+            XCTAssertEqual(retained.explicitlyBound, prior.explicitlyBound)
+        }
+
+        @MainActor
+        func testSupersededCatalogRejectsPreviouslyIssuedAuthority() async throws {
+            let fixture = try await makeFixture(rootPaths: [makeTemporaryRoot().path])
+            let authority = try await fixture.window.mcpServer.resolveFileToolAuthority(
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id
+            )
+            fixture.window.workspaceManager.republishReadyRootCatalogWithNextGenerationForTesting()
+
+            do {
+                try await authority.validate(
+                    workspaceManager: fixture.window.workspaceManager,
+                    store: fixture.window.promptManager.workspaceFileContextStore
+                )
+                XCTFail("A superseded readiness ticket must not remain usable")
+            } catch let failure as MCPServerViewModel.FileToolAuthorityFailure {
+                XCTAssertEqual(failure, .superseded)
+            }
+
+            var enteredCommit = false
+            let performed = try await fixture.window.mcpServer.performIfFileToolAuthorityIsCurrent(
+                authority,
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id
+            ) {
+                enteredCommit = true
+            }
+            XCTAssertFalse(performed)
+            XCTAssertFalse(enteredCommit)
+        }
+
+        @MainActor
+        func testCanonicalRootMutationAfterCaptureRejectsAuthority() async throws {
+            let fixture = try await makeFixture(rootPaths: [makeTemporaryRoot().path])
+            let authority = try await fixture.window.mcpServer.resolveFileToolAuthority(
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id
+            )
+            let additionalRoot = try makeTemporaryRoot()
+            let loaded = try await fixture.window.promptManager.workspaceFileContextStore.loadRoot(
+                path: additionalRoot.path,
+                kind: .primaryWorkspace
+            )
+            addTeardownBlock {
+                await fixture.window.promptManager.workspaceFileContextStore.unloadRoot(id: loaded.id)
+            }
+
+            do {
+                try await authority.validate(
+                    workspaceManager: fixture.window.workspaceManager,
+                    store: fixture.window.promptManager.workspaceFileContextStore
+                )
+                XCTFail("A changed canonical root set must invalidate captured authority")
+            } catch let failure as MCPServerViewModel.FileToolAuthorityFailure {
+                XCTAssertEqual(failure, .mismatchedProjection)
+            }
+        }
+
+        @MainActor
+        func testAffinityFailurePreservesPriorBindingAndAuthority() async throws {
+            let prior = try await makeFixture(rootPaths: [makeTemporaryRoot().path])
+            let replacement = try await makeFixture(rootPaths: [makeTemporaryRoot().path])
+            let priorAuthority = try await prior.window.mcpServer.resolveFileToolAuthority(
+                tabID: prior.contextID,
+                workspaceID: prior.workspace.id
+            )
+            try prior.window.mcpServer.bindTabForConnection(
+                connectionID: prior.connectionID,
+                clientName: nil,
+                tabID: prior.contextID,
+                workspaceID: prior.workspace.id,
+                windowID: prior.window.windowID,
+                frozenFileToolAuthority: priorAuthority
+            )
+            let replacementAuthority = try await replacement.window.mcpServer.resolveFileToolAuthority(
+                tabID: replacement.contextID,
+                workspaceID: replacement.workspace.id
+            )
+            let previousWindows = WindowStatesManager.shared.allWindows
+            WindowStatesManager.shared.allWindows = [prior.window, replacement.window]
+            addTeardownBlock { @MainActor in
+                WindowStatesManager.shared.allWindows = previousWindows
+            }
+            let service = WindowRoutingService(
+                windowStates: WindowStatesManager.shared,
+                networkMgr: ServerNetworkManager.shared,
+                setActiveWindowForCurrentConnection: { _ in throw AffinityFailure.injected }
+            )
+
+            do {
+                _ = try await service.test_bindTarget(
+                    windowID: replacement.window.windowID,
+                    workspaceID: replacement.workspace.id,
+                    tabID: replacement.contextID,
+                    repoPaths: replacement.workspace.repoPaths,
+                    connectionID: prior.connectionID,
+                    authority: replacementAuthority
+                )
+                XCTFail("The injected affinity failure must reject replacement")
+            } catch {
+                XCTAssertTrue(error is AffinityFailure)
+            }
+
+            let retained = prior.window.mcpServer.connectionBindingSnapshot(forConnection: prior.connectionID)
+            XCTAssertEqual(retained.windowID, prior.window.windowID)
+            XCTAssertEqual(retained.workspaceID, prior.workspace.id)
+            XCTAssertEqual(retained.tabID, prior.contextID)
+            let consumed = try await prior.window.mcpServer.requiredFileToolLookupContext(from: metadata(for: prior))
+            XCTAssertTrue(priorAuthority.hasSameRoutingAuthority(as: consumed))
+            XCTAssertNil(replacement.window.mcpServer.boundTabID(forConnection: prior.connectionID))
+        }
+
+        @MainActor
+        func testBindSerializesHeldHydrationAsRetryableAuthorityFailure() async throws {
+            let root = try makeTemporaryRoot()
+            let targetWindow = WindowState()
+            await targetWindow.workspaceManager.awaitInitialized()
+            let contextID = UUID()
+            let workspace = WorkspaceModel(
+                name: "Held Hydration",
+                repoPaths: [root.path],
+                composeTabs: [ComposeTabState(id: contextID, name: "Context")],
+                activeComposeTabID: contextID
+            )
+            targetWindow.workspaceManager.workspaces = [workspace]
+            let gate = RootHydrationSuspensionGate()
+            targetWindow.workspaceManager.setWorkspaceRootHydrationWillSpawnHandlerForTesting { _ in
+                await gate.hold()
+            }
+            addTeardownBlock { @MainActor in
+                targetWindow.workspaceManager.setWorkspaceRootHydrationWillSpawnHandlerForTesting(nil)
+                await gate.release()
+            }
+            let switchTask = Task { @MainActor in
+                await targetWindow.workspaceManager.switchWorkspace(
+                    to: workspace,
+                    saveState: false,
+                    reason: "bind-context-held-hydration-test"
+                )
+            }
+            await gate.waitUntilHeld()
+
+            let previousWindows = WindowStatesManager.shared.allWindows
+            WindowStatesManager.shared.allWindows = [targetWindow]
+            addTeardownBlock { @MainActor in
+                WindowStatesManager.shared.allWindows = previousWindows
+            }
+            try await AppGlobalMCPServiceComposition.shared.ensureRegistered()
+            let toolsEnabled = await targetWindow.mcpServer.setWindowToolsEnabled(true)
+            XCTAssertTrue(toolsEnabled)
+            addTeardownBlock { @MainActor in
+                _ = await targetWindow.mcpServer.setWindowToolsEnabled(false)
+            }
+            let connection = try await makeProductionMCPConnection()
+            addTeardownBlock { await connection.cleanup() }
+
+            let result = try await connection.client.callTool(name: "bind_context", arguments: [
+                "op": .string("bind"),
+                "context_id": .string(contextID.uuidString),
+                "_rawJSON": .bool(true)
+            ])
+            XCTAssertNotEqual(result.isError, true, toolText(result))
+            let data = try XCTUnwrap(toolText(result).data(using: .utf8))
+            let response = try JSONDecoder().decode(BindContextResponse.self, from: data)
+            XCTAssertEqual(response.changed, false)
+            XCTAssertEqual(response.errorCode, "workspace_authority_timeout")
+            XCTAssertEqual(response.retryable, true)
+            XCTAssertEqual(response.retryAfterMilliseconds, 1000)
+            XCTAssertFalse(response.binding.explicit)
+            XCTAssertNil(response.binding.contextID)
+
+            await gate.release()
+            _ = await switchTask.value
+        }
+
+        @MainActor
+        func testGenuinelyRootlessBindProducesExplicitEmptyAuthority() async throws {
+            let fixture = try await makeFixture(rootPaths: [])
+            let authority = try await fixture.window.mcpServer.resolveFileToolAuthority(
+                tabID: fixture.contextID,
+                workspaceID: fixture.workspace.id
+            )
+
+            XCTAssertTrue(authority.rootCatalogSnapshot.isGenuinelyRootless)
+            XCTAssertEqual(authority.lookupContext.bindingProjection, nil)
+        }
+
+        func testFileTreeReadinessFailureIsTypedAndRetryable() throws {
+            let value = try failureValue(tool: MCPWindowToolName.getFileTree, args: ["type": .string("roots")])
+            let reply = try XCTUnwrap(value.decode(ToolResultDTOs.FileTreeDTO.self))
+            XCTAssertEqual(reply.errorCode, "workspace_authority_timeout")
+            XCTAssertEqual(reply.retryable, true)
+            XCTAssertEqual(reply.retryAfterMilliseconds, 1000)
+        }
+
+        func testReadFileReadinessFailurePreservesRequestedPath() throws {
+            let value = try failureValue(tool: MCPWindowToolName.readFile, args: ["path": .string("README.md")])
+            let reply = try XCTUnwrap(value.decode(ToolResultDTOs.ReadFileReply.self))
+            XCTAssertEqual(reply.displayPath, "README.md")
+            XCTAssertEqual(reply.errorCode, "workspace_authority_timeout")
+            XCTAssertEqual(reply.retryable, true)
+        }
+
+        func testFileSearchReadinessFailureIsTypedAndEmpty() throws {
+            let value = try failureValue(tool: MCPWindowToolName.search, args: ["pattern": .string("needle")])
+            let reply = try XCTUnwrap(value.decode(ToolResultDTOs.SearchResultDTO.self))
+            XCTAssertEqual(reply.totalMatches, 0)
+            XCTAssertEqual(reply.errorCode, "workspace_authority_timeout")
+            XCTAssertEqual(reply.retryable, true)
+        }
+
+        func testCodeStructureReadinessFailurePrecedesProjection() throws {
+            let value = try failureValue(
+                tool: MCPWindowToolName.getCodeStructure,
+                args: ["paths": .array([.string("Sources")])]
+            )
+            let reply = try XCTUnwrap(value.decode(ToolResultDTOs.CodeStructureReplyDTO.self))
+            XCTAssertEqual(reply.status, .unavailable)
+            XCTAssertEqual(reply.issues.map(\.code), ["workspace_authority_timeout"])
+            XCTAssertEqual(reply.issues.map(\.retryable), [true])
+            XCTAssertEqual(reply.files, [])
+        }
+
+        private func failureValue(tool: String, args: [String: Value]) throws -> Value {
+            try MCPFileToolProvider.authorityFailureValue(
+                toolName: tool,
+                args: args,
+                failure: .timedOut
+            )
+        }
+
+        @MainActor
+        private func makeFixture(rootPaths: [String]) async throws -> Fixture {
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            defer { GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false) }
+            let window = WindowState()
+            await window.workspaceManager.awaitInitialized()
+            let contextID = UUID()
+            let workspace = WorkspaceModel(
+                name: "Authority",
+                repoPaths: rootPaths,
+                composeTabs: [ComposeTabState(id: contextID, name: "Context")],
+                activeComposeTabID: contextID
+            )
+            window.workspaceManager.workspaces = [workspace]
+            let result = await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "bind-context-file-authority-test"
+            )
+            XCTAssertTrue(result.didSwitch)
+            return Fixture(
+                window: window,
+                workspace: workspace,
+                contextID: contextID,
+                connectionID: UUID()
+            )
+        }
+
+        private func makeTemporaryRoot() throws -> URL {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("repoprompt-bind-authority-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+            return root
+        }
+
+        @MainActor
+        private func metadata(for fixture: Fixture) -> MCPServerViewModel.RequestMetadata {
+            MCPServerViewModel.RequestMetadata(
+                connectionID: fixture.connectionID,
+                clientName: "BindContextFileAuthorityTests",
+                windowID: fixture.window.windowID
+            )
+        }
+
+        private func toolText(_ result: (content: [MCP.Tool.Content], isError: Bool?)) -> String {
+            result.content.compactMap { content -> String? in
+                if case let .text(text, _, _) = content { return text }
+                return nil
+            }.joined(separator: "\n")
+        }
+
+        private func makeProductionMCPConnection() async throws -> ProductionMCPConnection {
+            var descriptors = [Int32](repeating: -1, count: 2)
+            guard Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .ENFILE)
+            }
+            defer {
+                for descriptor in descriptors where descriptor >= 0 {
+                    Darwin.close(descriptor)
+                }
+            }
+
+            let connectionID = UUID()
+            let sessionToken = "bind-file-authority-\(UUID().uuidString)"
+            let clientName = "BindContextFileAuthorityTests"
+            let networkManager = ServerNetworkManager.shared
+            let wasNetworkManagerRunning = await networkManager.isRunning()
+            let connectionManager = try BootstrapSocketConnectionManager(
+                connectionID: connectionID,
+                sessionToken: sessionToken,
+                clientPid: Int(getpid()),
+                observedKernelPeerPID: Int(getpid()),
+                clientName: clientName,
+                purpose: .unknown,
+                codeMapsDisabled: true,
+                connectedFD: descriptors[0],
+                parentManager: networkManager
+            )
+            descriptors[0] = -1
+            let clientTransport = try UnixSocketMCPTransport(
+                connectedFD: descriptors[1],
+                connectionID: connectionID,
+                correlationConnectionID: sessionToken
+            )
+            descriptors[1] = -1
+            await networkManager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: connectionID,
+                connection: connectionManager,
+                pendingClientID: clientName
+            )
+            _ = await networkManager.debugInstallConnectionLimiterForTesting(connectionID: connectionID)
+
+            do {
+                try await connectionManager.start { $0.name == clientName }
+                let client = Client(name: clientName, version: "1.0")
+                _ = try await client.connect(transport: clientTransport)
+                return ProductionMCPConnection(
+                    client: client,
+                    connectionID: connectionID,
+                    connectionManager: connectionManager,
+                    wasNetworkManagerRunning: wasNetworkManagerRunning
+                )
+            } catch {
+                await clientTransport.disconnect()
+                await connectionManager.stop()
+                await networkManager.debugRemoveConnection(connectionID)
+                if !wasNetworkManagerRunning {
+                    await networkManager.stop()
+                }
+                throw error
+            }
+        }
+    }
+
+    private struct Fixture {
+        let window: WindowState
+        let workspace: WorkspaceModel
+        let contextID: UUID
+        let connectionID: UUID
+    }
+
+    private enum AffinityFailure: Error {
+        case injected
+    }
+
+    private actor RootHydrationSuspensionGate {
+        private var held = false
+        private var released = false
+        private var heldWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func hold() async {
+            held = true
+            let waiters = heldWaiters
+            heldWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+            guard !released else { return }
+            await withCheckedContinuation { releaseWaiters.append($0) }
+        }
+
+        func waitUntilHeld() async {
+            guard !held else { return }
+            await withCheckedContinuation { heldWaiters.append($0) }
+        }
+
+        func release() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+    }
+
+    private struct ProductionMCPConnection {
+        let client: Client
+        let connectionID: UUID
+        let connectionManager: BootstrapSocketConnectionManager
+        let wasNetworkManagerRunning: Bool
+
+        func cleanup() async {
+            let networkManager = ServerNetworkManager.shared
+            await client.disconnect()
+            await connectionManager.stop()
+            await networkManager.debugRemoveConnection(connectionID)
+            if !wasNetworkManagerRunning {
+                await networkManager.stop()
+            }
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/MCP/FileToolLookupResolutionWaiterTests.swift
+++ b/Tests/RepoPromptTests/MCP/FileToolLookupResolutionWaiterTests.swift
@@ -1,0 +1,51 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class FileToolLookupResolutionWaiterTests: XCTestCase {
+    @MainActor
+    func testCancellingOneCallerWaiterDoesNotCancelSharedResolutionTask() async throws {
+        let gate = CacheResolutionGate()
+        let sharedTask: Task<MCPServerViewModel.FileToolLookupResolution, Never> = Task { @MainActor in
+            await gate.wait()
+            return .success(.visibleWorkspace)
+        }
+        let cancelledWaiter = Task { @MainActor in
+            try await MCPServerViewModel.FileToolLookupResolutionWaiter().value(from: sharedTask)
+        }
+        let survivingWaiter = Task { @MainActor in
+            try await MCPServerViewModel.FileToolLookupResolutionWaiter().value(from: sharedTask)
+        }
+
+        cancelledWaiter.cancel()
+        do {
+            _ = try await cancelledWaiter.value
+            XCTFail("Cancelling one caller must end only that caller's await")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertFalse(sharedTask.isCancelled)
+
+        await gate.release()
+
+        let survivingValue = try await survivingWaiter.value
+        XCTAssertEqual(try survivingValue.get(), .visibleWorkspace)
+        XCTAssertFalse(sharedTask.isCancelled)
+    }
+}
+
+private actor CacheResolutionGate {
+    private var released = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !released else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        released = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootBindingProjectionTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootBindingProjectionTests.swift
@@ -459,6 +459,58 @@ final class WorkspaceRootBindingProjectionTests: XCTestCase {
         )
     }
 
+    func testResolverRebuildsCachedProjectionWhenVisibleRootSetChanges() async throws {
+        let logicalRootURL = try makeTemporaryRoot(name: "ProjectionCacheLogical")
+        let addedRootURL = try makeTemporaryRoot(name: "ProjectionCacheAdded")
+        let physicalRootURL = try makeTemporaryRoot(name: "ProjectionCachePhysical")
+        let store = WorkspaceFileContextStore()
+        let loadedLogicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = WorkspaceRootRef(
+            id: loadedLogicalRoot.id,
+            name: loadedLogicalRoot.name,
+            fullPath: loadedLogicalRoot.standardizedFullPath
+        )
+        let physicalRoot = WorkspaceRootRef(
+            id: UUID(),
+            name: logicalRoot.name,
+            fullPath: physicalRootURL.path
+        )
+        let sessionID = UUID()
+        let source = AgentWorkspaceLookupContextSource(
+            activeAgentSessionID: sessionID,
+            worktreeBindings: [Self.binding(
+                logicalRoot: logicalRoot,
+                physicalRoot: physicalRoot,
+                worktreeID: "cache-visible-roots"
+            )]
+        )
+
+        let initial = try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+            source: source,
+            visibleRoots: [logicalRoot],
+            store: store
+        )
+        XCTAssertEqual(initial.bindingProjection?.visibleLogicalRootRefs, [logicalRoot])
+
+        let loadedAddedRoot = try await store.loadRoot(path: addedRootURL.path)
+        let addedRoot = WorkspaceRootRef(
+            id: loadedAddedRoot.id,
+            name: loadedAddedRoot.name,
+            fullPath: loadedAddedRoot.standardizedFullPath
+        )
+        let rebuilt = try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+            source: source,
+            visibleRoots: [logicalRoot, addedRoot],
+            store: store
+        )
+
+        XCTAssertEqual(
+            try Set(XCTUnwrap(rebuilt.bindingProjection).visibleLogicalRootRefs),
+            Set([logicalRoot, addedRoot])
+        )
+        XCTAssertNotEqual(initial, rebuilt)
+    }
+
     func testMaterializerFailsClosedWhenPhysicalRootCannotBeLoaded() async throws {
         let logicalRootURL = try makeTemporaryRoot(name: "ProjectionLogical")
         try write("let origin = \"base\"\n", to: logicalRootURL.appendingPathComponent("Sources/App.swift"))
@@ -488,27 +540,45 @@ final class WorkspaceRootBindingProjectionTests: XCTestCase {
         let visibleLookup = await store.lookupPath("Sources/App.swift", profile: .uiAssisted, rootScope: .visibleWorkspace)
         let ownership = await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
 
-        let failClosedProjection = try XCTUnwrap(materializedProjection)
-        let scopedLookup = await store.lookupPath(
-            "Sources/App.swift",
-            profile: .uiAssisted,
-            rootScope: failClosedProjection.lookupRootScope
-        )
-        let scopeAvailability = await store.rootScopeAvailability(failClosedProjection.lookupRootScope)
-        let catalogAccess = await store.searchCatalogAccess(rootScope: failClosedProjection.lookupRootScope)
-        XCTAssertEqual(failClosedProjection.physicalRootPaths, Set([unloadablePhysicalRoot.standardizedFileURL.path]))
-        XCTAssertFalse(failClosedProjection.isFullyMaterialized)
-        XCTAssertEqual(
-            failClosedProjection.lookupRootScope,
-            .validatedSessionBoundWorkspace(canonicalRoots: [], physicalRoots: [])
-        )
-        XCTAssertEqual(scopeAvailability, .sessionWorktreeUnavailable(missingPhysicalRootPaths: []))
-        XCTAssertEqual(
-            catalogAccess,
-            .unavailable(.sessionWorktreeUnavailable(missingPhysicalRootPaths: []))
-        )
+        XCTAssertNil(materializedProjection)
         XCTAssertNotNil(visibleLookup)
-        XCTAssertNil(scopedLookup)
+        XCTAssertEqual(ownership.installedOwnerCount, 0)
+        XCTAssertEqual(ownership.provisionalOwnerCount, 0)
+        XCTAssertEqual(ownership.rootClaimCount, 0)
+    }
+
+    func testMaterializerRejectsMissingLogicalRootWithoutSynthesizingIdentity() async throws {
+        let loadedRootURL = try makeTemporaryRoot(name: "ProjectionLoadedLogical")
+        let missingRootURL = try makeTemporaryRoot(name: "ProjectionMissingLogical")
+        let physicalRootURL = try makeTemporaryRoot(name: "ProjectionMissingPhysical")
+        let store = WorkspaceFileContextStore()
+        let loadedRoot = try await store.loadRoot(path: loadedRootURL.path)
+        let missingLogicalRoot = WorkspaceRootRef(
+            id: UUID(),
+            name: missingRootURL.lastPathComponent,
+            fullPath: missingRootURL.path
+        )
+        let physicalRoot = WorkspaceRootRef(
+            id: UUID(),
+            name: physicalRootURL.lastPathComponent,
+            fullPath: physicalRootURL.path
+        )
+        let sessionID = UUID()
+
+        let projection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: sessionID,
+            bindings: [Self.binding(
+                logicalRoot: missingLogicalRoot,
+                physicalRoot: physicalRoot,
+                worktreeID: "missing-logical"
+            )]
+        )
+        let roots = await store.roots()
+        let ownership = await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
+
+        XCTAssertNil(projection)
+        XCTAssertEqual(roots.map(\.id), [loadedRoot.id])
+        XCTAssertFalse(roots.contains { $0.id == missingLogicalRoot.id || $0.id == physicalRoot.id })
         XCTAssertEqual(ownership.installedOwnerCount, 0)
         XCTAssertEqual(ownership.provisionalOwnerCount, 0)
         XCTAssertEqual(ownership.rootClaimCount, 0)

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootCatalogAdmissibilityTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootCatalogAdmissibilityTests.swift
@@ -1,0 +1,60 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class WorkspaceRootCatalogAdmissibilityTests: XCTestCase {
+    func testCatalogAdmissionPrecedesSearchAdmissionOnlyAfterCatalogCompletion() {
+        let workspaceID = UUID()
+        let diagnostics = WorkspaceCatalogDiagnostics(
+            generation: 1,
+            rootScope: .visibleWorkspace,
+            rootCount: 1,
+            folderCount: 0,
+            fileCount: 0
+        )
+        let cases: [(WorkspaceSearchReadinessState, Bool, Bool)] = [
+            (.idle, false, false),
+            (.activating(workspaceID: workspaceID, generation: 1), false, false),
+            (.loadingCatalog(
+                workspaceID: workspaceID,
+                generation: 1,
+                loadedRootCount: 0,
+                expectedRootCount: 1,
+                failures: []
+            ), false, false),
+            (.buildingIndexes(
+                workspaceID: workspaceID,
+                generation: 1,
+                catalogGeneration: 1,
+                failures: []
+            ), true, false),
+            (.ready(
+                workspaceID: workspaceID,
+                generation: 1,
+                catalogGeneration: 1,
+                indexedGeneration: 1,
+                diagnostics: diagnostics
+            ), true, true),
+            (.degraded(
+                workspaceID: workspaceID,
+                generation: 1,
+                catalogGeneration: 1,
+                indexedGeneration: nil,
+                failures: [],
+                diagnostics: diagnostics
+            ), true, true),
+            (.degraded(
+                workspaceID: workspaceID,
+                generation: 1,
+                catalogGeneration: nil,
+                indexedGeneration: nil,
+                failures: [],
+                diagnostics: nil
+            ), false, true)
+        ]
+
+        for (state, expectedCatalog, expectedSearch) in cases {
+            XCTAssertEqual(state.isRootCatalogAdmissible, expectedCatalog, "state: \(state)")
+            XCTAssertEqual(state.isSearchAdmissible, expectedSearch, "state: \(state)")
+        }
+    }
+}

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceRootCatalogSnapshotTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceRootCatalogSnapshotTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+#if DEBUG
+    final class WorkspaceRootCatalogSnapshotTests: XCTestCase {
+        @MainActor
+        func testPostActivationWindowTimesOutInsteadOfReturningEmptyConfiguredSnapshot() async throws {
+            let rootURL = try makeTemporaryRoot(name: "CatalogHeld")
+            let source = WorkspaceModel(name: "Source", repoPaths: [])
+            let target = WorkspaceModel(name: "Target", repoPaths: [rootURL.path])
+            let manager = makeManager(workspaces: [source, target], active: source)
+            let gate = RootHydrationSuspensionGate()
+            manager.setWorkspaceRootHydrationWillSpawnHandlerForTesting { workspaceID in
+                guard workspaceID == target.id else { return }
+                await gate.hold()
+            }
+
+            let switchTask = Task { @MainActor in
+                await manager.switchWorkspace(to: target, saveState: false, reason: "catalog-test")
+            }
+            await gate.waitUntilHeld()
+            XCTAssertEqual(manager.activeWorkspaceID, target.id)
+
+            do {
+                _ = try await manager.awaitWorkspaceRootCatalogSnapshot(
+                    workspaceID: target.id,
+                    timeout: .milliseconds(20)
+                )
+                XCTFail("Configured workspace must not publish an empty snapshot while hydration is held")
+            } catch let error as WorkspaceRootCatalogSnapshotError {
+                XCTAssertEqual(error, .readinessTimedOut)
+            }
+
+            await gate.release()
+            let switchResult = await switchTask.value
+            XCTAssertTrue(switchResult.didSwitch)
+            let snapshot = try await manager.awaitWorkspaceRootCatalogSnapshot(
+                workspaceID: target.id,
+                timeout: .seconds(1)
+            )
+            let storeRoots = await manager.fileManager.workspaceFileContextStore.roots()
+                .filter { $0.kind == .primaryWorkspace }
+
+            XCTAssertEqual(snapshot.configuredRootPaths, [rootURL.standardizedFileURL.path])
+            XCTAssertEqual(snapshot.primaryRoots.map(\.id), storeRoots.map(\.id))
+            XCTAssertEqual(snapshot.primaryRoots.map(\.standardizedFullPath), [rootURL.standardizedFileURL.path])
+        }
+
+        @MainActor
+        func testCancelledCatalogWaitRemovesOnlyItsWaiter() async throws {
+            let rootURL = try makeTemporaryRoot(name: "CatalogCancelled")
+            let source = WorkspaceModel(name: "Source", repoPaths: [])
+            let target = WorkspaceModel(name: "Target", repoPaths: [rootURL.path])
+            let manager = makeManager(workspaces: [source, target], active: source)
+            let gate = RootHydrationSuspensionGate()
+            manager.setWorkspaceRootHydrationWillSpawnHandlerForTesting { workspaceID in
+                guard workspaceID == target.id else { return }
+                await gate.hold()
+            }
+            let switchTask = Task { @MainActor in
+                await manager.switchWorkspace(to: target, saveState: false, reason: "catalog-cancel-test")
+            }
+            await gate.waitUntilHeld()
+            let cancelledWait = Task { @MainActor in
+                try await manager.awaitWorkspaceRootCatalogSnapshot(
+                    workspaceID: target.id,
+                    timeout: .seconds(30)
+                )
+            }
+            let survivingWait = Task { @MainActor in
+                try await manager.awaitWorkspaceRootCatalogSnapshot(
+                    workspaceID: target.id,
+                    timeout: .seconds(30)
+                )
+            }
+            await Task.yield()
+            await Task.yield()
+
+            cancelledWait.cancel()
+            do {
+                _ = try await cancelledWait.value
+                XCTFail("Cancelled waiter must throw")
+            } catch is CancellationError {
+                // Expected.
+            }
+            await gate.release()
+            _ = await switchTask.value
+            let survivingSnapshot = try await survivingWait.value
+            XCTAssertEqual(survivingSnapshot.workspaceID, target.id)
+            XCTAssertEqual(manager.workspaceSearchReadinessWaiterCountForTesting, 0)
+        }
+
+        @MainActor
+        func testAdditionalLoadedPrimaryRootIsRejectedAsInconsistent() async throws {
+            let configuredRoot = try makeTemporaryRoot(name: "CatalogConfigured")
+            let extraRoot = try makeTemporaryRoot(name: "CatalogExtra")
+            let source = WorkspaceModel(name: "Source", repoPaths: [])
+            let target = WorkspaceModel(name: "Target", repoPaths: [configuredRoot.path])
+            let manager = makeManager(workspaces: [source, target], active: source)
+
+            let result = await manager.switchWorkspace(to: target, saveState: false, reason: "catalog-mismatch-test")
+            XCTAssertTrue(result.didSwitch)
+            _ = try await manager.fileManager.workspaceFileContextStore.loadRoot(path: extraRoot.path)
+
+            do {
+                _ = try await manager.awaitWorkspaceRootCatalogSnapshot(
+                    workspaceID: target.id,
+                    timeout: .seconds(1)
+                )
+                XCTFail("An additional primary root must invalidate exact catalog authority")
+            } catch let error as WorkspaceRootCatalogSnapshotError {
+                XCTAssertEqual(error, .inconsistentRootProjection)
+            }
+        }
+
+        @MainActor
+        func testGenerationInvalidationSupersedesPendingCatalogWait() async throws {
+            let rootURL = try makeTemporaryRoot(name: "CatalogSuperseded")
+            let source = WorkspaceModel(name: "Source", repoPaths: [])
+            let target = WorkspaceModel(name: "Target", repoPaths: [rootURL.path])
+            let manager = makeManager(workspaces: [source, target], active: source)
+            let gate = RootHydrationSuspensionGate()
+            manager.setWorkspaceRootHydrationWillSpawnHandlerForTesting { workspaceID in
+                guard workspaceID == target.id else { return }
+                await gate.hold()
+            }
+            let switchTask = Task { @MainActor in
+                await manager.switchWorkspace(to: target, saveState: false, reason: "catalog-supersede-test")
+            }
+            await gate.waitUntilHeld()
+            let waitTask = Task { @MainActor in
+                try await manager.awaitWorkspaceRootCatalogSnapshot(
+                    workspaceID: target.id,
+                    timeout: .seconds(30)
+                )
+            }
+            await Task.yield()
+            await Task.yield()
+
+            await manager.cancelCurrentWorkspaceSwitchAndReturnToSystem()
+            do {
+                _ = try await waitTask.value
+                XCTFail("Invalidating the hydration generation must supersede the pending snapshot")
+            } catch let error as WorkspaceRootCatalogSnapshotError {
+                XCTAssertEqual(error, .readinessSuperseded)
+            }
+            XCTAssertEqual(manager.workspaceSearchReadinessWaiterCountForTesting, 0)
+
+            await gate.release()
+            _ = await switchTask.value
+        }
+
+        @MainActor
+        func testGenerationInvalidationAfterRootCaptureUsesCatalogErrorTaxonomy() async throws {
+            let rootURL = try makeTemporaryRoot(name: "CatalogPostWaitSuperseded")
+            let source = WorkspaceModel(name: "Source", repoPaths: [])
+            let target = WorkspaceModel(name: "Target", repoPaths: [rootURL.path])
+            let manager = makeManager(workspaces: [source, target], active: source)
+            let result = await manager.switchWorkspace(
+                to: target,
+                saveState: false,
+                reason: "catalog-post-wait-supersede-test"
+            )
+            XCTAssertTrue(result.didSwitch)
+            manager.setWorkspaceRootCatalogDidCaptureRootsHandlerForTesting {
+                manager.republishReadyRootCatalogWithNextGenerationForTesting()
+            }
+            addTeardownBlock { @MainActor in
+                manager.setWorkspaceRootCatalogDidCaptureRootsHandlerForTesting(nil)
+            }
+
+            do {
+                _ = try await manager.awaitWorkspaceRootCatalogSnapshot(
+                    workspaceID: target.id,
+                    timeout: .seconds(1)
+                )
+                XCTFail("Post-wait readiness invalidation must supersede the catalog snapshot")
+            } catch let error as WorkspaceRootCatalogSnapshotError {
+                XCTAssertEqual(error, .readinessSuperseded)
+            } catch {
+                XCTFail("Catalog snapshot must not leak an unrelated readiness error: \(error)")
+            }
+        }
+
+        @MainActor
+        func testCancellationAfterRootCaptureDoesNotPublishCatalogSnapshot() async throws {
+            let rootURL = try makeTemporaryRoot(name: "CatalogPostCaptureCancellation")
+            let source = WorkspaceModel(name: "Source", repoPaths: [])
+            let target = WorkspaceModel(name: "Target", repoPaths: [rootURL.path])
+            let manager = makeManager(workspaces: [source, target], active: source)
+            let result = await manager.switchWorkspace(
+                to: target,
+                saveState: false,
+                reason: "catalog-post-capture-cancellation-test"
+            )
+            XCTAssertTrue(result.didSwitch)
+            let gate = RootHydrationSuspensionGate()
+            manager.setWorkspaceRootCatalogDidCaptureRootsHandlerForTesting {
+                await gate.hold()
+            }
+            addTeardownBlock { @MainActor in
+                manager.setWorkspaceRootCatalogDidCaptureRootsHandlerForTesting(nil)
+                await gate.release()
+            }
+
+            let snapshotTask = Task { @MainActor in
+                try await manager.awaitWorkspaceRootCatalogSnapshot(
+                    workspaceID: target.id,
+                    timeout: .seconds(1)
+                )
+            }
+            await gate.waitUntilHeld()
+            snapshotTask.cancel()
+            await gate.release()
+
+            do {
+                _ = try await snapshotTask.value
+                XCTFail("Cancellation after root capture must not publish a catalog snapshot")
+            } catch is CancellationError {
+                // Expected.
+            }
+        }
+
+        @MainActor
+        func testGenuinelyRootlessWorkspaceProducesSuccessfulEmptySnapshot() async throws {
+            let source = WorkspaceModel(name: "Source", repoPaths: [])
+            let target = WorkspaceModel(name: "Rootless", repoPaths: [])
+            let manager = makeManager(workspaces: [source, target], active: source)
+
+            let result = await manager.switchWorkspace(to: target, saveState: false, reason: "rootless-test")
+            XCTAssertTrue(result.didSwitch)
+            let snapshot = try await manager.awaitWorkspaceRootCatalogSnapshot(
+                workspaceID: target.id,
+                timeout: .seconds(1)
+            )
+
+            XCTAssertTrue(snapshot.isGenuinelyRootless)
+            XCTAssertEqual(snapshot.configuredRootPaths, [])
+            XCTAssertEqual(snapshot.primaryRoots, [])
+        }
+
+        @MainActor
+        private func makeManager(
+            workspaces: [WorkspaceModel],
+            active: WorkspaceModel
+        ) -> WorkspaceManagerViewModel {
+            let files = WorkspaceFilesViewModel()
+            let keyManager = KeyManager(
+                secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+            )
+            let apiSettings = APISettingsViewModel(
+                aiQueriesService: AIQueriesService(keyManager: keyManager),
+                keyManager: keyManager,
+                loadStoredDataOnInit: false
+            )
+            let prompt = PromptViewModel(
+                fileManager: files,
+                apiSettingsViewModel: apiSettings,
+                windowID: -1,
+                settingsManager: WindowSettingsManager(windowID: -1)
+            )
+            let manager = WorkspaceManagerViewModel(
+                fileManager: files,
+                promptViewModel: prompt,
+                performInitialWorkspaceActivation: false
+            )
+            manager.workspaces = workspaces
+            manager.activeWorkspace = active
+            return manager
+        }
+
+        private func makeTemporaryRoot(name: String) throws -> URL {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+            return root
+        }
+    }
+
+    private actor RootHydrationSuspensionGate {
+        private var held = false
+        private var released = false
+        private var heldWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func hold() async {
+            held = true
+            let waiters = heldWaiters
+            heldWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+            guard !released else { return }
+            await withCheckedContinuation { releaseWaiters.append($0) }
+        }
+
+        func waitUntilHeld() async {
+            guard !held else { return }
+            await withCheckedContinuation { heldWaiters.append($0) }
+        }
+
+        func release() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

- Freeze file-tool authority when an explicit context bind succeeds, so the immediately following file request uses the same workspace and root projection.
- Treat configured workspaces whose root catalogs are still restoring as retryable readiness failures instead of authorized empty scopes.
- Preserve prior usable bindings across failed or superseded binds while keeping genuinely rootless workspaces distinct.
- Bound readiness waits, cancellation, and physical file-provider settlement.

## Root cause

Context binding could publish the logical workspace before its root catalog and file-tool projection were ready. The bind therefore reported success, while the next file request independently resolved the incomplete projection as an empty workspace.

## Verification

- Binding authority suite — 34 tests passed
- Context Builder workspace-resolution suite — 4 tests passed
- MCP domain read-provider suite — 4 tests passed
- Full Swift test suite passed
- SwiftFormat and strict SwiftLint passed
- `RepoPrompt` and `repoprompt-mcp` product builds passed
- Repository guardrails and contribution preflights passed
- Packaged live checks passed for atomic post-restart roots, worktree-scoped search, exact worktree identity, and bounded cancellation with immediate tree responsiveness and zero retained settlement debt

Closes #962
