### PR TITLE
Make physical file reads cancellation-responsive

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
@@ -65,8 +65,11 @@ private struct ContentReadRequest {
     let mode: ContentReadMode
     let workloadClass: ContentReadWorkloadClass
     let schedulerOwnerID: UUID
+    let cacheRevision: UInt64
     #if DEBUG
         let chunkReadHandler: (@Sendable (String) async -> Void)?
+        let cacheCommitHandler: (@Sendable () async -> Void)?
+        let diskReadRecorder: @Sendable (_ bytes: Int, _ decodeMicroseconds: Int) -> Void
     #endif
 }
 
@@ -77,15 +80,26 @@ private enum ContentReadTelemetryOutcome: String {
 }
 
 private struct ContentReadResult {
-    let absolutePath: String
     let content: String?
     let detectedEncodingRawValue: UInt?
     let modificationDate: Date?
     let fingerprint: FileContentFingerprint?
+    let encodingCacheFingerprint: FileContentFingerprint?
     let telemetryOutcome: ContentReadTelemetryOutcome
 
     var detectedEncoding: String.Encoding? {
         detectedEncodingRawValue.map(String.Encoding.init(rawValue:))
+    }
+
+    func withEncodingCacheFingerprint(_ fingerprint: FileContentFingerprint?) -> Self {
+        Self(
+            content: content,
+            detectedEncodingRawValue: detectedEncodingRawValue,
+            modificationDate: modificationDate,
+            fingerprint: self.fingerprint,
+            encodingCacheFingerprint: fingerprint,
+            telemetryOutcome: telemetryOutcome
+        )
     }
 }
 
@@ -93,6 +107,78 @@ private struct RawContentReadResult {
     let data: Data
     let modificationDate: Date
     let fingerprint: FileContentFingerprint
+}
+
+/// Bridges cancellation across synchronous filesystem calls that cannot be interrupted.
+/// The lock protects the continuation, producer handle, and first terminal result; no
+/// continuation resume, task cancellation, suspension, or filesystem work occurs while locked.
+private final class CancellablePhysicalReadState<Value: Sendable>: @unchecked Sendable {
+    typealias Continuation = CheckedContinuation<Value, Error>
+
+    private let lock = NSLock()
+    private var continuation: Continuation?
+    private var producer: Task<Void, Never>?
+    private var terminalResult: Result<Value, Error>?
+
+    func install(_ continuation: Continuation) {
+        let resultToResume: Result<Value, Error>?
+        lock.lock()
+        if let terminalResult {
+            resultToResume = terminalResult
+        } else {
+            self.continuation = continuation
+            resultToResume = nil
+        }
+        lock.unlock()
+        resultToResume.map { continuation.resume(with: $0) }
+    }
+
+    func install(_ producer: Task<Void, Never>) {
+        let producerToCancel: Task<Void, Never>?
+        lock.lock()
+        if terminalResult == nil {
+            self.producer = producer
+            producerToCancel = nil
+        } else {
+            producerToCancel = producer
+        }
+        lock.unlock()
+        producerToCancel?.cancel()
+    }
+
+    func finish(_ result: Result<Value, Error>) {
+        let continuationToResume: Continuation?
+        lock.lock()
+        guard terminalResult == nil else {
+            producer = nil
+            lock.unlock()
+            return
+        }
+        terminalResult = result
+        continuationToResume = continuation
+        continuation = nil
+        producer = nil
+        lock.unlock()
+        continuationToResume?.resume(with: result)
+    }
+
+    func cancel() {
+        let continuationToResume: Continuation?
+        let producerToCancel: Task<Void, Never>?
+        lock.lock()
+        guard terminalResult == nil else {
+            lock.unlock()
+            return
+        }
+        terminalResult = .failure(CancellationError())
+        continuationToResume = continuation
+        producerToCancel = producer
+        continuation = nil
+        producer = nil
+        lock.unlock()
+        producerToCancel?.cancel()
+        continuationToResume?.resume(throwing: CancellationError())
+    }
 }
 
 struct FileContentPrefix {
@@ -111,6 +197,17 @@ private struct ValidatedContentFile {
     let fileSize: Int64
     let modificationDate: Date
     let fingerprint: FileContentFingerprint
+}
+
+enum FileSystemCatalogPathState: Equatable {
+    case regularFile
+    case directory
+    case missingOrOther
+}
+
+private struct PhysicalCatalogPathProbe {
+    let pathState: FileSystemCatalogPathState
+    let regularFileEligibility: CatalogRegularFileEligibility
 }
 
 private enum BoundedDataReadResult {
@@ -139,6 +236,8 @@ actor ContentReadAsyncLimiter {
             let activePermitCount: Int
             let queuedWaiterCount: Int
             let ownerLaneCount: Int
+            let activePermitCountsByWorkload: [String: Int]
+            let activePermitCountsByOwner: [UUID: Int]
             let cancellationCount: Int
             let grantCount: Int
             let overloadCount: Int
@@ -198,6 +297,9 @@ actor ContentReadAsyncLimiter {
     private var foregroundActivitiesByTokenID: [UUID: ContentReadForegroundActivityKind] = [:]
     private var waiterStates: [UUID: WaiterState] = [:]
     private var activePermitCountsByOwner: [UUID: Int] = [:]
+    #if DEBUG
+        private var activePermitCountsByWorkload: [String: Int] = [:]
+    #endif
     private var lastGrantOrdinalByOwner: [UUID: UInt64] = [:]
     private var nextEnqueueOrdinal: UInt64 = 0
     private var nextGrantOrdinal: UInt64 = 0
@@ -546,6 +648,16 @@ actor ContentReadAsyncLimiter {
             }
         }
         #if DEBUG
+            let workloadKey = acquisition.workloadClass.rawValue
+            if let activeCount = activePermitCountsByWorkload[workloadKey] {
+                if activeCount <= 1 {
+                    activePermitCountsByWorkload.removeValue(forKey: workloadKey)
+                } else {
+                    activePermitCountsByWorkload[workloadKey] = activeCount - 1
+                }
+            }
+        #endif
+        #if DEBUG
             assert(availablePermits < capacity, "Content read limiter over-release detected")
         #endif
         availablePermits = min(availablePermits + 1, capacity)
@@ -676,6 +788,9 @@ actor ContentReadAsyncLimiter {
             }
         }
         activePermitCountsByOwner[ownerID, default: 0] += 1
+        #if DEBUG
+            activePermitCountsByWorkload[workloadClass.rawValue, default: 0] += 1
+        #endif
         nextGrantOrdinal &+= 1
         lastGrantOrdinalByOwner[ownerID] = nextGrantOrdinal
         grantCount &+= 1
@@ -753,6 +868,8 @@ actor ContentReadAsyncLimiter {
                 activePermitCount: capacity - availablePermits,
                 queuedWaiterCount: waiterStates.count,
                 ownerLaneCount: ownerLaneCount,
+                activePermitCountsByWorkload: activePermitCountsByWorkload,
+                activePermitCountsByOwner: activePermitCountsByOwner,
                 cancellationCount: cancellationCount,
                 grantCount: grantCount,
                 overloadCount: overloadCount,
@@ -837,9 +954,12 @@ extension FileSystemService {
             fileSizeLimit: defaultContentReadFileSizeLimit,
             mode: .automatic,
             workloadClass: workloadClass,
-            schedulerOwnerID: UUID()
+            schedulerOwnerID: UUID(),
+            cacheRevision: 0
         )
-        let result = try await performContentReadOffActor(request)
+        let result = try await performCancellationResponsivePhysicalRead(request) {
+            try await readContentFromDisk(request)
+        }
         try Task.checkCancellation()
         return result.content
     }
@@ -858,7 +978,11 @@ extension FileSystemService {
         }
     #endif
 
-    func contentFingerprint(ofRelativePath relativePath: String) async throws -> FileContentFingerprint {
+    func contentFingerprint(
+        ofRelativePath relativePath: String,
+        workloadClass: ContentReadWorkloadClass = .contentSearch,
+        schedulerOwnerID: UUID? = nil
+    ) async throws -> FileContentFingerprint {
         #if DEBUG
             contentFingerprintRequestCountForTesting += 1
         #endif
@@ -867,11 +991,201 @@ extension FileSystemService {
             chunkSize: 1_048_576,
             fileSizeLimit: 10_000_000,
             mode: .automatic,
-            workloadClass: .contentSearch
+            workloadClass: workloadClass,
+            schedulerOwnerID: schedulerOwnerID
         )
-        return try await Task.detached(priority: Task.currentPriority) {
-            try Self.validateContentFileForReading(request).fingerprint
-        }.value
+        #if DEBUG
+            let physicalReadHandler = contentPhysicalReadHandler
+        #endif
+        return try await Self.performCancellationResponsivePhysicalRead(request) {
+            #if DEBUG
+                try physicalReadHandler?()
+            #endif
+            return try Self.validateContentFileForReading(request).fingerprint
+        }
+    }
+
+    /// Exact-file resolution performs the same potentially blocking metadata and
+    /// symlink checks as content loading. Keeping those checks behind the physical
+    /// worker boundary lets a cancelled provider settle without releasing the real
+    /// producer's limiter admission before the filesystem call returns.
+    func cancellationResponsiveRegularFileExistsOnDisk(
+        relativePath: String,
+        schedulerOwnerID: UUID? = nil
+    ) async throws -> Bool {
+        let request = try makeContentReadRequest(
+            cacheKey: relativePath,
+            chunkSize: 1,
+            fileSizeLimit: .max,
+            mode: .automatic,
+            workloadClass: .interactiveRead,
+            schedulerOwnerID: schedulerOwnerID
+        )
+        #if DEBUG
+            let physicalReadHandler = contentPhysicalReadHandler
+        #endif
+        do {
+            _ = try await Self.performCancellationResponsivePhysicalRead(request) {
+                #if DEBUG
+                    try physicalReadHandler?()
+                #endif
+                return try Self.validateContentFileForReading(request)
+            }
+            return true
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as ContentReadSchedulerError {
+            throw error
+        } catch {
+            return false
+        }
+    }
+
+    /// Bare relative-path resolution probes every visible root for ambiguity. A slow
+    /// metadata lookup in a root without a catalog record must not pin that root's actor
+    /// or prevent the cancelled provider from settling while the syscall finishes.
+    func cancellationResponsiveCatalogRegularFileEligibility(
+        relativePath: String,
+        schedulerOwnerID: UUID? = nil
+    ) async throws -> CatalogRegularFileEligibility {
+        let request: ContentReadRequest
+        do {
+            request = try makeContentReadRequest(
+                cacheKey: relativePath,
+                chunkSize: 1,
+                fileSizeLimit: .max,
+                mode: .automatic,
+                workloadClass: .interactiveRead,
+                schedulerOwnerID: schedulerOwnerID
+            )
+        } catch {
+            return .ineligible(.invalidRelativePath)
+        }
+        #if DEBUG
+            let physicalReadHandler = contentPhysicalReadHandler
+        #endif
+        let physicalEligibility = try await Self.performCancellationResponsivePhysicalRead(request) {
+            #if DEBUG
+                try physicalReadHandler?()
+            #endif
+            return Self.physicalCatalogPathProbe(request).regularFileEligibility
+        }
+        guard physicalEligibility == .eligible else { return physicalEligibility }
+        try Task.checkCancellation()
+
+        let isIgnored: Bool = if enableHierarchicalIgnores {
+            await isIgnoredHierarchical(relativePath: request.relativePath, isDirectory: false)
+                || isIgnoredPrefixCheck(relativePath: request.relativePath)
+        } else {
+            isIgnoredPrefixCheck(relativePath: request.relativePath)
+        }
+        try Task.checkCancellation()
+        return isIgnored ? .ineligible(.ignored) : .eligible
+    }
+
+    func cancellationResponsiveCatalogRegularFileEligibilityWithPolicy(
+        relativePath: String,
+        schedulerOwnerID: UUID? = nil
+    ) async throws -> (
+        eligibility: CatalogRegularFileEligibility,
+        policyIdentity: WorkspaceRootCatalogPolicyIdentity,
+        ignoreRulesRevision: UInt64
+    ) {
+        while true {
+            let startingPolicyIdentity = catalogPolicyIdentity
+            let startingIgnoreRulesRevision = ignoreRulesRevision
+            let eligibility = try await cancellationResponsiveCatalogRegularFileEligibility(
+                relativePath: relativePath,
+                schedulerOwnerID: schedulerOwnerID
+            )
+            try Task.checkCancellation()
+            guard startingPolicyIdentity == catalogPolicyIdentity,
+                  startingIgnoreRulesRevision == ignoreRulesRevision
+            else { continue }
+            return (eligibility, startingPolicyIdentity, startingIgnoreRulesRevision)
+        }
+    }
+
+    func cancellationResponsiveCatalogPathState(
+        relativePath: String,
+        schedulerOwnerID: UUID? = nil
+    ) async throws -> FileSystemCatalogPathState {
+        let request = try makeContentReadRequest(
+            cacheKey: relativePath,
+            chunkSize: 1,
+            fileSizeLimit: .max,
+            mode: .automatic,
+            workloadClass: .interactiveRead,
+            schedulerOwnerID: schedulerOwnerID
+        )
+        #if DEBUG
+            let physicalReadHandler = contentPhysicalReadHandler
+        #endif
+        return try await Self.performCancellationResponsivePhysicalRead(request) {
+            #if DEBUG
+                try physicalReadHandler?()
+            #endif
+            return Self.physicalCatalogPathProbe(request).pathState
+        }
+    }
+
+    private nonisolated static func physicalCatalogPathProbe(
+        _ request: ContentReadRequest
+    ) -> PhysicalCatalogPathProbe {
+        var isDirectory = ObjCBool(false)
+        guard FileManager.default.fileExists(atPath: request.absolutePath, isDirectory: &isDirectory) else {
+            return PhysicalCatalogPathProbe(
+                pathState: .missingOrOther,
+                regularFileEligibility: .ineligible(.missingOrDirectory)
+            )
+        }
+        let url = URL(fileURLWithPath: request.absolutePath)
+        if let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]) {
+            if values.isSymbolicLink == true {
+                return PhysicalCatalogPathProbe(
+                    pathState: .missingOrOther,
+                    regularFileEligibility: .ineligible(.symbolicLink)
+                )
+            }
+            if !isDirectory.boolValue, values.isRegularFile == false {
+                return PhysicalCatalogPathProbe(
+                    pathState: .missingOrOther,
+                    regularFileEligibility: .ineligible(.nonRegularFile)
+                )
+            }
+        }
+        if request.skipSymlinks,
+           pathContainsSymlinkComponent(
+               request.relativePath,
+               rootURL: URL(fileURLWithPath: request.standardizedRootPath)
+           )
+        {
+            return PhysicalCatalogPathProbe(
+                pathState: .missingOrOther,
+                regularFileEligibility: .ineligible(.symlinkComponent)
+            )
+        }
+
+        let canonicalPath = url.resolvingSymlinksInPath().path
+        let canonicalPrefix = request.canonicalRootPath.hasSuffix("/")
+            ? request.canonicalRootPath
+            : request.canonicalRootPath + "/"
+        guard canonicalPath == request.canonicalRootPath || canonicalPath.hasPrefix(canonicalPrefix) else {
+            return PhysicalCatalogPathProbe(
+                pathState: .missingOrOther,
+                regularFileEligibility: .ineligible(.outsideCanonicalRoot)
+            )
+        }
+        if isDirectory.boolValue {
+            return PhysicalCatalogPathProbe(
+                pathState: .directory,
+                regularFileEligibility: .ineligible(.missingOrDirectory)
+            )
+        }
+        return PhysicalCatalogPathProbe(
+            pathState: .regularFile,
+            regularFileEligibility: .eligible
+        )
     }
 
     func loadValidatedContent(
@@ -900,7 +1214,6 @@ extension FileSystemService {
         else {
             throw FileContentValidationError.fingerprintChanged
         }
-        commitContentReadResultIfCurrent(result, cacheKey: request.cacheKey)
         return ValidatedFileContentSnapshot(
             content: result.content,
             detectedEncodingRawValue: result.detectedEncodingRawValue,
@@ -1054,7 +1367,6 @@ extension FileSystemService {
             contentLoadOutcome = "cancelled"
             throw error
         }
-        commitContentReadResultIfCurrent(result, cacheKey: request.cacheKey)
         contentLoadOutcome = result.telemetryOutcome.rawValue
         return result.content
     }
@@ -1181,7 +1493,6 @@ extension FileSystemService {
             contentLoadOutcome = "cancelled"
             throw error
         }
-        commitContentReadResultIfCurrent(result, cacheKey: request.cacheKey)
         contentLoadOutcome = result.telemetryOutcome.rawValue
         return result.content
     }
@@ -1235,7 +1546,9 @@ extension FileSystemService {
                 mode: mode,
                 workloadClass: workloadClass,
                 schedulerOwnerID: schedulerOwnerID ?? diagnosticRootToken,
-                chunkReadHandler: contentReadChunkHandler
+                cacheRevision: contentReadCacheRevision,
+                chunkReadHandler: contentReadChunkHandler,
+                cacheCommitHandler: contentReadCacheCommitHandler
             )
         #else
             return Self.assembleContentReadRequest(
@@ -1249,7 +1562,8 @@ extension FileSystemService {
                 fileSizeLimit: fileSizeLimit,
                 mode: mode,
                 workloadClass: workloadClass,
-                schedulerOwnerID: schedulerOwnerID ?? diagnosticRootToken
+                schedulerOwnerID: schedulerOwnerID ?? diagnosticRootToken,
+                cacheRevision: contentReadCacheRevision
             )
         #endif
     }
@@ -1267,7 +1581,11 @@ extension FileSystemService {
             mode: ContentReadMode,
             workloadClass: ContentReadWorkloadClass,
             schedulerOwnerID: UUID,
-            chunkReadHandler: (@Sendable (String) async -> Void)? = nil
+            cacheRevision: UInt64,
+            chunkReadHandler: (@Sendable (String) async -> Void)? = nil,
+            cacheCommitHandler: (@Sendable () async -> Void)? = nil,
+            diskReadRecorder: @escaping @Sendable (_ bytes: Int, _ decodeMicroseconds: Int) -> Void = MCPToolWorkCountDiagnostics
+                .readFileDiskReadRecorder()
         ) -> ContentReadRequest {
             ContentReadRequest(
                 cacheKey: cacheKey,
@@ -1281,7 +1599,10 @@ extension FileSystemService {
                 mode: mode,
                 workloadClass: workloadClass,
                 schedulerOwnerID: schedulerOwnerID,
-                chunkReadHandler: chunkReadHandler
+                cacheRevision: cacheRevision,
+                chunkReadHandler: chunkReadHandler,
+                cacheCommitHandler: cacheCommitHandler,
+                diskReadRecorder: diskReadRecorder
             )
         }
     #else
@@ -1296,7 +1617,8 @@ extension FileSystemService {
             fileSizeLimit: Int64,
             mode: ContentReadMode,
             workloadClass: ContentReadWorkloadClass,
-            schedulerOwnerID: UUID
+            schedulerOwnerID: UUID,
+            cacheRevision: UInt64
         ) -> ContentReadRequest {
             ContentReadRequest(
                 cacheKey: cacheKey,
@@ -1309,7 +1631,8 @@ extension FileSystemService {
                 fileSizeLimit: fileSizeLimit,
                 mode: mode,
                 workloadClass: workloadClass,
-                schedulerOwnerID: schedulerOwnerID
+                schedulerOwnerID: schedulerOwnerID,
+                cacheRevision: cacheRevision
             )
         }
     #endif
@@ -1330,11 +1653,16 @@ extension FileSystemService {
             EditFlowPerf.Dimensions(workloadClass: request.workloadClass.rawValue, rootToken: diagnosticRootToken.uuidString)
         )
         do {
-            let result = try await Self.performContentReadOffActor(
-                request,
-                expectedFingerprint: expectedFingerprint,
-                requirePostReadValidation: requirePostReadValidation
-            )
+            let result = try await Self.performCancellationResponsivePhysicalRead(request) {
+                let result = try await Self.readContentFromDisk(
+                    request,
+                    expectedFingerprint: expectedFingerprint,
+                    requirePostReadValidation: requirePostReadValidation
+                )
+                try Task.checkCancellation()
+                await self.commitContentReadResultIfCurrent(result, request: request)
+                return result
+            }
             EditFlowPerf.end(
                 EditFlowPerf.Stage.FileSystem.contentReadOffActorAwait,
                 offActorState,
@@ -1370,63 +1698,28 @@ extension FileSystemService {
         }
     }
 
-    private func commitContentReadResultIfCurrent(_ result: ContentReadResult, cacheKey: String) {
+    private func commitContentReadResultIfCurrent(
+        _ result: ContentReadResult,
+        request: ContentReadRequest
+    ) {
+        guard !Task.isCancelled else { return }
         guard let detectedEncoding = result.detectedEncoding,
               let fingerprint = result.fingerprint
         else { return }
         let contentLoadState = EditFlowPerf.begin(EditFlowPerf.Stage.FileSystem.contentLoadActorBody)
         defer { EditFlowPerf.end(EditFlowPerf.Stage.FileSystem.contentLoadActorBody, contentLoadState) }
 
-        guard (try? FileContentFingerprintReader.fingerprint(atPath: result.absolutePath)) == fingerprint else { return }
-        encodingMap[cacheKey] = detectedEncoding
+        guard result.encodingCacheFingerprint == fingerprint else { return }
+        guard request.cacheRevision == contentReadCacheRevision else { return }
+        encodingMap[request.cacheKey] = detectedEncoding
     }
 
     private nonisolated static func performContentPrefixReadOffActor(
         _ request: ContentReadRequest,
         maximumBytes: Int
     ) async throws -> FileContentPrefix? {
-        let workerPriority = Task.currentPriority
-        return try await contentReadWorkerLimiter.withPermit(
-            workloadClass: request.workloadClass,
-            ownerID: request.schedulerOwnerID
-        ) {
-            try await withThrowingTaskGroup(of: FileContentPrefix?.self) { group in
-                group.addTask(priority: workerPriority) {
-                    try await readContentPrefixFromDisk(request, maximumBytes: maximumBytes)
-                }
-                guard let result = try await group.next() else {
-                    throw CancellationError()
-                }
-                group.cancelAll()
-                return result
-            }
-        }
-    }
-
-    private nonisolated static func performContentReadOffActor(
-        _ request: ContentReadRequest,
-        expectedFingerprint: FileContentFingerprint? = nil,
-        requirePostReadValidation: Bool = false
-    ) async throws -> ContentReadResult {
-        let workerPriority = Task.currentPriority
-        return try await contentReadWorkerLimiter.withPermit(
-            workloadClass: request.workloadClass,
-            ownerID: request.schedulerOwnerID
-        ) {
-            try await withThrowingTaskGroup(of: ContentReadResult.self) { group in
-                group.addTask(priority: workerPriority) {
-                    try await readContentFromDisk(
-                        request,
-                        expectedFingerprint: expectedFingerprint,
-                        requirePostReadValidation: requirePostReadValidation
-                    )
-                }
-                guard let result = try await group.next() else {
-                    throw CancellationError()
-                }
-                group.cancelAll()
-                return result
-            }
+        try await performCancellationResponsivePhysicalRead(request) {
+            try await readContentPrefixFromDisk(request, maximumBytes: maximumBytes)
         }
     }
 
@@ -1434,24 +1727,83 @@ extension FileSystemService {
         _ request: ContentReadRequest,
         expectedFingerprint: FileContentFingerprint?
     ) async throws -> RawContentReadResult {
-        let workerPriority = Task.currentPriority
-        return try await contentReadWorkerLimiter.withPermit(
+        try await performCancellationResponsivePhysicalRead(request) {
+            try await readRawContentFromDisk(
+                request,
+                expectedFingerprint: expectedFingerprint
+            )
+        }
+    }
+
+    private nonisolated static func performCancellationResponsivePhysicalRead<Value: Sendable>(
+        _ request: ContentReadRequest,
+        operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
+        try await withCancellationResponsivePhysicalReadPermit(
             workloadClass: request.workloadClass,
-            ownerID: request.schedulerOwnerID
-        ) {
-            try await withThrowingTaskGroup(of: RawContentReadResult.self) { group in
-                group.addTask(priority: workerPriority) {
-                    try await readRawContentFromDisk(
-                        request,
-                        expectedFingerprint: expectedFingerprint
-                    )
+            schedulerOwnerID: request.schedulerOwnerID,
+            priority: Task.currentPriority,
+            operation: operation
+        )
+    }
+
+    nonisolated static func withCancellationResponsivePhysicalReadPermit<Value: Sendable>(
+        workloadClass: ContentReadWorkloadClass,
+        schedulerOwnerID: UUID,
+        priority: TaskPriority,
+        beforeProducerInstallForTesting: (@Sendable () -> Void)? = nil,
+        operation: @escaping @Sendable () async throws -> Value
+    ) async throws -> Value {
+        let state = CancellablePhysicalReadState<Value>()
+        let lifecycleCorrelation = EditFlowPerf.currentLifecycleCorrelation
+        #if DEBUG
+            let benchmarkMetricTag = WorktreeStartupInstrumentation.currentBenchmarkMetricTag
+        #endif
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                state.install(continuation)
+                let producer = Task.detached(priority: priority) {
+                    let result: Result<Value, Error>
+                    do {
+                        let admittedOperation: @Sendable () async throws -> Value = {
+                            if workloadClass == .interactiveRead {
+                                return try await contentReadWorkerLimiter.withForegroundActivity(
+                                    kind: .interactiveRead,
+                                    operation
+                                )
+                            }
+                            return try await operation()
+                        }
+                        let value = try await EditFlowPerf.$currentLifecycleCorrelation.withValue(lifecycleCorrelation) {
+                            #if DEBUG
+                                try await WorktreeStartupInstrumentation.$currentBenchmarkMetricTag
+                                    .withValue(benchmarkMetricTag) {
+                                        try await contentReadWorkerLimiter.withPermit(
+                                            workloadClass: workloadClass,
+                                            ownerID: schedulerOwnerID
+                                        ) { try await admittedOperation() }
+                                    }
+                            #else
+                                try await contentReadWorkerLimiter.withPermit(
+                                    workloadClass: workloadClass,
+                                    ownerID: schedulerOwnerID
+                                ) { try await admittedOperation() }
+                            #endif
+                        }
+                        result = .success(value)
+                    } catch {
+                        result = .failure(error)
+                    }
+                    state.finish(result)
                 }
-                guard let result = try await group.next() else {
-                    throw CancellationError()
-                }
-                group.cancelAll()
-                return result
+                #if DEBUG
+                    beforeProducerInstallForTesting?()
+                #endif
+                state.install(producer)
             }
+        } onCancel: {
+            state.cancel()
         }
     }
 
@@ -1536,11 +1888,11 @@ extension FileSystemService {
             if hasAlwaysBinaryExtension(request.relativePath), !requirePostReadValidation {
                 workerBodyOutcome = ContentReadTelemetryOutcome.unavailable.rawValue
                 return ContentReadResult(
-                    absolutePath: request.absolutePath,
                     content: nil,
                     detectedEncodingRawValue: nil,
                     modificationDate: nil,
                     fingerprint: nil,
+                    encodingCacheFingerprint: nil,
                     telemetryOutcome: .unavailable
                 )
             }
@@ -1551,7 +1903,8 @@ extension FileSystemService {
                 throw FileContentValidationError.fingerprintChanged
             }
             workerBodyFileBytes = telemetryFileBytes(validated.fileSize)
-            MCPToolWorkCountDiagnostics.recordReadFileDiskRead(
+            recordReadFileDiskRead(
+                request,
                 bytes: workerBodyFileBytes ?? 0,
                 decodeMicroseconds: 0
             )
@@ -1569,14 +1922,25 @@ extension FileSystemService {
                     requireStableIdentity: requirePostReadValidation
                 )
             }
+            var postReadFingerprint: FileContentFingerprint?
+            if requirePostReadValidation || result.detectedEncoding != nil {
+                postReadFingerprint = try? FileContentFingerprintReader.fingerprint(atPath: request.absolutePath)
+            }
+            #if DEBUG
+                if result.detectedEncoding != nil,
+                   postReadFingerprint != nil,
+                   let cacheCommitHandler = request.cacheCommitHandler
+                {
+                    await cacheCommitHandler()
+                }
+            #endif
             if requirePostReadValidation {
-                let postReadFingerprint = try FileContentFingerprintReader.fingerprint(atPath: request.absolutePath)
                 guard postReadFingerprint == validated.fingerprint else {
                     throw FileContentValidationError.fingerprintChanged
                 }
             }
             workerBodyOutcome = result.telemetryOutcome.rawValue
-            return result
+            return result.withEncodingCacheFingerprint(postReadFingerprint)
         } catch {
             workerBodyOutcome = error is CancellationError ? "cancelled" : "failed"
             throw error
@@ -1637,6 +2001,21 @@ extension FileSystemService {
         Int(clamping: max(0, fileSize))
     }
 
+    private nonisolated static func recordReadFileDiskRead(
+        _ request: ContentReadRequest,
+        bytes: Int,
+        decodeMicroseconds: Int
+    ) {
+        #if DEBUG
+            request.diskReadRecorder(bytes, decodeMicroseconds)
+        #else
+            MCPToolWorkCountDiagnostics.recordReadFileDiskRead(
+                bytes: bytes,
+                decodeMicroseconds: decodeMicroseconds
+            )
+        #endif
+    }
+
     private nonisolated static func readAutomaticContent(
         _ request: ContentReadRequest,
         validated: ValidatedContentFile,
@@ -1681,7 +2060,8 @@ extension FileSystemService {
             let decodeStart = DispatchTime.now().uptimeNanoseconds
             let detected = try decodeSmallFileData(data)
             let decodeEnd = DispatchTime.now().uptimeNanoseconds
-            MCPToolWorkCountDiagnostics.recordReadFileDiskRead(
+            recordReadFileDiskRead(
+                request,
                 bytes: 0,
                 decodeMicroseconds: Int(clamping: decodeEnd >= decodeStart ? (decodeEnd - decodeStart) / 1000 : 0)
             )
@@ -1690,11 +2070,11 @@ extension FileSystemService {
                 handle,
                 validated: validated,
                 result: ContentReadResult(
-                    absolutePath: request.absolutePath,
                     content: detected.string,
                     detectedEncodingRawValue: detected.encoding.rawValue,
                     modificationDate: validated.modificationDate,
                     fingerprint: validated.fingerprint,
+                    encodingCacheFingerprint: nil,
                     telemetryOutcome: .loaded
                 ),
                 required: requireStableIdentity
@@ -1802,7 +2182,8 @@ extension FileSystemService {
         let decodeStart = DispatchTime.now().uptimeNanoseconds
         let decodedContent = String(data: fullData, encoding: encoding) ?? "[Binary data or unknown encoding]"
         let decodeEnd = DispatchTime.now().uptimeNanoseconds
-        MCPToolWorkCountDiagnostics.recordReadFileDiskRead(
+        recordReadFileDiskRead(
+            request,
             bytes: 0,
             decodeMicroseconds: Int(clamping: decodeEnd >= decodeStart ? (decodeEnd - decodeStart) / 1000 : 0)
         )
@@ -1810,11 +2191,11 @@ extension FileSystemService {
             handle,
             validated: validated,
             result: ContentReadResult(
-                absolutePath: request.absolutePath,
                 content: decodedContent,
                 detectedEncodingRawValue: encoding.rawValue,
                 modificationDate: validated.modificationDate,
                 fingerprint: validated.fingerprint,
+                encodingCacheFingerprint: nil,
                 telemetryOutcome: .loaded
             ),
             required: requireStableIdentity
@@ -1927,11 +2308,11 @@ extension FileSystemService {
         telemetryOutcome: ContentReadTelemetryOutcome = .unavailable
     ) -> ContentReadResult {
         ContentReadResult(
-            absolutePath: request.absolutePath,
             content: content,
             detectedEncodingRawValue: nil,
             modificationDate: validated.modificationDate,
             fingerprint: validated.fingerprint,
+            encodingCacheFingerprint: nil,
             telemetryOutcome: telemetryOutcome
         )
     }
@@ -2313,70 +2694,57 @@ extension FileSystemService {
     }
 
     private nonisolated static func performEncodingDetectionOffActor(_ request: ContentReadRequest) async throws -> String.Encoding {
-        let workerPriority = Task.currentPriority
-        return try await contentReadWorkerLimiter.withPermit(
-            workloadClass: request.workloadClass,
-            ownerID: request.schedulerOwnerID
-        ) {
-            try await withThrowingTaskGroup(of: String.Encoding.self) { group in
-                group.addTask(priority: workerPriority) {
-                    let workerBodyState = EditFlowPerf.begin(
-                        EditFlowPerf.Stage.FileSystem.contentReadWorkerBody,
-                        EditFlowPerf.Dimensions(
-                            workloadClass: request.workloadClass.rawValue,
-                            contentSource: "disk"
-                        )
+        try await performCancellationResponsivePhysicalRead(request) {
+            let workerBodyState = EditFlowPerf.begin(
+                EditFlowPerf.Stage.FileSystem.contentReadWorkerBody,
+                EditFlowPerf.Dimensions(
+                    workloadClass: request.workloadClass.rawValue,
+                    contentSource: "disk"
+                )
+            )
+            var workerBodyOutcome = "failed"
+            var workerBodyFileBytes: Int?
+            defer {
+                EditFlowPerf.end(
+                    EditFlowPerf.Stage.FileSystem.contentReadWorkerBody,
+                    workerBodyState,
+                    EditFlowPerf.Dimensions(
+                        outcome: workerBodyOutcome,
+                        fileBytes: workerBodyFileBytes,
+                        workloadClass: request.workloadClass.rawValue,
+                        contentSource: "disk"
                     )
-                    var workerBodyOutcome = "failed"
-                    var workerBodyFileBytes: Int?
-                    defer {
-                        EditFlowPerf.end(
-                            EditFlowPerf.Stage.FileSystem.contentReadWorkerBody,
-                            workerBodyState,
-                            EditFlowPerf.Dimensions(
-                                outcome: workerBodyOutcome,
-                                fileBytes: workerBodyFileBytes,
-                                workloadClass: request.workloadClass.rawValue,
-                                contentSource: "disk"
-                            )
-                        )
-                    }
-                    do {
-                        try Task.checkCancellation()
-                        let validated = try validateContentFileForReading(request)
-                        workerBodyFileBytes = telemetryFileBytes(validated.fileSize)
-                        let handle = try openValidatedContentHandle(
-                            request,
-                            validated: validated,
-                            requireStableIdentity: false
-                        )
-                        defer { try? handle.close() }
-                        switch try await readBoundedData(request, handle: handle) {
-                        case let .data(data):
-                            _ = try validateOpenContentHandle(
-                                handle,
-                                validated: validated,
-                                result: noEncodingContentReadResult(request, validated: validated, content: nil),
-                                required: false
-                            )
-                            workerBodyOutcome = "loaded"
-                            return detectFileEncoding(in: data)
-                        case .tooLarge:
-                            workerBodyOutcome = "oversized"
-                            throw FileSystemError.fileTooLarge
-                        }
-                    } catch {
-                        if error is CancellationError {
-                            workerBodyOutcome = "cancelled"
-                        }
-                        throw error
-                    }
+                )
+            }
+            do {
+                try Task.checkCancellation()
+                let validated = try validateContentFileForReading(request)
+                workerBodyFileBytes = telemetryFileBytes(validated.fileSize)
+                let handle = try openValidatedContentHandle(
+                    request,
+                    validated: validated,
+                    requireStableIdentity: false
+                )
+                defer { try? handle.close() }
+                switch try await readBoundedData(request, handle: handle) {
+                case let .data(data):
+                    _ = try validateOpenContentHandle(
+                        handle,
+                        validated: validated,
+                        result: noEncodingContentReadResult(request, validated: validated, content: nil),
+                        required: false
+                    )
+                    workerBodyOutcome = "loaded"
+                    return detectFileEncoding(in: data)
+                case .tooLarge:
+                    workerBodyOutcome = "oversized"
+                    throw FileSystemError.fileTooLarge
                 }
-                guard let encoding = try await group.next() else {
-                    throw CancellationError()
+            } catch {
+                if error is CancellationError {
+                    workerBodyOutcome = "cancelled"
                 }
-                group.cancelAll()
-                return encoding
+                throw error
             }
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
@@ -118,6 +118,9 @@ extension FileSystemService {
         guard !relativePath.isEmpty, !relativePath.hasPrefix("../"), relativePath != ".." else {
             return .ineligible(.invalidRelativePath)
         }
+        #if DEBUG
+            try? contentPhysicalReadHandler?()
+        #endif
         let absolutePath = fullPath(forRelativePath: relativePath)
         let standardizedAbsolutePath = (absolutePath as NSString).standardizingPath
         let rootPrefix = standardizedRootPath.hasSuffix("/") ? standardizedRootPath : standardizedRootPath + "/"
@@ -193,6 +196,16 @@ extension FileSystemService {
 
     func registerExplicitlyManagedRegularFile(relativePath rawRelativePath: String) async -> CatalogRegularFileEligibility {
         let eligibility = await catalogRegularFileEligibility(relativePath: rawRelativePath)
+        return registerExplicitlyManagedRegularFile(
+            relativePath: rawRelativePath,
+            validatedEligibility: eligibility
+        )
+    }
+
+    func registerExplicitlyManagedRegularFile(
+        relativePath rawRelativePath: String,
+        validatedEligibility eligibility: CatalogRegularFileEligibility
+    ) -> CatalogRegularFileEligibility {
         switch eligibility {
         case .eligible, .ineligible(.ignored):
             let relativePath = (rawRelativePath as NSString).standardizingPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
@@ -206,6 +219,57 @@ extension FileSystemService {
             break
         }
         return eligibility
+    }
+
+    func registerExplicitlyManagedRegularFile(
+        relativePath rawRelativePath: String,
+        validatedEligibility eligibility: CatalogRegularFileEligibility,
+        policyIdentity validatedPolicyIdentity: WorkspaceRootCatalogPolicyIdentity,
+        ignoreRulesRevision validatedIgnoreRulesRevision: UInt64
+    ) async throws -> CatalogRegularFileEligibility {
+        if catalogPolicyIdentity == validatedPolicyIdentity,
+           ignoreRulesRevision == validatedIgnoreRulesRevision
+        {
+            return registerExplicitlyManagedRegularFile(
+                relativePath: rawRelativePath,
+                validatedEligibility: eligibility
+            )
+        }
+        if catalogPolicyIdentity != validatedPolicyIdentity {
+            let refreshed = try await cancellationResponsiveCatalogRegularFileEligibilityWithPolicy(
+                relativePath: rawRelativePath
+            )
+            return registerExplicitlyManagedRegularFile(
+                relativePath: rawRelativePath,
+                validatedEligibility: refreshed.eligibility
+            )
+        }
+        switch eligibility {
+        case .eligible, .ineligible(.ignored):
+            let relativePath = (rawRelativePath as NSString).standardizingPath
+                .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            while true {
+                try Task.checkCancellation()
+                let startingPolicyIdentity = catalogPolicyIdentity
+                let startingIgnoreRulesRevision = ignoreRulesRevision
+                let isIgnored = if enableHierarchicalIgnores {
+                    await isIgnoredHierarchical(relativePath: relativePath, isDirectory: false)
+                        || isIgnoredPrefixCheck(relativePath: relativePath)
+                } else {
+                    isIgnoredPrefixCheck(relativePath: relativePath)
+                }
+                try Task.checkCancellation()
+                guard startingPolicyIdentity == catalogPolicyIdentity,
+                      startingIgnoreRulesRevision == ignoreRulesRevision
+                else { continue }
+                return registerExplicitlyManagedRegularFile(
+                    relativePath: relativePath,
+                    validatedEligibility: isIgnored ? .ineligible(.ignored) : .eligible
+                )
+            }
+        case .ineligible:
+            return eligibility
+        }
     }
 
     func pathContainsSymlinkComponent(relativePath: String) -> Bool {
@@ -1033,6 +1097,9 @@ extension FileSystemService {
             }
             return testMode ? [] : nil
         }
+        // Advance before event processing can suspend so a completed disk read cannot cache
+        // evidence that predates an invalidation already accepted by this actor.
+        contentReadCacheRevision &+= 1
 
         #if DEBUG
             if Self.enableDebugLogging {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
@@ -111,6 +111,9 @@ extension FileSystemService {
         }
         let id = UUID()
         inFlightMutations[id] = FileSystemInFlightMutation(relativePaths: authorityPaths)
+        // Reserve a newer cache generation before mutation preparation can suspend. Successful
+        // reads already in flight must not publish encoding evidence across this mutation boundary.
+        contentReadCacheRevision &+= 1
         do {
             #if DEBUG
                 let willBegin = mutationIOWillBeginHandler

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+Testing.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+Testing.swift
@@ -208,6 +208,18 @@ import Foundation
             contentReadChunkHandler = handler
         }
 
+        func setContentPhysicalReadHandlerForTesting(
+            _ handler: (@Sendable () throws -> Void)?
+        ) {
+            contentPhysicalReadHandler = handler
+        }
+
+        func setContentReadCacheCommitHandlerForTesting(
+            _ handler: (@Sendable () async -> Void)?
+        ) {
+            contentReadCacheCommitHandler = handler
+        }
+
         func resetContentFingerprintRequestCountForTesting() {
             contentFingerprintRequestCountForTesting = 0
         }
@@ -228,6 +240,10 @@ import Foundation
 
         func cachedEncodingForTesting(relativePath: String) -> String.Encoding? {
             encodingMap[relativePath]
+        }
+
+        func advanceContentReadCacheRevisionForTesting() {
+            contentReadCacheRevision &+= 1
         }
 
         func isWatchingForChangesForTesting() -> Bool {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
@@ -175,6 +175,10 @@ actor FileSystemService {
 
         /// Test-only hook invoked inside the real-filesystem off-actor content worker before each read.
         var contentReadChunkHandler: (@Sendable (String) async -> Void)?
+        /// Test-only synchronous gate immediately before fingerprint validation begins.
+        var contentPhysicalReadHandler: (@Sendable () throws -> Void)?
+        /// Test-only asynchronous gate immediately before a decoded-content cache commit.
+        var contentReadCacheCommitHandler: (@Sendable () async -> Void)?
         var contentFingerprintRequestCountForTesting = 0
         var cachedSearchContentWatcherActiveOverrideForTesting: Bool?
 
@@ -288,6 +292,8 @@ actor FileSystemService {
 
     /// Caches the detected encoding for every file we have successfully opened
     var encodingMap = [String: String.Encoding]()
+    /// A read may cache its detected encoding only while no newer filesystem invalidation is known.
+    var contentReadCacheRevision: UInt64 = 0
 
     /// Path we are managing
     let path: String

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPToolWorkCountDiagnostics.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPToolWorkCountDiagnostics.swift
@@ -21,6 +21,7 @@ enum MCPToolWorkCountDiagnostics {
         let requestIdentity: MCPRequestTimelineIdentity?
         let source: String
         let readBytes: Int
+        let diskReadRecordCount: Int
         let returnedBytes: Int
         let returnedLines: Int
         let decodeMicroseconds: Int
@@ -112,6 +113,7 @@ enum MCPToolWorkCountDiagnostics {
             let requestIdentity: MCPRequestTimelineIdentity?
             private var source = "unknown"
             private var readBytes = 0
+            private var diskReadRecordCount = 0
             private var returnedBytes = 0
             private var returnedLines = 0
             private var decodeMicroseconds = 0
@@ -125,6 +127,7 @@ enum MCPToolWorkCountDiagnostics {
                 lock.lock()
                 source = "disk"
                 readBytes += max(0, bytes)
+                diskReadRecordCount += 1
                 self.decodeMicroseconds += max(0, decodeMicroseconds)
                 lock.unlock()
             }
@@ -155,6 +158,7 @@ enum MCPToolWorkCountDiagnostics {
                     requestIdentity: requestIdentity,
                     source: source,
                     readBytes: readBytes,
+                    diskReadRecordCount: diskReadRecordCount,
                     returnedBytes: returnedBytes,
                     returnedLines: returnedLines,
                     decodeMicroseconds: decodeMicroseconds,
@@ -288,6 +292,17 @@ enum MCPToolWorkCountDiagnostics {
     static func recordReadFileDiskRead(bytes: Int, decodeMicroseconds: Int) {
         #if DEBUG
             currentReadFileCapture?.recordDiskRead(bytes: bytes, decodeMicroseconds: decodeMicroseconds)
+        #endif
+    }
+
+    static func readFileDiskReadRecorder() -> @Sendable (_ bytes: Int, _ decodeMicroseconds: Int) -> Void {
+        #if DEBUG
+            let capture = currentReadFileCapture
+            return { bytes, decodeMicroseconds in
+                capture?.recordDiskRead(bytes: bytes, decodeMicroseconds: decodeMicroseconds)
+            }
+        #else
+            return { _, _ in }
         #endif
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -6072,6 +6072,11 @@ final class MCPServerViewModel: ObservableObject {
         metadata: RequestMetadata,
         lookupContext: WorkspaceLookupContext
     ) async throws -> ToolResultDTOs.ReadFileReply? {
+        guard Self.shouldAttemptSelectedGitArtifactRead(
+            requestedPath: requestedPath,
+            translatedLookupPath: translatedLookupPath
+        ) else { return nil }
+
         guard var resolvedContext = try? resolveTabContextSnapshot(
             from: metadata,
             toolName: MCPWindowToolName.readFile
@@ -6144,22 +6149,48 @@ final class MCPServerViewModel: ObservableObject {
         }
     }
 
+    private nonisolated static func shouldAttemptSelectedGitArtifactRead(
+        requestedPath: String,
+        translatedLookupPath: String
+    ) -> Bool {
+        // Advertised aliases retain the `_git_data/` prefix and absolute artifacts retain
+        // the same path component, so ordinary reads never need selected-artifact authorization.
+        [requestedPath, translatedLookupPath]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .contains {
+                $0 == "_git_data"
+                    || $0.hasPrefix("_git_data/")
+                    || $0.contains("/_git_data/")
+            }
+    }
+
+    #if DEBUG
+        nonisolated static func shouldAttemptSelectedGitArtifactReadForTesting(
+            requestedPath: String,
+            translatedLookupPath: String
+        ) -> Bool {
+            shouldAttemptSelectedGitArtifactRead(
+                requestedPath: requestedPath,
+                translatedLookupPath: translatedLookupPath
+            )
+        }
+    #endif
+
     private func isGitDataArtifactRequest(
         _ requestedPath: String,
         resolvedPath: String,
         capability: SelectedGitArtifactCapability?
     ) -> Bool {
-        let candidates = [requestedPath, resolvedPath].map {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        if candidates.contains(where: {
-            $0 == "_git_data"
-                || $0.hasPrefix("_git_data/")
-                || $0.contains("/_git_data/")
-        }) {
+        if Self.shouldAttemptSelectedGitArtifactRead(
+            requestedPath: requestedPath,
+            translatedLookupPath: resolvedPath
+        ) {
             return true
         }
         guard let rootPath = capability?.gitDataRoot.standardizedFullPath else { return false }
+        let candidates = [requestedPath, resolvedPath].map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         return candidates.contains {
             $0 == rootPath || StandardizedPath.isDescendant($0, of: rootPath)
         }
@@ -6247,14 +6278,10 @@ final class MCPServerViewModel: ObservableObject {
             preparedContent = snapshot.preparedContent
             cacheHit = snapshot.cacheHit
         case let .external(externalFile):
-            do {
-                let full = try await readableService.readAlwaysReadableExternalFile(externalFile)
-                preparedContent = await WorkspaceInteractiveReadProcessor.prepareOffActor(full)
-            } catch is CancellationError {
-                throw CancellationError()
-            } catch {
-                throw MCPError.invalidParams("Cannot read '\(externalFile.displayPath)': \(error.localizedDescription)")
-            }
+            preparedContent = try await Self.prepareAlwaysReadableExternalFile(
+                externalFile,
+                readableService: readableService
+            )
             cacheHit = false
         }
         try Task.checkCancellation()
@@ -6285,6 +6312,31 @@ final class MCPServerViewModel: ObservableObject {
             return .nonSelecting(reply: preparedReply.reply)
         }
     }
+
+    private nonisolated static func prepareAlwaysReadableExternalFile(
+        _ externalFile: WorkspaceExternalReadableFile,
+        readableService: WorkspaceReadableFileService
+    ) async throws -> WorkspaceInteractiveReadPreparedContent {
+        do {
+            let full = try await readableService.readAlwaysReadableExternalFile(externalFile)
+            return await WorkspaceInteractiveReadProcessor.prepareOffActor(full)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as ContentReadSchedulerError {
+            throw error
+        } catch {
+            throw MCPError.invalidParams("Cannot read '\(externalFile.displayPath)': \(error.localizedDescription)")
+        }
+    }
+
+    #if DEBUG
+        nonisolated static func prepareAlwaysReadableExternalFileThroughEnvelopeForTesting(
+            _ externalFile: WorkspaceExternalReadableFile,
+            readableService: WorkspaceReadableFileService
+        ) async throws -> WorkspaceInteractiveReadPreparedContent {
+            try await prepareAlwaysReadableExternalFile(externalFile, readableService: readableService)
+        }
+    #endif
 
     /// Performs a file action (create, delete, or move/rename)
     private func performFileAction(

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1239,6 +1239,7 @@ actor WorkspaceFileContextStore {
         private var ensureIndexedFilesEligibilityDidResolveHandler: (@Sendable (UUID, String) async -> Void)?
         private var contextBuilderSelectionCandidateEligibilityDidResolveHandler: (@Sendable (UUID) async -> Void)?
         private var publishedGitArtifactIngressDidRegisterHandler: (@Sendable (UUID, String) async -> Void)?
+        private var interactiveReadFingerprintDidResolveHandler: (@Sendable () async -> Void)?
         private var explicitMaterializationDidAcquireCodemapFenceHandler: (@Sendable (FileSystemService) async -> Void)?
         private var watcherSinkWillApplyHandler: (@Sendable (UUID) async -> Void)?
         private var storeEditDeferredPublicationDidRegisterHandler: (@Sendable (UUID, String) async -> Void)?
@@ -1954,6 +1955,12 @@ actor WorkspaceFileContextStore {
             _ handler: (@Sendable (UUID, String) async -> Void)?
         ) {
             publishedGitArtifactIngressDidRegisterHandler = handler
+        }
+
+        func setInteractiveReadFingerprintDidResolveHandlerForTesting(
+            _ handler: (@Sendable () async -> Void)?
+        ) {
+            interactiveReadFingerprintDidResolveHandler = handler
         }
 
         func setExplicitMaterializationDidAcquireCodemapFenceHandlerForTesting(
@@ -11394,6 +11401,16 @@ actor WorkspaceFileContextStore {
     func interactiveReadSnapshot(
         for expectedRecord: WorkspaceFileRecord
     ) async throws -> WorkspaceInteractiveReadSnapshot? {
+        // The outer token spans the gap between fingerprint and content producers. Each producer
+        // also owns a token so cancellation cannot expose its still-running physical work.
+        try await FileSystemService.withContentReadForegroundActivity(kind: .interactiveRead) {
+            try await self.interactiveReadSnapshotWithinForegroundActivity(for: expectedRecord)
+        }
+    }
+
+    private func interactiveReadSnapshotWithinForegroundActivity(
+        for expectedRecord: WorkspaceFileRecord
+    ) async throws -> WorkspaceInteractiveReadSnapshot? {
         try await requirePublishedSeededAuthorityFresh(rootID: expectedRecord.rootID)
         for attempt in 0 ..< 2 {
             try Task.checkCancellation()
@@ -11433,6 +11450,12 @@ actor WorkspaceFileContextStore {
             } catch {
                 return nil
             }
+
+            #if DEBUG
+                if let handler = interactiveReadFingerprintDidResolveHandler {
+                    await handler()
+                }
+            #endif
 
             guard searchContentRecordIsCurrent(current, invalidationEpoch: epoch) else {
                 if attempt == 0 { continue }
@@ -17368,9 +17391,18 @@ actor WorkspaceFileContextStore {
                 hasUnavailableBinding = true
                 continue
             }
-            switch try await state.service.cancellationResponsiveCatalogRegularFileEligibility(
+            let eligibility = try await state.service.cancellationResponsiveCatalogRegularFileEligibility(
                 relativePath: relativePath
-            ) {
+            )
+            try Task.checkCancellation()
+            guard let currentState = rootStatesByID[binding.lookupRoot.id],
+                  currentState.lifetimeID == state.lifetimeID,
+                  currentState.service === state.service
+            else {
+                hasUnavailableBinding = true
+                continue
+            }
+            switch eligibility {
             case .eligible, .ineligible(.ignored):
                 matches.append(ExactFileCandidate(binding: binding, file: nil))
             case .ineligible(.missingOrDirectory):

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1239,6 +1239,7 @@ actor WorkspaceFileContextStore {
         private var ensureIndexedFilesEligibilityDidResolveHandler: (@Sendable (UUID, String) async -> Void)?
         private var contextBuilderSelectionCandidateEligibilityDidResolveHandler: (@Sendable (UUID) async -> Void)?
         private var publishedGitArtifactIngressDidRegisterHandler: (@Sendable (UUID, String) async -> Void)?
+        private var explicitMaterializationDidAcquireCodemapFenceHandler: (@Sendable (FileSystemService) async -> Void)?
         private var watcherSinkWillApplyHandler: (@Sendable (UUID) async -> Void)?
         private var storeEditDeferredPublicationDidRegisterHandler: (@Sendable (UUID, String) async -> Void)?
         private var publisherIngressWillWaitHandler: (@Sendable (Set<UUID>) async -> Void)?
@@ -1955,6 +1956,27 @@ actor WorkspaceFileContextStore {
             publishedGitArtifactIngressDidRegisterHandler = handler
         }
 
+        func setExplicitMaterializationDidAcquireCodemapFenceHandlerForTesting(
+            _ handler: (@Sendable (FileSystemService) async -> Void)?
+        ) {
+            explicitMaterializationDidAcquireCodemapFenceHandler = handler
+        }
+
+        func replaceRootLifetimeForTesting(rootID: UUID) throws {
+            guard let state = rootStatesByID[rootID] else {
+                throw WorkspaceFileContextStoreError.rootNotLoaded(rootID)
+            }
+            rootStatesByID[rootID] = RootState(
+                lifetimeID: UUID(),
+                root: state.root,
+                service: state.service,
+                folderIDsByRelativePath: state.folderIDsByRelativePath,
+                fileIDsByRelativePath: state.fileIDsByRelativePath,
+                childFolderIDsByFolderID: state.childFolderIDsByFolderID,
+                childFileIDsByFolderID: state.childFileIDsByFolderID
+            )
+        }
+
         func setWatcherSinkWillApplyHandler(_ handler: (@Sendable (UUID) async -> Void)?) {
             watcherSinkWillApplyHandler = handler
         }
@@ -2490,6 +2512,10 @@ actor WorkspaceFileContextStore {
 
         func interactiveReadCacheSnapshotForTesting() async -> WorkspaceInteractiveReadCache.Snapshot {
             await interactiveReadCache.snapshotForTesting()
+        }
+
+        func contentReadSchedulerOwnerIDsForTesting() -> (search: UUID, interactive: UUID) {
+            (searchContentSchedulerOwnerID, interactiveReadSchedulerOwnerID)
         }
 
         func searchLaneSnapshotForTesting() async -> StoreBackedWorkspaceSearchLane.Snapshot {
@@ -9435,6 +9461,15 @@ actor WorkspaceFileContextStore {
             guard let root = rootStatesByID[rootID]?.root else { return nil }
             return rootLoadConfigurationsByPath[root.standardizedFullPath]?.gitignorePolicyIdentity
         }
+
+        func setContentPhysicalReadHandlerForTesting(
+            rootID: UUID,
+            _ handler: (@Sendable () throws -> Void)?
+        ) async throws {
+            let state = try state(for: rootID)
+            await state.service.setContentPhysicalReadHandlerForTesting(handler)
+        }
+
     #endif
 
     func refreshFileSystemSettings(
@@ -11281,13 +11316,18 @@ actor WorkspaceFileContextStore {
                     isFresh: true
                 )
             }
+            let schedulerOwnerID = searchContentSchedulerOwnerID
             let fingerprint: FileContentFingerprint
             do {
                 fingerprint = try await service.contentFingerprint(
-                    ofRelativePath: current.standardizedRelativePath
+                    ofRelativePath: current.standardizedRelativePath,
+                    workloadClass: .contentSearch,
+                    schedulerOwnerID: schedulerOwnerID
                 )
             } catch is CancellationError {
                 throw CancellationError()
+            } catch let error as ContentReadSchedulerError {
+                throw error
             } catch FileSystemError.fileNotFound {
                 await pruneCatalogFileIfStillCurrent(current)
                 return staleSearchContentSnapshot(for: current)
@@ -11300,7 +11340,6 @@ actor WorkspaceFileContextStore {
                 return staleSearchContentSnapshot(for: current)
             }
 
-            let schedulerOwnerID = searchContentSchedulerOwnerID
             do {
                 let cached = try await searchDecodedContentCache.snapshot(
                     for: cacheKey,
@@ -11355,14 +11394,6 @@ actor WorkspaceFileContextStore {
     func interactiveReadSnapshot(
         for expectedRecord: WorkspaceFileRecord
     ) async throws -> WorkspaceInteractiveReadSnapshot? {
-        try await FileSystemService.withContentReadForegroundActivity(kind: .interactiveRead) {
-            try await self.interactiveReadSnapshotWithinForegroundActivity(for: expectedRecord)
-        }
-    }
-
-    private func interactiveReadSnapshotWithinForegroundActivity(
-        for expectedRecord: WorkspaceFileRecord
-    ) async throws -> WorkspaceInteractiveReadSnapshot? {
         try await requirePublishedSeededAuthorityFresh(rootID: expectedRecord.rootID)
         for attempt in 0 ..< 2 {
             try Task.checkCancellation()
@@ -11384,13 +11415,18 @@ actor WorkspaceFileContextStore {
                 fileID: current.id,
                 standardizedRelativePath: current.standardizedRelativePath
             )
+            let schedulerOwnerID = interactiveReadSchedulerOwnerID
             let fingerprint: FileContentFingerprint
             do {
                 fingerprint = try await service.contentFingerprint(
-                    ofRelativePath: current.standardizedRelativePath
+                    ofRelativePath: current.standardizedRelativePath,
+                    workloadClass: .interactiveRead,
+                    schedulerOwnerID: schedulerOwnerID
                 )
             } catch is CancellationError {
                 throw CancellationError()
+            } catch let error as ContentReadSchedulerError {
+                throw error
             } catch FileSystemError.fileNotFound {
                 await pruneCatalogFileIfStillCurrent(current)
                 return nil
@@ -11403,7 +11439,6 @@ actor WorkspaceFileContextStore {
                 return nil
             }
 
-            let schedulerOwnerID = interactiveReadSchedulerOwnerID
             do {
                 let cached = try await interactiveReadCache.snapshot(
                     for: cacheKey,
@@ -11546,11 +11581,24 @@ actor WorkspaceFileContextStore {
         try await requirePublishedSeededAuthorityFresh(rootID: rootID)
         let state = try state(for: rootID)
         let standardizedRelativePath = StandardizedPath.relative(relativePath)
-        let fingerprint = try await state.service.contentFingerprint(ofRelativePath: standardizedRelativePath)
+        let schedulerOwnerID = switch workloadClass {
+        case .interactiveRead:
+            interactiveReadSchedulerOwnerID
+        case .contentSearch:
+            searchContentSchedulerOwnerID
+        default:
+            state.service.diagnosticRootToken
+        }
+        let fingerprint = try await state.service.contentFingerprint(
+            ofRelativePath: standardizedRelativePath,
+            workloadClass: workloadClass,
+            schedulerOwnerID: schedulerOwnerID
+        )
         let result = try await state.service.loadValidatedContent(
             ofRelativePath: standardizedRelativePath,
             expectedFingerprint: fingerprint,
-            workloadClass: workloadClass
+            workloadClass: workloadClass,
+            schedulerOwnerID: schedulerOwnerID
         )
         try await requirePublishedSeededAuthorityFresh(rootID: rootID)
         return result
@@ -14272,6 +14320,10 @@ actor WorkspaceFileContextStore {
             }
         }
 
+        func isManagedOnlyFileForTesting(_ fileID: UUID) -> Bool {
+            managedOnlyFileIDs.contains(fileID)
+        }
+
         func discardedCodemapPathFenceReleaseCountForTesting() -> Int {
             discardedCodemapPathFenceReleaseCounterForTesting
         }
@@ -16834,7 +16886,40 @@ actor WorkspaceFileContextStore {
             outcome = "current"
             return current
         }
-        _ = await fenceAndPruneCatalogFileMissingOnDisk(
+        _ = try? await fenceAndPruneCatalogFileMissingOnDisk(
+            rootID: file.rootID,
+            relativePath: current.standardizedRelativePath,
+            publishDelta: true
+        )
+        return nil
+    }
+
+    private func validateCatalogFileStillPresentForExactRead(
+        _ file: WorkspaceFileRecord
+    ) async throws -> WorkspaceFileRecord? {
+        guard let state = rootStatesByID[file.rootID],
+              let current = self.file(rootID: file.rootID, relativePath: file.standardizedRelativePath),
+              current.id == file.id,
+              current.standardizedFullPath == file.standardizedFullPath
+        else { return nil }
+
+        let expectedLifetimeID = state.lifetimeID
+        let exists = try await state.service.cancellationResponsiveRegularFileExistsOnDisk(
+            relativePath: current.standardizedRelativePath
+        )
+        try Task.checkCancellation()
+        guard let currentState = rootStatesByID[file.rootID],
+              currentState.lifetimeID == expectedLifetimeID,
+              currentState.service === state.service,
+              let currentRecord = self.file(
+                  rootID: file.rootID,
+                  relativePath: current.standardizedRelativePath
+              ),
+              currentRecord.id == current.id,
+              currentRecord.standardizedFullPath == current.standardizedFullPath
+        else { return nil }
+        if exists { return currentRecord }
+        _ = try await fenceAndPruneCatalogFileMissingOnDisk(
             rootID: file.rootID,
             relativePath: current.standardizedRelativePath,
             publishDelta: true
@@ -17031,7 +17116,7 @@ actor WorkspaceFileContextStore {
                     namespace: namespace
                 ))
             }
-            let candidates = await exactFileCandidates(
+            let candidates = try await exactFileCandidates(
                 relativePath: target.relativePath,
                 bindings: [target.binding]
             )
@@ -17061,7 +17146,7 @@ actor WorkspaceFileContextStore {
         case let .explicitRoot(alias, relativePath):
             switch exactAliasBinding(alias: alias, namespace: namespace) {
             case let .success(binding):
-                let candidates = await exactFileCandidates(
+                let candidates = try await exactFileCandidates(
                     relativePath: relativePath,
                     bindings: [binding]
                 )
@@ -17089,7 +17174,7 @@ actor WorkspaceFileContextStore {
             }
 
         case let .relative(relativePath):
-            let literalCandidates = await exactFileCandidates(
+            let literalCandidates = try await exactFileCandidates(
                 relativePath: relativePath,
                 bindings: namespace.rootBindings
             )
@@ -17145,7 +17230,7 @@ actor WorkspaceFileContextStore {
                 guard let binding = namespace.rootBindings.first(where: {
                     $0.clientRoots.contains(where: { $0.id == clientRoot.id })
                 }) else { return .noCandidate }
-                let aliasCandidates = await exactFileCandidates(
+                let aliasCandidates = try await exactFileCandidates(
                     relativePath: remainder,
                     bindings: [binding]
                 )
@@ -17267,14 +17352,14 @@ actor WorkspaceFileContextStore {
     private func exactFileCandidates(
         relativePath: String,
         bindings: [WorkspaceExactFileNamespace.RootBinding]
-    ) async -> ExactFileCandidates {
+    ) async throws -> ExactFileCandidates {
         var matches: [ExactFileCandidate] = []
         var blocked = false
         var hasUnavailableBinding = false
         var directoryBindings: [WorkspaceExactFileNamespace.RootBinding] = []
         for binding in bindings {
             if let candidate = file(rootID: binding.lookupRoot.id, relativePath: relativePath),
-               let current = await validateCatalogFileStillPresent(candidate)
+               let current = try await validateCatalogFileStillPresentForExactRead(candidate)
             {
                 matches.append(ExactFileCandidate(binding: binding, file: current))
                 continue
@@ -17283,14 +17368,28 @@ actor WorkspaceFileContextStore {
                 hasUnavailableBinding = true
                 continue
             }
-            switch await state.service.catalogRegularFileEligibility(relativePath: relativePath) {
+            switch try await state.service.cancellationResponsiveCatalogRegularFileEligibility(
+                relativePath: relativePath
+            ) {
             case .eligible, .ineligible(.ignored):
                 matches.append(ExactFileCandidate(binding: binding, file: nil))
             case .ineligible(.missingOrDirectory):
-                if directoryAppearsPresentOnDisk(root: state.root, relativePath: relativePath) {
+                let pathState = try await state.service.cancellationResponsiveCatalogPathState(
+                    relativePath: relativePath
+                )
+                try Task.checkCancellation()
+                guard let currentState = rootStatesByID[binding.lookupRoot.id],
+                      currentState.lifetimeID == state.lifetimeID,
+                      currentState.service === state.service,
+                      file(rootID: binding.lookupRoot.id, relativePath: relativePath) == nil
+                else {
+                    hasUnavailableBinding = true
+                    continue
+                }
+                if pathState == .directory {
                     directoryBindings.append(binding)
                 }
-                _ = await fenceAndPruneCatalogFileMissingOnDisk(
+                _ = try await fenceAndPruneCatalogFileMissingOnDisk(
                     rootID: binding.lookupRoot.id,
                     relativePath: relativePath,
                     publishDelta: true
@@ -17330,7 +17429,7 @@ actor WorkspaceFileContextStore {
         _ file: WorkspaceFileRecord,
         namespace: WorkspaceExactFileNamespace
     ) async throws -> WorkspaceExactExistingFileMatch {
-        let candidates = await exactFileCandidates(
+        let candidates = try await exactFileCandidates(
             relativePath: file.standardizedRelativePath,
             bindings: namespace.rootBindings
         )
@@ -17396,17 +17495,34 @@ actor WorkspaceFileContextStore {
         case .ambiguousAlias:
             return .ambiguous
         }
-        var materializable: [(rootID: UUID, relativePath: String, managedOnly: Bool)] = []
+        var materializable: [(
+            rootID: UUID,
+            relativePath: String,
+            eligibility: CatalogRegularFileEligibility,
+            policyIdentity: WorkspaceRootCatalogPolicyIdentity,
+            ignoreRulesRevision: UInt64,
+            lifetimeID: UUID,
+            service: FileSystemService
+        )] = []
         var foundBlockedCandidate = false
         for candidate in candidates {
             guard let state = rootStatesByID[candidate.rootID] else { continue }
-            switch await state.service.catalogRegularFileEligibility(relativePath: candidate.relativePath) {
-            case .eligible:
-                materializable.append((candidate.rootID, candidate.relativePath, false))
-            case .ineligible(.ignored):
-                materializable.append((candidate.rootID, candidate.relativePath, true))
+            let evidence = try await state.service.cancellationResponsiveCatalogRegularFileEligibilityWithPolicy(
+                relativePath: candidate.relativePath
+            )
+            switch evidence.eligibility {
+            case .eligible, .ineligible(.ignored):
+                materializable.append((
+                    candidate.rootID,
+                    candidate.relativePath,
+                    evidence.eligibility,
+                    evidence.policyIdentity,
+                    evidence.ignoreRulesRevision,
+                    state.lifetimeID,
+                    state.service
+                ))
             case .ineligible(.missingOrDirectory):
-                _ = await fenceAndPruneCatalogFileMissingOnDisk(
+                _ = try await fenceAndPruneCatalogFileMissingOnDisk(
                     rootID: candidate.rootID,
                     relativePath: candidate.relativePath,
                     publishDelta: true
@@ -17418,30 +17534,50 @@ actor WorkspaceFileContextStore {
         }
         guard materializable.count <= 1 else { return .ambiguous }
         guard let candidate = materializable.first,
-              let state = rootStatesByID[candidate.rootID]
+              let state = rootStatesByID[candidate.rootID],
+              state.lifetimeID == candidate.lifetimeID,
+              state.service === candidate.service
         else { return foundBlockedCandidate ? .blocked : .noCandidate }
-        let registeredEligibility = await state.service.registerExplicitlyManagedRegularFile(relativePath: candidate.relativePath)
-        let managedOnly: Bool
-        switch registeredEligibility {
-        case .eligible:
-            managedOnly = false
-        case .ineligible(.ignored):
-            managedOnly = true
-        case .ineligible(.missingOrDirectory):
-            _ = await fenceAndPruneCatalogFileMissingOnDisk(
-                rootID: candidate.rootID,
-                relativePath: candidate.relativePath,
-                publishDelta: true
-            )
-            return .noCandidate
-        case .ineligible:
-            return .blocked
-        }
         guard let codemapFence = await beginCodemapRootMutationFence(
             rootID: candidate.rootID,
             command: .catalogAdvanced
         ) else { return .noCandidate }
         do {
+            #if DEBUG
+                if let handler = explicitMaterializationDidAcquireCodemapFenceHandler {
+                    await handler(state.service)
+                }
+            #endif
+            guard let currentState = rootStatesByID[candidate.rootID],
+                  currentState.lifetimeID == state.lifetimeID,
+                  currentState.service === state.service
+            else {
+                finishCodemapRootMutationFence(codemapFence, didCommitMutation: false)
+                return .noCandidate
+            }
+            let registeredEligibility = try await currentState.service.registerExplicitlyManagedRegularFile(
+                relativePath: candidate.relativePath,
+                validatedEligibility: candidate.eligibility,
+                policyIdentity: candidate.policyIdentity,
+                ignoreRulesRevision: candidate.ignoreRulesRevision
+            )
+            guard let registeredState = rootStatesByID[candidate.rootID],
+                  registeredState.lifetimeID == state.lifetimeID,
+                  registeredState.service === state.service
+            else {
+                finishCodemapRootMutationFence(codemapFence, didCommitMutation: false)
+                return .noCandidate
+            }
+            let managedOnly: Bool
+            switch registeredEligibility {
+            case .eligible:
+                managedOnly = false
+            case .ineligible(.ignored):
+                managedOnly = true
+            case .ineligible:
+                finishCodemapRootMutationFence(codemapFence, didCommitMutation: false)
+                return .blocked
+            }
             let materialized = try materializeCatalogRegularFile(
                 rootID: candidate.rootID,
                 relativePath: candidate.relativePath,
@@ -17799,20 +17935,34 @@ actor WorkspaceFileContextStore {
         rootID: UUID,
         relativePath: String,
         publishDelta: Bool
-    ) async -> Bool {
+    ) async throws -> Bool {
         let path = StandardizedPath.relative(relativePath)
+        guard let initialState = rootStatesByID[rootID] else { return false }
         let token = await fenceCodemapPaths(
             rootID: rootID,
             commands: [.deleted([path])]
         )
-        let didPrune = withCodemapPathLocalCatalogMutation(rootID: rootID) {
+        var didPrune = false
+        defer {
+            releaseCodemapPathFence(token, didCommitMutation: didPrune)
+        }
+        let fileExists = try await initialState.service.cancellationResponsiveRegularFileExistsOnDisk(
+            relativePath: path
+        )
+        try Task.checkCancellation()
+        guard
+            !fileExists,
+            let currentState = rootStatesByID[rootID],
+            currentState.lifetimeID == initialState.lifetimeID,
+            currentState.service === initialState.service
+        else { return false }
+        didPrune = withCodemapPathLocalCatalogMutation(rootID: rootID) {
             pruneCatalogFileMissingOnDisk(
                 rootID: rootID,
                 relativePath: path,
                 publishDelta: publishDelta
             )
         }
-        releaseCodemapPathFence(token, didCommitMutation: didPrune)
         return didPrune
     }
 
@@ -19596,7 +19746,7 @@ actor WorkspaceFileContextStore {
         guard let current = file(rootID: record.rootID, relativePath: record.standardizedRelativePath),
               current.id == record.id
         else { return }
-        _ = await fenceAndPruneCatalogFileMissingOnDisk(
+        _ = try? await fenceAndPruneCatalogFileMissingOnDisk(
             rootID: current.rootID,
             relativePath: current.standardizedRelativePath,
             publishDelta: true

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceReadableFileService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceReadableFileService.swift
@@ -261,8 +261,13 @@ struct WorkspaceReadableFileService {
         let chunkSize = Self.externalReadChunkSize
         let workRecorder = MCPToolWorkCountDiagnostics.readFileExternalRecorder()
         let beforeExternalReadOpenHook = beforeExternalReadOpenForTesting
+        let schedulerOwnerID = UUID()
         try Task.checkCancellation()
-        let readTask = Task.detached(priority: .userInitiated) {
+        return try await FileSystemService.withCancellationResponsivePhysicalReadPermit(
+            workloadClass: .interactiveRead,
+            schedulerOwnerID: schedulerOwnerID,
+            priority: .userInitiated
+        ) {
             try Task.checkCancellation()
             let homeDirectoryURL = URL(fileURLWithPath: homeDirectoryPath)
             let normalizedPath = AgentSupportDirectoryCatalog.normalizedPath(for: path)
@@ -342,11 +347,6 @@ struct WorkspaceReadableFileService {
             )
             return decoded
         }
-        return try await withTaskCancellationHandler(operation: {
-            try await readTask.value
-        }, onCancel: {
-            readTask.cancel()
-        })
     }
 
     func resolveAlwaysReadableExternalFile(atAbsolutePath path: String) -> WorkspaceExternalReadableFile? {

--- a/Tests/RepoPromptTests/Services/FileSystem/ContentReadCancellationTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/ContentReadCancellationTests.swift
@@ -964,6 +964,63 @@ final class ContentReadCancellationTests: XCTestCase {
         XCTAssertEqual(try materializationResult.get(), .noCandidate)
     }
 
+    func testExactCandidatesRejectUncataloguedEligibilityAfterRootTurnover() async throws {
+        let catalogRootURL = try makeTemporaryRoot()
+        let ignoredRootURL = try makeTemporaryRoot()
+        try "catalog match\n".write(
+            to: catalogRootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "Target.swift\n".write(
+            to: ignoredRootURL.appendingPathComponent(".gitignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "ignored physical match\n".write(
+            to: ignoredRootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: catalogRootURL.path)
+        let ignoredRoot = try await store.loadRoot(path: ignoredRootURL.path)
+        let roots = await store.rootRefs(scope: .visibleWorkspace)
+        let ignoredCatalogFile = await store.file(rootID: ignoredRoot.id, relativePath: "Target.swift")
+        XCTAssertNil(ignoredCatalogFile)
+        let physicalGate = SynchronousPhysicalReadGate()
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: ignoredRoot.id) {
+            physicalGate.blockUntilReleased()
+        }
+        addTeardownBlock {
+            physicalGate.release()
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: ignoredRoot.id, nil)
+        }
+
+        let resolutionTask = Task {
+            try await store.resolveExactExistingWorkspaceFile(
+                WorkspaceExactFileInput.parse("Target.swift"),
+                namespace: WorkspaceExactFileNamespace.identity(roots: roots)
+            )
+        }
+        guard await waitUntil({ physicalGate.isBlockedSnapshot() }) else {
+            resolutionTask.cancel()
+            physicalGate.release()
+            return XCTFail("Uncatalogued eligibility did not reach the controlled physical boundary")
+        }
+
+        try await store.replaceRootLifetimeForTesting(rootID: ignoredRoot.id)
+        physicalGate.release()
+        guard let observedResolution = await waitForTaskResult(resolutionTask) else {
+            return XCTFail("Exact resolution did not settle after root turnover")
+        }
+        XCTAssertEqual(
+            try observedResolution.get(),
+            .issue(.unresolved(input: "Target.swift"))
+        )
+    }
+
     func testSuccessiveOuterProviderTimeoutsDoNotEnterUnrelatedGitArtifactPreflight() async throws {
         XCTAssertTrue(MCPServerViewModel.shouldAttemptSelectedGitArtifactReadForTesting(
             requestedPath: "_git_data/repos/repo/snapshot/MAP.txt",
@@ -2012,7 +2069,7 @@ final class ContentReadCancellationTests: XCTestCase {
         }
         let codeMapQueued = await waitUntil {
             let snapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
-            return snapshot.foregroundActivityCountsByKind[.interactiveRead] == 1
+            return snapshot.foregroundActivityCountsByKind[.interactiveRead] == 2
                 && snapshot.activeCodemapPermitCount == 0
                 && snapshot.queuedCodemapWaiterCount == 1
         }
@@ -2048,6 +2105,78 @@ final class ContentReadCancellationTests: XCTestCase {
         try codeMapResult.get()
         let grantedAfterRelease = await codeMapGranted.isSignaledSnapshot()
         XCTAssertTrue(grantedAfterRelease)
+        let finalSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(finalSnapshot.isIdle)
+    }
+
+    func testWorkspaceInteractiveReadSuppressesCodeMapBetweenPhysicalStages() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "multi-stage foreground read\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        guard let record = await store.file(rootID: root.id, relativePath: "Target.swift") else {
+            return XCTFail("Expected loaded file record")
+        }
+        let fingerprintResolved = AsyncSignal()
+        let releaseStageGap = AsyncSignal()
+        await store.setInteractiveReadFingerprintDidResolveHandlerForTesting {
+            await fingerprintResolved.signal()
+            await releaseStageGap.wait()
+        }
+        let interactiveReadTask = Task { try await store.interactiveReadSnapshot(for: record) }
+        guard await waitUntil({ await fingerprintResolved.isSignaledSnapshot() }) else {
+            interactiveReadTask.cancel()
+            await releaseStageGap.signal()
+            return XCTFail("Interactive read did not reach the post-fingerprint stage gap")
+        }
+
+        let codeMapGranted = AsyncSignal()
+        let codeMapTask = Task {
+            try await FileSystemService.withCodeMapArtifactBuildPermit(
+                ownerID: UUID(),
+                priority: .utility
+            ) {
+                await codeMapGranted.signal()
+            }
+        }
+        addTeardownBlock {
+            await releaseStageGap.signal()
+            interactiveReadTask.cancel()
+            codeMapTask.cancel()
+            await store.setInteractiveReadFingerprintDidResolveHandlerForTesting(nil)
+            _ = await self.waitForTaskResult(interactiveReadTask)
+            _ = await self.waitForTaskResult(codeMapTask)
+            let teardownSnapshot = await self.waitForLimiterIdle()
+            XCTAssertTrue(teardownSnapshot.isIdle)
+        }
+        guard await waitUntil({
+            let snapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+            return snapshot.queuedCodemapWaiterCount == 1
+        }) else {
+            return XCTFail("CodeMap work was not queued behind the fingerprint stage")
+        }
+        let grantedBetweenStages = await codeMapGranted.isSignaledSnapshot()
+        XCTAssertFalse(grantedBetweenStages)
+        let stageGapSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(stageGapSnapshot.activePermitCount, 0)
+        XCTAssertEqual(stageGapSnapshot.foregroundActivityCountsByKind[.interactiveRead], 1)
+        XCTAssertEqual(stageGapSnapshot.activeCodemapPermitCount, 0)
+        XCTAssertEqual(stageGapSnapshot.queuedCodemapWaiterCount, 1)
+
+        await releaseStageGap.signal()
+        guard let interactiveResult = await waitForTaskResult(interactiveReadTask),
+              let codeMapResult = await waitForTaskResult(codeMapTask)
+        else {
+            return XCTFail("Foreground and CodeMap work did not settle after physical release")
+        }
+        XCTAssertNotNil(try interactiveResult.get())
+        try codeMapResult.get()
+        let grantedAfterRead = await codeMapGranted.isSignaledSnapshot()
+        XCTAssertTrue(grantedAfterRead)
         let finalSnapshot = await waitForLimiterIdle()
         XCTAssertTrue(finalSnapshot.isIdle)
     }

--- a/Tests/RepoPromptTests/Services/FileSystem/ContentReadCancellationTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/ContentReadCancellationTests.swift
@@ -1,0 +1,2868 @@
+import Foundation
+import MCP
+@testable import RepoPromptApp
+import RepoPromptDomainRuntime
+import XCTest
+
+final class ContentReadCancellationTests: XCTestCase {
+    func testCooperativeChunkReadCancellationSettlesAndReleasesLimiter() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "cooperative physical read\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let service = try await FileSystemService(path: rootURL.path)
+        let chunkReadEntered = AsyncSignal()
+        let cancellationGate = CancellableTestGate()
+        addTeardownBlock { await cancellationGate.releaseAll() }
+        await service.setContentReadChunkHandlerForTesting { _ in
+            await chunkReadEntered.signal()
+            _ = try? await cancellationGate.wait()
+        }
+        addTeardownBlock {
+            await service.setContentReadChunkHandlerForTesting(nil)
+        }
+
+        let readTask = Task {
+            try await service.loadContent(
+                ofRelativePath: "Target.swift",
+                workloadClass: .interactiveRead
+            )
+        }
+        let chunkReadDidEnter = await waitUntil { await chunkReadEntered.isSignaledSnapshot() }
+        guard chunkReadDidEnter else {
+            readTask.cancel()
+            return XCTFail("Chunk read did not reach the controlled cancellation gate")
+        }
+        readTask.cancel()
+
+        guard let readResult = await waitForTaskResult(readTask) else {
+            await cancellationGate.releaseAll()
+            return XCTFail("Cooperative chunk read did not settle after cancellation")
+        }
+        do {
+            _ = try readResult.get()
+            XCTFail("Expected cooperative chunk read cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let limiterSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(limiterSnapshot.isIdle)
+    }
+
+    func testWatchdogCancellationSettlesBeforeBlockedSynchronousFingerprintIsReleased() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "blocked physical read\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let service = try await FileSystemService(path: rootURL.path)
+        let physicalReadGate = SynchronousPhysicalReadGate()
+        let clock = SynchronousDurationClock()
+        let sleeps = ControlledWatchdogSleeps(clock: clock)
+        let events = WatchdogEventRecorder()
+        let settlementRecorder = SettlementRecorder()
+        let phaseRecorder = MCPToolExecutionHandlerPhaseRecorder(origin: .zero, now: { .zero })
+
+        await service.setContentPhysicalReadHandlerForTesting {
+            physicalReadGate.blockUntilReleased()
+        }
+        addTeardownBlock {
+            physicalReadGate.release()
+            await service.setContentPhysicalReadHandlerForTesting(nil)
+            await sleeps.releaseAll()
+        }
+
+        let watchdogTask = Task { () -> Result<Void, Error> in
+            do {
+                try await MCPToolExecutionWatchdog.execute(
+                    deadline: .seconds(30),
+                    cancellationGrace: .seconds(5),
+                    cleanupDisposition: .detachAndSettle,
+                    environment: MCPToolExecutionWatchdogEnvironment(
+                        now: { clock.now() },
+                        sleep: { duration in try await sleeps.sleep(for: duration) }
+                    ),
+                    onEvent: { event in await events.record(event) },
+                    onSynchronousSettlement: { settlement in
+                        await settlementRecorder.record(settlement)
+                    }
+                ) {
+                    try await MCPToolExecutionHandlerPhaseContext.$recorder.withValue(phaseRecorder) {
+                        await MCPToolExecutionHandlerPhaseContext.report(.readFileContentRead)
+                        let fingerprint = try await service.contentFingerprint(ofRelativePath: "Target.swift")
+                        _ = try await service.loadValidatedContent(
+                            ofRelativePath: "Target.swift",
+                            expectedFingerprint: fingerprint,
+                            workloadClass: .interactiveRead
+                        )
+                        await MCPToolExecutionHandlerPhaseContext.report(
+                            .readFileContentRead,
+                            transition: .completed
+                        )
+                    }
+                }
+                return .success(())
+            } catch {
+                return .failure(error)
+            }
+        }
+
+        let physicalReadDidBlock = await waitUntil { physicalReadGate.isBlockedSnapshot() }
+        guard physicalReadDidBlock else {
+            watchdogTask.cancel()
+            return XCTFail("Fingerprint read did not reach the physical gate")
+        }
+        let deadlineDidRegister = await waitUntil { await sleeps.registeredCountSnapshot() >= 1 }
+        guard deadlineDidRegister else {
+            watchdogTask.cancel()
+            return XCTFail("Watchdog deadline did not register")
+        }
+        await sleeps.releaseNext()
+
+        guard let observedWatchdogResult = await waitForTaskResult(watchdogTask) else {
+            physicalReadGate.release()
+            return XCTFail("Watchdog did not settle within the bounded observation window")
+        }
+        let watchdogResult = try observedWatchdogResult.get()
+        guard case let .failure(error) = watchdogResult,
+              error as? MCPToolExecutionWatchdogError == .executionTimedOut(settlement: .cancellation)
+        else {
+            return XCTFail("Expected the blocked physical read caller to settle cancellation during grace")
+        }
+        let recordedEvents = await events.snapshot()
+        XCTAssertEqual(
+            recordedEvents,
+            [
+                .deadlineExpired,
+                .cancellationRequested(origin: .watchdogDeadline),
+                .settledDuringGrace(.cancellation, cancellationRequested: true)
+            ]
+        )
+        XCTAssertEqual(phaseRecorder.snapshot()?.phase, .readFileContentRead)
+        XCTAssertEqual(phaseRecorder.snapshot()?.transition, .started)
+
+        let settlementBeforeRelease = await settlementRecorder.snapshot()
+        XCTAssertEqual(
+            settlementBeforeRelease,
+            .cancellation,
+            "Detached read must settle before a blocked synchronous filesystem operation is released"
+        )
+        let blockedLimiterSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(blockedLimiterSnapshot.activePermitCount, 1)
+        XCTAssertEqual(blockedLimiterSnapshot.queuedWaiterCount, 0)
+        XCTAssertFalse(blockedLimiterSnapshot.isIdle)
+
+        physicalReadGate.release()
+        let limiterSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(limiterSnapshot.isIdle)
+    }
+
+    func testOuterProviderSettlementReleasesRegistryBeforeBlockedPhysicalReadReturns() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "blocked provider read\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        guard let record = await store.file(rootID: root.id, relativePath: "Target.swift") else {
+            return XCTFail("Expected loaded file record")
+        }
+
+        let physicalReadGate = SynchronousPhysicalReadGate()
+        let clock = SynchronousDurationClock()
+        let sleeps = ControlledWatchdogSleeps(clock: clock)
+        let registry = MCPCodeStructureSettlementRegistry()
+        let windowID = 949
+        let connectionID = UUID()
+        let invocationID = UUID()
+        let admission = registry.admit(
+            windowID: windowID,
+            connectionID: connectionID,
+            invocationID: invocationID,
+            toolName: MCPWindowToolName.readFile,
+            now: .zero,
+            handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+        )
+        guard case let .admitted(settlementSlot) = admission else {
+            return XCTFail("Expected settlement-registry admission")
+        }
+
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+            physicalReadGate.blockUntilReleased()
+        }
+        addTeardownBlock {
+            physicalReadGate.release()
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+            await sleeps.releaseAll()
+        }
+
+        let watchdogTask = Task { () -> Result<Void, Error> in
+            do {
+                try await MCPToolExecutionWatchdog.execute(
+                    deadline: .seconds(30),
+                    cancellationGrace: .seconds(5),
+                    cleanupDisposition: .detachAndSettle,
+                    settlementSlot: settlementSlot,
+                    environment: MCPToolExecutionWatchdogEnvironment(
+                        now: { clock.now() },
+                        sleep: { duration in try await sleeps.sleep(for: duration) }
+                    )
+                ) {
+                    try await runMainActorProviderTask(
+                        store: store,
+                        record: record,
+                        roots: store.rootRefs(scope: .visibleWorkspace)
+                    )
+                }
+                return .success(())
+            } catch {
+                return .failure(error)
+            }
+        }
+
+        let physicalReadDidBlock = await waitUntil { physicalReadGate.isBlockedSnapshot() }
+        guard physicalReadDidBlock else {
+            watchdogTask.cancel()
+            return XCTFail("Provider read did not reach the controlled physical gate")
+        }
+        let deadlineDidRegister = await waitUntil { await sleeps.registeredCountSnapshot() >= 1 }
+        guard deadlineDidRegister else {
+            watchdogTask.cancel()
+            return XCTFail("Watchdog deadline did not register")
+        }
+        await sleeps.releaseNext()
+
+        guard let observedWatchdogResult = await waitForTaskResult(watchdogTask) else {
+            physicalReadGate.release()
+            return XCTFail("Outer provider did not settle within the bounded observation window")
+        }
+        let watchdogResult = try observedWatchdogResult.get()
+        guard case let .failure(error) = watchdogResult,
+              error as? MCPToolExecutionWatchdogError == .executionTimedOut(settlement: .cancellation)
+        else {
+            return XCTFail("Expected the outer provider to settle cancellation during grace")
+        }
+        XCTAssertEqual(
+            registry.snapshot(windowID: windowID),
+            .init(activeCount: 0, detachedCount: 0, releasedCount: 0)
+        )
+        let blockedLimiterSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(blockedLimiterSnapshot.activePermitCount, 1)
+
+        physicalReadGate.release()
+        let limiterSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(limiterSnapshot.isIdle)
+    }
+
+    func testDomainHostAndRunToolCancellationChainSettlesBeforeBlockedPhysicalReadReturns() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "blocked nested provider read\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        guard let record = await store.file(rootID: root.id, relativePath: "Target.swift") else {
+            return XCTFail("Expected loaded file record")
+        }
+
+        let physicalReadGate = SynchronousPhysicalReadGate()
+        let clock = SynchronousDurationClock()
+        let sleeps = ControlledWatchdogSleeps(clock: clock)
+        let registry = MCPCodeStructureSettlementRegistry()
+        let admission = registry.admit(
+            windowID: 950,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: MCPWindowToolName.readFile,
+            now: .zero,
+            handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+        )
+        guard case let .admitted(settlementSlot) = admission else {
+            return XCTFail("Expected settlement-registry admission")
+        }
+
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+            physicalReadGate.blockUntilReleased()
+        }
+        addTeardownBlock {
+            physicalReadGate.release()
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+            await sleeps.releaseAll()
+        }
+
+        let watchdogTask = Task { () -> Result<Void, Error> in
+            do {
+                try await MCPToolExecutionWatchdog.execute(
+                    deadline: .seconds(30),
+                    cancellationGrace: .seconds(5),
+                    cleanupDisposition: .detachAndSettle,
+                    settlementSlot: settlementSlot,
+                    environment: MCPToolExecutionWatchdogEnvironment(
+                        now: { clock.now() },
+                        sleep: { duration in try await sleeps.sleep(for: duration) }
+                    )
+                ) {
+                    try await runDomainHostProviderTask {
+                        try await runDomainReadProviderTask(path: record.standardizedRelativePath) {
+                            try await runMainActorProviderTask(
+                                store: store,
+                                record: record,
+                                roots: store.rootRefs(scope: .visibleWorkspace)
+                            )
+                        }
+                    }
+                }
+                return .success(())
+            } catch {
+                return .failure(error)
+            }
+        }
+
+        guard await waitUntil(iterations: 100_000, { physicalReadGate.isBlockedSnapshot() }) else {
+            watchdogTask.cancel()
+            return XCTFail("Nested provider did not reach the controlled physical gate")
+        }
+        guard await waitUntil({ await sleeps.pendingCountSnapshot() >= 1 }) else {
+            watchdogTask.cancel()
+            return XCTFail("Watchdog deadline did not register")
+        }
+        let deadlineSleepReleased = await sleeps.releaseNext()
+        XCTAssertTrue(deadlineSleepReleased)
+
+        guard let observedResult = await waitForTaskResult(watchdogTask) else {
+            physicalReadGate.release()
+            return XCTFail("Nested provider did not settle within cancellation grace")
+        }
+        guard case let .failure(error) = observedResult.get() else {
+            return XCTFail("Expected nested provider timeout")
+        }
+        XCTAssertEqual(
+            error as? MCPToolExecutionWatchdogError,
+            .executionTimedOut(settlement: .cancellation)
+        )
+        XCTAssertEqual(
+            registry.snapshot(windowID: 950),
+            .init(activeCount: 0, detachedCount: 0, releasedCount: 0)
+        )
+
+        physicalReadGate.release()
+        let limiterSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(limiterSnapshot.isIdle)
+    }
+
+    func testConcreteDomainHostAndAppBinderSettleBeforeBlockedPhysicalReadReturns() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "blocked concrete host read\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        guard let record = await store.file(rootID: root.id, relativePath: "Target.swift") else {
+            return XCTFail("Expected loaded file record")
+        }
+
+        let physicalReadGate = SynchronousPhysicalReadGate()
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+            physicalReadGate.blockUntilReleased()
+        }
+        addTeardownBlock {
+            physicalReadGate.release()
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+        }
+
+        let runtimeDirectory = rootURL.appendingPathComponent("Runtime", isDirectory: true)
+        let runtime = MCPDomainRuntime(configuration: .init(
+            mode: .app,
+            profileIdentifier: "content-read-cancellation",
+            storageDirectory: runtimeDirectory,
+            eventDirectory: rootURL.appendingPathComponent("Events", isDirectory: true),
+            temporaryDirectory: rootURL.appendingPathComponent("Temporary", isDirectory: true),
+            externalReloadInterval: nil
+        ))
+        try await runtime.start()
+        addTeardownBlock { _ = await runtime.shutdown() }
+
+        let path = record.standardizedRelativePath
+        let connectionID = UUID()
+        let readContext = DomainReadInvocationContext(
+            handle: DomainReadContextHandle(
+                runtimeID: runtime.identity.runtimeID,
+                runtimeGeneration: runtime.identity.lifecycleGeneration,
+                connectionID: connectionID,
+                connectionGeneration: 1,
+                context: DomainContextIdentity(workspaceID: UUID(), contextID: UUID()),
+                workspaceRevision: 1,
+                contextRevision: 1,
+                routingRevision: 1,
+                bindingKind: .explicit
+            ),
+            connectionID: connectionID,
+            refreshesDomainRouting: false
+        )
+        let rawProvider = MCPDomainReadToolProvider(
+            resolveContext: { _, _ in readContext },
+            backend: MCPDomainReadToolBackend { _, _, _, _ in
+                try await runMainActorProviderTask(
+                    store: store,
+                    record: record,
+                    roots: store.rootRefs(scope: .visibleWorkspace)
+                )
+                return .null
+            },
+            sideEffects: DomainReadSideEffectCoordinator(identity: runtime.identity)
+        )
+        let rawBinding = try XCTUnwrap(rawProvider.binding(named: MCPWindowToolName.readFile))
+        let (appBoundTool, appBinderRetention) = try await MainActor.run {
+            let binder = MCPAppToolBinder(windowID: 952) { _, _, arguments, implementation in
+                try await runAppBinderProviderTask {
+                    try await implementation(
+                        MCPAppToolInvocation(toolName: MCPWindowToolName.readFile, windowID: 952),
+                        arguments
+                    )
+                }
+            }
+            return try (
+                Tool(domainBinding: rawBinding, runtime: binder),
+                SendableObjectRetention(binder)
+            )
+        }
+        let registeredBinding = try appBoundTool.domainBinding()
+        _ = try await runtime.toolRegistry.register(
+            registrationID: MCPDomainToolRegistrationID(),
+            scope: .window(id: 952),
+            bindings: [registeredBinding]
+        )
+
+        _ = await runtime.routingCoordinator.registerConnection(
+            connectionID: connectionID,
+            operationID: UUID()
+        )
+        let registration = try await runtime.routingCoordinator.currentRegistration(
+            connectionID: connectionID
+        )
+        let resolution = try await runtime.domainHost.resolve(
+            toolName: MCPWindowToolName.readFile,
+            scope: .window(id: 952)
+        )
+        let invocationID = UUID()
+        let securityContext = DomainToolInvocationSecurityContext(
+            principal: DomainClientPrincipal(
+                principalID: UUID(),
+                stableKey: "content-read-cancellation",
+                displayName: "ContentReadCancellationTests",
+                kind: .appProxy,
+                assurance: .verifiedProcess,
+                processID: 949,
+                runID: nil,
+                provider: "test",
+                verifiedIdentityFingerprint: "content-read-cancellation"
+            ),
+            connectionID: connectionID,
+            connectionGeneration: registration.generation,
+            invocationID: invocationID,
+            runtimeID: runtime.identity.runtimeID,
+            runtimeGeneration: runtime.identity.lifecycleGeneration,
+            ephemeralGrantedToolNames: []
+        )
+
+        let clock = SynchronousDurationClock()
+        let sleeps = ControlledWatchdogSleeps(clock: clock)
+        let registry = MCPCodeStructureSettlementRegistry()
+        let admission = registry.admit(
+            windowID: 952,
+            connectionID: connectionID,
+            invocationID: invocationID,
+            toolName: MCPWindowToolName.readFile,
+            now: .zero,
+            handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+        )
+        guard case let .admitted(settlementSlot) = admission else {
+            return XCTFail("Expected settlement-registry admission")
+        }
+        addTeardownBlock { await sleeps.releaseAll() }
+
+        let watchdogTask = Task { () -> Result<Value, Error> in
+            do {
+                return try await .success(MCPToolExecutionWatchdog.execute(
+                    deadline: .seconds(30),
+                    cancellationGrace: .seconds(5),
+                    cleanupDisposition: .detachAndSettle,
+                    settlementSlot: settlementSlot,
+                    environment: MCPToolExecutionWatchdogEnvironment(
+                        now: { clock.now() },
+                        sleep: { duration in try await sleeps.sleep(for: duration) }
+                    )
+                ) {
+                    try await runtime.domainHost.invoke(MCPDomainHostInvocation(
+                        invocationID: invocationID,
+                        connectionID: connectionID,
+                        resolution: resolution,
+                        arguments: ["path": .string(path)],
+                        securityContext: securityContext
+                    ))
+                })
+            } catch {
+                return .failure(error)
+            }
+        }
+
+        guard await waitUntil(iterations: 100_000, { physicalReadGate.isBlockedSnapshot() }) else {
+            watchdogTask.cancel()
+            if let earlyResult = await waitForTaskResult(watchdogTask),
+               case let .failure(error) = earlyResult.get()
+            {
+                return XCTFail("Concrete host provider failed before the physical gate: \(String(reflecting: error))")
+            }
+            return XCTFail("Concrete host provider did not reach the controlled physical gate")
+        }
+        guard await waitUntil({ await sleeps.pendingCountSnapshot() >= 1 }) else {
+            watchdogTask.cancel()
+            return XCTFail("Watchdog deadline did not register")
+        }
+        let deadlineSleepReleased = await sleeps.releaseNext()
+        XCTAssertTrue(deadlineSleepReleased)
+
+        guard let observedResult = await waitForTaskResult(watchdogTask) else {
+            physicalReadGate.release()
+            return XCTFail("Concrete host provider did not settle within cancellation grace")
+        }
+        guard case let .failure(error) = observedResult.get() else {
+            return XCTFail("Expected concrete host provider timeout")
+        }
+        XCTAssertEqual(
+            error as? MCPToolExecutionWatchdogError,
+            .executionTimedOut(settlement: .cancellation)
+        )
+        XCTAssertEqual(
+            registry.snapshot(windowID: 952),
+            .init(activeCount: 0, detachedCount: 0, releasedCount: 0)
+        )
+
+        physicalReadGate.release()
+        let limiterSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(limiterSnapshot.isIdle)
+        _ = appBinderRetention
+    }
+
+    func testSuccessiveDomainProviderExplicitMaterializationTimeoutsDoNotExhaustReleasedProviderAllowance() async throws {
+        let firstRootURL = try makeTemporaryRoot()
+        try "Ignored.swift\n".write(
+            to: firstRootURL.appendingPathComponent(".gitignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let firstTargetURL = firstRootURL.appendingPathComponent("Ignored.swift")
+        try "first materialized read\n".write(to: firstTargetURL, atomically: true, encoding: .utf8)
+        let firstStore = WorkspaceFileContextStore()
+        let firstRoot = try await firstStore.loadRoot(path: firstRootURL.path)
+        let firstRoots = await firstStore.rootRefs(scope: .visibleWorkspace)
+        let firstCatalogedTarget = await firstStore.file(rootID: firstRoot.id, relativePath: "Ignored.swift")
+        XCTAssertNil(firstCatalogedTarget)
+
+        let secondRootURL = try makeTemporaryRoot()
+        try "Ignored.swift\n".write(
+            to: secondRootURL.appendingPathComponent(".gitignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let secondTargetURL = secondRootURL.appendingPathComponent("Ignored.swift")
+        try "second materialized read\n".write(to: secondTargetURL, atomically: true, encoding: .utf8)
+        let secondStore = WorkspaceFileContextStore()
+        let secondRoot = try await secondStore.loadRoot(path: secondRootURL.path)
+        let secondRoots = await secondStore.rootRefs(scope: .visibleWorkspace)
+        let secondCatalogedTarget = await secondStore.file(rootID: secondRoot.id, relativePath: "Ignored.swift")
+        XCTAssertNil(secondCatalogedTarget)
+
+        let firstPhysicalReadGate = SynchronousPhysicalReadGate()
+        let secondPhysicalReadGate = SynchronousPhysicalReadGate()
+        let clock = SynchronousDurationClock()
+        let registry = MCPCodeStructureSettlementRegistry()
+        try await firstStore.setContentPhysicalReadHandlerForTesting(rootID: firstRoot.id) {
+            firstPhysicalReadGate.blockUntilReleased()
+        }
+        try await secondStore.setContentPhysicalReadHandlerForTesting(rootID: secondRoot.id) {
+            secondPhysicalReadGate.blockUntilReleased()
+        }
+        addTeardownBlock {
+            firstPhysicalReadGate.release()
+            secondPhysicalReadGate.release()
+            try? await firstStore.setContentPhysicalReadHandlerForTesting(rootID: firstRoot.id, nil)
+            try? await secondStore.setContentPhysicalReadHandlerForTesting(rootID: secondRoot.id, nil)
+        }
+
+        let attempts = [
+            (
+                store: firstStore,
+                roots: firstRoots,
+                targetURL: firstTargetURL,
+                physicalReadGate: firstPhysicalReadGate
+            ),
+            (
+                store: secondStore,
+                roots: secondRoots,
+                targetURL: secondTargetURL,
+                physicalReadGate: secondPhysicalReadGate
+            )
+        ]
+        var watchdogTasks: [Task<Result<Void, Error>, Never>] = []
+        var watchdogResults: [Result<Void, Error>] = []
+        var controlledSleeps: [ControlledWatchdogSleeps] = []
+
+        for (index, attempt) in attempts.enumerated() {
+            let attemptNumber = index + 1
+            let sleeps = ControlledWatchdogSleeps(clock: clock)
+            controlledSleeps.append(sleeps)
+            let admission = registry.admit(
+                windowID: 951,
+                connectionID: UUID(),
+                invocationID: UUID(),
+                toolName: MCPWindowToolName.readFile,
+                now: clock.now(),
+                handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+            )
+            guard case let .admitted(settlementSlot) = admission else {
+                return XCTFail("Explicit-materialization attempt \(attemptNumber) was blocked before execution")
+            }
+            let watchdogTask = Task { () -> Result<Void, Error> in
+                do {
+                    try await MCPToolExecutionWatchdog.execute(
+                        deadline: .seconds(30),
+                        cancellationGrace: .seconds(5),
+                        cleanupDisposition: .detachAndSettle,
+                        settlementSlot: settlementSlot,
+                        environment: MCPToolExecutionWatchdogEnvironment(
+                            now: { clock.now() },
+                            sleep: { duration in try await sleeps.sleep(for: duration) }
+                        )
+                    ) {
+                        try await runDomainReadProviderTask(path: attempt.targetURL.path) {
+                            let materialization = try await attempt.store.materializeExplicitlyRequestedFile(
+                                attempt.targetURL.path,
+                                rootRefs: attempt.roots
+                            )
+                            guard case .materialized = materialization else {
+                                throw PhysicalReadTestError.syntheticFailure
+                            }
+                        }
+                    }
+                    return .success(())
+                } catch {
+                    return .failure(error)
+                }
+            }
+            watchdogTasks.append(watchdogTask)
+
+            guard await waitUntil(iterations: 100_000, { attempt.physicalReadGate.isBlockedSnapshot() }) else {
+                watchdogTask.cancel()
+                return XCTFail("Explicit-materialization attempt \(attemptNumber) did not reach its physical probe")
+            }
+            guard await waitUntil({ await sleeps.pendingCountSnapshot() >= 1 }) else {
+                watchdogTask.cancel()
+                return XCTFail("Explicit-materialization attempt \(attemptNumber) did not register its deadline")
+            }
+            let deadlineSleepReleased = await sleeps.releaseNext()
+            XCTAssertTrue(deadlineSleepReleased)
+            var observedResult = await waitForTaskResult(watchdogTask)
+            if observedResult == nil {
+                guard await waitUntil({ await sleeps.pendingCountSnapshot() >= 1 }) else {
+                    watchdogTask.cancel()
+                    return XCTFail("Explicit-materialization attempt \(attemptNumber) did not register cancellation grace")
+                }
+                let graceSleepReleased = await sleeps.releaseNext()
+                XCTAssertTrue(graceSleepReleased)
+                observedResult = await waitForTaskResult(watchdogTask)
+            }
+            guard let observedResult else {
+                attempt.physicalReadGate.release()
+                return XCTFail("Explicit-materialization attempt \(attemptNumber) did not settle")
+            }
+            watchdogResults.append(observedResult.get())
+
+            if index == 0 {
+                clock.advance(by: .seconds(30))
+            }
+        }
+
+        let thirdAdmission = registry.admit(
+            windowID: 951,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: MCPWindowToolName.readFile,
+            now: clock.now(),
+            handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+        )
+        let thirdAdmissionSucceeded: Bool
+        switch thirdAdmission {
+        case let .admitted(slot):
+            thirdAdmissionSucceeded = true
+            _ = slot.closeBeforeExecutionExit()
+        case .busy:
+            thirdAdmissionSucceeded = false
+        }
+
+        for (index, result) in watchdogResults.enumerated() {
+            guard case let .failure(error) = result else {
+                XCTFail("Explicit-materialization attempt \(index + 1) did not time out")
+                continue
+            }
+            XCTAssertEqual(
+                error as? MCPToolExecutionWatchdogError,
+                .executionTimedOut(settlement: .cancellation),
+                "Explicit-materialization attempt \(index + 1) detached instead of settling cancellation"
+            )
+        }
+        XCTAssertTrue(thirdAdmissionSucceeded, "Two released providers exhausted replacement admission")
+        XCTAssertEqual(
+            registry.snapshot(windowID: 951),
+            .init(activeCount: 0, detachedCount: 0, releasedCount: 0)
+        )
+        let blockedLimiterSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(blockedLimiterSnapshot.activePermitCount, 2)
+        XCTAssertEqual(blockedLimiterSnapshot.queuedWaiterCount, 0)
+
+        firstPhysicalReadGate.release()
+        secondPhysicalReadGate.release()
+        for sleeps in controlledSleeps {
+            await sleeps.releaseAll()
+        }
+        for task in watchdogTasks {
+            _ = await waitForTaskResult(task)
+        }
+        let limiterSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(limiterSnapshot.isIdle)
+    }
+
+    func testExplicitMaterializationReusesItsValidatedPhysicalEligibility() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "Ignored.swift\n".write(
+            to: rootURL.appendingPathComponent(".repo_ignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let targetURL = rootURL.appendingPathComponent("Ignored.swift")
+        try "single physical eligibility probe\n".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let roots = await store.rootRefs(scope: .visibleWorkspace)
+        let probeCount = SynchronousInvocationCounter()
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+            probeCount.recordInvocation()
+        }
+        addTeardownBlock {
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+        }
+
+        let result = try await store.materializeExplicitlyRequestedFile(
+            targetURL.path,
+            rootRefs: roots
+        )
+        guard case let .materialized(file) = result else {
+            return XCTFail("Expected ignored file to materialize")
+        }
+        XCTAssertEqual(file.standardizedFullPath, StandardizedPath.absolute(targetURL.path))
+        XCTAssertEqual(probeCount.snapshot(), 1)
+    }
+
+    func testExplicitRegistrationRechecksIgnoreRuleRevisionAfterEligibilityValidation() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "policy drift\n".write(
+            to: rootURL.appendingPathComponent("Ignored.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let service = try await FileSystemService(path: rootURL.path)
+        let probeCount = SynchronousInvocationCounter()
+        await service.setContentPhysicalReadHandlerForTesting {
+            probeCount.recordInvocation()
+        }
+        addTeardownBlock {
+            await service.setContentPhysicalReadHandlerForTesting(nil)
+        }
+        let evidence = try await service.cancellationResponsiveCatalogRegularFileEligibilityWithPolicy(
+            relativePath: "Ignored.swift"
+        )
+        XCTAssertEqual(evidence.eligibility, .eligible)
+
+        try "Ignored.swift\n".write(
+            to: rootURL.appendingPathComponent(".gitignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try await service.refreshIgnoreRules()
+        let refreshedPolicyIdentity = await service.currentWorkspaceRootCatalogPolicyIdentity()
+        XCTAssertEqual(refreshedPolicyIdentity, evidence.policyIdentity)
+        let registeredEligibility = try await service.registerExplicitlyManagedRegularFile(
+            relativePath: "Ignored.swift",
+            validatedEligibility: evidence.eligibility,
+            policyIdentity: evidence.policyIdentity,
+            ignoreRulesRevision: evidence.ignoreRulesRevision
+        )
+
+        XCTAssertEqual(registeredEligibility, .ineligible(.ignored))
+        XCTAssertEqual(probeCount.snapshot(), 1)
+    }
+
+    func testExplicitRegistrationRechecksPhysicalEligibilityAfterPolicyIdentityChanges() async throws {
+        let rootURL = try makeTemporaryRoot()
+        let realDirectoryURL = rootURL.appendingPathComponent("Real", isDirectory: true)
+        try FileManager.default.createDirectory(at: realDirectoryURL, withIntermediateDirectories: true)
+        try "policy identity drift\n".write(
+            to: realDirectoryURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.createSymbolicLink(
+            at: rootURL.appendingPathComponent("Alias"),
+            withDestinationURL: realDirectoryURL
+        )
+
+        let service = try await FileSystemService(path: rootURL.path, skipSymlinks: false)
+        let probeCount = SynchronousInvocationCounter()
+        await service.setContentPhysicalReadHandlerForTesting {
+            probeCount.recordInvocation()
+        }
+        addTeardownBlock {
+            await service.setContentPhysicalReadHandlerForTesting(nil)
+        }
+        let evidence = try await service.cancellationResponsiveCatalogRegularFileEligibilityWithPolicy(
+            relativePath: "Alias/Target.swift"
+        )
+        XCTAssertEqual(evidence.eligibility, .eligible)
+
+        await service.updateSkipSymlinks(true)
+        let registeredEligibility = try await service.registerExplicitlyManagedRegularFile(
+            relativePath: "Alias/Target.swift",
+            validatedEligibility: evidence.eligibility,
+            policyIdentity: evidence.policyIdentity,
+            ignoreRulesRevision: evidence.ignoreRulesRevision
+        )
+
+        XCTAssertEqual(registeredEligibility, .ineligible(.symlinkComponent))
+        XCTAssertEqual(probeCount.snapshot(), 2)
+    }
+
+    func testExplicitMaterializationRechecksIgnoreRuleRevisionAfterCodemapFence() async throws {
+        let rootURL = try makeTemporaryRoot()
+        let ignoreURL = rootURL.appendingPathComponent(".gitignore")
+        try "Ignored.swift\n".write(to: ignoreURL, atomically: true, encoding: .utf8)
+        let targetURL = rootURL.appendingPathComponent("Ignored.swift")
+        try "fence policy drift\n".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let roots = await store.rootRefs(scope: .visibleWorkspace)
+        let probeCount = SynchronousInvocationCounter()
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+            probeCount.recordInvocation()
+        }
+        await store.setExplicitMaterializationDidAcquireCodemapFenceHandlerForTesting { service in
+            try? "".write(to: ignoreURL, atomically: true, encoding: .utf8)
+            try? await service.refreshIgnoreRules()
+        }
+        addTeardownBlock {
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+            await store.setExplicitMaterializationDidAcquireCodemapFenceHandlerForTesting(nil)
+        }
+
+        let result = try await store.materializeExplicitlyRequestedFile(
+            targetURL.path,
+            rootRefs: roots
+        )
+        guard case let .materialized(file) = result else {
+            return XCTFail("Expected file to materialize after ignore policy changed")
+        }
+        let isManagedOnly = await store.isManagedOnlyFileForTesting(file.id)
+        XCTAssertFalse(isManagedOnly)
+        XCTAssertEqual(probeCount.snapshot(), 1)
+    }
+
+    func testExplicitMaterializationRejectsRootTurnoverDuringPolicyRevalidation() async throws {
+        let rootURL = try makeTemporaryRoot()
+        let targetURL = rootURL.appendingPathComponent("Target.swift")
+        try "root turnover\n".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let roots = await store.rootRefs(scope: .visibleWorkspace)
+        let physicalGate = SynchronousPhysicalReadGate()
+        await store.setExplicitMaterializationDidAcquireCodemapFenceHandlerForTesting { service in
+            await service.updateSkipSymlinks(false)
+            await service.setContentPhysicalReadHandlerForTesting {
+                physicalGate.blockUntilReleased()
+            }
+        }
+        addTeardownBlock {
+            physicalGate.release()
+            await store.setExplicitMaterializationDidAcquireCodemapFenceHandlerForTesting(nil)
+        }
+
+        let materializationTask = Task {
+            try await store.materializeExplicitlyRequestedFile(targetURL.path, rootRefs: roots)
+        }
+        guard await waitUntil({ physicalGate.isBlockedSnapshot() }) else {
+            materializationTask.cancel()
+            physicalGate.release()
+            return XCTFail("Policy revalidation did not reach the controlled physical boundary")
+        }
+
+        await store.unloadRoot(id: root.id)
+        physicalGate.release()
+        guard let materializationResult = await waitForTaskResult(materializationTask) else {
+            return XCTFail("Materialization did not settle after root turnover")
+        }
+        XCTAssertEqual(try materializationResult.get(), .noCandidate)
+        let materializedFile = await store.file(rootID: root.id, relativePath: "Target.swift")
+        XCTAssertNil(materializedFile)
+    }
+
+    func testExplicitMaterializationRejectsRootTurnoverDuringInitialEligibility() async throws {
+        let rootURL = try makeTemporaryRoot()
+        let targetURL = rootURL.appendingPathComponent("Target.swift")
+        try "initial eligibility turnover\n".write(to: targetURL, atomically: true, encoding: .utf8)
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        let roots = await store.rootRefs(scope: .visibleWorkspace)
+        let physicalGate = SynchronousPhysicalReadGate()
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+            physicalGate.blockUntilReleased()
+        }
+        addTeardownBlock {
+            physicalGate.release()
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+        }
+
+        let materializationTask = Task {
+            try await store.materializeExplicitlyRequestedFile(targetURL.path, rootRefs: roots)
+        }
+        guard await waitUntil({ physicalGate.isBlockedSnapshot() }) else {
+            materializationTask.cancel()
+            physicalGate.release()
+            return XCTFail("Initial eligibility did not reach the controlled physical boundary")
+        }
+
+        try await store.replaceRootLifetimeForTesting(rootID: root.id)
+        physicalGate.release()
+        guard let materializationResult = await waitForTaskResult(materializationTask) else {
+            return XCTFail("Materialization did not settle after initial-eligibility root turnover")
+        }
+        XCTAssertEqual(try materializationResult.get(), .noCandidate)
+    }
+
+    func testSuccessiveOuterProviderTimeoutsDoNotEnterUnrelatedGitArtifactPreflight() async throws {
+        XCTAssertTrue(MCPServerViewModel.shouldAttemptSelectedGitArtifactReadForTesting(
+            requestedPath: "_git_data/repos/repo/snapshot/MAP.txt",
+            translatedLookupPath: "/workspace/_git_data/repos/repo/snapshot/MAP.txt"
+        ))
+        XCTAssertFalse(MCPServerViewModel.shouldAttemptSelectedGitArtifactReadForTesting(
+            requestedPath: "Target.swift",
+            translatedLookupPath: "/workspace/Target.swift"
+        ))
+
+        let rootURL = try makeTemporaryRoot()
+        try "successive provider timeout\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        guard let record = await store.file(rootID: root.id, relativePath: "Target.swift") else {
+            return XCTFail("Expected loaded file record")
+        }
+
+        let registry = MCPCodeStructureSettlementRegistry()
+        let gitArtifactPreflightGate = AsyncSignal()
+        addTeardownBlock {
+            await gitArtifactPreflightGate.signal()
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+        }
+
+        for attempt in 1 ... 2 {
+            let physicalReadGate = SynchronousPhysicalReadGate()
+            let clock = SynchronousDurationClock()
+            let sleeps = ControlledWatchdogSleeps(clock: clock)
+            let invocationID = UUID()
+            let admission = registry.admit(
+                windowID: 949,
+                connectionID: UUID(),
+                invocationID: invocationID,
+                toolName: MCPWindowToolName.readFile,
+                now: clock.now(),
+                handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+            )
+            guard case let .admitted(settlementSlot) = admission else {
+                return XCTFail("Timeout attempt \(attempt) was blocked by prior provider settlement debt")
+            }
+
+            try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+                physicalReadGate.blockUntilReleased()
+            }
+            let watchdogTask = Task { () -> Result<Void, Error> in
+                do {
+                    try await MCPToolExecutionWatchdog.execute(
+                        deadline: .seconds(30),
+                        cancellationGrace: .seconds(5),
+                        cleanupDisposition: .detachAndSettle,
+                        settlementSlot: settlementSlot,
+                        environment: MCPToolExecutionWatchdogEnvironment(
+                            now: { clock.now() },
+                            sleep: { duration in try await sleeps.sleep(for: duration) }
+                        )
+                    ) {
+                        if MCPServerViewModel.shouldAttemptSelectedGitArtifactReadForTesting(
+                            requestedPath: "Target.swift",
+                            translatedLookupPath: record.standardizedFullPath
+                        ) {
+                            await gitArtifactPreflightGate.wait()
+                        }
+                        try await runMainActorProviderTask(
+                            store: store,
+                            record: record,
+                            roots: store.rootRefs(scope: .visibleWorkspace)
+                        )
+                    }
+                    return .success(())
+                } catch {
+                    return .failure(error)
+                }
+            }
+
+            let physicalReadDidBlock = await waitUntil { physicalReadGate.isBlockedSnapshot() }
+            guard physicalReadDidBlock else {
+                watchdogTask.cancel()
+                await gitArtifactPreflightGate.signal()
+                physicalReadGate.release()
+                await sleeps.releaseAll()
+                _ = await waitForTaskResult(watchdogTask)
+                return XCTFail("Timeout attempt \(attempt) stalled in unrelated Git-artifact preflight")
+            }
+            let deadlineDidRegister = await waitUntil { await sleeps.registeredCountSnapshot() >= 1 }
+            guard deadlineDidRegister else {
+                watchdogTask.cancel()
+                physicalReadGate.release()
+                await sleeps.releaseAll()
+                return XCTFail("Timeout attempt \(attempt) did not register its watchdog deadline")
+            }
+            await sleeps.releaseNext()
+
+            guard let observedWatchdogResult = await waitForTaskResult(watchdogTask) else {
+                physicalReadGate.release()
+                return XCTFail("Timeout attempt \(attempt) did not settle during cancellation grace")
+            }
+            let watchdogResult = try observedWatchdogResult.get()
+            guard case let .failure(error) = watchdogResult,
+                  error as? MCPToolExecutionWatchdogError == .executionTimedOut(settlement: .cancellation)
+            else {
+                physicalReadGate.release()
+                return XCTFail("Timeout attempt \(attempt) did not report cancellation settlement")
+            }
+            XCTAssertEqual(
+                registry.snapshot(windowID: 949),
+                .init(activeCount: 0, detachedCount: 0, releasedCount: 0)
+            )
+
+            physicalReadGate.release()
+            let limiterSnapshot = await waitForLimiterIdle()
+            XCTAssertTrue(limiterSnapshot.isIdle)
+            try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+        }
+    }
+
+    func testSuccessiveDomainProviderExactResolutionPathStateStallsSettleAndRecover() async throws {
+        let parentURL = try makeTemporaryRoot()
+        let rootURLs = ["catalog-hit", "catalog-miss-a", "catalog-miss-b"].map {
+            parentURL.appendingPathComponent($0, isDirectory: true)
+        }
+        for rootURL in rootURLs {
+            try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        }
+        try "cataloged target\n".write(
+            to: rootURLs[0].appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        for rootURL in rootURLs {
+            _ = try await store.loadRoot(path: rootURL.path)
+        }
+        let roots = await store.rootRefs(scope: .visibleWorkspace)
+        guard let catalogRoot = roots.first(where: {
+            $0.standardizedFullPath == StandardizedPath.absolute(rootURLs[0].path)
+        }), let record = await store.file(rootID: catalogRoot.id, relativePath: "Target.swift")
+        else {
+            return XCTFail("Expected cataloged target record")
+        }
+        let namespace = WorkspaceExactFileNamespace.identity(roots: roots)
+        let missingRootIDs = roots
+            .filter { $0.standardizedFullPath != StandardizedPath.absolute(rootURLs[0].path) }
+            .map(\.id)
+        XCTAssertEqual(missingRootIDs.count, 2)
+
+        let physicalReadGates = PeriodicPhysicalReadGates(interval: 2, count: 2)
+        let physicalReadHandler: @Sendable () -> Void = {
+            physicalReadGates.reachNextProbe()
+        }
+        for rootID in missingRootIDs {
+            try await store.setContentPhysicalReadHandlerForTesting(
+                rootID: rootID,
+                physicalReadHandler
+            )
+        }
+        addTeardownBlock {
+            physicalReadGates.releaseAll()
+            for rootID in missingRootIDs {
+                try? await store.setContentPhysicalReadHandlerForTesting(rootID: rootID, nil)
+            }
+        }
+
+        let registry = MCPCodeStructureSettlementRegistry()
+        let clock = SynchronousDurationClock()
+        func startWatchdogAttempt(
+            _ attempt: Int,
+            sleeps: ControlledWatchdogSleeps
+        ) -> Task<Result<Void, Error>, Never>? {
+            let admission = registry.admit(
+                windowID: 949,
+                connectionID: UUID(),
+                invocationID: UUID(),
+                toolName: MCPWindowToolName.readFile,
+                now: clock.now(),
+                handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+            )
+            guard case let .admitted(settlementSlot) = admission else {
+                XCTFail("Exact-resolution attempt \(attempt) was blocked before execution")
+                return nil
+            }
+            return Task { () -> Result<Void, Error> in
+                do {
+                    try await MCPToolExecutionWatchdog.execute(
+                        deadline: .seconds(30),
+                        cancellationGrace: .seconds(5),
+                        cleanupDisposition: .detachAndSettle,
+                        settlementSlot: settlementSlot,
+                        environment: MCPToolExecutionWatchdogEnvironment(
+                            now: { clock.now() },
+                            sleep: { duration in try await sleeps.sleep(for: duration) }
+                        )
+                    ) {
+                        try await runDomainReadProviderTask(
+                            store: store,
+                            record: record,
+                            roots: roots
+                        )
+                    }
+                    return .success(())
+                } catch {
+                    return .failure(error)
+                }
+            }
+        }
+
+        func finishWatchdogAttempt(
+            _ task: Task<Result<Void, Error>, Never>,
+            sleeps: ControlledWatchdogSleeps
+        ) async -> Result<Void, Error>? {
+            let deadlineDidRegister = await waitUntil {
+                await sleeps.pendingCountSnapshot() >= 1
+            }
+            guard deadlineDidRegister else {
+                task.cancel()
+                await sleeps.releaseAll()
+                return nil
+            }
+            guard await sleeps.releaseNext() else {
+                XCTFail("Exact-resolution deadline sleeper disappeared before release")
+                return nil
+            }
+            if let observedResult = await waitForTaskResult(task) {
+                return observedResult.get()
+            }
+            let graceDidRegister = await waitUntil {
+                await sleeps.pendingCountSnapshot() >= 1
+            }
+            guard graceDidRegister else { return nil }
+            guard await sleeps.releaseNext() else {
+                XCTFail("Exact-resolution grace sleeper disappeared before release")
+                return nil
+            }
+            guard let observedResult = await waitForTaskResult(task) else { return nil }
+            return observedResult.get()
+        }
+
+        let firstSleeps = ControlledWatchdogSleeps(clock: clock)
+        guard let firstTask = startWatchdogAttempt(1, sleeps: firstSleeps) else { return }
+        guard await waitUntil(iterations: 100_000, { physicalReadGates.isBlocked(at: 0) }) else {
+            firstTask.cancel()
+            let earlyResult = await waitForTaskResult(firstTask)
+            return XCTFail("First exact-resolution path-state probe did not block; result=\(String(describing: earlyResult))")
+        }
+        let firstResult = await finishWatchdogAttempt(firstTask, sleeps: firstSleeps)
+
+        // The settlement registry's recovery horizon admits a replacement provider even
+        // while the first cancellation-ignoring producer still owns its physical work.
+        clock.advance(by: .seconds(30))
+        let secondSleeps = ControlledWatchdogSleeps(clock: clock)
+        guard let secondTask = startWatchdogAttempt(2, sleeps: secondSleeps) else {
+            physicalReadGates.releaseAll()
+            return
+        }
+        let secondPhysicalReadDidBlock = await waitUntil { physicalReadGates.isBlocked(at: 1) }
+        let secondResult = await finishWatchdogAttempt(secondTask, sleeps: secondSleeps)
+
+        let thirdAdmission = registry.admit(
+            windowID: 949,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: MCPWindowToolName.readFile,
+            now: clock.now(),
+            handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+        )
+        let thirdAdmissionSucceeded: Bool
+        switch thirdAdmission {
+        case let .admitted(slot):
+            thirdAdmissionSucceeded = true
+            _ = slot.closeBeforeExecutionExit()
+        case .busy:
+            thirdAdmissionSucceeded = false
+        }
+
+        XCTAssertTrue(secondPhysicalReadDidBlock, "The second provider remained queued behind the first actor-pinning probe")
+        for (attempt, result) in [firstResult, secondResult].enumerated() {
+            guard case let .failure(error) = result else {
+                XCTFail("Exact-resolution attempt \(attempt + 1) did not time out")
+                continue
+            }
+            XCTAssertEqual(
+                error as? MCPToolExecutionWatchdogError,
+                .executionTimedOut(settlement: .cancellation),
+                "Exact-resolution attempt \(attempt + 1) detached instead of settling cancellation"
+            )
+        }
+        XCTAssertTrue(thirdAdmissionSucceeded, "Two detached providers exhausted the released-provider allowance")
+        XCTAssertEqual(
+            registry.snapshot(windowID: 949),
+            .init(activeCount: 0, detachedCount: 0, releasedCount: 0)
+        )
+
+        physicalReadGates.releaseAll()
+        await firstSleeps.releaseAll()
+        await secondSleeps.releaseAll()
+        _ = await waitForTaskResult(firstTask)
+        _ = await waitForTaskResult(secondTask)
+        let limiterSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(limiterSnapshot.isIdle)
+
+        let recovered = try await store.resolveExactExistingWorkspaceFile(
+            WorkspaceExactFileInput.parse("Target.swift"),
+            namespace: namespace
+        )
+        guard case let .matched(match) = recovered else {
+            return XCTFail("Expected exact resolution to recover after both physical reads returned")
+        }
+        XCTAssertEqual(match.file.standardizedFullPath, StandardizedPath.absolute(rootURLs[0].appendingPathComponent("Target.swift").path))
+        let finalLimiterSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertTrue(finalLimiterSnapshot.isIdle)
+    }
+
+    func testSuccessiveExactResolutionMissingFileRechecksSettleAndRecover() async throws {
+        let parentURL = try makeTemporaryRoot()
+        let rootURLs = ["catalog-hit", "catalog-miss-a", "catalog-miss-b"].map {
+            parentURL.appendingPathComponent($0, isDirectory: true)
+        }
+        for rootURL in rootURLs {
+            try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        }
+        try "cataloged target\n".write(
+            to: rootURLs[0].appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        for rootURL in rootURLs {
+            _ = try await store.loadRoot(path: rootURL.path)
+        }
+        let roots = await store.rootRefs(scope: .visibleWorkspace)
+        guard let catalogRoot = roots.first(where: {
+            $0.standardizedFullPath == StandardizedPath.absolute(rootURLs[0].path)
+        }), let record = await store.file(rootID: catalogRoot.id, relativePath: "Target.swift")
+        else {
+            return XCTFail("Expected cataloged target record")
+        }
+        let namespace = WorkspaceExactFileNamespace.identity(roots: roots)
+        let missingRootIDs = roots
+            .filter { $0.standardizedFullPath != StandardizedPath.absolute(rootURLs[0].path) }
+            .map(\.id)
+        XCTAssertEqual(missingRootIDs.count, 2)
+
+        let physicalReadGates = PeriodicPhysicalReadGates(interval: 3, count: 2)
+        let physicalReadHandler: @Sendable () -> Void = {
+            physicalReadGates.reachNextProbe()
+        }
+        for rootID in missingRootIDs {
+            try await store.setContentPhysicalReadHandlerForTesting(
+                rootID: rootID,
+                physicalReadHandler
+            )
+        }
+        addTeardownBlock {
+            physicalReadGates.releaseAll()
+            for rootID in missingRootIDs {
+                try? await store.setContentPhysicalReadHandlerForTesting(rootID: rootID, nil)
+            }
+        }
+
+        let registry = MCPCodeStructureSettlementRegistry()
+        let clock = SynchronousDurationClock()
+        func startWatchdogAttempt(
+            _ attempt: Int,
+            sleeps: ControlledWatchdogSleeps
+        ) -> Task<Result<Void, Error>, Never>? {
+            let admission = registry.admit(
+                windowID: 950,
+                connectionID: UUID(),
+                invocationID: UUID(),
+                toolName: MCPWindowToolName.readFile,
+                now: clock.now(),
+                handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+            )
+            guard case let .admitted(settlementSlot) = admission else {
+                XCTFail("Exact-resolution attempt \(attempt) was blocked before execution")
+                return nil
+            }
+            return Task { () -> Result<Void, Error> in
+                do {
+                    try await MCPToolExecutionWatchdog.execute(
+                        deadline: .seconds(30),
+                        cancellationGrace: .seconds(5),
+                        cleanupDisposition: .detachAndSettle,
+                        settlementSlot: settlementSlot,
+                        environment: MCPToolExecutionWatchdogEnvironment(
+                            now: { clock.now() },
+                            sleep: { duration in try await sleeps.sleep(for: duration) }
+                        )
+                    ) {
+                        try await runMainActorProviderTask(
+                            store: store,
+                            record: record,
+                            roots: roots
+                        )
+                    }
+                    return .success(())
+                } catch {
+                    return .failure(error)
+                }
+            }
+        }
+
+        func finishWatchdogAttempt(
+            _ task: Task<Result<Void, Error>, Never>,
+            sleeps: ControlledWatchdogSleeps
+        ) async -> Result<Void, Error>? {
+            let deadlineDidRegister = await waitUntil {
+                await sleeps.pendingCountSnapshot() >= 1
+            }
+            guard deadlineDidRegister else {
+                task.cancel()
+                await sleeps.releaseAll()
+                return nil
+            }
+            guard await sleeps.releaseNext() else {
+                XCTFail("Missing-file deadline sleeper disappeared before release")
+                return nil
+            }
+            if let observedResult = await waitForTaskResult(task) {
+                return observedResult.get()
+            }
+            let graceDidRegister = await waitUntil {
+                await sleeps.pendingCountSnapshot() >= 1
+            }
+            guard graceDidRegister else { return nil }
+            guard await sleeps.releaseNext() else {
+                XCTFail("Missing-file grace sleeper disappeared before release")
+                return nil
+            }
+            guard let observedResult = await waitForTaskResult(task) else { return nil }
+            return observedResult.get()
+        }
+
+        let firstSleeps = ControlledWatchdogSleeps(clock: clock)
+        guard let firstTask = startWatchdogAttempt(1, sleeps: firstSleeps) else { return }
+        guard await waitUntil({ physicalReadGates.isBlocked(at: 0) }) else {
+            firstTask.cancel()
+            return XCTFail("First exact-resolution missing-file recheck did not block")
+        }
+        let firstResult = await finishWatchdogAttempt(firstTask, sleeps: firstSleeps)
+
+        clock.advance(by: .seconds(30))
+        let secondSleeps = ControlledWatchdogSleeps(clock: clock)
+        guard let secondTask = startWatchdogAttempt(2, sleeps: secondSleeps) else {
+            physicalReadGates.releaseAll()
+            return
+        }
+        let secondPhysicalReadDidBlock = await waitUntil {
+            physicalReadGates.isBlocked(at: 1)
+        }
+        let secondResult = await finishWatchdogAttempt(secondTask, sleeps: secondSleeps)
+
+        let thirdAdmission = registry.admit(
+            windowID: 950,
+            connectionID: UUID(),
+            invocationID: UUID(),
+            toolName: MCPWindowToolName.readFile,
+            now: clock.now(),
+            handlerPhase: { MCPToolExecutionHandlerPhase.readFileContentRead.rawValue }
+        )
+        let thirdAdmissionSucceeded: Bool
+        switch thirdAdmission {
+        case let .admitted(slot):
+            thirdAdmissionSucceeded = true
+            _ = slot.closeBeforeExecutionExit()
+        case .busy:
+            thirdAdmissionSucceeded = false
+        }
+
+        XCTAssertTrue(
+            secondPhysicalReadDidBlock,
+            "The second provider remained queued behind the first actor-isolated regular-file probe"
+        )
+        for (attempt, result) in [firstResult, secondResult].enumerated() {
+            guard case let .failure(error) = result else {
+                XCTFail("Exact-resolution attempt \(attempt + 1) did not time out")
+                continue
+            }
+            XCTAssertEqual(
+                error as? MCPToolExecutionWatchdogError,
+                .executionTimedOut(settlement: .cancellation),
+                "Exact-resolution attempt \(attempt + 1) detached instead of settling cancellation"
+            )
+        }
+        XCTAssertTrue(thirdAdmissionSucceeded, "A released provider plus a second detachment exhausted admission")
+        XCTAssertEqual(
+            registry.snapshot(windowID: 950),
+            .init(activeCount: 0, detachedCount: 0, releasedCount: 0)
+        )
+        let blockedLimiterSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(blockedLimiterSnapshot.activePermitCount, 2)
+        XCTAssertEqual(blockedLimiterSnapshot.queuedWaiterCount, 0)
+
+        physicalReadGates.releaseAll()
+        await firstSleeps.releaseAll()
+        await secondSleeps.releaseAll()
+        _ = await waitForTaskResult(firstTask)
+        _ = await waitForTaskResult(secondTask)
+        let limiterSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(limiterSnapshot.isIdle)
+
+        let recovered = try await store.resolveExactExistingWorkspaceFile(
+            WorkspaceExactFileInput.parse("Target.swift"),
+            namespace: namespace
+        )
+        guard case let .matched(match) = recovered else {
+            return XCTFail("Expected exact resolution to recover after both missing-file probes returned")
+        }
+        XCTAssertEqual(
+            match.file.standardizedFullPath,
+            StandardizedPath.absolute(rootURLs[0].appendingPathComponent("Target.swift").path)
+        )
+    }
+
+    func testLimiterReportsBackpressureAndRemovesCancelledQueuedRead() async throws {
+        let limiter = ContentReadAsyncLimiter(
+            capacity: 1,
+            bulkPermitLimit: 1,
+            maxQueuedWaiterCount: 1,
+            retryAfterMilliseconds: 37
+        )
+        let activeReadStarted = AsyncSignal()
+        let releaseActiveRead = AsyncSignal()
+        let activeTask = Task {
+            try await limiter.withPermit(workloadClass: .interactiveRead, ownerID: UUID()) {
+                await activeReadStarted.signal()
+                await releaseActiveRead.wait()
+            }
+        }
+        let activeReadDidStart = await waitUntil { await activeReadStarted.isSignaledSnapshot() }
+        guard activeReadDidStart else {
+            activeTask.cancel()
+            await releaseActiveRead.signal()
+            return XCTFail("Active limiter read did not start")
+        }
+
+        let queuedTask = Task {
+            try await limiter.withPermit(workloadClass: .contentSearch, ownerID: UUID()) {}
+        }
+        let queuedSnapshot = await waitForLimiterSnapshot(limiter) { $0.queuedWaiterCount == 1 }
+        XCTAssertEqual(queuedSnapshot.activePermitCount, 1)
+        XCTAssertEqual(queuedSnapshot.ownerLaneCount, 2)
+
+        do {
+            try await limiter.withPermit(workloadClass: .contentSearch, ownerID: UUID()) {}
+            XCTFail("Expected an explicit queue-full error")
+        } catch {
+            XCTAssertEqual(error as? ContentReadSchedulerError, .queueFull(retryAfterMilliseconds: 37))
+        }
+
+        queuedTask.cancel()
+        guard let queuedResult = await waitForTaskResult(queuedTask) else {
+            await releaseActiveRead.signal()
+            return XCTFail("Queued limiter read did not settle after cancellation")
+        }
+        do {
+            try queuedResult.get()
+            XCTFail("Expected queued read cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let cancelledSnapshot = await limiter.snapshotForTesting()
+        XCTAssertEqual(cancelledSnapshot.activePermitCount, 1)
+        XCTAssertEqual(cancelledSnapshot.queuedWaiterCount, 0)
+        XCTAssertEqual(cancelledSnapshot.ownerLaneCount, 1)
+        XCTAssertEqual(cancelledSnapshot.cancellationCount, 1)
+        XCTAssertEqual(cancelledSnapshot.overloadCount, 1)
+
+        await releaseActiveRead.signal()
+        guard let activeResult = await waitForTaskResult(activeTask) else {
+            return XCTFail("Active limiter read did not settle after release")
+        }
+        try activeResult.get()
+        let idleSnapshot = await limiter.snapshotForTesting()
+        XCTAssertTrue(idleSnapshot.isIdle)
+    }
+
+    func testDetachedPhysicalReadPreservesTaskLocalAttribution() async throws {
+        let rootURL = try makeTemporaryRoot()
+        let contents = "attributed physical read\n"
+        try contents.write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let service = try await FileSystemService(path: rootURL.path)
+        EditFlowPerf.resetDebugCaptureForTesting()
+        _ = EditFlowPerf.beginDebugCapture(label: "physical-read-attribution", maxSamples: 32)
+        guard let lifecycleCorrelation = EditFlowPerf.makeLifecycleCorrelationIfActive() else {
+            return XCTFail("Expected an active lifecycle correlation")
+        }
+        let benchmarkMetricTag = WorktreeStartupInstrumentation.BenchmarkMetricTag(
+            correlationID: UUID(),
+            contextID: UUID(),
+            agentSessionID: UUID(),
+            logicalRootID: UUID(),
+            repositoryID: "repository",
+            destinationID: "destination"
+        )
+        let attributionRecorder = PhysicalReadAttributionRecorder()
+        await service.setContentPhysicalReadHandlerForTesting {
+            attributionRecorder.record(
+                lifecycleCorrelationID: EditFlowPerf.currentLifecycleCorrelation?.id,
+                benchmarkMetricTag: WorktreeStartupInstrumentation.currentBenchmarkMetricTag
+            )
+        }
+        addTeardownBlock {
+            await service.setContentPhysicalReadHandlerForTesting(nil)
+            MCPToolWorkCountDiagnostics.resetForTesting()
+            EditFlowPerf.resetDebugCaptureForTesting()
+        }
+        MCPToolWorkCountDiagnostics.resetForTesting()
+
+        try await EditFlowPerf.$currentLifecycleCorrelation.withValue(lifecycleCorrelation) {
+            try await WorktreeStartupInstrumentation.$currentBenchmarkMetricTag.withValue(benchmarkMetricTag) {
+                try await MCPToolWorkCountDiagnostics.withReadFileInvocation {
+                    let fingerprint = try await service.contentFingerprint(ofRelativePath: "Target.swift")
+                    let snapshot = try await service.loadValidatedContent(
+                        ofRelativePath: "Target.swift",
+                        expectedFingerprint: fingerprint,
+                        workloadClass: .interactiveRead
+                    )
+                    XCTAssertEqual(snapshot.content, contents)
+                }
+            }
+        }
+
+        XCTAssertEqual(attributionRecorder.snapshot()?.lifecycleCorrelationID, lifecycleCorrelation.id)
+        XCTAssertEqual(attributionRecorder.snapshot()?.benchmarkMetricTag, benchmarkMetricTag)
+        let readSnapshots = MCPToolWorkCountDiagnostics.debugSnapshots().readFile
+        XCTAssertEqual(readSnapshots.count, 1)
+        XCTAssertEqual(readSnapshots.first?.source, "disk")
+        XCTAssertEqual(readSnapshots.first?.readBytes, contents.utf8.count)
+        XCTAssertEqual(readSnapshots.first?.outcome, "success")
+    }
+
+    func testCancellingOnlyInteractiveCacheWaiterRemovesFlight() async throws {
+        let cache = WorkspaceInteractiveReadCache()
+        let loaderStarted = AsyncSignal()
+        let releaseLoader = AsyncSignal()
+        let task = Task {
+            try await cache.snapshot(
+                for: makeInteractiveReadCacheKey(),
+                fingerprint: makeFingerprint(),
+                invalidationEpoch: 0
+            ) {
+                await loaderStarted.signal()
+                await releaseLoader.wait()
+                return WorkspaceInteractiveReadProcessor.prepare("single waiter\n")
+            }
+        }
+        let loaderDidStart = await waitUntil { await loaderStarted.isSignaledSnapshot() }
+        guard loaderDidStart else {
+            task.cancel()
+            await releaseLoader.signal()
+            return XCTFail("Single-waiter cache loader did not start")
+        }
+
+        task.cancel()
+        guard let taskResult = await waitForTaskResult(task) else {
+            await releaseLoader.signal()
+            return XCTFail("Single cache waiter did not settle after cancellation")
+        }
+        do {
+            _ = try taskResult.get()
+            XCTFail("Expected the only cache waiter to observe cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let cancelledSnapshot = await waitForCacheSnapshot(cache) {
+            $0.activeFlightCount == 0 && $0.cancellationCount == 1
+        }
+        XCTAssertEqual(cancelledSnapshot.waiterCount, 0)
+        XCTAssertEqual(cancelledSnapshot.entryCount, 0)
+
+        await releaseLoader.signal()
+    }
+
+    func testCancellingOneOfTwoInteractiveCacheWaitersPreservesSharedFlight() async throws {
+        let cache = WorkspaceInteractiveReadCache()
+        let key = makeInteractiveReadCacheKey()
+        let fingerprint = makeFingerprint()
+        let loaderStarted = AsyncSignal()
+        let releaseLoader = AsyncSignal()
+        let expected = WorkspaceInteractiveReadProcessor.prepare("shared flight\n")
+        let firstTask = Task {
+            try await cache.snapshot(for: key, fingerprint: fingerprint, invalidationEpoch: 0) {
+                await loaderStarted.signal()
+                await releaseLoader.wait()
+                return expected
+            }
+        }
+        let loaderDidStart = await waitUntil { await loaderStarted.isSignaledSnapshot() }
+        guard loaderDidStart else {
+            firstTask.cancel()
+            await releaseLoader.signal()
+            return XCTFail("Shared cache loader did not start")
+        }
+        let secondTask = Task {
+            try await cache.snapshot(for: key, fingerprint: fingerprint, invalidationEpoch: 0) {
+                XCTFail("Joined waiter must not start a second loader")
+                return nil
+            }
+        }
+        let sharedSnapshot = await waitForCacheSnapshot(cache) { $0.waiterCount == 2 }
+        XCTAssertEqual(sharedSnapshot.waiterCount, 2)
+
+        firstTask.cancel()
+        guard let firstResult = await waitForTaskResult(firstTask) else {
+            await releaseLoader.signal()
+            return XCTFail("Cancelled shared cache waiter did not settle")
+        }
+        do {
+            _ = try firstResult.get()
+            XCTFail("Expected the cancelled waiter to settle independently")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let joinedSnapshot = await waitForCacheSnapshot(cache) {
+            $0.waiterCount == 1 && $0.cancellationCount == 1
+        }
+        XCTAssertEqual(joinedSnapshot.activeFlightCount, 1)
+        XCTAssertEqual(joinedSnapshot.preparationCount, 1)
+        XCTAssertEqual(joinedSnapshot.joinCount, 1)
+
+        await releaseLoader.signal()
+        guard let observedSecondResult = await waitForTaskResult(secondTask) else {
+            return XCTFail("Remaining shared cache waiter did not settle after release")
+        }
+        let secondResult = try observedSecondResult.get()
+        XCTAssertEqual(secondResult.preparedContent, expected)
+        let completedSnapshot = await cache.snapshotForTesting()
+        XCTAssertEqual(completedSnapshot.activeFlightCount, 0)
+        XCTAssertEqual(completedSnapshot.entryCount, 1)
+        XCTAssertEqual(completedSnapshot.acceptedPreparationCount, 1)
+    }
+
+    func testProducerCompletionBeforeHandleInstallationSettlesSuccessExactlyOnce() async throws {
+        let installGate = SynchronousPhysicalReadGate()
+        let producerCompleted = AsyncSignal()
+        addTeardownBlock { installGate.release() }
+
+        let task = Task {
+            try await FileSystemService.withCancellationResponsivePhysicalReadPermit(
+                workloadClass: .interactiveRead,
+                schedulerOwnerID: UUID(),
+                priority: .userInitiated,
+                beforeProducerInstallForTesting: { installGate.blockUntilReleased() }
+            ) {
+                await producerCompleted.signal()
+                return 42
+            }
+        }
+
+        let installDidBlock = await waitUntil { installGate.isBlockedSnapshot() }
+        let producerDidComplete = await waitUntil { await producerCompleted.isSignaledSnapshot() }
+        guard installDidBlock, producerDidComplete else {
+            task.cancel()
+            installGate.release()
+            return XCTFail("Completion-before-install interleaving was not reached")
+        }
+        installGate.release()
+        guard let observedResult = await waitForTaskResult(task) else {
+            return XCTFail("Completion-before-install result did not settle")
+        }
+        let result = try observedResult.get()
+        XCTAssertEqual(result, 42)
+        let idleSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(idleSnapshot.isIdle)
+    }
+
+    func testCancellationBeforeProducerHandleInstallationSettlesPromptlyAndCancelsProducer() async throws {
+        let installGate = SynchronousPhysicalReadGate()
+        let producerGate = SynchronousPhysicalReadGate()
+        addTeardownBlock {
+            installGate.release()
+            producerGate.release()
+        }
+
+        let task = Task {
+            try await FileSystemService.withCancellationResponsivePhysicalReadPermit(
+                workloadClass: .interactiveRead,
+                schedulerOwnerID: UUID(),
+                priority: .userInitiated,
+                beforeProducerInstallForTesting: { installGate.blockUntilReleased() }
+            ) {
+                producerGate.blockUntilReleased()
+                try Task.checkCancellation()
+                return 1
+            }
+        }
+        let installDidBlock = await waitUntil { installGate.isBlockedSnapshot() }
+        let producerDidBlock = await waitUntil { producerGate.isBlockedSnapshot() }
+        guard installDidBlock, producerDidBlock else {
+            task.cancel()
+            installGate.release()
+            producerGate.release()
+            return XCTFail("Cancellation-before-install interleaving was not reached")
+        }
+
+        task.cancel()
+        installGate.release()
+        guard let taskResult = await waitForTaskResult(task) else {
+            producerGate.release()
+            return XCTFail("Cancellation-before-install did not settle promptly")
+        }
+        do {
+            _ = try taskResult.get()
+            XCTFail("Expected cancellation before producer-handle installation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let blockedSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(blockedSnapshot.activePermitCount, 1)
+
+        producerGate.release()
+        let idleSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(idleSnapshot.isIdle)
+    }
+
+    func testCancelledCallerDiscardsLatePhysicalReadFailure() async throws {
+        let physicalGate = SynchronousPhysicalReadGate()
+        addTeardownBlock { physicalGate.release() }
+        let task = Task {
+            try await FileSystemService.withCancellationResponsivePhysicalReadPermit(
+                workloadClass: .interactiveRead,
+                schedulerOwnerID: UUID(),
+                priority: .userInitiated
+            ) {
+                physicalGate.blockUntilReleased()
+                throw PhysicalReadTestError.syntheticFailure
+            }
+        }
+        let physicalReadDidBlock = await waitUntil { physicalGate.isBlockedSnapshot() }
+        guard physicalReadDidBlock else {
+            task.cancel()
+            physicalGate.release()
+            return XCTFail("Late physical failure did not reach the controlled gate")
+        }
+
+        task.cancel()
+        guard let taskResult = await waitForTaskResult(task) else {
+            physicalGate.release()
+            return XCTFail("Caller did not settle before the late physical failure")
+        }
+        do {
+            _ = try taskResult.get()
+            XCTFail("Expected caller cancellation to win the late physical failure race")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let blockedSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(blockedSnapshot.activePermitCount, 1)
+
+        physicalGate.release()
+        let idleSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(idleSnapshot.isIdle)
+    }
+
+    func testStoreContentReadGrantsPreserveWorkloadAndOwnerAttribution() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "attributed store read\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        guard let record = await store.file(rootID: root.id, relativePath: "Target.swift") else {
+            return XCTFail("Expected loaded file record")
+        }
+        let idleSnapshot = await waitForLimiterIdle()
+        guard idleSnapshot.isIdle else {
+            return XCTFail("Shared content-read limiter was not idle before attribution verification")
+        }
+
+        let physicalGate = SynchronousPhysicalReadGate()
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+            physicalGate.blockUntilReleased()
+        }
+        addTeardownBlock {
+            physicalGate.release()
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+        }
+        let ownerIDs = await store.contentReadSchedulerOwnerIDsForTesting()
+        XCTAssertNotEqual(ownerIDs.search, ownerIDs.interactive)
+
+        let searchTask = Task { try await store.searchContentSnapshot(for: record) }
+        let interactiveTask = Task { try await store.interactiveReadSnapshot(for: record) }
+        let bothReadsBlocked = await waitUntil { physicalGate.blockedCountSnapshot() >= 2 }
+        guard bothReadsBlocked else {
+            searchTask.cancel()
+            interactiveTask.cancel()
+            physicalGate.release()
+            return XCTFail("Store reads did not both reach their controlled physical-read grants")
+        }
+
+        let activeSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(activeSnapshot.activePermitCount, 2)
+        XCTAssertEqual(activeSnapshot.activePermitCountsByWorkload[ContentReadWorkloadClass.contentSearch.rawValue], 1)
+        XCTAssertEqual(activeSnapshot.activePermitCountsByWorkload[ContentReadWorkloadClass.interactiveRead.rawValue], 1)
+        XCTAssertEqual(activeSnapshot.activePermitCountsByOwner[ownerIDs.search], 1)
+        XCTAssertEqual(activeSnapshot.activePermitCountsByOwner[ownerIDs.interactive], 1)
+
+        physicalGate.release()
+        guard let searchResult = await waitForTaskResult(searchTask),
+              let interactiveResult = await waitForTaskResult(interactiveTask)
+        else {
+            return XCTFail("Attributed store reads did not settle after release")
+        }
+        XCTAssertTrue(try searchResult.get().isFresh)
+        XCTAssertNotNil(try interactiveResult.get())
+        let finalSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(finalSnapshot.isIdle)
+    }
+
+    func testCacheCommitDoesNotReenterSharedLimiterAfterValidatedRead() async throws {
+        let rootURL = try makeTemporaryRoot()
+        let contents = "validated content survives cache pressure\n"
+        try contents.write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let service = try await FileSystemService(path: rootURL.path)
+        let fingerprint = try await service.contentFingerprint(ofRelativePath: "Target.swift")
+        let cacheCommitReached = AsyncSignal()
+        let releaseCacheCommit = AsyncSignal()
+        await service.setContentReadCacheCommitHandlerForTesting {
+            await cacheCommitReached.signal()
+            await releaseCacheCommit.wait()
+        }
+        addTeardownBlock {
+            await releaseCacheCommit.signal()
+            await service.setContentReadCacheCommitHandlerForTesting(nil)
+        }
+
+        let readTask = Task {
+            try await service.loadValidatedContent(
+                ofRelativePath: "Target.swift",
+                expectedFingerprint: fingerprint,
+                workloadClass: .interactiveRead
+            )
+        }
+        addTeardownBlock {
+            await releaseCacheCommit.signal()
+            readTask.cancel()
+            let readResult = await self.waitForTaskResult(readTask)
+            XCTAssertNotNil(readResult, "Validated read did not settle during teardown")
+        }
+        guard await waitUntil({ await cacheCommitReached.isSignaledSnapshot() }) else {
+            return XCTFail("Validated read did not reach the cache-only commit boundary")
+        }
+        let beforeCommitSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(beforeCommitSnapshot.activePermitCount, 1)
+
+        await releaseCacheCommit.signal()
+        guard let observedReadResult = await waitForTaskResult(readTask) else {
+            return XCTFail("Validated read did not settle after cache commit")
+        }
+        let snapshot = try observedReadResult.get()
+        XCTAssertEqual(snapshot.content, contents)
+        let afterReadSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(afterReadSnapshot.grantCount, beforeCommitSnapshot.grantCount)
+        XCTAssertEqual(afterReadSnapshot.overloadCount, beforeCommitSnapshot.overloadCount)
+        let cachedEncoding = await service.cachedEncodingForTesting(relativePath: "Target.swift")
+        XCTAssertNotNil(cachedEncoding)
+        XCTAssertTrue(afterReadSnapshot.isIdle)
+    }
+
+    func testCacheCommitRejectsInvalidationAfterFinalFingerprint() async throws {
+        let rootURL = try makeTemporaryRoot()
+        let targetURL = rootURL.appendingPathComponent("Target.swift")
+        let originalContents = "original cache content\n"
+        try originalContents.write(to: targetURL, atomically: true, encoding: .utf8)
+        let service = try await FileSystemService(path: rootURL.path)
+        await service.setContentReadCacheCommitHandlerForTesting {
+            try? "replacement cache content\n".write(to: targetURL, atomically: true, encoding: .utf8)
+            await service.advanceContentReadCacheRevisionForTesting()
+        }
+        addTeardownBlock {
+            await service.setContentReadCacheCommitHandlerForTesting(nil)
+        }
+
+        let content = try await service.loadContent(
+            ofRelativePath: "Target.swift",
+            workloadClass: .interactiveRead
+        )
+
+        XCTAssertEqual(content, originalContents)
+        let cachedEncoding = await service.cachedEncodingForTesting(relativePath: "Target.swift")
+        XCTAssertNil(cachedEncoding)
+    }
+
+    func testCancelledWorkspaceInteractiveReadSuppressesCodeMapUntilPhysicalCompletion() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "foreground workspace read\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        guard let record = await store.file(rootID: root.id, relativePath: "Target.swift") else {
+            return XCTFail("Expected loaded file record")
+        }
+        let physicalGate = SynchronousPhysicalReadGate()
+        try await store.setContentPhysicalReadHandlerForTesting(rootID: root.id) {
+            physicalGate.blockUntilReleased()
+        }
+        let interactiveReadTask = Task { try await store.interactiveReadSnapshot(for: record) }
+        guard await waitUntil({ physicalGate.isBlockedSnapshot() }) else {
+            interactiveReadTask.cancel()
+            physicalGate.release()
+            return XCTFail("Workspace read did not reach its controlled physical boundary")
+        }
+
+        let codeMapGranted = AsyncSignal()
+        let codeMapTask = Task {
+            try await FileSystemService.withCodeMapArtifactBuildPermit(
+                ownerID: UUID(),
+                priority: .utility
+            ) {
+                await codeMapGranted.signal()
+            }
+        }
+        addTeardownBlock {
+            physicalGate.release()
+            interactiveReadTask.cancel()
+            codeMapTask.cancel()
+            try? await store.setContentPhysicalReadHandlerForTesting(rootID: root.id, nil)
+            let interactiveResult = await self.waitForTaskResult(interactiveReadTask)
+            let codeMapResult = await self.waitForTaskResult(codeMapTask)
+            XCTAssertNotNil(interactiveResult, "Workspace read did not settle during teardown")
+            XCTAssertNotNil(codeMapResult, "CodeMap permit task did not settle during teardown")
+            let teardownSnapshot = await self.waitForLimiterIdle()
+            XCTAssertTrue(teardownSnapshot.isIdle)
+        }
+        let codeMapQueued = await waitUntil {
+            let snapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+            return snapshot.foregroundActivityCountsByKind[.interactiveRead] == 1
+                && snapshot.activeCodemapPermitCount == 0
+                && snapshot.queuedCodemapWaiterCount == 1
+        }
+        guard codeMapQueued else {
+            return XCTFail("CodeMap work was not held behind workspace interactive activity")
+        }
+        let grantedBeforeCancellation = await codeMapGranted.isSignaledSnapshot()
+        XCTAssertFalse(grantedBeforeCancellation)
+
+        interactiveReadTask.cancel()
+        guard let cancelledResult = await waitForTaskResult(interactiveReadTask) else {
+            physicalGate.release()
+            return XCTFail("Cancelled workspace caller did not settle before physical completion")
+        }
+        do {
+            _ = try cancelledResult.get()
+            XCTFail("Expected workspace caller cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let cancelledSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(cancelledSnapshot.activePermitCount, 1)
+        XCTAssertEqual(cancelledSnapshot.foregroundActivityCountsByKind[.interactiveRead], 1)
+        XCTAssertEqual(cancelledSnapshot.activeCodemapPermitCount, 0)
+        XCTAssertEqual(cancelledSnapshot.queuedCodemapWaiterCount, 1)
+        let grantedAfterCallerCancellation = await codeMapGranted.isSignaledSnapshot()
+        XCTAssertFalse(grantedAfterCallerCancellation)
+
+        physicalGate.release()
+        guard let codeMapResult = await waitForTaskResult(codeMapTask) else {
+            return XCTFail("Queued CodeMap work did not settle after physical release")
+        }
+        try codeMapResult.get()
+        let grantedAfterRelease = await codeMapGranted.isSignaledSnapshot()
+        XCTAssertTrue(grantedAfterRelease)
+        let finalSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(finalSnapshot.isIdle)
+    }
+
+    func testCancelledAllowlistedExternalReadSuppressesCodeMapUntilPhysicalCompletion() async throws {
+        let homeURL = try makeTemporaryRoot()
+        let skillsURL = homeURL.appendingPathComponent(".agents/skills", isDirectory: true)
+        try FileManager.default.createDirectory(at: skillsURL, withIntermediateDirectories: true)
+        let fileURL = skillsURL.appendingPathComponent("External.md")
+        let contents = "foreground external read\n"
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        let physicalGate = SynchronousPhysicalReadGate()
+        let readableService = WorkspaceReadableFileService(
+            store: WorkspaceFileContextStore(),
+            homeDirectoryURL: homeURL,
+            beforeExternalReadOpenForTesting: { _ in physicalGate.blockUntilReleased() }
+        )
+        let file = WorkspaceExternalReadableFile(
+            absolutePath: fileURL.path,
+            displayPath: "~/.agents/skills/External.md"
+        )
+        let externalReadTask = Task { try await readableService.readAlwaysReadableExternalFile(file) }
+        guard await waitUntil({ physicalGate.isBlockedSnapshot() }) else {
+            externalReadTask.cancel()
+            physicalGate.release()
+            return XCTFail("External read did not reach its controlled physical boundary")
+        }
+
+        let codeMapGranted = AsyncSignal()
+        let codeMapTask = Task {
+            try await FileSystemService.withCodeMapArtifactBuildPermit(
+                ownerID: UUID(),
+                priority: .utility
+            ) {
+                await codeMapGranted.signal()
+            }
+        }
+        addTeardownBlock {
+            physicalGate.release()
+            externalReadTask.cancel()
+            codeMapTask.cancel()
+            let externalResult = await self.waitForTaskResult(externalReadTask)
+            let codeMapResult = await self.waitForTaskResult(codeMapTask)
+            XCTAssertNotNil(externalResult, "External read did not settle during teardown")
+            XCTAssertNotNil(codeMapResult, "CodeMap permit task did not settle during teardown")
+            let teardownSnapshot = await self.waitForLimiterIdle()
+            XCTAssertTrue(teardownSnapshot.isIdle)
+        }
+        let codeMapQueued = await waitUntil {
+            let snapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+            return snapshot.foregroundActivityCountsByKind[.interactiveRead] == 1
+                && snapshot.activeCodemapPermitCount == 0
+                && snapshot.queuedCodemapWaiterCount == 1
+        }
+        guard codeMapQueued else {
+            return XCTFail("CodeMap work was not held behind external interactive activity")
+        }
+        let grantedBeforeRelease = await codeMapGranted.isSignaledSnapshot()
+        XCTAssertFalse(grantedBeforeRelease)
+
+        externalReadTask.cancel()
+        guard let cancelledExternalResult = await waitForTaskResult(externalReadTask) else {
+            physicalGate.release()
+            return XCTFail("Cancelled external caller did not settle before physical completion")
+        }
+        do {
+            _ = try cancelledExternalResult.get()
+            XCTFail("Expected external caller cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let cancelledSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(cancelledSnapshot.activePermitCount, 1)
+        XCTAssertEqual(cancelledSnapshot.foregroundActivityCountsByKind[.interactiveRead], 1)
+        XCTAssertEqual(cancelledSnapshot.activeCodemapPermitCount, 0)
+        XCTAssertEqual(cancelledSnapshot.queuedCodemapWaiterCount, 1)
+        let grantedAfterCallerCancellation = await codeMapGranted.isSignaledSnapshot()
+        XCTAssertFalse(grantedAfterCallerCancellation)
+
+        physicalGate.release()
+        guard let codeMapResult = await waitForTaskResult(codeMapTask) else {
+            return XCTFail("Queued CodeMap work did not settle after physical release")
+        }
+        try codeMapResult.get()
+        let grantedAfterRelease = await codeMapGranted.isSignaledSnapshot()
+        XCTAssertTrue(grantedAfterRelease)
+        let finalSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(finalSnapshot.isIdle)
+    }
+
+    func testSharedLimiterQueueFullPropagatesThroughStoreAndExternalReadPaths() async throws {
+        let rootURL = try makeTemporaryRoot()
+        try "queue full\n".write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: rootURL.path)
+        guard let record = await store.file(rootID: root.id, relativePath: "Target.swift") else {
+            return XCTFail("Expected loaded file record")
+        }
+
+        let homeURL = try makeTemporaryRoot()
+        let skillsURL = homeURL.appendingPathComponent(".agents/skills", isDirectory: true)
+        try FileManager.default.createDirectory(at: skillsURL, withIntermediateDirectories: true)
+        let externalURL = skillsURL.appendingPathComponent("External.md")
+        try "external queue full\n".write(to: externalURL, atomically: true, encoding: .utf8)
+        let readableService = WorkspaceReadableFileService(store: store, homeDirectoryURL: homeURL)
+        let externalFile = WorkspaceExternalReadableFile(
+            absolutePath: externalURL.path,
+            displayPath: "~/.agents/skills/External.md"
+        )
+
+        guard let saturation = await saturateSharedContentReadLimiter() else {
+            return XCTFail("Shared content-read limiter did not reach its production bounds")
+        }
+        addTeardownBlock {
+            let settlement = await self.settleSharedContentReadLimiter(saturation)
+            XCTAssertTrue(settlement.activeSettled, "Active saturation tasks did not settle during teardown")
+            XCTAssertTrue(settlement.queuedSettled, "Queued saturation tasks did not settle during teardown")
+            XCTAssertTrue(settlement.limiterIdle, "Shared limiter was not idle after saturation teardown")
+        }
+        let expected = ContentReadSchedulerError.queueFull(retryAfterMilliseconds: 1000)
+
+        do {
+            _ = try await store.searchContentSnapshot(for: record)
+            XCTFail("Expected search fingerprint backpressure")
+        } catch {
+            XCTAssertEqual(error as? ContentReadSchedulerError, expected)
+        }
+        do {
+            _ = try await store.interactiveReadSnapshot(for: record)
+            XCTFail("Expected interactive fingerprint backpressure")
+        } catch {
+            XCTAssertEqual(error as? ContentReadSchedulerError, expected)
+        }
+        do {
+            _ = try await MCPServerViewModel.prepareAlwaysReadableExternalFileThroughEnvelopeForTesting(
+                externalFile,
+                readableService: readableService
+            )
+            XCTFail("Expected view-model external-read backpressure")
+        } catch {
+            XCTAssertEqual(error as? ContentReadSchedulerError, expected)
+        }
+
+        let settlement = await settleSharedContentReadLimiter(saturation)
+        XCTAssertTrue(settlement.activeSettled, "Active saturation tasks did not settle")
+        XCTAssertTrue(settlement.queuedSettled, "Queued saturation tasks did not settle")
+        XCTAssertTrue(settlement.limiterIdle, "Shared limiter was not idle after saturation")
+    }
+
+    func testAllowlistedExternalReadCancellationKeepsSharedPermitUntilPhysicalReturn() async throws {
+        let homeURL = try makeTemporaryRoot()
+        let skillsURL = homeURL.appendingPathComponent(".agents/skills", isDirectory: true)
+        try FileManager.default.createDirectory(at: skillsURL, withIntermediateDirectories: true)
+        let fileURL = skillsURL.appendingPathComponent("External.md")
+        try "external read\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        let physicalGate = SynchronousPhysicalReadGate()
+        addTeardownBlock { physicalGate.release() }
+        let readableService = WorkspaceReadableFileService(
+            store: WorkspaceFileContextStore(),
+            homeDirectoryURL: homeURL,
+            beforeExternalReadOpenForTesting: { _ in physicalGate.blockUntilReleased() }
+        )
+        let file = WorkspaceExternalReadableFile(absolutePath: fileURL.path, displayPath: "~/.agents/skills/External.md")
+        let task = Task { try await readableService.readAlwaysReadableExternalFile(file) }
+        let physicalReadDidBlock = await waitUntil { physicalGate.isBlockedSnapshot() }
+        guard physicalReadDidBlock else {
+            task.cancel()
+            physicalGate.release()
+            return XCTFail("External read did not reach the controlled open gate")
+        }
+
+        task.cancel()
+        guard let taskResult = await waitForTaskResult(task) else {
+            physicalGate.release()
+            return XCTFail("External read caller did not settle after cancellation")
+        }
+        do {
+            _ = try taskResult.get()
+            XCTFail("Expected external read cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let blockedSnapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+        XCTAssertEqual(blockedSnapshot.activePermitCount, 1)
+        XCTAssertFalse(blockedSnapshot.isIdle)
+
+        physicalGate.release()
+        let idleSnapshot = await waitForLimiterIdle()
+        XCTAssertTrue(idleSnapshot.isIdle)
+    }
+
+    func testStreamedDecodeUsesReadFileRecorderCapturedBeforeDetachment() async throws {
+        let rootURL = try makeTemporaryRoot()
+        let contents = "first\nsecond\nthird\n"
+        try contents.write(
+            to: rootURL.appendingPathComponent("Target.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let service = try await FileSystemService(path: rootURL.path)
+        MCPToolWorkCountDiagnostics.resetForTesting()
+        addTeardownBlock { MCPToolWorkCountDiagnostics.resetForTesting() }
+
+        try await MCPToolWorkCountDiagnostics.withReadFileInvocation {
+            let loaded = try await service.loadEntireFileContentOptimized(
+                ofRelativePath: "Target.swift",
+                chunkSize: 4,
+                workloadClass: .interactiveRead
+            )
+            XCTAssertEqual(loaded, contents)
+        }
+
+        let snapshots = MCPToolWorkCountDiagnostics.debugSnapshots().readFile
+        XCTAssertEqual(snapshots.count, 1)
+        XCTAssertEqual(snapshots.first?.source, "disk")
+        XCTAssertEqual(snapshots.first?.readBytes, contents.utf8.count)
+        XCTAssertEqual(snapshots.first?.diskReadRecordCount, 2)
+    }
+
+    private func saturateSharedContentReadLimiter() async -> SharedLimiterSaturation? {
+        let initialSnapshot = await waitForLimiterIdle()
+        guard initialSnapshot.isIdle else { return nil }
+
+        let releaseActiveReads = AsyncSignal()
+        let activeTasks: [Task<Void, Error>] = (0 ..< initialSnapshot.capacity).map { _ in
+            Task {
+                try await FileSystemService.withCancellationResponsivePhysicalReadPermit(
+                    workloadClass: .interactiveRead,
+                    schedulerOwnerID: UUID(),
+                    priority: .userInitiated
+                ) {
+                    await releaseActiveReads.wait()
+                }
+            }
+        }
+        let allPermitsHeld = await waitUntil {
+            let snapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+            return snapshot.activePermitCount == snapshot.capacity
+        }
+        guard allPermitsHeld else {
+            _ = await settleSharedContentReadLimiter(
+                SharedLimiterSaturation(
+                    releaseActiveReads: releaseActiveReads,
+                    activeTasks: activeTasks,
+                    queuedTasks: []
+                )
+            )
+            return nil
+        }
+
+        let queuedTasks: [Task<Void, Error>] = (0 ..< initialSnapshot.maxQueuedWaiterCount).map { _ in
+            Task {
+                try await FileSystemService.withCancellationResponsivePhysicalReadPermit(
+                    workloadClass: .contentSearch,
+                    schedulerOwnerID: UUID(),
+                    priority: .utility
+                ) {}
+            }
+        }
+        let queueDidFill = await waitUntil {
+            let snapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+            return snapshot.activePermitCount == snapshot.capacity
+                && snapshot.queuedWaiterCount == snapshot.maxQueuedWaiterCount
+        }
+        let saturation = SharedLimiterSaturation(
+            releaseActiveReads: releaseActiveReads,
+            activeTasks: activeTasks,
+            queuedTasks: queuedTasks
+        )
+        guard queueDidFill else {
+            _ = await settleSharedContentReadLimiter(saturation)
+            return nil
+        }
+        return saturation
+    }
+
+    private func settleSharedContentReadLimiter(
+        _ saturation: SharedLimiterSaturation
+    ) async -> SharedLimiterSettlement {
+        await saturation.releaseActiveReads.signal()
+        saturation.activeTasks.forEach { $0.cancel() }
+        saturation.queuedTasks.forEach { $0.cancel() }
+        let activeResults = await waitForTaskResults(saturation.activeTasks)
+        let queuedResults = await waitForTaskResults(saturation.queuedTasks)
+        let finalSnapshot = await waitForLimiterIdle()
+        return SharedLimiterSettlement(
+            activeSettled: activeResults != nil,
+            queuedSettled: queuedResults != nil,
+            limiterIdle: finalSnapshot.isIdle
+        )
+    }
+
+    private func waitForLimiterIdle() async -> ContentReadAsyncLimiter.Snapshot {
+        for _ in 0 ..< 10000 {
+            let snapshot = await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+            if snapshot.isIdle { return snapshot }
+            await Task.yield()
+        }
+        return await FileSystemService.contentReadWorkerLimiterSnapshotForTesting()
+    }
+
+    private func waitForLimiterSnapshot(
+        _ limiter: ContentReadAsyncLimiter,
+        matching predicate: (ContentReadAsyncLimiter.Snapshot) -> Bool
+    ) async -> ContentReadAsyncLimiter.Snapshot {
+        for _ in 0 ..< 10000 {
+            let snapshot = await limiter.snapshotForTesting()
+            if predicate(snapshot) { return snapshot }
+            await Task.yield()
+        }
+        return await limiter.snapshotForTesting()
+    }
+
+    private func waitForCacheSnapshot(
+        _ cache: WorkspaceInteractiveReadCache,
+        matching predicate: (WorkspaceInteractiveReadCache.Snapshot) -> Bool
+    ) async -> WorkspaceInteractiveReadCache.Snapshot {
+        for _ in 0 ..< 10000 {
+            let snapshot = await cache.snapshotForTesting()
+            if predicate(snapshot) { return snapshot }
+            await Task.yield()
+        }
+        return await cache.snapshotForTesting()
+    }
+
+    private func waitUntil(
+        iterations: Int = 10000,
+        _ predicate: () async -> Bool
+    ) async -> Bool {
+        for _ in 0 ..< iterations {
+            if await predicate() { return true }
+            await Task.yield()
+        }
+        return await predicate()
+    }
+
+    private func waitForTaskResult<Success: Sendable, Failure: Error & Sendable>(
+        _ task: Task<Success, Failure>
+    ) async -> Result<Success, Failure>? {
+        let recorder = TaskResultRecorder<Success, Failure>()
+        Task { await recorder.record(task.result) }
+        guard await waitUntil({ await recorder.hasResult() }) else { return nil }
+        return await recorder.snapshot()
+    }
+
+    private func waitForTaskResults<Success: Sendable, Failure: Error & Sendable>(
+        _ tasks: [Task<Success, Failure>]
+    ) async -> [Result<Success, Failure>]? {
+        let recorder = TaskResultsRecorder<Success, Failure>(expectedCount: tasks.count)
+        for (index, task) in tasks.enumerated() {
+            Task { await recorder.record(task.result, at: index) }
+        }
+        guard await waitUntil({ await recorder.isComplete() }) else { return nil }
+        return await recorder.snapshot()
+    }
+
+    private func makeInteractiveReadCacheKey() -> WorkspaceInteractiveReadCacheKey {
+        WorkspaceInteractiveReadCacheKey(
+            rootID: UUID(),
+            rootLifetimeID: UUID(),
+            fileID: UUID(),
+            standardizedRelativePath: "Target.swift"
+        )
+    }
+
+    private func makeFingerprint() -> FileContentFingerprint {
+        FileContentFingerprint(
+            deviceID: 1,
+            fileNumber: 2,
+            byteSize: 3,
+            modificationSeconds: 4,
+            modificationNanoseconds: 5,
+            statusChangeSeconds: 6,
+            statusChangeNanoseconds: 7
+        )
+    }
+
+    private func makeTemporaryRoot() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPromptTests", isDirectory: true)
+            .appendingPathComponent("ContentReadCancellation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+}
+
+@MainActor
+private func runMainActorProviderTask(
+    store: WorkspaceFileContextStore,
+    record: WorkspaceFileRecord,
+    roots: [WorkspaceRootRef]
+) async throws {
+    // `MCPServerViewModel.runTool` creates this task while isolated to MainActor.
+    let providerTask = Task {
+        let readableService = WorkspaceReadableFileService(store: store)
+        let resolution = try await readableService.resolveReadFileRequest(
+            .relative(record.standardizedRelativePath),
+            rootScope: .visibleWorkspace,
+            rootRefs: roots,
+            namespace: .identity(roots: roots)
+        )
+        guard case let .workspace(match) = resolution else {
+            throw PhysicalReadTestError.syntheticFailure
+        }
+        _ = try await store.interactiveReadSnapshot(for: match.file)
+    }
+    return try await withTaskCancellationHandler {
+        try await providerTask.value
+    } onCancel: {
+        providerTask.cancel()
+    }
+}
+
+@MainActor
+private func runAppBinderProviderTask<T: Sendable>(
+    operation: @Sendable @escaping () async throws -> T
+) async throws -> T {
+    // `MCPServerViewModel.runTool` creates this task while isolated to MainActor.
+    let providerTask = Task {
+        try Task.checkCancellation()
+        return try await operation()
+    }
+    return try await withTaskCancellationHandler {
+        try await providerTask.value
+    } onCancel: {
+        providerTask.cancel()
+    }
+}
+
+private func runDomainHostProviderTask(
+    operation: @Sendable @escaping () async throws -> Void
+) async throws {
+    // `MCPDomainHost.invoke` owns an unstructured invocation task and forwards caller cancellation.
+    let invocationTask = Task {
+        try Task.checkCancellation()
+        try await operation()
+    }
+    return try await withTaskCancellationHandler {
+        try await invocationTask.value
+    } onCancel: {
+        invocationTask.cancel()
+    }
+}
+
+private func runDomainReadProviderTask(
+    store: WorkspaceFileContextStore,
+    record: WorkspaceFileRecord,
+    roots: [WorkspaceRootRef]
+) async throws {
+    try await runDomainReadProviderTask(path: record.standardizedRelativePath) {
+        try await runMainActorProviderTask(store: store, record: record, roots: roots)
+    }
+}
+
+private func runDomainReadProviderTask(
+    path: String,
+    operation: @Sendable @escaping () async throws -> Void
+) async throws {
+    let runtimeIdentity = DomainRuntimeIdentity(
+        runtimeID: UUID(),
+        lifecycleGeneration: 1,
+        processID: 949,
+        mode: .app,
+        createdAt: Date(timeIntervalSince1970: 0)
+    )
+    let connectionID = UUID()
+    let context = DomainReadInvocationContext(
+        handle: DomainReadContextHandle(
+            runtimeID: runtimeIdentity.runtimeID,
+            runtimeGeneration: runtimeIdentity.lifecycleGeneration,
+            connectionID: connectionID,
+            connectionGeneration: 1,
+            context: DomainContextIdentity(workspaceID: UUID(), contextID: UUID()),
+            workspaceRevision: 1,
+            contextRevision: 1,
+            routingRevision: 1,
+            bindingKind: .explicit
+        ),
+        connectionID: connectionID
+    )
+    let provider = MCPDomainReadToolProvider(
+        resolveContext: { _, _ in context },
+        backend: MCPDomainReadToolBackend { _, _, _, _ in
+            try await operation()
+            return .null
+        },
+        sideEffects: DomainReadSideEffectCoordinator(identity: runtimeIdentity)
+    )
+    let readFile = try XCTUnwrap(provider.binding(named: MCPWindowToolName.readFile))
+    _ = try await readFile(["path": .string(path)])
+}
+
+private struct SharedLimiterSaturation {
+    let releaseActiveReads: AsyncSignal
+    let activeTasks: [Task<Void, Error>]
+    let queuedTasks: [Task<Void, Error>]
+}
+
+private struct SharedLimiterSettlement {
+    let activeSettled: Bool
+    let queuedSettled: Bool
+    let limiterIdle: Bool
+}
+
+private actor AsyncSignal {
+    private var isSignaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        isSignaled = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        if isSignaled { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func isSignaledSnapshot() -> Bool {
+        isSignaled
+    }
+}
+
+private actor CancellableTestGate {
+    private var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+
+    func wait() async throws {
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                waiters[waiterID] = continuation
+            }
+        } onCancel: {
+            Task { await self.cancel(waiterID) }
+        }
+    }
+
+    private func cancel(_ waiterID: UUID) {
+        waiters.removeValue(forKey: waiterID)?.resume(throwing: CancellationError())
+    }
+
+    func releaseAll() {
+        let pending = waiters.values
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+private actor TaskResultRecorder<Success: Sendable, Failure: Error & Sendable> {
+    private var result: Result<Success, Failure>?
+
+    func record(_ result: Result<Success, Failure>) {
+        self.result = result
+    }
+
+    func hasResult() -> Bool {
+        result != nil
+    }
+
+    func snapshot() -> Result<Success, Failure>? {
+        result
+    }
+}
+
+private actor TaskResultsRecorder<Success: Sendable, Failure: Error & Sendable> {
+    private let expectedCount: Int
+    private var results: [Int: Result<Success, Failure>] = [:]
+
+    init(expectedCount: Int) {
+        self.expectedCount = expectedCount
+    }
+
+    func record(_ result: Result<Success, Failure>, at index: Int) {
+        results[index] = result
+    }
+
+    func isComplete() -> Bool {
+        results.count == expectedCount
+    }
+
+    func snapshot() -> [Result<Success, Failure>]? {
+        guard isComplete() else { return nil }
+        return (0 ..< expectedCount).compactMap { results[$0] }
+    }
+}
+
+private enum PhysicalReadTestError: Error {
+    case syntheticFailure
+}
+
+private final class SendableObjectRetention: @unchecked Sendable {
+    private let object: AnyObject
+
+    init(_ object: AnyObject) {
+        self.object = object
+    }
+}
+
+private final class SynchronousPhysicalReadGate: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var blockedCount = 0
+    private var isReleased = false
+
+    func blockUntilReleased() {
+        condition.lock()
+        blockedCount += 1
+        condition.broadcast()
+        while !isReleased {
+            condition.wait()
+        }
+        condition.unlock()
+    }
+
+    func isBlockedSnapshot() -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return blockedCount > 0
+    }
+
+    func blockedCountSnapshot() -> Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return blockedCount
+    }
+
+    func release() {
+        condition.lock()
+        isReleased = true
+        condition.broadcast()
+        condition.unlock()
+    }
+}
+
+private final class SynchronousInvocationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func recordInvocation() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    func snapshot() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
+
+private final class PeriodicPhysicalReadGates: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var probeCount = 0
+    private var blockedIndices: Set<Int> = []
+    private var releasedIndices: Set<Int> = []
+    private let interval: Int
+    private let gates: Int
+
+    init(interval: Int, count: Int) {
+        self.interval = interval
+        gates = count
+    }
+
+    func reachNextProbe() {
+        condition.lock()
+        probeCount += 1
+        guard probeCount.isMultiple(of: interval) else {
+            condition.unlock()
+            return
+        }
+        let index = probeCount / interval - 1
+        guard index < gates else {
+            condition.unlock()
+            return
+        }
+        blockedIndices.insert(index)
+        condition.broadcast()
+        while !releasedIndices.contains(index) {
+            condition.wait()
+        }
+        condition.unlock()
+    }
+
+    func isBlocked(at index: Int) -> Bool {
+        condition.lock()
+        defer { condition.unlock() }
+        return blockedIndices.contains(index)
+    }
+
+    func releaseAll() {
+        condition.lock()
+        releasedIndices.formUnion(0 ..< gates)
+        condition.broadcast()
+        condition.unlock()
+    }
+}
+
+private final class PhysicalReadAttributionRecorder: @unchecked Sendable {
+    struct Snapshot {
+        let lifecycleCorrelationID: UUID?
+        let benchmarkMetricTag: WorktreeStartupInstrumentation.BenchmarkMetricTag?
+    }
+
+    private let lock = NSLock()
+    private var value: Snapshot?
+
+    func record(
+        lifecycleCorrelationID: UUID?,
+        benchmarkMetricTag: WorktreeStartupInstrumentation.BenchmarkMetricTag?
+    ) {
+        lock.lock()
+        value = Snapshot(
+            lifecycleCorrelationID: lifecycleCorrelationID,
+            benchmarkMetricTag: benchmarkMetricTag
+        )
+        lock.unlock()
+    }
+
+    func snapshot() -> Snapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}
+
+private actor ControlledWatchdogSleeps {
+    private let clock: SynchronousDurationClock
+    private var registeredCount = 0
+    private var sleepers: [(duration: Duration, continuation: CheckedContinuation<Void, Error>)] = []
+
+    init(clock: SynchronousDurationClock) {
+        self.clock = clock
+    }
+
+    func sleep(for duration: Duration) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            registeredCount += 1
+            sleepers.append((duration, continuation))
+        }
+    }
+
+    func registeredCountSnapshot() -> Int {
+        registeredCount
+    }
+
+    func pendingCountSnapshot() -> Int {
+        sleepers.count
+    }
+
+    @discardableResult
+    func releaseNext() -> Bool {
+        guard !sleepers.isEmpty else { return false }
+        let sleeper = sleepers.removeFirst()
+        clock.advance(by: sleeper.duration)
+        sleeper.continuation.resume()
+        return true
+    }
+
+    func releaseAll() {
+        let pending = sleepers
+        sleepers.removeAll()
+        pending.forEach { $0.continuation.resume() }
+    }
+}
+
+private final class SynchronousDurationClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var instant = Duration.zero
+
+    func now() -> Duration {
+        lock.lock()
+        defer { lock.unlock() }
+        return instant
+    }
+
+    func advance(by duration: Duration) {
+        lock.lock()
+        instant += duration
+        lock.unlock()
+    }
+}
+
+private actor WatchdogEventRecorder {
+    private var events: [MCPToolExecutionWatchdogEvent] = []
+
+    func record(_ event: MCPToolExecutionWatchdogEvent) {
+        events.append(event)
+    }
+
+    func snapshot() -> [MCPToolExecutionWatchdogEvent] {
+        events
+    }
+}
+
+private actor SettlementRecorder {
+    private var settlement: MCPToolExecutionSettlement?
+
+    func record(_ settlement: MCPToolExecutionSettlement) {
+        self.settlement = settlement
+    }
+
+    func snapshot() -> MCPToolExecutionSettlement? {
+        settlement
+    }
+}


### PR DESCRIPTION
## Summary

- route content, fingerprint, catalog, and exact-resolution disk work through a bounded cancellation-responsive physical-read bridge
- keep detached producers responsible for limiter permits and interactive foreground suppression until synchronous I/O actually returns
- preserve typed queue-full behavior and attribution while fencing encoding-cache, catalog-policy, and root-lifetime freshness
- add deterministic regression coverage for watchdog settlement, blocked physical reads, cache invalidation, policy turnover, admission, and teardown

## Validation

- `make dev-test FILTER=ContentReadCancellationTests` — 30 tests passed
- `make dev-test`
- `make dev-lint`
- `make guardrails`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-swift-build PRODUCT=repoprompt-mcp`
- contribution `commit`, `push`, and `pr-ready` preflights
- independent correctness and refactor reviews passed
- packaged CE acceptance: blocked existing-file reads settled by cancellation at about 30 seconds, immediate tree requests remained responsive, and limiter plus settlement counters returned to idle

Closes #949