### PR TITLE
Put workspace first in window titles

### DIFF
--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -63,7 +63,7 @@ enum WindowTitleFormatter {
             return workspaceTitle
         }
 
-        return "\(trimmedSessionTitle) — \(workspaceTitle)"
+        return "\(workspaceTitle) — \(trimmedSessionTitle)"
     }
 
     static func applyingOverseerPrefix(to baseTitle: String, isOverseer: Bool) -> String {


### PR DESCRIPTION
## Summary

Display composed native window titles as `workspace — chat` instead of `chat — workspace`, making the macOS Window menu easier to scan by workspace.

The shared formatter intentionally applies the same ordering to the window titlebar and native tabs. Workspace-only titles, duplicate-title suppression, instance suffixes, and overseer decoration are unchanged.

## Validation

- `make dev-swift-build PRODUCT=RepoPrompt`
- contribution commit and push preflights
- no new tests; this is a one-line presentation-order change