### PR TITLE
Fix: prevent codemap indexing page restart on git churn

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
@@ -904,6 +904,51 @@ actor WorkspaceCodemapGitCapabilityService {
             }
             try Task.checkCancellation()
 
+            // Recheck candidate-local evidence after the repository capture.
+            for index in candidates.indices {
+                guard let path = candidatePaths[index],
+                      let expectedFingerprint = postPathFingerprints[index],
+                      let expectedAttributes = postAttributeGenerations[index]
+                else { continue }
+                do {
+                    let attributes = try digestEvidence(
+                        urls: Self.candidateAttributeURLs(
+                            layout: capability.repositoryLayout,
+                            candidateRepositoryRelativePath: path
+                        ),
+                        includeBoundedContents: true
+                    )
+                    guard attributes == expectedAttributes else {
+                        hooks.sourceAuthorityRejected(.candidateAttributesChanged(index: index))
+                        postAttributeGenerations[index] = nil
+                        continue
+                    }
+                } catch {
+                    hooks.sourceAuthorityRejected(.candidateAttributesChanged(index: index))
+                    postAttributeGenerations[index] = nil
+                    continue
+                }
+                do {
+                    let fingerprint = try pathFingerprintClient.fingerprint(
+                        capability.repositoryLayout.workTreeRoot,
+                        path
+                    )
+                    #if DEBUG
+                        await hooks.afterSourcePathFingerprintCapture()
+                    #endif
+                    guard fingerprint == expectedFingerprint, fingerprint.isRegularFile else {
+                        hooks.sourceAuthorityRejected(.candidatePathChanged(index: index))
+                        postPathFingerprints[index] = nil
+                        continue
+                    }
+                    postPathFingerprints[index] = fingerprint
+                } catch {
+                    hooks.sourceAuthorityRejected(.candidateFingerprintUnavailable(index: index))
+                    postPathFingerprints[index] = nil
+                }
+                try Task.checkCancellation()
+            }
+
             var authorities = unavailable
             for index in candidates.indices {
                 guard let path = candidatePaths[index],

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
@@ -884,9 +884,11 @@ actor WorkspaceCodemapGitCapabilityService {
                 expectedLayout: capability.repositoryLayout,
                 prefix: capability.repositoryRelativeLoadedRootPrefix
             )
-            // Earlier root-wide churn does not invalidate the current request, but this request
-            // must observe one unchanged root authority across its two captures.
-            guard preRepository == postRepository else {
+            // Candidate-local fingerprints and attributes establish source stability. Unrelated
+            // index or metadata churn must not reject the entire batch.
+            guard preRepository.sourceClassificationEvidence == postRepository.sourceClassificationEvidence,
+                  preRepository.matchesSourceAuthorityStability(of: postRepository)
+            else {
                 hooks.sourceAuthorityRejected(.repositoryAuthorityChangedDuringIssuance)
                 return unavailable
             }

--- a/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
@@ -37,7 +37,10 @@ final class CodemapStoreFixture: @unchecked Sendable {
     private let runtimeTracker: CodemapRuntimeTracker
     private let runtimeProvider: CodeMapArtifactRuntimeProvider
 
-    init(name: String) throws {
+    init(
+        name: String,
+        capabilityHooks: WorkspaceCodemapGitCapabilityServiceHooks = .none
+    ) throws {
         let registry = WorkspaceCodemapBindingIntegrationRegistry()
         let builtSourceTexts = CodemapLockedValues<String>()
         let runtimeTracker = CodemapRuntimeTracker()
@@ -79,7 +82,8 @@ final class CodemapStoreFixture: @unchecked Sendable {
                             namespaceSalt: Data(
                                 repeating: 0x6C,
                                 count: GitBlobRepositoryNamespace.saltByteCount
-                            )
+                            ),
+                            hooks: capabilityHooks
                         ),
                         sourceReader: registry.makeValidatedSourceReaderClient(),
                         catalogClient: registry.makeBindingCatalogClient()

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
@@ -3,6 +3,55 @@ import Foundation
 import XCTest
 
 final class CodemapAutomaticSelectionGraphNativeTests: XCTestCase {
+    func testUnrelatedGitIndexChurnDoesNotRestartGraphPage() async throws {
+        let repository = try ReviewGitRepositoryFixture(name: #function)
+        let rootURL = try repository.makeRepository(
+            named: "root",
+            files: [
+                "Sources/First.swift": "struct First {}\n",
+                "Sources/Second.swift": "struct Second {}\n"
+            ]
+        )
+        let indexURL = rootURL.appendingPathComponent(".git/index")
+        let authorityCaptures = CodemapLockedValues<Int>()
+        let fixture = try CodemapStoreFixture(
+            name: #function,
+            capabilityHooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                afterFirstAuthorityCapture: {
+                    let shouldChurn = !authorityCaptures.values.isEmpty
+                    authorityCaptures.append(1)
+                    if shouldChurn {
+                        try? FileManager.default.setAttributes(
+                            [.modificationDate: Date()],
+                            ofItemAtPath: indexURL.path
+                        )
+                    }
+                }
+            )
+        )
+        let store = fixture.makeStore()
+        let loaded = try await store.loadRoot(path: rootURL.path)
+        addTeardownBlock {
+            await store.unloadRoot(id: loaded.id)
+            await fixture.shutdown()
+            repository.cleanup()
+        }
+
+        let engine = try fixture.runtime().bindingEngine()
+        let rootAccounting = try await waitForGraphCompletion(
+            engine: engine,
+            rootID: loaded.id
+        )
+
+        XCTAssertEqual(rootAccounting.phase, .complete)
+        XCTAssertEqual(rootAccounting.retryAttempt, 0)
+        XCTAssertNil(rootAccounting.retry)
+        XCTAssertEqual(rootAccounting.progress.counts.processedCandidateCount, 2)
+        XCTAssertGreaterThan(authorityCaptures.values.count, 1)
+        let accounting = await engine.accounting()
+        XCTAssertEqual(accounting.counters.graphIndexRetries, 0)
+    }
+
     func testNestedRepositoryGraphUsesValidatedWorktreeBytesAndCompletesWithoutRetry() async throws {
         let repository = try ReviewGitRepositoryFixture(name: #function)
         let relativePath = "Nested/Sources/Feature.swift"

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapGitCapabilityServiceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapGitCapabilityServiceTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class WorkspaceCodemapGitCapabilityServiceTests: XCTestCase {
+    func testSourceAuthorityRejectsCandidateChangedAfterPostRepositoryCapture() async throws {
+        let repository = try ReviewGitRepositoryFixture(name: #function)
+        let relativePath = "Sources/Feature.swift"
+        let rootURL = try repository.makeRepository(
+            named: "root",
+            files: [relativePath: "struct BeforeCapture {}\n"]
+        )
+        let sourceURL = rootURL.appendingPathComponent(relativePath)
+        let pathCaptures = CodemapLockedValues<Int>()
+        let service = WorkspaceCodemapGitCapabilityService(
+            namespaceSalt: Data(repeating: 0x6C, count: GitBlobRepositoryNamespace.saltByteCount),
+            hooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                afterSourcePathFingerprintCapture: {
+                    let shouldChangeCandidate = pathCaptures.values.count == 1
+                    pathCaptures.append(1)
+                    if shouldChangeCandidate {
+                        try? Data("struct AfterCapture {}\n".utf8).write(to: sourceURL, options: .atomic)
+                    }
+                }
+            )
+        )
+        let request = WorkspaceCodemapGitCapabilityRequest(
+            rootID: UUID(),
+            rootLifetimeID: UUID(),
+            loadedRootURL: rootURL
+        )
+        guard case let .eligible(capability) = await service.resolve(root: request) else {
+            return XCTFail("Expected an eligible Git Code Map capability")
+        }
+        addTeardownBlock {
+            await service.release(rootEpoch: request.rootEpoch)
+            repository.cleanup()
+        }
+
+        let authority = await service.makeSourceAuthority(
+            capability: capability,
+            observedRootEpoch: request.rootEpoch,
+            observedRepositoryAuthority: capability.repositoryAuthority,
+            candidateRepositoryRelativePath: relativePath,
+            observedPathGeneration: 1,
+            currentPathGeneration: 1,
+            observedIngressGeneration: 1,
+            currentIngressGeneration: 1
+        )
+
+        XCTAssertEqual(try String(contentsOf: sourceURL, encoding: .utf8), "struct AfterCapture {}\n")
+        XCTAssertNil(authority)
+    }
+}


### PR DESCRIPTION
Follow-up to #913 for a remaining Code Map indexing retry loop.

In a real workspace, indexing repeatedly moved between 1,725 and 1,789 of 1,860 files without completing.  Source-authority issuance was rejecting an entire 64-file catalog page whenever unrelated Git index or metadata activity occurred between its repository captures.  RPCE's own Git-status work could provide that churn indefinitely.

This patch uses the existing candidate-local stability contract already used during source-authority revalidation.  Repository binding, candidate fingerprints, attributes, and checkout configuration must remain stable, while unrelated index activity no longer restarts the page.

## Summary

- Prevent unrelated Git index and metadata churn from rejecting a Code Map batch
- Preserve candidate-local source and repository-binding validation
- Add a deterministic regression reproducing the infinite page-retry loop
- Add no retries, timeout changes, or alternate indexing path

## Validation

- Fresh regression timed out against baseline, then passed with zero graph retries after the fix
- `CodemapAutomaticSelectionGraphNativeTests`: 2 tests passed
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- Commit safety preflight, including staged-index secret scanning and repository guardrails
- E2E validation in the affected workspace