### PR TITLE
Fix Sparkle startup update isolation

### DIFF
--- a/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
+++ b/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
@@ -40,16 +40,17 @@ enum SparkleUpdaterStartDecision: Equatable {
 #endif
 
 /// Class to monitor updates and provide UI notifications
+@MainActor
 final class SparkleUpdaterManager: ObservableObject {
     /// Singleton instance - set by AppDelegate on launch
     static var shared: SparkleUpdaterManager!
-    private static let stableFeedURL = SecurityObfuscation.decode(SecurityObfuscation.stableFeedURLEncoded)
-    private static let tipFeedURL = SecurityObfuscation.decode(SecurityObfuscation.tipFeedURLEncoded)
-    private static let expectedPublicEdKey = SecurityObfuscation.decode(SecurityObfuscation.expectedPublicEdKeyEncoded)
-    static let stableRecoveryDownloadsURL = URL(
+    private nonisolated static let stableFeedURL = SecurityObfuscation.decode(SecurityObfuscation.stableFeedURLEncoded)
+    private nonisolated static let tipFeedURL = SecurityObfuscation.decode(SecurityObfuscation.tipFeedURLEncoded)
+    private nonisolated static let expectedPublicEdKey = SecurityObfuscation.decode(SecurityObfuscation.expectedPublicEdKeyEncoded)
+    nonisolated static let stableRecoveryDownloadsURL = URL(
         string: "https://github.com/repoprompt/repoprompt-ce-updates/releases"
     )
-    static let recoveryDownloadsCaveat =
+    nonisolated static let recoveryDownloadsCaveat =
         "Opening this page only provides recovery downloads; it does not verify that manually installing or downgrading a build is safe for this Mac."
 
     private struct CanonicalURL: Hashable {
@@ -73,7 +74,7 @@ final class SparkleUpdaterManager: ObservableObject {
         let downloadURL: URL?
     }
 
-    private static func canonicalizeFeedURL(_ raw: String) -> CanonicalURL? {
+    private nonisolated static func canonicalizeFeedURL(_ raw: String) -> CanonicalURL? {
         guard let url = URL(string: raw.trimmingCharacters(in: .whitespacesAndNewlines)) else { return nil }
         guard let scheme = url.scheme?.lowercased(),
               let host = url.host?.lowercased() else { return nil }
@@ -88,7 +89,7 @@ final class SparkleUpdaterManager: ObservableObject {
         return CanonicalURL(scheme: scheme, host: host, port: port, path: path)
     }
 
-    private static var acceptedConfigurations: [AcceptedSparkleConfiguration] {
+    private nonisolated static var acceptedConfigurations: [AcceptedSparkleConfiguration] {
         [stableFeedURL, tipFeedURL].compactMap { rawFeed in
             guard let canonical = canonicalizeFeedURL(rawFeed) else { return nil }
             return AcceptedSparkleConfiguration(feed: canonical, publicEdKey: expectedPublicEdKey)
@@ -119,13 +120,13 @@ final class SparkleUpdaterManager: ObservableObject {
     private let httpClient: HTTPClient = DefaultHTTPClient.uiCriticalClient
 
     /// How often to check for updates (12 hours in seconds)
-    private static let updateCheckInterval: TimeInterval = 12 * 60 * 60
+    private nonisolated static let updateCheckInterval: TimeInterval = 12 * 60 * 60
 
     /// UserDefaults key for last passive appcast check timestamp
-    private static let lastCheckKey = "SparkleLastUpdateCheck"
+    private nonisolated static let lastCheckKey = "SparkleLastUpdateCheck"
 
     /// UserDefaults key for RepoPrompt's passive appcast-check preference.
-    private static let passiveAppcastChecksKey = "RepoPromptPassiveAppcastChecksEnabled"
+    private nonisolated static let passiveAppcastChecksKey = "RepoPromptPassiveAppcastChecksEnabled"
 
     /// Expose updater for settings UI
     var updater: SPUUpdater {
@@ -207,14 +208,14 @@ final class SparkleUpdaterManager: ObservableObject {
         )
     }
 
-    static func recoveryDownloadsURL(
+    nonisolated static func recoveryDownloadsURL(
         identityMigrationBlockedMessage: String?
     ) -> URL? {
         guard identityMigrationBlockedMessage != nil else { return nil }
         return stableRecoveryDownloadsURL
     }
 
-    static func updateCheckMenuTitle(
+    nonisolated static func updateCheckMenuTitle(
         checkState: SparkleAppcastCheckState
     ) -> String {
         switch checkState {
@@ -229,14 +230,14 @@ final class SparkleUpdaterManager: ObservableObject {
         }
     }
 
-    static func checkStateAfterCancellation(
+    nonisolated static func checkStateAfterCancellation(
         currentState: SparkleAppcastCheckState,
         hadActiveRequest: Bool
     ) -> SparkleAppcastCheckState {
         hadActiveRequest ? .notChecked : currentState
     }
 
-    static func manualDownloadURL(
+    nonisolated static func manualDownloadURL(
         for notice: AvailableUpdateNotice?,
         identityMigrationBlockedMessage: String?
     ) -> URL? {
@@ -247,7 +248,7 @@ final class SparkleUpdaterManager: ObservableObject {
         return notice.downloadURL
     }
 
-    static func updateStatusText(
+    nonisolated static func updateStatusText(
         availableUpdate: AvailableUpdateNotice?,
         checkState: SparkleAppcastCheckState
     ) -> String {
@@ -332,7 +333,7 @@ final class SparkleUpdaterManager: ObservableObject {
         setupPeriodicUpdateCheck()
     }
 
-    static func startDecision(
+    nonisolated static func startDecision(
         sparkleConfigurationValid: Bool,
         discoveryEnabled: Bool,
         identityMigrationBlockedMessage: String?
@@ -341,7 +342,7 @@ final class SparkleUpdaterManager: ObservableObject {
         return identityMigrationBlockedMessage == nil ? .start : .discoveryOnly
     }
 
-    static func userInitiatedUpdateAction(
+    nonisolated static func userInitiatedUpdateAction(
         discoveryEnabled: Bool,
         sparkleConfigurationValid: Bool,
         identityMigrationBlockedMessage: String?
@@ -405,7 +406,7 @@ final class SparkleUpdaterManager: ObservableObject {
     }
 
     @discardableResult
-    static func performPassiveAppcastCheck(
+    nonisolated static func performPassiveAppcastCheck(
         check: () async -> Bool,
         now: Date = Date(),
         defaults: UserDefaults = .standard
@@ -426,9 +427,7 @@ final class SparkleUpdaterManager: ObservableObject {
         }
 
         invalidateActiveAppcastCheck()
-        await MainActor.run {
-            appcastCheckState = .checking
-        }
+        appcastCheckState = .checking
 
         let checkedChannel = updateChannel
         let requestIdentity = AppcastCheckRequestIdentity(channel: checkedChannel)
@@ -451,34 +450,32 @@ final class SparkleUpdaterManager: ObservableObject {
         appcastCheckTask = task
         let appcastInfo = await task.value
 
-        return await MainActor.run {
-            guard Self.appcastResultIsCurrent(
-                request: requestIdentity,
-                activeRequest: self.activeAppcastCheckRequest,
-                selectedChannel: self.updateChannel
-            ), self.userInitiatedObserverState.activeRequest == nil else {
-                sparkleUpdaterManagerDebugLog("Discarding stale appcast result for channel \(checkedChannel.rawValue)")
-                return false
-            }
-
-            defer {
-                self.activeAppcastCheckRequest = nil
-                self.appcastCheckTask = nil
-            }
-
-            guard !task.isCancelled else { return false }
-            self.apply(
-                appcastInfo: appcastInfo,
-                currentVersion: currentVersion,
-                currentBuildNumber: currentBuildNumber,
-                checkedChannel: checkedChannel
-            )
-            self.appcastCheckState = appcastInfo == nil ? .failed : .succeeded
-            return appcastInfo != nil
+        guard Self.appcastResultIsCurrent(
+            request: requestIdentity,
+            activeRequest: activeAppcastCheckRequest,
+            selectedChannel: updateChannel
+        ), userInitiatedObserverState.activeRequest == nil else {
+            sparkleUpdaterManagerDebugLog("Discarding stale appcast result for channel \(checkedChannel.rawValue)")
+            return false
         }
+
+        defer {
+            activeAppcastCheckRequest = nil
+            appcastCheckTask = nil
+        }
+
+        guard !task.isCancelled else { return false }
+        apply(
+            appcastInfo: appcastInfo,
+            currentVersion: currentVersion,
+            currentBuildNumber: currentBuildNumber,
+            checkedChannel: checkedChannel
+        )
+        appcastCheckState = appcastInfo == nil ? .failed : .succeeded
+        return appcastInfo != nil
     }
 
-    static func appcastResultIsCurrent(
+    nonisolated static func appcastResultIsCurrent(
         request: AppcastCheckRequestIdentity,
         activeRequest: AppcastCheckRequestIdentity?,
         selectedChannel: UpdateChannel
@@ -486,7 +483,7 @@ final class SparkleUpdaterManager: ObservableObject {
         request == activeRequest && request.channel == selectedChannel
     }
 
-    static func updateChannel(forAppcastItemURL url: URL?) -> UpdateChannel? {
+    nonisolated static func updateChannel(forAppcastItemURL url: URL?) -> UpdateChannel? {
         guard let url,
               url.scheme?.lowercased() == "https",
               url.host?.lowercased() == "github.com",
@@ -514,7 +511,7 @@ final class SparkleUpdaterManager: ObservableObject {
         }
     }
 
-    static func makePassiveAppcastRequest(feedURL: URL) -> URLRequest {
+    nonisolated static func makePassiveAppcastRequest(feedURL: URL) -> URLRequest {
         var request = URLRequest(url: feedURL)
         request.timeoutInterval = 15
         request.cachePolicy = .reloadIgnoringLocalCacheData
@@ -523,7 +520,7 @@ final class SparkleUpdaterManager: ObservableObject {
         return request
     }
 
-    static func testFetchAndParseAppcastVersion(feedURL: URL, httpClient: HTTPClient) async -> String? {
+    nonisolated static func testFetchAndParseAppcastVersion(feedURL: URL, httpClient: HTTPClient) async -> String? {
         let currentBuildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
         return await fetchAndParseAppcast(
             feedURL: feedURL,
@@ -532,7 +529,7 @@ final class SparkleUpdaterManager: ObservableObject {
         )?.latestVersion
     }
 
-    static func currentEligibilityContext(
+    nonisolated static func currentEligibilityContext(
         currentBuildNumber: String
     ) -> AppcastEligibilityContext {
         let osVersion = ProcessInfo.processInfo.operatingSystemVersion
@@ -546,7 +543,7 @@ final class SparkleUpdaterManager: ObservableObject {
         )
     }
 
-    private static func fetchAndParseAppcast(
+    private nonisolated static func fetchAndParseAppcast(
         feedURL: URL,
         httpClient: HTTPClient,
         context: AppcastEligibilityContext
@@ -706,7 +703,7 @@ final class SparkleUpdaterManager: ObservableObject {
             .store(in: &cancellables)
     }
 
-    static func sparkleResultIsNotOlderThanKnownUpdate(
+    nonisolated static func sparkleResultIsNotOlderThanKnownUpdate(
         candidateBuildNumber: String,
         knownBuildNumber: String?
     ) -> Bool {
@@ -717,7 +714,7 @@ final class SparkleUpdaterManager: ObservableObject {
         return candidateBuild >= knownBuild
     }
 
-    static func presentationVersion(
+    nonisolated static func presentationVersion(
         channel: UpdateChannel,
         displayVersion: String,
         title: String?
@@ -727,7 +724,7 @@ final class SparkleUpdaterManager: ObservableObject {
         return AvailableUpdateNotice.marketingVersion(fromTipTitle: title) ?? fallbackVersion
     }
 
-    static func sanitizeVersionString(_ version: String) -> String {
+    nonisolated static func sanitizeVersionString(_ version: String) -> String {
         var version = version.trimmingCharacters(in: .whitespacesAndNewlines)
         if version.lowercased().hasPrefix("tip build") {
             version.removeFirst("tip build".count)
@@ -944,28 +941,32 @@ final class SparkleUpdaterManager: ObservableObject {
 
 #if DEBUG
     extension SparkleUpdaterManager {
-        static var debugLastCheckKey: String {
+        static func debugMainActorIsolationProbe() -> Bool {
+            Thread.isMainThread
+        }
+
+        nonisolated static var debugLastCheckKey: String {
             lastCheckKey
         }
 
-        static var debugPassiveAppcastChecksKey: String {
+        nonisolated static var debugPassiveAppcastChecksKey: String {
             passiveAppcastChecksKey
         }
 
-        static var debugExpectedFeedURL: String {
+        nonisolated static var debugExpectedFeedURL: String {
             stableFeedURL
         }
 
-        static var debugTipFeedURL: String {
+        nonisolated static var debugTipFeedURL: String {
             tipFeedURL
         }
 
-        static func debugFeedURLMatchesExpected(_ raw: String) -> Bool {
+        nonisolated static func debugFeedURLMatchesExpected(_ raw: String) -> Bool {
             guard let canonical = canonicalizeFeedURL(raw) else { return false }
             return acceptedConfigurations.contains { $0.feed == canonical }
         }
 
-        static func debugIsVersion(_ lhs: String, newerThan rhs: String) -> Bool {
+        nonisolated static func debugIsVersion(_ lhs: String, newerThan rhs: String) -> Bool {
             SparkleVersionComparison.isVersion(lhs, newerThan: rhs)
         }
 

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugSparkleDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugSparkleDiagnostics.swift
@@ -216,7 +216,7 @@ import MCP
                 return debugDiagnosticsError(op: op, code: "invalid_params", message: "sparkle_trigger_passive_check requires allow_destructive=true because it writes the real SparkleLastUpdateCheck on success.")
             }
 
-            guard let manager = SparkleUpdaterManager.shared else {
+            guard let manager = await MainActor.run(body: { SparkleUpdaterManager.shared }) else {
                 return debugDiagnosticsError(op: op, code: "unavailable", message: "SparkleUpdaterManager.shared is not initialized.")
             }
 

--- a/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
+++ b/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
@@ -2,6 +2,17 @@
 import XCTest
 
 final class AppPlatformUtilityRecoveryTests: XCTestCase {
+    func testSparkleUpdaterManagerRunsOnMainActorFromDetachedCaller() async {
+        let (detachedCallerWasOnMainThread, managerRanOnMainThread) = await Task.detached {
+            let detachedCallerWasOnMainThread = Thread.isMainThread
+            let managerRanOnMainThread = await SparkleUpdaterManager.debugMainActorIsolationProbe()
+            return (detachedCallerWasOnMainThread, managerRanOnMainThread)
+        }.value
+
+        XCTAssertFalse(detachedCallerWasOnMainThread)
+        XCTAssertTrue(managerRanOnMainThread)
+    }
+
     func testSparkleUpdaterStartDecisionKeepsDiscoveryAvailableDuringIdentityMigrationBlock() {
         XCTAssertEqual(
             SparkleUpdaterManager.startDecision(


### PR DESCRIPTION
## Summary
- Isolate `SparkleUpdaterManager` and its mutable/UI-observable state to `MainActor`.
- Keep stateless helpers nonisolated and preserve detached appcast fetching/parsing.
- Route the DEBUG diagnostic singleton read through the main actor and add a focused actor-isolation regression test.

## Problem and cause
Two local CE debug startup crashes on macOS 26.6.2 reported SIGABRT on a cooperative worker. The stack passes through `performPassiveAppcastCheck` → `checkAppcastDirectly` → `invalidateActiveAppcastCheck` → `@Published appcastCheckState` → SwiftUI/AppKit menu updates. On the base commit, invalidation occurs before the method's narrow `MainActor.run`, allowing a UI-observable mutation off-main.

The manager is constructed by the main-actor AppDelegate and owns Sparkle/AppKit objects, published state, request generation, and cancellation. Expressing that ownership at the type boundary protects the complete operation instead of just individual assignments. Detached network/parsing work, update policy, timer cadence, cancellation, and stale-result checks are retained.

## Validation
- `make dev-test FILTER='RepoPromptTests.AppPlatformUtilityRecoveryTests'`: 22 passed.
- Final focused actor regression: 1 passed (no sleeps, retries, network, or app launch).
- `make dev-format`: passed; final run required no changes.
- `make dev-lint`: passed.
- `make dev-swift-build PRODUCT=RepoPrompt`: passed.
- Commit and push safety preflight: passed.

The unit test verifies inherited manager actor isolation from a detached caller; it is not an end-to-end startup reproduction. The full local root suite/PR-ready lane remains unrun.

### Live debug verification — passed
Built and launched this exact head on macOS 26.6.2 using conductor (ticket `84c96a9e-8d78-4e51-957d-3c8dbc4e8b11`, exit 0). Confirmed the built, installed, and running debug executable share the same Mach-O UUID.

After choosing **Reopen** in macOS's prior-crash window-restoration dialog (without resetting saved state), normal startup enabled the updater and completed its passive appcast check: `checking` → `succeeded`, update state published, task cleared. An additional real `sparkle_trigger_passive_check` through `rpce-cli-debug` returned `ok=true`, `succeeded=true`, and `appcast_task_present=false`; it advanced the normal successful-check timestamp. Follow-up MCP status/windows queries succeeded, the same process remained alive, and no new RepoPrompt crash report appeared during the observation.

This confirms the previously crashing startup/passive-check path on this debug build, not update installation or long-duration/release behavior. No update was installed or model request submitted.

## Scope
Based directly on main `f3909b782342ef1268823c330f7039f8f418f79c`. Contains only this three-file crash fix; no prompt-evaluation/GEPA workbench changes.
