### PR TITLE
Preserve settled Oracle group replies and consistent lane presentation

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
@@ -124,13 +124,17 @@ enum AgentOraclePillLogic {
         session.oracleGroupID != nil && (session.oracleGroupSize ?? 1) > 1
     }
 
-    static func aggregateOracleCount(configuredAdditionalCount: Int, sessions: [ChatSession]) -> Int {
-        let configured = 1 + configuredAdditionalCount
-        guard let latest = sessions.max(by: { $0.savedAt < $1.savedAt }),
-              latest.oracleGroupID != nil
-        else { return configured }
-        let projected = min(max(latest.oracleGroupSize ?? 1, 1), 5)
-        return max(configured, projected)
+    static func aggregateOracleCount(session: ChatSession?) -> Int {
+        guard let session, session.oracleGroupID != nil else { return 1 }
+        return min(max(session.oracleGroupSize ?? 1, 1), 5)
+    }
+
+    static func groupMemberSessions(for session: ChatSession, in sessions: [ChatSession]) -> [ChatSession] {
+        guard let groupID = session.oracleGroupID else { return [] }
+        return sessions.filter {
+            $0.oracleGroupID == groupID && $0.workspaceID == session.workspaceID
+                && $0.composeTabID == session.composeTabID
+        }.sorted { ($0.oracleLaneIndex ?? .max) < ($1.oracleLaneIndex ?? .max) }
     }
 
     static func latestStreamingSession(
@@ -196,33 +200,15 @@ enum AgentOraclePillLogic {
         return matches[0]
     }
 
-    enum LaneDotState: Equatable {
-        case streaming
-        case failed
-        case completed
-    }
-
-    static func lastAssistantContent(
-        liveMessages: [AIChatMessage],
-        storedMessages: [StoredMessage]
-    ) -> String? {
-        if let last = liveMessages.last(where: { !$0.isUser }) {
-            return last.content
-        }
-        return storedMessages.last(where: { !$0.isUser })?.rawText
-    }
-
-    static func assistantContentIndicatesFailure(_ content: String?) -> Bool {
-        guard let content else { return false }
-        if content.contains("\n--\nError:\n") { return true }
-        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.hasPrefix("Error:")
-    }
-
-    static func laneDotState(isStreaming: Bool, lastAssistantContent: String?) -> LaneDotState {
-        if isStreaming { return .streaming }
-        if assistantContentIndicatesFailure(lastAssistantContent) { return .failed }
-        return .completed
+    static func laneStatus(
+        session: ChatSession,
+        isStreaming: Bool,
+        payload: OracleLaneMarkdownPayload?
+    ) -> OracleLaneMarkdownPayload.Status {
+        if isStreaming { return .running }
+        return payload?.lanes.first {
+            $0.chatID == session.shortID && $0.laneIndex == session.oracleLaneIndex
+        }?.status ?? .unavailable
     }
 }
 
@@ -251,10 +237,17 @@ struct AgentOraclePill: View {
 
     @State private var presentedPopover: PopoverPresentation?
     @State private var copyAllFeedback: CopyAllFeedback?
+    @State private var groupPayload: OracleLaneMarkdownPayload?
+    @State private var groupPayloadSessionID: UUID?
+
+    private struct GroupReadKey: Hashable {
+        let sessionID: UUID
+        let streamingSessionIDs: Set<UUID>
+    }
+
     @State private var autoScrollEnabled = false
     @State private var openRequestGeneration: UInt64 = 0
     @ObservedObject private var fontScale = FontScaleManager.shared
-    @ObservedObject private var settingsStore = GlobalSettingsStore.shared
     private var fontPreset: FontScalePreset {
         fontScale.preset
     }
@@ -281,25 +274,23 @@ struct AgentOraclePill: View {
         currentTabID.map(oracleViewModel.sessions(forTabID:)) ?? []
     }
 
+    private var displayedSession: ChatSession? {
+        if let presentedPopover { return presentedSession(for: presentedPopover) }
+        return latestTabSession
+    }
+
     private var oracleCount: Int {
-        let workspaceID = oracleViewModel.workspaceManager.activeWorkspaceID
-        let configuredAdditional = settingsStore
-            .effectiveAgentModelsProfile(workspaceID: workspaceID)
-            .additionalOracleModelRaws.count
-        return AgentOraclePillLogic.aggregateOracleCount(
-            configuredAdditionalCount: configuredAdditional,
-            sessions: currentTabSessions
-        )
+        AgentOraclePillLogic.aggregateOracleCount(session: displayedSession)
     }
 
     private var isStreaming: Bool {
-        guard let latestTabSession else { return false }
-        if let groupID = latestTabSession.oracleGroupID {
-            return currentTabSessions.contains {
-                $0.oracleGroupID == groupID && oracleViewModel.streamingSessions.contains($0.id)
+        guard let session = displayedSession else { return false }
+        if session.oracleGroupID != nil {
+            return groupMemberSessions(for: session).contains {
+                oracleViewModel.streamingSessions.contains($0.id)
             }
         }
-        return oracleViewModel.streamingSessions.contains(latestTabSession.id)
+        return oracleViewModel.streamingSessions.contains(session.id)
     }
 
     private func presentedSession(for presentation: PopoverPresentation) -> ChatSession? {
@@ -319,17 +310,25 @@ struct AgentOraclePill: View {
         return session.name
     }
 
-    private func laneDotColor(for session: ChatSession) -> Color {
-        switch AgentOraclePillLogic.laneDotState(
+    private func canonicalPayload(for presentation: PopoverPresentation) -> OracleLaneMarkdownPayload? {
+        groupPayloadSessionID == presentation.sessionID ? groupPayload : nil
+    }
+
+    private func laneStatus(for session: ChatSession, presentation: PopoverPresentation) -> OracleLaneMarkdownPayload.Status {
+        AgentOraclePillLogic.laneStatus(
+            session: session,
             isStreaming: oracleViewModel.streamingSessions.contains(session.id),
-            lastAssistantContent: AgentOraclePillLogic.lastAssistantContent(
-                liveMessages: oracleViewModel.messagesSnapshot(for: session.id),
-                storedMessages: session.messages
-            )
-        ) {
-        case .streaming: Color.purple
-        case .failed: Color.red
-        case .completed: Color.green
+            payload: canonicalPayload(for: presentation)
+        )
+    }
+
+    private func laneDotColor(for status: OracleLaneMarkdownPayload.Status) -> Color {
+        switch status {
+        case .running: .purple
+        case .failed: .red
+        case .completed: .green
+        case .cancelled: .orange
+        case .unavailable: .secondary
         }
     }
 
@@ -427,10 +426,7 @@ struct AgentOraclePill: View {
     }
 
     private func groupMemberSessions(for session: ChatSession) -> [ChatSession] {
-        guard let groupID = session.oracleGroupID else { return [] }
-        return currentTabSessions
-            .filter { $0.oracleGroupID == groupID }
-            .sorted { ($0.oracleLaneIndex ?? .max) < ($1.oracleLaneIndex ?? .max) }
+        AgentOraclePillLogic.groupMemberSessions(for: session, in: currentTabSessions)
     }
 
     @ViewBuilder
@@ -475,6 +471,7 @@ struct AgentOraclePill: View {
                     HStack(spacing: 6) {
                         ForEach(members) { member in
                             let laneIndex = member.oracleLaneIndex ?? 0
+                            let status = laneStatus(for: member, presentation: presentation)
                             Button {
                                 openRequestGeneration &+= 1
                                 present(
@@ -486,7 +483,7 @@ struct AgentOraclePill: View {
                             } label: {
                                 HStack(spacing: 4) {
                                     Circle()
-                                        .fill(laneDotColor(for: member))
+                                        .fill(laneDotColor(for: status))
                                         .frame(width: 6, height: 6)
                                     Text(OracleViewModel.oracleLabel(laneIndex: laneIndex))
                                         .lineLimit(1)
@@ -494,9 +491,26 @@ struct AgentOraclePill: View {
                             }
                             .buttonStyle(.bordered)
                             .controlSize(.small)
-                            .hoverTooltip(member.oracleModelRaw ?? "Oracle model")
+                            .hoverTooltip("\(member.oracleModelRaw ?? "Oracle model") · \(status.rawValue)")
+                            .accessibilityLabel("\(OracleViewModel.oracleLabel(laneIndex: laneIndex)): \(status.rawValue)")
                         }
                     }
+                }
+            }
+
+            if let presented = presentedSession(for: presentation), presented.oracleGroupID != nil {
+                let lane = canonicalPayload(for: presentation)?.lanes.first {
+                    $0.chatID == presented.shortID && $0.laneIndex == presented.oracleLaneIndex
+                }
+                let status = laneStatus(for: presented, presentation: presentation)
+                Text(status.rawValue)
+                    .font(.caption)
+                    .foregroundStyle(laneDotColor(for: status))
+                if let error = lane?.errorMessage, status != .running {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
                 }
             }
 
@@ -514,6 +528,37 @@ struct AgentOraclePill: View {
         }
         .padding(14)
         .frame(width: popoverWidth)
+        .task(id: GroupReadKey(
+            sessionID: presentation.sessionID,
+            streamingSessionIDs: oracleViewModel.streamingSessions
+        )) {
+            await refreshGroupPayload(presentation)
+        }
+    }
+
+    @MainActor
+    private func refreshGroupPayload(_ presentation: PopoverPresentation) async {
+        groupPayload = nil
+        groupPayloadSessionID = presentation.sessionID
+        guard let session = presentedSession(for: presentation), session.oracleGroupID != nil else { return }
+        // A stream can end before the runtime publishes its terminal turn. Continue reading
+        // the existing canonical seam until publication; never infer completion from text.
+        while !Task.isCancelled {
+            do {
+                let payload = try await oracleViewModel.oracleGroupCopyPayload(containing: session)
+                try Task.checkCancellation()
+                guard presentedPopover?.sessionID == presentation.sessionID else { return }
+                groupPayload = payload
+                groupPayloadSessionID = presentation.sessionID
+                guard payload.lanes.contains(where: { $0.status == .running }) else { return }
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+            } catch {
+                if !Task.isCancelled, presentedPopover?.sessionID == presentation.sessionID {
+                    groupPayload = nil
+                }
+                return
+            }
+        }
     }
 
     private func copyAllLanes(containing session: ChatSession) {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
@@ -647,7 +647,7 @@ func contextBuilderOracleLaneSummaries(
             chatID: lane.chatID,
             modelID: lane.executionProfile?.modelID ?? lane.modelID,
             effectiveReasoningEffort: lane.executionProfile?.effectiveReasoningEffort,
-            status: lane.status == OracleLaneResultStatus.completed.rawValue ? "done" : "failed"
+            status: lane.status == OracleLaneResultStatus.completed.rawValue ? "done" : lane.status
         )
     }
 }

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -4496,17 +4496,13 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     @MainActor
     func planStatus(for tabID: UUID?) -> ContextBuilderPlanStatus {
         guard let id = tabID, let session = sessions[id] else { return .idle }
-        if session.isBackgroundPlanGenerating {
-            return .generating
-        }
-        if let error = session.backgroundPlanError {
-            return .error(error)
-        }
-        if let route = session.generatedAnswerRoute {
-            let preview = session.backgroundPlanResponsePreviewText ?? session.backgroundPlanResponseText
-            return .ready(route: route, previewText: preview)
-        }
-        return .idle
+        return session.planStatus
+    }
+
+    @MainActor
+    func failedAnswerRoute(for tabID: UUID?) -> ContextBuilderGeneratedAnswerRoute? {
+        guard let tabID else { return nil }
+        return sessions[tabID]?.failedAnswerRoute
     }
 
     /// Returns the current context-builder follow-up Oracle chat ID for a tab, when known.
@@ -4782,10 +4778,6 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     "Context Builder Oracle group result did not match its prepared members"
                 )
             }
-            guard let primary = session.followUpOracleGroupState.members.first else {
-                throw ChatToolError.internalError("Context Builder Oracle group completed without Primary state")
-            }
-            let primaryResult = groupReply.result.primary
             try await oracleStore.releaseArtifactReservation(
                 frozenPack.reservation,
                 removeIfUnreferenced: false
@@ -4795,36 +4787,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 await runTestHooks?.afterOracleArtifactReservationReleased?(generation)
             #endif
             try requireCurrentOracleRun(session: session, generation: generation)
-            if primaryResult.status != .completed,
-               let partialResponse = primaryResult.error?.partialResponse,
-               !partialResponse.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            {
-                session.backgroundPlanResponseText = partialResponse
-            }
-            let primaryResponse = try groupReply.requiredCompletedPrimaryResponse()
-            let errors = groupReply.orderedResults.compactMap { result in
-                result.error.map {
-                    "\(OracleViewModel.oracleLabel(laneIndex: result.laneIndex)) failed: \($0.message)"
-                }
-            }
-            let reply = ChatSendReply(
-                chatId: primary.sessionID,
-                shortId: primary.chatID,
-                mode: mode.mcpModeName,
-                response: primaryResponse,
-                errors: errors.isEmpty ? nil : errors,
-                oracleGroup: groupReply
+            let reply = try session.completeOracleGroupReply(
+                groupReply,
+                generation: generation,
+                originWorkspaceID: originWorkspaceID,
+                mode: mode
             )
-            session.isBackgroundPlanGenerating = false
-            session.backgroundPlanResponseText = reply.response
-            session.backgroundPlanReasoningText = nil
-            session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
-                workspaceID: originWorkspaceID,
-                tabID: tabID,
-                chatID: primary.chatID
-            )
-            session.followUpOracleGroupState.finish(generation: generation)
-            session.followUpOracleGroupTask = nil
             clearPendingBackgroundPlanUIRefresh(for: tabID)
             applyPlanPreview(to: session)
             updateRuntimeBindings(from: session)
@@ -5847,6 +5815,73 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 message: message
             )
         )
+    }
+}
+
+extension ContextBuilderAgentViewModel.TabSession {
+    /// Called only after the runtime settled and artifact reservation release succeeded.
+    /// A failed primary is a group outcome, not a failure to deliver the group.
+    @MainActor
+    func completeOracleGroupReply(
+        _ groupReply: ContextBuilderOracleGroupReply,
+        generation: UInt64,
+        originWorkspaceID: UUID,
+        mode: HeadlessMode
+    ) throws -> ChatSendReply {
+        try Task.checkCancellation()
+        guard followUpOracleGroupState.generation == generation else { throw CancellationError() }
+        guard followUpOracleGroupState.matchesFinalResult(groupReply.result, generation: generation),
+              let primary = followUpOracleGroupState.members.first
+        else {
+            throw ChatToolError.internalError("Context Builder Oracle group result did not match its prepared members")
+        }
+        let primaryResult = groupReply.result.primary
+        let errors = groupReply.orderedResults.compactMap { result in
+            result.error.map {
+                "\(OracleViewModel.oracleLabel(laneIndex: result.laneIndex)) \(result.status.rawValue): \($0.message)"
+            }
+        }
+        let reply = ChatSendReply(
+            chatId: primary.sessionID,
+            shortId: primary.chatID,
+            mode: mode.mcpModeName,
+            response: primaryResult.status == .completed ? primaryResult.response : nil,
+            errors: errors.isEmpty ? nil : errors,
+            oracleGroup: groupReply
+        )
+        isBackgroundPlanGenerating = false
+        backgroundPlanResponseText = reply.response ?? primaryResult.error?.partialResponse
+        backgroundPlanReasoningText = nil
+        backgroundPlanError = primaryResult.status == .completed ? nil :
+            ContextBuilderOraclePrimaryCompletionError.notCompleted(
+                status: primaryResult.status,
+                code: primaryResult.error?.code ?? "oracle_primary_not_completed",
+                message: primaryResult.error?.message ?? "Primary Oracle did not complete successfully."
+            ).localizedDescription
+        generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
+            workspaceID: originWorkspaceID,
+            tabID: tabID,
+            chatID: primary.chatID
+        )
+        followUpOracleGroupState.finish(generation: generation)
+        followUpOracleGroupTask = nil
+        return reply
+    }
+
+    @MainActor
+    var planStatus: ContextBuilderPlanStatus {
+        if isBackgroundPlanGenerating { return .generating }
+        if let error = backgroundPlanError { return .error(error) }
+        if let route = generatedAnswerRoute {
+            return .ready(route: route, previewText: backgroundPlanResponsePreviewText ?? backgroundPlanResponseText)
+        }
+        return .idle
+    }
+
+    @MainActor
+    var failedAnswerRoute: ContextBuilderGeneratedAnswerRoute? {
+        guard !isBackgroundPlanGenerating, backgroundPlanError != nil else { return nil }
+        return generatedAnswerRoute
     }
 }
 

--- a/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderAgentView.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderAgentView.swift
@@ -254,6 +254,11 @@ struct ContextBuilderAgentView: View {
             // Line 3: Plan actions (only when plan is ready)
             if case let .ready(route, previewText) = status {
                 planReadyActions(route: route, previewText: previewText)
+            } else if let route = viewModel.failedAnswerRoute(for: subjectTabID) {
+                Button("View in Chat", systemImage: "bubble.left.and.bubble.right") {
+                    viewGeneratedPlan(route: route)
+                }
+                .hoverTooltip(ContextBuilderGeneratedAnswerActionText.viewInChatTooltip)
             }
         }
         .padding(10)

--- a/Tests/RepoPromptTests/AgentMode/AgentOraclePillRoutingTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentOraclePillRoutingTests.swift
@@ -400,94 +400,83 @@ final class AgentOraclePillRoutingTests: XCTestCase {
         XCTAssertNil(wrongWorkspace)
     }
 
-    func testAggregateOraclePillCountAndLabelsUseConfiguredOrLatestProjectedGroup() {
-        let historical = ChatSession(
-            oracleGroupID: UUID(),
-            oracleLaneIndex: 0,
-            oracleGroupSize: 5,
-            name: "Historical",
-            savedAt: Date(timeIntervalSince1970: 100)
-        )
-        let latestSingle = ChatSession(
-            name: "Latest Single",
-            savedAt: Date(timeIntervalSince1970: 200)
-        )
-        let latestGroupID = UUID()
-        let latestProjected = ChatSession(
-            oracleGroupID: latestGroupID,
-            oracleLaneIndex: 0,
-            oracleGroupSize: 4,
-            name: "Latest Group",
-            savedAt: Date(timeIntervalSince1970: 300)
-        )
-        let staleSiblingProjection = ChatSession(
-            oracleGroupID: latestGroupID,
-            oracleLaneIndex: 1,
-            oracleGroupSize: 5,
-            name: "Stale Group Sibling",
-            savedAt: Date(timeIntervalSince1970: 200)
-        )
-        let invalidProjected = ChatSession(
-            oracleGroupID: UUID(),
-            oracleLaneIndex: 0,
-            oracleGroupSize: 99,
-            name: "Invalid Projection",
-            savedAt: Date(timeIntervalSince1970: 400)
-        )
+    func testBadgeUsesSelectedStoredRosterAndDoesNotCreateMissingMembers() {
+        let single = ChatSession(name: "Legacy single")
+        let group = ChatSession(oracleGroupID: UUID(), oracleLaneIndex: 0, oracleGroupSize: 2)
+        // Configuration is deliberately absent from the presentation API: changing it cannot
+        // promote a historical single chat or change an existing group's stored roster.
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(session: single), 1)
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(session: group), 2)
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(session: nil), 1)
+        XCTAssertTrue(AgentOraclePillLogic.groupMemberSessions(for: single, in: [single, group]).isEmpty)
+        XCTAssertEqual(AgentOraclePillLogic.groupMemberSessions(for: group, in: [single, group]).map(\.id), [group.id])
+        XCTAssertFalse(AgentOraclePillLogic.canCopyAll(single))
+        XCTAssertTrue(AgentOraclePillLogic.canCopyAll(group))
+    }
 
-        XCTAssertEqual(
-            AgentOraclePillLogic.aggregateOracleCount(
-                configuredAdditionalCount: 0,
-                sessions: [historical, latestSingle]
-            ),
-            1
+    func testBadgeFollowsOwnerFilteringStreamingSelectionAndExplicitHistory() throws {
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let owner = UUID()
+        let runID = UUID()
+        func session(size: Int, savedAt: TimeInterval, agent: UUID) -> ChatSession {
+            ChatSession(
+                workspaceID: workspaceID, composeTabID: tabID,
+                agentModeSessionID: agent, agentModeRunID: runID,
+                oracleGroupID: UUID(), oracleLaneIndex: 0, oracleGroupSize: size,
+                savedAt: Date(timeIntervalSince1970: savedAt),
+                messages: [StoredMessage(isUser: false, rawText: "answer", sequenceIndex: 0)]
+            )
+        }
+        let streaming = session(size: 2, savedAt: 100, agent: owner)
+        let newer = session(size: 3, savedAt: 200, agent: owner)
+        let foreign = session(size: 5, savedAt: 300, agent: UUID())
+        let sessions = [foreign, newer, streaming]
+        let eligible = AgentOraclePillLogic.eligibleSessions(
+            sessions: sessions, streamingSessionIDs: [streaming.id], liveMessageCount: { _ in nil },
+            activeAgentSessionID: owner, activeRunID: runID
         )
-        XCTAssertEqual(
-            AgentOraclePillLogic.aggregateOracleCount(
-                configuredAdditionalCount: 0,
-                sessions: [historical, staleSiblingProjection, latestProjected]
-            ),
-            4
+        XCTAssertFalse(eligible.contains { $0.id == foreign.id })
+        let selected = try XCTUnwrap(AgentOraclePillLogic.latestSession(
+            in: eligible, streamingSessionIDs: [streaming.id]
+        ))
+        XCTAssertEqual(selected.id, streaming.id)
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(session: selected), 2)
+        let historicalID = AgentOraclePillLogic.reconciledPresentedSessionID(
+            currentSessionID: newer.id, isExplicit: true, currentWorkspaceID: workspaceID,
+            sameTabSessions: sessions, eligibleSessions: eligible, streamingSessionIDs: [streaming.id]
         )
-        XCTAssertEqual(
-            AgentOraclePillLogic.aggregateOracleCount(configuredAdditionalCount: 2, sessions: []),
-            3
+        XCTAssertEqual(historicalID, newer.id)
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(
+            session: sessions.first { $0.id == historicalID }
+        ), 3)
+    }
+
+    func testLaneStatusUsesCanonicalOutcomeInsteadOfAssistantText() {
+        let groupID = UUID()
+        let primary = ChatSession(oracleGroupID: groupID, oracleLaneIndex: 0, oracleGroupSize: 3)
+        let secondary = ChatSession(
+            oracleGroupID: groupID, oracleLaneIndex: 1, oracleGroupSize: 3,
+            messages: [StoredMessage(isUser: false, rawText: "Error: valid answer", sequenceIndex: 0)]
         )
-        XCTAssertEqual(
-            AgentOraclePillLogic.aggregateOracleCount(configuredAdditionalCount: 0, sessions: [invalidProjected]),
-            5
-        )
-        XCTAssertFalse(AgentOraclePillLogic.canCopyAll(latestSingle))
-        XCTAssertTrue(AgentOraclePillLogic.canCopyAll(latestProjected))
-        XCTAssertEqual(
-            (0 ... 4).map(OracleViewModel.oracleLabel(laneIndex:)),
-            ["Oracle", "Oracle 2", "Oracle 3", "Oracle 4", "Oracle 5"]
-        )
-        XCTAssertEqual(
-            AgentOraclePillLogic.laneDotState(isStreaming: true, lastAssistantContent: "Error: stale"),
-            .streaming
-        )
-        XCTAssertEqual(
-            AgentOraclePillLogic.laneDotState(
-                isStreaming: false,
-                lastAssistantContent: "partial answer\n\n--\nError:\nstatus code 502"
-            ),
-            .failed
-        )
-        XCTAssertEqual(
-            AgentOraclePillLogic.laneDotState(
-                isStreaming: false,
-                lastAssistantContent: "Error: status code 502 Gemini response stalled"
-            ),
-            .failed
-        )
-        XCTAssertEqual(
-            AgentOraclePillLogic.laneDotState(
-                isStreaming: false,
-                lastAssistantContent: "Review looks correct. Mention error handling."
-            ),
-            .completed
-        )
+        let cancelled = ChatSession(oracleGroupID: groupID, oracleLaneIndex: 2, oracleGroupSize: 3)
+        let sessions = [primary, secondary, cancelled]
+        let statuses: [OracleLaneMarkdownPayload.Status] = [.failed, .completed, .cancelled]
+        let payload = OracleLaneMarkdownPayload(lanes: zip(sessions, statuses).enumerated().map { index, pair in
+            OracleLaneMarkdownPayload.Lane(
+                laneIndex: index, chatID: pair.0.shortID, providerID: nil, modelID: "same-model",
+                effectiveReasoningEffort: nil, status: pair.1,
+                response: index == 1 ? "Error: valid answer" : nil, partialResponse: nil,
+                errorCode: index == 0 ? "invalid_model" : nil,
+                errorMessage: index == 0 ? "failed before sending" : nil
+            )
+        })
+        XCTAssertEqual(sessions.map {
+            AgentOraclePillLogic.laneStatus(session: $0, isStreaming: false, payload: payload)
+        }, statuses)
+        XCTAssertEqual(AgentOraclePillLogic.laneStatus(session: primary, isStreaming: false, payload: nil), .unavailable)
+        XCTAssertEqual(AgentOraclePillLogic.laneStatus(session: primary, isStreaming: true, payload: payload), .running)
+        XCTAssertEqual(AgentOraclePillLogic.groupMemberSessions(for: primary, in: Array(sessions.reversed())).map(\.id), sessions.map(\.id))
     }
 
     func testGroupedDeleteFallsBackToProjectionCleanupWhenCanonicalDocumentIsMissing() async throws {

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderOracleResultTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderOracleResultTests.swift
@@ -97,7 +97,7 @@ final class ContextBuilderOracleResultTests: XCTestCase {
         XCTAssertFalse(text.contains("- Status: Failed"), text)
     }
 
-    func testFailedOrCancelledPrimaryIsNotPublishable() throws {
+    func testStrictPrimaryResponseAccessorStillRejectsFailedOrCancelledPrimary() throws {
         for status in [OracleLaneResultStatus.failed, .cancelled] {
             let reply = try ContextBuilderOracleGroupReply(result: groupResult(
                 status: .failed,
@@ -170,6 +170,171 @@ final class ContextBuilderOracleResultTests: XCTestCase {
             reply.toMCPFields()["oracle_results"]?.arrayValue?[0]
                 .objectValue?["execution_profile"]
         )
+    }
+
+    @MainActor
+    func testSettledReplyBoundaryDeliversFailedPrimaryAndKeepsErrorNavigation() throws {
+        for mode in [HeadlessMode.plan, .review] {
+            for primaryStatus in [OracleLaneResultStatus.failed, .cancelled] {
+                let result = try groupResult(status: .failed, lanes: [
+                    lane(index: 0, status: primaryStatus, error: laneError(
+                        code: "primary_stopped", message: "primary stopped", partialResponse: "primary partial"
+                    )),
+                    lane(index: 1, status: .completed, response: "Error: is legitimate answer text"),
+                    lane(index: 2, status: .completed, response: "third answer")
+                ])
+                let (session, generation, members) = try preparedSession(for: result)
+                let workspaceID = UUID()
+                let reply = try session.completeOracleGroupReply(
+                    ContextBuilderOracleGroupReply(result: result),
+                    generation: generation,
+                    originWorkspaceID: workspaceID,
+                    mode: mode
+                )
+                XCTAssertEqual(reply.chatId, members[0].sessionID)
+                XCTAssertEqual(reply.shortId, "chat-0")
+                XCTAssertNil(reply.response, "A secondary answer must never become the primary response")
+                XCTAssertEqual(reply.oracleGroup?.result, result)
+                XCTAssertEqual(reply.errors, ["Oracle \(primaryStatus.rawValue): primary stopped"])
+                XCTAssertFalse(session.isBackgroundPlanGenerating)
+                XCTAssertEqual(session.backgroundPlanResponseText, "primary partial")
+                guard case let .error(message) = session.planStatus else {
+                    return XCTFail("Primary failure must remain visible")
+                }
+                XCTAssertTrue(message.contains("primary stopped"))
+                XCTAssertEqual(session.failedAnswerRoute, ContextBuilderGeneratedAnswerRoute(
+                    workspaceID: workspaceID, tabID: session.tabID, chatID: "chat-0"
+                ))
+                XCTAssertTrue(session.followUpOracleGroupState.members.isEmpty)
+
+                let branch = mode == .review ? "review" : "plan"
+                let raw: Value = .object([
+                    "response_type": .string(branch),
+                    branch: reply.toMCPValue()
+                ])
+                let dto = try XCTUnwrap(raw.decode(ToolResultDTOs.ContextBuilderDTO.self))
+                let summaries = contextBuilderOracleLaneSummaries(for: dto)
+                XCTAssertEqual(summaries.map(\.chatID), ["chat-0", "chat-1", "chat-2"])
+                XCTAssertEqual(summaries.map(\.status), [primaryStatus.rawValue, "done", "done"])
+                XCTAssertEqual(contextBuilderFollowUpChatID(for: dto), "chat-0")
+                let text = ToolOutputFormatter.formatDiscoverContext(value: raw).compactMap { block -> String? in
+                    guard case let .text(text, _, _) = block else { return nil }
+                    return text
+                }.joined(separator: "\n")
+                XCTAssertTrue(text.contains("primary stopped"), text)
+                XCTAssertTrue(text.contains("Error: is legitimate answer text"), text)
+                XCTAssertTrue(text.contains("third answer"), text)
+            }
+        }
+    }
+
+    @MainActor
+    func testSettledReplyBoundaryPreservesSuccessAndPartialFailure() throws {
+        for additionalStatus in [OracleLaneResultStatus.completed, .failed] {
+            let result = try groupResult(
+                status: additionalStatus == .completed ? .completed : .partialFailure,
+                lanes: [
+                    lane(index: 0, status: .completed, response: "primary answer"),
+                    lane(index: 1, status: additionalStatus,
+                         response: additionalStatus == .completed ? "second answer" : nil,
+                         error: additionalStatus == .failed ? laneError(message: "second failed") : nil)
+                ]
+            )
+            let (session, generation, _) = try preparedSession(for: result)
+            let reply = try session.completeOracleGroupReply(
+                ContextBuilderOracleGroupReply(result: result), generation: generation,
+                originWorkspaceID: UUID(), mode: .plan
+            )
+            XCTAssertEqual(reply.response, "primary answer")
+            XCTAssertEqual(reply.oracleGroup?.result, result)
+            XCTAssertNil(session.backgroundPlanError)
+            XCTAssertNil(session.failedAnswerRoute)
+            guard case .ready = session.planStatus else { return XCTFail("Expected ready") }
+        }
+    }
+
+    @MainActor
+    func testSettledReplyBoundaryRejectsStaleGenerationAndMismatchedMembershipBeforeMutation() throws {
+        let result = try groupResult(lanes: [
+            lane(index: 0, status: .completed, response: "primary"),
+            lane(index: 1, status: .completed, response: "secondary")
+        ])
+        let (session, generation, members) = try preparedSession(for: result)
+        let differentGroup = try groupResult(lanes: result.oracleResults)
+        XCTAssertThrowsError(try session.completeOracleGroupReply(
+            ContextBuilderOracleGroupReply(result: differentGroup), generation: generation,
+            originWorkspaceID: UUID(), mode: .review
+        ))
+        XCTAssertEqual(session.followUpOracleGroupState.members, members)
+        XCTAssertTrue(session.isBackgroundPlanGenerating)
+        XCTAssertNil(session.generatedAnswerRoute)
+
+        let wrongMember = try OracleLaneResult(
+            laneIndex: 1, chatID: "different-chat", providerID: "provider-1", modelID: "model-1",
+            status: .completed, response: "unrelated answer"
+        )
+        let mismatchedMembers = try groupResult(
+            groupID: result.groupID.rawValue, lanes: [result.primary, wrongMember]
+        )
+        XCTAssertThrowsError(try session.completeOracleGroupReply(
+            ContextBuilderOracleGroupReply(result: mismatchedMembers), generation: generation,
+            originWorkspaceID: UUID(), mode: .review
+        ))
+        XCTAssertEqual(session.followUpOracleGroupState.members, members)
+        XCTAssertNil(session.generatedAnswerRoute)
+
+        _ = session.followUpOracleGroupState.beginRun()
+        XCTAssertThrowsError(try session.completeOracleGroupReply(
+            ContextBuilderOracleGroupReply(result: result), generation: generation,
+            originWorkspaceID: UUID(), mode: .review
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertTrue(session.isBackgroundPlanGenerating)
+        XCTAssertNil(session.generatedAnswerRoute)
+    }
+
+    @MainActor
+    func testSettledReplyBoundaryHonorsTaskCancellation() async throws {
+        let result = try groupResult(lanes: [
+            lane(index: 0, status: .completed, response: "primary"),
+            lane(index: 1, status: .completed, response: "secondary")
+        ])
+        let (session, generation, members) = try preparedSession(for: result)
+        let task = Task { @MainActor in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try session.completeOracleGroupReply(
+                ContextBuilderOracleGroupReply(result: result), generation: generation,
+                originWorkspaceID: UUID(), mode: .review
+            )
+        }
+        do {
+            _ = try await task.value
+            XCTFail("Cancelled work must not publish a reply")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(session.followUpOracleGroupState.members, members)
+        XCTAssertTrue(session.isBackgroundPlanGenerating)
+        XCTAssertNil(session.generatedAnswerRoute)
+    }
+
+    @MainActor
+    private func preparedSession(for result: OracleGroupResult) throws -> (
+        ContextBuilderAgentViewModel.TabSession, UInt64, [ContextBuilderOracleMemberHandle]
+    ) {
+        let session = ContextBuilderAgentViewModel.TabSession(tabID: UUID())
+        session.isBackgroundPlanGenerating = true
+        let generation = session.followUpOracleGroupState.beginRun()
+        let members = try result.oracleResults.map {
+            ContextBuilderOracleMemberHandle(
+                laneID: try OracleLaneID(index: $0.laneIndex), sessionID: UUID(), chatID: $0.chatID
+            )
+        }
+        XCTAssertTrue(session.followUpOracleGroupState.bind(
+            groupID: result.groupID, turnID: OracleTurnID(), members: members, generation: generation
+        ))
+        return (session, generation, members)
     }
 
     private func groupResult(


### PR DESCRIPTION
Context Builder currently throws away an already-settled Oracle group reply when the primary lane fails, hiding successful secondary results from the structured reply. The Oracles badge also counts from current configuration and the newest tab session while the popover can present a different owner-filtered, streaming, or explicitly selected session.

This follow-up to #884:
- Delivers every ordered settled lane result with the original primary identity, canonical group status, and errors; a failed primary has no promoted secondary response.
- Keeps primary failure visible and makes View in Chat available independently of successful-plan actions.
- Counts from the presented session's stored roster and retains selectors for actual group projections only.
- Uses the existing canonical group-read payload for lane statuses and empty-transcript errors, preserving cancelled and unavailable outcomes instead of inferring status from answer text.
- Adds focused regression tests at the production reply/state boundary and for badge selection, lane ordering, cancellation, stale generations, and membership mismatches.

Runtime settlement, persistence, ownership, provider retries, and model configuration are unchanged. Strict completion-policy forwarding remains outside this patch.

Validation:
- Patch applicability against upstream main at b7550313ee38fd25e4af59d8428e9666e643c516 and staged whitespace checks passed.
- Source snapshot blob hashes and applied-file byte comparisons were verified.
- Commit preflight was attempted but blocked by missing Gitleaks. Installation failed because the binary download's network approval was cancelled.
- Repository guardrails were attempted but blocked by unavailable Swift and xcrun.
- XCTest, SwiftFormat/SwiftLint, product build, live CE verification, and push preflight have not passed in this Linux environment. The requester explicitly directed publication after these blockers were disclosed.

Keep this PR in draft until macOS validation is complete:
- [ ] make dev-format and make dev-lint
- [ ] Focused ContextBuilderOracleResultTests and AgentOraclePillRoutingTests
- [ ] Existing ContextBuilderOracleGroupStateTests and OracleLaneMarkdownFormatterTests
- [ ] RepoPrompt product build and contribution preflights
- [ ] App-backed Context Builder primary-failure verification: all ordered replies/chat IDs and durable records retained, visible failure navigation, matching badge/roster, and no invented lanes

The regression tests are authored but unrun; this PR does not claim that live integration is fixed.