### PR TITLE
feat: add Oracle images and OMP/Devin ACP providers

### DIFF
--- a/Sources/RepoPrompt/App/AppTerminationSignalRouter.swift
+++ b/Sources/RepoPrompt/App/AppTerminationSignalRouter.swift
@@ -13,7 +13,7 @@ protocol TerminationSignalObserving: AnyObject {
     func observe(_ signal: Int32, handler: @escaping () -> Void)
 }
 
-/// Bridges POSIX signals onto the main queue where AppKit lifecycle work is serialized.
+/// Delivers signals through a main run-loop callout.
 final class DispatchTerminationSignalObserver: TerminationSignalObserving {
     /// Dispatch sources only remain active while retained, so the observer owns them for its
     /// lifetime rather than relying on the caller to preserve an implementation detail.
@@ -25,7 +25,9 @@ final class DispatchTerminationSignalObserver: TerminationSignalObserving {
 
     func observe(_ signal: Int32, handler: @escaping () -> Void) {
         let source = DispatchSource.makeSignalSource(signal: signal, queue: .main)
-        source.setEventHandler(handler: handler)
+        source.setEventHandler {
+            RunLoop.main.perform(inModes: [.common], block: handler)
+        }
         sources[signal] = source
         source.activate()
     }

--- a/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
+++ b/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
@@ -41,4 +41,13 @@ extension Notification.Name {
     /// Posted when Grok Build CLI connection status changes
     /// userInfo mirrors `claudeCodeConnectionChanged`
     static let grokBuildConnectionChanged = Notification.Name("grokBuildConnectionChanged")
+    /// Posted when Oh My Pi CLI connection status changes
+    /// userInfo mirrors `claudeCodeConnectionChanged`
+    static let ompConnectionChanged = Notification.Name("ompConnectionChanged")
+    /// Posted when Devin CLI connection status changes
+    /// userInfo mirrors `claudeCodeConnectionChanged`
+    static let devinConnectionChanged = Notification.Name("devinConnectionChanged")
+    /// Posted when ACP model discovery changes for one provider (`userInfo["providerID"]`),
+    /// or with no userInfo when the persisted catalogs finish warming.
+    static let acpDiscoveredModelsChanged = Notification.Name("acpDiscoveredModelsChanged")
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentACPModelRegistry.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentACPModelRegistry.swift
@@ -2,6 +2,7 @@ import Foundation
 
 final class AgentACPModelRegistry {
     static let shared = AgentACPModelRegistry()
+    static let providerIDUserInfoKey = "providerID"
 
     private let lock = NSLock()
     private var liveSnapshotsByProvider: [ACPProviderID: ACPDiscoveredSessionModels] = [:]
@@ -38,6 +39,11 @@ final class AgentACPModelRegistry {
 
         guard didChange else { return false }
         ACPDynamicModelStore.save(normalizedSnapshot, for: providerID)
+        NotificationCenter.default.post(
+            name: .acpDiscoveredModelsChanged,
+            object: nil,
+            userInfo: [Self.providerIDUserInfoKey: providerID.rawValue]
+        )
         return true
     }
 
@@ -74,12 +80,18 @@ final class AgentACPModelRegistry {
         guard let plan else { return }
         let loadedSnapshots = await plan.task.value
 
-        lock.withLock {
-            guard plan.generation == standardStoreWarmGeneration else { return }
+        let didApply: Bool = lock.withLock {
+            guard plan.generation == standardStoreWarmGeneration, !didWarmStandardStore else {
+                return false
+            }
             persistedSnapshotsByProvider = loadedSnapshots
             didWarmStandardStore = true
             standardStoreWarmTask = nil
+            return true
         }
+        // No provider ID: warming can publish catalogs for every persisted provider at once.
+        guard didApply else { return }
+        NotificationCenter.default.post(name: .acpDiscoveredModelsChanged, object: nil)
     }
 
     private struct StandardStoreWarmPlan {

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -304,7 +304,7 @@ enum AgentModel: String, CaseIterable, Codable {
             ]
         case .openCode:
             [.defaultModel]
-        case .grokBuild:
+        case .grokBuild, .omp, .devin:
             [.defaultModel]
         case .antigravity:
             []

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -8,6 +8,8 @@ enum AgentModelCatalog {
         let cursorAvailable: Bool
         let grokBuildAvailable: Bool
         let antigravityAvailable: Bool
+        let ompAvailable: Bool
+        let devinAvailable: Bool
         let zaiConfigured: Bool
         let kimiConfigured: Bool
         let customClaudeCompatibleConfigured: Bool
@@ -19,6 +21,8 @@ enum AgentModelCatalog {
             cursorAvailable: false,
             grokBuildAvailable: false,
             antigravityAvailable: false,
+            ompAvailable: false,
+            devinAvailable: false,
             zaiConfigured: false,
             kimiConfigured: false,
             customClaudeCompatibleConfigured: false
@@ -32,6 +36,8 @@ enum AgentModelCatalog {
                 cursorAvailable: cursorAvailable && providers.contains(.cursor),
                 grokBuildAvailable: grokBuildAvailable && providers.contains(.grokBuild),
                 antigravityAvailable: antigravityAvailable,
+                ompAvailable: false,
+                devinAvailable: false,
                 zaiConfigured: zaiConfigured && providers.contains(.claudeCode),
                 kimiConfigured: kimiConfigured && providers.contains(.claudeCode),
                 customClaudeCompatibleConfigured: customClaudeCompatibleConfigured && providers.contains(.claudeCode)
@@ -47,6 +53,8 @@ enum AgentModelCatalog {
                 cursorAvailable: false,
                 grokBuildAvailable: false,
                 antigravityAvailable: AntigravityRuntimeManager.installedRuntimeSync() != nil,
+                ompAvailable: false,
+                devinAvailable: false,
                 zaiConfigured: backendIsAvailable(.glmZAI, store: store),
                 kimiConfigured: backendIsAvailable(.kimi, store: store),
                 customClaudeCompatibleConfigured: backendIsAvailable(.custom, store: store)
@@ -60,6 +68,8 @@ enum AgentModelCatalog {
             cursorAvailable: Bool = false,
             grokBuildAvailable: Bool = false,
             antigravityAvailable: Bool = false,
+            ompAvailable: Bool = false,
+            devinAvailable: Bool = false,
             zaiConfigured: Bool = false,
             kimiConfigured: Bool = false,
             customClaudeCompatibleConfigured: Bool = false
@@ -70,6 +80,8 @@ enum AgentModelCatalog {
             self.cursorAvailable = cursorAvailable
             self.grokBuildAvailable = grokBuildAvailable
             self.antigravityAvailable = antigravityAvailable
+            self.ompAvailable = ompAvailable
+            self.devinAvailable = devinAvailable
             self.zaiConfigured = zaiConfigured
             self.kimiConfigured = kimiConfigured
             self.customClaudeCompatibleConfigured = customClaudeCompatibleConfigured
@@ -94,6 +106,8 @@ enum AgentModelCatalog {
                 cursorAvailable: cursorAvailable || agentKind == .cursor,
                 grokBuildAvailable: grokBuildAvailable || agentKind == .grokBuild,
                 antigravityAvailable: antigravityAvailable || agentKind == .antigravity,
+                ompAvailable: ompAvailable || agentKind == .omp,
+                devinAvailable: devinAvailable || agentKind == .devin,
                 zaiConfigured: zaiConfigured || agentKind == .claudeCodeGLM,
                 kimiConfigured: kimiConfigured || agentKind == .kimiCode,
                 customClaudeCompatibleConfigured: customClaudeCompatibleConfigured || agentKind == .customClaudeCompatible
@@ -201,14 +215,16 @@ enum AgentModelCatalog {
         .openCode,
         .cursor,
         .grokBuild,
-        .antigravity
+        .antigravity,
+        .omp,
+        .devin
     ]
 
     static func selectableAgents(
         availability: AvailabilityContext = .current,
         surface: AgentSelectionSurface = .general
     ) -> [AgentProviderKind] {
-        [.codexExec, .claudeCode, .openCode, .cursor, .grokBuild, .antigravity, .claudeCodeGLM, .kimiCode, .customClaudeCompatible]
+        [.codexExec, .claudeCode, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin, .claudeCodeGLM, .kimiCode, .customClaudeCompatible]
             .filter { surface.allows($0) && isAgentAvailable($0, availability: availability) }
     }
 
@@ -242,6 +258,10 @@ enum AgentModelCatalog {
             availability.grokBuildAvailable
         case .antigravity:
             availability.antigravityAvailable
+        case .omp:
+            availability.ompAvailable
+        case .devin:
+            availability.devinAvailable
         }
     }
 
@@ -254,8 +274,9 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return AgentModel.cursorAuto.rawValue
         }
-        if agentKind == .grokBuild {
-            // Grok's default follows its own configuration.
+        if agentKind == .grokBuild || agentKind == .omp || agentKind == .devin {
+            // Provider-managed defaults must never become a discovered session's current
+            // model: "default" sends no mutation and follows the provider configuration.
             return AgentModel.defaultModel.rawValue
         }
         if agentKind == .antigravity {
@@ -272,7 +293,7 @@ enum AgentModelCatalog {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             return ClaudeCompatibleModelCatalogAdapter.defaultModelRaw(for: agentKind, availability: availability)
                 ?? AgentModel.defaultModel.rawValue
-        case .codexExec, .openCode, .grokBuild:
+        case .codexExec, .openCode, .grokBuild, .omp, .devin:
             return AgentModel.defaultModel.rawValue
         case .antigravity:
             return ""
@@ -355,8 +376,8 @@ enum AgentModelCatalog {
         if agentKind == .antigravity {
             return resolvedACPDiscoveredModels(for: .antigravity)?.options ?? []
         }
-        if agentKind == .grokBuild {
-            let fallback = staticOption(.defaultModel, for: .grokBuild)
+        if agentKind == .grokBuild || agentKind == .omp || agentKind == .devin {
+            let fallback = staticOption(.defaultModel, for: agentKind)
             guard let discoveredOptions = resolvedACPDiscoveredModels(for: agentKind)?.options,
                   !discoveredOptions.isEmpty
             else {
@@ -385,7 +406,7 @@ enum AgentModelCatalog {
                 availability: availability,
                 includeClaudeEffortVariants: includeClaudeEffortVariants
             ) ?? []
-        case .openCode, .cursor, .grokBuild:
+        case .openCode, .cursor, .grokBuild, .omp, .devin:
             return AgentModel.modelsForAgent(agentKind)
                 .filter { isAvailable($0, for: agentKind, availability: availability) }
                 .map { staticOption($0, for: agentKind) }
@@ -407,7 +428,7 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return CursorAIModelCatalog.contains(modelRaw: normalized)
         }
-        if agentKind == .grokBuild,
+        if agentKind == .grokBuild || agentKind == .omp || agentKind == .devin,
            normalized.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame
         {
             return true
@@ -517,6 +538,63 @@ enum AgentModelCatalog {
         }
 
         return baseDisplayName(for: effectiveRaw)
+    }
+
+    /// A `nil` grouping label renders inline instead of as a submenu, so the provider-managed
+    /// "default" option and any ungrouped model never produce a blank submenu row.
+    struct OMPProviderModelGroup: Identifiable {
+        let providerID: String?
+        let options: [AgentModelOption]
+
+        var id: String {
+            providerID ?? ""
+        }
+    }
+
+    /// OMP's ACP advertisement already applies its own authentication and enabled-model
+    /// filters, so this groups that exact set by the `provider/model` prefix OMP publishes.
+    /// It never synthesizes models or reads opaque suffixes as reasoning variants.
+    static func ompModelGroups(for options: [AgentModelOption]) -> [OMPProviderModelGroup] {
+        let grouped = Dictionary(grouping: options) { option -> String in
+            guard !option.isPlaceholderDefault,
+                  let slash = option.rawValue.firstIndex(of: "/"),
+                  slash != option.rawValue.startIndex,
+                  option.rawValue.index(after: slash) != option.rawValue.endIndex
+            else {
+                return ""
+            }
+            return String(option.rawValue[..<slash])
+        }
+        return grouped.keys.sorted().map { provider in
+            OMPProviderModelGroup(
+                providerID: provider.isEmpty ? nil : provider,
+                options: grouped[provider] ?? []
+            )
+        }
+    }
+
+    struct DevinModelFamilyGroup: Identifiable {
+        let family: AgentModelFamily?
+        let options: [AgentModelOption]
+
+        var id: String {
+            family?.id ?? ""
+        }
+    }
+
+    /// Devin's family metadata is advisory: a model with no family (or the placeholder
+    /// default) groups inline rather than under an empty label.
+    static func devinModelGroups(for options: [AgentModelOption]) -> [DevinModelFamilyGroup] {
+        let grouped = Dictionary(grouping: options) { option in
+            option.isPlaceholderDefault ? "" : (option.modelFamily?.id ?? "")
+        }
+        return grouped.keys.sorted().map { id in
+            let groupOptions = grouped[id] ?? []
+            return DevinModelFamilyGroup(
+                family: id.isEmpty ? nil : groupOptions.first?.modelFamily,
+                options: groupOptions
+            )
+        }
     }
 
     static func openCodeMenu(for options: [AgentModelOption]) -> OpenCodeMenu {
@@ -1406,7 +1484,7 @@ enum AgentModelCatalog {
             .kimi
         case .customClaudeCompatible:
             .custom
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }
@@ -1609,7 +1687,7 @@ enum AgentModelCatalog {
             availability.kimiConfigured
         case .customClaudeCompatible:
             availability.customClaudeCompatibleConfigured
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             true
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelOption.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelOption.swift
@@ -8,6 +8,13 @@ struct AgentModelEffortVariant: Hashable, Codable {
     let reasoningEffort: CodexReasoningEffort
 }
 
+/// Native grouping a provider advertises for a model (Devin's account catalog families).
+/// Presentation only: it never adds or removes a selectable model.
+struct AgentModelFamily: Hashable, Codable {
+    let id: String
+    let displayName: String
+}
+
 struct AgentModelOption: Identifiable, Hashable {
     let rawValue: String
     let displayName: String
@@ -17,6 +24,7 @@ struct AgentModelOption: Identifiable, Hashable {
     let supportedReasoningEfforts: [CodexReasoningEffort]
     let defaultReasoningEffort: CodexReasoningEffort?
     let effortVariant: AgentModelEffortVariant?
+    let modelFamily: AgentModelFamily?
 
     init(
         rawValue: String,
@@ -26,7 +34,8 @@ struct AgentModelOption: Identifiable, Hashable {
         isProviderDefault: Bool,
         supportedReasoningEfforts: [CodexReasoningEffort] = [],
         defaultReasoningEffort: CodexReasoningEffort? = nil,
-        effortVariant: AgentModelEffortVariant? = nil
+        effortVariant: AgentModelEffortVariant? = nil,
+        modelFamily: AgentModelFamily? = nil
     ) {
         self.rawValue = rawValue
         self.displayName = displayName
@@ -36,6 +45,7 @@ struct AgentModelOption: Identifiable, Hashable {
         self.supportedReasoningEfforts = supportedReasoningEfforts
         self.defaultReasoningEffort = defaultReasoningEffort
         self.effortVariant = effortVariant
+        self.modelFamily = modelFamily
     }
 
     init(
@@ -45,7 +55,8 @@ struct AgentModelOption: Identifiable, Hashable {
         isDefault: Bool,
         supportedReasoningEfforts: [CodexReasoningEffort] = [],
         defaultReasoningEffort: CodexReasoningEffort? = nil,
-        effortVariant: AgentModelEffortVariant? = nil
+        effortVariant: AgentModelEffortVariant? = nil,
+        modelFamily: AgentModelFamily? = nil
     ) {
         let isPlaceholder =
             rawValue.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame
@@ -57,6 +68,7 @@ struct AgentModelOption: Identifiable, Hashable {
         self.supportedReasoningEfforts = supportedReasoningEfforts
         self.defaultReasoningEffort = defaultReasoningEffort
         self.effortVariant = effortVariant
+        self.modelFamily = modelFamily
     }
 
     var isDefault: Bool {

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
@@ -5,6 +5,8 @@ enum ACPProviderID: String, Codable, Hashable {
     case cursor
     case grokBuild
     case antigravity
+    case omp
+    case devin
 }
 
 enum ACPSupportResult: Equatable {
@@ -300,6 +302,9 @@ protocol ACPAgentProvider: Sendable {
     ) -> [NormalizedAgentRuntimeEvent]
     func preferredAuthMethodID(context: ACPAuthenticationContext) -> String?
     func cleanupLaunchArtifacts(for configuration: ACPLaunchConfiguration) async
+    /// Advisory native grouping for a model the session advertised. Never a source of
+    /// selectable models: the controller annotates only IDs the runtime already listed.
+    func modelFamily(for rawModel: String) -> AgentModelFamily?
     func normalizeError(_ error: Error) -> Error
 
     /// Opts a provider into ACP's parameterized model picker capability and classifies
@@ -319,6 +324,10 @@ extension ACPAgentProvider {
     }
 
     func modelParameterKind(for _: ACPModelParameterClassificationInput) -> ACPModelParameterKind? {
+        nil
+    }
+
+    func modelFamily(for _: String) -> AgentModelFamily? {
         nil
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -362,7 +362,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
             .kimi
         case .customClaudeCompatible:
             .custom
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatiblePluginBridge.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatiblePluginBridge.swift
@@ -18,7 +18,7 @@ enum ClaudeCompatiblePluginBridge {
             .kimiClaudeCode
         case .customClaudeCompatible:
             .customClaudeCompatible
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }
@@ -208,7 +208,7 @@ enum ClaudeCompatiblePluginBridge {
             "Claude Code is unavailable."
         case .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             "Claude-compatible backend is not configured."
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             "Not a Claude-compatible provider."
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
@@ -388,7 +388,7 @@ final class AutoRecommendationEngine {
                 enabledRecommendationProviders.contains(.grokBuild)
             case .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
                 true
-            case .antigravity:
+            case .antigravity, .omp, .devin:
                 false
             }
         }) else {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSkillCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSkillCatalog.swift
@@ -423,7 +423,7 @@ final class AgentSkillCatalog {
                 precedenceRank: 7
             )
 
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             // Codex, OpenCode, and Cursor continue to share only the generic `.agents` namespace.
             appendWorkspaceRoots(
                 relativeRoot: ".agents/skills",

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
@@ -239,6 +239,10 @@ final class AgentModeProviderBindingService {
                         updateActiveBindings(session)
                     }
                 }
+            case .omp, .devin:
+                // Devin owns its internal tool permissions; RepoPrompt exposes no mutable
+                // provider preference to push into a live session.
+                break
             case .grokBuild:
                 // Grok full access is a launch-time `--always-approve` flag; it applies to
                 // newly launched processes and never mutates a running controller. The next

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingID.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingID.swift
@@ -7,6 +7,8 @@ enum AgentProviderBindingID: String, CaseIterable, Hashable {
     case cursor
     case grokBuild
     case antigravity
+    case omp
+    case devin
 
     var displayName: String {
         switch self {
@@ -22,6 +24,10 @@ enum AgentProviderBindingID: String, CaseIterable, Hashable {
             "Grok Build"
         case .antigravity:
             "Google Antigravity"
+        case .omp:
+            "Oh My Pi"
+        case .devin:
+            "Devin"
         }
     }
 }
@@ -41,6 +47,10 @@ extension AgentProviderKind {
             .grokBuild
         case .antigravity:
             .antigravity
+        case .omp:
+            .omp
+        case .devin:
+            .devin
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
@@ -20,6 +20,14 @@ enum AgentProviderPermissionLevelID: Hashable {
     case antigravity(AntigravityAgentToolPreferences.PermissionLevel)
     case cursor(CursorAgentToolPreferences.PermissionLevel)
     case grokBuild(GrokBuildAgentToolPreferences.PermissionLevel)
+    case omp
+    /// Devin owns its internal tool permissions end-to-end, so it advertises exactly one
+    /// immutable level rather than a stored RepoPrompt preference.
+    case devin
+
+    /// Persisted raw value for `.devin`; the only value that round-trips.
+    static let devinProviderManagedRawValue = "providerManaged"
+    static let ompProviderManagedRawValue = "providerManaged"
 
     var providerID: AgentProviderBindingID {
         switch self {
@@ -35,6 +43,10 @@ enum AgentProviderPermissionLevelID: Hashable {
             .cursor
         case .grokBuild:
             .grokBuild
+        case .omp:
+            .omp
+        case .devin:
+            .devin
         }
     }
 
@@ -52,6 +64,10 @@ enum AgentProviderPermissionLevelID: Hashable {
             .cursor(.managedDefault)
         case .grokBuild:
             .grokBuild(.managedDefault)
+        case .omp:
+            .omp
+        case .devin:
+            .devin
         }
     }
 
@@ -69,6 +85,10 @@ enum AgentProviderPermissionLevelID: Hashable {
             CursorAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.cursor)
         case .grokBuild:
             GrokBuildAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.grokBuild)
+        case .omp:
+            [.omp]
+        case .devin:
+            [.devin]
         }
     }
 
@@ -93,6 +113,12 @@ enum AgentProviderPermissionLevelID: Hashable {
         case .grokBuild:
             guard let level = GrokBuildAgentToolPreferences.PermissionLevel(rawValue: raw) else { return nil }
             self = .grokBuild(level)
+        case .omp:
+            guard raw == Self.ompProviderManagedRawValue else { return nil }
+            self = .omp
+        case .devin:
+            guard raw == Self.devinProviderManagedRawValue else { return nil }
+            self = .devin
         }
     }
 
@@ -110,6 +136,10 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.rawValue
         case let .grokBuild(level):
             level.rawValue
+        case .omp:
+            Self.ompProviderManagedRawValue
+        case .devin:
+            Self.devinProviderManagedRawValue
         }
     }
 
@@ -127,6 +157,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.displayName
         case let .grokBuild(level):
             level.displayName
+        case .omp, .devin:
+            "Provider Managed"
         }
     }
 
@@ -144,6 +176,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.iconName
         case let .grokBuild(level):
             level.iconName
+        case .omp, .devin:
+            "shield"
         }
     }
 
@@ -161,6 +195,10 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.detailText
         case let .grokBuild(level):
             level.detailText
+        case .omp:
+            "OMP controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools."
+        case .devin:
+            "Devin controls its internal tools. RepoPrompt policy applies only to RepoPrompt MCP tools."
         }
     }
 
@@ -178,6 +216,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.isWarning
         case let .grokBuild(level):
             level.isWarning
+        case .omp, .devin:
+            false
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
@@ -159,7 +159,8 @@ extension AgentProviderPermissionProfile {
         switch agent {
         case .openCode:
             openCodeSessionModeID
-        case .cursor, .grokBuild, .antigravity:
+        // Devin advertises session modes live per session; RepoPrompt never requests one.
+        case .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .codexExec:
             nil

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
@@ -154,6 +154,10 @@ final class AgentProviderPreferenceSnapshotStore {
                 autoApproveAllACPToolPermissions: level.launchesWithAlwaysApprove,
                 acceptsPendingACPApprovalWhenActivated: level.launchesWithAlwaysApprove
             )
+        case .omp, .devin:
+            // Devin owns its internal tool permissions; RepoPrompt requests no session mode
+            // and never auto-approves its ACP permission options.
+            return AgentProviderRuntimePermissionBinding()
         }
     }
 
@@ -172,6 +176,9 @@ final class AgentProviderPreferenceSnapshotStore {
             CursorAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .grokBuild(level):
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
+        case .omp, .devin:
+            // Devin exposes no mutable RepoPrompt-side permission preference.
+            break
         }
         bumpRevision(for: id.providerID)
         return id.providerID
@@ -437,6 +444,26 @@ final class AgentProviderPreferenceSnapshotStore {
                     )
                 }
             )
+        case .omp, .devin:
+            let level = AgentProviderPermissionLevelID.subagentDefault(for: providerID)
+            return AgentPermissionChromeBinding(
+                providerID: providerID,
+                displayName: level.displayName,
+                iconName: level.iconName,
+                isWarning: false,
+                externallyManagedReason: externallyManagedReason,
+                options: [
+                    AgentPermissionOptionBinding(
+                        id: level,
+                        title: level.displayName,
+                        iconName: level.iconName,
+                        detailText: level.detailText,
+                        isWarning: false,
+                        isSelected: true,
+                        isEnabled: false
+                    )
+                ]
+            )
         }
     }
 
@@ -668,6 +695,8 @@ final class AgentProviderPreferenceSnapshotStore {
         case .cursor: .cursor
         case .grokBuild: .grokBuild
         case .antigravity: .antigravity
+        case .omp: .omp
+        case .devin: .devin
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
@@ -42,6 +42,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
     case cursor
     case grokBuild
     case antigravity
+    case omp
+    case devin
     case claudeCodeGLM
     case kimiCode
     case customClaudeCompatible
@@ -50,6 +52,9 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
     static let codexMCPClientID = "codex-mcp-client"
     static let openCodeMCPClientID = "opencode"
     static let cursorMCPClientID = "cursor"
+    static let ompMCPClientID = "omp-coding-agent"
+    /// Devin's built-in Rust MCP client reports this exact `initialize` name.
+    static let devinMCPClientID = "rmcp"
     /// Grok Build presents `grok-shell-<injected server name>` (e.g. `grok-shell-RepoPromptCE`)
     /// to MCP servers. The hint must equal that exact registered name: the pending run-scoped
     /// tab-context store keys are raw client names (no family canonicalization), so a
@@ -71,6 +76,10 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "grok"
         case .antigravity:
             "agy_acp_server.par"
+        case .omp:
+            "omp"
+        case .devin:
+            "devin"
         }
     }
 
@@ -88,6 +97,10 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "Grok Build"
         case .antigravity:
             "Google Antigravity"
+        case .omp:
+            "Oh My Pi"
+        case .devin:
+            "Devin"
         case .claudeCodeGLM:
             ClaudeCodeCompatibleBackendStore.shared.config(for: .glmZAI).normalizedDisplayName
         case .kimiCode:
@@ -111,6 +124,10 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             Self.grokBuildMCPClientID
         case .antigravity:
             "antigravity"
+        case .omp:
+            Self.ompMCPClientID
+        case .devin:
+            Self.devinMCPClientID
         }
     }
 
@@ -124,6 +141,10 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             .grokBuild
         case .antigravity:
             .antigravity
+        case .omp:
+            .omp
+        case .devin:
+            .devin
         case .claudeCode, .codexExec, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             nil
         }
@@ -133,7 +154,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
         switch self {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             false
         }
     }
@@ -144,7 +165,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
 
     var requiresExpectedPIDOwnedAgentModeMCPRouting: Bool {
         switch self {
-        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
         }
     }
@@ -153,7 +174,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
         switch self {
         case .cursor, .grokBuild, .antigravity:
             false
-        case .claudeCode, .codexExec, .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+        case .claudeCode, .codexExec, .openCode, .omp, .devin, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
         }
     }
@@ -173,6 +194,10 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             return "Cursor CLI ACP agent. Uses Cursor's ACP runtime and injects RepoPrompt MCP tools through ACP session configuration."
         case .grokBuild:
             return "xAI Grok Build ACP agent. Uses Grok Build's ACP runtime (`grok agent stdio`) and injects RepoPrompt MCP tools through ACP session configuration."
+        case .omp:
+            return "Installed Oh My Pi ACP agent. OMP owns authentication, provider and model selection, fallbacks, memory, compaction, and internal tools; RepoPrompt injects its MCP tools."
+        case .devin:
+            return "Installed Devin ACP agent for interactive Agent Mode. Devin owns authentication, model selection, modes, and internal tools; RepoPrompt injects its MCP tools through an isolated MCP configuration."
         case .claudeCodeGLM:
             let config = ClaudeCodeCompatibleBackendStore.shared.config(for: .glmZAI)
             if case let .claudeSlotMapping(mapping) = config.modelBehavior {
@@ -209,6 +234,10 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "cursor_acp"
         case .grokBuild:
             "grok_build_acp"
+        case .omp:
+            "omp_acp"
+        case .devin:
+            "devin_acp"
         }
     }
 
@@ -222,7 +251,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             .kimi
         case .customClaudeCompatible:
             .customCompatible
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }
@@ -323,9 +352,22 @@ final class AgentRuntimeProviderService {
                 Self.logger.debug("Created GrokBuildACPHeadlessAgentProvider")
             }
             return GrokBuildACPHeadlessAgentProvider(config: config, workspacePath: workspacePath)
+        case .omp:
+            let config = OMPAgentConfig(
+                enableDebugLogging: Self.enableDebugLogging,
+                modelString: modelString
+            )
+            if Self.enableDebugLogging {
+                Self.logger.debug("Created OMPACPHeadlessAgentProvider")
+            }
+            return OMPACPHeadlessAgentProvider(config: config, workspacePath: workspacePath)
         case .antigravity:
             return UnsupportedHeadlessAgentProvider(
                 reason: "Google Antigravity is currently supported only in interactive Agent Mode. Choose another provider for Context Builder or delegated headless runs."
+            )
+        case .devin:
+            return UnsupportedHeadlessAgentProvider(
+                reason: "Devin is currently supported only in interactive Agent Mode. Choose another provider for Context Builder or delegated headless runs."
             )
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -921,7 +921,11 @@ final class ACPIntegratedAgentModeRunner {
         agentKind: AgentProviderKind,
         modelString: String?
     ) throws -> String? {
-        guard agentKind == .openCode || agentKind == .cursor || agentKind == .grokBuild || agentKind == .antigravity else { return nil }
+        guard agentKind == .openCode || agentKind == .cursor || agentKind == .grokBuild
+            || agentKind == .antigravity || agentKind == .omp || agentKind == .devin
+        else {
+            return nil
+        }
         guard let model = modelString?.trimmingCharacters(in: .whitespacesAndNewlines),
               !model.isEmpty,
               model.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) != .orderedSame
@@ -936,7 +940,7 @@ final class ACPIntegratedAgentModeRunner {
                 detail: "Cursor model `\(model)` is not in this release's supported model catalog. Update RepoPrompt CE or choose Cursor Auto."
             )
         }
-        if agentKind == .grokBuild || agentKind == .antigravity,
+        if agentKind == .grokBuild || agentKind == .antigravity || agentKind == .omp || agentKind == .devin,
            let providerID = agentKind.acpProviderID,
            AgentACPModelRegistry.shared.resolvedSnapshot(for: providerID)?.contains(rawModel: model) != true
         {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/SessionLinks/AgentSessionLinkPromptContext.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/SessionLinks/AgentSessionLinkPromptContext.swift
@@ -246,6 +246,8 @@ enum AgentSessionLinkPromptProviderContext: String, Hashable, CaseIterable {
     case cursor
     case grokBuild
     case antigravity
+    case omp
+    case devin
 
     init(agentKind: AgentProviderKind?) {
         guard let agentKind else {
@@ -262,6 +264,8 @@ enum AgentSessionLinkPromptProviderContext: String, Hashable, CaseIterable {
         case .cursor: self = .cursor
         case .grokBuild: self = .grokBuild
         case .antigravity: self = .antigravity
+        case .omp: self = .omp
+        case .devin: self = .devin
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ContextUsage.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ContextUsage.swift
@@ -6,7 +6,7 @@ extension AgentModeViewModel {
         switch agent {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             claudeContextUsageEstimator
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             nil
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -5404,7 +5404,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     modelContextWindow: session.codexContextUsage?.modelContextWindow
                 )
             }
-        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity:
+        case .codexExec, .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             break
         }
         session.contextUsageSnapshot = ContextUsageSnapshot.fromAgentContextUsage(
@@ -17108,7 +17108,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         switch agent {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .openCode, .cursor, .antigravity:
             return renderAtPathAttachmentMessage(text: text, attachments: attachments)
-        case .codexExec, .grokBuild:
+        // Devin and OMP receive attachments as ACP image blocks, so the transcript text
+        // must not be rewritten into `@path` references.
+        case .codexExec, .grokBuild, .omp, .devin:
             return text
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
@@ -172,6 +172,30 @@ struct AgentPermissionCapabilitySummaryBuilder {
                 approvalModeDescription: level.autoApprovesACPToolPermissions ? "Auto-approve: on" : "Auto-approve: off",
                 warnings: warnings
             )
+        case .omp:
+            return AgentPermissionCapabilitySummary(
+                providerID: providerID,
+                providerName: providerID.displayName,
+                isAvailable: isAvailable,
+                fileMutation: "Managed by Oh My Pi",
+                shell: "Handled by Oh My Pi",
+                externalMCP: "Third-party MCP: managed by Oh My Pi",
+                search: "Managed by Oh My Pi",
+                approvalModeDescription: "Provider managed",
+                warnings: []
+            )
+        case .devin:
+            return AgentPermissionCapabilitySummary(
+                providerID: providerID,
+                providerName: providerID.displayName,
+                isAvailable: isAvailable,
+                fileMutation: "Managed by Devin",
+                shell: "Handled by Devin",
+                externalMCP: "Third-party MCP: managed by Devin",
+                search: "Managed by Devin",
+                approvalModeDescription: "Provider managed",
+                warnings: []
+            )
         case .grokBuild:
             let level = grokBuildPermissionLevel(profile: profile)
             let warnings = level == .fullAccess
@@ -229,6 +253,8 @@ struct AgentPermissionCapabilitySummaryBuilder {
         case .cursor: availability.cursorAvailable
         case .grokBuild: availability.grokBuildAvailable
         case .antigravity: availability.antigravityAvailable
+        case .omp: availability.ompAvailable
+        case .devin: availability.devinAvailable
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentProviderPermissionsSettingsViewModel.swift
@@ -191,6 +191,8 @@ final class AgentProviderPermissionsSettingsViewModel: ObservableObject {
             CursorAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .grokBuild(level):
             GrokBuildAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
+        case .omp, .devin:
+            break
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
@@ -59,7 +59,7 @@ final class AgentRuntimeSidebarViewModel: ObservableObject {
             }
             switch selectedAgent {
             case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible: return 200_000
-            case .openCode, .cursor, .antigravity: return 200_000
+            case .openCode, .cursor, .antigravity, .omp, .devin: return 200_000
             case .grokBuild: return 500_000 // grok 4.5/4.6 advertise totalContextTokens 500000
             case .codexExec, .none: return 200_000
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
@@ -124,13 +124,60 @@ enum AgentOraclePillLogic {
         session.oracleGroupID != nil && (session.oracleGroupSize ?? 1) > 1
     }
 
-    static func aggregateOracleCount(configuredAdditionalCount: Int, sessions: [ChatSession]) -> Int {
-        let configured = 1 + configuredAdditionalCount
-        guard let latest = sessions.max(by: { $0.savedAt < $1.savedAt }),
-              latest.oracleGroupID != nil
-        else { return configured }
-        let projected = min(max(latest.oracleGroupSize ?? 1, 1), 5)
-        return max(configured, projected)
+    struct LanePresentation: Identifiable, Equatable {
+        let laneIndex: Int
+        let sessionID: UUID?
+        let modelID: String
+        let status: OracleLaneMarkdownPayload.Status
+
+        var id: Int {
+            laneIndex
+        }
+    }
+
+    static func aggregateOracleCount(session: ChatSession?, payload: OracleLaneMarkdownPayload? = nil) -> Int {
+        guard let session, session.oracleGroupID != nil else { return 1 }
+        return min(max(payload?.lanes.count ?? session.oracleGroupSize ?? 1, 1), 5)
+    }
+
+    static func groupMemberSessions(for session: ChatSession, in sessions: [ChatSession]) -> [ChatSession] {
+        guard let groupID = session.oracleGroupID else { return [] }
+        return sessions.filter {
+            $0.oracleGroupID == groupID && $0.workspaceID == session.workspaceID
+                && $0.composeTabID == session.composeTabID
+        }.sorted { ($0.oracleLaneIndex ?? .max) < ($1.oracleLaneIndex ?? .max) }
+    }
+
+    static func lanePresentations(
+        for session: ChatSession,
+        in sessions: [ChatSession],
+        streamingSessionIDs: Set<UUID>,
+        payload: OracleLaneMarkdownPayload?
+    ) -> [LanePresentation] {
+        let members = groupMemberSessions(for: session, in: sessions)
+        guard let payload else {
+            let count = aggregateOracleCount(session: session)
+            return (0 ..< count).map { laneIndex in
+                let member = members.first { $0.oracleLaneIndex == laneIndex }
+                return LanePresentation(
+                    laneIndex: laneIndex,
+                    sessionID: member?.id,
+                    modelID: member?.oracleModelRaw ?? "Oracle model",
+                    status: member.map { streamingSessionIDs.contains($0.id) } == true ? .running : .unavailable
+                )
+            }
+        }
+        return payload.lanes.sorted { $0.laneIndex < $1.laneIndex }.map { lane in
+            let member = members.first {
+                $0.shortID == lane.chatID && $0.oracleLaneIndex == lane.laneIndex
+            }
+            return LanePresentation(
+                laneIndex: lane.laneIndex,
+                sessionID: member?.id,
+                modelID: lane.modelID,
+                status: member.map { streamingSessionIDs.contains($0.id) } == true ? .running : lane.status
+            )
+        }
     }
 
     static func latestStreamingSession(
@@ -196,33 +243,15 @@ enum AgentOraclePillLogic {
         return matches[0]
     }
 
-    enum LaneDotState: Equatable {
-        case streaming
-        case failed
-        case completed
-    }
-
-    static func lastAssistantContent(
-        liveMessages: [AIChatMessage],
-        storedMessages: [StoredMessage]
-    ) -> String? {
-        if let last = liveMessages.last(where: { !$0.isUser }) {
-            return last.content
-        }
-        return storedMessages.last(where: { !$0.isUser })?.rawText
-    }
-
-    static func assistantContentIndicatesFailure(_ content: String?) -> Bool {
-        guard let content else { return false }
-        if content.contains("\n--\nError:\n") { return true }
-        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.hasPrefix("Error:")
-    }
-
-    static func laneDotState(isStreaming: Bool, lastAssistantContent: String?) -> LaneDotState {
-        if isStreaming { return .streaming }
-        if assistantContentIndicatesFailure(lastAssistantContent) { return .failed }
-        return .completed
+    static func laneStatus(
+        session: ChatSession,
+        isStreaming: Bool,
+        payload: OracleLaneMarkdownPayload?
+    ) -> OracleLaneMarkdownPayload.Status {
+        if isStreaming { return .running }
+        return payload?.lanes.first {
+            $0.chatID == session.shortID && $0.laneIndex == session.oracleLaneIndex
+        }?.status ?? .unavailable
     }
 }
 
@@ -251,10 +280,18 @@ struct AgentOraclePill: View {
 
     @State private var presentedPopover: PopoverPresentation?
     @State private var copyAllFeedback: CopyAllFeedback?
+    @State private var groupPayload: OracleLaneMarkdownPayload?
+    @State private var groupPayloadGroupID: UUID?
+    @State private var groupPayloadError: String?
+
+    private struct GroupReadKey: Hashable {
+        let groupID: UUID?
+        let streamingSessionIDs: Set<UUID>
+    }
+
     @State private var autoScrollEnabled = false
     @State private var openRequestGeneration: UInt64 = 0
     @ObservedObject private var fontScale = FontScaleManager.shared
-    @ObservedObject private var settingsStore = GlobalSettingsStore.shared
     private var fontPreset: FontScalePreset {
         fontScale.preset
     }
@@ -281,25 +318,28 @@ struct AgentOraclePill: View {
         currentTabID.map(oracleViewModel.sessions(forTabID:)) ?? []
     }
 
+    private var displayedSession: ChatSession? {
+        if let presentedPopover { return presentedSession(for: presentedPopover) }
+        return latestTabSession
+    }
+
+    private var displayedPayload: OracleLaneMarkdownPayload? {
+        guard displayedSession?.oracleGroupID == groupPayloadGroupID else { return nil }
+        return groupPayload
+    }
+
     private var oracleCount: Int {
-        let workspaceID = oracleViewModel.workspaceManager.activeWorkspaceID
-        let configuredAdditional = settingsStore
-            .effectiveAgentModelsProfile(workspaceID: workspaceID)
-            .additionalOracleModelRaws.count
-        return AgentOraclePillLogic.aggregateOracleCount(
-            configuredAdditionalCount: configuredAdditional,
-            sessions: currentTabSessions
-        )
+        AgentOraclePillLogic.aggregateOracleCount(session: displayedSession, payload: displayedPayload)
     }
 
     private var isStreaming: Bool {
-        guard let latestTabSession else { return false }
-        if let groupID = latestTabSession.oracleGroupID {
-            return currentTabSessions.contains {
-                $0.oracleGroupID == groupID && oracleViewModel.streamingSessions.contains($0.id)
+        guard let session = displayedSession else { return false }
+        if session.oracleGroupID != nil {
+            return groupMemberSessions(for: session).contains {
+                oracleViewModel.streamingSessions.contains($0.id)
             }
         }
-        return oracleViewModel.streamingSessions.contains(latestTabSession.id)
+        return oracleViewModel.streamingSessions.contains(session.id)
     }
 
     private func presentedSession(for presentation: PopoverPresentation) -> ChatSession? {
@@ -319,17 +359,40 @@ struct AgentOraclePill: View {
         return session.name
     }
 
-    private func laneDotColor(for session: ChatSession) -> Color {
-        switch AgentOraclePillLogic.laneDotState(
+    private func canonicalPayload(for presentation: PopoverPresentation) -> OracleLaneMarkdownPayload? {
+        guard presentedSession(for: presentation)?.oracleGroupID == groupPayloadGroupID else { return nil }
+        return groupPayload
+    }
+
+    private func canonicalPayloadError(for presentation: PopoverPresentation) -> String? {
+        guard presentedSession(for: presentation)?.oracleGroupID == groupPayloadGroupID else { return nil }
+        return groupPayloadError
+    }
+
+    private func lanePresentations(for session: ChatSession, presentation: PopoverPresentation) -> [AgentOraclePillLogic.LanePresentation] {
+        AgentOraclePillLogic.lanePresentations(
+            for: session,
+            in: currentTabSessions,
+            streamingSessionIDs: oracleViewModel.streamingSessions,
+            payload: canonicalPayload(for: presentation)
+        )
+    }
+
+    private func laneStatus(for session: ChatSession, presentation: PopoverPresentation) -> OracleLaneMarkdownPayload.Status {
+        AgentOraclePillLogic.laneStatus(
+            session: session,
             isStreaming: oracleViewModel.streamingSessions.contains(session.id),
-            lastAssistantContent: AgentOraclePillLogic.lastAssistantContent(
-                liveMessages: oracleViewModel.messagesSnapshot(for: session.id),
-                storedMessages: session.messages
-            )
-        ) {
-        case .streaming: Color.purple
-        case .failed: Color.red
-        case .completed: Color.green
+            payload: canonicalPayload(for: presentation)
+        )
+    }
+
+    private func laneDotColor(for status: OracleLaneMarkdownPayload.Status) -> Color {
+        switch status {
+        case .running: .purple
+        case .failed: .red
+        case .completed: .green
+        case .cancelled: .orange
+        case .unavailable: .secondary
         }
     }
 
@@ -427,10 +490,7 @@ struct AgentOraclePill: View {
     }
 
     private func groupMemberSessions(for session: ChatSession) -> [ChatSession] {
-        guard let groupID = session.oracleGroupID else { return [] }
-        return currentTabSessions
-            .filter { $0.oracleGroupID == groupID }
-            .sorted { ($0.oracleLaneIndex ?? .max) < ($1.oracleLaneIndex ?? .max) }
+        AgentOraclePillLogic.groupMemberSessions(for: session, in: currentTabSessions)
     }
 
     @ViewBuilder
@@ -470,15 +530,18 @@ struct AgentOraclePill: View {
             }
 
             if let presented = presentedSession(for: presentation) {
-                let members = groupMemberSessions(for: presented)
-                if members.count > 1 {
+                let lanes = lanePresentations(for: presented, presentation: presentation)
+                if lanes.count > 1 {
                     HStack(spacing: 6) {
-                        ForEach(members) { member in
-                            let laneIndex = member.oracleLaneIndex ?? 0
+                        ForEach(lanes) { lane in
+                            let statusDetail = lane.status == .unavailable
+                                ? (canonicalPayloadError(for: presentation) ?? lane.status.rawValue)
+                                : lane.status.rawValue
                             Button {
+                                guard let sessionID = lane.sessionID else { return }
                                 openRequestGeneration &+= 1
                                 present(
-                                    sessionID: member.id,
+                                    sessionID: sessionID,
                                     isExplicit: presentation.isExplicit,
                                     actionPolicy: presentation.actionPolicy,
                                     generation: openRequestGeneration
@@ -486,17 +549,40 @@ struct AgentOraclePill: View {
                             } label: {
                                 HStack(spacing: 4) {
                                     Circle()
-                                        .fill(laneDotColor(for: member))
+                                        .fill(laneDotColor(for: lane.status))
                                         .frame(width: 6, height: 6)
-                                    Text(OracleViewModel.oracleLabel(laneIndex: laneIndex))
+                                    Text(OracleViewModel.oracleLabel(laneIndex: lane.laneIndex))
                                         .lineLimit(1)
                                 }
                             }
                             .buttonStyle(.bordered)
                             .controlSize(.small)
-                            .hoverTooltip(member.oracleModelRaw ?? "Oracle model")
+                            .disabled(lane.sessionID == nil)
+                            .hoverTooltip("\(lane.modelID) · \(statusDetail)")
+                            .accessibilityLabel("\(OracleViewModel.oracleLabel(laneIndex: lane.laneIndex)): \(lane.status.rawValue)")
                         }
                     }
+                }
+            }
+
+            if let presented = presentedSession(for: presentation), presented.oracleGroupID != nil {
+                let lane = canonicalPayload(for: presentation)?.lanes.first {
+                    $0.chatID == presented.shortID && $0.laneIndex == presented.oracleLaneIndex
+                }
+                let status = laneStatus(for: presented, presentation: presentation)
+                Text(status.rawValue)
+                    .font(.caption)
+                    .foregroundStyle(laneDotColor(for: status))
+                if let error = lane?.errorMessage, status != .running {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                } else if status == .unavailable, let payloadError = canonicalPayloadError(for: presentation) {
+                    Text(payloadError)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
                 }
             }
 
@@ -514,6 +600,45 @@ struct AgentOraclePill: View {
         }
         .padding(14)
         .frame(width: popoverWidth)
+        .task(id: GroupReadKey(
+            groupID: presentedSession(for: presentation)?.oracleGroupID,
+            streamingSessionIDs: oracleViewModel.streamingSessions
+        )) {
+            await refreshGroupPayload(presentation)
+        }
+    }
+
+    @MainActor
+    private func refreshGroupPayload(_ presentation: PopoverPresentation) async {
+        guard let session = presentedSession(for: presentation), let groupID = session.oracleGroupID else { return }
+        if groupPayloadGroupID != groupID {
+            groupPayload = nil
+            groupPayloadError = nil
+        }
+        groupPayloadGroupID = groupID
+        // A stream can end before the runtime publishes its terminal turn. Continue reading
+        // the existing canonical seam until publication; never infer completion from text.
+        while !Task.isCancelled {
+            do {
+                let payload = try await oracleViewModel.oracleGroupCopyPayload(containing: session)
+                try Task.checkCancellation()
+                guard let current = presentedPopover,
+                      presentedSession(for: current)?.oracleGroupID == groupID else { return }
+                groupPayload = payload
+                groupPayloadGroupID = groupID
+                groupPayloadError = nil
+                guard payload.lanes.contains(where: { $0.status == .running }) else { return }
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+            } catch {
+                if !Task.isCancelled,
+                   let current = presentedPopover,
+                   presentedSession(for: current)?.oracleGroupID == groupID
+                {
+                    groupPayloadError = error.localizedDescription
+                }
+                return
+            }
+        }
     }
 
     private func copyAllLanes(containing session: ChatSession) {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -1546,6 +1546,8 @@ extension AgentProviderKind {
         case .openCode, .antigravity: "curlybraces.square"
         case .cursor: "cursorarrow"
         case .grokBuild: "bolt.circle.fill"
+        case .omp: "circle.hexagongrid"
+        case .devin: "sparkles"
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
@@ -647,7 +647,7 @@ func contextBuilderOracleLaneSummaries(
             chatID: lane.chatID,
             modelID: lane.executionProfile?.modelID ?? lane.modelID,
             effectiveReasoningEffort: lane.executionProfile?.effectiveReasoningEffort,
-            status: lane.status == OracleLaneResultStatus.completed.rawValue ? "done" : "failed"
+            status: lane.status == OracleLaneResultStatus.completed.rawValue ? "done" : lane.status
         )
     }
 }

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+Groups.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+Groups.swift
@@ -80,6 +80,8 @@ enum AppOracleGroupRouting {
         case .openCode: "openCode"
         case .cursor: "cursor"
         case .grokBuild: "grokBuild"
+        case .omp: "omp"
+        case .devin: "devin"
         }
     }
 }
@@ -677,7 +679,8 @@ extension OracleViewModel {
             agentModeSessionID: context.agentModeSessionID,
             agentModeRunID: context.agentModeRunID,
             activationPolicy: .background,
-            packaging: context.packaging
+            packaging: context.packaging,
+            transientImages: context.transientImages
         )
     }
 
@@ -738,6 +741,7 @@ extension OracleViewModel {
                 }
             }
             purgeSessionStorage(projection.id)
+            discardTransientImages(for: projection.id)
         }
         sessions.removeAll { memberIDs.contains($0.id) }
         for projection in removed {

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -129,6 +129,8 @@ extension OracleViewModel {
         let agentModeRunID: UUID?
         let activationPolicy: OracleSendActivationPolicy
         let packaging: OracleSendPackagingContext
+        /// Images loaded from the MCP surface for this call; never persisted.
+        let transientImages: [AITransientImage]
 
         init(
             tabID: UUID,
@@ -137,7 +139,8 @@ extension OracleViewModel {
             agentModeSessionID: UUID? = nil,
             agentModeRunID: UUID? = nil,
             activationPolicy: OracleSendActivationPolicy = .foregroundWhenActive,
-            packaging: OracleSendPackagingContext
+            packaging: OracleSendPackagingContext,
+            transientImages: [AITransientImage] = []
         ) {
             self.tabID = tabID
             self.workspaceID = workspaceID
@@ -146,6 +149,7 @@ extension OracleViewModel {
             self.agentModeRunID = agentModeRunID
             self.activationPolicy = activationPolicy
             self.packaging = packaging
+            self.transientImages = transientImages
         }
     }
 
@@ -1182,6 +1186,12 @@ extension OracleViewModel {
         }
 
         let selectedModel = modelSelection.model
+        let transientImages = tabContext?.transientImages ?? []
+        if !transientImages.isEmpty, !OracleImageRouteAdmission.supports(selectedModel) {
+            throw ChatToolError.invalidParams(
+                "Image attachments are not supported by the selected Oracle model '\(selectedModel.displayName)' on provider '\(selectedModel.providerType.displayName)'."
+            )
+        }
         let mcpControlledModel = modelSelection.mcpControlInfo
         let overrideModelName = selectedModel.displayName
         let overrideChatPresetName: String? = {
@@ -1210,6 +1220,11 @@ extension OracleViewModel {
             agentModeRunID: tabContext?.agentModeRunID,
             implicitSessionID: implicitSessionID
         )
+        if !OracleImageRouteAdmission.supports(selectedModel), hasHistoricalTransientImages(in: chatID) {
+            throw ChatToolError.invalidParams(
+                "Image attachments are not supported by the selected Oracle model '\(selectedModel.displayName)' on provider '\(selectedModel.providerType.displayName)'."
+            )
+        }
         pinSession(chatID)
         defer { unpinSession(chatID) }
 
@@ -1245,6 +1260,7 @@ extension OracleViewModel {
                 lookupContextOverride: lookupContextOverride,
                 reviewGitContextOverride: reviewGitContextOverride,
                 overrideAIMessage: tabContext?.packaging.prebuiltAIMessage,
+                oracleTransientImages: transientImages,
                 onProgress: onProgress
             )
         }

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -465,6 +465,8 @@ class OracleViewModel: ObservableObject {
     /// Per-session sequence numbering
     private var nextSequenceIndexBySession: [UUID: Int] = [:]
 
+    private var transientImagesBySession: [UUID: [UUID: [AITransientImage]]] = [:]
+
     /// Maps AI message/query IDs to the underlying AIQueriesService stream IDs for targeted cancellation.
     private var streamIDsByQueryId: [UUID: ChatStreamID] = [:]
 
@@ -1016,6 +1018,7 @@ class OracleViewModel: ObservableObject {
     private func clearAllSessionStorage() {
         sessionSwitchGeneration += 1
         messageStore.removeAll(keepingCapacity: false)
+        transientImagesBySession.removeAll(keepingCapacity: false)
         messageStoreRevision &+= 1
         sessionIDByMessageId.removeAll(keepingCapacity: false)
         runStateBySession.removeAll(keepingCapacity: false)
@@ -1727,6 +1730,7 @@ class OracleViewModel: ObservableObject {
         withAnimation {
             guard let idx = sessions.firstIndex(where: { $0.id == session.id }) else { return }
             purgeSessionStorage(session.id)
+            discardTransientImages(for: session.id)
             sessions.remove(at: idx)
 
             if let tabID = session.composeTabID,
@@ -2394,6 +2398,12 @@ class OracleViewModel: ObservableObject {
             selectedChatPresetID: originalSession.selectedChatPresetID
         )
 
+        copyTransientImages(
+            from: originalSession.id,
+            to: newSession.id,
+            messageIDs: Set(messagesToCopy.map(\.id))
+        )
+
         // Add the new session to the list and switch to it
         sessions.append(newSession)
         await switchToSession(newSession.id)
@@ -2971,6 +2981,7 @@ class OracleViewModel: ObservableObject {
             msgs.removeAll { $0.id == messageId }
         }
         sessionIDByMessageId.removeValue(forKey: messageId)
+        discardTransientImages(for: messageId, in: sessionID)
 
         // if no more AI messages exist, reset the current query ID:
         if runStateBySession[sessionID]?.activeQueryId == messageId {
@@ -3011,6 +3022,7 @@ class OracleViewModel: ObservableObject {
                 for id in removedIds {
                     sessionIDByMessageId.removeValue(forKey: id)
                 }
+                discardTransientImages(for: session.id)
             } else {
                 // Fork to the message BEFORE the one we're editing
                 // This way the forked chat will end right before the message we want to replace
@@ -3023,6 +3035,7 @@ class OracleViewModel: ObservableObject {
                 msgs.removeAll { $0.id == messageId }
             }
             sessionIDByMessageId.removeValue(forKey: messageId)
+            discardTransientImages(for: messageId, in: session.id)
         }
 
         // Send the edited message (this creates a new user message and gets AI response)
@@ -3068,6 +3081,7 @@ class OracleViewModel: ObservableObject {
         lookupContextOverride: WorkspaceLookupContext? = nil,
         reviewGitContextOverride: FrozenPromptGitReviewContext? = nil,
         overrideAIMessage: AIMessage? = nil,
+        oracleTransientImages: [AITransientImage] = [],
         completionPolicy: OracleResponseCompletionPolicy = .interactive,
         onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
     ) async -> UUID? {
@@ -3107,6 +3121,7 @@ class OracleViewModel: ObservableObject {
             msgs.append(userMessage)
         }
         registerMessage(userId, sessionID: targetSessionID)
+        recordTransientImages(oracleTransientImages, for: userId, in: targetSessionID)
 
         let conversation = buildConversationEntries(for: targetSessionID)
 
@@ -3189,7 +3204,7 @@ class OracleViewModel: ObservableObject {
                         overrideMode: overrideMode
                     )
                 }) {
-                    aiMessage = overrideAIMessage
+                    aiMessage = overrideAIMessage.attachingImagesToFinalUserTurn(oracleTransientImages)
                 } else {
                     // Build override context from the specified chat preset or current one
                     let chatPreset: ChatPreset = if let presetID = overrideChatPresetID,
@@ -3572,12 +3587,52 @@ class OracleViewModel: ObservableObject {
 
     /// Builds conversation entries from raw user and assistant text.
     @MainActor
-    private func buildConversationEntries(for sessionID: UUID) -> [ConversationEntry] {
+    func buildConversationEntries(for sessionID: UUID) -> [ConversationEntry] {
         guard let sessionMessages = messageStore[sessionID] else { return [] }
         return sessionMessages.map { msg in
             let role: ConversationEntry.Role = msg.isUser ? .user : .assistant
-            return ConversationEntry(role: role, content: msg.content)
+            return ConversationEntry(
+                role: role,
+                content: msg.content,
+                images: msg.isUser ? transientImages(for: msg.id, in: sessionID) : []
+            )
         }
+    }
+
+    @MainActor
+    func recordTransientImages(_ images: [AITransientImage], for messageID: UUID, in sessionID: UUID) {
+        guard !images.isEmpty else { return }
+        transientImagesBySession[sessionID, default: [:]][messageID] = images
+    }
+
+    @MainActor
+    private func transientImages(for messageID: UUID, in sessionID: UUID) -> [AITransientImage] {
+        transientImagesBySession[sessionID]?[messageID] ?? []
+    }
+
+    @MainActor
+    func discardTransientImages(for sessionID: UUID) {
+        transientImagesBySession.removeValue(forKey: sessionID)
+    }
+
+    @MainActor
+    func discardTransientImages(for messageID: UUID, in sessionID: UUID) {
+        transientImagesBySession[sessionID]?.removeValue(forKey: messageID)
+        if transientImagesBySession[sessionID]?.isEmpty == true {
+            transientImagesBySession.removeValue(forKey: sessionID)
+        }
+    }
+
+    @MainActor
+    private func copyTransientImages(from sessionID: UUID, to targetSessionID: UUID, messageIDs: Set<UUID>) {
+        let carried = transientImagesBySession[sessionID]?.filter { messageIDs.contains($0.key) } ?? [:]
+        guard !carried.isEmpty else { return }
+        transientImagesBySession[targetSessionID, default: [:]].merge(carried) { _, new in new }
+    }
+
+    @MainActor
+    func hasHistoricalTransientImages(in sessionID: UUID) -> Bool {
+        transientImagesBySession[sessionID]?.isEmpty == false
     }
 
     private func userFriendlyErrorMessage(for error: Error, tokenCount: Int = 0) -> String {

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -4496,17 +4496,13 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     @MainActor
     func planStatus(for tabID: UUID?) -> ContextBuilderPlanStatus {
         guard let id = tabID, let session = sessions[id] else { return .idle }
-        if session.isBackgroundPlanGenerating {
-            return .generating
-        }
-        if let error = session.backgroundPlanError {
-            return .error(error)
-        }
-        if let route = session.generatedAnswerRoute {
-            let preview = session.backgroundPlanResponsePreviewText ?? session.backgroundPlanResponseText
-            return .ready(route: route, previewText: preview)
-        }
-        return .idle
+        return session.planStatus
+    }
+
+    @MainActor
+    func failedAnswerRoute(for tabID: UUID?) -> ContextBuilderGeneratedAnswerRoute? {
+        guard let tabID else { return nil }
+        return sessions[tabID]?.failedAnswerRoute
     }
 
     /// Returns the current context-builder follow-up Oracle chat ID for a tab, when known.
@@ -4782,10 +4778,6 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     "Context Builder Oracle group result did not match its prepared members"
                 )
             }
-            guard let primary = session.followUpOracleGroupState.members.first else {
-                throw ChatToolError.internalError("Context Builder Oracle group completed without Primary state")
-            }
-            let primaryResult = groupReply.result.primary
             try await oracleStore.releaseArtifactReservation(
                 frozenPack.reservation,
                 removeIfUnreferenced: false
@@ -4795,36 +4787,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 await runTestHooks?.afterOracleArtifactReservationReleased?(generation)
             #endif
             try requireCurrentOracleRun(session: session, generation: generation)
-            if primaryResult.status != .completed,
-               let partialResponse = primaryResult.error?.partialResponse,
-               !partialResponse.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            {
-                session.backgroundPlanResponseText = partialResponse
-            }
-            let primaryResponse = try groupReply.requiredCompletedPrimaryResponse()
-            let errors = groupReply.orderedResults.compactMap { result in
-                result.error.map {
-                    "\(OracleViewModel.oracleLabel(laneIndex: result.laneIndex)) failed: \($0.message)"
-                }
-            }
-            let reply = ChatSendReply(
-                chatId: primary.sessionID,
-                shortId: primary.chatID,
-                mode: mode.mcpModeName,
-                response: primaryResponse,
-                errors: errors.isEmpty ? nil : errors,
-                oracleGroup: groupReply
+            let reply = try session.completeOracleGroupReply(
+                groupReply,
+                generation: generation,
+                originWorkspaceID: originWorkspaceID,
+                mode: mode
             )
-            session.isBackgroundPlanGenerating = false
-            session.backgroundPlanResponseText = reply.response
-            session.backgroundPlanReasoningText = nil
-            session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
-                workspaceID: originWorkspaceID,
-                tabID: tabID,
-                chatID: primary.chatID
-            )
-            session.followUpOracleGroupState.finish(generation: generation)
-            session.followUpOracleGroupTask = nil
             clearPendingBackgroundPlanUIRefresh(for: tabID)
             applyPlanPreview(to: session)
             updateRuntimeBindings(from: session)
@@ -5847,6 +5815,73 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 message: message
             )
         )
+    }
+}
+
+extension ContextBuilderAgentViewModel.TabSession {
+    /// Called only after the runtime settled and artifact reservation release succeeded.
+    /// A failed primary is a group outcome, not a failure to deliver the group.
+    @MainActor
+    func completeOracleGroupReply(
+        _ groupReply: ContextBuilderOracleGroupReply,
+        generation: UInt64,
+        originWorkspaceID: UUID,
+        mode: HeadlessMode
+    ) throws -> ChatSendReply {
+        try Task.checkCancellation()
+        guard followUpOracleGroupState.generation == generation else { throw CancellationError() }
+        guard followUpOracleGroupState.matchesFinalResult(groupReply.result, generation: generation),
+              let primary = followUpOracleGroupState.members.first
+        else {
+            throw ChatToolError.internalError("Context Builder Oracle group result did not match its prepared members")
+        }
+        let primaryResult = groupReply.result.primary
+        let errors = groupReply.orderedResults.compactMap { result in
+            result.error.map {
+                "\(OracleViewModel.oracleLabel(laneIndex: result.laneIndex)) \(result.status.rawValue): \($0.message)"
+            }
+        }
+        let reply = ChatSendReply(
+            chatId: primary.sessionID,
+            shortId: primary.chatID,
+            mode: mode.mcpModeName,
+            response: primaryResult.status == .completed ? primaryResult.response : nil,
+            errors: errors.isEmpty ? nil : errors,
+            oracleGroup: groupReply
+        )
+        isBackgroundPlanGenerating = false
+        backgroundPlanResponseText = reply.response ?? primaryResult.error?.partialResponse
+        backgroundPlanReasoningText = nil
+        backgroundPlanError = primaryResult.status == .completed ? nil :
+            ContextBuilderOraclePrimaryCompletionError.notCompleted(
+                status: primaryResult.status,
+                code: primaryResult.error?.code ?? "oracle_primary_not_completed",
+                message: primaryResult.error?.message ?? "Primary Oracle did not complete successfully."
+            ).localizedDescription
+        generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
+            workspaceID: originWorkspaceID,
+            tabID: tabID,
+            chatID: primary.chatID
+        )
+        followUpOracleGroupState.finish(generation: generation)
+        followUpOracleGroupTask = nil
+        return reply
+    }
+
+    @MainActor
+    var planStatus: ContextBuilderPlanStatus {
+        if isBackgroundPlanGenerating { return .generating }
+        if let error = backgroundPlanError { return .error(error) }
+        if let route = generatedAnswerRoute {
+            return .ready(route: route, previewText: backgroundPlanResponsePreviewText ?? backgroundPlanResponseText)
+        }
+        return .idle
+    }
+
+    @MainActor
+    var failedAnswerRoute: ContextBuilderGeneratedAnswerRoute? {
+        guard !isBackgroundPlanGenerating, backgroundPlanError != nil else { return nil }
+        return generatedAnswerRoute
     }
 }
 

--- a/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderAgentView.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderAgentView.swift
@@ -254,6 +254,11 @@ struct ContextBuilderAgentView: View {
             // Line 3: Plan actions (only when plan is ready)
             if case let .ready(route, previewText) = status {
                 planReadyActions(route: route, previewText: previewText)
+            } else if let route = viewModel.failedAnswerRoute(for: subjectTabID) {
+                Button("View in Chat", systemImage: "bubble.left.and.bubble.right") {
+                    viewGeneratedPlan(route: route)
+                }
+                .hoverTooltip(ContextBuilderGeneratedAnswerActionText.viewInChatTooltip)
             }
         }
         .padding(10)

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptPackagingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptPackagingService.swift
@@ -85,7 +85,11 @@ enum PromptPackagingService {
 
             // Replace the immutable entry with a new one
             updatedConversation[lastUserIndex] =
-                ConversationEntry(role: lastUserEntry.role, content: newContent)
+                ConversationEntry(
+                    role: lastUserEntry.role,
+                    content: newContent,
+                    images: lastUserEntry.images
+                )
         }
 
         // 3️⃣  Package everything into AIMessage

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -6408,6 +6408,10 @@ class PromptViewModel: ObservableObject {
             return api.isCursorConnected
         case .grokBuild:
             return api.isGrokBuildConnected
+        case .omp:
+            return api.isOMPConnected
+        case .devin:
+            return api.isDevinConnected
         }
     }
 
@@ -6429,7 +6433,7 @@ class PromptViewModel: ObservableObject {
             // Custom models are always valid (user explicitly configured them)
             if model.isCustom { return true }
             switch model.providerType {
-            case .claudeCode, .codex, .openCode, .cursor, .grokBuild:
+            case .claudeCode, .codex, .openCode, .cursor, .grokBuild, .omp, .devin:
                 return true
             default:
                 // Check if the model's provider has an API key configured

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -307,6 +307,12 @@ public class APISettingsViewModel: ObservableObject {
     @Published var grokBuildError: String? = nil
     @Published private(set) var availableGrokBuildModelOptions: [AgentModelOption] = []
     private var grokBuildLogCollector: CLIProcessLogCollector?
+    // Oh My Pi CLI / ACP
+    @Published var isOMPConnected: Bool = UserDefaults.standard.bool(forKey: "OMPCLIConnected")
+    @Published var ompError: String? = nil
+    // Devin CLI / ACP
+    @Published var isDevinConnected: Bool = UserDefaults.standard.bool(forKey: "DevinCLIConnected")
+    @Published var devinError: String? = nil
 
     /// CLI connection flags are persisted configuration hints, not proof that the provider is
     /// usable in the current process. Context Builder restoration waits for this validation pass
@@ -390,6 +396,8 @@ public class APISettingsViewModel: ObservableObject {
             cursorAvailable: isCursorConnected,
             grokBuildAvailable: isGrokBuildConnected,
             antigravityAvailable: AntigravityRuntimeManager.installedRuntimeSync() != nil,
+            ompAvailable: isOMPConnected,
+            devinAvailable: isDevinConnected,
             zaiConfigured: compatibleBackendIsActive(.glmZAI),
             kimiConfigured: compatibleBackendIsActive(.kimi),
             customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
@@ -421,6 +429,8 @@ public class APISettingsViewModel: ObservableObject {
             $isOpenCodeConnected.map { _ in () }.eraseToAnyPublisher(),
             $isCursorConnected.map { _ in () }.eraseToAnyPublisher(),
             $isGrokBuildConnected.map { _ in () }.eraseToAnyPublisher(),
+            $isOMPConnected.map { _ in () }.eraseToAnyPublisher(),
+            $isDevinConnected.map { _ in () }.eraseToAnyPublisher(),
             $claudeCodeCLIStatus.map { _ in () }.eraseToAnyPublisher(),
             $compatibleBackendConfigs.map { _ in () }.eraseToAnyPublisher(),
             $compatibleBackendSecretPresence.map { _ in () }.eraseToAnyPublisher()
@@ -442,6 +452,9 @@ public class APISettingsViewModel: ObservableObject {
             openCodeAvailable: isVerifiedContextBuilderProvider(.openCode) && isOpenCodeConnected,
             cursorAvailable: isVerifiedContextBuilderProvider(.cursor) && isCursorConnected,
             grokBuildAvailable: isVerifiedContextBuilderProvider(.grokBuild) && isGrokBuildConnected,
+            ompAvailable: isVerifiedContextBuilderProvider(.omp) && isOMPConnected,
+            // Devin is interactive-only; it never backs a headless Context Builder run.
+            devinAvailable: false,
             zaiConfigured: compatibleBackendIsActive(.glmZAI),
             kimiConfigured: compatibleBackendIsActive(.kimi),
             customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
@@ -499,6 +512,10 @@ public class APISettingsViewModel: ObservableObject {
             isGrokBuildConnected
         case .antigravity:
             AntigravityRuntimeManager.installedRuntimeSync() != nil
+        case .omp:
+            isOMPConnected
+        case .devin:
+            isDevinConnected
         case .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             false
         }
@@ -547,7 +564,9 @@ public class APISettingsViewModel: ObservableObject {
             NotificationCenter.default.publisher(for: .codexConnectionChanged).map { _ in AgentProviderKind.codexExec },
             NotificationCenter.default.publisher(for: .openCodeConnectionChanged).map { _ in AgentProviderKind.openCode },
             NotificationCenter.default.publisher(for: .cursorConnectionChanged).map { _ in AgentProviderKind.cursor },
-            NotificationCenter.default.publisher(for: .grokBuildConnectionChanged).map { _ in AgentProviderKind.grokBuild }
+            NotificationCenter.default.publisher(for: .grokBuildConnectionChanged).map { _ in AgentProviderKind.grokBuild },
+            NotificationCenter.default.publisher(for: .ompConnectionChanged).map { _ in AgentProviderKind.omp },
+            NotificationCenter.default.publisher(for: .devinConnectionChanged).map { _ in AgentProviderKind.devin }
         ])
         .receive(on: DispatchQueue.main)
         .sink { [weak self] provider in
@@ -567,6 +586,22 @@ public class APISettingsViewModel: ObservableObject {
             }
         }
         .store(in: &cliConnectionCancellables)
+
+        // OMP and Devin feed their discovered catalogs into the non-agent
+        // (chat/Oracle) model list, so a run that discovers models must refresh it.
+        NotificationCenter.default.publisher(for: .acpDiscoveredModelsChanged)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard let self, !hasPreparedForWindowClose else { return }
+                let changedProviderID = notification.userInfo?[
+                    AgentACPModelRegistry.providerIDUserInfoKey
+                ] as? String
+                guard changedProviderID == nil || changedProviderID == ACPProviderID.omp.rawValue || changedProviderID == ACPProviderID.devin.rawValue else {
+                    return
+                }
+                Task { await self.updateAvailableModels() }
+            }
+            .store(in: &cliConnectionCancellables)
     }
 
     private func applyAuthoritativeCodexDisconnectedState() {
@@ -590,6 +625,8 @@ public class APISettingsViewModel: ObservableObject {
     private func reloadCLIConnectionFlagsFromDefaults() {
         let wasCursorConnected = isCursorConnected
         let wasGrokBuildConnected = isGrokBuildConnected
+        let wasOMPConnected = isOMPConnected
+        let wasDevinConnected = isDevinConnected
         isClaudeCodeConnected = UserDefaults.standard.bool(forKey: "ClaudeCodeConnected")
         if isClaudeCodeConnected {
             claudeCodeCLIStatus = .binaryPresent
@@ -601,6 +638,8 @@ public class APISettingsViewModel: ObservableObject {
         isOpenCodeConnected = UserDefaults.standard.bool(forKey: "OpenCodeCLIConnected")
         isCursorConnected = UserDefaults.standard.bool(forKey: "CursorCLIConnected")
         isGrokBuildConnected = UserDefaults.standard.bool(forKey: "GrokBuildCLIConnected")
+        isOMPConnected = UserDefaults.standard.bool(forKey: "OMPCLIConnected")
+        isDevinConnected = UserDefaults.standard.bool(forKey: "DevinCLIConnected")
         if wasGrokBuildConnected != isGrokBuildConnected {
             if isGrokBuildConnected {
                 startGrokBuildModelsSubscriptionIfNeeded(workspacePath: nil)
@@ -614,6 +653,9 @@ public class APISettingsViewModel: ObservableObject {
             } else {
                 stopCursorModelsSubscription(clearModels: true)
             }
+            Task { await updateAvailableModels() }
+        }
+        if wasOMPConnected != isOMPConnected || wasDevinConnected != isDevinConnected {
             Task { await updateAvailableModels() }
         }
     }
@@ -1223,6 +1265,7 @@ public class APISettingsViewModel: ObservableObject {
         let shouldValidateOpenCode = isOpenCodeConnected
         let shouldValidateCursor = isCursorConnected
         let shouldValidateGrokBuild = isGrokBuildConnected
+        let shouldValidateOMP = isOMPConnected
 
         let task = Task { @MainActor [weak self] in
             guard let self, !Task.isCancelled, !hasPreparedForWindowClose else { return }
@@ -1235,7 +1278,8 @@ public class APISettingsViewModel: ObservableObject {
             async let openCodeReady = probeCachedOpenCodeConnection(ifNeeded: shouldValidateOpenCode)
             async let cursorReady = probeCachedCursorConnection(ifNeeded: shouldValidateCursor)
             async let grokBuildReady = probeCachedGrokBuildConnection(ifNeeded: shouldValidateGrokBuild)
-            let readiness = await (claudeReady, codexReady, openCodeReady, cursorReady, grokBuildReady)
+            async let ompReady = probeCachedOMPConnection(ifNeeded: shouldValidateOMP)
+            let readiness = await (claudeReady, codexReady, openCodeReady, cursorReady, grokBuildReady, ompReady)
             guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
             applyContextBuilderProviderValidationResult(readiness.0, provider: .claudeCode)
@@ -1247,6 +1291,7 @@ public class APISettingsViewModel: ObservableObject {
             applyContextBuilderProviderValidationResult(readiness.2, provider: .openCode)
             applyContextBuilderProviderValidationResult(readiness.3, provider: .cursor)
             applyContextBuilderProviderValidationResult(readiness.4, provider: .grokBuild)
+            applyContextBuilderProviderValidationResult(readiness.5, provider: .omp)
             if codexPublicationAllowed,
                isCodexConnected,
                isVerifiedContextBuilderProvider(.codexExec)
@@ -1352,6 +1397,18 @@ public class APISettingsViewModel: ObservableObject {
             return true
         }
         return await GrokBuildACPModelPollingService.shared.refreshNow(workspacePath: nil)
+    }
+
+    private func probeCachedOMPConnection(ifNeeded: Bool) async -> Bool {
+        guard ifNeeded else { return false }
+        return await Self.probeACPCLISupport(spec: .omp, config: OMPAgentConfig())
+    }
+
+    private static func probeACPCLISupport(
+        spec: ACPCLILaunchSpec,
+        config: some ACPCLILaunchConfiguring
+    ) async -> Bool {
+        await (try? ACPCLILaunchResolver(spec: spec).probeSupport(for: config)) == .supported
     }
 
     private func diagnosticReason(for error: Error) -> APIKeychainAccessDiagnostic.Reason {
@@ -1866,6 +1923,14 @@ public class APISettingsViewModel: ObservableObject {
             modelSet.formUnion(AIModel.modelsForProvider(.grokBuild))
         }
 
+        if isOMPConnected {
+            modelSet.formUnion(AIModel.modelsForProvider(.omp))
+        }
+
+        if isDevinConnected {
+            modelSet.formUnion(AIModel.modelsForProvider(.devin))
+        }
+
         // ── Custom provider (OpenAI compatible) ────────────────────────────────
         if isCustomProviderValid,
            let config = try? CustomProviderConfiguration.load()
@@ -1935,6 +2000,8 @@ public class APISettingsViewModel: ObservableObject {
         case .claudeCode: "claude_code"
         case .codex: "codex"
         case .openCode: "opencode"
+        case .omp: "omp"
+        case .devin: "devin"
         }
     }
 
@@ -2011,6 +2078,8 @@ public class APISettingsViewModel: ObservableObject {
                 break
             case .grokBuild:
                 break
+            case .omp, .devin:
+                break
             }
 
             await updateAvailableModels()
@@ -2072,6 +2141,8 @@ public class APISettingsViewModel: ObservableObject {
         case .cursor:
             break
         case .grokBuild:
+            break
+        case .omp, .devin:
             break
         }
         await updateAvailableModels()
@@ -3731,6 +3802,111 @@ public class APISettingsViewModel: ObservableObject {
         if clearModels {
             availableCursorModelOptions = []
         }
+    }
+
+    // MARK: - Oh My Pi CLI / ACP
+
+    func testOMPConnection() async throws -> Bool {
+        try await testACPCLIConnection(
+            spec: .omp,
+            config: OMPAgentConfig(),
+            defaultsKey: "OMPCLIConnected",
+            notification: .ompConnectionChanged,
+            markContextBuilderVerified: true,
+            apply: { [weak self] connected, message in
+                self?.isOMPConnected = connected
+                self?.ompError = message
+            }
+        )
+    }
+
+    func disconnectOMP() {
+        isOMPConnected = false
+        setContextBuilderProviderVerified(.omp, verified: false)
+        ompError = nil
+        UserDefaults.standard.set(false, forKey: "OMPCLIConnected")
+        Task { await updateAvailableModels() }
+        postCLIConnectionChanged(.ompConnectionChanged)
+    }
+
+    // MARK: - Devin CLI / ACP
+
+    func testDevinConnection() async throws -> Bool {
+        try await testACPCLIConnection(
+            spec: .devin,
+            config: DevinAgentConfig(),
+            defaultsKey: "DevinCLIConnected",
+            notification: .devinConnectionChanged,
+            markContextBuilderVerified: false,
+            apply: { [weak self] connected, message in
+                self?.isDevinConnected = connected
+                self?.devinError = message
+            }
+        )
+    }
+
+    func disconnectDevin() {
+        isDevinConnected = false
+        devinError = nil
+        UserDefaults.standard.set(false, forKey: "DevinCLIConnected")
+        Task { await updateAvailableModels() }
+        postCLIConnectionChanged(.devinConnectionChanged)
+    }
+
+    /// Shared connect/verify flow for ACP providers whose only readiness signal is the
+    /// `<cli> acp --help` preflight. The resolver's failure text already names every
+    /// candidate path it tried, so it is surfaced verbatim as the user-facing error.
+    private func testACPCLIConnection(
+        spec: ACPCLILaunchSpec,
+        config: some ACPCLILaunchConfiguring,
+        defaultsKey: String,
+        notification: Notification.Name,
+        markContextBuilderVerified: Bool,
+        apply: @MainActor @escaping (_ connected: Bool, _ error: String?) -> Void
+    ) async throws -> Bool {
+        await CLIEnvironmentCache.shared.invalidate()
+        do {
+            let support = try await ACPCLILaunchResolver(spec: spec).probeSupport(for: config)
+            guard support == .supported else {
+                throw AIProviderError.invalidConfiguration(
+                    detail: support.reason ?? "Installed \(spec.displayName) CLI does not support ACP mode."
+                )
+            }
+            apply(true, nil)
+            if markContextBuilderVerified {
+                setContextBuilderProviderVerified(spec.providerKind, verified: true)
+            }
+            UserDefaults.standard.set(true, forKey: defaultsKey)
+            // Best effort: publish the provider's advertised catalog now so the pickers are
+            // populated at connect time instead of only after the first run. An ACP-capable
+            // CLI that advertises nothing still connects and uses its own default model.
+            _ = try? await ACPCLIModelDiscoveryService.discoverModels(for: spec.providerKind)
+            await updateAvailableModels()
+            postCLIConnectionChanged(notification)
+            return true
+        } catch {
+            apply(false, friendlyACPCLIMessage(for: error))
+            if markContextBuilderVerified {
+                setContextBuilderProviderVerified(spec.providerKind, verified: false)
+            }
+            UserDefaults.standard.set(false, forKey: defaultsKey)
+            await updateAvailableModels()
+            postCLIConnectionChanged(notification)
+            throw error
+        }
+    }
+
+    private func friendlyACPCLIMessage(for error: Error) -> String {
+        if let providerError = error as? AIProviderError,
+           case let .invalidConfiguration(detail) = providerError
+        {
+            return detail
+        }
+        return error.localizedDescription
+    }
+
+    private func postCLIConnectionChanged(_ name: Notification.Name) {
+        NotificationCenter.default.post(name: name, object: nil, userInfo: ["windowID": 0])
     }
 
     // MARK: - Grok Build CLI / ACP

--- a/Sources/RepoPrompt/Features/Settings/Views/AIModelDropDown.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AIModelDropDown.swift
@@ -146,6 +146,13 @@ struct AIModelDropdown: View {
                         items: group.models.map(aiModelMenuItem)
                     )
                 }
+            } else if provider == .omp {
+                AIModel.ompMenuGroups(for: models).flatMap { group -> [StableMenuItem] in
+                    let items = group.models.map(aiModelMenuItem)
+                    // Ungrouped models render inline; a titleless submenu would be a blank row.
+                    guard let displayName = group.displayName else { return items }
+                    return [.submenu(displayName, items: items)]
+                }
             } else if provider == .openCode {
                 AIModel.openCodeMenu(for: models).providerGroups.flatMap { providerGroup -> [StableMenuItem] in
                     let modelItems = providerGroup.groups.map(aiModelOpenCodeMenuItem)

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -583,6 +583,8 @@ struct AgentModeGeneralSettingsView: View {
         case .antigravity: AntigravityRuntimeManager.installedRuntimeSync() != nil
         case .cursor: apiSettingsVM.isCursorConnected
         case .grokBuild: apiSettingsVM.isGrokBuildConnected
+        case .omp: apiSettingsVM.isOMPConnected
+        case .devin: apiSettingsVM.isDevinConnected
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
@@ -59,7 +59,7 @@ struct AgentProviderPermissionLevelSection: View {
                 }
                 .pickerStyle(.menu)
                 .labelsHidden()
-                .disabled(binding.externallyManagedReason != nil)
+                .disabled(binding.externallyManagedReason != nil || binding.options.allSatisfy { !$0.isEnabled })
                 .frame(idealWidth: 320, maxWidth: 420, alignment: .leading)
 
                 if let detail = selected.detailText,
@@ -90,6 +90,7 @@ struct AgentProviderPermissionLevelSection: View {
         case .openCode, .antigravity: "ACP Session Mode"
         case .cursor: "ACP Auto-Approve"
         case .grokBuild: "Always-Approve Launch"
+        case .omp, .devin: "Tool Permissions"
         }
     }
 }
@@ -140,7 +141,7 @@ struct AgentProviderToolsRuntimeDisclosure: View {
         switch providerID {
         case .codex: binding.codexTools != nil
         case .claude: binding.claudeTools != nil
-        case .openCode, .cursor, .grokBuild, .antigravity: false
+        case .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin: false
         }
     }
 }
@@ -168,7 +169,7 @@ struct AgentProviderToolsRuntimeControls: View {
                         onApplyMutation: onApplyClaudeToolSettingMutation
                     )
                 }
-            case .openCode, .cursor, .grokBuild, .antigravity:
+            case .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
                 EmptyView()
             }
         }

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -53,6 +53,8 @@ struct CLIProvidersSettingsView: View {
     @State private var isTestingAntigravity = false
     @State private var isAntigravityInstalled = false
     @State private var isAntigravityExpanded = false
+    @State private var isLoadingOMP = false
+    @State private var isLoadingDevin = false
     @State private var isLoadingZAI = false
     @State private var showClaudeCodeTraceDump = false
     @State private var showCodexTraceDump = false
@@ -76,6 +78,8 @@ struct CLIProvidersSettingsView: View {
     @State private var isOpenCodeExpanded: Bool = false
     @State private var isCursorExpanded: Bool = false
     @State private var isGrokBuildExpanded: Bool = false
+    @State private var isOMPExpanded: Bool = false
+    @State private var isDevinExpanded: Bool = false
 
     // Per-backend secret text entry buffers (GLM uses viewModel.zaiApiKey directly).
     // SEARCH-HELPER: Claude-Compatible Backends settings, Kimi API key entry, Custom backend key entry
@@ -95,6 +99,8 @@ struct CLIProvidersSettingsView: View {
             || viewModel.isOpenCodeConnected
             || viewModel.isCursorConnected
             || viewModel.isGrokBuildConnected
+            || viewModel.isOMPConnected
+            || viewModel.isDevinConnected
     }
 
     private var codexStatusText: String? {
@@ -127,7 +133,7 @@ struct CLIProvidersSettingsView: View {
                         .font(.title2)
                         .fontWeight(.semibold)
 
-                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, or Cursor to leverage your existing subscriptions — OpenCode can also proxy any API key.")
+                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, Cursor, Oh My Pi, or Devin to leverage your existing subscriptions — OpenCode can also proxy any API key.")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -156,6 +162,8 @@ struct CLIProvidersSettingsView: View {
                 cursorCard
                 grokBuildCard
                 antigravityCard
+                ompCard
+                devinCard
             }
             .padding(16)
         }
@@ -2246,6 +2254,110 @@ struct CLIProvidersSettingsView: View {
         return count == 1 ? "1 model available." : "\(count) models available (including Default)."
     }
 
+    // MARK: - Oh My Pi CLI / ACP card
+
+    private var ompCard: some View {
+        acpCLIProviderCard(
+            title: "Oh My Pi",
+            subtitle: "Uses the installed `omp acp` runtime for Agent Mode and headless tasks. OMP keeps authority over authentication, models, fallbacks, memory, compaction, and its built-in tools.",
+            infoURL: "https://github.com/can1357/oh-my-pi",
+            connectedNote: "Uses OMP's configured provider, model, and fallback behavior.",
+            disconnectedNote: "Install and authenticate OMP separately, then ensure `omp acp` is available.",
+            isConnected: viewModel.isOMPConnected,
+            isExpanded: $isOMPExpanded,
+            isLoading: isLoadingOMP,
+            error: viewModel.ompError,
+            connect: connectOMP,
+            disconnect: disconnectOMP
+        )
+    }
+
+    // MARK: - Devin CLI / ACP card
+
+    private var devinCard: some View {
+        acpCLIProviderCard(
+            title: "Devin",
+            subtitle: "Uses the installed `devin acp` runtime for interactive Agent Mode. Devin keeps authority over authentication, models, modes, and built-in tools.",
+            infoURL: "https://docs.devin.ai/cli/acp/zed",
+            connectedNote: "Devin owns model selection and its internal tools; RepoPrompt injects its MCP tools.",
+            disconnectedNote: "Install and authenticate Devin separately, then ensure `devin acp` is available.",
+            isConnected: viewModel.isDevinConnected,
+            isExpanded: $isDevinExpanded,
+            isLoading: isLoadingDevin,
+            error: viewModel.devinError,
+            connect: connectDevin,
+            disconnect: disconnectDevin
+        )
+    }
+
+    /// Card body shared by the ACP CLI providers whose only RepoPrompt-side control is the
+    /// connection itself: everything else stays under provider authority.
+    private func acpCLIProviderCard(
+        title: String,
+        subtitle: String,
+        infoURL: String,
+        connectedNote: String,
+        disconnectedNote: String,
+        isConnected: Bool,
+        isExpanded: Binding<Bool>,
+        isLoading: Bool,
+        error: String?,
+        connect: @escaping () -> Void,
+        disconnect: @escaping () -> Void
+    ) -> some View {
+        providerCard(
+            title: title,
+            subtitle: subtitle,
+            infoURL: infoURL,
+            isConnected: isConnected,
+            isExpanded: isExpanded
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 10) {
+                    Button(action: connect) {
+                        if isLoading {
+                            ProgressView()
+                                .scaleEffect(0.6)
+                                .frame(height: 16)
+                        } else if isConnected {
+                            Label("Test Connection", systemImage: "antenna.radiowaves.left.and.right")
+                        } else {
+                            Label("Connect", systemImage: "link")
+                        }
+                    }
+                    .disabled(isLoading)
+                    .buttonStyle(CustomButtonStyle())
+
+                    if isConnected {
+                        Spacer()
+
+                        Button(action: disconnect) {
+                            Text("Disconnect")
+                                .foregroundColor(.secondary)
+                        }
+                        .disabled(isLoading)
+                        .buttonStyle(CustomButtonStyle())
+                    } else if let error, !error.isEmpty {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        Text(disconnectedNote)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                if isConnected {
+                    Text(connectedNote)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
     // MARK: - Cursor CLI / ACP card
 
     private var cursorCard: some View {
@@ -2804,6 +2916,62 @@ struct CLIProvidersSettingsView: View {
         viewModel.disconnectCursor()
         alertMessage = "Signed out from Cursor CLI"
         showCursorTraceDump = false
+        showAlert = true
+        onAPIKeyUpdated?()
+    }
+
+    private func connectOMP() {
+        isLoadingOMP = true
+        Task {
+            do {
+                _ = try await viewModel.testOMPConnection()
+                await MainActor.run {
+                    isLoadingOMP = false
+                    alertMessage = "Oh My Pi connected. OMP will use its configured provider and model."
+                    showAlert = true
+                    onAPIKeyUpdated?()
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingOMP = false
+                    alertMessage = viewModel.ompError ?? error.asFriendlyString()
+                    showAlert = true
+                }
+            }
+        }
+    }
+
+    private func disconnectOMP() {
+        viewModel.disconnectOMP()
+        alertMessage = "Disconnected Oh My Pi"
+        showAlert = true
+        onAPIKeyUpdated?()
+    }
+
+    private func connectDevin() {
+        isLoadingDevin = true
+        Task {
+            do {
+                _ = try await viewModel.testDevinConnection()
+                await MainActor.run {
+                    isLoadingDevin = false
+                    alertMessage = "Devin connected. Devin will use its configured model and modes."
+                    showAlert = true
+                    onAPIKeyUpdated?()
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingDevin = false
+                    alertMessage = viewModel.devinError ?? error.asFriendlyString()
+                    showAlert = true
+                }
+            }
+        }
+    }
+
+    private func disconnectDevin() {
+        viewModel.disconnectDevin()
+        alertMessage = "Disconnected Devin"
         showAlert = true
         onAPIKeyUpdated?()
     }

--- a/Sources/RepoPrompt/Features/Settings/Views/OptimizedModelPicker.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/OptimizedModelPicker.swift
@@ -162,6 +162,20 @@ struct OptimizedModelPicker: View {
                     modelButton(option.model, title: option.displayName)
                 }
             }
+        } else if provider == .omp {
+            ForEach(AIModel.ompMenuGroups(for: models)) { group in
+                if let displayName = group.displayName {
+                    Menu(displayName) {
+                        ForEach(group.models, id: \.rawValue) { model in
+                            modelButton(model)
+                        }
+                    }
+                } else {
+                    ForEach(group.models, id: \.rawValue) { model in
+                        modelButton(model)
+                    }
+                }
+            }
         } else if provider == .openCode {
             ForEach(AIModel.openCodeMenu(for: models).providerGroups) { providerGroup in
                 if providerGroup.rendersAsSubmenu {

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentProviderFactory.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentProviderFactory.swift
@@ -33,6 +33,19 @@ enum ACPAgentProviderFactory {
                     modelString: modelString
                 )
             )
+        case .omp:
+            OMPACPAgentProvider(
+                config: OMPAgentConfig(
+                    enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
+                    modelString: modelString
+                )
+            )
+        case .devin:
+            DevinACPAgentProvider(
+                config: DevinAgentConfig(
+                    enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging
+                )
+            )
         case .grokBuild:
             try await GrokBuildACPAgentProvider(
                 config: GrokBuildAgentConfig(

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -725,7 +725,7 @@ actor ACPAgentSessionController {
         }
 
         switch provider.providerID {
-        case .openCode, .cursor, .grokBuild, .antigravity:
+        case .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             if let sessionModelFailureReason {
                 throw ControllerError.protocolViolation("malformed modern model config option: \(sessionModelFailureReason)")
             }
@@ -2302,7 +2302,10 @@ actor ACPAgentSessionController {
         if error is ExecutableFileIdentityError {
             return "executable_identity"
         }
-        if error is CursorACPLaunchResolutionError || error is OpenCodeACPLaunchResolutionError {
+        if error is CursorACPLaunchResolutionError
+            || error is OpenCodeACPLaunchResolutionError
+            || error is ACPCLILaunchResolutionError
+        {
             return "launch_resolution"
         }
         if error is CLIProcessRunnerError {
@@ -2921,7 +2924,8 @@ actor ACPAgentSessionController {
             displayName: displayName,
             description: normalizedACPModelString(rawOption["description"] as? String),
             isPlaceholderDefault: false,
-            isProviderDefault: rawOption["isDefault"] as? Bool ?? false
+            isProviderDefault: rawOption["isDefault"] as? Bool ?? false,
+            modelFamily: provider.modelFamily(for: rawValue)
         )
     }
 
@@ -3259,7 +3263,7 @@ actor ACPAgentSessionController {
 
     private func preferredAllowOptionID(for options: [PermissionOption], sessionScoped: Bool) -> String {
         let preferences: [PermissionOptionPreference] = switch provider.providerID {
-        case .openCode, .cursor, .antigravity:
+        case .openCode, .cursor, .antigravity, .omp, .devin:
             genericAllowOptionPreferences(sessionScoped: sessionScoped)
         case .grokBuild:
             grokBuildAllowOptionPreferences(sessionScoped: sessionScoped)
@@ -3310,7 +3314,7 @@ actor ACPAgentSessionController {
         switch provider.providerID {
         case .cursor:
             return optionID(for: options, preferences: genericAllowOptionPreferences(sessionScoped: true))
-        case .openCode, .grokBuild, .antigravity:
+        case .openCode, .grokBuild, .antigravity, .omp, .devin:
             // Grok full access is provider-native (`grok agent --always-approve stdio`); the
             // controller never auto-selects permission options for it.
             return nil
@@ -3355,7 +3359,7 @@ actor ACPAgentSessionController {
         }
 
         let preferences: [PermissionOptionPreference] = switch provider.providerID {
-        case .openCode, .cursor, .antigravity:
+        case .openCode, .cursor, .antigravity, .omp, .devin:
             [
                 .optionID("always"),
                 .optionID("allow_always"),
@@ -3569,6 +3573,10 @@ actor ACPAgentSessionController {
                 "RP_GROK_BUILD_ACP_RAW_CAPTURE_PATH"
             case .antigravity:
                 "RP_ANTIGRAVITY_ACP_RAW_CAPTURE_PATH"
+            case .omp:
+                "RP_OMP_ACP_RAW_CAPTURE_PATH"
+            case .devin:
+                "RP_DEVIN_ACP_RAW_CAPTURE_PATH"
             }
             let customPath = providerSpecificKey.flatMap { key in
                 env[key]?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPCLIChatProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPCLIChatProvider.swift
@@ -1,0 +1,261 @@
+import Foundation
+
+/// Shared non-agent (chat / Oracle / AI queries) adapter for ACP-backed CLI providers.
+/// Every request runs a fresh headless ACP session; the only provider-specific parts are
+/// the per-request config, the name used in error text, and the `AIProviderType` whose
+/// advertised model IDs may be forwarded.
+///
+/// OpenCode and Oh My Pi share this engine rather than each carrying its own copy of the
+/// stream bridge, replacement/disposal bookkeeping, and conversation flattening.
+final class ACPCLIChatProviderEngine<Provider: AnyObject & HeadlessAgentProvider>: AIProvider {
+    typealias ProviderFactory = @Sendable (_ modelName: String?) -> Provider
+
+    private let providerName: String
+    private let providerType: AIProviderType
+    private let makeProvider: ProviderFactory
+    private let activeProviders = ActiveACPCLIProviderStore<Provider>()
+
+    init(
+        providerName: String,
+        providerType: AIProviderType,
+        makeProvider: @escaping ProviderFactory
+    ) {
+        self.providerName = providerName
+        self.providerType = providerType
+        self.makeProvider = makeProvider
+    }
+
+    func streamMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens _: Int? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        let provider = makeProvider(modelName(for: model))
+        if let replacedProvider = activeProviders.replace(provider) {
+            await replacedProvider.dispose()
+        }
+
+        let upstream: AsyncThrowingStream<AIStreamResult, Error>
+        do {
+            upstream = try await provider.streamAgentMessage(agentMessage(from: aiMessage), runID: nil)
+        } catch {
+            activeProviders.remove(provider)
+            await provider.dispose()
+            throw error
+        }
+        guard activeProviders.contains(provider) else {
+            await provider.dispose()
+            throw CancellationError()
+        }
+
+        return AsyncThrowingStream { continuation in
+            let bridgeTask = Task {
+                do {
+                    for try await result in upstream {
+                        guard result.type != "system", result.type != "status" else { continue }
+                        continuation.yield(result)
+                    }
+                    continuation.finish()
+                } catch {
+                    if Task.isCancelled {
+                        continuation.finish()
+                    } else {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                if self.activeProviders.remove(provider) {
+                    await provider.dispose()
+                }
+            }
+
+            continuation.onTermination = { [activeProviders] termination in
+                bridgeTask.cancel()
+                guard case .cancelled = termination else { return }
+                Task {
+                    if activeProviders.remove(provider) {
+                        await provider.dispose()
+                    }
+                }
+            }
+        }
+    }
+
+    func completeMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AICompletionResult {
+        let stream = try await streamMessage(aiMessage, model: model, maxTokens: maxTokens)
+        var textParts: [String] = []
+        var finalContent: String?
+        var promptTokens: Int?
+        var completionTokens: Int?
+        var cost: Double?
+        var sawMessageStop = false
+
+        for try await result in stream {
+            switch result.type {
+            case "content":
+                if let text = result.text, !text.isEmpty {
+                    textParts.append(text)
+                }
+            case "final_content":
+                if let text = result.text, !text.isEmpty {
+                    finalContent = text
+                }
+            case "message_stop":
+                sawMessageStop = true
+                if let value = result.promptTokens { promptTokens = value }
+                if let value = result.completionTokens { completionTokens = value }
+                if let value = result.cost { cost = value }
+            case "error":
+                throw AIProviderError.invalidConfiguration(
+                    detail: result.text ?? "\(providerName) ACP reported an error"
+                )
+            default:
+                continue
+            }
+        }
+
+        let text = textParts.isEmpty ? (finalContent ?? "") : textParts.joined()
+        guard sawMessageStop || !text.isEmpty else {
+            throw AIProviderError.invalidResponse(detail: "\(providerName) returned no completion")
+        }
+
+        return AICompletionResult(
+            text: text,
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            cost: cost
+        )
+    }
+
+    func dispose() async {
+        let providers = activeProviders.removeAll()
+        for provider in providers {
+            await provider.dispose()
+        }
+    }
+
+    #if DEBUG
+        func test_agentMessage(from aiMessage: AIMessage) -> AgentMessage {
+            agentMessage(from: aiMessage)
+        }
+    #endif
+
+    /// A model ID is forwarded only when it came from this provider's own catalog; anything
+    /// else leaves the CLI on its configured default.
+    private func modelName(for model: AIModel) -> String? {
+        guard model.providerType == providerType else { return nil }
+        let trimmed = model.modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func agentMessage(from aiMessage: AIMessage) -> AgentMessage {
+        let turns = renderedTurns(from: aiMessage)
+        var message = AgentMessage(
+            systemPrompt: aiMessage.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines),
+            userMessage: turns.map(\.text).joined(separator: "\n\n"),
+            resumeSessionID: nil
+        )
+        message.promptContentParts = Self.promptContentParts(from: turns)
+        return message
+    }
+
+    private struct RenderedTurn {
+        let text: String
+        let images: [AITransientImage]
+    }
+
+    /// ACP takes a single prompt string, so the conversation is flattened with the packaged
+    /// context tail attached to the final user turn.
+    private func renderedTurns(from aiMessage: AIMessage) -> [RenderedTurn] {
+        let tail = aiMessage.buildTail(embedSystemPrompt: false)
+        var turns: [RenderedTurn] = []
+        let lastUserIndex = aiMessage.conversationMessages.lastIndex { $0.role == .user }
+        for (index, message) in aiMessage.conversationMessages.enumerated() {
+            var text = message.content
+            if message.role == .user,
+               index == lastUserIndex,
+               !tail.isEmpty
+            {
+                text = tail + "\n\n" + text
+            }
+            let prefix = message.role == .user ? "User" : "Assistant"
+            turns.append(RenderedTurn(text: "\(prefix): \(text)", images: message.images))
+        }
+        if aiMessage.conversationMessages.isEmpty, !tail.isEmpty {
+            turns = [RenderedTurn(text: "User: \(tail)", images: [])]
+        }
+        return turns
+    }
+
+    private static func promptContentParts(from turns: [RenderedTurn]) -> [AgentPromptContentPart] {
+        guard turns.contains(where: { !$0.images.isEmpty }) else { return [] }
+        var parts: [AgentPromptContentPart] = []
+        var buffer: [String] = []
+        for turn in turns {
+            buffer.append(turn.text)
+            guard !turn.images.isEmpty else { continue }
+            parts.append(.text(buffer.joined(separator: "\n\n")))
+            buffer.removeAll(keepingCapacity: true)
+            parts.append(contentsOf: turn.images.map { .image($0) })
+        }
+        if !buffer.isEmpty {
+            parts.append(.text(buffer.joined(separator: "\n\n")))
+        }
+        return parts
+    }
+}
+
+/// Tracks the headless providers a chat engine has in flight so a superseded or cancelled
+/// request is disposed exactly once.
+final class ActiveACPCLIProviderStore<Provider: AnyObject>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var providers: [ObjectIdentifier: Provider] = [:]
+    private var currentProviderID: ObjectIdentifier?
+
+    func replace(_ provider: Provider) -> Provider? {
+        lock.lock()
+        let providerID = ObjectIdentifier(provider)
+        let previousProvider = currentProviderID.flatMap { providers[$0] }
+        providers[providerID] = provider
+        currentProviderID = providerID
+        lock.unlock()
+        guard let previousProvider,
+              previousProvider !== provider
+        else {
+            return nil
+        }
+        return previousProvider
+    }
+
+    func contains(_ provider: Provider) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return providers[ObjectIdentifier(provider)] != nil
+    }
+
+    @discardableResult
+    func remove(_ provider: Provider) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let providerID = ObjectIdentifier(provider)
+        let removedProvider = providers.removeValue(forKey: providerID)
+        if currentProviderID == providerID {
+            currentProviderID = nil
+        }
+        return removedProvider != nil
+    }
+
+    func removeAll() -> [Provider] {
+        lock.lock()
+        let currentProviders = Array(providers.values)
+        providers.removeAll()
+        currentProviderID = nil
+        lock.unlock()
+        return currentProviders
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPCLILaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPCLILaunchResolver.swift
@@ -1,0 +1,416 @@
+import Foundation
+
+/// Launch configuration an ACP provider hands to `ACPCLILaunchResolver`. `Sendable` because
+/// the serialized preflight captures it in a `@Sendable` closure.
+protocol ACPCLILaunchConfiguring: Sendable {
+    /// Either the profile's bare command name or an absolute path to it.
+    var commandName: String { get }
+    var additionalPathHints: [String] { get }
+    var enableDebugLogging: Bool { get }
+}
+
+/// The provider-specific facts of a `<cli> acp`-style stdio launch. Candidate ordering,
+/// executable-identity capture, caching, and the `--help` preflight are shared.
+struct ACPCLILaunchSpec {
+    let providerID: ACPProviderID
+    let providerKind: AgentProviderKind
+    /// Product name used verbatim in every user-facing diagnostic ("Devin", "Oh My Pi").
+    let displayName: String
+    let profile: CLILaunchProfile
+    let launchArguments: [String]
+    let helpArguments: [String]
+    /// Case-insensitive substrings the preflight output must ALL contain before the
+    /// installed CLI counts as ACP-capable.
+    let requiredHelpAdvertisements: [String]
+
+    var commandName: String {
+        profile.commandName
+    }
+
+    fileprivate var helpInvocation: String {
+        ([commandName] + helpArguments).joined(separator: " ")
+    }
+}
+
+struct ACPCLIResolvedLaunch: Equatable {
+    let command: String
+    let arguments: [String]
+    let additionalPathHints: [String]
+    /// The effective child environment this resolution was performed against. Providers
+    /// that overlay isolated configuration (Devin's `XDG_CONFIG_HOME`) read the native
+    /// `HOME`/`XDG_CONFIG_HOME` from here instead of re-deriving them.
+    let environment: [String: String]
+    let executableIdentity: ExecutableFileIdentity
+}
+
+enum ACPCLILaunchResolutionError: Error, Equatable, LocalizedError {
+    case missingConfiguredCommand(agent: String, expected: String)
+    case unsafeConfiguredCommand(agent: String, command: String)
+    case exactPathNotFound(agent: String, command: String)
+    case noValidLaunchCandidate(agent: String, command: String, failures: [String], source: ShellEnvironmentSource?)
+    case environmentDiscoveryRequired(agent: String, command: String)
+    case unsafeApplicationPath(agent: String, path: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingConfiguredCommand(agent, expected):
+            "\(agent) CLI launch requires an exact `\(expected)` command or absolute path."
+        case let .unsafeConfiguredCommand(agent, command):
+            "Refusing unsafe \(agent) ACP command `\(command)`. Configure the installed executable."
+        case let .exactPathNotFound(agent, command):
+            "\(agent) CLI was not found as a valid executable regular file for `\(command)`. Install \(agent) or configure its absolute path."
+        case let .noValidLaunchCandidate(agent, command, failures, source):
+            AgentCLILaunchDiagnostics.appendFallbackEnvironmentHint(
+                to: "\(agent) CLI was not found as a valid executable regular file for `\(command)`. Tried: \(failures.joined(separator: "; "))",
+                source: source
+            )
+        case let .environmentDiscoveryRequired(agent, command):
+            "\(agent) CLI path discovery has not completed for `\(command)`. Run the \(agent) ACP support preflight or configure an absolute path."
+        case let .unsafeApplicationPath(agent, path):
+            "Refusing \(agent) ACP executable inside an application bundle: \(path)"
+        }
+    }
+}
+
+/// Shared resolver for ACP providers whose runtime is a locally installed CLI invoked as
+/// `<command> acp` over stdio. Behavior matches the per-provider resolvers it generalizes:
+/// only the profile's exact basename is accepted, executables inside `.app` bundles are
+/// refused, and the resolution cache exists only to bridge a successful `probeSupport`
+/// to the launch configuration that immediately follows it.
+final class ACPCLILaunchResolver: @unchecked Sendable {
+    typealias EnvironmentProvider = @Sendable (_ enableDebugLogging: Bool) async -> ACPLaunchEnvironment
+
+    let spec: ACPCLILaunchSpec
+
+    private let environmentProvider: EnvironmentProvider
+    private let probeMutex = AsyncMutex()
+    private let lock = NSLock()
+    private var cachedLaunchByKey: [String: ACPCLIResolvedLaunch] = [:]
+
+    init(
+        spec: ACPCLILaunchSpec,
+        launchEnvironmentProvider: EnvironmentProvider? = nil
+    ) {
+        self.spec = spec
+        environmentProvider = launchEnvironmentProvider ?? { enableDebugLogging in
+            let result = await ProcessEnvironmentBuilder.build(
+                ProcessEnvironmentRequest(
+                    purpose: .acpAgent(providerID: spec.providerID.rawValue),
+                    enableDebugLogging: enableDebugLogging
+                )
+            )
+            return ACPLaunchEnvironment(
+                environment: result.environment,
+                shellEnvironmentSource: result.shellEnvironmentSource
+            )
+        }
+    }
+
+    func resolvedLaunch(for config: some ACPCLILaunchConfiguring) throws -> ACPCLIResolvedLaunch {
+        let key = cacheKey(for: config)
+        if let cached = cachedLaunch(forKey: key) {
+            do {
+                try cached.executableIdentity.validateForTrustedPathLaunch(atPath: cached.command)
+                return cached
+            } catch {
+                invalidate(key: key)
+                throw error
+            }
+        }
+
+        let launch = try resolveExplicitLaunch(for: config)
+        cache(launch, key: key)
+        return launch
+    }
+
+    func probeSupport(for config: some ACPCLILaunchConfiguring) async throws -> ACPSupportResult {
+        try await probeMutex.withLock { [self] in
+            try await probeSupportSerially(for: config)
+        }
+    }
+
+    private func probeSupportSerially(for config: some ACPCLILaunchConfiguring) async throws -> ACPSupportResult {
+        let key = cacheKey(for: config)
+        invalidate(key: key)
+        do {
+            // Resolve from the current effective environment on every support check.
+            let launch = try await resolveLaunchForProbe(for: config)
+            let result = try await CLIProcessRunner(
+                config: CLIProcessConfiguration(
+                    command: launch.command,
+                    additionalPaths: [],
+                    enableDebugLogging: config.enableDebugLogging,
+                    shellLookupMode: .fallbackOnly
+                )
+            ).run(
+                args: spec.helpArguments,
+                stdin: nil,
+                outputMode: .none,
+                timeout: 10,
+                cancelChildOnTaskCancellation: true
+            )
+            guard result.status == 0 else {
+                return .unsupported(
+                    reason: "\(spec.displayName) CLI ACP preflight failed: `\(spec.helpInvocation)` exited with status \(result.status)."
+                )
+            }
+
+            let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            let combined = "\(stdout)\n\(stderr)"
+            guard spec.requiredHelpAdvertisements.allSatisfy(combined.localizedCaseInsensitiveContains) else {
+                return .unsupported(
+                    reason: "\(spec.displayName) CLI ACP preflight failed: `\(spec.helpInvocation)` did not advertise ACP support."
+                )
+            }
+
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
+            cache(launch, key: key)
+            return .supported
+        } catch is CancellationError {
+            invalidate(key: key)
+            throw CancellationError()
+        } catch {
+            invalidate(key: key)
+            return .unsupported(reason: error.localizedDescription)
+        }
+    }
+
+    private func resolveLaunchForProbe(for config: some ACPCLILaunchConfiguring) async throws -> ACPCLIResolvedLaunch {
+        let configuredCommand = try validatedConfiguredCommand(config)
+        let launchEnvironment = await environmentProvider(config.enableDebugLogging)
+        let environment = launchEnvironment.environment
+        try Task.checkCancellation()
+        if configuredCommand.contains("/") {
+            return try resolveExplicitLaunch(
+                for: config,
+                environment: environment,
+                shellEnvironmentSource: launchEnvironment.shellEnvironmentSource
+            )
+        }
+
+        let hints = effectiveHints(for: config)
+        return try firstValidLaunch(
+            candidates: launchCandidates(additionalPathHints: hints, environment: environment),
+            configuredCommand: configuredCommand,
+            additionalPathHints: hints,
+            environment: environment,
+            shellEnvironmentSource: launchEnvironment.shellEnvironmentSource
+        )
+    }
+
+    private func resolveExplicitLaunch(
+        for config: some ACPCLILaunchConfiguring,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        shellEnvironmentSource: ShellEnvironmentSource? = nil
+    ) throws -> ACPCLIResolvedLaunch {
+        let configuredCommand = try validatedConfiguredCommand(config)
+        guard configuredCommand.contains("/") else {
+            throw ACPCLILaunchResolutionError.environmentDiscoveryRequired(
+                agent: spec.displayName,
+                command: configuredCommand
+            )
+        }
+        do {
+            return try validatedLaunch(
+                entryPath: CommandPathResolver.expandPath(configuredCommand, environment: environment),
+                configuredCommand: configuredCommand,
+                additionalPathHints: effectiveHints(for: config),
+                environment: environment
+            )
+        } catch {
+            // Explicit-path failures keep their specific errors and omit the fallback-PATH
+            // hint: an exact configured path does not depend on PATH discovery.
+            AgentCLILaunchDiagnostics.recordPathResolutionFailure(
+                providerKind: .init(agentKind: spec.providerKind),
+                shellEnvironmentSource: shellEnvironmentSource,
+                candidateCount: 1
+            )
+            throw error
+        }
+    }
+
+    private func validatedConfiguredCommand(_ config: some ACPCLILaunchConfiguring) throws -> String {
+        let configuredCommand = config.commandName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !configuredCommand.isEmpty else {
+            throw ACPCLILaunchResolutionError.missingConfiguredCommand(
+                agent: spec.displayName,
+                expected: spec.commandName
+            )
+        }
+        let basename = configuredCommand.contains("/")
+            ? (configuredCommand as NSString).lastPathComponent
+            : configuredCommand
+        guard basename.caseInsensitiveCompare(spec.commandName) == .orderedSame else {
+            throw ACPCLILaunchResolutionError.unsafeConfiguredCommand(
+                agent: spec.displayName,
+                command: configuredCommand
+            )
+        }
+        return configuredCommand
+    }
+
+    private func validatedLaunch(
+        entryPath: String,
+        configuredCommand: String,
+        additionalPathHints: [String],
+        environment: [String: String],
+        preserveValidationError: Bool = false
+    ) throws -> ACPCLIResolvedLaunch {
+        guard entryPath.hasPrefix("/"),
+              (entryPath as NSString).lastPathComponent.caseInsensitiveCompare(spec.commandName) == .orderedSame
+        else {
+            throw ACPCLILaunchResolutionError.exactPathNotFound(
+                agent: spec.displayName,
+                command: configuredCommand
+            )
+        }
+
+        let identity: ExecutableFileIdentity
+        do {
+            identity = try ExecutableFileIdentity.captureForTrustedPathLaunch(atPath: entryPath)
+        } catch {
+            if preserveValidationError { throw error }
+            throw ACPCLILaunchResolutionError.exactPathNotFound(
+                agent: spec.displayName,
+                command: configuredCommand
+            )
+        }
+
+        if identity.canonicalPath.split(separator: "/").contains(where: { $0.lowercased().hasSuffix(".app") }) {
+            throw ACPCLILaunchResolutionError.unsafeApplicationPath(
+                agent: spec.displayName,
+                path: identity.canonicalPath
+            )
+        }
+        return ACPCLIResolvedLaunch(
+            command: identity.canonicalPath,
+            arguments: spec.launchArguments,
+            additionalPathHints: additionalPathHints,
+            environment: environment,
+            executableIdentity: identity
+        )
+    }
+
+    private func launchCandidates(
+        additionalPathHints: [String],
+        environment: [String: String]
+    ) -> [String] {
+        var candidates: [String] = []
+        var seen = Set<String>()
+
+        func append(_ candidate: String) {
+            let expanded = CommandPathResolver.expandPath(candidate, environment: environment)
+            guard !expanded.isEmpty,
+                  expanded.hasPrefix("/"),
+                  seen.insert(expanded).inserted
+            else { return }
+            candidates.append(expanded)
+        }
+
+        append(
+            CommandPathResolver.resolve(
+                spec.commandName,
+                environment: environment,
+                additionalPaths: additionalPathHints,
+                preferredBasenames: spec.profile.preferredBasenames,
+                shellLookupMode: .fallbackOnly
+            )
+        )
+        for directory in CommandPathResolver.mergedPathComponents(
+            environment: environment,
+            additionalPaths: additionalPathHints
+        ) {
+            append((directory as NSString).appendingPathComponent(spec.commandName))
+        }
+        return candidates
+    }
+
+    private func firstValidLaunch(
+        candidates: [String],
+        configuredCommand: String,
+        additionalPathHints: [String],
+        environment: [String: String],
+        shellEnvironmentSource: ShellEnvironmentSource?
+    ) throws -> ACPCLIResolvedLaunch {
+        var failures: [String] = []
+        for candidate in candidates {
+            do {
+                return try validatedLaunch(
+                    entryPath: candidate,
+                    configuredCommand: configuredCommand,
+                    additionalPathHints: additionalPathHints,
+                    environment: environment,
+                    preserveValidationError: true
+                )
+            } catch {
+                failures.append("\(candidate): \(error.localizedDescription)")
+            }
+        }
+        if failures.isEmpty {
+            throw ACPCLILaunchResolutionError.exactPathNotFound(
+                agent: spec.displayName,
+                command: configuredCommand
+            )
+        }
+        AgentCLILaunchDiagnostics.recordPathResolutionFailure(
+            providerKind: .init(agentKind: spec.providerKind),
+            shellEnvironmentSource: shellEnvironmentSource,
+            candidateCount: candidates.count
+        )
+        throw ACPCLILaunchResolutionError.noValidLaunchCandidate(
+            agent: spec.displayName,
+            command: configuredCommand,
+            failures: failures,
+            source: shellEnvironmentSource
+        )
+    }
+
+    private func effectiveHints(for config: some ACPCLILaunchConfiguring) -> [String] {
+        CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(config.additionalPathHints)
+    }
+
+    private func cachedLaunch(forKey key: String) -> ACPCLIResolvedLaunch? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedLaunchByKey[key]
+    }
+
+    private func cache(_ launch: ACPCLIResolvedLaunch, key: String) {
+        lock.lock()
+        cachedLaunchByKey[key] = launch
+        lock.unlock()
+    }
+
+    private func invalidate(key: String) {
+        lock.lock()
+        cachedLaunchByKey.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    private func cacheKey(for config: some ACPCLILaunchConfiguring) -> String {
+        ([config.commandName] + config.additionalPathHints).joined(separator: "\u{1F}")
+    }
+}
+
+extension ACPCLILaunchSpec {
+    static let devin = ACPCLILaunchSpec(
+        providerID: .devin,
+        providerKind: .devin,
+        displayName: "Devin",
+        profile: CLILaunchProfiles.devin,
+        launchArguments: ["acp"],
+        helpArguments: ["acp", "--help"],
+        requiredHelpAdvertisements: ["run as an acp", "server over stdio"]
+    )
+
+    static let omp = ACPCLILaunchSpec(
+        providerID: .omp,
+        providerKind: .omp,
+        displayName: "Oh My Pi",
+        profile: CLILaunchProfiles.omp,
+        launchArguments: ["acp"],
+        helpArguments: ["acp", "--help"],
+        requiredHelpAdvertisements: ["run oh my pi as an acp", "server over stdio"]
+    )
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPCLIModelDiscoveryService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPCLIModelDiscoveryService.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Connect-time model discovery for ACP CLI providers whose catalog is only advertised by a
+/// live session. One throwaway session is bootstrapped so `AgentACPModelRegistry` (and the
+/// pickers reading it) are populated before the first real run instead of after it.
+///
+/// Discovery never injects the RepoPrompt MCP server and never sets a model: a session that
+/// exists only to read `session/new` metadata must not spawn tool servers or mutate state.
+/// Grok Build is intentionally absent — it owns a polling service with session reuse.
+enum ACPCLIModelDiscoveryService {
+    static func discoverModels(
+        for agentKind: AgentProviderKind,
+        workspacePath: String? = nil
+    ) async throws -> ACPDiscoveredSessionModels? {
+        guard let providerID = agentKind.acpProviderID,
+              let provider = discoveryProvider(for: agentKind)
+        else {
+            return nil
+        }
+
+        let request = ACPRunRequest(
+            agentKind: agentKind,
+            modelString: nil,
+            workspacePath: workspacePath,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+        let support = try await provider.support(for: request)
+        guard support == .supported else {
+            throw AIProviderError.invalidConfiguration(
+                detail: support.reason ?? "Installed CLI does not support ACP mode."
+            )
+        }
+
+        let controller = try ACPAgentSessionController(provider: provider, runRequest: request)
+        do {
+            _ = try await controller.bootstrap()
+            // The controller publishes advertised models into the registry during bootstrap.
+            let snapshot = AgentACPModelRegistry.shared.currentSnapshot(for: providerID)
+            await controller.shutdown()
+            return snapshot
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+    }
+
+    private static func discoveryProvider(for agentKind: AgentProviderKind) -> (any ACPAgentProvider)? {
+        switch agentKind {
+        case .omp:
+            OMPACPAgentProvider(
+                config: OMPAgentConfig(
+                    enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
+                    includeRepoPromptMCPServer: false
+                )
+            )
+        case .devin:
+            DevinACPAgentProvider(
+                config: DevinAgentConfig(
+                    enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
+                    includeRepoPromptMCPServer: false
+                )
+            )
+        default:
+            nil
+        }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPPromptComposition.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPPromptComposition.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Shared first-turn prompt text composition for ACP providers that have no separate
+/// system-prompt channel: the system prompt is prepended once on session open and never
+/// repeated on a resumed session, where the agent already holds it.
+enum ACPPromptComposition {
+    static func promptText(for message: AgentMessage, request: ACPRunRequest) -> String {
+        let isFollowUp = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+        let systemPrompt = message.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let userMessage = message.userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        if isFollowUp || systemPrompt.isEmpty {
+            return userMessage.isEmpty ? message.userMessage : userMessage
+        }
+        if userMessage.isEmpty {
+            return systemPrompt
+        }
+        return "\(systemPrompt)\n\n\(userMessage)"
+    }
+
+    static func promptContentParts(
+        for message: AgentMessage,
+        request: ACPRunRequest
+    ) -> [AgentPromptContentPart] {
+        guard !message.promptContentParts.isEmpty else {
+            return [.text(promptText(for: message, request: request))]
+        }
+
+        var parts = message.promptContentParts
+        let textIndices = parts.indices.filter { parts[$0].text != nil }
+        if let index = textIndices.first, let text = parts[index].text {
+            parts[index] = .text(String(text.drop(while: \.isWhitespace)))
+        }
+        if let index = textIndices.last, let text = parts[index].text {
+            parts[index] = .text(String(text.reversed().drop(while: \.isWhitespace).reversed()))
+        }
+        parts.removeAll { $0.text?.isEmpty == true }
+
+        let isFollowUp = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+        let systemPrompt = message.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !isFollowUp, !systemPrompt.isEmpty else { return parts }
+
+        if let first = parts.first?.text {
+            parts[0] = .text("\(systemPrompt)\n\n\(first)")
+        } else {
+            parts.insert(.text(systemPrompt), at: 0)
+        }
+        return parts
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPPromptContentBuilder.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPPromptContentBuilder.swift
@@ -4,11 +4,14 @@ import UniformTypeIdentifiers
 enum ACPPromptContentBuilder {
     enum Error: LocalizedError, Equatable {
         case unreadableLocalImage(String)
+        case unsupportedRemoteImage(String)
 
         var errorDescription: String? {
             switch self {
             case let .unreadableLocalImage(path):
                 "Unable to read image attachment at \(path)."
+            case let .unsupportedRemoteImage(url):
+                "Unable to send remote image attachment at \(url) because ACP requires inline image data."
             }
         }
     }
@@ -17,18 +20,48 @@ enum ACPPromptContentBuilder {
         text: String,
         attachments: [AgentImageAttachment]
     ) throws -> [[String: Any]] {
+        try blocks(content: [.text(text)], attachments: attachments)
+    }
+
+    static func blocks(
+        content: [AgentPromptContentPart],
+        attachments: [AgentImageAttachment]
+    ) throws -> [[String: Any]] {
         var blocks: [[String: Any]] = []
-        if !text.isEmpty || attachments.isEmpty {
-            blocks.append([
-                "type": "text",
-                "text": text
-            ])
+        for part in content {
+            switch part {
+            case let .text(text):
+                guard !text.isEmpty else { continue }
+                blocks.append([
+                    "type": "text",
+                    "text": text
+                ])
+            case let .image(image):
+                if let title = image.normalizedTitle {
+                    blocks.append([
+                        "type": "text",
+                        "text": "Image title: \(title)"
+                    ])
+                }
+                blocks.append([
+                    "type": "image",
+                    "mimeType": image.mediaType.rawValue,
+                    "data": image.base64Payload
+                ])
+            }
         }
 
         for attachment in attachments {
             if let block = try imageBlock(for: attachment) {
                 blocks.append(block)
             }
+        }
+
+        if blocks.isEmpty {
+            blocks.append([
+                "type": "text",
+                "text": ""
+            ])
         }
 
         return blocks
@@ -53,14 +86,7 @@ enum ACPPromptContentBuilder {
                 "uri": url.absoluteString
             ]
         case let .url(rawURL):
-            let urlString = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !urlString.isEmpty else { return nil }
-            let extensionCandidate = URL(string: urlString)?.pathExtension
-            return [
-                "type": "image",
-                "mimeType": mimeType(forPathExtension: extensionCandidate, fallbackTitle: attachment.title),
-                "uri": urlString
-            ]
+            throw Error.unsupportedRemoteImage(rawURL.trimmingCharacters(in: .whitespacesAndNewlines))
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPProviderSupport.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPProviderSupport.swift
@@ -629,7 +629,7 @@ enum ACPPermissionOptionPolicy {
     /// bare kind match would otherwise select it and broaden approval beyond the request.
     static func denylistedAutoSelectOptionIDs(for providerID: ACPProviderID) -> Set<String> {
         switch providerID {
-        case .openCode, .cursor, .antigravity:
+        case .openCode, .cursor, .antigravity, .omp, .devin:
             []
         case .grokBuild:
             ["enable-always-approve"]

--- a/Sources/RepoPrompt/Infrastructure/AI/AIMessage.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIMessage.swift
@@ -1,6 +1,35 @@
 import Foundation
 import SwiftOpenAI
 
+enum AIImageMediaType: String, Equatable {
+    case png = "image/png"
+    case jpeg = "image/jpeg"
+    case gif = "image/gif"
+    case webp = "image/webp"
+}
+
+/// Image data for a single Oracle user turn. Deliberately non-Codable
+/// and path-free so it never lands in persisted chat history.
+struct AITransientImage: Equatable {
+    let bytes: Data
+    let mediaType: AIImageMediaType
+    let title: String?
+
+    var base64Payload: String {
+        bytes.base64EncodedString()
+    }
+
+    var openAIDataURL: String {
+        "data:\(mediaType.rawValue);base64,\(base64Payload)"
+    }
+
+    var normalizedTitle: String? {
+        guard let title else { return nil }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
 /// A single conversation entry
 struct ConversationEntry {
     enum Role {
@@ -10,6 +39,13 @@ struct ConversationEntry {
 
     let role: Role
     let content: String
+    let images: [AITransientImage]
+
+    init(role: Role, content: String, images: [AITransientImage] = []) {
+        self.role = role
+        self.content = content
+        self.images = images
+    }
 }
 
 /// Keep each piece separate. We also provide "XML getters" for certain fields.
@@ -227,10 +263,49 @@ struct AIMessage {
             let role: ChatCompletionParameters.Message.Role = (entry.role == .user)
                 ? .user
                 : .assistant
-            msgs.append(.init(role: role, content: .text(text)))
+            if entry.role == .user, !entry.images.isEmpty {
+                msgs.append(.init(role: role, content: openAIChatContent(text: text, images: entry.images)))
+            } else {
+                msgs.append(.init(role: role, content: .text(text)))
+            }
         }
 
         return msgs
+    }
+
+    private func openAIChatContent(
+        text: String,
+        images: [AITransientImage]
+    ) -> ChatCompletionParameters.Message.ContentType {
+        var parts: [ChatCompletionParameters.Message.ContentType.MessageContent] = []
+        if !text.isEmpty {
+            parts.append(.text(text))
+        }
+        for image in images {
+            if let title = image.normalizedTitle {
+                parts.append(.text("Image title: \(title)"))
+            }
+            guard let url = URL(string: image.openAIDataURL) else { continue }
+            parts.append(.imageUrl(.init(url: url, detail: nil)))
+        }
+        return .contentArray(parts)
+    }
+
+    private func openAIResponsesContent(
+        text: String,
+        images: [AITransientImage]
+    ) -> SwiftOpenAI.MessageContent {
+        var parts: [SwiftOpenAI.ContentItem] = []
+        if !text.isEmpty {
+            parts.append(.text(SwiftOpenAI.TextContent(text: text)))
+        }
+        for image in images {
+            if let title = image.normalizedTitle {
+                parts.append(.text(SwiftOpenAI.TextContent(text: "Image title: \(title)")))
+            }
+            parts.append(.image(SwiftOpenAI.ImageContent(detail: "auto", imageUrl: image.openAIDataURL)))
+        }
+        return .array(parts)
     }
 
     /// Generates the full array of `InputItem`s for the Responses-API,
@@ -259,9 +334,12 @@ struct AIMessage {
                     firstUser = false
                 }
 
+                let content: SwiftOpenAI.MessageContent = entry.images.isEmpty
+                    ? .text(text)
+                    : openAIResponsesContent(text: text, images: entry.images)
                 let msg = SwiftOpenAI.InputMessage(
                     role: "user",
-                    content: .text(text)
+                    content: content
                 )
                 items.append(.message(msg))
 
@@ -285,6 +363,32 @@ struct AIMessage {
         }
 
         return .array(items)
+    }
+
+    func attachingImagesToFinalUserTurn(_ images: [AITransientImage]) -> AIMessage {
+        guard !images.isEmpty,
+              let lastUserIndex = conversationMessages.lastIndex(where: { $0.role == .user })
+        else {
+            return self
+        }
+        var updated = conversationMessages
+        updated[lastUserIndex] = ConversationEntry(
+            role: .user,
+            content: updated[lastUserIndex].content,
+            images: images
+        )
+        return AIMessage(
+            systemPrompt: systemPrompt,
+            metaPrompts: metaPrompts,
+            fileTree: fileTree,
+            fileBlocks: fileBlocks,
+            gitDiff: gitDiff,
+            conversationMessages: updated,
+            temperature: temperature,
+            promptSectionsOrder: promptSectionsOrder,
+            disabledPromptSections: disabledPromptSections,
+            duplicateUserInstructionsAtTop: duplicateUserInstructionsAtTop
+        )
     }
 
     // MARK: - Temperature helpers

--- a/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIModel.swift
@@ -180,6 +180,8 @@ public enum AIModel: Equatable, Hashable {
     case openCodeCustom(name: String)
     case cursorCustom(name: String)
     case grokBuildCustom(name: String)
+    case ompCustom(name: String)
+    case devinCustom(name: String)
 
     // Custom Provider Models
     case customProvider(name: String, provider: String, model: String)
@@ -539,6 +541,10 @@ public enum AIModel: Equatable, Hashable {
             return "cursor_custom_\(n)"
         case let .grokBuildCustom(n):
             return "grokbuild_custom_\(n)"
+        case let .ompCustom(n):
+            return "omp_custom_\(n)"
+        case let .devinCustom(n):
+            return "devin_custom_\(n)"
         case let .customProvider(_, _, model):
             return "custom_provider_\(model)"
         case let .customProviderUser(name):
@@ -609,6 +615,12 @@ public enum AIModel: Equatable, Hashable {
         if case let .grokBuildCustom(n) = self {
             return ACPAIModelCatalog.grokBuildModelOption(for: n)?.displayName ?? n
         }
+        if case let .ompCustom(n) = self {
+            return ACPAIModelCatalog.ompModelOption(for: n)?.displayName ?? n
+        }
+        if case let .devinCustom(n) = self {
+            return ACPAIModelCatalog.devinModelOption(for: n)?.displayName ?? n
+        }
         if case let .customProviderUser(name) = self { return "Custom/\(name)" }
         if case .ollama = self {
             return "local/" + modelName
@@ -638,6 +650,8 @@ public enum AIModel: Equatable, Hashable {
         case .openCode: OpenCodeCLIProvider.self
         case .cursor: CursorCLIProvider.self
         case .grokBuild: GrokBuildCLIProvider.self
+        case .omp: OMPCLIProvider.self
+        case .devin: DevinCLIProvider.self
         }
     }
 
@@ -667,6 +681,8 @@ public enum AIModel: Equatable, Hashable {
         case .openCodeCustom: return .openCode
         case .cursorCustom: return .cursor
         case .grokBuildCustom: return .grokBuild
+        case .ompCustom: return .omp
+        case .devinCustom: return .devin
         case .customProviderUser: return .customProvider
         // or, if you prefer the old modelGroups approach:
         default:
@@ -722,7 +738,9 @@ public enum AIModel: Equatable, Hashable {
              let .codexCustom(n),
              let .openCodeCustom(n),
              let .cursorCustom(n),
-             let .grokBuildCustom(n):
+             let .grokBuildCustom(n),
+             let .ompCustom(n),
+             let .devinCustom(n):
             return n
         case let .customProviderUser(name):
             return name
@@ -1163,7 +1181,7 @@ public enum AIModel: Equatable, Hashable {
             return SwiftOpenAI.Model.custom(modelName)
         case .anthropic:
             return SwiftAnthropic.Model.other(modelName)
-        case .azure, .openRouter, .customProvider, .claudeCode, .codex, .openCode, .cursor, .grokBuild:
+        case .azure, .openRouter, .customProvider, .claudeCode, .codex, .openCode, .cursor, .grokBuild, .omp, .devin:
             // For these providers, use the actual model name when available
             if let modelInfo = Self.modelDefinitions.first(where: { $0.model == self }),
                let actualName = modelInfo.actualName
@@ -1257,6 +1275,12 @@ public enum AIModel: Equatable, Hashable {
         }
         if normalizedRawValue.hasPrefix("grokbuild_custom_") {
             return .grokBuildCustom(name: String(normalizedRawValue.dropFirst("grokbuild_custom_".count)))
+        }
+        if normalizedRawValue.hasPrefix("omp_custom_") {
+            return .ompCustom(name: String(normalizedRawValue.dropFirst("omp_custom_".count)))
+        }
+        if normalizedRawValue.hasPrefix("devin_custom_") {
+            return .devinCustom(name: String(normalizedRawValue.dropFirst("devin_custom_".count)))
         }
 
         if normalizedRawValue.hasPrefix("openai_custom_reasoning_") {
@@ -1372,6 +1396,10 @@ public enum AIModel: Equatable, Hashable {
             models = ACPAIModelCatalog.cursorModelsFromStore()
         case .grokBuild:
             models = ACPAIModelCatalog.grokBuildModelsFromStore()
+        case .omp:
+            models = ACPAIModelCatalog.ompModelsFromStore()
+        case .devin:
+            models = ACPAIModelCatalog.devinModelsFromStore()
         }
 
         // Filter out models that are not yet available based on their release date
@@ -1559,6 +1587,36 @@ public enum AIModel: Equatable, Hashable {
 
     static func openCodeMenuGroups(for models: [AIModel]) -> [OpenCodePickerMenuGroup] {
         openCodeMenu(for: models).groups
+    }
+
+    /// Menu grouping for chat/Oracle pickers driven by an ACP provider's advertised catalog.
+    /// `displayName == nil` renders inline rather than as a submenu, so an ungrouped model
+    /// never produces a blank submenu row.
+    struct ACPPickerMenuGroup: Identifiable, Hashable {
+        let id: String
+        let displayName: String?
+        let models: [AIModel]
+    }
+
+    static func ompMenuGroups(for models: [AIModel]) -> [ACPPickerMenuGroup] {
+        let modelsByRaw = Dictionary(
+            models
+                .filter { $0.providerType == .omp }
+                .map { ($0.modelName.lowercased(), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let options = ACPAIModelCatalog.ompModelOptionsFromStore().filter {
+            modelsByRaw[$0.rawValue.lowercased()] != nil
+        }
+        return AgentModelCatalog.ompModelGroups(for: options).compactMap { group in
+            let groupedModels = group.options.compactMap { modelsByRaw[$0.rawValue.lowercased()] }
+            guard !groupedModels.isEmpty else { return nil }
+            return ACPPickerMenuGroup(
+                id: group.id,
+                displayName: group.providerID,
+                models: groupedModels
+            )
+        }
     }
 
     static func codexMenuGroups(for models: [AIModel]) -> [CodexPickerMenuGroup] {
@@ -1958,6 +2016,8 @@ public enum AIModel: Equatable, Hashable {
                 models.append(contentsOf: group)
             }
         }
+        models.append(contentsOf: ACPAIModelCatalog.ompModelsFromStore())
+        models.append(contentsOf: ACPAIModelCatalog.devinModelsFromStore())
         models.append(.ollama)
         // Filter out models that are not yet available based on their release date
         return models.filter(\.isAvailable)
@@ -1981,6 +2041,8 @@ public enum AIModel: Equatable, Hashable {
         case openCodeCustom(name: String)
         case cursorCustom(name: String)
         case grokBuildCustom(name: String)
+        case ompCustom(name: String)
+        case devinCustom(name: String)
         case customProvider(name: String, provider: String, model: String)
         case customProviderUser(name: String)
         case claudeCodeModel(normalizedSpecifier: String)
@@ -2137,6 +2199,10 @@ public enum AIModel: Equatable, Hashable {
             .cursorCustom(name: name)
         case let .grokBuildCustom(name):
             .grokBuildCustom(name: name)
+        case let .ompCustom(name):
+            .ompCustom(name: name)
+        case let .devinCustom(name):
+            .devinCustom(name: name)
         case let .customProvider(name, provider, model):
             .customProvider(name: name, provider: provider, model: model)
         case let .customProviderUser(name):

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ACPAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ACPAIModelCatalog.swift
@@ -11,6 +11,8 @@ struct ACPDynamicModelRecord: Codable, Hashable {
     /// Variant provenance for synthesized effort options. Optional so records persisted
     /// before effort support decode unchanged.
     var effortVariant: AgentModelEffortVariant? = nil
+    /// Advisory native grouping. Optional so records persisted before family support decode unchanged.
+    var modelFamily: AgentModelFamily? = nil
 }
 
 struct ACPDynamicProviderRecord: Codable, Hashable {
@@ -206,7 +208,8 @@ enum ACPDynamicModelStore {
             isProviderDefault: option.isProviderDefault,
             supportedReasoningEfforts: supportedReasoningEfforts,
             defaultReasoningEffort: option.defaultReasoningEffort?.rawValue,
-            effortVariant: option.effortVariant
+            effortVariant: option.effortVariant,
+            modelFamily: option.modelFamily
         )
     }
 
@@ -224,7 +227,8 @@ enum ACPDynamicModelStore {
             isProviderDefault: record.isProviderDefault,
             supportedReasoningEfforts: supportedReasoningEfforts,
             defaultReasoningEffort: CodexReasoningEffort.parse(record.defaultReasoningEffort),
-            effortVariant: record.effortVariant
+            effortVariant: record.effortVariant,
+            modelFamily: record.modelFamily
         )
     }
 
@@ -278,7 +282,8 @@ enum ACPDynamicModelStore {
             defaultReasoningEffort: metadataRecord.defaultReasoningEffort ?? fallbackRecord.defaultReasoningEffort,
             // Variant provenance is semantic identity, not metadata: keep it only when both
             // records agree, so a real base (nil) never inherits stale variant provenance.
-            effortVariant: existing.effortVariant == candidate.effortVariant ? existing.effortVariant : nil
+            effortVariant: existing.effortVariant == candidate.effortVariant ? existing.effortVariant : nil,
+            modelFamily: metadataRecord.modelFamily ?? fallbackRecord.modelFamily
         )
     }
 
@@ -377,11 +382,33 @@ enum ACPAIModelCatalog {
         grokBuildModelOptionsFromStore().map { .grokBuildCustom(name: $0.rawValue) }
     }
 
+    /// Keep `AIModel`'s static paths one-way: registry data only, never `AgentModelCatalog`.
+    static func ompModelOptionsFromStore() -> [AgentModelOption] {
+        AgentACPModelRegistry.shared.resolvedSnapshot(for: .omp)?.options ?? []
+    }
+
+    static func ompModelsFromStore() -> [AIModel] {
+        ompModelOptionsFromStore().map { .ompCustom(name: $0.rawValue) }
+    }
+
+    static func devinModelOptionsFromStore() -> [AgentModelOption] {
+        AgentACPModelRegistry.shared.resolvedSnapshot(for: .devin)?.options ?? []
+    }
+
+    static func devinModelsFromStore() -> [AIModel] {
+        devinModelOptionsFromStore().map { .devinCustom(name: $0.rawValue) }
+    }
+
     static func openCodeModelOption(for rawValue: String) -> AgentModelOption? {
-        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalized.isEmpty else { return nil }
-        return openCodeModelOptionsFromStore()
-            .first { $0.rawValue.caseInsensitiveCompare(normalized) == .orderedSame }
+        option(for: rawValue, in: openCodeModelOptionsFromStore())
+    }
+
+    static func ompModelOption(for rawValue: String) -> AgentModelOption? {
+        option(for: rawValue, in: ompModelOptionsFromStore())
+    }
+
+    static func devinModelOption(for rawValue: String) -> AgentModelOption? {
+        option(for: rawValue, in: devinModelOptionsFromStore())
     }
 
     static func cursorModelOption(for rawValue: String) -> AgentModelOption? {
@@ -389,10 +416,13 @@ enum ACPAIModelCatalog {
     }
 
     static func grokBuildModelOption(for rawValue: String) -> AgentModelOption? {
+        option(for: rawValue, in: grokBuildModelOptionsFromStore())
+    }
+
+    private static func option(for rawValue: String, in options: [AgentModelOption]) -> AgentModelOption? {
         let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else { return nil }
-        return grokBuildModelOptionsFromStore()
-            .first { $0.rawValue.caseInsensitiveCompare(normalized) == .orderedSame }
+        return options.first { $0.rawValue.caseInsensitiveCompare(normalized) == .orderedSame }
     }
 
     static func normalizedCursorModelAlias(_ value: String) -> String {

--- a/Sources/RepoPrompt/Infrastructure/AI/Prompts/AgentSessionLinkPrompts.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Prompts/AgentSessionLinkPrompts.swift
@@ -166,7 +166,9 @@ enum AgentSessionLinkPrompts {
         switch agentKind {
         case .codexExec, .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             return "mcp__\(MCPIntegrationHelper.repoPromptMCPServerName)__\(canonical)"
-        case .openCode, .cursor, .grokBuild, .antigravity:
+        // Devin exposes MCP only through its `mcp_*` gateway meta-tools, so no qualified
+        // per-tool name exists to promise the model.
+        case .openCode, .cursor, .grokBuild, .antigravity, .omp, .devin:
             return canonical
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AIProviderFactory.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AIProviderFactory.swift
@@ -18,7 +18,7 @@ class AIProviderFactory {
         }
 
         // CLI providers don't need API keys - they leverage existing authentication
-        if providerType == .claudeCode || providerType == .codex || providerType == .openCode || providerType == .cursor || providerType == .grokBuild {
+        if providerType == .claudeCode || providerType == .codex || providerType == .openCode || providerType == .cursor || providerType == .grokBuild || providerType == .omp || providerType == .devin {
             return try await createProvider(
                 for: providerType,
                 key: "",
@@ -89,6 +89,10 @@ class AIProviderFactory {
             return CursorCLIProvider()
         case .grokBuild:
             return GrokBuildCLIProvider()
+        case .omp:
+            return OMPCLIProvider()
+        case .devin:
+            return DevinCLIProvider()
         case .customProvider:
             let config = try CustomProviderConfiguration.load()
 
@@ -181,6 +185,8 @@ enum AIProviderType: Codable, Equatable {
     case openCode // OpenCode CLI provider case
     case cursor // Cursor CLI provider case
     case grokBuild // Grok Build CLI provider case
+    case omp // Oh My Pi CLI provider case
+    case devin // Devin CLI provider case
 }
 
 extension AIProviderType {
@@ -203,6 +209,8 @@ extension AIProviderType {
         case .openCode: "OpenCode"
         case .cursor: "Cursor CLI"
         case .grokBuild: "Grok Build"
+        case .omp: "Oh My Pi"
+        case .devin: "Devin"
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AgentMessage.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AgentMessage.swift
@@ -9,6 +9,16 @@
 
 import Foundation
 
+enum AgentPromptContentPart: Equatable {
+    case text(String)
+    case image(AITransientImage)
+
+    var text: String? {
+        guard case let .text(text) = self else { return nil }
+        return text
+    }
+}
+
 /// A minimal message for headless agent providers.
 /// Contains just the system prompt channel and user message channel.
 public struct AgentMessage: Sendable, Equatable {
@@ -17,6 +27,8 @@ public struct AgentMessage: Sendable, Equatable {
 
     /// The user's message / task
     public var userMessage: String
+
+    var promptContentParts: [AgentPromptContentPart] = []
 
     /// Optional provider-specific session ID for resuming conversations
     /// Used by Claude CLI to resume with --resume <session-id> instead of replaying history

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicProvider.swift
@@ -17,7 +17,7 @@ class AnthropicProvider: AIProvider {
         }
     }
 
-    private func createMessages(for aiMessage: AIMessage) -> [MessageParameter.Message] {
+    static func makeMessages(for aiMessage: AIMessage) -> [MessageParameter.Message] {
         let tail = aiMessage.buildTail(embedSystemPrompt: false)
         let lastUserIndex = aiMessage.conversationMessages.lastIndex { $0.role == .user }
         var messages: [MessageParameter.Message] = []
@@ -34,15 +34,45 @@ class AnthropicProvider: AIProvider {
             }
 
             let role: MessageParameter.Message.Role = (entry.role == .user) ? .user : .assistant
+            let content: MessageParameter.Message.Content =
+                if entry.role == .user, !entry.images.isEmpty {
+                    .list(imageBlocks(text: contentText, images: entry.images))
+                } else {
+                    .text(contentText)
+                }
             messages.append(
                 MessageParameter.Message(
                     role: role,
-                    content: .text(contentText)
+                    content: content
                 )
             )
         }
 
         return messages
+    }
+
+    private static func imageBlocks(
+        text: String,
+        images: [AITransientImage]
+    ) -> [MessageParameter.Message.Content.ContentObject] {
+        var blocks: [MessageParameter.Message.Content.ContentObject] = [.text(text)]
+        for image in images {
+            if let title = image.normalizedTitle {
+                blocks.append(.text("Image title: \(title)"))
+            }
+            let mediaType: MessageParameter.Message.Content.ImageSource.MediaType = switch image.mediaType {
+            case .png: .png
+            case .jpeg: .jpeg
+            case .gif: .gif
+            case .webp: .webp
+            }
+            blocks.append(.image(.init(
+                type: .base64,
+                mediaType: mediaType,
+                data: image.base64Payload
+            )))
+        }
+        return blocks
     }
 
     private func createSystemParameter(systemPrompt: String) -> MessageParameter.System {
@@ -108,7 +138,7 @@ class AnthropicProvider: AIProvider {
 
         // Use your existing helper functions
         let systemParameter = createSystemParameter(systemPrompt: aiMessage.systemPrompt)
-        let messages = createMessages(for: aiMessage)
+        let messages = Self.makeMessages(for: aiMessage)
 
         var temperature: Double? = 0
         // Skip temperature setting for thinking models
@@ -279,7 +309,7 @@ class AnthropicProvider: AIProvider {
         }
 
         let systemParameter = createSystemParameter(systemPrompt: aiMessage.systemPrompt)
-        let messages = createMessages(for: aiMessage)
+        let messages = Self.makeMessages(for: aiMessage)
 
         let parameters = MessageParameter(
             model: model,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/CLIPathHints.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/CLIPathHints.swift
@@ -7,6 +7,8 @@ enum CLIPathHints {
     static let codex: [String] = CLILaunchProfiles.codex.supplementalSearchPaths
     static let openCode: [String] = CLILaunchProfiles.openCodeProviderSpecificPaths
     static let cursor: [String] = CLILaunchProfiles.cursorProviderSpecificPaths
+    static let omp: [String] = CLILaunchProfiles.ompProviderSpecificPaths
+    static let devin: [String] = CLILaunchProfiles.devinProviderSpecificPaths
     static let grokBuild: [String] = CLILaunchProfiles.grokBuildProviderSpecificPaths
 
     static func nativeDefaultsSupplemented(with providerSpecificPaths: [String]) -> [String] {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/CustomOpenai/CustomOpenAIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/CustomOpenai/CustomOpenAIProvider.swift
@@ -2,16 +2,55 @@ import Foundation
 
 /// Common chat completion parameters
 enum CompletionParams {
-    struct Message {
-        enum Role: String {
+    struct Message: Encodable {
+        enum Role: String, Encodable {
             case system
             case user
             case assistant
         }
 
-        enum Content {
+        /// Wire content: a bare string, or the OpenAI multimodal part array.
+        enum Content: Encodable {
             case text(String)
-            case contentArray([Content])
+            case parts([Part])
+
+            enum Part: Encodable {
+                case text(String)
+                case imageURL(url: String, detail: String)
+
+                private struct ImageURL: Encodable {
+                    let url: String
+                    let detail: String
+                }
+
+                private enum CodingKeys: String, CodingKey {
+                    case type
+                    case text
+                    case imageURL = "image_url"
+                }
+
+                func encode(to encoder: Encoder) throws {
+                    var container = encoder.container(keyedBy: CodingKeys.self)
+                    switch self {
+                    case let .text(text):
+                        try container.encode("text", forKey: .type)
+                        try container.encode(text, forKey: .text)
+                    case let .imageURL(url, detail):
+                        try container.encode("image_url", forKey: .type)
+                        try container.encode(ImageURL(url: url, detail: detail), forKey: .imageURL)
+                    }
+                }
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                switch self {
+                case let .text(text):
+                    try container.encode(text)
+                case let .parts(parts):
+                    try container.encode(parts)
+                }
+            }
         }
 
         let role: Role
@@ -120,20 +159,20 @@ class CustomOpenAIProvider: AIProvider, AIModelGetter {
         }
     }
 
-    struct ChatMessage: Codable {
+    struct ChatMessage: Encodable {
         let role: String
-        let content: String
+        let content: CompletionParams.Message.Content
     }
 
     /// Added support for max_tokens and temperature in the request payload
-    struct ChatRequest: Codable {
+    struct ChatRequest: Encodable {
         let model: String
         let messages: [ChatMessage]
         let max_tokens: Int?
         let temperature: Double?
     }
 
-    struct ChatStreamRequest: Codable {
+    struct ChatStreamRequest: Encodable {
         let model: String
         let messages: [ChatMessage]
         let stream: Bool
@@ -432,12 +471,10 @@ class CustomOpenAIProvider: AIProvider, AIModelGetter {
                     userContent = entry.content
                 }
 
-                results.append(
-                    CompletionParams.Message(
-                        role: .user,
-                        content: .text(userContent)
-                    )
-                )
+                let content: CompletionParams.Message.Content = entry.images.isEmpty
+                    ? .text(userContent)
+                    : .parts(Self.imageParts(text: userContent, images: entry.images))
+                results.append(CompletionParams.Message(role: .user, content: content))
             } else {
                 results.append(
                     CompletionParams.Message(
@@ -449,6 +486,23 @@ class CustomOpenAIProvider: AIProvider, AIModelGetter {
         }
 
         return results
+    }
+
+    private static func imageParts(
+        text: String,
+        images: [AITransientImage]
+    ) -> [CompletionParams.Message.Content.Part] {
+        var parts: [CompletionParams.Message.Content.Part] = []
+        if !text.isEmpty {
+            parts.append(.text(text))
+        }
+        for image in images {
+            if let title = image.normalizedTitle {
+                parts.append(.text("Image title: \(title)"))
+            }
+            parts.append(.imageURL(url: image.openAIDataURL, detail: "auto"))
+        }
+        return parts
     }
 
     #if DEBUG
@@ -674,22 +728,8 @@ class CustomOpenAIProvider: AIProvider, AIModelGetter {
             request.setValue(value, forHTTPHeaderField: key)
         }
 
-        let openAIMessages = messages.map { message -> ChatMessage in
-            let content: String = switch message.content {
-            case let .text(text):
-                text
-            case let .contentArray(array):
-                array.compactMap { chunk -> String? in
-                    if case let .text(part) = chunk {
-                        return part
-                    }
-                    return nil
-                }.joined(separator: "\n")
-            }
-            return ChatMessage(
-                role: message.role.rawValue,
-                content: content
-            )
+        let openAIMessages = messages.map { message in
+            ChatMessage(role: message.role.rawValue, content: message.content)
         }
 
         // Use the provided temperature if available, or fall back to the provider default

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPAgentProvider.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// Interactive Devin CLI ACP agent (`devin acp`, protocol version 1).
+///
+/// Verified against devin 3000.6.14: `promptCapabilities.image = true`,
+/// `mcpCapabilities` is stdio-only, and MCP servers handed to `session/new` are spawned
+/// but never registered into the state Devin's `mcp_*` gateway tools read. The isolated
+/// `XDG_CONFIG_HOME` overlay prepared by `DevinIntegrationConfiguration` is therefore the
+/// only route by which RepoPrompt's MCP tools reach Devin's model.
+struct DevinACPAgentProvider: ACPAgentProvider {
+    private let modelFamilies = DevinModelFamilyCatalog()
+    private let config: DevinAgentConfig
+    private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
+    private let launchResolver: ACPCLILaunchResolver
+
+    init(
+        config: DevinAgentConfig,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        launchResolver: ACPCLILaunchResolver = ACPCLILaunchResolver(spec: .devin)
+    ) {
+        self.config = config
+        self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
+        self.launchResolver = launchResolver
+    }
+
+    var providerID: ACPProviderID {
+        .devin
+    }
+
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
+        let result = try await launchResolver.probeSupport(for: config)
+        if result == .supported {
+            try await modelFamilies.refresh(launch: launchResolver.resolvedLaunch(for: config))
+        }
+        return result
+    }
+
+    func modelFamily(for rawModel: String) -> AgentModelFamily? {
+        modelFamilies.family(for: rawModel)
+    }
+
+    func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        let workingDirectory = try standardizedWorkingDirectory(from: request.workspacePath)
+        let resolvedLaunch = try launchResolver.resolvedLaunch(for: config)
+        let integration: DevinIntegrationConfiguration.PreparedConfiguration? = if config.includeRepoPromptMCPServer {
+            try DevinIntegrationConfiguration.prepare(
+                workingDirectory: workingDirectory,
+                repoPromptMCPConfiguration: repoPromptMCPConfiguration,
+                sourceEnvironment: resolvedLaunch.environment
+            )
+        } else {
+            nil
+        }
+        return ACPLaunchConfiguration(
+            providerID: providerID,
+            command: resolvedLaunch.command,
+            arguments: resolvedLaunch.arguments,
+            environment: integration?.environment ?? [:],
+            workingDirectory: workingDirectory,
+            additionalPathHints: resolvedLaunch.additionalPathHints,
+            enableDebugLogging: config.enableDebugLogging,
+            cleanupArtifact: integration?.cleanupArtifact,
+            expectedExecutableIdentity: resolvedLaunch.executableIdentity
+        )
+    }
+
+    func makeSessionConfiguration(
+        for request: ACPRunRequest,
+        mcpServer _: RepoPromptMCPServerConfiguration
+    ) throws -> ACPSessionConfiguration {
+        let mode: ACPSessionConfiguration.Mode = if let resume = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !resume.isEmpty
+        {
+            .load(existingSessionID: resume)
+        } else {
+            .new
+        }
+        return try ACPSessionConfiguration(
+            mode: mode,
+            workingDirectory: standardizedWorkingDirectory(from: request.workspacePath),
+            // Devin connects `session/new.mcpServers` but never registers them with its
+            // `mcp_*` gateway, so a session-scoped server is invisible to the model. The
+            // isolated XDG configuration overlay is the only working delivery path.
+            mcpServers: []
+        )
+    }
+
+    func buildPromptBlocks(
+        for message: AgentMessage,
+        request: ACPRunRequest
+    ) throws -> [[String: Any]] {
+        try ACPPromptContentBuilder.blocks(
+            content: ACPPromptComposition.promptContentParts(for: message, request: request),
+            attachments: request.attachments
+        )
+    }
+
+    func normalizeSessionUpdate(
+        _ payload: [String: Any],
+        sessionID _: String
+    ) -> [NormalizedAgentRuntimeEvent] {
+        var projected = payload
+        if let update = (payload["sessionUpdate"] as? String)?.lowercased(),
+           update == "tool_call" || update == "tool_call_update",
+           let metadata = payload["_meta"] as? [String: Any],
+           let toolName = ACPRuntimeEventParsing.firstMachineIdentifier(
+               in: metadata,
+               keys: ["cognition.ai/toolName", "cognition.ai/inferenceToolName"]
+           ),
+           // MCP calls arrive through Devin's `mcp_call_tool` gateway meta-tool; that
+           // generic dispatcher name says nothing about the concrete tool, so leave it
+           // unresolved rather than labelling every MCP call `mcp_call_tool`.
+           toolName != "mcp_call_tool"
+        {
+            projected["toolName"] = toolName
+        }
+        return ACPDefaultSessionUpdateNormalizer.normalize(projected, providerID: .devin)
+    }
+
+    func cleanupLaunchArtifacts(for configuration: ACPLaunchConfiguration) async {
+        guard let artifact = configuration.cleanupArtifact else { return }
+        DevinIntegrationConfiguration.cleanup(artifact: artifact)
+    }
+
+    func shouldEmitStderrLine(_ line: String) -> Bool {
+        // Devin traces routine INFO lines to stderr. Diagnostics still record every line;
+        // only the exact observed tracing prefix is suppressed from the transcript.
+        line.range(
+            of: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+INFO\s+"#,
+            options: .regularExpression
+        ) == nil
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        if error is AIProviderError { return error }
+        if let runnerError = error as? CLIProcessRunnerError,
+           case .commandNotFound = runnerError
+        {
+            return AIProviderError.invalidConfiguration(
+                detail: "Devin ACP server not found. Install Devin and ensure `devin acp` is available."
+            )
+        }
+        if error is ACPCLILaunchResolutionError || error is ExecutableFileIdentityError {
+            return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
+        }
+        return AIProviderError.apiError(source: error)
+    }
+
+    private func standardizedWorkingDirectory(from workspacePath: String?) throws -> String {
+        if let cwd = workspacePath?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty {
+            return URL(fileURLWithPath: cwd, isDirectory: true).standardizedFileURL.path
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPromptDevinACPPreflight", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL.path
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinACPHeadlessAgentProvider.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+final class DevinACPHeadlessAgentProvider: HeadlessAgentProvider {
+    typealias ProviderFactory = @Sendable (_ config: DevinAgentConfig) -> any ACPAgentProvider
+    typealias ControllerFactory = ACPHeadlessAgentProviderBridge.ControllerFactory
+
+    private let config: DevinAgentConfig
+    private let bridge: ACPHeadlessAgentProviderBridge
+
+    #if DEBUG
+        var test_config: DevinAgentConfig {
+            config
+        }
+    #endif
+
+    init(
+        config: DevinAgentConfig,
+        workspacePath: String? = nil,
+        providerFactory: ProviderFactory? = nil,
+        controllerFactory: @escaping ControllerFactory = { provider, request, diagnosticSink in
+            try ACPAgentSessionController(
+                provider: provider,
+                runRequest: request,
+                diagnosticSink: diagnosticSink
+            )
+        }
+    ) {
+        self.config = config
+        let resolvedProviderFactory = providerFactory ?? { config in
+            DevinACPAgentProvider(config: config)
+        }
+        bridge = ACPHeadlessAgentProviderBridge(
+            providerName: "Devin",
+            makeProvider: { resolvedProviderFactory(config) },
+            makeRequest: { message, _ in
+                ACPRunRequest(
+                    agentKind: .devin,
+                    modelString: config.modelString,
+                    workspacePath: workspacePath,
+                    resumeSessionID: message.resumeSessionID,
+                    attachments: [],
+                    taskLabelKind: nil
+                )
+            },
+            makeController: controllerFactory,
+            beforePrompt: { controller, request in
+                guard let model = request.modelString?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !model.isEmpty,
+                      model.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) != .orderedSame
+                else { return }
+                try await controller.setSessionModel(model)
+            },
+            approvalPolicy: .declineUnsupported
+        )
+    }
+
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        try await bridge.streamAgentMessage(message, runID: runID)
+    }
+
+    func dispose() async {
+        await bridge.dispose()
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinAgentConfig.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinAgentConfig.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct DevinAgentConfig: ACPCLILaunchConfiguring {
+    let commandName: String
+    let additionalPathHints: [String]
+    let enableDebugLogging: Bool
+    let includeRepoPromptMCPServer: Bool
+    let modelString: String?
+
+    init(
+        commandName: String = CLILaunchProfiles.devin.commandName,
+        additionalPathHints: [String] = CLIPathHints.devin,
+        enableDebugLogging: Bool = false,
+        includeRepoPromptMCPServer: Bool = true,
+        modelString: String? = nil
+    ) {
+        self.commandName = commandName
+        self.additionalPathHints = additionalPathHints
+        self.enableDebugLogging = enableDebugLogging
+        self.includeRepoPromptMCPServer = includeRepoPromptMCPServer
+        self.modelString = modelString
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinCLIProvider.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+final class DevinCLIProvider: AIProvider {
+    private let engine = ACPCLIChatProviderEngine<DevinACPHeadlessAgentProvider>(
+        providerName: "Devin",
+        providerType: .devin,
+        makeProvider: { modelName in
+            DevinACPHeadlessAgentProvider(
+                config: DevinCLIProvider.makeHeadlessConfig(modelName: modelName),
+                workspacePath: nil
+            )
+        }
+    )
+
+    #if DEBUG
+        static func test_makeHeadlessConfig(modelName: String?) -> DevinAgentConfig {
+            makeHeadlessConfig(modelName: modelName)
+        }
+    #endif
+
+    func streamMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        try await engine.streamMessage(aiMessage, model: model, maxTokens: maxTokens)
+    }
+
+    func completeMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AICompletionResult {
+        try await engine.completeMessage(aiMessage, model: model, maxTokens: maxTokens)
+    }
+
+    func dispose() async {
+        await engine.dispose()
+    }
+
+    private static func makeHeadlessConfig(modelName: String?) -> DevinAgentConfig {
+        DevinAgentConfig(
+            enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
+            includeRepoPromptMCPServer: false,
+            modelString: modelName
+        )
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinIntegrationConfiguration.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// Prepares an isolated `XDG_CONFIG_HOME` root holding `devin/mcp_config.json` with the
+/// RepoPrompt MCP server merged in.
+///
+/// This overlay is the only delivery path Devin's model can reach: verified against devin
+/// 3000.6.14, servers passed through ACP `session/new.mcpServers` are spawned and
+/// handshaked but never registered into the state its `mcp_list_servers` /
+/// `mcp_list_tools` / `mcp_call_tool` gateway tools read.
+///
+/// The overlay is per-launch and removed on teardown. The user's real `devin` directory is
+/// symlinked entry-by-entry so unrelated configuration keeps working, and any stale
+/// user-level RepoPrompt entry is overwritten because it collides on the same server key.
+enum DevinIntegrationConfiguration {
+    static let cleanupArtifactKind = "devinIsolatedMCPConfiguration"
+    private static let directoryPrefix = "RepoPromptDevinACP-"
+
+    struct PreparedConfiguration {
+        let environment: [String: String]
+        let cleanupArtifact: ACPLaunchCleanupArtifact
+    }
+
+    static func prepare(
+        workingDirectory: String,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration,
+        sourceEnvironment: [String: String]
+    ) throws -> PreparedConfiguration {
+        try repoPromptMCPConfiguration.validateACPLaunchCommand(workingDirectory: workingDirectory)
+
+        let id = UUID()
+        let root = configurationRoot(id: id)
+        let devinDirectory = root.appendingPathComponent("devin", isDirectory: true)
+        let configURL = devinDirectory.appendingPathComponent("mcp_config.json")
+        do {
+            try FileManager.default.createDirectory(
+                at: devinDirectory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let sourceDevinDirectory = sourceConfigurationRoot(environment: sourceEnvironment)
+                .appendingPathComponent("devin", isDirectory: true)
+            try linkExistingConfiguration(from: sourceDevinDirectory, to: devinDirectory)
+
+            var rootObject = try existingMCPRootObject(
+                at: sourceDevinDirectory.appendingPathComponent("mcp_config.json")
+            )
+            var servers = rootObject["mcpServers"] as? [String: Any] ?? [:]
+            var server: [String: Any] = [
+                "transport": "stdio",
+                "command": repoPromptMCPConfiguration.command,
+                "args": repoPromptMCPConfiguration.args
+            ]
+            if !repoPromptMCPConfiguration.env.isEmpty {
+                server["env"] = repoPromptMCPConfiguration.environmentDictionary
+            }
+            servers[repoPromptMCPConfiguration.name] = server
+            // The overlay is for Devin, not for its MCP children. Point every known stdio
+            // child back at the native configuration root without overriding an explicit
+            // per-server `env` value.
+            for (name, value) in servers {
+                guard var child = value as? [String: Any],
+                      child["transport"] as? String == "stdio",
+                      child["env"] == nil || child["env"] is [String: String]
+                else { continue }
+                var environment = child["env"] as? [String: String] ?? [:]
+                if environment["XDG_CONFIG_HOME"] == nil {
+                    // A child `HOME` override owns the fallback when native XDG is unset.
+                    let nativeEnvironment = sourceEnvironment.merging(environment) { _, child in child }
+                    environment["XDG_CONFIG_HOME"] = sourceConfigurationRoot(environment: nativeEnvironment).path
+                }
+                child["env"] = environment
+                servers[name] = child
+            }
+            rootObject["mcpServers"] = servers
+
+            try JSONSerialization.data(
+                withJSONObject: rootObject,
+                options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            ).write(to: configURL, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: configURL.path
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: root)
+            throw AIProviderError.invalidConfiguration(
+                detail: "Unable to prepare Devin MCP configuration: \(error.localizedDescription)"
+            )
+        }
+
+        return PreparedConfiguration(
+            environment: ["XDG_CONFIG_HOME": root.path],
+            cleanupArtifact: ACPLaunchCleanupArtifact(
+                providerID: .devin,
+                id: id,
+                kind: cleanupArtifactKind
+            )
+        )
+    }
+
+    static func cleanup(artifact: ACPLaunchCleanupArtifact) {
+        guard artifact.providerID == .devin,
+              artifact.kind == cleanupArtifactKind
+        else {
+            return
+        }
+        try? FileManager.default.removeItem(at: configurationRoot(id: artifact.id))
+    }
+
+    private static func configurationRoot(id: UUID) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(directoryPrefix)\(id.uuidString)", isDirectory: true)
+            .standardizedFileURL
+    }
+
+    private static func sourceConfigurationRoot(environment: [String: String]) -> URL {
+        if let configured = environment["XDG_CONFIG_HOME"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !configured.isEmpty
+        {
+            let expanded = CommandPathResolver.expandPath(configured, environment: environment)
+            return URL(fileURLWithPath: expanded, isDirectory: true).standardizedFileURL
+        }
+        let home = environment["HOME"].flatMap { $0.isEmpty ? nil : $0 }
+            ?? FileManager.default.homeDirectoryForCurrentUser.path
+        return URL(fileURLWithPath: home, isDirectory: true)
+            .appendingPathComponent(".config", isDirectory: true)
+            .standardizedFileURL
+    }
+
+    private static func linkExistingConfiguration(from source: URL, to destination: URL) throws {
+        guard FileManager.default.fileExists(atPath: source.path) else { return }
+        for entry in try FileManager.default.contentsOfDirectory(
+            at: source,
+            includingPropertiesForKeys: nil
+        ) where entry.lastPathComponent != "mcp_config.json" {
+            try FileManager.default.createSymbolicLink(
+                at: destination.appendingPathComponent(entry.lastPathComponent),
+                withDestinationURL: entry
+            )
+        }
+    }
+
+    private static func existingMCPRootObject(at url: URL) throws -> [String: Any] {
+        guard FileManager.default.fileExists(atPath: url.path) else { return [:] }
+        let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url))
+        guard let root = object as? [String: Any] else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Unable to merge Devin MCP configuration at \(url.path): expected a JSON object."
+            )
+        }
+        if let servers = root["mcpServers"], !(servers is [String: Any]) {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Unable to merge Devin MCP configuration at \(url.path): expected mcpServers to be a JSON object."
+            )
+        }
+        return root
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinModelFamilyCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Devin/DevinModelFamilyCatalog.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Advisory presentation metadata read from `devin models list --format json`. It never adds
+/// a selectable model: the ACP controller annotates only the model IDs its session advertises.
+final class DevinModelFamilyCatalog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var familiesByModel: [String: AgentModelFamily] = [:]
+
+    func family(for rawModel: String) -> AgentModelFamily? {
+        lock.withLock { familiesByModel[rawModel] }
+    }
+
+    func refresh(launch: ACPCLIResolvedLaunch) async throws {
+        lock.withLock { familiesByModel = [:] }
+        do {
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
+            let runner = CLIProcessRunner(config: CLIProcessConfiguration(
+                command: launch.command,
+                environment: launch.environment,
+                additionalPaths: [],
+                enableDebugLogging: false,
+                shellLookupMode: .fallbackOnly
+            ))
+            let result = try await runner.run(
+                args: ["models", "list", "--format", "json"],
+                stdin: nil,
+                outputMode: .none,
+                timeout: 10,
+                cancelChildOnTaskCancellation: true
+            )
+            try Task.checkCancellation()
+            guard result.status == 0 else { return }
+            let parsed = try Self.parse(result.stdout)
+            lock.withLock { familiesByModel = parsed }
+        } catch {
+            // An older CLI or an unreachable account catalog leaves an ordinary flat picker.
+            // Never block a valid ACP session, and never infer a family from a model ID.
+            try Task.checkCancellation()
+        }
+    }
+
+    /// Rejects the whole catalog on duplicate or blank identity rather than grouping models
+    /// under an ambiguous label.
+    static func parse(_ data: Data) throws -> [String: AgentModelFamily] {
+        struct Catalog: Decodable {
+            struct Family: Decodable {
+                struct Variant: Decodable {
+                    let modelID: String
+                    enum CodingKeys: String, CodingKey { case modelID = "model_uid" }
+                }
+
+                let familyID: String
+                let familyLabel: String
+                let variants: [Variant]
+                enum CodingKeys: String, CodingKey {
+                    case familyID = "family_uid"
+                    case familyLabel = "family_label"
+                    case variants
+                }
+            }
+
+            let families: [Family]
+        }
+        enum InvalidCatalog: Error { case invalidOrDuplicateIdentity }
+
+        let catalog = try JSONDecoder().decode(Catalog.self, from: data)
+        var result: [String: AgentModelFamily] = [:]
+        var familyIDs = Set<String>()
+        for family in catalog.families {
+            guard !family.familyID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  !family.familyLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  familyIDs.insert(family.familyID).inserted
+            else {
+                throw InvalidCatalog.invalidOrDuplicateIdentity
+            }
+            for variant in family.variants {
+                guard !variant.modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                      result[variant.modelID] == nil
+                else {
+                    throw InvalidCatalog.invalidOrDuplicateIdentity
+                }
+                result[variant.modelID] = AgentModelFamily(id: family.familyID, displayName: family.familyLabel)
+            }
+        }
+        return result
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPAgentProvider.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Oh My Pi CLI ACP agent (`omp acp`). OMP owns authentication, provider/model routing,
+/// memory, compaction, and its internal tools; RepoPrompt injects its MCP server through
+/// the standard ACP `session/new.mcpServers` contract.
+struct OMPACPAgentProvider: ACPAgentProvider {
+    private let config: OMPAgentConfig
+    private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
+    private let launchResolver: ACPCLILaunchResolver
+
+    init(
+        config: OMPAgentConfig,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        launchResolver: ACPCLILaunchResolver = ACPCLILaunchResolver(spec: .omp)
+    ) {
+        self.config = config
+        self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
+        self.launchResolver = launchResolver
+    }
+
+    var providerID: ACPProviderID {
+        .omp
+    }
+
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
+        try await launchResolver.probeSupport(for: config)
+    }
+
+    func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        let workingDirectory = try standardizedWorkingDirectory(from: request.workspacePath)
+        let resolvedLaunch = try launchResolver.resolvedLaunch(for: config)
+        return ACPLaunchConfiguration(
+            providerID: providerID,
+            command: resolvedLaunch.command,
+            arguments: resolvedLaunch.arguments,
+            environment: [:],
+            workingDirectory: workingDirectory,
+            additionalPathHints: resolvedLaunch.additionalPathHints,
+            enableDebugLogging: config.enableDebugLogging,
+            expectedExecutableIdentity: resolvedLaunch.executableIdentity
+        )
+    }
+
+    func makeSessionConfiguration(
+        for request: ACPRunRequest,
+        mcpServer _: RepoPromptMCPServerConfiguration
+    ) throws -> ACPSessionConfiguration {
+        let mode: ACPSessionConfiguration.Mode = if let resume = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !resume.isEmpty
+        {
+            .load(existingSessionID: resume)
+        } else {
+            .new
+        }
+        return try ACPSessionConfiguration(
+            mode: mode,
+            workingDirectory: standardizedWorkingDirectory(from: request.workspacePath),
+            mcpServers: config.includeRepoPromptMCPServer ? [repoPromptMCPConfiguration] : []
+        )
+    }
+
+    func buildPromptBlocks(
+        for message: AgentMessage,
+        request: ACPRunRequest
+    ) throws -> [[String: Any]] {
+        try ACPPromptContentBuilder.blocks(
+            content: ACPPromptComposition.promptContentParts(for: message, request: request),
+            attachments: request.attachments
+        )
+    }
+
+    func normalizeSessionUpdate(
+        _ payload: [String: Any],
+        sessionID _: String
+    ) -> [NormalizedAgentRuntimeEvent] {
+        ACPDefaultSessionUpdateNormalizer.normalize(payload, providerID: .omp)
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        if error is AIProviderError { return error }
+        if let runnerError = error as? CLIProcessRunnerError,
+           case .commandNotFound = runnerError
+        {
+            return AIProviderError.invalidConfiguration(
+                detail: "Oh My Pi ACP server not found. Install OMP and ensure `omp acp` is available."
+            )
+        }
+        if error is ACPCLILaunchResolutionError || error is ExecutableFileIdentityError {
+            return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
+        }
+        return AIProviderError.apiError(source: error)
+    }
+
+    private func standardizedWorkingDirectory(from workspacePath: String?) throws -> String {
+        if let cwd = workspacePath?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty {
+            return URL(fileURLWithPath: cwd, isDirectory: true).standardizedFileURL.path
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPromptOMPACPPreflight", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL.path
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPACPHeadlessAgentProvider.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Headless/discovery adapter for the installed Oh My Pi ACP runtime.
+final class OMPACPHeadlessAgentProvider: HeadlessAgentProvider {
+    typealias ProviderFactory = @Sendable (_ config: OMPAgentConfig) -> any ACPAgentProvider
+    typealias ControllerFactory = ACPHeadlessAgentProviderBridge.ControllerFactory
+
+    private let config: OMPAgentConfig
+    private let bridge: ACPHeadlessAgentProviderBridge
+
+    #if DEBUG
+        var test_config: OMPAgentConfig {
+            config
+        }
+    #endif
+
+    init(
+        config: OMPAgentConfig,
+        workspacePath: String? = nil,
+        providerFactory: ProviderFactory? = nil,
+        controllerFactory: @escaping ControllerFactory = { provider, request, diagnosticSink in
+            try ACPAgentSessionController(
+                provider: provider,
+                runRequest: request,
+                diagnosticSink: diagnosticSink
+            )
+        }
+    ) {
+        self.config = config
+        let resolvedProviderFactory = providerFactory ?? { config in
+            OMPACPAgentProvider(config: config)
+        }
+        bridge = ACPHeadlessAgentProviderBridge(
+            providerName: "Oh My Pi",
+            makeProvider: { resolvedProviderFactory(config) },
+            makeRequest: { message, _ in
+                ACPRunRequest(
+                    agentKind: .omp,
+                    modelString: config.modelString,
+                    workspacePath: workspacePath,
+                    resumeSessionID: message.resumeSessionID,
+                    attachments: [],
+                    taskLabelKind: nil
+                )
+            },
+            makeController: controllerFactory,
+            beforePrompt: { controller, request in
+                guard let model = request.modelString?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !model.isEmpty,
+                      model.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) != .orderedSame
+                else { return }
+                try await controller.setSessionModel(model)
+            },
+            approvalPolicy: .declineUnsupported
+        )
+    }
+
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        try await bridge.streamAgentMessage(message, runID: runID)
+    }
+
+    func dispose() async {
+        await bridge.dispose()
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentConfig.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPAgentConfig.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct OMPAgentConfig: ACPCLILaunchConfiguring {
+    let commandName: String
+    let additionalPathHints: [String]
+    let enableDebugLogging: Bool
+    let modelString: String?
+    /// Prompt-only sessions (non-agent chat, connect-time model discovery) must not spawn a
+    /// tool server, so RepoPrompt's MCP server is opt-out per session.
+    let includeRepoPromptMCPServer: Bool
+
+    init(
+        commandName: String = CLILaunchProfiles.omp.commandName,
+        additionalPathHints: [String] = CLIPathHints.omp,
+        enableDebugLogging: Bool = false,
+        modelString: String? = nil,
+        includeRepoPromptMCPServer: Bool = true
+    ) {
+        self.commandName = commandName
+        self.additionalPathHints = additionalPathHints
+        self.enableDebugLogging = enableDebugLogging
+        self.modelString = modelString
+        self.includeRepoPromptMCPServer = includeRepoPromptMCPServer
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OMP/OMPCLIProvider.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Oh My Pi provider for non-agent use (chat, Oracle, AI queries) backed by ACP.
+/// Runs a fresh ACP session per request while preserving OMP's advertised model IDs.
+final class OMPCLIProvider: AIProvider {
+    private let engine = ACPCLIChatProviderEngine<OMPACPHeadlessAgentProvider>(
+        providerName: "Oh My Pi",
+        providerType: .omp,
+        makeProvider: { modelName in
+            OMPACPHeadlessAgentProvider(
+                config: OMPCLIProvider.makeHeadlessConfig(modelName: modelName),
+                workspacePath: nil
+            )
+        }
+    )
+
+    #if DEBUG
+        static func test_makeHeadlessConfig(modelName: String?) -> OMPAgentConfig {
+            makeHeadlessConfig(modelName: modelName)
+        }
+    #endif
+
+    func streamMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        try await engine.streamMessage(aiMessage, model: model, maxTokens: maxTokens)
+    }
+
+    func completeMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AICompletionResult {
+        try await engine.completeMessage(aiMessage, model: model, maxTokens: maxTokens)
+    }
+
+    func dispose() async {
+        await engine.dispose()
+    }
+
+    /// A chat/Oracle turn is prompt-only: OMP keeps its own tools, but RepoPrompt's MCP
+    /// server is never injected into a non-agent session.
+    private static func makeHeadlessConfig(modelName: String?) -> OMPAgentConfig {
+        OMPAgentConfig(
+            enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
+            modelString: modelName,
+            includeRepoPromptMCPServer: false
+        )
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeCLIProvider.swift
@@ -3,7 +3,16 @@ import Foundation
 /// OpenCode CLI provider for non-agent use (chat, Oracle, AI queries) backed by ACP.
 /// Runs a fresh prompt-only-style ACP session per request while preserving OpenCode's raw model IDs.
 final class OpenCodeCLIProvider: AIProvider {
-    private let activeProviders = ActiveOpenCodeCLIProviderStore<OpenCodeACPHeadlessAgentProvider>()
+    private let engine = ACPCLIChatProviderEngine<OpenCodeACPHeadlessAgentProvider>(
+        providerName: "OpenCode",
+        providerType: .openCode,
+        makeProvider: { modelName in
+            OpenCodeACPHeadlessAgentProvider(
+                config: OpenCodeCLIProvider.makeHeadlessConfig(modelName: modelName),
+                workspacePath: nil
+            )
+        }
+    )
 
     #if DEBUG
         static func test_makeHeadlessConfig(modelName: String?) -> OpenCodeAgentConfig {
@@ -11,108 +20,24 @@ final class OpenCodeCLIProvider: AIProvider {
         }
     #endif
 
-    func streamMessage(_ aiMessage: AIMessage, model: AIModel, maxTokens _: Int? = nil) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
-        let provider = OpenCodeACPHeadlessAgentProvider(
-            config: Self.makeHeadlessConfig(modelName: openCodeModelName(for: model)),
-            workspacePath: nil
-        )
-        if let replacedProvider = activeProviders.replace(provider) {
-            await replacedProvider.dispose()
-        }
-
-        let upstream: AsyncThrowingStream<AIStreamResult, Error>
-        do {
-            upstream = try await provider.streamAgentMessage(makeAgentMessage(from: aiMessage), runID: nil)
-        } catch {
-            activeProviders.remove(provider)
-            await provider.dispose()
-            throw error
-        }
-        guard activeProviders.contains(provider) else {
-            await provider.dispose()
-            throw CancellationError()
-        }
-
-        return AsyncThrowingStream { continuation in
-            let bridgeTask = Task {
-                do {
-                    for try await result in upstream {
-                        continuation.yield(result)
-                    }
-                    continuation.finish()
-                } catch {
-                    if Task.isCancelled {
-                        continuation.finish()
-                    } else {
-                        continuation.finish(throwing: error)
-                    }
-                }
-                if self.activeProviders.remove(provider) {
-                    await provider.dispose()
-                }
-            }
-
-            continuation.onTermination = { [activeProviders] termination in
-                bridgeTask.cancel()
-                guard case .cancelled = termination else { return }
-                Task {
-                    if activeProviders.remove(provider) {
-                        await provider.dispose()
-                    }
-                }
-            }
-        }
+    func streamMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        try await engine.streamMessage(aiMessage, model: model, maxTokens: maxTokens)
     }
 
-    func completeMessage(_ aiMessage: AIMessage, model: AIModel, maxTokens: Int? = nil) async throws -> AICompletionResult {
-        let stream = try await streamMessage(aiMessage, model: model, maxTokens: maxTokens)
-        var textParts: [String] = []
-        var finalContent: String?
-        var promptTokens: Int?
-        var completionTokens: Int?
-        var cost: Double?
-        var sawMessageStop = false
-
-        for try await result in stream {
-            switch result.type {
-            case "content":
-                if let text = result.text, !text.isEmpty {
-                    textParts.append(text)
-                }
-            case "final_content":
-                if let text = result.text, !text.isEmpty {
-                    finalContent = text
-                }
-            case "message_stop":
-                sawMessageStop = true
-                if let value = result.promptTokens { promptTokens = value }
-                if let value = result.completionTokens { completionTokens = value }
-                if let value = result.cost { cost = value }
-            case "error":
-                throw AIProviderError.invalidConfiguration(detail: result.text ?? "OpenCode ACP reported an error")
-            default:
-                continue
-            }
-        }
-
-        let text = textParts.isEmpty ? (finalContent ?? "") : textParts.joined()
-        guard sawMessageStop || !text.isEmpty else {
-            throw AIProviderError.invalidResponse(detail: "OpenCode returned no completion")
-        }
-
-        return AICompletionResult(
-            text: text,
-            promptTokens: promptTokens,
-            completionTokens: completionTokens,
-            cost: cost
-        )
+    func completeMessage(
+        _ aiMessage: AIMessage,
+        model: AIModel,
+        maxTokens: Int? = nil
+    ) async throws -> AICompletionResult {
+        try await engine.completeMessage(aiMessage, model: model, maxTokens: maxTokens)
     }
 
     func dispose() async {
-        let providers = activeProviders.removeAll()
-        for provider in providers {
-            await provider.dispose()
-        }
+        await engine.dispose()
     }
 
     private static func makeHeadlessConfig(modelName: String?) -> OpenCodeAgentConfig {
@@ -124,93 +49,5 @@ final class OpenCodeCLIProvider: AIProvider {
             cleanupLegacyPersistentConfig: true,
             toolProfile: .noTools
         )
-    }
-
-    private func makeAgentMessage(from aiMessage: AIMessage) -> AgentMessage {
-        AgentMessage(
-            systemPrompt: aiMessage.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines),
-            userMessage: buildPrompt(from: aiMessage),
-            resumeSessionID: nil
-        )
-    }
-
-    private func buildPrompt(from aiMessage: AIMessage) -> String {
-        let tail = aiMessage.buildTail(embedSystemPrompt: false)
-        var conversation = ""
-        let lastUserIndex = aiMessage.conversationMessages.lastIndex { $0.role == .user }
-        for (index, message) in aiMessage.conversationMessages.enumerated() {
-            var text = message.content
-            if message.role == .user,
-               index == lastUserIndex,
-               !tail.isEmpty
-            {
-                text = tail + "\n\n" + text
-            }
-            let prefix = message.role == .user ? "User" : "Assistant"
-            if !conversation.isEmpty {
-                conversation += "\n\n"
-            }
-            conversation += "\(prefix): \(text)"
-        }
-        if aiMessage.conversationMessages.isEmpty, !tail.isEmpty {
-            conversation = "User: \(tail)"
-        }
-        return conversation
-    }
-
-    private func openCodeModelName(for model: AIModel) -> String? {
-        guard model.providerType == .openCode else { return nil }
-        let trimmed = model.modelName.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-    }
-}
-
-final class ActiveOpenCodeCLIProviderStore<Provider: AnyObject>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var providers: [ObjectIdentifier: Provider] = [:]
-    private var currentProviderID: ObjectIdentifier?
-
-    func replace(_ provider: Provider) -> Provider? {
-        lock.lock()
-        let providerID = ObjectIdentifier(provider)
-        let previousProvider = currentProviderID.flatMap { providers[$0] }
-        providers[providerID] = provider
-        currentProviderID = providerID
-        lock.unlock()
-        guard let previousProvider,
-              previousProvider !== provider
-        else {
-            return nil
-        }
-        return previousProvider
-    }
-
-    func contains(_ provider: Provider) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-
-        return providers[ObjectIdentifier(provider)] != nil
-    }
-
-    @discardableResult
-    func remove(_ provider: Provider) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-
-        let providerID = ObjectIdentifier(provider)
-        let removedProvider = providers.removeValue(forKey: providerID)
-        if currentProviderID == providerID {
-            currentProviderID = nil
-        }
-        return removedProvider != nil
-    }
-
-    func removeAll() -> [Provider] {
-        lock.lock()
-        let currentProviders = Array(providers.values)
-        providers.removeAll()
-        currentProviderID = nil
-        lock.unlock()
-        return currentProviders
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
@@ -1415,6 +1415,10 @@ private enum AppSettingsMCPRegistry {
             .codex
         case .openCode:
             .openCode
+        case .omp:
+            .omp
+        case .devin:
+            .devin
         case .antigravity:
             nil
         case .cursor:
@@ -1443,6 +1447,8 @@ private enum AppSettingsMCPRegistry {
         case .openCode: "openCode"
         case .cursor: "cursor"
         case .grokBuild: "grokBuild"
+        case .omp: "omp"
+        case .devin: "devin"
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -117,17 +117,18 @@ struct MCPOracleToolService {
     // MARK: - ask_oracle (agent-mode only)
 
     func executeAskOracle(args: [String: Value]) async throws -> Value {
-        let allowedArgs: Set = ["message", "mode", "chat_id", "new_chat", "model", "export_response"]
+        let allowedArgs: Set = ["message", "mode", "chat_id", "new_chat", "model", "images", "export_response"]
         let unsupported = args.keys
             .filter { !$0.hasPrefix("_") && !allowedArgs.contains($0) }
             .sorted()
         if !unsupported.isEmpty {
             throw MCPError.invalidParams(
-                "ask_oracle only accepts: message, mode, chat_id, new_chat, model, export_response. Unsupported args: \(unsupported.joined(separator: ", "))"
+                "ask_oracle only accepts: message, mode, chat_id, new_chat, model, images, export_response. Unsupported args: \(unsupported.joined(separator: ", "))"
             )
         }
 
         try validateCommonOracleArgs(args)
+        let imageRequests = try Self.parseOracleImageRequests(args["images"])
 
         guard let connectionID = ServerNetworkManager.currentConnectionID else {
             throw MCPError.invalidParams("ask_oracle requires an active MCP connection")
@@ -185,13 +186,15 @@ struct MCPOracleToolService {
                 from: virtualContext,
                 owner: owner,
                 origin: .askOracle,
-                mode: modeRaw
+                mode: modeRaw,
+                imageRequests: imageRequests
             )
         } else {
             guard let tabSnapshot = targetWindow.workspaceManager.composeTabSnapshot(for: tabID) else {
                 throw MCPError.internalError("Unable to resolve compose tab context for ask_oracle")
             }
             let lookupContext = try await oraclePackagingLookupContext(owner: owner)
+            let transientImages = try await loadOracleImages(imageRequests, lookupContext: lookupContext)
             let reviewGitContext = await promptVM.freezePromptGitReviewContext(
                 workspaceID: targetWindow.workspaceManager.activeWorkspace?.id,
                 tabID: tabID,
@@ -230,7 +233,8 @@ struct MCPOracleToolService {
                 origin: .askOracle,
                 agentModeSessionID: owner.agentSessionID,
                 agentModeRunID: owner.runID,
-                packaging: packaging
+                packaging: packaging,
+                transientImages: transientImages
             )
         }
 
@@ -291,17 +295,18 @@ struct MCPOracleToolService {
     // MARK: - oracle_send
 
     func executeOracleSend(args: [String: Value]) async throws -> Value {
-        let allowedArgs: Set = ["message", "mode", "chat_id", "new_chat", "model", "export_response"]
+        let allowedArgs: Set = ["message", "mode", "chat_id", "new_chat", "model", "images", "export_response"]
         let unsupported = args.keys
             .filter { !$0.hasPrefix("_") && !allowedArgs.contains($0) }
             .sorted()
         if !unsupported.isEmpty {
             throw MCPError.invalidParams(
-                "oracle_send only accepts: message, mode, chat_id, new_chat, model, export_response. Unsupported args: \(unsupported.joined(separator: ", "))"
+                "oracle_send only accepts: message, mode, chat_id, new_chat, model, images, export_response. Unsupported args: \(unsupported.joined(separator: ", "))"
             )
         }
 
         try validateCommonOracleArgs(args)
+        let imageRequests = try Self.parseOracleImageRequests(args["images"])
         let message = (args["message"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let modeRaw = args["mode"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? "chat"
         let exportResponse = try parseExportResponseFlag(args)
@@ -351,13 +356,15 @@ struct MCPOracleToolService {
                 from: context,
                 owner: owner,
                 origin: .oracleSend,
-                mode: modeRaw
+                mode: modeRaw,
+                imageRequests: imageRequests
             )
         } else {
             tabContext = try await oracleSendTabContext(
                 from: context,
                 origin: .oracleSend,
-                mode: modeRaw
+                mode: modeRaw,
+                imageRequests: imageRequests
             )
         }
 
@@ -376,6 +383,8 @@ struct MCPOracleToolService {
 
         var chatArgs = args
         chatArgs.removeValue(forKey: "export_response")
+        // Images are already loaded into the tab context; the send path never sees raw paths.
+        chatArgs.removeValue(forKey: "images")
 
         let capturedTabContext = tabContext
         let capturedChatArgs = chatArgs
@@ -428,6 +437,77 @@ struct MCPOracleToolService {
             throw MCPError.invalidParams("export_response must be a boolean")
         }
         return boolValue
+    }
+
+    static func parseOracleImageRequests(_ value: Value?) throws -> [OracleImageRequest] {
+        guard let value else { return [] }
+        guard case let .array(items) = value else {
+            throw MCPError.invalidParams("images must be an array of objects.")
+        }
+        guard items.count <= OracleImageAttachmentLimits.production.maxCount else {
+            throw MCPError.invalidParams(
+                "images supports at most \(OracleImageAttachmentLimits.production.maxCount) items."
+            )
+        }
+        return try items.enumerated().map { index, item in
+            guard case let .object(object) = item else {
+                throw MCPError.invalidParams("images[\(index)] must be an object.")
+            }
+            let unsupported = object.keys
+                .filter { !$0.hasPrefix("_") && !["path", "title"].contains($0) }
+                .sorted()
+            guard unsupported.isEmpty else {
+                throw MCPError.invalidParams(
+                    "images[\(index)] unsupported keys: \(unsupported.joined(separator: ", "))."
+                )
+            }
+            guard let rawPath = object["path"]?.stringValue,
+                  !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                throw MCPError.invalidParams("images[\(index)].path must be a non-empty string.")
+            }
+            var title: String? = nil
+            if let titleValue = object["title"] {
+                guard let rawTitle = titleValue.stringValue else {
+                    throw MCPError.invalidParams("images[\(index)].title must be a string.")
+                }
+                let normalized = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard normalized.count <= 200 else {
+                    throw MCPError.invalidParams("images[\(index)].title exceeds 200 characters.")
+                }
+                title = normalized.isEmpty ? nil : normalized
+            }
+            return OracleImageRequest(index: index, path: rawPath, title: title)
+        }
+    }
+
+    /// Loads the requested images against the workspace roots this Oracle request
+    /// already resolved, translating client-visible logical paths to physical ones.
+    private func loadOracleImages(
+        _ requests: [OracleImageRequest],
+        lookupContext: WorkspaceLookupContext
+    ) async throws -> [AITransientImage] {
+        guard !requests.isEmpty else { return [] }
+        let rootPaths = await promptVM.workspaceFileContextStore
+            .rootRefs(scope: lookupContext.rootScope)
+            .map(\.standardizedFullPath)
+        let physicalRequests = requests.map {
+            OracleImageRequest(
+                index: $0.index,
+                path: lookupContext.translateInputPath($0.path),
+                title: $0.title
+            )
+        }
+        do {
+            return try await OracleImageAttachmentLoader.loadDetached(
+                requests: physicalRequests,
+                loader: OracleImageAttachmentLoader(workspaceRootPaths: rootPaths)
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw MCPError.invalidParams(error.localizedDescription)
+        }
     }
 
     private func parseOracleModelOverride(_ value: Value?) throws -> String? {
@@ -674,10 +754,12 @@ struct MCPOracleToolService {
             worktreeBindingState: .notApplicable
         ),
         origin: OracleSendOrigin,
-        mode: String
+        mode: String,
+        imageRequests: [OracleImageRequest] = []
     ) async throws -> OracleViewModel.OracleSendTabContext {
         let stabilizedContext = await stabilizedVirtualContext(context)
         let lookupContext = try await oraclePackagingLookupContext(for: stabilizedContext)
+        let transientImages = try await loadOracleImages(imageRequests, lookupContext: lookupContext)
         let reviewGitContext = await promptVM.freezePromptGitReviewContext(
             workspaceID: stabilizedContext.workspaceID,
             tabID: stabilizedContext.tabID,
@@ -710,7 +792,8 @@ struct MCPOracleToolService {
             origin: origin,
             agentModeSessionID: owner.agentSessionID,
             agentModeRunID: owner.runID,
-            packaging: packaging
+            packaging: packaging,
+            transientImages: transientImages
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleImageAttachmentLoader.swift
@@ -1,0 +1,203 @@
+import Foundation
+import RepoPromptWorkspaceCore
+
+/// One image attachment requested through the Oracle MCP surface.
+struct OracleImageRequest: Equatable {
+    let index: Int
+    /// Physical absolute path, already translated out of any logical root projection.
+    let path: String
+    let title: String?
+}
+
+struct OracleImageAttachmentLimits: Equatable {
+    let maxCount: Int
+    let maxBytesPerImage: Int
+    let maxTotalBytes: Int
+
+    static let production = OracleImageAttachmentLimits(
+        maxCount: 10,
+        maxBytesPerImage: 20 * 1024 * 1024,
+        maxTotalBytes: 50 * 1024 * 1024
+    )
+}
+
+enum OracleImageLoadError: Error, LocalizedError, Equatable {
+    case tooMany(maximumCount: Int)
+    case invalidPath(index: Int)
+    case outsideWorkspaceRoots(index: Int)
+    case missingOrUnreadable(index: Int)
+    case notRegularFile(index: Int)
+    case tooLarge(index: Int, maximumBytes: Int)
+    case totalTooLarge(maximumBytes: Int)
+    case unsupportedFormat(index: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case let .tooMany(maximumCount):
+            "images supports at most \(maximumCount) items."
+        case let .invalidPath(index):
+            "images[\(index)].path must be a canonical absolute local workspace path."
+        case let .outsideWorkspaceRoots(index):
+            "images[\(index)].path is outside the current workspace roots."
+        case let .missingOrUnreadable(index):
+            "images[\(index)] is missing or unreadable."
+        case let .notRegularFile(index):
+            "images[\(index)] must point to a regular file."
+        case let .tooLarge(index, maximumBytes):
+            "images[\(index)] exceeds the \(maximumBytes) byte per-image limit."
+        case let .totalTooLarge(maximumBytes):
+            "images total size exceeds the \(maximumBytes) byte limit."
+        case let .unsupportedFormat(index):
+            "images[\(index)] is not a supported PNG, JPEG, GIF, or WebP file."
+        }
+    }
+}
+
+/// Reads request-scoped Oracle image attachments off disk.
+///
+/// Authority is a containment check: a request's symlink-resolved path must live
+/// inside one of the symlink-resolved workspace roots the request already resolved
+/// against. Nothing else on the machine is readable through this surface.
+struct OracleImageAttachmentLoader {
+    let limits: OracleImageAttachmentLimits
+    private let resolvedRootPaths: [String]
+
+    init(
+        workspaceRootPaths: [String],
+        limits: OracleImageAttachmentLimits = .production
+    ) {
+        self.limits = limits
+        resolvedRootPaths = Set(workspaceRootPaths.map(Self.resolved)).sorted()
+    }
+
+    /// Runs the blocking file reads off the caller's actor while staying cancellable.
+    static func loadDetached(
+        requests: [OracleImageRequest],
+        loader: OracleImageAttachmentLoader
+    ) async throws -> [AITransientImage] {
+        try Task.checkCancellation()
+        let task = Task.detached(priority: .userInitiated) {
+            try loader.load(requests)
+        }
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    func load(_ requests: [OracleImageRequest]) throws -> [AITransientImage] {
+        guard requests.count <= limits.maxCount else {
+            throw OracleImageLoadError.tooMany(maximumCount: limits.maxCount)
+        }
+        guard !requests.isEmpty else { return [] }
+
+        var images: [AITransientImage] = []
+        var totalBytes = 0
+        for request in requests {
+            try Task.checkCancellation()
+            let url = try admittedFileURL(for: request)
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            guard let attributes else {
+                throw OracleImageLoadError.missingOrUnreadable(index: request.index)
+            }
+            guard attributes[.type] as? FileAttributeType == .typeRegular else {
+                throw OracleImageLoadError.notRegularFile(index: request.index)
+            }
+            guard let declaredSize = (attributes[.size] as? NSNumber)?.intValue,
+                  declaredSize <= limits.maxBytesPerImage
+            else {
+                throw OracleImageLoadError.tooLarge(
+                    index: request.index,
+                    maximumBytes: limits.maxBytesPerImage
+                )
+            }
+            guard let bytes = try? Data(contentsOf: url, options: .uncached) else {
+                throw OracleImageLoadError.missingOrUnreadable(index: request.index)
+            }
+            guard bytes.count <= limits.maxBytesPerImage else {
+                throw OracleImageLoadError.tooLarge(
+                    index: request.index,
+                    maximumBytes: limits.maxBytesPerImage
+                )
+            }
+            totalBytes += bytes.count
+            guard totalBytes <= limits.maxTotalBytes else {
+                throw OracleImageLoadError.totalTooLarge(maximumBytes: limits.maxTotalBytes)
+            }
+            try images.append(AITransientImage(
+                bytes: bytes,
+                mediaType: Self.mediaType(of: bytes, index: request.index),
+                title: request.title
+            ))
+        }
+        return images
+    }
+
+    private func admittedFileURL(for request: OracleImageRequest) throws -> URL {
+        let raw = request.path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard raw.hasPrefix("/"), !raw.contains("\0"), !raw.hasSuffix("/") else {
+            throw OracleImageLoadError.invalidPath(index: request.index)
+        }
+        let resolvedPath = Self.resolved(raw)
+        guard resolvedRootPaths.contains(where: { resolvedPath.hasPrefix($0 + "/") }) else {
+            throw OracleImageLoadError.outsideWorkspaceRoots(index: request.index)
+        }
+        return URL(fileURLWithPath: resolvedPath)
+    }
+
+    /// Standardizes and symlink-resolves a path so containment cannot be escaped
+    /// through `..`, a tilde, or a symlink anywhere along the way.
+    private static func resolved(_ path: String) -> String {
+        let standardized = StandardizedPath.absolute(path)
+        let resolved = URL(fileURLWithPath: standardized).resolvingSymlinksInPath().path
+        return StandardizedPath.absolute(resolved)
+    }
+
+    /// Content sniffing is authoritative; the file extension is never trusted.
+    private static func mediaType(of data: Data, index: Int) throws -> AIImageMediaType {
+        if data.starts(with: [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+            return .png
+        }
+        if data.starts(with: [0xFF, 0xD8, 0xFF]) {
+            return .jpeg
+        }
+        if data.starts(with: Array("GIF87a".utf8)) || data.starts(with: Array("GIF89a".utf8)) {
+            return .gif
+        }
+        if data.count >= 12,
+           data.starts(with: Array("RIFF".utf8)),
+           Array(data[8 ..< 12]) == Array("WEBP".utf8)
+        {
+            return .webp
+        }
+        throw OracleImageLoadError.unsupportedFormat(index: index)
+    }
+}
+
+enum OracleImageRouteAdmission {
+    /// Transports whose Oracle request serialization emits a native image block.
+    /// Unsupported CLI transports are rejected up front instead of silently sending
+    /// a text-only prompt.
+    static func supports(_ model: AIModel) -> Bool {
+        switch model.providerType {
+        case .anthropic,
+             .openAI,
+             .azure,
+             .openRouter,
+             .gemini,
+             .deepseek,
+             .customProvider,
+             .fireworks,
+             .grok,
+             .groq,
+             .zAI,
+             .ollama,
+             .omp,
+             .devin:
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/Policies/AgentModeMCPToolPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Policies/AgentModeMCPToolPolicy.swift
@@ -42,7 +42,7 @@ enum AgentModeMCPToolPolicy {
             codexNativeGrantedTools
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             claudeNativeGrantedTools
-        case .openCode, .antigravity:
+        case .openCode, .antigravity, .omp, .devin:
             openCodeGrantedTools
         case .cursor:
             cursorGrantedTools

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -5982,96 +5982,6 @@ extension ToolOutputFormatter {
         return [.text(lines.joined(separator: "\n"))]
     }
 
-    private static func agentListGroupingEffort(modelID: String, reasoningEffort: String?) -> String? {
-        if let normalizedEffort = normalizedAgentListReasoningEffort(reasoningEffort) {
-            return normalizedEffort
-        }
-        return CodexModelSpecifier(raw: modelID).reasoningEffort?.rawValue
-    }
-
-    private static func normalizedAgentListReasoningEffort(_ raw: String?) -> String? {
-        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else { return nil }
-        return CodexReasoningEffort.parse(trimmed)?.rawValue ?? trimmed.lowercased()
-    }
-
-    private static func agentListFamilyBase(modelID: String, groupingEffort: String?) -> String {
-        guard let groupingEffort,
-              let stripped = stripAgentListEffortSuffix(from: modelID, groupingEffort: groupingEffort)
-        else {
-            return modelID
-        }
-        return stripped
-    }
-
-    private static func stripAgentListEffortSuffix(from value: String, groupingEffort: String) -> String? {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        let lowered = trimmed.lowercased()
-        for suffix in agentListEffortIDMarkers(for: groupingEffort) where lowered.hasSuffix(suffix) {
-            let stripped = String(trimmed.dropLast(suffix.count))
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return stripped.isEmpty ? nil : stripped
-        }
-        return nil
-    }
-
-    private static func agentListEffortIDMarkers(for groupingEffort: String) -> [String] {
-        let normalized = groupingEffort.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !normalized.isEmpty else { return [] }
-        var markers = ["-\(normalized)"]
-        let hyphenated = normalized
-            .replacingOccurrences(of: "_", with: "-")
-            .replacingOccurrences(of: " ", with: "-")
-        if hyphenated != normalized {
-            markers.append("-\(hyphenated)")
-        }
-        switch CodexReasoningEffort.parse(normalized) {
-        case .some(.xhigh):
-            markers.append("-x-high")
-        case .some(.max):
-            markers.append("-maximum")
-        case .some(.medium):
-            markers.append("-med")
-        default:
-            break
-        }
-        return Array(Set(markers))
-    }
-
-    private static func agentListFamilyDisplayName(
-        _ modelName: String,
-        modelID: String,
-        groupingEffort: String
-    ) -> String {
-        let fallback = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmed = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let candidate = trimmed.isEmpty ? fallback : trimmed
-        guard !candidate.isEmpty else { return modelName }
-        let lowered = candidate.lowercased()
-        for suffix in agentListEffortDisplayMarkers(for: groupingEffort) where lowered.hasSuffix(suffix) {
-            let stripped = String(candidate.dropLast(suffix.count))
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return stripped.isEmpty ? candidate : stripped
-        }
-        return candidate
-    }
-
-    private static func agentListEffortDisplayMarkers(for groupingEffort: String) -> [String] {
-        let normalized = groupingEffort.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalized.isEmpty else { return [] }
-        let readableFallback = normalized
-            .replacingOccurrences(of: "_", with: " ")
-            .replacingOccurrences(of: "-", with: " ")
-        var labels = [normalized, readableFallback]
-        if let parsed = CodexReasoningEffort.parse(normalized) {
-            labels.append(parsed.displayName)
-            if parsed == .xhigh {
-                labels.append("X-High")
-            }
-        }
-        return Array(Set(labels.map { " \($0.lowercased())" }))
-    }
-
     static func formatAgentManage(args: [String: Value], value: Value) -> [MCP.Tool.Content] {
         guard let object = value.objectValue else {
             return formatGeneric(value: value)
@@ -6178,61 +6088,20 @@ extension ToolOutputFormatter {
                 let defaultModelID = agent["default_model_id"]?.stringValue
                 guard let models = agent["models"]?.arrayValue, !models.isEmpty else { continue }
 
-                // Group models by base ID (strip effort suffix) to collapse Codex families.
+                // Every rendered `model_id` is reproduced verbatim from the payload: this surface
+                // is where callers learn the IDs they paste back into agent_run op=start, so it
+                // must never synthesize or abbreviate one (a collapsed `base-{effort}` family
+                // token is not a real model_id and fails catalog validation).
                 // Per-agent model entries are explicit compound `model_id` targets only;
-                // role routing is surfaced via top-level `task_labels` above.
-                var families: [(base: String, name: String, efforts: [String])] = []
-                var seen: Set<String> = []
-
+                // role routing is surfaced via the top-level `task_labels` above.
                 for model in models {
-                    guard let m = model.objectValue else { continue }
-                    let modelID = m["model_id"]?.stringValue ?? ""
-                    let modelName = m["name"]?.stringValue ?? ""
-                    let effort = m["reasoning_effort"]?.stringValue
-
-                    // Extract base: everything after "agentRaw:" minus an explicit or supported effort suffix.
-                    let afterColon = modelID.contains(":") ? String(modelID[modelID.index(after: modelID.firstIndex(of: ":")!)...]) : modelID
-                    let agentPrefix = modelID.contains(":") ? String(modelID[...modelID.firstIndex(of: ":")!]) : ""
-                    let groupingEffort = agentListGroupingEffort(modelID: afterColon, reasoningEffort: effort)
-                    let base = agentListFamilyBase(modelID: afterColon, groupingEffort: groupingEffort)
-                    let familyKey = agentPrefix + base
-
-                    if let groupingEffort, seen.contains(familyKey) {
-                        // Add effort to existing family
-                        if let idx = families.firstIndex(where: { familyKey == "\(agentPrefix)\($0.base)" }),
-                           !families[idx].efforts.contains(groupingEffort)
-                        {
-                            families[idx].efforts.append(groupingEffort)
-                        }
-                    } else if let groupingEffort, !seen.contains(familyKey) {
-                        // New family with efforts
-                        seen.insert(familyKey)
-                        let baseName = agentListFamilyDisplayName(
-                            modelName,
-                            modelID: afterColon,
-                            groupingEffort: groupingEffort
-                        )
-                        families.append((base: base, name: baseName, efforts: [groupingEffort]))
-                    } else {
-                        // Simple model (no effort variants)
-                        families.append((base: base, name: modelName, efforts: []))
-                    }
-                }
-
-                let agentPrefix: String = {
-                    guard let first = models.first?.objectValue?["model_id"]?.stringValue,
-                          let colonIdx = first.firstIndex(of: ":") else { return "" }
-                    return String(first[...colonIdx])
-                }()
-
-                for family in families {
-                    if family.efforts.isEmpty {
-                        if family.base == "default" { continue }
-                        lines.append("  `\(agentPrefix)\(family.base)` — \(family.name)")
-                    } else {
-                        let effortList = family.efforts.joined(separator: "|")
-                        lines.append("  `\(agentPrefix)\(family.base)-{\(effortList)}` — \(family.name)")
-                    }
+                    guard let modelObject = model.objectValue,
+                          let modelID = modelObject["model_id"]?.stringValue,
+                          !modelID.isEmpty
+                    else { continue }
+                    let modelName = modelObject["name"]?.stringValue ?? modelID
+                    let defaultSuffix = modelID == defaultModelID ? " (default)" : ""
+                    lines.append("  `\(modelID)` — \(modelName)\(defaultSuffix)")
                 }
                 for model in models {
                     guard let modelObject = model.objectValue,

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPOracleToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPOracleToolProvider.swift
@@ -8,6 +8,24 @@ import RepoPromptDomainRuntime
 final class MCPOracleToolProvider: MCPAppToolProviding {
     let group: MCPAppToolGroup = .oracle
 
+    static let oracleImageUsageDescription = "Optional `images` attaches workspace-local PNG, JPEG, GIF, or WebP files when the resolved Oracle model's transport supports image input. Each item is `{path,title?}` with an absolute path inside a currently loaded workspace root. Transports without image support, URLs, screenshots, and files outside the loaded roots are rejected before a message is sent. Limits: \(OracleImageAttachmentLimits.production.maxCount) images, \(OracleImageAttachmentLimits.production.maxBytesPerImage / 1_048_576) MiB each, \(OracleImageAttachmentLimits.production.maxTotalBytes / 1_048_576) MiB total."
+
+    static let oracleImagesArgumentDescription = "Optional workspace-local PNG/JPEG/GIF/WebP images for transports that support image input. Each item requires an absolute `path` inside a loaded root and may include a transient `title`. Unsupported transports, URLs, and screenshots are rejected. Max \(OracleImageAttachmentLimits.production.maxCount) images, \(OracleImageAttachmentLimits.production.maxBytesPerImage / 1_048_576) MiB each, \(OracleImageAttachmentLimits.production.maxTotalBytes / 1_048_576) MiB total."
+
+    private static var oracleImagesSchema: JSONSchema {
+        .array(
+            description: oracleImagesArgumentDescription,
+            items: .object(
+                properties: [
+                    "path": .string(description: "Absolute path inside a currently loaded workspace root"),
+                    "title": .string(description: "Optional transient image title", maxLength: 200)
+                ],
+                required: ["path"]
+            ),
+            maxItems: OracleImageAttachmentLimits.production.maxCount
+        )
+    }
+
     private let runtime: MCPAppToolBinder
     private let dependencies: MCPAppPhysicalCapabilityAdapters.Execution
 
@@ -60,6 +78,8 @@ final class MCPOracleToolProvider: MCPAppToolProviding {
 
             Use this to start or continue an oracle conversation in `chat`, `plan`, or `review` mode for the current agent tab. Omit `chat_id` or set `new_chat=true` to start; otherwise `chat_id` continues. The optional `model` override changes only the primary model of a new conversation.
 
+            \(Self.oracleImageUsageDescription)
+
             Pass `export_response: true` to write the response to a shareable file and get back shareable `oracle_export_path` / `oracle_export_instruction` values. To hand the export to a child agent, include `oracle_export_path` inside the `message` (or `messages`) you send on your next delegation call; your system prompt names the specific delegation tool available to you.
 
             Use `oracle_chat_log` after compaction to recover recent oracle messages.
@@ -86,6 +106,7 @@ final class MCPOracleToolProvider: MCPAppToolProviding {
                         description: "Optional primary-model override for a new conversation; rejected on continuation.",
                         maxLength: OracleRosterContract.maximumModelIdentifierLength
                     ),
+                    "images": Self.oracleImagesSchema,
                     "export_response": .boolean(
                         description: "When true, export the response to a file and return `oracle_export_path` plus `oracle_export_instruction`. Include `oracle_export_path` inside the `message` you send on your next delegation call; the specific delegation tool is named by your system prompt."
                     )
@@ -106,6 +127,8 @@ final class MCPOracleToolProvider: MCPAppToolProviding {
 
             Use this to start or continue an oracle conversation in `chat`, `plan`, or `review` mode. When `chat_id` and `new_chat` are omitted, the resolved tab resumes its selected eligible conversation, falling back to the most recent eligible conversation. Set `new_chat=true` to force a new conversation; `model` is valid only for that explicit start.
             Use `oracle_utils` for passive helpers like models and sessions.
+
+            \(Self.oracleImageUsageDescription)
 
             Pass `export_response: true` to write the response to a shareable file and get back shareable `oracle_export_path` / `oracle_export_instruction` values. To hand the export to a child agent, include `oracle_export_path` inside the `message` (or `messages`) you send on your next delegation call; your system prompt names the specific delegation tool available to you.
 
@@ -133,6 +156,7 @@ final class MCPOracleToolProvider: MCPAppToolProviding {
                         description: "Optional primary-model override for an explicit new_chat=true start; rejected on continuation.",
                         maxLength: OracleRosterContract.maximumModelIdentifierLength
                     ),
+                    "images": Self.oracleImagesSchema,
                     "export_response": .boolean(
                         description: "When true, export the response to a file and return `oracle_export_path` plus `oracle_export_instruction`. Include `oracle_export_path` inside the `message` you send on your next delegation call; the specific delegation tool is named by your system prompt."
                     )

--- a/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
@@ -16,6 +16,12 @@ enum CLILaunchProfiles {
     ]
     static let cursorProviderSpecificPaths: [String] = []
 
+    /// Bun global-install location used by OMP's published CLI.
+    static let ompProviderSpecificPaths: [String] = ["~/.bun/bin"]
+
+    /// Devin's installer links its versioned CLI shim here.
+    static let devinProviderSpecificPaths: [String] = ["~/.local/bin"]
+
     /// Official Grok Build installer location (`GROK_BIN_DIR` overrides it, but a custom
     /// value is honored through PATH or an explicitly configured absolute command only).
     static let grokBuildProviderSpecificPaths: [String] = [
@@ -64,6 +70,18 @@ enum CLILaunchProfiles {
         commandName: "cursor-agent",
         preferredBasenames: ["cursor-agent"],
         supplementalSearchPaths: nativeDefaultsSupplemented(with: cursorProviderSpecificPaths)
+    )
+
+    static let omp = CLILaunchProfile(
+        commandName: "omp",
+        preferredBasenames: ["omp"],
+        supplementalSearchPaths: providerSpecificPathsSupplementedWithNativeDefaults(ompProviderSpecificPaths)
+    )
+
+    static let devin = CLILaunchProfile(
+        commandName: "devin",
+        preferredBasenames: ["devin"],
+        supplementalSearchPaths: providerSpecificPathsSupplementedWithNativeDefaults(devinProviderSpecificPaths)
     )
 
     static let grokBuild = CLILaunchProfile(

--- a/Sources/RepoPrompt/Infrastructure/Security/KeyManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/KeyManager.swift
@@ -19,7 +19,9 @@ actor KeyManager {
             return cached
         }
 
-        let account = provider.secureStorageAccount
+        // A provider with no account keeps its credentials in its own CLI; there is
+        // nothing for RepoPrompt to read.
+        guard let account = provider.secureStorageAccount else { return nil }
         let keyFromDisk = try await secureService.getAPIKey(for: account, accessMode: accessMode)
 
         if let k = keyFromDisk {
@@ -35,8 +37,12 @@ actor KeyManager {
         for provider: AIProviderType,
         accessMode: KeychainAccessMode = .interactive
     ) throws {
+        guard let account = provider.secureStorageAccount else {
+            throw AIProviderError.invalidConfiguration(
+                detail: "\(provider.displayName) does not store an API key in RepoPrompt."
+            )
+        }
         cache[provider] = key
-        let account = provider.secureStorageAccount
         try secureService.saveAPIKey(key, for: account, accessMode: accessMode)
     }
 
@@ -46,14 +52,15 @@ actor KeyManager {
         accessMode: KeychainAccessMode = .interactive
     ) throws {
         cache.removeValue(forKey: provider)
-        let account = provider.secureStorageAccount
+        guard let account = provider.secureStorageAccount else { return }
         try secureService.deleteAPIKey(for: account, accessMode: accessMode)
     }
 }
 
 extension AIProviderType {
-    /// Maps each provider to its frozen secure-storage account.
-    var secureStorageAccount: SecureStorageAccount {
+    /// Maps each provider to its frozen secure-storage account, or `nil` when the provider
+    /// authenticates entirely through its own CLI and RepoPrompt stores no secret for it.
+    var secureStorageAccount: SecureStorageAccount? {
         switch self {
         case .anthropic: .anthropicAPI
         case .openAI: .openAIAPI
@@ -72,6 +79,7 @@ extension AIProviderType {
         case .cursor: .cursorCLIAPI
         case .grokBuild: .grokAPI
         case .zAI: .zAIAPI
+        case .omp, .devin: nil
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryModel.swift
@@ -199,6 +199,8 @@ extension SentryTelemetryBootstrap {
         case openCode = "opencode"
         case grokBuild = "grok_build"
         case antigravity
+        case omp
+        case devin
 
         init(agentKind: AgentProviderKind) {
             switch agentKind {
@@ -214,6 +216,10 @@ extension SentryTelemetryBootstrap {
                 self = .grokBuild
             case .antigravity:
                 self = .antigravity
+            case .omp:
+                self = .omp
+            case .devin:
+                self = .devin
             case .claudeCodeGLM:
                 self = .claudeCodeGLM
             case .kimiCode:

--- a/Sources/RepoPrompt/Infrastructure/UI/Agent/AgentModelOptionsMenuContent.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Agent/AgentModelOptionsMenuContent.swift
@@ -90,6 +90,34 @@ struct AgentModelOptionsMenuContent: View {
                     modelOptionButton(option)
                 }
             }
+        } else if agentKind == .devin {
+            ForEach(AgentModelCatalog.devinModelGroups(for: options)) { group in
+                if let family = group.family {
+                    Menu(family.displayName) {
+                        ForEach(group.options, id: \.rawValue) { option in
+                            modelOptionButton(option)
+                        }
+                    }
+                } else {
+                    ForEach(group.options, id: \.rawValue) { option in
+                        modelOptionButton(option)
+                    }
+                }
+            }
+        } else if agentKind == .omp {
+            ForEach(AgentModelCatalog.ompModelGroups(for: options)) { group in
+                if let providerID = group.providerID {
+                    Menu(providerID) {
+                        ForEach(group.options, id: \.rawValue) { option in
+                            modelOptionButton(option)
+                        }
+                    }
+                } else {
+                    ForEach(group.options, id: \.rawValue) { option in
+                        modelOptionButton(option)
+                    }
+                }
+            }
         } else if agentKind == .openCode {
             ForEach(AgentModelCatalog.openCodeMenu(for: options).providerGroups) { providerGroup in
                 if providerGroup.rendersAsSubmenu {
@@ -224,6 +252,37 @@ enum AgentModelStableMenuItems {
                 selectedModelRaw: selectedModelRaw,
                 onSelect: onSelect
             )
+        }
+        if agentKind == .devin {
+            return AgentModelCatalog.devinModelGroups(for: visibleOptions).flatMap { group -> [StableMenuItem] in
+                let items = group.options.map { option in
+                    modelItem(
+                        option,
+                        agentKind: agentKind,
+                        selectedAgent: selectedAgent,
+                        selectedModelRaw: selectedModelRaw,
+                        onSelect: onSelect
+                    )
+                }
+                // An unlabelled group renders inline: a submenu with no title would be blank.
+                guard let family = group.family else { return items }
+                return [.submenu(family.displayName, items: items)]
+            }
+        }
+        if agentKind == .omp {
+            return AgentModelCatalog.ompModelGroups(for: visibleOptions).flatMap { group -> [StableMenuItem] in
+                let items = group.options.map { option in
+                    modelItem(
+                        option,
+                        agentKind: agentKind,
+                        selectedAgent: selectedAgent,
+                        selectedModelRaw: selectedModelRaw,
+                        onSelect: onSelect
+                    )
+                }
+                guard let providerID = group.providerID else { return items }
+                return [.submenu(providerID, items: items)]
+            }
         }
         if agentKind == .openCode, groupOpenCode {
             return AgentModelCatalog.openCodeMenu(for: visibleOptions).providerGroups.flatMap { providerGroup -> [StableMenuItem] in

--- a/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
+++ b/Tests/RepoPromptTests/AI/OracleImageSerializationTests.swift
@@ -1,0 +1,365 @@
+import Foundation
+@testable import RepoPromptApp
+import SwiftAnthropic
+import XCTest
+
+/// Each image-capable Oracle transport must emit its own native image block, attach it to the
+/// turn the image arrived with, and leave text-only requests byte-identical to before.
+final class OracleImageSerializationTests: XCTestCase {
+    func testAnthropicAttachesImageBlocksOnlyToFinalUserTurn() throws {
+        let json = try jsonObject(AnthropicProvider.makeMessages(for: makeMessage()))
+        let messages = try XCTUnwrap(json as? [[String: Any]])
+
+        XCTAssertEqual(countObjects(type: "image", in: json), 1)
+        XCTAssertTrue(try jsonText(json).contains("Image title: Diagram"))
+        XCTAssertFalse(try jsonText(messages[0]).contains("AQID"))
+        XCTAssertTrue(try jsonText(XCTUnwrap(messages.last)).contains("AQID"))
+    }
+
+    func testOpenAIChatAttachesImagePartsOnlyToFinalUserTurn() throws {
+        let json = try jsonObject(makeMessage().openAIChatMessages(embedSystemPrompt: false))
+        let messages = try XCTUnwrap(json as? [[String: Any]])
+
+        XCTAssertEqual(countObjects(type: "image_url", in: json), 1)
+        XCTAssertTrue(try containsPNGDataURL(jsonText(json)))
+        XCTAssertTrue(try jsonText(json).contains("Image title: Diagram"))
+        XCTAssertFalse(try jsonText(messages[1]).contains("AQID"))
+        XCTAssertTrue(try jsonText(XCTUnwrap(messages.last)).contains("AQID"))
+    }
+
+    func testOpenAIResponsesAttachesImagePartsOnlyToFinalUserTurn() throws {
+        let json = try jsonObject(makeMessage().openAIResponsesInput())
+        let text = try jsonText(json)
+
+        XCTAssertEqual(countObjects(type: "input_image", in: json), 1)
+        XCTAssertTrue(containsPNGDataURL(text))
+        XCTAssertTrue(text.contains("Image title: Diagram"))
+    }
+
+    func testCustomOpenAIEncodesFinalUserTurnAsPartArray() throws {
+        let json = try jsonObject(customProvider().serializedMessagesForTesting(makeMessage()))
+        let messages = try XCTUnwrap(json as? [[String: Any]])
+        let finalContent = try XCTUnwrap(messages.last?["content"] as? [[String: Any]])
+
+        XCTAssertTrue(messages[1]["content"] is String)
+        XCTAssertEqual(countObjects(type: "image_url", in: finalContent), 1)
+        XCTAssertTrue(try containsPNGDataURL(jsonText(finalContent)))
+        XCTAssertEqual(finalContent.first?["type"] as? String, "text")
+    }
+
+    func testNativeTransportsReplayHistoricalImageOnItsOriginatingTurn() throws {
+        let message = makeContinuationMessage()
+
+        let anthropic = try jsonObject(AnthropicProvider.makeMessages(for: message))
+        let anthropicMessages = try XCTUnwrap(anthropic as? [[String: Any]])
+        XCTAssertEqual(countObjects(type: "image", in: anthropic), 1)
+        XCTAssertTrue(try jsonText(anthropicMessages[0]).contains("AQID"))
+        XCTAssertFalse(try jsonText(XCTUnwrap(anthropicMessages.last)).contains("AQID"))
+
+        let chat = try jsonObject(message.openAIChatMessages(embedSystemPrompt: false))
+        let chatMessages = try XCTUnwrap(chat as? [[String: Any]])
+        XCTAssertEqual(countObjects(type: "image_url", in: chat), 1)
+        XCTAssertTrue(try containsPNGDataURL(jsonText(chatMessages[1])))
+        XCTAssertTrue(chatMessages.last?["content"] is String)
+
+        let responses = try jsonObject(message.openAIResponsesInput())
+        let responseItems = try XCTUnwrap(responses as? [[String: Any]])
+        XCTAssertEqual(countObjects(type: "input_image", in: responses), 1)
+        XCTAssertTrue(try containsPNGDataURL(jsonText(responseItems[0])))
+        XCTAssertFalse(try containsPNGDataURL(jsonText(XCTUnwrap(responseItems.last))))
+
+        let custom = try jsonObject(customProvider().serializedMessagesForTesting(message))
+        let customMessages = try XCTUnwrap(custom as? [[String: Any]])
+        XCTAssertEqual(countObjects(type: "image_url", in: custom), 1)
+        XCTAssertTrue(customMessages[1]["content"] is [[String: Any]])
+        XCTAssertTrue(customMessages.last?["content"] is String)
+    }
+
+    func testPromptPackagingPreservesFinalTurnImagesThroughRewrap() {
+        let packaged = PromptPackagingService.buildAIMessage(
+            systemPrompt: "system",
+            metaInstructions: [],
+            fileTree: "",
+            fileContents: [],
+            conversation: [
+                ConversationEntry(role: .user, content: "first", images: [makeImage(title: "History")]),
+                ConversationEntry(role: .assistant, content: "answer"),
+                ConversationEntry(role: .user, content: "final", images: [makeImage()])
+            ],
+            temperature: nil,
+            promptSectionsOrder: [],
+            disabledPromptSections: []
+        )
+
+        XCTAssertEqual(packaged.conversationMessages.count, 3)
+        XCTAssertEqual(packaged.conversationMessages[0].images, [makeImage(title: "History")])
+        XCTAssertEqual(packaged.conversationMessages[1].images, [])
+        XCTAssertEqual(packaged.conversationMessages[2].images, [makeImage()])
+        XCTAssertTrue(packaged.conversationMessages[2].content.contains("<user_instructions>"))
+        XCTAssertEqual(packaged.conversationMessages[0].content, "first")
+    }
+
+    func testTextOnlyRequestsKeepScalarContent() throws {
+        let message = AIMessage(systemPrompt: "system", userMessage: "plain")
+
+        let chat = try XCTUnwrap(try jsonObject(message.openAIChatMessages(embedSystemPrompt: false)) as? [[String: Any]])
+        XCTAssertTrue(chat.allSatisfy { $0["content"] is String })
+
+        let custom = try XCTUnwrap(
+            try jsonObject(customProvider().serializedMessagesForTesting(message)) as? [[String: Any]]
+        )
+        XCTAssertTrue(custom.allSatisfy { $0["content"] is String })
+
+        let anthropic = try jsonObject(AnthropicProvider.makeMessages(for: message))
+        XCTAssertEqual(countObjects(type: "image", in: anthropic), 0)
+
+        let responses = try XCTUnwrap(try jsonObject(message.openAIResponsesInput()) as? [[String: Any]])
+        XCTAssertEqual(responses.count, 1)
+        XCTAssertEqual(responses.first?["role"] as? String, "user")
+    }
+
+    func testACPCLIProjectionPreservesTransientImagesWithoutChangingText() {
+        let engine = ompEngine()
+        let withImages = engine.test_agentMessage(from: makeMessage())
+        let withoutImages = engine.test_agentMessage(from: AIMessage(
+            systemPrompt: "system",
+            conversationMessages: [
+                ConversationEntry(role: .user, content: "first"),
+                ConversationEntry(role: .assistant, content: "answer"),
+                ConversationEntry(role: .user, content: "final")
+            ],
+            temperature: nil,
+            promptSectionsOrder: [],
+            disabledPromptSections: []
+        ))
+
+        XCTAssertEqual(withImages.promptContentParts.last, .image(makeImage()))
+        XCTAssertEqual(withImages.systemPrompt, withoutImages.systemPrompt)
+        XCTAssertTrue(withImages.userMessage.hasSuffix("User: final"))
+        XCTAssertEqual(withImages.userMessage, withoutImages.userMessage)
+        XCTAssertTrue(withoutImages.promptContentParts.isEmpty)
+    }
+
+    func testACPCLIProjectionKeepsHistoricalImageOnItsOwnTurn() {
+        let message = ompEngine().test_agentMessage(from: makeContinuationMessage())
+
+        XCTAssertEqual(message.userMessage, "User: first\n\nAssistant: answer\n\nUser: final")
+        XCTAssertEqual(message.promptContentParts, [
+            .text("User: first"),
+            .image(makeImage()),
+            .text("Assistant: answer\n\nUser: final")
+        ])
+        XCTAssertEqual(
+            message.promptContentParts.compactMap(\.text).joined(separator: "\n\n"),
+            message.userMessage
+        )
+    }
+
+    func testACPImageBearingPromptRendersIdenticalTextToTextOnlyComposition() {
+        let padded = AIMessage(
+            systemPrompt: "system",
+            conversationMessages: [
+                ConversationEntry(role: .user, content: "first  ", images: [makeImage()]),
+                ConversationEntry(role: .assistant, content: "answer"),
+                ConversationEntry(role: .user, content: "final  ")
+            ],
+            temperature: nil,
+            promptSectionsOrder: [],
+            disabledPromptSections: []
+        )
+        let message = ompEngine().test_agentMessage(from: padded)
+        var textOnly = message
+        textOnly.promptContentParts = []
+        let request = runRequest(for: .omp)
+
+        let ordered = ACPPromptComposition.promptContentParts(for: message, request: request)
+        XCTAssertEqual(
+            ordered.compactMap(\.text).joined(separator: "\n\n"),
+            ACPPromptComposition.promptText(for: textOnly, request: request)
+        )
+        XCTAssertEqual(ordered.first?.text, "system\n\nUser: first  ")
+    }
+
+    func testOMPAndDevinEmitSchemaValidTransientImageBlocks() throws {
+        let source = AIMessage(
+            systemPrompt: "system",
+            conversationMessages: [
+                ConversationEntry(role: .user, content: "first"),
+                ConversationEntry(role: .assistant, content: "answer"),
+                ConversationEntry(role: .user, content: "final", images: [makeImage(title: " Diagram ")])
+            ],
+            temperature: nil,
+            promptSectionsOrder: [],
+            disabledPromptSections: []
+        )
+        for (provider, agentKind, message) in acpProviderCases(for: source) {
+            let request = runRequest(for: agentKind)
+            let blocks = try provider.buildPromptBlocks(for: message, request: request)
+
+            XCTAssertEqual(blocks.count, 3)
+            XCTAssertEqual(blocks[0]["type"] as? String, "text")
+            XCTAssertEqual(blocks[1]["text"] as? String, "Image title: Diagram")
+            XCTAssertEqual(blocks[2]["type"] as? String, "image")
+            XCTAssertEqual(blocks[2]["mimeType"] as? String, "image/png")
+            XCTAssertEqual(blocks[2]["data"] as? String, "AQID")
+            XCTAssertNil(blocks[2]["uri"])
+
+            var textOnlyMessage = message
+            textOnlyMessage.promptContentParts = []
+            let textOnlyBlocks = try provider.buildPromptBlocks(for: textOnlyMessage, request: request)
+            XCTAssertEqual(textOnlyBlocks.count, 1)
+            XCTAssertEqual(blocks[0]["text"] as? String, textOnlyBlocks[0]["text"] as? String)
+            XCTAssertTrue((blocks[0]["text"] as? String)?.hasSuffix("User: final") == true)
+        }
+    }
+
+    func testOMPAndDevinReplayHistoricalImageOnceInChronologicalOrder() throws {
+        for (provider, agentKind, message) in acpProviderCases(for: makeContinuationMessage()) {
+            let blocks = try provider.buildPromptBlocks(for: message, request: runRequest(for: agentKind))
+
+            XCTAssertEqual(blocks.count, 4)
+            XCTAssertEqual(blocks[0]["text"] as? String, "system\n\nUser: first")
+            XCTAssertEqual(blocks[1]["text"] as? String, "Image title: Diagram")
+            XCTAssertEqual(blocks[2]["type"] as? String, "image")
+            XCTAssertEqual(blocks[2]["data"] as? String, "AQID")
+            XCTAssertNil(blocks[2]["uri"])
+            XCTAssertEqual(blocks[3]["text"] as? String, "Assistant: answer\n\nUser: final")
+            XCTAssertEqual(countObjects(type: "image", in: blocks), 1)
+        }
+    }
+
+    func testOMPAndDevinTextOnlyContinuationEmitsSingleFlattenedBlock() throws {
+        let textOnly = AIMessage(
+            systemPrompt: "system",
+            conversationMessages: [
+                ConversationEntry(role: .user, content: "first"),
+                ConversationEntry(role: .assistant, content: "answer"),
+                ConversationEntry(role: .user, content: "final")
+            ],
+            temperature: nil,
+            promptSectionsOrder: [],
+            disabledPromptSections: []
+        )
+        for (provider, agentKind, message) in acpProviderCases(for: textOnly) {
+            XCTAssertTrue(message.promptContentParts.isEmpty)
+            let blocks = try provider.buildPromptBlocks(for: message, request: runRequest(for: agentKind))
+
+            XCTAssertEqual(blocks.count, 1)
+            XCTAssertEqual(
+                blocks[0]["text"] as? String,
+                "system\n\nUser: first\n\nAssistant: answer\n\nUser: final"
+            )
+        }
+    }
+
+    func testACPRejectsRemoteImageAttachmentsInsteadOfEmittingInvalidBlocks() {
+        let attachment = AgentImageAttachment(source: .url("https://example.test/image.png"))
+
+        XCTAssertThrowsError(try ACPPromptContentBuilder.blocks(
+            text: "inspect",
+            attachments: [attachment]
+        )) { error in
+            XCTAssertEqual(
+                error as? ACPPromptContentBuilder.Error,
+                .unsupportedRemoteImage("https://example.test/image.png")
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeImage(title: String? = "Diagram") -> AITransientImage {
+        AITransientImage(bytes: Data([1, 2, 3]), mediaType: .png, title: title)
+    }
+
+    private func makeMessage() -> AIMessage {
+        makeMessage(imagesOnFirstUserTurn: false)
+    }
+
+    private func makeContinuationMessage() -> AIMessage {
+        makeMessage(imagesOnFirstUserTurn: true)
+    }
+
+    private func makeMessage(imagesOnFirstUserTurn: Bool) -> AIMessage {
+        let images = [makeImage()]
+        return AIMessage(
+            systemPrompt: "system",
+            conversationMessages: [
+                ConversationEntry(role: .user, content: "first", images: imagesOnFirstUserTurn ? images : []),
+                ConversationEntry(role: .assistant, content: "answer"),
+                ConversationEntry(role: .user, content: "final", images: imagesOnFirstUserTurn ? [] : images)
+            ],
+            temperature: nil,
+            promptSectionsOrder: [],
+            disabledPromptSections: []
+        )
+    }
+
+    private func ompEngine() -> ACPCLIChatProviderEngine<OMPACPHeadlessAgentProvider> {
+        ACPCLIChatProviderEngine<OMPACPHeadlessAgentProvider>(
+            providerName: "Oh My Pi",
+            providerType: .omp,
+            makeProvider: { _ in OMPACPHeadlessAgentProvider(config: OMPAgentConfig()) }
+        )
+    }
+
+    private func devinEngine() -> ACPCLIChatProviderEngine<DevinACPHeadlessAgentProvider> {
+        ACPCLIChatProviderEngine<DevinACPHeadlessAgentProvider>(
+            providerName: "Devin",
+            providerType: .devin,
+            makeProvider: { _ in DevinACPHeadlessAgentProvider(config: DevinAgentConfig()) }
+        )
+    }
+
+    private func acpProviderCases(
+        for source: AIMessage
+    ) -> [(any ACPAgentProvider, AgentProviderKind, AgentMessage)] {
+        [
+            (OMPACPAgentProvider(config: OMPAgentConfig()), .omp, ompEngine().test_agentMessage(from: source)),
+            (DevinACPAgentProvider(config: DevinAgentConfig()), .devin, devinEngine().test_agentMessage(from: source))
+        ]
+    }
+
+    private func runRequest(for agentKind: AgentProviderKind) -> ACPRunRequest {
+        ACPRunRequest(
+            agentKind: agentKind,
+            modelString: nil,
+            workspacePath: nil,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+    }
+
+    private func customProvider() -> CustomOpenAIProvider {
+        CustomOpenAIProvider(
+            baseURL: "https://example.test/v1",
+            apiKey: "key",
+            defaultModel: "vision-model"
+        )
+    }
+
+    private func containsPNGDataURL(_ text: String) -> Bool {
+        text.contains("data:image/png;base64,AQID") || text.contains("data:image\\/png;base64,AQID")
+    }
+
+    private func jsonObject(_ value: some Encodable) throws -> Any {
+        try JSONSerialization.jsonObject(with: JSONEncoder().encode(value))
+    }
+
+    private func jsonText(_ value: Any) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+        return try XCTUnwrap(String(data: data, encoding: .utf8))
+    }
+
+    private func countObjects(type: String, in value: Any) -> Int {
+        if let object = value as? [String: Any] {
+            return (object["type"] as? String == type ? 1 : 0)
+                + object.values.reduce(0) { $0 + countObjects(type: type, in: $1) }
+        }
+        if let array = value as? [Any] {
+            return array.reduce(0) { $0 + countObjects(type: type, in: $1) }
+        }
+        return 0
+    }
+}

--- a/Tests/RepoPromptTests/AI/ProviderStreamCompletionTests.swift
+++ b/Tests/RepoPromptTests/AI/ProviderStreamCompletionTests.swift
@@ -4,6 +4,37 @@ import SwiftOpenAI
 import XCTest
 
 final class ProviderStreamCompletionTests: XCTestCase {
+    func testACPChatStreamExcludesSystemAndStatusWithoutDroppingAssistantOrTransportResults() async throws {
+        let engine = ACPCLIChatProviderEngine(
+            providerName: "Devin",
+            providerType: .devin,
+            makeProvider: { _ in ScriptedACPChatProvider() }
+        )
+        let stream = try await engine.streamMessage(
+            AIMessage(systemPrompt: "system", userMessage: "question"),
+            model: .devinCustom(name: "claude-opus-4-6")
+        )
+        var results: [AIStreamResult] = []
+        for try await result in stream {
+            results.append(result)
+        }
+        await engine.dispose()
+
+        XCTAssertEqual(results.compactMap(\.text), ["answer", "final answer"])
+        XCTAssertEqual(results.compactMap(\.reasoning), ["thinking"])
+        XCTAssertEqual(results.map(\.type), [
+            AIStreamResult.lifecycleType,
+            "content",
+            AIStreamResult.transportActivityType,
+            "final_content",
+            "message_stop"
+        ])
+        XCTAssertEqual(results.last?.promptTokens, 11)
+        XCTAssertEqual(results.last?.completionTokens, 7)
+        XCTAssertEqual(results.last?.cost, 0.25)
+        XCTAssertEqual(results.last?.providerSessionID, "session-1")
+    }
+
     func testOpenAIStopReasonReportsSuccessfulCompletion() {
         XCTAssertEqual(openAIChatCompletionOutcome(.string("stop")), .completed)
         XCTAssertNil(openAIChatCompletionOutcome(nil))
@@ -46,4 +77,32 @@ final class ProviderStreamCompletionTests: XCTestCase {
             )
         }
     }
+}
+
+private final class ScriptedACPChatProvider: HeadlessAgentProvider {
+    func streamAgentMessage(_: AgentMessage, runID _: UUID?) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        AsyncThrowingStream { continuation in
+            for result in [
+                AIStreamResult(type: "system", text: "provider warning"),
+                AIStreamResult(type: "status", text: "Oracle prompt title"),
+                AIStreamResult(type: AIStreamResult.lifecycleType, text: nil),
+                AIStreamResult(type: "content", text: "answer", reasoning: "thinking"),
+                AIStreamResult(type: AIStreamResult.transportActivityType, text: nil),
+                AIStreamResult(type: "final_content", text: "final answer"),
+                AIStreamResult(
+                    type: "message_stop",
+                    text: nil,
+                    promptTokens: 11,
+                    completionTokens: 7,
+                    cost: 0.25,
+                    providerSessionID: "session-1"
+                )
+            ] {
+                continuation.yield(result)
+            }
+            continuation.finish()
+        }
+    }
+
+    func dispose() async {}
 }

--- a/Tests/RepoPromptTests/AgentMode/ACPCLILaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPCLILaunchResolverTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+/// Covers the shared `<cli> acp` launch resolution both new ACP providers depend on:
+/// profile pinning, basename safety, the `--help` advertisement preflight, and the
+/// resolved-launch shape (canonical path, `acp` arguments, captured environment).
+final class ACPCLILaunchResolverTests: XCTestCase {
+    private struct Fixture {
+        let spec: ACPCLILaunchSpec
+        let config: any ACPCLILaunchConfiguring
+        let helpOutput: String
+        let hint: String
+    }
+
+    private var fixtures: [Fixture] {
+        [
+            Fixture(
+                spec: .devin,
+                config: DevinAgentConfig(additionalPathHints: []),
+                helpOutput: "Run as an ACP (Agent Client Protocol) server over stdio",
+                hint: "~/.local/bin"
+            ),
+            Fixture(
+                spec: .omp,
+                config: OMPAgentConfig(additionalPathHints: []),
+                helpOutput: "Run Oh My Pi as an ACP server over stdio",
+                hint: "~/.bun/bin"
+            )
+        ]
+    }
+
+    func testProviderProfilesPinCommandsAndSearchHints() {
+        XCTAssertEqual(CLILaunchProfiles.devin.commandName, "devin")
+        XCTAssertEqual(CLILaunchProfiles.omp.commandName, "omp")
+        XCTAssertTrue(CLIPathHints.devin.contains("~/.local/bin"))
+        XCTAssertTrue(CLIPathHints.omp.contains("~/.bun/bin"))
+        for fixture in fixtures {
+            XCTAssertEqual(fixture.spec.commandName, fixture.spec.profile.commandName)
+            XCTAssertEqual(fixture.spec.launchArguments, ["acp"])
+            XCTAssertEqual(fixture.spec.helpArguments, ["acp", "--help"])
+            XCTAssertTrue(
+                fixture.spec.profile.supplementalSearchPaths.contains(fixture.hint),
+                "\(fixture.spec.displayName) must search \(fixture.hint)"
+            )
+        }
+    }
+
+    func testProviderKindsMapToTheirACPProviderIDs() {
+        XCTAssertEqual(AgentProviderKind.devin.acpProviderID, .devin)
+        XCTAssertEqual(AgentProviderKind.omp.acpProviderID, .omp)
+        XCTAssertEqual(AgentProviderKind.devin.providerBindingID, .devin)
+        XCTAssertEqual(AgentProviderKind.omp.providerBindingID, .omp)
+    }
+
+    func testForeignCommandBasenameIsRefused() async throws {
+        for fixture in fixtures {
+            let resolver = ACPCLILaunchResolver(spec: fixture.spec, launchEnvironmentProvider: { _ in
+                ACPLaunchEnvironment(environment: [:])
+            })
+            let support = try await resolver.probeSupport(
+                for: ImpostorConfig(commandName: "not-\(fixture.spec.commandName)")
+            )
+            guard case let .unsupported(reason) = support else {
+                return XCTFail("expected unsupported for \(fixture.spec.displayName), got \(support)")
+            }
+            XCTAssertTrue(
+                reason.contains("Refusing unsafe \(fixture.spec.displayName) ACP command"),
+                "unexpected reason: \(reason)"
+            )
+        }
+    }
+
+    func testSupportProbeRequiresZeroExitStatus() async throws {
+        for fixture in fixtures {
+            let directory = try makeTestDirectory(name: "ACPCLILaunchResolverExit")
+            try makeExecutable(named: fixture.spec.commandName, in: directory, output: fixture.helpOutput, exitStatus: 3)
+            let resolver = makeResolver(fixture.spec, path: directory)
+
+            let support = try await resolver.probeSupport(for: fixture.config)
+
+            guard case let .unsupported(reason) = support else {
+                return XCTFail("expected unsupported for \(fixture.spec.displayName), got \(support)")
+            }
+            XCTAssertTrue(
+                reason.contains("`\(fixture.spec.commandName) acp --help` exited with status 3"),
+                "unexpected reason: \(reason)"
+            )
+        }
+    }
+
+    func testSupportProbeRequiresEveryACPHelpAdvertisement() async throws {
+        for fixture in fixtures {
+            let directory = try makeTestDirectory(name: "ACPCLILaunchResolverHelp")
+            try makeExecutable(named: fixture.spec.commandName, in: directory, output: "generic help")
+            let resolver = makeResolver(fixture.spec, path: directory)
+
+            let support = try await resolver.probeSupport(for: fixture.config)
+
+            guard case let .unsupported(reason) = support else {
+                return XCTFail("expected unsupported for \(fixture.spec.displayName), got \(support)")
+            }
+            XCTAssertTrue(reason.contains("did not advertise ACP support"), "unexpected reason: \(reason)")
+        }
+    }
+
+    func testProbeResolvesSymlinkedExecutableAndCarriesLaunchShape() async throws {
+        for fixture in fixtures {
+            let directory = try makeTestDirectory(name: "ACPCLILaunchResolverSymlink")
+            let packageDirectory = directory.appendingPathComponent("package", isDirectory: true)
+            try FileManager.default.createDirectory(at: packageDirectory, withIntermediateDirectories: true)
+            let target = try makeExecutable(
+                named: "\(fixture.spec.commandName)-entry",
+                in: packageDirectory,
+                output: fixture.helpOutput
+            )
+            let binDirectory = directory.appendingPathComponent("bin", isDirectory: true)
+            try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+            try FileManager.default.createSymbolicLink(
+                at: binDirectory.appendingPathComponent(fixture.spec.commandName),
+                withDestinationURL: target
+            )
+            let resolver = makeResolver(fixture.spec, path: binDirectory)
+
+            let support = try await resolver.probeSupport(for: fixture.config)
+            XCTAssertEqual(support, .supported)
+
+            let launch = try resolver.resolvedLaunch(for: fixture.config)
+            XCTAssertEqual(launch.arguments, ["acp"])
+            XCTAssertEqual(launch.command, launch.executableIdentity.canonicalPath)
+            XCTAssertTrue(
+                launch.command.hasSuffix("\(fixture.spec.commandName)-entry"),
+                "unexpected command: \(launch.command)"
+            )
+            // Devin's isolated MCP-configuration overlay derives the native config root
+            // from this captured environment, so it must survive resolution.
+            XCTAssertEqual(launch.environment["PATH"], binDirectory.path)
+        }
+    }
+
+    func testBareCommandWithoutProbeRequiresEnvironmentDiscovery() {
+        for fixture in fixtures {
+            let resolver = ACPCLILaunchResolver(spec: fixture.spec, launchEnvironmentProvider: { _ in
+                ACPLaunchEnvironment(environment: [:])
+            })
+            XCTAssertThrowsError(try resolver.resolvedLaunch(for: fixture.config)) { error in
+                XCTAssertEqual(
+                    error as? ACPCLILaunchResolutionError,
+                    .environmentDiscoveryRequired(
+                        agent: fixture.spec.displayName,
+                        command: fixture.spec.commandName
+                    )
+                )
+            }
+        }
+    }
+
+    func testExecutableInsideApplicationBundleIsRefused() async throws {
+        let spec = ACPCLILaunchSpec.devin
+        let directory = try makeTestDirectory(name: "ACPCLILaunchResolverAppBundle")
+        let bundleBin = directory
+            .appendingPathComponent("Impostor.app/Contents/MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: bundleBin, withIntermediateDirectories: true)
+        let executable = try makeExecutable(named: spec.commandName, in: bundleBin)
+        let resolver = makeResolver(spec, path: bundleBin)
+
+        // The bundled executable is named as an explicit absolute path: PATH discovery
+        // would otherwise fall through to a real CLI installed on the host machine and
+        // report `.supported` for a different binary entirely.
+        let support = try await resolver.probeSupport(
+            for: DevinAgentConfig(commandName: executable.path, additionalPathHints: [])
+        )
+
+        guard case let .unsupported(reason) = support else {
+            return XCTFail("expected unsupported, got \(support)")
+        }
+        XCTAssertTrue(
+            reason.contains("Refusing Devin ACP executable inside an application bundle"),
+            "unexpected reason: \(reason)"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private struct ImpostorConfig: ACPCLILaunchConfiguring {
+        let commandName: String
+        let additionalPathHints: [String] = []
+        let enableDebugLogging = false
+    }
+
+    private func makeResolver(_ spec: ACPCLILaunchSpec, path: URL) -> ACPCLILaunchResolver {
+        ACPCLILaunchResolver(spec: spec, launchEnvironmentProvider: { _ in
+            ACPLaunchEnvironment(environment: ["PATH": path.path, "SHELL": "/bin/false"])
+        })
+    }
+
+    @discardableResult
+    private func makeExecutable(
+        named name: String,
+        in directory: URL,
+        output: String = "Run as an ACP server over stdio",
+        exitStatus: Int32 = 0
+    ) throws -> URL {
+        let executable = directory.appendingPathComponent(name)
+        let script = "#!/bin/sh\nprintf '%s\\n' '\(output)'\nexit \(exitStatus)\n"
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return executable
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentOraclePillRoutingTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentOraclePillRoutingTests.swift
@@ -400,94 +400,146 @@ final class AgentOraclePillRoutingTests: XCTestCase {
         XCTAssertNil(wrongWorkspace)
     }
 
-    func testAggregateOraclePillCountAndLabelsUseConfiguredOrLatestProjectedGroup() {
-        let historical = ChatSession(
-            oracleGroupID: UUID(),
-            oracleLaneIndex: 0,
-            oracleGroupSize: 5,
-            name: "Historical",
-            savedAt: Date(timeIntervalSince1970: 100)
+    func testBadgeAndSelectorsUseCanonicalRosterWithUnavailableMissingMember() {
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let groupID = UUID()
+        let single = ChatSession(name: "Legacy single")
+        let primary = ChatSession(
+            workspaceID: workspaceID, composeTabID: tabID,
+            oracleGroupID: groupID, oracleLaneIndex: 0, oracleGroupSize: 3
         )
-        let latestSingle = ChatSession(
-            name: "Latest Single",
-            savedAt: Date(timeIntervalSince1970: 200)
+        let secondary = ChatSession(
+            workspaceID: workspaceID, composeTabID: tabID,
+            oracleGroupID: groupID, oracleLaneIndex: 1, oracleGroupSize: 3
         )
-        let latestGroupID = UUID()
-        let latestProjected = ChatSession(
-            oracleGroupID: latestGroupID,
-            oracleLaneIndex: 0,
-            oracleGroupSize: 4,
-            name: "Latest Group",
-            savedAt: Date(timeIntervalSince1970: 300)
+        let payload = OracleLaneMarkdownPayload(lanes: [
+            .init(
+                laneIndex: 0, chatID: primary.shortID, providerID: nil, modelID: "primary",
+                effectiveReasoningEffort: nil, status: .failed, response: nil, partialResponse: nil,
+                errorCode: "provider_failed", errorMessage: "failed"
+            ),
+            .init(
+                laneIndex: 1, chatID: secondary.shortID, providerID: nil, modelID: "secondary",
+                effectiveReasoningEffort: nil, status: .completed, response: "answer", partialResponse: nil,
+                errorCode: nil, errorMessage: nil
+            ),
+            .init(
+                laneIndex: 2, chatID: "missing-chat", providerID: nil, modelID: "missing",
+                effectiveReasoningEffort: nil, status: .unavailable, response: nil, partialResponse: nil,
+                errorCode: nil, errorMessage: nil
+            )
+        ])
+        let lanes = AgentOraclePillLogic.lanePresentations(
+            for: primary,
+            in: [single, secondary, primary],
+            streamingSessionIDs: [],
+            payload: payload
         )
-        let staleSiblingProjection = ChatSession(
-            oracleGroupID: latestGroupID,
-            oracleLaneIndex: 1,
-            oracleGroupSize: 5,
-            name: "Stale Group Sibling",
-            savedAt: Date(timeIntervalSince1970: 200)
-        )
-        let invalidProjected = ChatSession(
-            oracleGroupID: UUID(),
-            oracleLaneIndex: 0,
-            oracleGroupSize: 99,
-            name: "Invalid Projection",
-            savedAt: Date(timeIntervalSince1970: 400)
+        let fallbackLanes = AgentOraclePillLogic.lanePresentations(
+            for: primary,
+            in: [single, secondary, primary],
+            streamingSessionIDs: [],
+            payload: nil
         )
 
-        XCTAssertEqual(
-            AgentOraclePillLogic.aggregateOracleCount(
-                configuredAdditionalCount: 0,
-                sessions: [historical, latestSingle]
-            ),
-            1
+        // Configuration is deliberately absent from the presentation API: changing it cannot
+        // promote a historical single chat or change an existing group's stored roster.
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(session: single), 1)
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(session: primary, payload: payload), lanes.count)
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(session: nil), 1)
+        XCTAssertEqual(lanes.map(\.laneIndex), [0, 1, 2])
+        XCTAssertEqual(lanes.map(\.sessionID), [primary.id, secondary.id, nil])
+        XCTAssertEqual(lanes.map(\.status), [.failed, .completed, .unavailable])
+        XCTAssertEqual(fallbackLanes.count, AgentOraclePillLogic.aggregateOracleCount(session: primary))
+        XCTAssertEqual(fallbackLanes.map(\.sessionID), [primary.id, secondary.id, nil])
+        XCTAssertEqual(fallbackLanes.map(\.status), [.unavailable, .unavailable, .unavailable])
+        XCTAssertTrue(AgentOraclePillLogic.groupMemberSessions(for: single, in: [single, primary]).isEmpty)
+        XCTAssertFalse(AgentOraclePillLogic.canCopyAll(single))
+        XCTAssertTrue(AgentOraclePillLogic.canCopyAll(primary))
+    }
+
+    func testBadgeFollowsOwnerFilteringStreamingSelectionAndExplicitHistory() throws {
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let owner = UUID()
+        let runID = UUID()
+        func session(size: Int, savedAt: TimeInterval, agent: UUID) -> ChatSession {
+            ChatSession(
+                workspaceID: workspaceID, composeTabID: tabID,
+                agentModeSessionID: agent, agentModeRunID: runID,
+                oracleGroupID: UUID(), oracleLaneIndex: 0, oracleGroupSize: size,
+                savedAt: Date(timeIntervalSince1970: savedAt),
+                messages: [StoredMessage(isUser: false, rawText: "answer", sequenceIndex: 0)]
+            )
+        }
+        let streaming = session(size: 2, savedAt: 100, agent: owner)
+        let newer = session(size: 3, savedAt: 200, agent: owner)
+        let foreign = session(size: 5, savedAt: 300, agent: UUID())
+        let sessions = [foreign, newer, streaming]
+        let eligible = AgentOraclePillLogic.eligibleSessions(
+            sessions: sessions, streamingSessionIDs: [streaming.id], liveMessageCount: { _ in nil },
+            activeAgentSessionID: owner, activeRunID: runID
         )
-        XCTAssertEqual(
-            AgentOraclePillLogic.aggregateOracleCount(
-                configuredAdditionalCount: 0,
-                sessions: [historical, staleSiblingProjection, latestProjected]
-            ),
-            4
+        XCTAssertFalse(eligible.contains { $0.id == foreign.id })
+        let selected = try XCTUnwrap(AgentOraclePillLogic.latestSession(
+            in: eligible, streamingSessionIDs: [streaming.id]
+        ))
+        XCTAssertEqual(selected.id, streaming.id)
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(session: selected), 2)
+        let historicalID = AgentOraclePillLogic.reconciledPresentedSessionID(
+            currentSessionID: newer.id, isExplicit: true, currentWorkspaceID: workspaceID,
+            sameTabSessions: sessions, eligibleSessions: eligible, streamingSessionIDs: [streaming.id]
         )
-        XCTAssertEqual(
-            AgentOraclePillLogic.aggregateOracleCount(configuredAdditionalCount: 2, sessions: []),
-            3
+        XCTAssertEqual(historicalID, newer.id)
+        XCTAssertEqual(AgentOraclePillLogic.aggregateOracleCount(
+            session: sessions.first { $0.id == historicalID }
+        ), 3)
+    }
+
+    func testLaneStatusUsesCanonicalOutcomeInsteadOfAssistantText() {
+        let groupID = UUID()
+        let primary = ChatSession(oracleGroupID: groupID, oracleLaneIndex: 0, oracleGroupSize: 3)
+        let secondary = ChatSession(
+            oracleGroupID: groupID, oracleLaneIndex: 1, oracleGroupSize: 3,
+            messages: [StoredMessage(isUser: false, rawText: "Error: valid answer", sequenceIndex: 0)]
         )
-        XCTAssertEqual(
-            AgentOraclePillLogic.aggregateOracleCount(configuredAdditionalCount: 0, sessions: [invalidProjected]),
-            5
-        )
-        XCTAssertFalse(AgentOraclePillLogic.canCopyAll(latestSingle))
-        XCTAssertTrue(AgentOraclePillLogic.canCopyAll(latestProjected))
-        XCTAssertEqual(
-            (0 ... 4).map(OracleViewModel.oracleLabel(laneIndex:)),
-            ["Oracle", "Oracle 2", "Oracle 3", "Oracle 4", "Oracle 5"]
-        )
-        XCTAssertEqual(
-            AgentOraclePillLogic.laneDotState(isStreaming: true, lastAssistantContent: "Error: stale"),
-            .streaming
-        )
-        XCTAssertEqual(
-            AgentOraclePillLogic.laneDotState(
-                isStreaming: false,
-                lastAssistantContent: "partial answer\n\n--\nError:\nstatus code 502"
-            ),
-            .failed
-        )
-        XCTAssertEqual(
-            AgentOraclePillLogic.laneDotState(
-                isStreaming: false,
-                lastAssistantContent: "Error: status code 502 Gemini response stalled"
-            ),
-            .failed
-        )
-        XCTAssertEqual(
-            AgentOraclePillLogic.laneDotState(
-                isStreaming: false,
-                lastAssistantContent: "Review looks correct. Mention error handling."
-            ),
-            .completed
-        )
+        let cancelled = ChatSession(oracleGroupID: groupID, oracleLaneIndex: 2, oracleGroupSize: 3)
+        let sessions = [primary, secondary, cancelled]
+        let statuses: [OracleLaneMarkdownPayload.Status] = [.failed, .completed, .cancelled]
+        let payload = OracleLaneMarkdownPayload(lanes: zip(sessions, statuses).enumerated().map { index, pair in
+            OracleLaneMarkdownPayload.Lane(
+                laneIndex: index, chatID: pair.0.shortID, providerID: nil, modelID: "same-model",
+                effectiveReasoningEffort: nil, status: pair.1,
+                response: index == 1 ? "Error: valid answer" : nil, partialResponse: nil,
+                errorCode: index == 0 ? "invalid_model" : nil,
+                errorMessage: index == 0 ? "failed before sending" : nil
+            )
+        })
+        XCTAssertEqual(sessions.map {
+            AgentOraclePillLogic.laneStatus(session: $0, isStreaming: false, payload: payload)
+        }, statuses)
+        XCTAssertEqual(AgentOraclePillLogic.laneStatus(session: primary, isStreaming: false, payload: nil), .unavailable)
+        XCTAssertEqual(AgentOraclePillLogic.laneStatus(session: primary, isStreaming: true, payload: payload), .running)
+        XCTAssertEqual(AgentOraclePillLogic.groupMemberSessions(for: primary, in: Array(sessions.reversed())).map(\.id), sessions.map(\.id))
+        XCTAssertEqual(AgentOraclePillLogic.lanePresentations(
+            for: primary,
+            in: Array(sessions.reversed()),
+            streamingSessionIDs: [],
+            payload: payload
+        ).map(\.status), statuses)
+        XCTAssertEqual(AgentOraclePillLogic.lanePresentations(
+            for: primary,
+            in: sessions,
+            streamingSessionIDs: [secondary.id],
+            payload: payload
+        ).map(\.status), [.failed, .running, .cancelled])
+        XCTAssertEqual(AgentOraclePillLogic.lanePresentations(
+            for: primary,
+            in: sessions,
+            streamingSessionIDs: [],
+            payload: nil
+        ).map(\.status), [.unavailable, .unavailable, .unavailable])
     }
 
     func testGroupedDeleteFallsBackToProjectionCleanupWhenCanonicalDocumentIsMissing() async throws {

--- a/Tests/RepoPromptTests/AgentMode/AutoRecommendationEngineScopedSettingsTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AutoRecommendationEngineScopedSettingsTests.swift
@@ -4,6 +4,31 @@ import XCTest
 
 @MainActor
 final class AutoRecommendationEngineScopedSettingsTests: XCTestCase {
+    func testOMPAndDevinRemainExplicitSelectionsButNotAutomaticFallbacks() {
+        for agent in [AgentProviderKind.omp, .devin] {
+            let availability = AgentModelCatalog.AvailabilityContext(
+                claudeCodeAvailable: false,
+                codexAvailable: false,
+                openCodeAvailable: false,
+                ompAvailable: agent == .omp,
+                devinAvailable: agent == .devin
+            )
+            XCTAssertNil(AutoRecommendationEngine.resolveContextBuilderSelection(
+                persistedAgentRaw: nil,
+                persistedModelRaw: nil,
+                availability: availability
+            ))
+
+            let restored = AutoRecommendationEngine.resolveContextBuilderSelection(
+                persistedAgentRaw: agent.rawValue,
+                persistedModelRaw: AgentModel.defaultModel.rawValue,
+                availability: availability
+            )
+            XCTAssertEqual(restored?.agent, agent)
+            XCTAssertEqual(restored?.modelRaw, AgentModel.defaultModel.rawValue)
+        }
+    }
+
     func testOperationIdentityRejectsWorkspaceAndInheritanceChanges() {
         let workspaceID = UUID()
         let identity = AgentModelsOperationIdentity(

--- a/Tests/RepoPromptTests/AgentMode/DevinIntegrationConfigurationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinIntegrationConfigurationTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+/// Devin's isolated `XDG_CONFIG_HOME` overlay is the only delivery path its `mcp_*`
+/// gateway tools can see (session-scoped ACP `mcpServers` connect but are never
+/// registered), so the merge behavior it depends on is covered directly.
+final class DevinIntegrationConfigurationTests: XCTestCase {
+    func testOverlayOverwritesStaleEntryPreservesNativeConfigurationAndLinksSiblings() throws {
+        let sourceRoot = try makeTestDirectory(name: "DevinOverlaySource")
+        let sourceDevin = sourceRoot.appendingPathComponent("devin", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDevin, withIntermediateDirectories: true)
+        let auth = sourceDevin.appendingPathComponent("auth.json")
+        try Data(#"{"synthetic":"not-a-credential"}"#.utf8).write(to: auth)
+
+        let nativeStdio: [String: Any] = ["transport": "stdio", "command": "/bin/echo", "args": ["native"]]
+        let explicitStdio: [String: Any] = [
+            "transport": "stdio",
+            "command": "/bin/echo",
+            "env": ["XDG_CONFIG_HOME": "/explicit/native/root"]
+        ]
+        let remote: [String: Any] = ["transport": "http", "url": "https://example.invalid"]
+        // A stale user-level RepoPrompt entry pointing at a non-CE bundle must be replaced,
+        // not merged: it collides on the same server key.
+        let staleRepoPrompt: [String: Any] = [
+            "transport": "stdio",
+            "command": "/Applications/RepoPrompt.app/Contents/MacOS/repoprompt-mcp"
+        ]
+        let sourceJSON = try JSONSerialization.data(
+            withJSONObject: [
+                "custom": "retained",
+                "mcpServers": [
+                    "Native": nativeStdio,
+                    "Explicit": explicitStdio,
+                    "Remote": remote,
+                    RepoPromptMCPServerConfiguration.defaultServerName: staleRepoPrompt
+                ]
+            ],
+            options: [.sortedKeys]
+        )
+        let sourceConfigURL = sourceDevin.appendingPathComponent("mcp_config.json")
+        try sourceJSON.write(to: sourceConfigURL)
+
+        let prepared = try DevinIntegrationConfiguration.prepare(
+            workingDirectory: sourceRoot.path,
+            repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(
+                command: "/bin/echo",
+                args: ["--backend", "app"],
+                env: [.init(name: "RP_MARKER", value: "run-scoped")]
+            ),
+            sourceEnvironment: ["XDG_CONFIG_HOME": sourceRoot.path]
+        )
+        defer { DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact) }
+
+        let overlayRoot = try URL(fileURLWithPath: XCTUnwrap(prepared.environment["XDG_CONFIG_HOME"]))
+        XCTAssertEqual(prepared.environment.count, 1, "the overlay contributes exactly one launch override")
+        XCTAssertEqual(prepared.cleanupArtifact.providerID, .devin)
+        XCTAssertEqual(prepared.cleanupArtifact.kind, DevinIntegrationConfiguration.cleanupArtifactKind)
+
+        let overlayConfigURL = overlayRoot.appendingPathComponent("devin/mcp_config.json")
+        let root = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: overlayConfigURL)) as? [String: Any]
+        )
+        XCTAssertEqual(root["custom"] as? String, "retained", "unrelated root keys survive the merge")
+        let servers = try XCTUnwrap(root["mcpServers"] as? [String: [String: Any]])
+
+        let injected = try XCTUnwrap(servers[RepoPromptMCPServerConfiguration.defaultServerName])
+        XCTAssertEqual(injected["transport"] as? String, "stdio")
+        XCTAssertEqual(injected["command"] as? String, "/bin/echo")
+        XCTAssertEqual(injected["args"] as? [String], ["--backend", "app"])
+        XCTAssertEqual(
+            injected["env"] as? [String: String],
+            ["RP_MARKER": "run-scoped", "XDG_CONFIG_HOME": sourceRoot.path]
+        )
+
+        // Known stdio children keep reading the user's real configuration root.
+        XCTAssertEqual(
+            servers["Native"]?["env"] as? [String: String],
+            ["XDG_CONFIG_HOME": sourceRoot.path]
+        )
+        // An explicit per-server override is never rewritten.
+        XCTAssertEqual(
+            servers["Explicit"]?["env"] as? [String: String],
+            ["XDG_CONFIG_HOME": "/explicit/native/root"]
+        )
+        // Non-stdio entries pass through untouched.
+        XCTAssertEqual(servers["Remote"] as NSDictionary?, remote as NSDictionary)
+
+        // The user's own configuration file is never mutated.
+        XCTAssertEqual(try Data(contentsOf: sourceConfigURL), sourceJSON)
+
+        // Siblings are symlinked, so native credential refreshes stay visible.
+        let linkedAuth = overlayRoot.appendingPathComponent("devin/auth.json")
+        XCTAssertEqual(linkedAuth.resolvingSymlinksInPath(), auth.resolvingSymlinksInPath())
+        try Data(#"{"synthetic":"refreshed"}"#.utf8).write(to: auth)
+        XCTAssertEqual(try Data(contentsOf: linkedAuth), Data(#"{"synthetic":"refreshed"}"#.utf8))
+    }
+
+    func testSourceRootFallsBackToHomeConfigWhenXDGIsUnsetOrBlank() throws {
+        let home = try makeTestDirectory(name: "DevinOverlayHome")
+        let sourceDevin = home.appendingPathComponent(".config/devin", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDevin, withIntermediateDirectories: true)
+        try Data(#"{"homeMarker":true,"mcpServers":{}}"#.utf8)
+            .write(to: sourceDevin.appendingPathComponent("mcp_config.json"))
+
+        for xdg in [nil, "  "] as [String?] {
+            var environment = ["HOME": home.path]
+            environment["XDG_CONFIG_HOME"] = xdg
+
+            let prepared = try DevinIntegrationConfiguration.prepare(
+                workingDirectory: home.path,
+                repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(command: "/bin/echo"),
+                sourceEnvironment: environment
+            )
+            defer { DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact) }
+
+            let overlayRoot = try URL(fileURLWithPath: XCTUnwrap(prepared.environment["XDG_CONFIG_HOME"]))
+            let root = try XCTUnwrap(
+                JSONSerialization.jsonObject(
+                    with: Data(contentsOf: overlayRoot.appendingPathComponent("devin/mcp_config.json"))
+                ) as? [String: Any]
+            )
+            XCTAssertEqual(root["homeMarker"] as? Bool, true, "expected $HOME/.config fallback for XDG=\(xdg ?? "nil")")
+        }
+    }
+
+    func testPreparationRejectsAMissingRepoPromptCommand() throws {
+        let sourceRoot = try makeTestDirectory(name: "DevinOverlayInvalidCommand")
+        XCTAssertThrowsError(
+            try DevinIntegrationConfiguration.prepare(
+                workingDirectory: sourceRoot.path,
+                repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(
+                    command: sourceRoot.appendingPathComponent("missing-repoprompt-mcp").path
+                ),
+                sourceEnvironment: ["XDG_CONFIG_HOME": sourceRoot.path]
+            )
+        )
+    }
+
+    func testCleanupRemovesTheOverlayAndIgnoresForeignArtifacts() throws {
+        let sourceRoot = try makeTestDirectory(name: "DevinOverlayCleanup")
+        let prepared = try DevinIntegrationConfiguration.prepare(
+            workingDirectory: sourceRoot.path,
+            repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration(command: "/bin/echo"),
+            sourceEnvironment: ["XDG_CONFIG_HOME": sourceRoot.path]
+        )
+        let overlayRoot = try XCTUnwrap(prepared.environment["XDG_CONFIG_HOME"])
+
+        DevinIntegrationConfiguration.cleanup(
+            artifact: ACPLaunchCleanupArtifact(providerID: .cursor, id: prepared.cleanupArtifact.id, kind: DevinIntegrationConfiguration.cleanupArtifactKind)
+        )
+        DevinIntegrationConfiguration.cleanup(
+            artifact: ACPLaunchCleanupArtifact(providerID: .devin, id: prepared.cleanupArtifact.id, kind: "someOtherKind")
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: overlayRoot))
+
+        DevinIntegrationConfiguration.cleanup(artifact: prepared.cleanupArtifact)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: overlayRoot))
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/DevinOMPModelSelectionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/DevinOMPModelSelectionTests.swift
@@ -1,0 +1,545 @@
+import Foundation
+import MCP
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+/// Model selection for the two ACP providers added alongside these tests: catalog exposure,
+/// provider/family grouping in the pickers, and the runner's pre-prompt selection decision.
+@MainActor
+final class DevinOMPModelSelectionTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        AgentACPModelRegistry.shared.test_reset(providerID: .omp)
+        AgentACPModelRegistry.shared.test_reset(providerID: .devin)
+    }
+
+    override func tearDown() {
+        AgentACPModelRegistry.shared.test_reset(providerID: .omp)
+        AgentACPModelRegistry.shared.test_reset(providerID: .devin)
+        super.tearDown()
+    }
+
+    // MARK: - Catalog exposure
+
+    func testOMPAndDevinExposeProviderDefaultBeforeAnyDiscovery() {
+        for agentKind in [AgentProviderKind.omp, .devin] {
+            let options = AgentModelCatalog.options(
+                for: agentKind,
+                availability: availability(for: agentKind)
+            )
+
+            XCTAssertEqual(
+                options.map(\.rawValue),
+                [AgentModel.defaultModel.rawValue],
+                "\(agentKind.rawValue) must offer its provider-managed default with no discovery"
+            )
+            XCTAssertTrue(
+                AgentModelCatalog.isValid(
+                    rawModel: AgentModel.defaultModel.rawValue,
+                    for: agentKind,
+                    availability: availability(for: agentKind)
+                )
+            )
+        }
+    }
+
+    func testDiscoveredModelsAppendAfterTheProviderDefault() {
+        publishOMPModels()
+
+        let options = AgentModelCatalog.options(for: .omp, availability: availability(for: .omp))
+
+        XCTAssertEqual(options.first?.rawValue, AgentModel.defaultModel.rawValue)
+        XCTAssertEqual(
+            Set(options.dropFirst().map(\.rawValue)),
+            ["anthropic/claude-opus-4-5", "openai/gpt-5.2", "openai/gpt-5.2-codex", "local-model"]
+        )
+        // A single provider-managed default must never be duplicated by discovery.
+        XCTAssertEqual(
+            options.count { $0.rawValue == AgentModel.defaultModel.rawValue },
+            1
+        )
+    }
+
+    // MARK: - Discovery → run round-trip
+
+    /// `list_agents` is where callers learn which `model_id` values exist, so every ID it emits
+    /// must be accepted verbatim by the run surface. The raw values here carry `/`, `.`, and `:`,
+    /// plus a bare model that also has an effort-suffixed sibling — the shape that used to be
+    /// rendered as a fabricated `base-{effort}` token.
+    func testEveryEmittedOMPModelIDRoundTripsBackToTheSameAgentAndModel() throws {
+        publishPunctuatedOMPModels()
+        let availability = availability(for: .omp)
+
+        let targets = try emittedOMPStartTargets(availability: availability)
+
+        XCTAssertEqual(
+            Set(targets.map(\.modelRaw)),
+            Set([AgentModel.defaultModel.rawValue] + Self.punctuatedOMPRawValues)
+        )
+        for target in targets {
+            let emitted = target.selectionID.rawValue
+            let parsed = try XCTUnwrap(AgentModelSelectionID.parse(emitted), emitted)
+            XCTAssertEqual(parsed.agentRaw, AgentProviderKind.omp.rawValue, emitted)
+            XCTAssertEqual(parsed.modelRaw, target.modelRaw, emitted)
+            XCTAssertTrue(
+                AgentModelCatalog.isValid(
+                    rawModel: parsed.modelRaw,
+                    for: .omp,
+                    availability: availability
+                ),
+                "list_agents emitted '\(emitted)' but the run surface rejects it"
+            )
+        }
+    }
+
+    /// The rendered text is the surface agents actually copy from, so it must reproduce each
+    /// `model_id` verbatim — no collapsed families, no dropped entries.
+    func testRenderedAgentListEmitsEveryModelIDVerbatimAndNothingElse() throws {
+        publishPunctuatedOMPModels()
+        let availability = availability(for: .omp)
+        let targets = try emittedOMPStartTargets(availability: availability)
+
+        let text = try renderedListAgentsText(for: targets)
+        let renderedIDs = Self.backtickedModelIDs(in: text)
+
+        XCTAssertEqual(Set(renderedIDs), Set(targets.map(\.selectionID.rawValue)))
+        XCTAssertEqual(renderedIDs.count, targets.count, "no model_id may be rendered twice")
+        for emitted in renderedIDs {
+            let parsed = try XCTUnwrap(AgentModelSelectionID.parse(emitted), emitted)
+            XCTAssertEqual(parsed.agentRaw, AgentProviderKind.omp.rawValue, emitted)
+            XCTAssertTrue(
+                AgentModelCatalog.isValid(
+                    rawModel: parsed.modelRaw,
+                    for: .omp,
+                    availability: availability
+                ),
+                "rendered list_agents advertises '\(emitted)' but the run surface rejects it"
+            )
+        }
+    }
+
+    // MARK: - Picker grouping
+
+    func testOMPGroupsByAdvertisedProviderPrefixAndNeverEmitsABlankLabel() {
+        publishOMPModels()
+        let options = AgentModelCatalog.options(for: .omp, availability: availability(for: .omp))
+
+        let groups = AgentModelCatalog.ompModelGroups(for: options)
+
+        XCTAssertEqual(groups.map(\.providerID), [nil, "anthropic", "openai"])
+        XCTAssertEqual(
+            groups.first(where: { $0.providerID == "openai" })?.options.map(\.rawValue),
+            ["openai/gpt-5.2", "openai/gpt-5.2-codex"]
+        )
+        // The placeholder default and an unprefixed model stay inline rather than under an
+        // empty submenu title.
+        XCTAssertEqual(
+            Set(groups.first(where: { $0.providerID == nil })?.options.map(\.rawValue) ?? []),
+            [AgentModel.defaultModel.rawValue, "local-model"]
+        )
+        for group in groups {
+            XCTAssertNotEqual(group.providerID, "", "a submenu label must never be blank")
+            XCTAssertFalse(group.options.isEmpty, "a rendered group must never be empty")
+        }
+    }
+
+    func testDevinGroupsByNativeFamilyAndKeepsUnfamiliedModelsInline() {
+        publishDevinModels()
+        let options = AgentModelCatalog.options(for: .devin, availability: availability(for: .devin))
+
+        let groups = AgentModelCatalog.devinModelGroups(for: options)
+
+        XCTAssertEqual(groups.map { $0.family?.id }, [nil, "family-claude", "family-gpt"])
+        XCTAssertEqual(
+            groups.first(where: { $0.family?.id == "family-claude" })?.family?.displayName,
+            "Claude"
+        )
+        XCTAssertEqual(
+            groups.first(where: { $0.family?.id == "family-claude" })?.options.map(\.rawValue),
+            ["devin-claude-opus", "devin-claude-sonnet"]
+        )
+        XCTAssertEqual(
+            Set(groups.first(where: { $0.family == nil })?.options.map(\.rawValue) ?? []),
+            [AgentModel.defaultModel.rawValue, "devin-unclassified"]
+        )
+        for group in groups {
+            XCTAssertNotEqual(group.family?.displayName, "", "a family submenu label must never be blank")
+        }
+    }
+
+    /// The reference implementation shipped blank submenu rows because a discovered option
+    /// carried no `displayName`; the store must fall back to the raw model ID instead.
+    func testDiscoveredOptionWithoutADisplayNameFallsBackToItsRawValue() {
+        AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [option(raw: "openai/gpt-5.2", displayName: "")],
+                currentModelRaw: nil
+            ),
+            for: .omp
+        )
+
+        let options = AgentModelCatalog.options(for: .omp, availability: availability(for: .omp))
+
+        XCTAssertEqual(
+            options.first(where: { $0.rawValue == "openai/gpt-5.2" })?.displayName,
+            "openai/gpt-5.2"
+        )
+        XCTAssertFalse(options.contains { $0.displayName.isEmpty })
+    }
+
+    // MARK: - Family metadata persistence
+
+    func testModelFamilySurvivesTheDiscoveredModelStoreRoundTrip() throws {
+        let family = AgentModelFamily(id: "family-gpt", displayName: "GPT")
+        let snapshot = ACPDiscoveredSessionModels(
+            options: [option(raw: "devin-gpt-5.2", displayName: "GPT 5.2", family: family)],
+            currentModelRaw: "devin-gpt-5.2"
+        )
+        let record = try XCTUnwrap(
+            ACPDynamicModelStore.canonicalProviderRecord(from: snapshot, providerID: .devin)
+        )
+
+        let encoded = try JSONEncoder().encode(record)
+        let decoded = try JSONDecoder().decode(ACPDynamicProviderRecord.self, from: encoded)
+        let restored = try XCTUnwrap(ACPDynamicModelStore.snapshot(from: decoded))
+
+        XCTAssertEqual(restored.options.first?.modelFamily, family)
+    }
+
+    /// Records persisted before family support must keep decoding.
+    func testRecordWithoutAFamilyStillDecodes() throws {
+        let json = """
+        {
+          "providerID": "devin",
+          "currentModelRaw": "devin-gpt-5.2",
+          "options": [{
+            "rawValue": "devin-gpt-5.2",
+            "displayName": "GPT 5.2",
+            "isPlaceholderDefault": false,
+            "isProviderDefault": false,
+            "supportedReasoningEfforts": []
+          }]
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(
+            ACPDynamicProviderRecord.self,
+            from: Data(json.utf8)
+        )
+        let restored = try XCTUnwrap(ACPDynamicModelStore.snapshot(from: decoded))
+
+        XCTAssertNil(restored.options.first?.modelFamily)
+        XCTAssertEqual(restored.options.first?.rawValue, "devin-gpt-5.2")
+    }
+
+    // MARK: - `devin models list` family catalog
+
+    func testDevinFamilyCatalogParsesAccountFamilies() throws {
+        let json = """
+        {"families": [
+          {"family_uid": "family-claude", "family_label": "Claude", "variants": [
+            {"model_uid": "devin-claude-opus"}, {"model_uid": "devin-claude-sonnet"}]},
+          {"family_uid": "family-gpt", "family_label": "GPT", "variants": [
+            {"model_uid": "devin-gpt-5.2"}]}
+        ]}
+        """
+
+        let parsed = try DevinModelFamilyCatalog.parse(Data(json.utf8))
+
+        XCTAssertEqual(
+            parsed["devin-claude-opus"],
+            AgentModelFamily(id: "family-claude", displayName: "Claude")
+        )
+        XCTAssertEqual(
+            parsed["devin-claude-sonnet"],
+            AgentModelFamily(id: "family-claude", displayName: "Claude")
+        )
+        XCTAssertEqual(parsed["devin-gpt-5.2"], AgentModelFamily(id: "family-gpt", displayName: "GPT"))
+        XCTAssertEqual(parsed.count, 3)
+    }
+
+    /// Ambiguous identity is rejected wholesale rather than grouping models under a label
+    /// that cannot be trusted.
+    func testDevinFamilyCatalogRejectsBlankOrDuplicateIdentity() {
+        let cases = [
+            "{\"families\": [{\"family_uid\": \"\", \"family_label\": \"Claude\", \"variants\": []}]}",
+            "{\"families\": [{\"family_uid\": \"f\", \"family_label\": \" \", \"variants\": []}]}",
+            """
+            {"families": [
+              {"family_uid": "f", "family_label": "A", "variants": [{"model_uid": "m"}]},
+              {"family_uid": "f", "family_label": "B", "variants": []}]}
+            """,
+            """
+            {"families": [
+              {"family_uid": "a", "family_label": "A", "variants": [{"model_uid": "m"}]},
+              {"family_uid": "b", "family_label": "B", "variants": [{"model_uid": "m"}]}]}
+            """
+        ]
+
+        for json in cases {
+            XCTAssertThrowsError(
+                try DevinModelFamilyCatalog.parse(Data(json.utf8)),
+                "expected rejection for \(json)"
+            )
+        }
+    }
+
+    // MARK: - Selection reaches the ACP run
+
+    func testSelectedModelIsAppliedBeforeThePromptForBothProviders() throws {
+        publishOMPModels()
+        publishDevinModels()
+
+        XCTAssertEqual(
+            try ACPIntegratedAgentModeRunner.testExplicitSelectedModel(
+                agentKind: .omp,
+                modelString: "openai/gpt-5.2"
+            ),
+            "openai/gpt-5.2"
+        )
+        XCTAssertEqual(
+            try ACPIntegratedAgentModeRunner.testExplicitSelectedModel(
+                agentKind: .devin,
+                modelString: "devin-claude-opus"
+            ),
+            "devin-claude-opus"
+        )
+    }
+
+    /// "default" is a provider-managed placeholder: it must send no model mutation.
+    func testProviderManagedDefaultSendsNoModelMutation() throws {
+        publishOMPModels()
+        publishDevinModels()
+
+        for agentKind in [AgentProviderKind.omp, .devin] {
+            XCTAssertNil(try ACPIntegratedAgentModeRunner.testExplicitSelectedModel(
+                agentKind: agentKind,
+                modelString: AgentModel.defaultModel.rawValue
+            ))
+            XCTAssertNil(try ACPIntegratedAgentModeRunner.testExplicitSelectedModel(
+                agentKind: agentKind,
+                modelString: nil
+            ))
+        }
+    }
+
+    func testUndiscoveredModelFailsClosedInsteadOfSilentlyRunningTheDefault() {
+        publishOMPModels()
+        publishDevinModels()
+
+        for agentKind in [AgentProviderKind.omp, .devin] {
+            XCTAssertThrowsError(try ACPIntegratedAgentModeRunner.testExplicitSelectedModel(
+                agentKind: agentKind,
+                modelString: "never-advertised"
+            )) { error in
+                guard case let AIProviderError.invalidConfiguration(detail) = error else {
+                    return XCTFail("Expected an invalid configuration error, got \(error)")
+                }
+                XCTAssertTrue(detail.contains("never-advertised"), detail)
+            }
+        }
+    }
+
+    // MARK: - Oracle / chat exposure for OMP
+
+    func testConnectedOMPAndDevinModelsAppearInOracleAvailability() async {
+        publishOMPModels()
+        publishDevinModels()
+        let apiSettings = makeAPISettingsViewModel()
+        apiSettings.isOMPConnected = true
+        apiSettings.isDevinConnected = true
+
+        await apiSettings.updateAvailableModels()
+
+        XCTAssertTrue(apiSettings.availableModels.contains(.ompCustom(name: "openai/gpt-5.2")))
+        XCTAssertTrue(apiSettings.availableModels.contains(.devinCustom(name: "devin-gpt-5.2")))
+        apiSettings.prepareForWindowClose()
+    }
+
+    func testOMPChatModelsRoundTripThroughAIModel() {
+        publishOMPModels()
+
+        let parsed = AIModel.fromModelName("omp_custom_openai/gpt-5.2")
+
+        XCTAssertEqual(parsed, .ompCustom(name: "openai/gpt-5.2"))
+        XCTAssertEqual(parsed?.providerType, .omp)
+        XCTAssertEqual(parsed?.modelName, "openai/gpt-5.2")
+        XCTAssertEqual(parsed?.rawValue, "omp_custom_openai/gpt-5.2")
+    }
+
+    func testDevinChatModelsRoundTripThroughAIModel() {
+        publishDevinModels()
+
+        let parsed = AIModel.fromModelName("devin_custom_devin-gpt-5.2")
+
+        XCTAssertEqual(parsed, .devinCustom(name: "devin-gpt-5.2"))
+        XCTAssertEqual(parsed?.providerType, .devin)
+        XCTAssertEqual(parsed?.modelName, "devin-gpt-5.2")
+        XCTAssertEqual(parsed?.displayName, "GPT 5.2")
+        XCTAssertEqual(parsed?.rawValue, "devin_custom_devin-gpt-5.2")
+    }
+
+    func testProviderOwnedOracleConfigsPreserveSelectedModelsWithoutMCP() {
+        let omp = OMPCLIProvider.test_makeHeadlessConfig(modelName: "openai/gpt-5.2")
+        let devin = DevinCLIProvider.test_makeHeadlessConfig(modelName: "devin-gpt-5.2")
+
+        XCTAssertEqual(omp.modelString, "openai/gpt-5.2")
+        XCTAssertFalse(omp.includeRepoPromptMCPServer)
+        XCTAssertEqual(devin.modelString, "devin-gpt-5.2")
+        XCTAssertFalse(devin.includeRepoPromptMCPServer)
+    }
+
+    func testOMPChatPickerGroupsDiscoveredModelsWithoutBlankSubmenus() {
+        publishOMPModels()
+        let models = ACPAIModelCatalog.ompModelsFromStore()
+
+        let groups = AIModel.ompMenuGroups(for: models)
+
+        XCTAssertEqual(groups.map(\.displayName), [nil, "anthropic", "openai"])
+        XCTAssertEqual(
+            groups.first(where: { $0.displayName == "openai" })?.models.map(\.modelName),
+            ["openai/gpt-5.2", "openai/gpt-5.2-codex"]
+        )
+        for group in groups {
+            XCTAssertNotEqual(group.displayName, "")
+            XCTAssertFalse(group.models.isEmpty)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeAPISettingsViewModel() -> APISettingsViewModel {
+        let keyManager = KeyManager(
+            secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+        )
+        return APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+    }
+
+    private func availability(for agentKind: AgentProviderKind) -> AgentModelCatalog.AvailabilityContext {
+        AgentModelCatalog.AvailabilityContext(
+            ompAvailable: agentKind == .omp,
+            devinAvailable: agentKind == .devin
+        )
+    }
+
+    private func option(
+        raw: String,
+        displayName: String,
+        family: AgentModelFamily? = nil
+    ) -> AgentModelOption {
+        AgentModelOption(
+            rawValue: raw,
+            displayName: displayName,
+            description: nil,
+            isDefault: false,
+            modelFamily: family
+        )
+    }
+
+    /// OMP advertises fully qualified provider paths, so raw values contain `/` and `.`, and
+    /// Bedrock identifiers additionally contain `:`.
+    private static let punctuatedOMPRawValues = [
+        "amazon-bedrock/anthropic.claude-sonnet-5",
+        "amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "litellm/claude-sonnet-5",
+        "litellm/claude-sonnet-5-xhigh",
+        "litellm/gpt-5.4-pro-med"
+    ]
+
+    private func publishPunctuatedOMPModels() {
+        AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: Self.punctuatedOMPRawValues.map { option(raw: $0, displayName: "Model \($0)") },
+                currentModelRaw: nil
+            ),
+            for: .omp
+        )
+    }
+
+    private func emittedOMPStartTargets(
+        availability: AgentModelCatalog.AvailabilityContext
+    ) throws -> [AgentModelCatalog.DiscoveryStartTarget] {
+        let agent = try XCTUnwrap(
+            AgentModelCatalog.discoveryAgents(availability: availability).first { $0.agent == .omp }
+        )
+        XCTAssertTrue(agent.available)
+        let targets = agent.models.flatMap(\.startTargets)
+        XCTAssertFalse(targets.isEmpty)
+        return targets
+    }
+
+    /// Mirrors the `list_agents` payload shape produced by `AgentManageMCPToolService`.
+    private func renderedListAgentsText(
+        for targets: [AgentModelCatalog.DiscoveryStartTarget]
+    ) throws -> String {
+        let models: [Value] = targets.map { target in
+            .object([
+                "model_id": .string(target.selectionID.rawValue),
+                "name": .string(target.name)
+            ])
+        }
+        let payload = Value.object([
+            "agents": .array([
+                .object([
+                    "name": .string(AgentProviderKind.omp.displayName),
+                    "available": .bool(true),
+                    "models": .array(models)
+                ])
+            ])
+        ])
+
+        let blocks = ToolOutputFormatter.formatAgentManage(
+            args: ["op": .string("list_agents")],
+            value: payload
+        )
+        let first = try XCTUnwrap(blocks.first)
+        guard case let .text(text, _, _) = first else {
+            XCTFail("Expected text content")
+            return ""
+        }
+        return text
+    }
+
+    /// Every backticked token that looks like an `omp:` compound ID in the rendered output.
+    private static func backtickedModelIDs(in text: String) -> [String] {
+        text.split(separator: "`")
+            .map(String.init)
+            .filter { $0.hasPrefix("\(AgentProviderKind.omp.rawValue):") }
+    }
+
+    private func publishOMPModels() {
+        AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [
+                    option(raw: "openai/gpt-5.2", displayName: "GPT 5.2"),
+                    option(raw: "openai/gpt-5.2-codex", displayName: "GPT 5.2 Codex"),
+                    option(raw: "anthropic/claude-opus-4-5", displayName: "Claude Opus 4.5"),
+                    option(raw: "local-model", displayName: "Local Model")
+                ],
+                currentModelRaw: nil
+            ),
+            for: .omp
+        )
+    }
+
+    private func publishDevinModels() {
+        let claude = AgentModelFamily(id: "family-claude", displayName: "Claude")
+        let gpt = AgentModelFamily(id: "family-gpt", displayName: "GPT")
+        AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [
+                    option(raw: "devin-claude-opus", displayName: "Claude Opus", family: claude),
+                    option(raw: "devin-claude-sonnet", displayName: "Claude Sonnet", family: claude),
+                    option(raw: "devin-gpt-5.2", displayName: "GPT 5.2", family: gpt),
+                    option(raw: "devin-unclassified", displayName: "Unclassified")
+                ],
+                currentModelRaw: nil
+            ),
+            for: .devin
+        )
+    }
+}

--- a/Tests/RepoPromptTests/App/DispatchTerminationSignalObserverTests.swift
+++ b/Tests/RepoPromptTests/App/DispatchTerminationSignalObserverTests.swift
@@ -1,0 +1,58 @@
+import AppKit
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class DispatchTerminationSignalObserverTests: XCTestCase {
+    func testHandlerDeliveryLetsANestedModalPanelRunLoopDrainMainActorJobs() {
+        XCTAssertTrue(Thread.isMainThread)
+        CFRunLoopAddCommonMode(
+            CFRunLoopGetMain(),
+            CFRunLoopMode(rawValue: RunLoop.Mode.modalPanel.rawValue as CFString)
+        )
+
+        let observer = DispatchTerminationSignalObserver()
+        var invocationCount = 0
+        var handlerRanOnMainThread = false
+        var mainActorJobRanInsideNestedLoop = false
+
+        observer.ignoreDefaultDisposition(for: SIGUSR2)
+        observer.observe(SIGUSR2) {
+            invocationCount += 1
+            handlerRanOnMainThread = Thread.isMainThread
+
+            let shutdownJob = MainActorJobFlag()
+            Task { @MainActor in shutdownJob.value = true }
+
+            let jobDeadline = Date().addingTimeInterval(2)
+            while !shutdownJob.value, Date() < jobDeadline {
+                if !RunLoop.main.run(mode: .modalPanel, before: Date().addingTimeInterval(0.05)) {
+                    usleep(5000)
+                }
+            }
+            mainActorJobRanInsideNestedLoop = shutdownJob.value
+        }
+
+        let deliveryDeadline = Date().addingTimeInterval(5)
+        while invocationCount == 0, Date() < deliveryDeadline {
+            XCTAssertEqual(kill(getpid(), SIGUSR2), 0)
+            _ = RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+
+        XCTAssertGreaterThanOrEqual(invocationCount, 1)
+        XCTAssertTrue(handlerRanOnMainThread)
+        XCTAssertTrue(
+            mainActorJobRanInsideNestedLoop,
+            """
+            The handler ran inside a main-dispatch-queue callout, so the nested run loop could not \
+            drain the main queue and the main-actor job never started. In the app this is the \
+            signal-initiated quit deadlock: AppKit waits in its nested loop for a reply that only \
+            the starved shutdown task can send.
+            """
+        )
+    }
+}
+
+private final class MainActorJobFlag: @unchecked Sendable {
+    var value = false
+}

--- a/Tests/RepoPromptTests/Chat/OracleTransientImageHistoryTests.swift
+++ b/Tests/RepoPromptTests/Chat/OracleTransientImageHistoryTests.swift
@@ -1,0 +1,247 @@
+import Foundation
+import MCP
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class OracleTransientImageHistoryTests: XCTestCase {
+    func testOverrideAttachmentTargetsOnlyTheFinalUserTurn() {
+        let override = AIMessage(
+            systemPrompt: "system",
+            conversationMessages: [
+                ConversationEntry(role: .user, content: "first"),
+                ConversationEntry(role: .assistant, content: "answer"),
+                ConversationEntry(role: .user, content: "final")
+            ],
+            temperature: nil,
+            promptSectionsOrder: [],
+            disabledPromptSections: []
+        )
+
+        let attached = override.attachingImagesToFinalUserTurn([image()])
+        XCTAssertEqual(attached.conversationMessages.map(\.images), [[], [], [image()]])
+        XCTAssertEqual(
+            attached.conversationMessages.map(\.content),
+            override.conversationMessages.map(\.content)
+        )
+        XCTAssertEqual(override.attachingImagesToFinalUserTurn([]).conversationMessages.map(\.images), [[], [], []])
+    }
+
+    func testContinuationAfterSessionUnloadRejectsNonImageModelBeforeUserRowOrDispatch() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let composition = WindowStateCompositionFactory.make(
+            windowID: -3312,
+            deferredInitialAgentSystemWorkspaceRefresh: true,
+            sharedMCPService: MCPService()
+        )
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        await composition.workspaceManager.awaitInitialized()
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OracleTransientImageHistoryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("Chats", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let oracle = composition.oracleViewModel
+        defer {
+            oracle.sessions = []
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        var workspace = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
+        let tab = ComposeTabState(id: UUID())
+        workspace.customStoragePath = root
+        workspace.composeTabs = [tab]
+        workspace.activeComposeTabID = tab.id
+        if let index = composition.workspaceManager.workspaces.firstIndex(where: { $0.id == workspace.id }) {
+            composition.workspaceManager.workspaces[index] = workspace
+        }
+        composition.workspaceManager.activeWorkspace = workspace
+        composition.promptManager.loadComposeTabsFromWorkspace(workspace)
+        await oracle.loadSessionsFromWorkspace()
+
+        let imageChat = ChatSession(
+            workspaceID: workspace.id,
+            composeTabID: tab.id,
+            name: "Image History",
+            messages: [
+                StoredMessage(isUser: true, rawText: "what colors", sequenceIndex: 0),
+                StoredMessage(isUser: false, rawText: "COLORS: red,green,blue", sequenceIndex: 1)
+            ]
+        )
+        oracle.sessions.append(imageChat)
+        if oracle.currentSessionID == nil {
+            _ = await oracle.startNewChatSession(name: "Foreground", tabID: tab.id)
+        }
+        let foregroundSessionID = try XCTUnwrap(oracle.currentSessionID)
+        XCTAssertNotEqual(foregroundSessionID, imageChat.id)
+
+        let loaded = await oracle.ensureSessionMessagesLoaded(imageChat.id)
+        XCTAssertTrue(loaded)
+        let imageTurn = try XCTUnwrap(oracle.messagesSnapshot(for: imageChat.id).first)
+        oracle.recordTransientImages([image()], for: imageTurn.id, in: imageChat.id)
+
+        oracle.pinSession(imageChat.id)
+        oracle.unpinSession(imageChat.id)
+        XCTAssertTrue(oracle.messagesSnapshot(for: imageChat.id).isEmpty)
+        XCTAssertTrue(oracle.hasHistoricalTransientImages(in: imageChat.id))
+        XCTAssertFalse(oracle.hasHistoricalTransientImages(in: foregroundSessionID))
+
+        do {
+            _ = try await oracle.tool_chatSend(
+                args: [
+                    "message": .string("which one is in the middle?"),
+                    "chat_id": .string(imageChat.id.uuidString.lowercased())
+                ],
+                promptVM: composition.promptManager,
+                resolvedModel: .codexCustom(name: "codex")
+            )
+            XCTFail("Expected a ChatToolError for an image-bearing chat on a non-image model")
+        } catch let error as ChatToolError {
+            XCTAssertEqual(error.code, .invalidParams)
+            XCTAssertTrue(error.message.hasPrefix("Image attachments are not supported"))
+        }
+
+        XCTAssertEqual(
+            oracle.messagesSnapshot(for: imageChat.id).map(\.content),
+            ["what colors", "COLORS: red,green,blue"]
+        )
+        XCTAssertFalse(oracle.isSessionStreaming(imageChat.id))
+
+        let replayed = oracle.buildConversationEntries(for: imageChat.id)
+        XCTAssertEqual(replayed.map(\.content), ["what colors", "COLORS: red,green,blue"])
+        XCTAssertEqual(replayed.map(\.images), [[image()], []])
+
+        let storedImageChat = try XCTUnwrap(oracle.sessions.first(where: { $0.id == imageChat.id }))
+        await oracle.deleteSession(storedImageChat)
+        XCTAssertFalse(oracle.hasHistoricalTransientImages(in: imageChat.id))
+        await oracle.drainTrackedAutosaves(for: workspace.id)
+    }
+
+    func testRemovingAnImageBearingTurnReleasesItsImages() async throws {
+        let fixture = makeOracleFixture(windowID: -3313)
+        let oracle = fixture.oracle
+        let sessionID = try await startImageTurn(in: oracle, message: "what colors")
+
+        let imageTurn = try XCTUnwrap(oracle.messagesSnapshot(for: sessionID).first)
+        await oracle.removeMessage(imageTurn.id)
+
+        XCTAssertFalse(oracle.hasHistoricalTransientImages(in: sessionID))
+        XCTAssertEqual(oracle.buildConversationEntries(for: sessionID).flatMap(\.images), [])
+    }
+
+    func testEditingTheFirstImageBearingTurnReleasesTruncatedImages() async throws {
+        let fixture = makeOracleFixture(windowID: -3314)
+        let oracle = fixture.oracle
+        let sessionID = try await startImageTurn(in: oracle, message: "what colors")
+
+        let imageTurn = try XCTUnwrap(oracle.messagesSnapshot(for: sessionID).first)
+        await oracle.editAndResendMessage(messageId: imageTurn.id, newContent: "what colors now")
+
+        XCTAssertFalse(oracle.hasHistoricalTransientImages(in: sessionID))
+        XCTAssertEqual(
+            oracle.messagesSnapshot(for: sessionID).filter(\.isUser).map(\.content),
+            ["what colors now"]
+        )
+        XCTAssertEqual(oracle.buildConversationEntries(for: sessionID).flatMap(\.images), [])
+    }
+
+    func testEditingTheLastImageBearingTurnReleasesItsImages() async throws {
+        let fixture = makeOracleFixture(windowID: -3315)
+        let oracle = fixture.oracle
+        let sessionID = try await startImageTurn(in: oracle, message: "what colors")
+
+        let rows = oracle.messagesSnapshot(for: sessionID)
+        let imageTurn = try XCTUnwrap(rows.first)
+        let assistantRow = try XCTUnwrap(rows.dropFirst().first)
+        XCTAssertFalse(assistantRow.isUser)
+        await oracle.removeMessage(assistantRow.id)
+        XCTAssertTrue(oracle.hasHistoricalTransientImages(in: sessionID))
+
+        await oracle.editAndResendMessage(messageId: imageTurn.id, newContent: "what colors now")
+
+        XCTAssertFalse(oracle.hasHistoricalTransientImages(in: sessionID))
+        XCTAssertEqual(oracle.buildConversationEntries(for: sessionID).flatMap(\.images), [])
+    }
+
+    func testForkCarriesRetainedImageTurnsIntoTheNewSession() async throws {
+        let fixture = makeOracleFixture(windowID: -3316)
+        let oracle = fixture.oracle
+        let sessionID = try await startImageTurn(in: oracle, message: "what colors")
+        let forkPoint = try XCTUnwrap(oracle.messagesSnapshot(for: sessionID).last)
+
+        await oracle.forkChatSession(from: forkPoint.id)
+
+        let forkedID = try XCTUnwrap(oracle.sessions.first(where: { $0.id != sessionID })?.id)
+        XCTAssertEqual(oracle.currentSessionID, forkedID)
+        XCTAssertTrue(oracle.hasHistoricalTransientImages(in: forkedID))
+        XCTAssertTrue(oracle.hasHistoricalTransientImages(in: sessionID))
+
+        let forkedEntries = oracle.buildConversationEntries(for: forkedID)
+        XCTAssertEqual(forkedEntries.first?.content, "what colors")
+        XCTAssertEqual(forkedEntries.first?.images, [image()])
+        XCTAssertEqual(forkedEntries.dropFirst().flatMap(\.images), [])
+    }
+
+    @MainActor
+    private func startImageTurn(in oracle: OracleViewModel, message: String) async throws -> UUID {
+        let workspace = try WorkspaceModel(
+            name: "Image history",
+            repoPaths: [],
+            customStoragePath: makeTestDirectory()
+        )
+        oracle.workspaceManager.workspaces = [workspace]
+        oracle.workspaceManager.activeWorkspace = workspace
+        addTeardownBlock {
+            await oracle.drainTrackedAutosaves(for: workspace.id)
+        }
+        let session = ChatSession(workspaceID: workspace.id, name: "Image chat")
+        oracle.sessions = [session]
+        oracle.currentSessionID = session.id
+        _ = await oracle.sendMessage(message, sessionID: session.id, oracleTransientImages: [image()])
+
+        let rows = oracle.messagesSnapshot(for: session.id)
+        XCTAssertEqual(rows.first?.content, message)
+        XCTAssertFalse(oracle.isSessionStreaming(session.id))
+        XCTAssertTrue(oracle.hasHistoricalTransientImages(in: session.id))
+        return session.id
+    }
+
+    @MainActor
+    private func makeOracleFixture(windowID: Int) -> (oracle: OracleViewModel, apiSettings: APISettingsViewModel) {
+        let keyManager = KeyManager(
+            secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+        )
+        let aiQueriesService = AIQueriesService(keyManager: keyManager)
+        let fileManager = WorkspaceFilesViewModel()
+        let apiSettings = APISettingsViewModel(
+            aiQueriesService: aiQueriesService,
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        let prompt = PromptViewModel(
+            fileManager: fileManager,
+            apiSettingsViewModel: apiSettings,
+            windowID: windowID,
+            settingsManager: WindowSettingsManager(windowID: windowID)
+        )
+        let workspaceManager = WorkspaceManagerViewModel(
+            fileManager: fileManager,
+            promptViewModel: prompt,
+            performInitialWorkspaceActivation: false
+        )
+        let oracle = OracleViewModel(
+            aiQueriesService: aiQueriesService,
+            promptViewModel: prompt,
+            workspaceManager: workspaceManager,
+            chatData: ChatDataService()
+        )
+        return (oracle, apiSettings)
+    }
+
+    private func image(title: String? = "Diagram") -> AITransientImage {
+        AITransientImage(bytes: Data([1, 2, 3]), mediaType: .png, title: title)
+    }
+}

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderOracleResultTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderOracleResultTests.swift
@@ -97,7 +97,7 @@ final class ContextBuilderOracleResultTests: XCTestCase {
         XCTAssertFalse(text.contains("- Status: Failed"), text)
     }
 
-    func testFailedOrCancelledPrimaryIsNotPublishable() throws {
+    func testStrictPrimaryResponseAccessorStillRejectsFailedOrCancelledPrimary() throws {
         for status in [OracleLaneResultStatus.failed, .cancelled] {
             let reply = try ContextBuilderOracleGroupReply(result: groupResult(
                 status: .failed,
@@ -170,6 +170,174 @@ final class ContextBuilderOracleResultTests: XCTestCase {
             reply.toMCPFields()["oracle_results"]?.arrayValue?[0]
                 .objectValue?["execution_profile"]
         )
+    }
+
+    @MainActor
+    func testSettledReplyBoundaryDeliversFailedPrimaryAndKeepsErrorNavigation() throws {
+        for mode in [HeadlessMode.plan, .review] {
+            for primaryStatus in [OracleLaneResultStatus.failed, .cancelled] {
+                let result = try groupResult(status: .failed, lanes: [
+                    lane(index: 0, status: primaryStatus, error: laneError(
+                        code: "primary_stopped", message: "primary stopped", partialResponse: "primary partial"
+                    )),
+                    lane(index: 1, status: .completed, response: "Error: is legitimate answer text"),
+                    lane(index: 2, status: .completed, response: "third answer")
+                ])
+                let (session, generation, members) = try preparedSession(for: result)
+                let workspaceID = UUID()
+                let reply = try session.completeOracleGroupReply(
+                    ContextBuilderOracleGroupReply(result: result),
+                    generation: generation,
+                    originWorkspaceID: workspaceID,
+                    mode: mode
+                )
+                XCTAssertEqual(reply.chatId, members[0].sessionID)
+                XCTAssertEqual(reply.shortId, "chat-0")
+                XCTAssertNil(reply.response, "A secondary answer must never become the primary response")
+                XCTAssertEqual(reply.oracleGroup?.result, result)
+                XCTAssertEqual(reply.errors, ["Oracle \(primaryStatus.rawValue): primary stopped"])
+                XCTAssertFalse(session.isBackgroundPlanGenerating)
+                XCTAssertEqual(session.backgroundPlanResponseText, "primary partial")
+                guard case let .error(message) = session.planStatus else {
+                    return XCTFail("Primary failure must remain visible")
+                }
+                XCTAssertTrue(message.contains("primary stopped"))
+                XCTAssertEqual(session.failedAnswerRoute, ContextBuilderGeneratedAnswerRoute(
+                    workspaceID: workspaceID, tabID: session.tabID, chatID: "chat-0"
+                ))
+                XCTAssertTrue(session.followUpOracleGroupState.members.isEmpty)
+
+                let branch = mode == .review ? "review" : "plan"
+                let raw: Value = .object([
+                    "response_type": .string(branch),
+                    branch: reply.toMCPValue()
+                ])
+                let dto = try XCTUnwrap(raw.decode(ToolResultDTOs.ContextBuilderDTO.self))
+                let summaries = contextBuilderOracleLaneSummaries(for: dto)
+                XCTAssertEqual(summaries.map(\.chatID), ["chat-0", "chat-1", "chat-2"])
+                XCTAssertEqual(summaries.map(\.status), [primaryStatus.rawValue, "done", "done"])
+                XCTAssertEqual(contextBuilderFollowUpChatID(for: dto), "chat-0")
+                let text = ToolOutputFormatter.formatDiscoverContext(value: raw).compactMap { block -> String? in
+                    guard case let .text(text, _, _) = block else { return nil }
+                    return text
+                }.joined(separator: "\n")
+                XCTAssertTrue(text.contains("primary stopped"), text)
+                XCTAssertTrue(text.contains("Error: is legitimate answer text"), text)
+                XCTAssertTrue(text.contains("third answer"), text)
+            }
+        }
+    }
+
+    @MainActor
+    func testSettledReplyBoundaryPreservesSuccessAndPartialFailure() throws {
+        for additionalStatus in [OracleLaneResultStatus.completed, .failed] {
+            let result = try groupResult(
+                status: additionalStatus == .completed ? .completed : .partialFailure,
+                lanes: [
+                    lane(index: 0, status: .completed, response: "primary answer"),
+                    lane(
+                        index: 1,
+                        status: additionalStatus,
+                        response: additionalStatus == .completed ? "second answer" : nil,
+                        error: additionalStatus == .failed ? laneError(message: "second failed") : nil
+                    )
+                ]
+            )
+            let (session, generation, _) = try preparedSession(for: result)
+            let reply = try session.completeOracleGroupReply(
+                ContextBuilderOracleGroupReply(result: result), generation: generation,
+                originWorkspaceID: UUID(), mode: .plan
+            )
+            XCTAssertEqual(reply.response, "primary answer")
+            XCTAssertEqual(reply.oracleGroup?.result, result)
+            XCTAssertNil(session.backgroundPlanError)
+            XCTAssertNil(session.failedAnswerRoute)
+            guard case .ready = session.planStatus else { return XCTFail("Expected ready") }
+        }
+    }
+
+    @MainActor
+    func testSettledReplyBoundaryRejectsStaleGenerationAndMismatchedMembershipBeforeMutation() throws {
+        let result = try groupResult(lanes: [
+            lane(index: 0, status: .completed, response: "primary"),
+            lane(index: 1, status: .completed, response: "secondary")
+        ])
+        let (session, generation, members) = try preparedSession(for: result)
+        let differentGroup = try groupResult(lanes: result.oracleResults)
+        XCTAssertThrowsError(try session.completeOracleGroupReply(
+            ContextBuilderOracleGroupReply(result: differentGroup), generation: generation,
+            originWorkspaceID: UUID(), mode: .review
+        ))
+        XCTAssertEqual(session.followUpOracleGroupState.members, members)
+        XCTAssertTrue(session.isBackgroundPlanGenerating)
+        XCTAssertNil(session.generatedAnswerRoute)
+
+        let wrongMember = try OracleLaneResult(
+            laneIndex: 1, chatID: "different-chat", providerID: "provider-1", modelID: "model-1",
+            status: .completed, response: "unrelated answer"
+        )
+        let mismatchedMembers = try groupResult(
+            groupID: result.groupID.rawValue, lanes: [result.primary, wrongMember]
+        )
+        XCTAssertThrowsError(try session.completeOracleGroupReply(
+            ContextBuilderOracleGroupReply(result: mismatchedMembers), generation: generation,
+            originWorkspaceID: UUID(), mode: .review
+        ))
+        XCTAssertEqual(session.followUpOracleGroupState.members, members)
+        XCTAssertNil(session.generatedAnswerRoute)
+
+        _ = session.followUpOracleGroupState.beginRun()
+        XCTAssertThrowsError(try session.completeOracleGroupReply(
+            ContextBuilderOracleGroupReply(result: result), generation: generation,
+            originWorkspaceID: UUID(), mode: .review
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertTrue(session.isBackgroundPlanGenerating)
+        XCTAssertNil(session.generatedAnswerRoute)
+    }
+
+    @MainActor
+    func testSettledReplyBoundaryHonorsTaskCancellation() async throws {
+        let result = try groupResult(lanes: [
+            lane(index: 0, status: .completed, response: "primary"),
+            lane(index: 1, status: .completed, response: "secondary")
+        ])
+        let (session, generation, members) = try preparedSession(for: result)
+        let task = Task { @MainActor in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try session.completeOracleGroupReply(
+                ContextBuilderOracleGroupReply(result: result), generation: generation,
+                originWorkspaceID: UUID(), mode: .review
+            )
+        }
+        do {
+            _ = try await task.value
+            XCTFail("Cancelled work must not publish a reply")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(session.followUpOracleGroupState.members, members)
+        XCTAssertTrue(session.isBackgroundPlanGenerating)
+        XCTAssertNil(session.generatedAnswerRoute)
+    }
+
+    @MainActor
+    private func preparedSession(for result: OracleGroupResult) throws -> (
+        ContextBuilderAgentViewModel.TabSession, UInt64, [ContextBuilderOracleMemberHandle]
+    ) {
+        let session = ContextBuilderAgentViewModel.TabSession(tabID: UUID())
+        session.isBackgroundPlanGenerating = true
+        let generation = session.followUpOracleGroupState.beginRun()
+        let members = try result.oracleResults.map {
+            try ContextBuilderOracleMemberHandle(
+                laneID: OracleLaneID(index: $0.laneIndex), sessionID: UUID(), chatID: $0.chatID
+            )
+        }
+        XCTAssertTrue(session.followUpOracleGroupState.bind(
+            groupID: result.groupID, turnID: OracleTurnID(), members: members, generation: generation
+        ))
+        return (session, generation, members)
     }
 
     private func groupResult(

--- a/Tests/RepoPromptTests/MCP/OracleImageAttachmentTests.swift
+++ b/Tests/RepoPromptTests/MCP/OracleImageAttachmentTests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import MCP
+@testable import RepoPromptApp
+import XCTest
+
+/// Contract for the Oracle MCP image-attachment surface: argument parsing,
+/// workspace-root confinement, content sniffing, limits, and transport admission.
+final class OracleImageAttachmentTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("OracleImageAttachmentTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Loading
+
+    func testLoadsSupportedFormatsAndSniffsMediaTypeIgnoringExtension() throws {
+        let png = try write("diagram.png", bytes: Self.pngBytes)
+        // Extension deliberately lies: sniffing is authoritative.
+        let jpeg = try write("photo.png", bytes: Self.jpegBytes)
+
+        let images = try loader().load([
+            OracleImageRequest(index: 0, path: png.path, title: "  Diagram  "),
+            OracleImageRequest(index: 1, path: jpeg.path, title: "   ")
+        ])
+
+        XCTAssertEqual(images.map(\.mediaType), [.png, .jpeg])
+        XCTAssertEqual(images[0].bytes, Self.pngBytes)
+        XCTAssertEqual(images[0].title, "  Diagram  ")
+        XCTAssertEqual(images[0].normalizedTitle, "Diagram")
+        XCTAssertNil(images[1].normalizedTitle)
+        XCTAssertEqual(images[0].openAIDataURL, "data:image/png;base64,\(Self.pngBytes.base64EncodedString())")
+    }
+
+    func testRejectsPathsOutsideWorkspaceRootsIncludingSymlinkAndTraversalEscapes() throws {
+        let outside = root.appendingPathComponent("outside")
+        let inside = root.appendingPathComponent("inside")
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: inside, withIntermediateDirectories: true)
+        let secret = outside.appendingPathComponent("secret.png")
+        try Self.pngBytes.write(to: secret)
+        let escape = inside.appendingPathComponent("escape.png")
+        try FileManager.default.createSymbolicLink(at: escape, withDestinationURL: secret)
+
+        let scoped = OracleImageAttachmentLoader(workspaceRootPaths: [inside.path])
+
+        assertLoadError(.outsideWorkspaceRoots(index: 0)) {
+            try scoped.load([OracleImageRequest(index: 0, path: secret.path, title: nil)])
+        }
+        assertLoadError(.outsideWorkspaceRoots(index: 0)) {
+            try scoped.load([OracleImageRequest(index: 0, path: escape.path, title: nil)])
+        }
+        assertLoadError(.outsideWorkspaceRoots(index: 0)) {
+            try scoped.load([OracleImageRequest(
+                index: 0,
+                path: inside.path + "/../outside/secret.png",
+                title: nil
+            )])
+        }
+        assertLoadError(.invalidPath(index: 0)) {
+            try scoped.load([OracleImageRequest(index: 0, path: "relative/secret.png", title: nil)])
+        }
+        // An empty root list admits nothing.
+        assertLoadError(.outsideWorkspaceRoots(index: 0)) {
+            try OracleImageAttachmentLoader(workspaceRootPaths: [])
+                .load([OracleImageRequest(index: 0, path: secret.path, title: nil)])
+        }
+    }
+
+    func testRejectsDirectoriesMissingFilesAndUnsupportedContent() throws {
+        let directory = root.appendingPathComponent("folder.png")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let text = try write("notes.png", bytes: Data("not an image".utf8))
+
+        assertLoadError(.notRegularFile(index: 0)) {
+            try loader().load([OracleImageRequest(index: 0, path: directory.path, title: nil)])
+        }
+        assertLoadError(.missingOrUnreadable(index: 0)) {
+            try loader().load([OracleImageRequest(
+                index: 0,
+                path: root.appendingPathComponent("absent.png").path,
+                title: nil
+            )])
+        }
+        assertLoadError(.unsupportedFormat(index: 0)) {
+            try loader().load([OracleImageRequest(index: 0, path: text.path, title: nil)])
+        }
+    }
+
+    func testEnforcesCountPerImageAndTotalLimits() throws {
+        let png = try write("diagram.png", bytes: Self.pngBytes)
+        let request = OracleImageRequest(index: 0, path: png.path, title: nil)
+
+        assertLoadError(.tooMany(maximumCount: 1)) {
+            try loader(limits: OracleImageAttachmentLimits(maxCount: 1, maxBytesPerImage: 64, maxTotalBytes: 128))
+                .load([request, OracleImageRequest(index: 1, path: png.path, title: nil)])
+        }
+        assertLoadError(.tooLarge(index: 0, maximumBytes: 4)) {
+            try loader(limits: OracleImageAttachmentLimits(maxCount: 2, maxBytesPerImage: 4, maxTotalBytes: 128))
+                .load([request])
+        }
+        assertLoadError(.totalTooLarge(maximumBytes: Self.pngBytes.count + 1)) {
+            try loader(limits: OracleImageAttachmentLimits(
+                maxCount: 2,
+                maxBytesPerImage: 1024,
+                maxTotalBytes: Self.pngBytes.count + 1
+            )).load([request, OracleImageRequest(index: 1, path: png.path, title: nil)])
+        }
+        XCTAssertEqual(try loader().load([]).count, 0)
+    }
+
+    // MARK: - MCP argument contract
+
+    @MainActor
+    func testParserAcceptsBoundedPathAndOptionalTitleObjects() throws {
+        XCTAssertEqual(try MCPOracleToolService.parseOracleImageRequests(nil), [])
+        XCTAssertEqual(try MCPOracleToolService.parseOracleImageRequests(.array([])), [])
+
+        let parsed = try MCPOracleToolService.parseOracleImageRequests(.array([
+            .object([
+                "path": .string("/workspace/diagram.png"),
+                "title": .string("  Architecture  "),
+                "_meta": .string("ignored")
+            ]),
+            .object(["path": .string("/workspace/photo.jpg")])
+        ]))
+
+        XCTAssertEqual(parsed, [
+            OracleImageRequest(index: 0, path: "/workspace/diagram.png", title: "Architecture"),
+            OracleImageRequest(index: 1, path: "/workspace/photo.jpg", title: nil)
+        ])
+    }
+
+    @MainActor
+    func testParserRejectsExpandedAttachmentShapes() {
+        let cases: [Value] = [
+            .string("/workspace/diagram.png"),
+            .array([.string("/workspace/diagram.png")]),
+            .array([.object([:])]),
+            .array([.object(["path": .string("   ")])]),
+            .array([.object([
+                "path": .string("/workspace/diagram.png"),
+                "url": .string("https://example.com/image.png")
+            ])]),
+            .array([.object([
+                "path": .string("/workspace/diagram.png"),
+                "title": .string(String(repeating: "x", count: 201))
+            ])]),
+            .array((0 ... OracleImageAttachmentLimits.production.maxCount).map {
+                .object(["path": .string("/workspace/\($0).png")])
+            })
+        ]
+        for value in cases {
+            XCTAssertThrowsError(
+                try MCPOracleToolService.parseOracleImageRequests(value),
+                "Expected \(value) to be rejected"
+            )
+        }
+    }
+
+    // MARK: - Transport admission
+
+    func testAdmissionAllowsImageCapableTransportsAndRejectsUnsupportedCLIOnes() {
+        let supported: [AIModel] = [
+            .claude4Sonnet,
+            .gpt5,
+            .openaiCustom(name: "custom"),
+            .ollama,
+            .geminiFlash25,
+            .deepseekChat,
+            .ompCustom(name: "openai/gpt-5.2"),
+            .devinCustom(name: "devin-gpt-5.2")
+        ]
+        for model in supported {
+            XCTAssertTrue(OracleImageRouteAdmission.supports(model), "Expected \(model) to admit images")
+        }
+
+        let rejected: [AIModel] = [
+            .claudeCodeSonnet,
+            .codexCustom(name: "codex"),
+            .cursorCustom(name: "cursor"),
+            .grokBuildCustom(name: "grok")
+        ]
+        for model in rejected {
+            XCTAssertFalse(OracleImageRouteAdmission.supports(model), "Expected \(model) to reject images")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static let pngBytes = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01, 0x02, 0x03])
+    private static let jpegBytes = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46])
+
+    private func loader(
+        limits: OracleImageAttachmentLimits = .production
+    ) -> OracleImageAttachmentLoader {
+        OracleImageAttachmentLoader(workspaceRootPaths: [root.path], limits: limits)
+    }
+
+    private func write(_ name: String, bytes: Data) throws -> URL {
+        let url = root.appendingPathComponent(name)
+        try bytes.write(to: url)
+        return url
+    }
+
+    private func assertLoadError(
+        _ expected: OracleImageLoadError,
+        line: UInt = #line,
+        _ expression: () throws -> [AITransientImage]
+    ) {
+        XCTAssertThrowsError(try expression(), line: line) { error in
+            XCTAssertEqual(error as? OracleImageLoadError, expected, line: line)
+        }
+    }
+}

--- a/Tests/RepoPromptTests/Security/AgentPermissionSecureStoreTests.swift
+++ b/Tests/RepoPromptTests/Security/AgentPermissionSecureStoreTests.swift
@@ -136,6 +136,36 @@ final class AgentPermissionSecureStoreTests: XCTestCase {
         XCTAssertEqual(binding.codexTools?.bashToolEnabled, true)
     }
 
+    @MainActor
+    func testOMPProviderManagedPermissionsHaveNoMutableMode() throws {
+        let suiteName = "AgentPermissionSecureStoreTests.OMP.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let snapshots = AgentProviderPreferenceSnapshotStore(defaults: defaults, codexMCPServerEntries: { [] })
+        let level = AgentProviderPermissionLevelID.subagentDefault(for: .omp)
+
+        XCTAssertEqual(AgentProviderPermissionLevelID.options(for: .omp), [level])
+        XCTAssertEqual(level.subagentRawValue, "providerManaged")
+        XCTAssertEqual(AgentProviderPermissionLevelID(providerID: .omp, subagentRawValue: "providerManaged"), level)
+        XCTAssertNil(AgentProviderPermissionLevelID(providerID: .omp, subagentRawValue: "plan"))
+
+        let binding = snapshots.topLevelSettingsControlsBinding(providerID: .omp)
+        XCTAssertEqual(binding.permission.displayName, "Provider Managed")
+        XCTAssertEqual(binding.permission.options.map(\.id), [level])
+        XCTAssertTrue(binding.permission.options.allSatisfy { $0.isSelected && !$0.isEnabled })
+
+        for profile in [AgentProviderPermissionProfile.userConfigured, .mcpSafeDefaults, .providerOverride(level)] {
+            XCTAssertEqual(snapshots.runtimePermission(for: .omp, profile: profile), AgentProviderRuntimePermissionBinding())
+            XCTAssertNil(profile.acpSessionModeID(for: .omp))
+        }
+
+        snapshots.setPermissionLevel(level)
+        XCTAssertNil(defaults.object(forKey: "ompACPSessionMode"))
+        let settings = AgentProviderPermissionsSettingsViewModel(defaults: defaults, notificationCenter: NotificationCenter())
+        settings.setPermissionLevel(level)
+        XCTAssertNil(defaults.object(forKey: "ompACPSessionMode"))
+    }
+
     func testSuccessfulResetPersistsProductDefaultsAcrossRelaunch() throws {
         let secureStrings = FakeSecurePlainStringStore()
         let key = AgentPermissionSecureDomain.codex.storageKey

--- a/Tests/RepoPromptTests/Security/SecureStorageAccountCatalogTests.swift
+++ b/Tests/RepoPromptTests/Security/SecureStorageAccountCatalogTests.swift
@@ -89,8 +89,13 @@ final class SecureStorageAccountCatalogTests: XCTestCase {
             (.zAI, .zAIAPI)
         ]
 
-        XCTAssertEqual(mappings.map(\.0.secureStorageAccount), mappings.map(\.1))
+        XCTAssertEqual(mappings.map(\.0.secureStorageAccount), mappings.map { Optional($0.1) })
         XCTAssertEqual(mappings.map(\.1), SecureStorageAccountCatalog.providerAndCLIAccounts)
+
+        // Grok Build reuses the xAI account; Oh My Pi authenticates entirely through its own
+        // CLI, so it must not own or borrow a secure-storage account.
+        XCTAssertEqual(AIProviderType.grokBuild.secureStorageAccount, .grokAPI)
+        XCTAssertNil(AIProviderType.omp.secureStorageAccount)
     }
 
     func testClaudeCompatibleMappingsUseCatalogAccounts() {


### PR DESCRIPTION
## What
- add transient image attachments across Oracle MCP input, grouped execution, provider serialization, ACP prompt blocks, history, and result UI
- add shared ACP launch, discovery, chat, model-selection, and permission infrastructure with an OMP provider
- add Devin ACP launch isolation, model-family discovery, Oracle execution, image support, and stream filtering
- expose discovered OMP and Devin models in Oracle selectors with stable model-ID round trips

## Why
OMP and Devin existed only partially across Agent Mode and Oracle surfaces, while Oracle attachments could not be transported safely across every supported route. This completes those paths while keeping the ACP model registry authoritative and avoiding duplicated provider launch machinery.

## How to test
- [x] `./conductor test --filter 'OracleImageSerializationTests|OracleImageAttachmentTests|ACPCLILaunchResolverTests|DevinIntegrationConfigurationTests|DevinOMPModelSelectionTests|AgentPermissionSecureStoreTests|AutoRecommendationEngineScopedSettingsTests|AgentOraclePillRoutingTests|OracleGroupContractTests|ContextBuilder|SecureStorage'` — 232 tests passed
- [x] `make dev-lint`
- [x] `make dev-swift-build PRODUCT=RepoPrompt`
- [x] `make guardrails`
- [x] commit and push preflight secret scans
- [ ] Full `make dev-test`: one unchanged `StoreBackedWorkspaceSearchTests.testExactAbsoluteScopeHelperQualifiesTrimmedAndTildePathsButRejectsRelativeAliasAndNULInputs` failure (`ambiguousGitTopology`) reproduces at `origin/main` in the same standalone clone

## Breaking changes
- OMP permission presentation is provider-managed rather than a mutable RepoPrompt-owned session-mode preference.

Generated with [Devin](https://devin.ai)